### PR TITLE
script: Include constructors and static methods in generated DOM traits

### DIFF
--- a/components/script/dom/analysernode.rs
+++ b/components/script/dom/analysernode.rs
@@ -131,9 +131,14 @@ impl AnalyserNode {
         Ok(object)
     }
 
+    pub fn push_block(&self, block: Block) {
+        self.engine.borrow_mut().push(block)
+    }
+}
+
+impl AnalyserNodeMethods for AnalyserNode {
     /// <https://webaudio.github.io/web-audio-api/#dom-analysernode-analysernode>
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+    fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -143,12 +148,6 @@ impl AnalyserNode {
         AnalyserNode::new_with_proto(window, proto, context, options, can_gc)
     }
 
-    pub fn push_block(&self, block: Block) {
-        self.engine.borrow_mut().push(block)
-    }
-}
-
-impl AnalyserNodeMethods for AnalyserNode {
     #[allow(unsafe_code)]
     /// <https://webaudio.github.io/web-audio-api/#dom-analysernode-getfloatfrequencydata>
     fn GetFloatFrequencyData(&self, mut array: CustomAutoRooterGuard<Float32Array>) {

--- a/components/script/dom/animationevent.rs
+++ b/components/script/dom/animationevent.rs
@@ -61,9 +61,10 @@ impl AnimationEvent {
         }
         ev
     }
+}
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+impl AnimationEventMethods for AnimationEvent {
+    fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -72,9 +73,7 @@ impl AnimationEvent {
     ) -> DomRoot<AnimationEvent> {
         AnimationEvent::new_with_proto(window, proto, Atom::from(type_), init, can_gc)
     }
-}
 
-impl AnimationEventMethods for AnimationEvent {
     // https://drafts.csswg.org/css-animations/#interface-animationevent-attributes
     fn AnimationName(&self) -> DOMString {
         DOMString::from(&*self.animation_name)

--- a/components/script/dom/animationevent.rs
+++ b/components/script/dom/animationevent.rs
@@ -64,6 +64,7 @@ impl AnimationEvent {
 }
 
 impl AnimationEventMethods for AnimationEvent {
+    // https://drafts.csswg.org/css-animations/#dom-animationevent-animationevent
     fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/audiobuffer.rs
+++ b/components/script/dom/audiobuffer.rs
@@ -109,33 +109,6 @@ impl AudioBuffer {
         buffer
     }
 
-    // https://webaudio.github.io/web-audio-api/#dom-audiobuffer-audiobuffer
-    #[allow(non_snake_case)]
-    pub fn Constructor(
-        window: &Window,
-        proto: Option<HandleObject>,
-        can_gc: CanGc,
-        options: &AudioBufferOptions,
-    ) -> Fallible<DomRoot<AudioBuffer>> {
-        if options.length == 0 ||
-            options.numberOfChannels == 0 ||
-            options.numberOfChannels > MAX_CHANNEL_COUNT ||
-            *options.sampleRate < MIN_SAMPLE_RATE ||
-            *options.sampleRate > MAX_SAMPLE_RATE
-        {
-            return Err(Error::NotSupported);
-        }
-        Ok(AudioBuffer::new_with_proto(
-            window,
-            proto,
-            options.numberOfChannels,
-            options.length,
-            *options.sampleRate,
-            None,
-            can_gc,
-        ))
-    }
-
     // Initialize the underlying channels data with initial data provided by
     // the user or silence otherwise.
     fn set_initial_data(&self, initial_data: Option<&[Vec<f32>]>) {
@@ -210,6 +183,32 @@ impl AudioBuffer {
 }
 
 impl AudioBufferMethods for AudioBuffer {
+    // https://webaudio.github.io/web-audio-api/#dom-audiobuffer-audiobuffer
+    fn Constructor(
+        window: &Window,
+        proto: Option<HandleObject>,
+        can_gc: CanGc,
+        options: &AudioBufferOptions,
+    ) -> Fallible<DomRoot<AudioBuffer>> {
+        if options.length == 0 ||
+            options.numberOfChannels == 0 ||
+            options.numberOfChannels > MAX_CHANNEL_COUNT ||
+            *options.sampleRate < MIN_SAMPLE_RATE ||
+            *options.sampleRate > MAX_SAMPLE_RATE
+        {
+            return Err(Error::NotSupported);
+        }
+        Ok(AudioBuffer::new_with_proto(
+            window,
+            proto,
+            options.numberOfChannels,
+            options.length,
+            *options.sampleRate,
+            None,
+            can_gc,
+        ))
+    }
+
     // https://webaudio.github.io/web-audio-api/#dom-audiobuffer-samplerate
     fn SampleRate(&self) -> Finite<f32> {
         Finite::wrap(self.sample_rate)

--- a/components/script/dom/audiobuffersourcenode.rs
+++ b/components/script/dom/audiobuffersourcenode.rs
@@ -123,6 +123,7 @@ impl AudioBufferSourceNode {
 }
 
 impl AudioBufferSourceNodeMethods for AudioBufferSourceNode {
+    // https://webaudio.github.io/web-audio-api/#dom-audiobuffersourcenode-audiobuffersourcenode
     fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/audiobuffersourcenode.rs
+++ b/components/script/dom/audiobuffersourcenode.rs
@@ -120,9 +120,10 @@ impl AudioBufferSourceNode {
             can_gc,
         ))
     }
+}
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+impl AudioBufferSourceNodeMethods for AudioBufferSourceNode {
+    fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -131,9 +132,7 @@ impl AudioBufferSourceNode {
     ) -> Fallible<DomRoot<AudioBufferSourceNode>> {
         AudioBufferSourceNode::new_with_proto(window, proto, context, options, can_gc)
     }
-}
 
-impl AudioBufferSourceNodeMethods for AudioBufferSourceNode {
     // https://webaudio.github.io/web-audio-api/#dom-audiobuffersourcenode-buffer
     fn GetBuffer(&self) -> Fallible<Option<DomRoot<AudioBuffer>>> {
         Ok(self.buffer.get())

--- a/components/script/dom/audiocontext.rs
+++ b/components/script/dom/audiocontext.rs
@@ -96,17 +96,6 @@ impl AudioContext {
         Ok(context)
     }
 
-    // https://webaudio.github.io/web-audio-api/#AudioContext-constructors
-    #[allow(non_snake_case)]
-    pub fn Constructor(
-        window: &Window,
-        proto: Option<HandleObject>,
-        can_gc: CanGc,
-        options: &AudioContextOptions,
-    ) -> Fallible<DomRoot<AudioContext>> {
-        AudioContext::new(window, proto, options, can_gc)
-    }
-
     fn resume(&self) {
         // Step 5.
         if self.context.is_allowed_to_start() {
@@ -121,6 +110,16 @@ impl AudioContext {
 }
 
 impl AudioContextMethods for AudioContext {
+    // https://webaudio.github.io/web-audio-api/#AudioContext-constructors
+    fn Constructor(
+        window: &Window,
+        proto: Option<HandleObject>,
+        can_gc: CanGc,
+        options: &AudioContextOptions,
+    ) -> Fallible<DomRoot<AudioContext>> {
+        AudioContext::new(window, proto, options, can_gc)
+    }
+
     // https://webaudio.github.io/web-audio-api/#dom-audiocontext-baselatency
     fn BaseLatency(&self) -> Finite<f64> {
         Finite::wrap(self.base_latency)

--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -2176,7 +2176,7 @@ class CGImports(CGWrapper):
                 types += componentTypes(returnType)
                 for arg in arguments:
                     types += componentTypes(arg.type)
-                
+
             return types
 
         def getIdentifier(t):
@@ -2219,7 +2219,10 @@ class CGImports(CGWrapper):
                 if m.isMethod():
                     types += relatedTypesForSignatures(m)
                     if m.isStatic():
-                        types += [descriptorProvider.getDescriptor(iface).interface for iface in d.interface.exposureSet]
+                        types += [
+                            descriptorProvider.getDescriptor(iface).interface
+                            for iface in d.interface.exposureSet
+                        ]
                 elif m.isAttr():
                     types += componentTypes(m.type)
 
@@ -6414,19 +6417,29 @@ class CGInterfaceTrait(CGThing):
                 arguments = [arguments[0]] + extra + arguments[1:]
             else:
                 arguments = extra + arguments
-            methods.append(CGGeneric(f"{unsafe}fn {name}({selfArg}{fmt(arguments, leadingComma=not isStatic)}){returnType};\n"))
+            methods.append(CGGeneric(
+                f"{unsafe}fn {name}({selfArg}"
+                f"{fmt(arguments, leadingComma=not isStatic)}){returnType};\n"
+            ))
 
         def ctorMethod(ctor, baseName=None):
             infallible = 'infallible' in descriptor.getExtendedAttributes(ctor)
             for (i, (rettype, arguments)) in enumerate(ctor.signatures()):
                 name = (baseName or ctor.identifier.name) + ('_' * i)
                 args = list(method_arguments(descriptor, rettype, arguments))
-                extra = [("global", f"&{exposedGlobal}"), ("proto", "Option<HandleObject>"), ("can_gc", "CanGc")]
+                extra = [
+                    ("global", f"&{exposedGlobal}"),
+                    ("proto", "Option<HandleObject>"),
+                    ("can_gc", "CanGc"),
+                ]
                 if args and args[0][0] == "cx":
                     args = [args[0]] + extra + args[1:]
                 else:
                     args = extra + args
-                yield CGGeneric(f"fn {name}({fmt(args, leadingComma=False)}) -> {return_type(descriptorProvider, rettype, infallible)};\n")
+                yield CGGeneric(
+                    f"fn {name}({fmt(args, leadingComma=False)}) -> "
+                    f"{return_type(descriptorProvider, rettype, infallible)};\n"
+                )
 
         ctor = descriptor.interface.ctor()
         if ctor and not ctor.isHTMLConstructor():
@@ -6611,7 +6624,6 @@ class CGDescriptor(CGThing):
                             CGGeneric("];\n")], "\n"))
             if descriptor.concrete or descriptor.hasDescendants():
                 cgThings.append(CGIDLInterface(descriptor))
-
 
             if descriptor.weakReferenceable:
                 cgThings.append(CGWeakReferenceableTrait(descriptor))

--- a/components/script/dom/biquadfilternode.rs
+++ b/components/script/dom/biquadfilternode.rs
@@ -140,6 +140,7 @@ impl BiquadFilterNode {
 }
 
 impl BiquadFilterNodeMethods for BiquadFilterNode {
+    // https://webaudio.github.io/web-audio-api/#dom-biquadfilternode-biquadfilternode-context-options
     fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/biquadfilternode.rs
+++ b/components/script/dom/biquadfilternode.rs
@@ -137,9 +137,10 @@ impl BiquadFilterNode {
             can_gc,
         ))
     }
+}
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+impl BiquadFilterNodeMethods for BiquadFilterNode {
+    fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -148,9 +149,7 @@ impl BiquadFilterNode {
     ) -> Fallible<DomRoot<BiquadFilterNode>> {
         BiquadFilterNode::new_with_proto(window, proto, context, options, can_gc)
     }
-}
 
-impl BiquadFilterNodeMethods for BiquadFilterNode {
     // https://webaudio.github.io/web-audio-api/#dom-biquadfilternode-gain
     fn Gain(&self) -> DomRoot<AudioParam> {
         DomRoot::from_ref(&self.gain)

--- a/components/script/dom/blob.rs
+++ b/components/script/dom/blob.rs
@@ -69,29 +69,6 @@ impl Blob {
         }
     }
 
-    // https://w3c.github.io/FileAPI/#constructorBlob
-    #[allow(non_snake_case)]
-    pub fn Constructor(
-        global: &GlobalScope,
-        proto: Option<HandleObject>,
-        can_gc: CanGc,
-        blobParts: Option<Vec<ArrayBufferOrArrayBufferViewOrBlobOrString>>,
-        blobPropertyBag: &BlobBinding::BlobPropertyBag,
-    ) -> Fallible<DomRoot<Blob>> {
-        let bytes: Vec<u8> = match blobParts {
-            None => Vec::new(),
-            Some(blobparts) => match blob_parts_to_bytes(blobparts) {
-                Ok(bytes) => bytes,
-                Err(_) => return Err(Error::InvalidCharacter),
-            },
-        };
-
-        let type_string = normalize_type_string(blobPropertyBag.type_.as_ref());
-        let blob_impl = BlobImpl::new_from_bytes(bytes, type_string);
-
-        Ok(Blob::new_with_proto(global, proto, blob_impl, can_gc))
-    }
-
     /// Get a slice to inner data, this might incur synchronous read and caching
     pub fn get_bytes(&self) -> Result<Vec<u8>, ()> {
         self.global().get_blob_bytes(&self.blob_id)
@@ -225,6 +202,29 @@ pub fn blob_parts_to_bytes(
 }
 
 impl BlobMethods for Blob {
+    // https://w3c.github.io/FileAPI/#constructorBlob
+    #[allow(non_snake_case)]
+    fn Constructor(
+        global: &GlobalScope,
+        proto: Option<HandleObject>,
+        can_gc: CanGc,
+        blobParts: Option<Vec<ArrayBufferOrArrayBufferViewOrBlobOrString>>,
+        blobPropertyBag: &BlobBinding::BlobPropertyBag,
+    ) -> Fallible<DomRoot<Blob>> {
+        let bytes: Vec<u8> = match blobParts {
+            None => Vec::new(),
+            Some(blobparts) => match blob_parts_to_bytes(blobparts) {
+                Ok(bytes) => bytes,
+                Err(_) => return Err(Error::InvalidCharacter),
+            },
+        };
+
+        let type_string = normalize_type_string(blobPropertyBag.type_.as_ref());
+        let blob_impl = BlobImpl::new_from_bytes(bytes, type_string);
+
+        Ok(Blob::new_with_proto(global, proto, blob_impl, can_gc))
+    }
+
     // https://w3c.github.io/FileAPI/#dfn-size
     fn Size(&self) -> u64 {
         self.global().get_blob_size(&self.blob_id)

--- a/components/script/dom/bluetoothadvertisingevent.rs
+++ b/components/script/dom/bluetoothadvertisingevent.rs
@@ -79,9 +79,12 @@ impl BluetoothAdvertisingEvent {
         }
         ev
     }
+}
 
+impl BluetoothAdvertisingEventMethods for BluetoothAdvertisingEvent {
     // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothadvertisingevent-bluetoothadvertisingevent
-    pub fn Constructor(
+    #[allow(non_snake_case)]
+    fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -109,9 +112,7 @@ impl BluetoothAdvertisingEvent {
             can_gc,
         ))
     }
-}
 
-impl BluetoothAdvertisingEventMethods for BluetoothAdvertisingEvent {
     // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothadvertisingevent-device
     fn Device(&self) -> DomRoot<BluetoothDevice> {
         DomRoot::from_ref(&*self.device)

--- a/components/script/dom/bluetoothuuid.rs
+++ b/components/script/dom/bluetoothuuid.rs
@@ -5,6 +5,7 @@
 use dom_struct::dom_struct;
 use regex::Regex;
 
+use crate::dom::bindings::codegen::Bindings::BluetoothUUIDBinding::BluetoothUUIDMethods;
 use crate::dom::bindings::codegen::UnionTypes::StringOrUnsignedLong;
 use crate::dom::bindings::error::Error::Type;
 use crate::dom::bindings::error::Fallible;
@@ -582,25 +583,24 @@ const CHARACTERISTIC_ERROR_MESSAGE: &str =
 const DESCRIPTOR_ERROR_MESSAGE: &str = "https://developer.bluetooth.org/gatt/descriptors/Pages/\
      DescriptorsHomePage.aspx\ne.g. 'gatt.characteristic_presentation_format'.";
 
-#[allow(non_snake_case)]
-impl BluetoothUUID {
+impl BluetoothUUIDMethods for BluetoothUUID {
     // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothuuid-canonicaluuid
-    pub fn CanonicalUUID(_: &Window, alias: u32) -> UUID {
+    fn CanonicalUUID(_: &Window, alias: u32) -> UUID {
         canonical_uuid(alias)
     }
 
     // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothuuid-getservice
-    pub fn GetService(_: &Window, name: BluetoothServiceUUID) -> Fallible<UUID> {
+    fn GetService(_: &Window, name: BluetoothServiceUUID) -> Fallible<UUID> {
         Self::service(name)
     }
 
     // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothuuid-getcharacteristic
-    pub fn GetCharacteristic(_: &Window, name: BluetoothCharacteristicUUID) -> Fallible<UUID> {
+    fn GetCharacteristic(_: &Window, name: BluetoothCharacteristicUUID) -> Fallible<UUID> {
         Self::characteristic(name)
     }
 
     // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothuuid-getdescriptor
-    pub fn GetDescriptor(_: &Window, name: BluetoothDescriptorUUID) -> Fallible<UUID> {
+    fn GetDescriptor(_: &Window, name: BluetoothDescriptorUUID) -> Fallible<UUID> {
         Self::descriptor(name)
     }
 }

--- a/components/script/dom/broadcastchannel.rs
+++ b/components/script/dom/broadcastchannel.rs
@@ -29,17 +29,6 @@ pub struct BroadcastChannel {
 }
 
 impl BroadcastChannel {
-    /// <https://html.spec.whatwg.org/multipage/#broadcastchannel>
-    #[allow(non_snake_case)]
-    pub fn Constructor(
-        global: &GlobalScope,
-        proto: Option<HandleObject>,
-        can_gc: CanGc,
-        name: DOMString,
-    ) -> DomRoot<BroadcastChannel> {
-        BroadcastChannel::new(global, proto, name, can_gc)
-    }
-
     fn new(
         global: &GlobalScope,
         proto: Option<HandleObject>,
@@ -78,6 +67,16 @@ impl BroadcastChannel {
 }
 
 impl BroadcastChannelMethods for BroadcastChannel {
+    /// <https://html.spec.whatwg.org/multipage/#broadcastchannel>
+    fn Constructor(
+        global: &GlobalScope,
+        proto: Option<HandleObject>,
+        can_gc: CanGc,
+        name: DOMString,
+    ) -> DomRoot<BroadcastChannel> {
+        BroadcastChannel::new(global, proto, name, can_gc)
+    }
+
     /// <https://html.spec.whatwg.org/multipage/#dom-messageport-postmessage>
     fn PostMessage(&self, cx: SafeJSContext, message: HandleValue) -> ErrorResult {
         // Step 3, if closed.

--- a/components/script/dom/channelmergernode.rs
+++ b/components/script/dom/channelmergernode.rs
@@ -84,6 +84,7 @@ impl ChannelMergerNode {
 }
 
 impl ChannelMergerNodeMethods for ChannelMergerNode {
+    /// <https://webaudio.github.io/web-audio-api/#dom-channelmergernode-channelmergernode>
     fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/channelmergernode.rs
+++ b/components/script/dom/channelmergernode.rs
@@ -12,7 +12,9 @@ use crate::dom::baseaudiocontext::BaseAudioContext;
 use crate::dom::bindings::codegen::Bindings::AudioNodeBinding::{
     ChannelCountMode, ChannelInterpretation,
 };
-use crate::dom::bindings::codegen::Bindings::ChannelMergerNodeBinding::ChannelMergerOptions;
+use crate::dom::bindings::codegen::Bindings::ChannelMergerNodeBinding::{
+    ChannelMergerNodeMethods, ChannelMergerOptions,
+};
 use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::reflector::reflect_dom_object_with_proto;
 use crate::dom::bindings::root::DomRoot;
@@ -79,9 +81,10 @@ impl ChannelMergerNode {
             can_gc,
         ))
     }
+}
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+impl ChannelMergerNodeMethods for ChannelMergerNode {
+    fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,

--- a/components/script/dom/channelsplitternode.rs
+++ b/components/script/dom/channelsplitternode.rs
@@ -86,6 +86,7 @@ impl ChannelSplitterNode {
 }
 
 impl ChannelSplitterNodeMethods for ChannelSplitterNode {
+    /// <https://webaudio.github.io/web-audio-api/#dom-channelsplitternode-channelsplitternode>
     fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/channelsplitternode.rs
+++ b/components/script/dom/channelsplitternode.rs
@@ -11,7 +11,9 @@ use crate::dom::baseaudiocontext::BaseAudioContext;
 use crate::dom::bindings::codegen::Bindings::AudioNodeBinding::{
     ChannelCountMode, ChannelInterpretation,
 };
-use crate::dom::bindings::codegen::Bindings::ChannelSplitterNodeBinding::ChannelSplitterOptions;
+use crate::dom::bindings::codegen::Bindings::ChannelSplitterNodeBinding::{
+    ChannelSplitterNodeMethods, ChannelSplitterOptions,
+};
 use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::reflector::reflect_dom_object_with_proto;
 use crate::dom::bindings::root::DomRoot;
@@ -81,9 +83,10 @@ impl ChannelSplitterNode {
             can_gc,
         ))
     }
+}
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+impl ChannelSplitterNodeMethods for ChannelSplitterNode {
+    fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,

--- a/components/script/dom/closeevent.rs
+++ b/components/script/dom/closeevent.rs
@@ -79,8 +79,10 @@ impl CloseEvent {
         }
         ev
     }
+}
 
-    pub fn Constructor(
+impl CloseEventMethods for CloseEvent {
+    fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -101,9 +103,7 @@ impl CloseEvent {
             can_gc,
         ))
     }
-}
 
-impl CloseEventMethods for CloseEvent {
     // https://html.spec.whatwg.org/multipage/#dom-closeevent-wasclean
     fn WasClean(&self) -> bool {
         self.was_clean

--- a/components/script/dom/closeevent.rs
+++ b/components/script/dom/closeevent.rs
@@ -82,6 +82,7 @@ impl CloseEvent {
 }
 
 impl CloseEventMethods for CloseEvent {
+    // https://websockets.spec.whatwg.org/#the-closeevent-interface
     fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
@@ -104,17 +105,17 @@ impl CloseEventMethods for CloseEvent {
         ))
     }
 
-    // https://html.spec.whatwg.org/multipage/#dom-closeevent-wasclean
+    // https://websockets.spec.whatwg.org/#dom-closeevent-wasclean
     fn WasClean(&self) -> bool {
         self.was_clean
     }
 
-    // https://html.spec.whatwg.org/multipage/#dom-closeevent-code
+    // https://websockets.spec.whatwg.org/#dom-closeevent-code
     fn Code(&self) -> u16 {
         self.code
     }
 
-    // https://html.spec.whatwg.org/multipage/#dom-closeevent-reason
+    // https://websockets.spec.whatwg.org/#dom-closeevent-reason
     fn Reason(&self) -> DOMString {
         self.reason.clone()
     }

--- a/components/script/dom/comment.rs
+++ b/components/script/dom/comment.rs
@@ -5,6 +5,7 @@
 use dom_struct::dom_struct;
 use js::rust::HandleObject;
 
+use crate::dom::bindings::codegen::Bindings::CommentBinding::CommentMethods;
 use crate::dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
 use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::root::DomRoot;
@@ -39,9 +40,10 @@ impl Comment {
             proto,
         )
     }
+}
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+impl CommentMethods for Comment {
+    fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
         _can_gc: CanGc,

--- a/components/script/dom/comment.rs
+++ b/components/script/dom/comment.rs
@@ -43,6 +43,7 @@ impl Comment {
 }
 
 impl CommentMethods for Comment {
+    /// <https://dom.spec.whatwg.org/#dom-comment-comment>
     fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/compositionevent.rs
+++ b/components/script/dom/compositionevent.rs
@@ -83,8 +83,13 @@ impl CompositionEvent {
         ev
     }
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+    pub fn data(&self) -> &str {
+        &self.data
+    }
+}
+
+impl CompositionEventMethods for CompositionEvent {
+    fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -105,12 +110,6 @@ impl CompositionEvent {
         Ok(event)
     }
 
-    pub fn data(&self) -> &str {
-        &self.data
-    }
-}
-
-impl CompositionEventMethods for CompositionEvent {
     // https://w3c.github.io/uievents/#dom-compositionevent-data
     fn Data(&self) -> DOMString {
         self.data.clone()

--- a/components/script/dom/compositionevent.rs
+++ b/components/script/dom/compositionevent.rs
@@ -89,6 +89,7 @@ impl CompositionEvent {
 }
 
 impl CompositionEventMethods for CompositionEvent {
+    // https://w3c.github.io/uievents/#dom-compositionevent-compositionevent
     fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/constantsourcenode.rs
+++ b/components/script/dom/constantsourcenode.rs
@@ -90,6 +90,7 @@ impl ConstantSourceNode {
 }
 
 impl ConstantSourceNodeMethods for ConstantSourceNode {
+    // https://webaudio.github.io/web-audio-api/#dom-constantsourcenode-constantsourcenode
     fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/constantsourcenode.rs
+++ b/components/script/dom/constantsourcenode.rs
@@ -87,9 +87,10 @@ impl ConstantSourceNode {
             can_gc,
         ))
     }
+}
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+impl ConstantSourceNodeMethods for ConstantSourceNode {
+    fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -98,9 +99,7 @@ impl ConstantSourceNode {
     ) -> Fallible<DomRoot<ConstantSourceNode>> {
         ConstantSourceNode::new_with_proto(window, proto, context, options, can_gc)
     }
-}
 
-impl ConstantSourceNodeMethods for ConstantSourceNode {
     // https://webaudio.github.io/web-audio-api/#dom-constantsourcenode-offset
     fn Offset(&self) -> DomRoot<AudioParam> {
         DomRoot::from_ref(&self.offset)

--- a/components/script/dom/css.rs
+++ b/components/script/dom/css.rs
@@ -10,6 +10,7 @@ use style::stylesheets::supports_rule::{parse_condition_or_declaration, Declarat
 use style::stylesheets::{CssRuleType, Origin, UrlExtraData};
 use style_traits::ParsingMode;
 
+use crate::dom::bindings::codegen::Bindings::CSSBinding::CSSMethods;
 use crate::dom::bindings::codegen::Bindings::WindowBinding::Window_Binding::WindowMethods;
 use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::reflector::Reflector;
@@ -23,17 +24,16 @@ pub struct CSS {
     reflector_: Reflector,
 }
 
-#[allow(non_snake_case)]
-impl CSS {
+impl CSSMethods for CSS {
     /// <http://dev.w3.org/csswg/cssom/#serialize-an-identifier>
-    pub fn Escape(_: &Window, ident: DOMString) -> Fallible<DOMString> {
+    fn Escape(_: &Window, ident: DOMString) -> Fallible<DOMString> {
         let mut escaped = String::new();
         serialize_identifier(&ident, &mut escaped).unwrap();
         Ok(DOMString::from(escaped))
     }
 
     /// <https://drafts.csswg.org/css-conditional/#dom-css-supports>
-    pub fn Supports(win: &Window, property: DOMString, value: DOMString) -> bool {
+    fn Supports(win: &Window, property: DOMString, value: DOMString) -> bool {
         let mut decl = String::new();
         serialize_identifier(&property, &mut decl).unwrap();
         decl.push_str(": ");
@@ -54,7 +54,7 @@ impl CSS {
     }
 
     /// <https://drafts.csswg.org/css-conditional/#dom-css-supports>
-    pub fn Supports_(win: &Window, condition: DOMString) -> bool {
+    fn Supports_(win: &Window, condition: DOMString) -> bool {
         let mut input = ParserInput::new(&condition);
         let mut input = Parser::new(&mut input);
         let cond = match parse_condition_or_declaration(&mut input) {
@@ -77,7 +77,7 @@ impl CSS {
     }
 
     /// <https://drafts.css-houdini.org/css-paint-api-1/#paint-worklet>
-    pub fn PaintWorklet(win: &Window) -> DomRoot<Worklet> {
+    fn PaintWorklet(win: &Window) -> DomRoot<Worklet> {
         win.paint_worklet()
     }
 }

--- a/components/script/dom/css.rs
+++ b/components/script/dom/css.rs
@@ -25,7 +25,7 @@ pub struct CSS {
 }
 
 impl CSSMethods for CSS {
-    /// <http://dev.w3.org/csswg/cssom/#serialize-an-identifier>
+    /// <https://drafts.csswg.org/cssom/#the-css.escape()-method>
     fn Escape(_: &Window, ident: DOMString) -> Fallible<DOMString> {
         let mut escaped = String::new();
         serialize_identifier(&ident, &mut escaped).unwrap();

--- a/components/script/dom/customevent.rs
+++ b/components/script/dom/customevent.rs
@@ -85,6 +85,7 @@ impl CustomEvent {
 }
 
 impl CustomEventMethods for CustomEvent {
+    // https://dom.spec.whatwg.org/#dom-customevent-customevent
     fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,

--- a/components/script/dom/customevent.rs
+++ b/components/script/dom/customevent.rs
@@ -67,25 +67,6 @@ impl CustomEvent {
         ev
     }
 
-    #[allow(unsafe_code, non_snake_case)]
-    pub fn Constructor(
-        global: &GlobalScope,
-        proto: Option<HandleObject>,
-        can_gc: CanGc,
-        type_: DOMString,
-        init: RootedTraceableBox<CustomEventBinding::CustomEventInit>,
-    ) -> DomRoot<CustomEvent> {
-        CustomEvent::new(
-            global,
-            proto,
-            Atom::from(type_),
-            init.parent.bubbles,
-            init.parent.cancelable,
-            init.detail.handle(),
-            can_gc,
-        )
-    }
-
     fn init_custom_event(
         &self,
         type_: Atom,
@@ -104,6 +85,24 @@ impl CustomEvent {
 }
 
 impl CustomEventMethods for CustomEvent {
+    fn Constructor(
+        global: &GlobalScope,
+        proto: Option<HandleObject>,
+        can_gc: CanGc,
+        type_: DOMString,
+        init: RootedTraceableBox<CustomEventBinding::CustomEventInit>,
+    ) -> DomRoot<CustomEvent> {
+        CustomEvent::new(
+            global,
+            proto,
+            Atom::from(type_),
+            init.parent.bubbles,
+            init.parent.cancelable,
+            init.detail.handle(),
+            can_gc,
+        )
+    }
+
     // https://dom.spec.whatwg.org/#dom-customevent-detail
     fn Detail(&self, _cx: JSContext) -> JSVal {
         self.detail.get()

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -3440,35 +3440,6 @@ impl Document {
         );
     }
 
-    // https://dom.spec.whatwg.org/#dom-document-document
-    #[allow(non_snake_case)]
-    pub fn Constructor(
-        window: &Window,
-        proto: Option<HandleObject>,
-        can_gc: CanGc,
-    ) -> Fallible<DomRoot<Document>> {
-        let doc = window.Document();
-        let docloader = DocumentLoader::new(&doc.loader());
-        Ok(Document::new_with_proto(
-            window,
-            proto,
-            HasBrowsingContext::No,
-            None,
-            doc.origin().clone(),
-            IsHTMLDocument::NonHTMLDocument,
-            None,
-            None,
-            DocumentActivity::Inactive,
-            DocumentSource::NotFromParser,
-            docloader,
-            None,
-            None,
-            None,
-            Default::default(),
-            can_gc,
-        ))
-    }
-
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         window: &Window,
@@ -4180,6 +4151,34 @@ impl ProfilerMetadataFactory for Document {
 }
 
 impl DocumentMethods for Document {
+    // https://dom.spec.whatwg.org/#dom-document-document
+    fn Constructor(
+        window: &Window,
+        proto: Option<HandleObject>,
+        can_gc: CanGc,
+    ) -> Fallible<DomRoot<Document>> {
+        let doc = window.Document();
+        let docloader = DocumentLoader::new(&doc.loader());
+        Ok(Document::new_with_proto(
+            window,
+            proto,
+            HasBrowsingContext::No,
+            None,
+            doc.origin().clone(),
+            IsHTMLDocument::NonHTMLDocument,
+            None,
+            None,
+            DocumentActivity::Inactive,
+            DocumentSource::NotFromParser,
+            docloader,
+            None,
+            None,
+            None,
+            Default::default(),
+            can_gc,
+        ))
+    }
+
     // https://w3c.github.io/editing/ActiveDocuments/execCommand.html#querycommandsupported()
     fn QueryCommandSupported(&self, _command: DOMString) -> bool {
         false

--- a/components/script/dom/documentfragment.rs
+++ b/components/script/dom/documentfragment.rs
@@ -61,6 +61,7 @@ impl DocumentFragment {
 }
 
 impl DocumentFragmentMethods for DocumentFragment {
+    // https://dom.spec.whatwg.org/#dom-documentfragment-documentfragment
     fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/documentfragment.rs
+++ b/components/script/dom/documentfragment.rs
@@ -55,8 +55,13 @@ impl DocumentFragment {
         )
     }
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+    pub fn id_map(&self) -> &DomRefCell<HashMapTracedValues<Atom, Vec<Dom<Element>>>> {
+        &self.id_map
+    }
+}
+
+impl DocumentFragmentMethods for DocumentFragment {
+    fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
         _can_gc: CanGc,
@@ -66,12 +71,6 @@ impl DocumentFragment {
         Ok(DocumentFragment::new_with_proto(&document, proto))
     }
 
-    pub fn id_map(&self) -> &DomRefCell<HashMapTracedValues<Atom, Vec<Dom<Element>>>> {
-        &self.id_map
-    }
-}
-
-impl DocumentFragmentMethods for DocumentFragment {
     // https://dom.spec.whatwg.org/#dom-parentnode-children
     fn Children(&self) -> DomRoot<HTMLCollection> {
         let window = window_from_node(self);

--- a/components/script/dom/domexception.rs
+++ b/components/script/dom/domexception.rs
@@ -147,8 +147,14 @@ impl DOMException {
         reflect_dom_object(Box::new(DOMException::new_inherited(message, name)), global)
     }
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+    // not an IDL stringifier, used internally
+    pub fn stringifier(&self) -> DOMString {
+        DOMString::from(format!("{}: {}", self.name, self.message))
+    }
+}
+
+impl DOMExceptionMethods for DOMException {
+    fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -163,13 +169,6 @@ impl DOMException {
         ))
     }
 
-    // not an IDL stringifier, used internally
-    pub fn stringifier(&self) -> DOMString {
-        DOMString::from(format!("{}: {}", self.name, self.message))
-    }
-}
-
-impl DOMExceptionMethods for DOMException {
     // https://heycam.github.io/webidl/#dom-domexception-code
     fn Code(&self) -> u16 {
         match DOMErrorName::from(&self.name) {

--- a/components/script/dom/domexception.rs
+++ b/components/script/dom/domexception.rs
@@ -154,6 +154,7 @@ impl DOMException {
 }
 
 impl DOMExceptionMethods for DOMException {
+    // https://webidl.spec.whatwg.org/#dom-domexception-domexception
     fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
@@ -169,7 +170,7 @@ impl DOMExceptionMethods for DOMException {
         ))
     }
 
-    // https://heycam.github.io/webidl/#dom-domexception-code
+    // https://webidl.spec.whatwg.org/#dom-domexception-code
     fn Code(&self) -> u16 {
         match DOMErrorName::from(&self.name) {
             Some(code) if code <= DOMErrorName::DataCloneError => code as u16,
@@ -177,12 +178,12 @@ impl DOMExceptionMethods for DOMException {
         }
     }
 
-    // https://heycam.github.io/webidl/#idl-DOMException-error-names
+    // https://webidl.spec.whatwg.org/#dom-domexception-name
     fn Name(&self) -> DOMString {
         self.name.clone()
     }
 
-    // https://heycam.github.io/webidl/#error-names
+    // https://webidl.spec.whatwg.org/#dom-domexception-message
     fn Message(&self) -> DOMString {
         self.message.clone()
     }

--- a/components/script/dom/dommatrix.rs
+++ b/components/script/dom/dommatrix.rs
@@ -51,8 +51,15 @@ impl DOMMatrix {
         }
     }
 
+    pub fn from_readonly(global: &GlobalScope, ro: &DOMMatrixReadOnly) -> DomRoot<Self> {
+        Self::new(global, ro.is2D(), *ro.matrix())
+    }
+}
+
+#[allow(non_snake_case)]
+impl DOMMatrixMethods for DOMMatrix {
     // https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-dommatrixreadonly
-    pub fn Constructor(
+    fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -88,16 +95,12 @@ impl DOMMatrix {
     }
 
     // https://drafts.fxtf.org/geometry-1/#dom-dommatrix-frommatrix
-    pub fn FromMatrix(global: &GlobalScope, other: &DOMMatrixInit) -> Fallible<DomRoot<Self>> {
+    fn FromMatrix(global: &GlobalScope, other: &DOMMatrixInit) -> Fallible<DomRoot<Self>> {
         dommatrixinit_to_matrix(other).map(|(is2D, matrix)| Self::new(global, is2D, matrix))
     }
 
-    pub fn from_readonly(global: &GlobalScope, ro: &DOMMatrixReadOnly) -> DomRoot<Self> {
-        Self::new(global, ro.is2D(), *ro.matrix())
-    }
-
     // https://drafts.fxtf.org/geometry-1/#dom-dommatrix-fromfloat32array
-    pub fn FromFloat32Array(
+    fn FromFloat32Array(
         global: &GlobalScope,
         array: CustomAutoRooterGuard<Float32Array>,
     ) -> Fallible<DomRoot<DOMMatrix>> {
@@ -111,7 +114,7 @@ impl DOMMatrix {
     }
 
     // https://drafts.fxtf.org/geometry-1/#dom-dommatrix-fromfloat64array
-    pub fn FromFloat64Array(
+    fn FromFloat64Array(
         global: &GlobalScope,
         array: CustomAutoRooterGuard<Float64Array>,
     ) -> Fallible<DomRoot<DOMMatrix>> {
@@ -123,10 +126,7 @@ impl DOMMatrix {
             Some(StringOrUnrestrictedDoubleSequence::UnrestrictedDoubleSequence(vec)),
         )
     }
-}
 
-#[allow(non_snake_case)]
-impl DOMMatrixMethods for DOMMatrix {
     // https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-m11
     fn M11(&self) -> f64 {
         self.upcast::<DOMMatrixReadOnly>().M11()

--- a/components/script/dom/dommatrixreadonly.rs
+++ b/components/script/dom/dommatrixreadonly.rs
@@ -67,47 +67,6 @@ impl DOMMatrixReadOnly {
         }
     }
 
-    // https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-dommatrixreadonly
-    pub fn Constructor(
-        global: &GlobalScope,
-        proto: Option<HandleObject>,
-        can_gc: CanGc,
-        init: Option<StringOrUnrestrictedDoubleSequence>,
-    ) -> Fallible<DomRoot<Self>> {
-        if init.is_none() {
-            return Ok(Self::new_with_proto(
-                global,
-                proto,
-                true,
-                Transform3D::identity(),
-                can_gc,
-            ));
-        }
-        match init.unwrap() {
-            StringOrUnrestrictedDoubleSequence::String(ref s) => {
-                if global.downcast::<Window>().is_none() {
-                    return Err(error::Error::Type(
-                        "String constructor is only supported in the main thread.".to_owned(),
-                    ));
-                }
-                if s.is_empty() {
-                    return Ok(Self::new(global, true, Transform3D::identity()));
-                }
-                transform_to_matrix(s.to_string())
-                    .map(|(is2D, matrix)| Self::new_with_proto(global, proto, is2D, matrix, can_gc))
-            },
-            StringOrUnrestrictedDoubleSequence::UnrestrictedDoubleSequence(ref entries) => {
-                entries_to_matrix(&entries[..])
-                    .map(|(is2D, matrix)| Self::new_with_proto(global, proto, is2D, matrix, can_gc))
-            },
-        }
-    }
-
-    // https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-frommatrix
-    pub fn FromMatrix(global: &GlobalScope, other: &DOMMatrixInit) -> Fallible<DomRoot<Self>> {
-        dommatrixinit_to_matrix(other).map(|(is2D, matrix)| Self::new(global, is2D, matrix))
-    }
-
     pub fn matrix(&self) -> Ref<Transform3D<f64>> {
         self.matrix.borrow()
     }
@@ -403,10 +362,53 @@ impl DOMMatrixReadOnly {
         })
         // Step 3 in DOMMatrix.InvertSelf
     }
+}
+
+#[allow(non_snake_case)]
+impl DOMMatrixReadOnlyMethods for DOMMatrixReadOnly {
+    // https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-dommatrixreadonly
+    fn Constructor(
+        global: &GlobalScope,
+        proto: Option<HandleObject>,
+        can_gc: CanGc,
+        init: Option<StringOrUnrestrictedDoubleSequence>,
+    ) -> Fallible<DomRoot<Self>> {
+        if init.is_none() {
+            return Ok(Self::new_with_proto(
+                global,
+                proto,
+                true,
+                Transform3D::identity(),
+                can_gc,
+            ));
+        }
+        match init.unwrap() {
+            StringOrUnrestrictedDoubleSequence::String(ref s) => {
+                if global.downcast::<Window>().is_none() {
+                    return Err(error::Error::Type(
+                        "String constructor is only supported in the main thread.".to_owned(),
+                    ));
+                }
+                if s.is_empty() {
+                    return Ok(Self::new(global, true, Transform3D::identity()));
+                }
+                transform_to_matrix(s.to_string())
+                    .map(|(is2D, matrix)| Self::new_with_proto(global, proto, is2D, matrix, can_gc))
+            },
+            StringOrUnrestrictedDoubleSequence::UnrestrictedDoubleSequence(ref entries) => {
+                entries_to_matrix(&entries[..])
+                    .map(|(is2D, matrix)| Self::new_with_proto(global, proto, is2D, matrix, can_gc))
+            },
+        }
+    }
+
+    // https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-frommatrix
+    fn FromMatrix(global: &GlobalScope, other: &DOMMatrixInit) -> Fallible<DomRoot<Self>> {
+        dommatrixinit_to_matrix(other).map(|(is2D, matrix)| Self::new(global, is2D, matrix))
+    }
 
     // https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-fromfloat32array
-    #[allow(unsafe_code)]
-    pub fn FromFloat32Array(
+    fn FromFloat32Array(
         global: &GlobalScope,
         array: CustomAutoRooterGuard<Float32Array>,
     ) -> Fallible<DomRoot<DOMMatrixReadOnly>> {
@@ -420,8 +422,7 @@ impl DOMMatrixReadOnly {
     }
 
     // https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-fromfloat64array
-    #[allow(unsafe_code)]
-    pub fn FromFloat64Array(
+    fn FromFloat64Array(
         global: &GlobalScope,
         array: CustomAutoRooterGuard<Float64Array>,
     ) -> Fallible<DomRoot<DOMMatrixReadOnly>> {
@@ -433,10 +434,7 @@ impl DOMMatrixReadOnly {
             Some(StringOrUnrestrictedDoubleSequence::UnrestrictedDoubleSequence(vec)),
         )
     }
-}
 
-#[allow(non_snake_case)]
-impl DOMMatrixReadOnlyMethods for DOMMatrixReadOnly {
     // https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-m11
     fn M11(&self) -> f64 {
         self.matrix.borrow().m11

--- a/components/script/dom/domparser.rs
+++ b/components/script/dom/domparser.rs
@@ -45,18 +45,17 @@ impl DOMParser {
             can_gc,
         )
     }
+}
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+impl DOMParserMethods for DOMParser {
+    fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
     ) -> Fallible<DomRoot<DOMParser>> {
         Ok(DOMParser::new(window, proto, can_gc))
     }
-}
 
-impl DOMParserMethods for DOMParser {
     // https://w3c.github.io/DOM-Parsing/#the-domparser-interface
     fn ParseFromString(
         &self,

--- a/components/script/dom/domparser.rs
+++ b/components/script/dom/domparser.rs
@@ -48,6 +48,7 @@ impl DOMParser {
 }
 
 impl DOMParserMethods for DOMParser {
+    /// <https://html.spec.whatwg.org/multipage/#dom-domparser-constructor>
     fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
@@ -56,7 +57,7 @@ impl DOMParserMethods for DOMParser {
         Ok(DOMParser::new(window, proto, can_gc))
     }
 
-    // https://w3c.github.io/DOM-Parsing/#the-domparser-interface
+    /// <https://html.spec.whatwg.org/multipage/#dom-domparser-parsefromstring>
     fn ParseFromString(
         &self,
         s: DOMString,

--- a/components/script/dom/dompoint.rs
+++ b/components/script/dom/dompoint.rs
@@ -49,7 +49,13 @@ impl DOMPoint {
         )
     }
 
-    pub fn Constructor(
+    pub fn new_from_init(global: &GlobalScope, p: &DOMPointInit) -> DomRoot<DOMPoint> {
+        DOMPoint::new(global, p.x, p.y, p.z, p.w)
+    }
+}
+
+impl DOMPointMethods for DOMPoint {
+    fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -62,16 +68,10 @@ impl DOMPoint {
     }
 
     // https://drafts.fxtf.org/geometry/#dom-dompoint-frompoint
-    pub fn FromPoint(global: &GlobalScope, init: &DOMPointInit) -> DomRoot<Self> {
+    fn FromPoint(global: &GlobalScope, init: &DOMPointInit) -> DomRoot<Self> {
         Self::new_from_init(global, init)
     }
 
-    pub fn new_from_init(global: &GlobalScope, p: &DOMPointInit) -> DomRoot<DOMPoint> {
-        DOMPoint::new(global, p.x, p.y, p.z, p.w)
-    }
-}
-
-impl DOMPointMethods for DOMPoint {
     // https://dev.w3.org/fxtf/geometry/Overview.html#dom-dompointreadonly-x
     fn X(&self) -> f64 {
         self.point.X()

--- a/components/script/dom/dompoint.rs
+++ b/components/script/dom/dompoint.rs
@@ -55,6 +55,7 @@ impl DOMPoint {
 }
 
 impl DOMPointMethods for DOMPoint {
+    // https://drafts.fxtf.org/geometry/#dom-dompointreadonly-dompointreadonly
     fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,

--- a/components/script/dom/dompointreadonly.rs
+++ b/components/script/dom/dompointreadonly.rs
@@ -61,6 +61,7 @@ impl DOMPointReadOnly {
 
 #[allow(non_snake_case)]
 impl DOMPointReadOnlyMethods for DOMPointReadOnly {
+    // https://drafts.fxtf.org/geometry/#dom-dompoint-dompoint
     fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,

--- a/components/script/dom/dompointreadonly.rs
+++ b/components/script/dom/dompointreadonly.rs
@@ -57,8 +57,11 @@ impl DOMPointReadOnly {
             can_gc,
         )
     }
+}
 
-    pub fn Constructor(
+#[allow(non_snake_case)]
+impl DOMPointReadOnlyMethods for DOMPointReadOnly {
+    fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -73,13 +76,10 @@ impl DOMPointReadOnly {
     }
 
     // https://drafts.fxtf.org/geometry/#dom-dompointreadonly-frompoint
-    pub fn FromPoint(global: &GlobalScope, init: &DOMPointInit) -> DomRoot<Self> {
+    fn FromPoint(global: &GlobalScope, init: &DOMPointInit) -> DomRoot<Self> {
         Self::new(global, init.x, init.y, init.z, init.w)
     }
-}
 
-#[allow(non_snake_case)]
-impl DOMPointReadOnlyMethods for DOMPointReadOnly {
     // https://dev.w3.org/fxtf/geometry/Overview.html#dom-dompointreadonly-x
     fn X(&self) -> f64 {
         self.x.get()

--- a/components/script/dom/domquad.rs
+++ b/components/script/dom/domquad.rs
@@ -26,7 +26,6 @@ pub struct DOMQuad {
     p4: Dom<DOMPoint>,
 }
 
-#[allow(non_snake_case)]
 impl DOMQuad {
     fn new_inherited(p1: &DOMPoint, p2: &DOMPoint, p3: &DOMPoint, p4: &DOMPoint) -> DOMQuad {
         DOMQuad {
@@ -64,8 +63,10 @@ impl DOMQuad {
             can_gc,
         )
     }
+}
 
-    pub fn Constructor(
+impl DOMQuadMethods for DOMQuad {
+    fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -86,7 +87,7 @@ impl DOMQuad {
     }
 
     // https://drafts.fxtf.org/geometry/#dom-domquad-fromrect
-    pub fn FromRect(global: &GlobalScope, other: &DOMRectInit) -> DomRoot<DOMQuad> {
+    fn FromRect(global: &GlobalScope, other: &DOMRectInit) -> DomRoot<DOMQuad> {
         DOMQuad::new(
             global,
             &DOMPoint::new(global, other.x, other.y, 0f64, 1f64),
@@ -103,7 +104,7 @@ impl DOMQuad {
     }
 
     // https://drafts.fxtf.org/geometry/#dom-domquad-fromquad
-    pub fn FromQuad(global: &GlobalScope, other: &DOMQuadInit) -> DomRoot<DOMQuad> {
+    fn FromQuad(global: &GlobalScope, other: &DOMQuadInit) -> DomRoot<DOMQuad> {
         DOMQuad::new(
             global,
             &DOMPoint::new_from_init(global, &other.p1),
@@ -112,9 +113,7 @@ impl DOMQuad {
             &DOMPoint::new_from_init(global, &other.p4),
         )
     }
-}
 
-impl DOMQuadMethods for DOMQuad {
     // https://drafts.fxtf.org/geometry/#dom-domquad-p1
     fn P1(&self) -> DomRoot<DOMPoint> {
         DomRoot::from_ref(&self.p1)

--- a/components/script/dom/domquad.rs
+++ b/components/script/dom/domquad.rs
@@ -66,6 +66,7 @@ impl DOMQuad {
 }
 
 impl DOMQuadMethods for DOMQuad {
+    // https://drafts.fxtf.org/geometry/#dom-domquad-domquad
     fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,

--- a/components/script/dom/domrect.rs
+++ b/components/script/dom/domrect.rs
@@ -49,6 +49,7 @@ impl DOMRect {
 }
 
 impl DOMRectMethods for DOMRect {
+    // https://drafts.fxtf.org/geometry/#dom-domrect-domrect
     fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,

--- a/components/script/dom/domrect.rs
+++ b/components/script/dom/domrect.rs
@@ -46,9 +46,10 @@ impl DOMRect {
             can_gc,
         )
     }
+}
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+impl DOMRectMethods for DOMRect {
+    fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -61,9 +62,7 @@ impl DOMRect {
             global, proto, x, y, width, height, can_gc,
         ))
     }
-}
 
-impl DOMRectMethods for DOMRect {
     // https://drafts.fxtf.org/geometry/#dom-domrect-x
     fn X(&self) -> f64 {
         self.rect.X()

--- a/components/script/dom/domrectreadonly.rs
+++ b/components/script/dom/domrectreadonly.rs
@@ -51,21 +51,6 @@ impl DOMRectReadOnly {
         )
     }
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
-        global: &GlobalScope,
-        proto: Option<HandleObject>,
-        can_gc: CanGc,
-        x: f64,
-        y: f64,
-        width: f64,
-        height: f64,
-    ) -> Fallible<DomRoot<DOMRectReadOnly>> {
-        Ok(DOMRectReadOnly::new(
-            global, proto, x, y, width, height, can_gc,
-        ))
-    }
-
     pub fn set_x(&self, value: f64) {
         self.x.set(value);
     }
@@ -84,6 +69,20 @@ impl DOMRectReadOnly {
 }
 
 impl DOMRectReadOnlyMethods for DOMRectReadOnly {
+    fn Constructor(
+        global: &GlobalScope,
+        proto: Option<HandleObject>,
+        can_gc: CanGc,
+        x: f64,
+        y: f64,
+        width: f64,
+        height: f64,
+    ) -> Fallible<DomRoot<DOMRectReadOnly>> {
+        Ok(DOMRectReadOnly::new(
+            global, proto, x, y, width, height, can_gc,
+        ))
+    }
+
     // https://drafts.fxtf.org/geometry/#dom-domrectreadonly-x
     fn X(&self) -> f64 {
         self.x.get()

--- a/components/script/dom/domrectreadonly.rs
+++ b/components/script/dom/domrectreadonly.rs
@@ -69,6 +69,7 @@ impl DOMRectReadOnly {
 }
 
 impl DOMRectReadOnlyMethods for DOMRectReadOnly {
+    // https://drafts.fxtf.org/geometry/#dom-domrectreadonly-domrectreadonly
     fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,

--- a/components/script/dom/errorevent.rs
+++ b/components/script/dom/errorevent.rs
@@ -111,6 +111,7 @@ impl ErrorEvent {
 }
 
 impl ErrorEventMethods for ErrorEvent {
+    // https://html.spec.whatwg.org/multipage/#errorevent
     fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,

--- a/components/script/dom/errorevent.rs
+++ b/components/script/dom/errorevent.rs
@@ -108,9 +108,10 @@ impl ErrorEvent {
         ev.error.set(error.get());
         ev
     }
+}
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+impl ErrorEventMethods for ErrorEvent {
+    fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -150,9 +151,7 @@ impl ErrorEvent {
         );
         Ok(event)
     }
-}
 
-impl ErrorEventMethods for ErrorEvent {
     // https://html.spec.whatwg.org/multipage/#dom-errorevent-lineno
     fn Lineno(&self) -> u32 {
         self.lineno.get()

--- a/components/script/dom/event.rs
+++ b/components/script/dom/event.rs
@@ -384,6 +384,7 @@ impl Event {
 }
 
 impl EventMethods for Event {
+    /// <https://dom.spec.whatwg.org/#dom-event-event>
     fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,

--- a/components/script/dom/event.rs
+++ b/components/script/dom/event.rs
@@ -109,26 +109,6 @@ impl Event {
         event
     }
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
-        global: &GlobalScope,
-        proto: Option<HandleObject>,
-        can_gc: CanGc,
-        type_: DOMString,
-        init: &EventBinding::EventInit,
-    ) -> Fallible<DomRoot<Event>> {
-        let bubbles = EventBubbles::from(init.bubbles);
-        let cancelable = EventCancelable::from(init.cancelable);
-        Ok(Event::new_with_proto(
-            global,
-            proto,
-            Atom::from(type_),
-            bubbles,
-            cancelable,
-            can_gc,
-        ))
-    }
-
     pub fn init_event(&self, type_: Atom, bubbles: bool, cancelable: bool) {
         if self.dispatching.get() {
             return;
@@ -404,6 +384,25 @@ impl Event {
 }
 
 impl EventMethods for Event {
+    fn Constructor(
+        global: &GlobalScope,
+        proto: Option<HandleObject>,
+        can_gc: CanGc,
+        type_: DOMString,
+        init: &EventBinding::EventInit,
+    ) -> Fallible<DomRoot<Event>> {
+        let bubbles = EventBubbles::from(init.bubbles);
+        let cancelable = EventCancelable::from(init.cancelable);
+        Ok(Event::new_with_proto(
+            global,
+            proto,
+            Atom::from(type_),
+            bubbles,
+            cancelable,
+            can_gc,
+        ))
+    }
+
     /// <https://dom.spec.whatwg.org/#dom-event-eventphase>
     fn EventPhase(&self) -> u16 {
         self.phase.get() as u16

--- a/components/script/dom/eventsource.rs
+++ b/components/script/dom/eventsource.rs
@@ -514,10 +514,20 @@ impl EventSource {
     pub fn url(&self) -> &ServoUrl {
         &self.url
     }
+}
 
+// https://html.spec.whatwg.org/multipage/#garbage-collection-2
+impl Drop for EventSource {
+    fn drop(&mut self) {
+        // If an EventSource object is garbage collected while its connection is still open,
+        // the user agent must abort any instance of the fetch algorithm opened by this EventSource.
+        self.canceller.borrow_mut().cancel();
+    }
+}
+
+impl EventSourceMethods for EventSource {
     // https://html.spec.whatwg.org/multipage/#dom-eventsource
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+    fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -610,18 +620,7 @@ impl EventSource {
         // Step 13
         Ok(ev)
     }
-}
 
-// https://html.spec.whatwg.org/multipage/#garbage-collection-2
-impl Drop for EventSource {
-    fn drop(&mut self) {
-        // If an EventSource object is garbage collected while its connection is still open,
-        // the user agent must abort any instance of the fetch algorithm opened by this EventSource.
-        self.canceller.borrow_mut().cancel();
-    }
-}
-
-impl EventSourceMethods for EventSource {
     // https://html.spec.whatwg.org/multipage/#handler-eventsource-onopen
     event_handler!(open, GetOnopen, SetOnopen);
 

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -748,6 +748,7 @@ impl EventTarget {
 }
 
 impl EventTargetMethods for EventTarget {
+    // https://dom.spec.whatwg.org/#dom-eventtarget-eventtarget
     fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -374,15 +374,6 @@ impl EventTarget {
         )
     }
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
-        global: &GlobalScope,
-        proto: Option<HandleObject>,
-        can_gc: CanGc,
-    ) -> Fallible<DomRoot<EventTarget>> {
-        Ok(EventTarget::new(global, proto, can_gc))
-    }
-
     /// Determine if there are any listeners for a given event type.
     /// See <https://github.com/whatwg/dom/issues/453>.
     pub fn has_listeners_for(&self, type_: &Atom) -> bool {
@@ -757,6 +748,14 @@ impl EventTarget {
 }
 
 impl EventTargetMethods for EventTarget {
+    fn Constructor(
+        global: &GlobalScope,
+        proto: Option<HandleObject>,
+        can_gc: CanGc,
+    ) -> Fallible<DomRoot<EventTarget>> {
+        Ok(EventTarget::new(global, proto, can_gc))
+    }
+
     // https://dom.spec.whatwg.org/#dom-eventtarget-addeventlistener
     fn AddEventListener(
         &self,

--- a/components/script/dom/extendableevent.rs
+++ b/components/script/dom/extendableevent.rs
@@ -67,6 +67,7 @@ impl ExtendableEvent {
 }
 
 impl ExtendableEventMethods for ExtendableEvent {
+    // https://w3c.github.io/ServiceWorker/#dom-extendableevent-extendableevent
     fn Constructor(
         worker: &ServiceWorkerGlobalScope,
         proto: Option<HandleObject>,

--- a/components/script/dom/extendableevent.rs
+++ b/components/script/dom/extendableevent.rs
@@ -7,7 +7,9 @@ use js::rust::{HandleObject, HandleValue};
 use servo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::EventMethods;
-use crate::dom::bindings::codegen::Bindings::ExtendableEventBinding;
+use crate::dom::bindings::codegen::Bindings::ExtendableEventBinding::{
+    ExtendableEventInit, ExtendableEventMethods,
+};
 use crate::dom::bindings::error::{Error, ErrorResult, Fallible};
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::reflect_dom_object_with_proto;
@@ -62,13 +64,15 @@ impl ExtendableEvent {
         }
         ev
     }
+}
 
-    pub fn Constructor(
+impl ExtendableEventMethods for ExtendableEvent {
+    fn Constructor(
         worker: &ServiceWorkerGlobalScope,
         proto: Option<HandleObject>,
         can_gc: CanGc,
         type_: DOMString,
-        init: &ExtendableEventBinding::ExtendableEventInit,
+        init: &ExtendableEventInit,
     ) -> Fallible<DomRoot<ExtendableEvent>> {
         Ok(ExtendableEvent::new_with_proto(
             worker,
@@ -81,7 +85,7 @@ impl ExtendableEvent {
     }
 
     // https://w3c.github.io/ServiceWorker/#wait-until-method
-    pub fn WaitUntil(&self, _cx: JSContext, _val: HandleValue) -> ErrorResult {
+    fn WaitUntil(&self, _cx: JSContext, _val: HandleValue) -> ErrorResult {
         // Step 1
         if !self.extensions_allowed {
             return Err(Error::InvalidState);
@@ -92,12 +96,12 @@ impl ExtendableEvent {
     }
 
     // https://dom.spec.whatwg.org/#dom-event-istrusted
-    pub fn IsTrusted(&self) -> bool {
+    fn IsTrusted(&self) -> bool {
         self.event.IsTrusted()
     }
 }
 
-impl Default for ExtendableEventBinding::ExtendableEventInit {
+impl Default for ExtendableEventInit {
     fn default() -> Self {
         Self::empty()
     }

--- a/components/script/dom/extendablemessageevent.rs
+++ b/components/script/dom/extendablemessageevent.rs
@@ -157,6 +157,7 @@ impl ExtendableMessageEvent {
 }
 
 impl ExtendableMessageEventMethods for ExtendableMessageEvent {
+    /// <https://w3c.github.io/ServiceWorker/#dom-extendablemessageevent-extendablemessageevent>
     fn Constructor(
         worker: &ServiceWorkerGlobalScope,
         proto: Option<HandleObject>,
@@ -180,22 +181,22 @@ impl ExtendableMessageEventMethods for ExtendableMessageEvent {
         Ok(ev)
     }
 
-    // https://w3c.github.io/ServiceWorker/#extendablemessage-event-data-attribute
+    /// <https://w3c.github.io/ServiceWorker/#dom-extendablemessageevent-data>
     fn Data(&self, _cx: JSContext) -> JSVal {
         self.data.get()
     }
 
-    // https://w3c.github.io/ServiceWorker/#extendablemessage-event-origin-attribute
+    /// <https://w3c.github.io/ServiceWorker/#dom-extendablemessageevent-origin>
     fn Origin(&self) -> DOMString {
         self.origin.clone()
     }
 
-    // https://w3c.github.io/ServiceWorker/#extendablemessage-event-lasteventid-attribute
+    /// <https://w3c.github.io/ServiceWorker/#dom-extendablemessageevent-lasteventid>
     fn LastEventId(&self) -> DOMString {
         self.lastEventId.clone()
     }
 
-    // https://dom.spec.whatwg.org/#dom-event-istrusted
+    /// <https://dom.spec.whatwg.org/#dom-event-istrusted>
     fn IsTrusted(&self) -> bool {
         self.event.IsTrusted()
     }

--- a/components/script/dom/extendablemessageevent.rs
+++ b/components/script/dom/extendablemessageevent.rs
@@ -9,6 +9,7 @@ use js::rust::{HandleObject, HandleValue};
 use servo_atoms::Atom;
 
 use crate::dom::bindings::cell::DomRefCell;
+use crate::dom::bindings::codegen::Bindings::ExtendableEventBinding::ExtendableEvent_Binding::ExtendableEventMethods;
 use crate::dom::bindings::codegen::Bindings::ExtendableMessageEventBinding;
 use crate::dom::bindings::codegen::Bindings::ExtendableMessageEventBinding::ExtendableMessageEventMethods;
 use crate::dom::bindings::error::Fallible;
@@ -116,29 +117,6 @@ impl ExtendableMessageEvent {
 
         ev
     }
-
-    pub fn Constructor(
-        worker: &ServiceWorkerGlobalScope,
-        proto: Option<HandleObject>,
-        can_gc: CanGc,
-        type_: DOMString,
-        init: RootedTraceableBox<ExtendableMessageEventBinding::ExtendableMessageEventInit>,
-    ) -> Fallible<DomRoot<ExtendableMessageEvent>> {
-        let global = worker.upcast::<GlobalScope>();
-        let ev = ExtendableMessageEvent::new_with_proto(
-            global,
-            proto,
-            Atom::from(type_),
-            init.parent.parent.bubbles,
-            init.parent.parent.cancelable,
-            init.data.handle(),
-            init.origin.clone(),
-            init.lastEventId.clone(),
-            vec![],
-            can_gc,
-        );
-        Ok(ev)
-    }
 }
 
 #[allow(non_snake_case)]
@@ -179,6 +157,29 @@ impl ExtendableMessageEvent {
 }
 
 impl ExtendableMessageEventMethods for ExtendableMessageEvent {
+    fn Constructor(
+        worker: &ServiceWorkerGlobalScope,
+        proto: Option<HandleObject>,
+        can_gc: CanGc,
+        type_: DOMString,
+        init: RootedTraceableBox<ExtendableMessageEventBinding::ExtendableMessageEventInit>,
+    ) -> Fallible<DomRoot<ExtendableMessageEvent>> {
+        let global = worker.upcast::<GlobalScope>();
+        let ev = ExtendableMessageEvent::new_with_proto(
+            global,
+            proto,
+            Atom::from(type_),
+            init.parent.parent.bubbles,
+            init.parent.parent.cancelable,
+            init.data.handle(),
+            init.origin.clone(),
+            init.lastEventId.clone(),
+            vec![],
+            can_gc,
+        );
+        Ok(ev)
+    }
+
     // https://w3c.github.io/ServiceWorker/#extendablemessage-event-data-attribute
     fn Data(&self, _cx: JSContext) -> JSVal {
         self.data.get()

--- a/components/script/dom/file.rs
+++ b/components/script/dom/file.rs
@@ -91,9 +91,15 @@ impl File {
         )
     }
 
+    pub fn name(&self) -> &DOMString {
+        &self.name
+    }
+}
+
+impl FileMethods for File {
     // https://w3c.github.io/FileAPI/#file-constructor
     #[allow(non_snake_case)]
-    pub fn Constructor(
+    fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -126,12 +132,6 @@ impl File {
         ))
     }
 
-    pub fn name(&self) -> &DOMString {
-        &self.name
-    }
-}
-
-impl FileMethods for File {
     // https://w3c.github.io/FileAPI/#dfn-name
     fn Name(&self) -> DOMString {
         self.name.clone()

--- a/components/script/dom/filereader.rs
+++ b/components/script/dom/filereader.rs
@@ -325,6 +325,7 @@ impl FileReader {
 }
 
 impl FileReaderMethods for FileReader {
+    // https://w3c.github.io/FileAPI/#filereaderConstrctr
     fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,

--- a/components/script/dom/filereader.rs
+++ b/components/script/dom/filereader.rs
@@ -161,15 +161,6 @@ impl FileReader {
         reflect_dom_object_with_proto(Box::new(FileReader::new_inherited()), global, proto, can_gc)
     }
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
-        global: &GlobalScope,
-        proto: Option<HandleObject>,
-        can_gc: CanGc,
-    ) -> Fallible<DomRoot<FileReader>> {
-        Ok(FileReader::new(global, proto, can_gc))
-    }
-
     //https://w3c.github.io/FileAPI/#dfn-error-steps
     pub fn process_read_error(
         filereader: TrustedFileReader,
@@ -334,6 +325,14 @@ impl FileReader {
 }
 
 impl FileReaderMethods for FileReader {
+    fn Constructor(
+        global: &GlobalScope,
+        proto: Option<HandleObject>,
+        can_gc: CanGc,
+    ) -> Fallible<DomRoot<FileReader>> {
+        Ok(FileReader::new(global, proto, can_gc))
+    }
+
     // https://w3c.github.io/FileAPI/#dfn-onloadstart
     event_handler!(loadstart, GetOnloadstart, SetOnloadstart);
 

--- a/components/script/dom/filereadersync.rs
+++ b/components/script/dom/filereadersync.rs
@@ -52,6 +52,7 @@ impl FileReaderSync {
 }
 
 impl FileReaderSyncMethods for FileReaderSync {
+    /// <https://w3c.github.io/FileAPI/#filereadersyncConstrctr>
     fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,

--- a/components/script/dom/filereadersync.rs
+++ b/components/script/dom/filereadersync.rs
@@ -46,8 +46,13 @@ impl FileReaderSync {
         )
     }
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+    fn get_blob_bytes(blob: &Blob) -> Result<Vec<u8>, Error> {
+        blob.get_bytes().map_err(|_| Error::NotReadable)
+    }
+}
+
+impl FileReaderSyncMethods for FileReaderSync {
+    fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -55,12 +60,6 @@ impl FileReaderSync {
         Ok(FileReaderSync::new(global, proto, can_gc))
     }
 
-    fn get_blob_bytes(blob: &Blob) -> Result<Vec<u8>, Error> {
-        blob.get_bytes().map_err(|_| Error::NotReadable)
-    }
-}
-
-impl FileReaderSyncMethods for FileReaderSync {
     /// <https://w3c.github.io/FileAPI/#readAsBinaryStringSyncSection>
     fn ReadAsBinaryString(&self, blob: &Blob) -> Fallible<DOMString> {
         // step 1

--- a/components/script/dom/focusevent.rs
+++ b/components/script/dom/focusevent.rs
@@ -95,6 +95,7 @@ impl FocusEvent {
 }
 
 impl FocusEventMethods for FocusEvent {
+    // https://w3c.github.io/uievents/#dom-focusevent-focusevent
     fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/focusevent.rs
+++ b/components/script/dom/focusevent.rs
@@ -92,9 +92,10 @@ impl FocusEvent {
         ev.related_target.set(related_target);
         ev
     }
+}
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+impl FocusEventMethods for FocusEvent {
+    fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -116,9 +117,7 @@ impl FocusEvent {
         );
         Ok(event)
     }
-}
 
-impl FocusEventMethods for FocusEvent {
     // https://w3c.github.io/uievents/#widl-FocusEvent-relatedTarget
     fn GetRelatedTarget(&self) -> Option<DomRoot<EventTarget>> {
         self.related_target.get()

--- a/components/script/dom/formdata.rs
+++ b/components/script/dom/formdata.rs
@@ -62,10 +62,11 @@ impl FormData {
             can_gc,
         )
     }
+}
 
+impl FormDataMethods for FormData {
     // https://xhr.spec.whatwg.org/#dom-formdata
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+    fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -85,9 +86,7 @@ impl FormData {
 
         Ok(FormData::new_with_proto(None, global, proto, can_gc))
     }
-}
 
-impl FormDataMethods for FormData {
     // https://xhr.spec.whatwg.org/#dom-formdata-append
     fn Append(&self, name: USVString, str_value: USVString) {
         let datum = FormDatum {

--- a/components/script/dom/formdataevent.rs
+++ b/components/script/dom/formdataevent.rs
@@ -73,6 +73,7 @@ impl FormDataEvent {
 }
 
 impl FormDataEventMethods for FormDataEvent {
+    // https://html.spec.whatwg.org/multipage/#formdataevent
     fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/formdataevent.rs
+++ b/components/script/dom/formdataevent.rs
@@ -70,9 +70,10 @@ impl FormDataEvent {
         }
         ev
     }
+}
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+impl FormDataEventMethods for FormDataEvent {
+    fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -94,9 +95,7 @@ impl FormDataEvent {
 
         Ok(event)
     }
-}
 
-impl FormDataEventMethods for FormDataEvent {
     // https://html.spec.whatwg.org/multipage/#dom-formdataevent-formdata
     fn FormData(&self) -> DomRoot<FormData> {
         DomRoot::from_ref(&*self.form_data)

--- a/components/script/dom/gainnode.rs
+++ b/components/script/dom/gainnode.rs
@@ -89,9 +89,10 @@ impl GainNode {
             can_gc,
         ))
     }
+}
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+impl GainNodeMethods for GainNode {
+    fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -100,9 +101,7 @@ impl GainNode {
     ) -> Fallible<DomRoot<GainNode>> {
         GainNode::new_with_proto(window, proto, context, options, can_gc)
     }
-}
 
-impl GainNodeMethods for GainNode {
     // https://webaudio.github.io/web-audio-api/#dom-gainnode-gain
     fn Gain(&self) -> DomRoot<AudioParam> {
         DomRoot::from_ref(&self.gain)

--- a/components/script/dom/gainnode.rs
+++ b/components/script/dom/gainnode.rs
@@ -92,6 +92,7 @@ impl GainNode {
 }
 
 impl GainNodeMethods for GainNode {
+    // https://webaudio.github.io/web-audio-api/#dom-gainnode-gainnode
     fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/gamepadevent.rs
+++ b/components/script/dom/gamepadevent.rs
@@ -91,10 +91,11 @@ impl GamepadEvent {
 
         GamepadEvent::new(global, name.into(), false, false, gamepad)
     }
+}
 
+impl GamepadEventMethods for GamepadEvent {
     // https://w3c.github.io/gamepad/#gamepadevent-interface
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+    fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -111,9 +112,7 @@ impl GamepadEvent {
             can_gc,
         ))
     }
-}
 
-impl GamepadEventMethods for GamepadEvent {
     // https://w3c.github.io/gamepad/#gamepadevent-interface
     fn Gamepad(&self) -> DomRoot<Gamepad> {
         DomRoot::from_ref(&*self.gamepad)

--- a/components/script/dom/gpuinternalerror.rs
+++ b/components/script/dom/gpuinternalerror.rs
@@ -6,6 +6,7 @@ use dom_struct::dom_struct;
 use js::rust::HandleObject;
 
 use super::types::GPUError;
+use crate::dom::bindings::codegen::Bindings::WebGPUBinding::GPUInternalError_Binding::GPUInternalErrorMethods;
 use crate::dom::bindings::reflector::reflect_dom_object_with_proto;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
@@ -37,10 +38,11 @@ impl GPUInternalError {
             can_gc,
         )
     }
+}
 
+impl GPUInternalErrorMethods for GPUInternalError {
     /// <https://gpuweb.github.io/gpuweb/#dom-GPUInternalError-GPUInternalError>
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+    fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
         can_gc: CanGc,

--- a/components/script/dom/gpuoutofmemoryerror.rs
+++ b/components/script/dom/gpuoutofmemoryerror.rs
@@ -6,6 +6,7 @@ use dom_struct::dom_struct;
 use js::rust::HandleObject;
 
 use super::types::GPUError;
+use crate::dom::bindings::codegen::Bindings::WebGPUBinding::GPUOutOfMemoryError_Binding::GPUOutOfMemoryErrorMethods;
 use crate::dom::bindings::reflector::reflect_dom_object_with_proto;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
@@ -37,10 +38,11 @@ impl GPUOutOfMemoryError {
             can_gc,
         )
     }
+}
 
+impl GPUOutOfMemoryErrorMethods for GPUOutOfMemoryError {
     /// <https://gpuweb.github.io/gpuweb/#dom-GPUOutOfMemoryError-GPUOutOfMemoryError>
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+    fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
         can_gc: CanGc,

--- a/components/script/dom/gpupipelineerror.rs
+++ b/components/script/dom/gpupipelineerror.rs
@@ -52,10 +52,11 @@ impl GPUPipelineError {
     ) -> DomRoot<Self> {
         Self::new_with_proto(global, None, message, reason, CanGc::note())
     }
+}
 
+impl GPUPipelineErrorMethods for GPUPipelineError {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpupipelineerror-constructor>
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+    fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -64,9 +65,7 @@ impl GPUPipelineError {
     ) -> DomRoot<Self> {
         Self::new_with_proto(global, proto, message, options.reason, can_gc)
     }
-}
 
-impl GPUPipelineErrorMethods for GPUPipelineError {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpupipelineerror-reason>
     fn Reason(&self) -> GPUPipelineErrorReason {
         self.reason

--- a/components/script/dom/gpuuncapturederrorevent.rs
+++ b/components/script/dom/gpuuncapturederrorevent.rs
@@ -62,9 +62,14 @@ impl GPUUncapturedErrorEvent {
         ev
     }
 
+    pub fn event(&self) -> &Event {
+        &self.event
+    }
+}
+
+impl GPUUncapturedErrorEventMethods for GPUUncapturedErrorEvent {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuuncapturederrorevent-gpuuncapturederrorevent>
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+    fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -73,15 +78,7 @@ impl GPUUncapturedErrorEvent {
     ) -> DomRoot<Self> {
         GPUUncapturedErrorEvent::new_with_proto(global, proto, type_, init, can_gc)
     }
-}
 
-impl GPUUncapturedErrorEvent {
-    pub fn event(&self) -> &Event {
-        &self.event
-    }
-}
-
-impl GPUUncapturedErrorEventMethods for GPUUncapturedErrorEvent {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuuncapturederrorevent-error>
     fn Error(&self) -> DomRoot<GPUError> {
         DomRoot::from_ref(&self.gpu_error)

--- a/components/script/dom/gpuvalidationerror.rs
+++ b/components/script/dom/gpuvalidationerror.rs
@@ -6,6 +6,7 @@ use dom_struct::dom_struct;
 use js::rust::HandleObject;
 
 use super::types::GPUError;
+use crate::dom::bindings::codegen::Bindings::WebGPUBinding::GPUValidationError_Binding::GPUValidationErrorMethods;
 use crate::dom::bindings::reflector::reflect_dom_object_with_proto;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
@@ -37,10 +38,11 @@ impl GPUValidationError {
             can_gc,
         )
     }
+}
 
+impl GPUValidationErrorMethods for GPUValidationError {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuvalidationerror-gpuvalidationerror>
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+    fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
         can_gc: CanGc,

--- a/components/script/dom/hashchangeevent.rs
+++ b/components/script/dom/hashchangeevent.rs
@@ -97,6 +97,7 @@ impl HashChangeEvent {
 }
 
 impl HashChangeEventMethods for HashChangeEvent {
+    // https://html.spec.whatwg.org/multipage/#hashchangeevent
     fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/hashchangeevent.rs
+++ b/components/script/dom/hashchangeevent.rs
@@ -94,9 +94,10 @@ impl HashChangeEvent {
         }
         ev
     }
+}
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+impl HashChangeEventMethods for HashChangeEvent {
+    fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -114,9 +115,7 @@ impl HashChangeEvent {
             can_gc,
         ))
     }
-}
 
-impl HashChangeEventMethods for HashChangeEvent {
     // https://html.spec.whatwg.org/multipage/#dom-hashchangeevent-oldurl
     fn OldURL(&self) -> USVString {
         USVString(self.old_url.clone())

--- a/components/script/dom/headers.rs
+++ b/components/script/dom/headers.rs
@@ -63,10 +63,11 @@ impl Headers {
     ) -> DomRoot<Headers> {
         reflect_dom_object_with_proto(Box::new(Headers::new_inherited()), global, proto, can_gc)
     }
+}
 
+impl HeadersMethods for Headers {
     // https://fetch.spec.whatwg.org/#dom-headers
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+    fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -76,9 +77,7 @@ impl Headers {
         dom_headers_new.fill(init)?;
         Ok(dom_headers_new)
     }
-}
 
-impl HeadersMethods for Headers {
     // https://fetch.spec.whatwg.org/#concept-headers-append
     fn Append(&self, name: ByteString, value: ByteString) -> ErrorResult {
         // Step 1

--- a/components/script/dom/htmlaudioelement.rs
+++ b/components/script/dom/htmlaudioelement.rs
@@ -7,6 +7,7 @@ use html5ever::{local_name, namespace_url, ns, LocalName, Prefix, QualName};
 use js::rust::HandleObject;
 
 use crate::dom::bindings::codegen::Bindings::ElementBinding::Element_Binding::ElementMethods;
+use crate::dom::bindings::codegen::Bindings::HTMLAudioElementBinding::HTMLAudioElementMethods;
 use crate::dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
 use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::inheritance::Castable;
@@ -50,10 +51,11 @@ impl HTMLAudioElement {
             proto,
         )
     }
+}
 
+impl HTMLAudioElementMethods for HTMLAudioElement {
     // https://html.spec.whatwg.org/multipage/#dom-audio
-    #[allow(non_snake_case)]
-    pub fn Audio(
+    fn Audio(
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,

--- a/components/script/dom/htmlformcontrolscollection.rs
+++ b/components/script/dom/htmlformcontrolscollection.rs
@@ -55,6 +55,7 @@ impl HTMLFormControlsCollection {
 impl HTMLFormControlsCollectionMethods for HTMLFormControlsCollection {
     // FIXME: This shouldn't need to be implemented here since HTMLCollection (the parent of
     // HTMLFormControlsCollection) implements Length
+    // https://dom.spec.whatwg.org/#dom-htmlcollection-length
     fn Length(&self) -> u32 {
         self.collection.Length()
     }

--- a/components/script/dom/htmlformcontrolscollection.rs
+++ b/components/script/dom/htmlformcontrolscollection.rs
@@ -50,16 +50,15 @@ impl HTMLFormControlsCollection {
             window,
         )
     }
-
-    // FIXME: This shouldn't need to be implemented here since HTMLCollection (the parent of
-    // HTMLFormControlsCollection) implements Length
-    #[allow(non_snake_case)]
-    pub fn Length(&self) -> u32 {
-        self.collection.Length()
-    }
 }
 
 impl HTMLFormControlsCollectionMethods for HTMLFormControlsCollection {
+    // FIXME: This shouldn't need to be implemented here since HTMLCollection (the parent of
+    // HTMLFormControlsCollection) implements Length
+    fn Length(&self) -> u32 {
+        self.collection.Length()
+    }
+
     // https://html.spec.whatwg.org/multipage/#dom-htmlformcontrolscollection-nameditem
     fn NamedItem(&self, name: DOMString) -> Option<RadioNodeListOrElement> {
         // Step 1

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -38,6 +38,7 @@ use crate::dom::bindings::codegen::Bindings::HTMLInputElementBinding::HTMLInputE
 use crate::dom::bindings::codegen::Bindings::HTMLTextAreaElementBinding::HTMLTextAreaElementMethods;
 use crate::dom::bindings::codegen::Bindings::NodeBinding::{NodeConstants, NodeMethods};
 use crate::dom::bindings::codegen::Bindings::NodeListBinding::NodeListMethods;
+use crate::dom::bindings::codegen::Bindings::RadioNodeListBinding::RadioNodeListMethods;
 use crate::dom::bindings::codegen::Bindings::WindowBinding::Window_Binding::WindowMethods;
 use crate::dom::bindings::codegen::UnionTypes::RadioNodeListOrElement;
 use crate::dom::bindings::error::{Error, Fallible};

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -1356,37 +1356,6 @@ impl HTMLImageElement {
         )
     }
 
-    pub fn Image(
-        window: &Window,
-        proto: Option<HandleObject>,
-        can_gc: CanGc,
-        width: Option<u32>,
-        height: Option<u32>,
-    ) -> Fallible<DomRoot<HTMLImageElement>> {
-        let element = Element::create(
-            QualName::new(None, ns!(html), local_name!("img")),
-            None,
-            &window.Document(),
-            ElementCreator::ScriptCreated,
-            CustomElementCreationMode::Synchronous,
-            proto,
-            can_gc,
-        );
-
-        let image = DomRoot::downcast::<HTMLImageElement>(element).unwrap();
-        if let Some(w) = width {
-            image.SetWidth(w);
-        }
-        if let Some(h) = height {
-            image.SetHeight(h);
-        }
-
-        // run update_the_image_data when the element is created.
-        // https://html.spec.whatwg.org/multipage/#when-to-obtain-images
-        image.update_the_image_data(can_gc);
-
-        Ok(image)
-    }
     pub fn areas(&self) -> Option<Vec<DomRoot<HTMLAreaElement>>> {
         let elem = self.upcast::<Element>();
         let usemap_attr = elem.get_attribute(&ns!(), &local_name!("usemap"))?;
@@ -1568,6 +1537,38 @@ fn get_correct_referrerpolicy_from_raw_token(token: &DOMString) -> DOMString {
 }
 
 impl HTMLImageElementMethods for HTMLImageElement {
+    fn Image(
+        window: &Window,
+        proto: Option<HandleObject>,
+        can_gc: CanGc,
+        width: Option<u32>,
+        height: Option<u32>,
+    ) -> Fallible<DomRoot<HTMLImageElement>> {
+        let element = Element::create(
+            QualName::new(None, ns!(html), local_name!("img")),
+            None,
+            &window.Document(),
+            ElementCreator::ScriptCreated,
+            CustomElementCreationMode::Synchronous,
+            proto,
+            can_gc,
+        );
+
+        let image = DomRoot::downcast::<HTMLImageElement>(element).unwrap();
+        if let Some(w) = width {
+            image.SetWidth(w);
+        }
+        if let Some(h) = height {
+            image.SetHeight(h);
+        }
+
+        // run update_the_image_data when the element is created.
+        // https://html.spec.whatwg.org/multipage/#when-to-obtain-images
+        image.update_the_image_data(can_gc);
+
+        Ok(image)
+    }
+
     // https://html.spec.whatwg.org/multipage/#dom-img-alt
     make_getter!(Alt, "alt");
     // https://html.spec.whatwg.org/multipage/#dom-img-alt

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -1537,6 +1537,7 @@ fn get_correct_referrerpolicy_from_raw_token(token: &DOMString) -> DOMString {
 }
 
 impl HTMLImageElementMethods for HTMLImageElement {
+    // https://html.spec.whatwg.org/multipage/#dom-image
     fn Image(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -55,6 +55,7 @@ use crate::dom::bindings::codegen::Bindings::MediaErrorBinding::MediaErrorMethod
 use crate::dom::bindings::codegen::Bindings::NavigatorBinding::Navigator_Binding::NavigatorMethods;
 use crate::dom::bindings::codegen::Bindings::NodeBinding::Node_Binding::NodeMethods;
 use crate::dom::bindings::codegen::Bindings::TextTrackBinding::{TextTrackKind, TextTrackMode};
+use crate::dom::bindings::codegen::Bindings::URLBinding::URLMethods;
 use crate::dom::bindings::codegen::Bindings::WindowBinding::Window_Binding::WindowMethods;
 use crate::dom::bindings::codegen::InheritTypes::{
     ElementTypeId, HTMLElementTypeId, HTMLMediaElementTypeId, NodeTypeId,

--- a/components/script/dom/htmloptionelement.rs
+++ b/components/script/dom/htmloptionelement.rs
@@ -82,43 +82,6 @@ impl HTMLOptionElement {
         )
     }
 
-    // https://html.spec.whatwg.org/multipage/#dom-option
-    #[allow(non_snake_case)]
-    pub fn Option(
-        window: &Window,
-        proto: Option<HandleObject>,
-        can_gc: CanGc,
-        text: DOMString,
-        value: Option<DOMString>,
-        default_selected: bool,
-        selected: bool,
-    ) -> Fallible<DomRoot<HTMLOptionElement>> {
-        let element = Element::create(
-            QualName::new(None, ns!(html), local_name!("option")),
-            None,
-            &window.Document(),
-            ElementCreator::ScriptCreated,
-            CustomElementCreationMode::Synchronous,
-            proto,
-            can_gc,
-        );
-
-        let option = DomRoot::downcast::<HTMLOptionElement>(element).unwrap();
-
-        if !text.is_empty() {
-            option.upcast::<Node>().SetTextContent(Some(text))
-        }
-
-        if let Some(val) = value {
-            option.SetValue(val)
-        }
-
-        option.SetDefaultSelected(default_selected);
-        option.set_selectedness(selected);
-        option.update_select_validity();
-        Ok(option)
-    }
-
     pub fn set_selectedness(&self, selected: bool) {
         self.selectedness.set(selected);
     }
@@ -210,6 +173,42 @@ fn collect_text(element: &Element, value: &mut String) {
 }
 
 impl HTMLOptionElementMethods for HTMLOptionElement {
+    // https://html.spec.whatwg.org/multipage/#dom-option
+    fn Option(
+        window: &Window,
+        proto: Option<HandleObject>,
+        can_gc: CanGc,
+        text: DOMString,
+        value: Option<DOMString>,
+        default_selected: bool,
+        selected: bool,
+    ) -> Fallible<DomRoot<HTMLOptionElement>> {
+        let element = Element::create(
+            QualName::new(None, ns!(html), local_name!("option")),
+            None,
+            &window.Document(),
+            ElementCreator::ScriptCreated,
+            CustomElementCreationMode::Synchronous,
+            proto,
+            can_gc,
+        );
+
+        let option = DomRoot::downcast::<HTMLOptionElement>(element).unwrap();
+
+        if !text.is_empty() {
+            option.upcast::<Node>().SetTextContent(Some(text))
+        }
+
+        if let Some(val) = value {
+            option.SetValue(val)
+        }
+
+        option.SetDefaultSelected(default_selected);
+        option.set_selectedness(selected);
+        option.update_select_validity();
+        Ok(option)
+    }
+
     // https://html.spec.whatwg.org/multipage/#dom-option-disabled
     make_bool_getter!(Disabled, "disabled");
 

--- a/components/script/dom/iirfilternode.rs
+++ b/components/script/dom/iirfilternode.rs
@@ -95,6 +95,7 @@ impl IIRFilterNode {
 }
 
 impl IIRFilterNodeMethods for IIRFilterNode {
+    /// <https://webaudio.github.io/web-audio-api/#dom-iirfilternode-iirfilternode>
     fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/iirfilternode.rs
+++ b/components/script/dom/iirfilternode.rs
@@ -92,9 +92,10 @@ impl IIRFilterNode {
             can_gc,
         ))
     }
+}
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+impl IIRFilterNodeMethods for IIRFilterNode {
+    fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -103,9 +104,7 @@ impl IIRFilterNode {
     ) -> Fallible<DomRoot<IIRFilterNode>> {
         IIRFilterNode::new_with_proto(window, proto, context, options, can_gc)
     }
-}
 
-impl IIRFilterNodeMethods for IIRFilterNode {
     #[allow(unsafe_code)]
     /// <https://webaudio.github.io/web-audio-api/#dom-iirfilternode-getfrequencyresponse>
     fn GetFrequencyResponse(

--- a/components/script/dom/inputevent.rs
+++ b/components/script/dom/inputevent.rs
@@ -50,9 +50,10 @@ impl InputEvent {
             .InitUIEvent(type_, can_bubble, cancelable, view, detail);
         ev
     }
+}
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+impl InputEventMethods for InputEvent {
+    fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -73,9 +74,7 @@ impl InputEvent {
         );
         Ok(event)
     }
-}
 
-impl InputEventMethods for InputEvent {
     // https://w3c.github.io/uievents/#dom-inputevent-data
     fn GetData(&self) -> Option<DOMString> {
         self.data.clone()

--- a/components/script/dom/inputevent.rs
+++ b/components/script/dom/inputevent.rs
@@ -53,6 +53,7 @@ impl InputEvent {
 }
 
 impl InputEventMethods for InputEvent {
+    // https://w3c.github.io/uievents/#dom-inputevent-inputevent
     fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/keyboardevent.rs
+++ b/components/script/dom/keyboardevent.rs
@@ -148,8 +148,17 @@ impl KeyboardEvent {
         ev
     }
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+    pub fn key(&self) -> Key {
+        self.typed_key.borrow().clone()
+    }
+
+    pub fn modifiers(&self) -> Modifiers {
+        self.modifiers.get()
+    }
+}
+
+impl KeyboardEventMethods for KeyboardEvent {
+    fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -182,19 +191,7 @@ impl KeyboardEvent {
         *event.key.borrow_mut() = init.key.clone();
         Ok(event)
     }
-}
 
-impl KeyboardEvent {
-    pub fn key(&self) -> Key {
-        self.typed_key.borrow().clone()
-    }
-
-    pub fn modifiers(&self) -> Modifiers {
-        self.modifiers.get()
-    }
-}
-
-impl KeyboardEventMethods for KeyboardEvent {
     // https://w3c.github.io/uievents/#widl-KeyboardEvent-initKeyboardEvent
     fn InitKeyboardEvent(
         &self,

--- a/components/script/dom/keyboardevent.rs
+++ b/components/script/dom/keyboardevent.rs
@@ -158,6 +158,7 @@ impl KeyboardEvent {
 }
 
 impl KeyboardEventMethods for KeyboardEvent {
+    /// <https://w3c.github.io/uievents/#dom-keyboardevent-keyboardevent>
     fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
@@ -216,52 +217,52 @@ impl KeyboardEventMethods for KeyboardEvent {
         self.repeat.set(repeat);
     }
 
-    // https://w3c.github.io/uievents/#widl-KeyboardEvent-key
+    /// <https://w3c.github.io/uievents/#dom-keyboardevent-initkeyboardevent>
     fn Key(&self) -> DOMString {
         self.key.borrow().clone()
     }
 
-    // https://w3c.github.io/uievents/#widl-KeyboardEvent-code
+    /// <https://w3c.github.io/uievents/#dom-keyboardevent-code>
     fn Code(&self) -> DOMString {
         self.code.borrow().clone()
     }
 
-    // https://w3c.github.io/uievents/#widl-KeyboardEvent-location
+    /// <https://w3c.github.io/uievents/#dom-keyboardevent-location>
     fn Location(&self) -> u32 {
         self.location.get()
     }
 
-    // https://w3c.github.io/uievents/#widl-KeyboardEvent-ctrlKey
+    /// <https://w3c.github.io/uievents/#dom-keyboardevent-ctrlkey>
     fn CtrlKey(&self) -> bool {
         self.modifiers.get().contains(Modifiers::CONTROL)
     }
 
-    // https://w3c.github.io/uievents/#widl-KeyboardEvent-shiftKey
+    /// <https://w3c.github.io/uievents/#dom-keyboardevent-shiftkey>
     fn ShiftKey(&self) -> bool {
         self.modifiers.get().contains(Modifiers::SHIFT)
     }
 
-    // https://w3c.github.io/uievents/#widl-KeyboardEvent-altKey
+    /// <https://w3c.github.io/uievents/#dom-keyboardevent-altkey>
     fn AltKey(&self) -> bool {
         self.modifiers.get().contains(Modifiers::ALT)
     }
 
-    // https://w3c.github.io/uievents/#widl-KeyboardEvent-metaKey
+    /// <https://w3c.github.io/uievents/#dom-keyboardevent-metakey>
     fn MetaKey(&self) -> bool {
         self.modifiers.get().contains(Modifiers::META)
     }
 
-    // https://w3c.github.io/uievents/#widl-KeyboardEvent-repeat
+    /// <https://w3c.github.io/uievents/#dom-keyboardevent-repeat>
     fn Repeat(&self) -> bool {
         self.repeat.get()
     }
 
-    // https://w3c.github.io/uievents/#widl-KeyboardEvent-isComposing
+    /// <https://w3c.github.io/uievents/#dom-keyboardevent-iscomposing>
     fn IsComposing(&self) -> bool {
         self.is_composing.get()
     }
 
-    // https://w3c.github.io/uievents/#dom-keyboardevent-getmodifierstate
+    /// <https://w3c.github.io/uievents/#dom-keyboardevent-getmodifierstate>
     fn GetModifierState(&self, key_arg: DOMString) -> bool {
         self.modifiers.get().contains(match &*key_arg {
             "Alt" => Modifiers::ALT,
@@ -280,17 +281,17 @@ impl KeyboardEventMethods for KeyboardEvent {
         })
     }
 
-    // https://w3c.github.io/uievents/#widl-KeyboardEvent-charCode
+    /// <https://w3c.github.io/uievents/#dom-keyboardevent-charcode>
     fn CharCode(&self) -> u32 {
         self.char_code.get()
     }
 
-    // https://w3c.github.io/uievents/#widl-KeyboardEvent-keyCode
+    /// <https://w3c.github.io/uievents/#dom-keyboardevent-keycode>
     fn KeyCode(&self) -> u32 {
         self.key_code.get()
     }
 
-    // https://w3c.github.io/uievents/#widl-KeyboardEvent-which
+    /// <https://w3c.github.io/uievents/#dom-uievent-which>
     fn Which(&self) -> u32 {
         if self.char_code.get() != 0 {
             self.char_code.get()
@@ -299,7 +300,7 @@ impl KeyboardEventMethods for KeyboardEvent {
         }
     }
 
-    // https://dom.spec.whatwg.org/#dom-event-istrusted
+    /// <https://dom.spec.whatwg.org/#dom-event-istrusted>
     fn IsTrusted(&self) -> bool {
         self.uievent.IsTrusted()
     }

--- a/components/script/dom/mediaelementaudiosourcenode.rs
+++ b/components/script/dom/mediaelementaudiosourcenode.rs
@@ -81,6 +81,7 @@ impl MediaElementAudioSourceNode {
 }
 
 impl MediaElementAudioSourceNodeMethods for MediaElementAudioSourceNode {
+    /// <https://webaudio.github.io/web-audio-api/#dom-mediaelementaudiosourcenode-mediaelementaudiosourcenode>
     fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/mediaelementaudiosourcenode.rs
+++ b/components/script/dom/mediaelementaudiosourcenode.rs
@@ -78,9 +78,10 @@ impl MediaElementAudioSourceNode {
             can_gc,
         ))
     }
+}
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+impl MediaElementAudioSourceNodeMethods for MediaElementAudioSourceNode {
+    fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -95,9 +96,7 @@ impl MediaElementAudioSourceNode {
             can_gc,
         )
     }
-}
 
-impl MediaElementAudioSourceNodeMethods for MediaElementAudioSourceNode {
     /// <https://webaudio.github.io/web-audio-api/#dom-mediaelementaudiosourcenode-mediaelement>
     fn MediaElement(&self) -> DomRoot<HTMLMediaElement> {
         DomRoot::from_ref(&*self.media_element)

--- a/components/script/dom/mediametadata.rs
+++ b/components/script/dom/mediametadata.rs
@@ -55,17 +55,6 @@ impl MediaMetadata {
         )
     }
 
-    /// <https://w3c.github.io/mediasession/#dom-mediametadata-mediametadata>
-    #[allow(non_snake_case)]
-    pub fn Constructor(
-        window: &Window,
-        proto: Option<HandleObject>,
-        can_gc: CanGc,
-        init: &MediaMetadataInit,
-    ) -> Fallible<DomRoot<MediaMetadata>> {
-        Ok(MediaMetadata::new_with_proto(window, proto, init, can_gc))
-    }
-
     fn queue_update_metadata_algorithm(&self) {
         if self.session.get().is_none() {}
     }
@@ -76,6 +65,16 @@ impl MediaMetadata {
 }
 
 impl MediaMetadataMethods for MediaMetadata {
+    /// <https://w3c.github.io/mediasession/#dom-mediametadata-mediametadata>
+    fn Constructor(
+        window: &Window,
+        proto: Option<HandleObject>,
+        can_gc: CanGc,
+        init: &MediaMetadataInit,
+    ) -> Fallible<DomRoot<MediaMetadata>> {
+        Ok(MediaMetadata::new_with_proto(window, proto, init, can_gc))
+    }
+
     /// <https://w3c.github.io/mediasession/#dom-mediametadata-title>
     fn Title(&self) -> DOMString {
         self.title.borrow().clone()

--- a/components/script/dom/mediaquerylistevent.rs
+++ b/components/script/dom/mediaquerylistevent.rs
@@ -87,6 +87,7 @@ impl MediaQueryListEvent {
 }
 
 impl MediaQueryListEventMethods for MediaQueryListEvent {
+    // https://drafts.csswg.org/cssom-view/#dom-mediaquerylistevent-mediaquerylistevent
     fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/mediaquerylistevent.rs
+++ b/components/script/dom/mediaquerylistevent.rs
@@ -84,9 +84,10 @@ impl MediaQueryListEvent {
         }
         ev
     }
+}
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+impl MediaQueryListEventMethods for MediaQueryListEvent {
+    fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -105,9 +106,7 @@ impl MediaQueryListEvent {
             can_gc,
         ))
     }
-}
 
-impl MediaQueryListEventMethods for MediaQueryListEvent {
     // https://drafts.csswg.org/cssom-view/#dom-mediaquerylistevent-media
     fn Media(&self) -> DOMString {
         self.media.clone()

--- a/components/script/dom/mediastream.rs
+++ b/components/script/dom/mediastream.rs
@@ -25,7 +25,6 @@ pub struct MediaStream {
     tracks: DomRefCell<Vec<Dom<MediaStreamTrack>>>,
 }
 
-#[allow(non_snake_case)]
 impl MediaStream {
     pub fn new_inherited() -> MediaStream {
         MediaStream {
@@ -62,7 +61,17 @@ impl MediaStream {
         this
     }
 
-    pub fn Constructor(
+    pub fn get_tracks(&self) -> Ref<[Dom<MediaStreamTrack>]> {
+        Ref::map(self.tracks.borrow(), |tracks| &**tracks)
+    }
+
+    pub fn add_track(&self, track: &MediaStreamTrack) {
+        self.tracks.borrow_mut().push(Dom::from_ref(track))
+    }
+}
+
+impl MediaStreamMethods for MediaStream {
+    fn Constructor(
         global: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -70,7 +79,7 @@ impl MediaStream {
         Ok(MediaStream::new_with_proto(&global.global(), proto, can_gc))
     }
 
-    pub fn Constructor_(
+    fn Constructor_(
         _: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -79,7 +88,7 @@ impl MediaStream {
         Ok(stream.clone_with_proto(proto, can_gc))
     }
 
-    pub fn Constructor__(
+    fn Constructor__(
         global: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -94,16 +103,6 @@ impl MediaStream {
         Ok(new)
     }
 
-    pub fn get_tracks(&self) -> Ref<[Dom<MediaStreamTrack>]> {
-        Ref::map(self.tracks.borrow(), |tracks| &**tracks)
-    }
-
-    pub fn add_track(&self, track: &MediaStreamTrack) {
-        self.tracks.borrow_mut().push(Dom::from_ref(track))
-    }
-}
-
-impl MediaStreamMethods for MediaStream {
     /// <https://w3c.github.io/mediacapture-main/#dom-mediastream-gettracks>
     fn GetTracks(&self) -> Vec<DomRoot<MediaStreamTrack>> {
         self.tracks

--- a/components/script/dom/mediastream.rs
+++ b/components/script/dom/mediastream.rs
@@ -71,6 +71,7 @@ impl MediaStream {
 }
 
 impl MediaStreamMethods for MediaStream {
+    /// <https://w3c.github.io/mediacapture-main/#dom-mediastream-constructor>
     fn Constructor(
         global: &Window,
         proto: Option<HandleObject>,
@@ -79,6 +80,7 @@ impl MediaStreamMethods for MediaStream {
         Ok(MediaStream::new_with_proto(&global.global(), proto, can_gc))
     }
 
+    /// <https://w3c.github.io/mediacapture-main/#dom-mediastream-constructor>
     fn Constructor_(
         _: &Window,
         proto: Option<HandleObject>,
@@ -88,6 +90,7 @@ impl MediaStreamMethods for MediaStream {
         Ok(stream.clone_with_proto(proto, can_gc))
     }
 
+    /// <https://w3c.github.io/mediacapture-main/#dom-mediastream-constructor>
     fn Constructor__(
         global: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/mediastreamaudiodestinationnode.rs
+++ b/components/script/dom/mediastreamaudiodestinationnode.rs
@@ -79,9 +79,10 @@ impl MediaStreamAudioDestinationNode {
             can_gc,
         ))
     }
+}
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+impl MediaStreamAudioDestinationNodeMethods for MediaStreamAudioDestinationNode {
+    fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -90,9 +91,7 @@ impl MediaStreamAudioDestinationNode {
     ) -> Fallible<DomRoot<MediaStreamAudioDestinationNode>> {
         MediaStreamAudioDestinationNode::new_with_proto(window, proto, context, options, can_gc)
     }
-}
 
-impl MediaStreamAudioDestinationNodeMethods for MediaStreamAudioDestinationNode {
     /// <https://webaudio.github.io/web-audio-api/#dom-mediastreamaudiodestinationnode-stream>
     fn Stream(&self) -> DomRoot<MediaStream> {
         DomRoot::from_ref(&self.stream)

--- a/components/script/dom/mediastreamaudiodestinationnode.rs
+++ b/components/script/dom/mediastreamaudiodestinationnode.rs
@@ -82,6 +82,7 @@ impl MediaStreamAudioDestinationNode {
 }
 
 impl MediaStreamAudioDestinationNodeMethods for MediaStreamAudioDestinationNode {
+    /// <https://webaudio.github.io/web-audio-api/#dom-mediastreamaudiodestinationnode-mediastreamaudiodestinationnode>
     fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/mediastreamaudiosourcenode.rs
+++ b/components/script/dom/mediastreamaudiosourcenode.rs
@@ -75,9 +75,10 @@ impl MediaStreamAudioSourceNode {
             can_gc,
         ))
     }
+}
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+impl MediaStreamAudioSourceNodeMethods for MediaStreamAudioSourceNode {
+    fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -92,9 +93,7 @@ impl MediaStreamAudioSourceNode {
             can_gc,
         )
     }
-}
 
-impl MediaStreamAudioSourceNodeMethods for MediaStreamAudioSourceNode {
     /// <https://webaudio.github.io/web-audio-api/#dom-MediaStreamAudioSourceNode-stream>
     fn MediaStream(&self) -> DomRoot<MediaStream> {
         DomRoot::from_ref(&self.stream)

--- a/components/script/dom/mediastreamaudiosourcenode.rs
+++ b/components/script/dom/mediastreamaudiosourcenode.rs
@@ -78,6 +78,7 @@ impl MediaStreamAudioSourceNode {
 }
 
 impl MediaStreamAudioSourceNodeMethods for MediaStreamAudioSourceNode {
+    /// <https://webaudio.github.io/web-audio-api/#dom-mediastreamaudiosourcenode-mediastreamaudiosourcenode>
     fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/mediastreamtrackaudiosourcenode.rs
+++ b/components/script/dom/mediastreamtrackaudiosourcenode.rs
@@ -71,6 +71,7 @@ impl MediaStreamTrackAudioSourceNode {
 }
 
 impl MediaStreamTrackAudioSourceNodeMethods for MediaStreamTrackAudioSourceNode {
+    /// <https://webaudio.github.io/web-audio-api/#dom-mediastreamtrackaudiosourcenode-mediastreamtrackaudiosourcenode>
     fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/mediastreamtrackaudiosourcenode.rs
+++ b/components/script/dom/mediastreamtrackaudiosourcenode.rs
@@ -8,7 +8,9 @@ use servo_media::audio::node::AudioNodeInit;
 
 use crate::dom::audiocontext::AudioContext;
 use crate::dom::audionode::AudioNode;
-use crate::dom::bindings::codegen::Bindings::MediaStreamTrackAudioSourceNodeBinding::MediaStreamTrackAudioSourceOptions;
+use crate::dom::bindings::codegen::Bindings::MediaStreamTrackAudioSourceNodeBinding::{
+    MediaStreamTrackAudioSourceNodeMethods, MediaStreamTrackAudioSourceOptions,
+};
 use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::reflect_dom_object_with_proto;
@@ -66,9 +68,10 @@ impl MediaStreamTrackAudioSourceNode {
             can_gc,
         ))
     }
+}
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+impl MediaStreamTrackAudioSourceNodeMethods for MediaStreamTrackAudioSourceNode {
+    fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,

--- a/components/script/dom/messagechannel.rs
+++ b/components/script/dom/messagechannel.rs
@@ -21,16 +21,6 @@ pub struct MessageChannel {
 
 impl MessageChannel {
     /// <https://html.spec.whatwg.org/multipage/#dom-messagechannel>
-    #[allow(non_snake_case)]
-    pub fn Constructor(
-        global: &GlobalScope,
-        proto: Option<HandleObject>,
-        can_gc: CanGc,
-    ) -> DomRoot<MessageChannel> {
-        MessageChannel::new(global, proto, can_gc)
-    }
-
-    /// <https://html.spec.whatwg.org/multipage/#dom-messagechannel>
     fn new(
         incumbent: &GlobalScope,
         proto: Option<HandleObject>,
@@ -67,6 +57,15 @@ impl MessageChannel {
 }
 
 impl MessageChannelMethods for MessageChannel {
+    /// <https://html.spec.whatwg.org/multipage/#dom-messagechannel>
+    fn Constructor(
+        global: &GlobalScope,
+        proto: Option<HandleObject>,
+        can_gc: CanGc,
+    ) -> DomRoot<MessageChannel> {
+        MessageChannel::new(global, proto, can_gc)
+    }
+
     /// <https://html.spec.whatwg.org/multipage/#dom-messagechannel-port1>
     fn Port1(&self) -> DomRoot<MessagePort> {
         DomRoot::from_ref(&*self.port1)

--- a/components/script/dom/messageevent.rs
+++ b/components/script/dom/messageevent.rs
@@ -237,6 +237,7 @@ impl MessageEvent {
 }
 
 impl MessageEventMethods for MessageEvent {
+    /// <https://html.spec.whatwg.org/multipage/#messageevent>
     fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,

--- a/components/script/dom/messageevent.rs
+++ b/components/script/dom/messageevent.rs
@@ -193,31 +193,6 @@ impl MessageEvent {
         ev
     }
 
-    pub fn Constructor(
-        global: &GlobalScope,
-        proto: Option<HandleObject>,
-        can_gc: CanGc,
-        type_: DOMString,
-        init: RootedTraceableBox<MessageEventBinding::MessageEventInit>,
-    ) -> Fallible<DomRoot<MessageEvent>> {
-        let ev = MessageEvent::new_with_proto(
-            global,
-            proto,
-            Atom::from(type_),
-            init.parent.bubbles,
-            init.parent.cancelable,
-            init.data.handle(),
-            init.origin.clone(),
-            init.source.as_ref(),
-            init.lastEventId.clone(),
-            init.ports.clone(),
-            can_gc,
-        );
-        Ok(ev)
-    }
-}
-
-impl MessageEvent {
     pub fn dispatch_jsval(
         target: &EventTarget,
         scope: &GlobalScope,
@@ -262,6 +237,29 @@ impl MessageEvent {
 }
 
 impl MessageEventMethods for MessageEvent {
+    fn Constructor(
+        global: &GlobalScope,
+        proto: Option<HandleObject>,
+        can_gc: CanGc,
+        type_: DOMString,
+        init: RootedTraceableBox<MessageEventBinding::MessageEventInit>,
+    ) -> Fallible<DomRoot<MessageEvent>> {
+        let ev = MessageEvent::new_with_proto(
+            global,
+            proto,
+            Atom::from(type_),
+            init.parent.bubbles,
+            init.parent.cancelable,
+            init.data.handle(),
+            init.origin.clone(),
+            init.source.as_ref(),
+            init.lastEventId.clone(),
+            init.ports.clone(),
+            can_gc,
+        );
+        Ok(ev)
+    }
+
     /// <https://html.spec.whatwg.org/multipage/#dom-messageevent-data>
     fn Data(&self, _cx: JSContext) -> JSVal {
         self.data.get()

--- a/components/script/dom/mouseevent.rs
+++ b/components/script/dom/mouseevent.rs
@@ -181,8 +181,13 @@ impl MouseEvent {
         ev
     }
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+    pub fn point_in_target(&self) -> Option<Point2D<f32>> {
+        self.point_in_target.get()
+    }
+}
+
+impl MouseEventMethods for MouseEvent {
+    fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -216,12 +221,6 @@ impl MouseEvent {
         Ok(event)
     }
 
-    pub fn point_in_target(&self) -> Option<Point2D<f32>> {
-        self.point_in_target.get()
-    }
-}
-
-impl MouseEventMethods for MouseEvent {
     // https://w3c.github.io/uievents/#widl-MouseEvent-screenX
     fn ScreenX(&self) -> i32 {
         self.screen_x.get()

--- a/components/script/dom/mouseevent.rs
+++ b/components/script/dom/mouseevent.rs
@@ -187,6 +187,7 @@ impl MouseEvent {
 }
 
 impl MouseEventMethods for MouseEvent {
+    // https://w3c.github.io/uievents/#dom-mouseevent-mouseevent
     fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/mutationobserver.rs
+++ b/components/script/dom/mutationobserver.rs
@@ -88,19 +88,6 @@ impl MutationObserver {
         }
     }
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
-        global: &Window,
-        proto: Option<HandleObject>,
-        can_gc: CanGc,
-        callback: Rc<MutationCallback>,
-    ) -> Fallible<DomRoot<MutationObserver>> {
-        global.set_exists_mut_observer();
-        let observer = MutationObserver::new_with_proto(global, proto, callback, can_gc);
-        ScriptThread::add_mutation_observer(&observer);
-        Ok(observer)
-    }
-
     /// <https://dom.spec.whatwg.org/#queue-a-mutation-observer-compound-microtask>
     pub fn queue_mutation_observer_microtask() {
         // Step 1
@@ -261,6 +248,18 @@ impl MutationObserver {
 }
 
 impl MutationObserverMethods for MutationObserver {
+    fn Constructor(
+        global: &Window,
+        proto: Option<HandleObject>,
+        can_gc: CanGc,
+        callback: Rc<MutationCallback>,
+    ) -> Fallible<DomRoot<MutationObserver>> {
+        global.set_exists_mut_observer();
+        let observer = MutationObserver::new_with_proto(global, proto, callback, can_gc);
+        ScriptThread::add_mutation_observer(&observer);
+        Ok(observer)
+    }
+
     /// <https://dom.spec.whatwg.org/#dom-mutationobserver-observe>
     fn Observe(&self, target: &Node, options: &MutationObserverInit) -> Fallible<()> {
         let attribute_filter = options.attributeFilter.clone().unwrap_or_default();

--- a/components/script/dom/mutationobserver.rs
+++ b/components/script/dom/mutationobserver.rs
@@ -248,6 +248,7 @@ impl MutationObserver {
 }
 
 impl MutationObserverMethods for MutationObserver {
+    /// <https://dom.spec.whatwg.org/#dom-mutationobserver-mutationobserver>
     fn Constructor(
         global: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/offlineaudiocompletionevent.rs
+++ b/components/script/dom/offlineaudiocompletionevent.rs
@@ -69,9 +69,10 @@ impl OfflineAudioCompletionEvent {
         }
         ev
     }
+}
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+impl OfflineAudioCompletionEventMethods for OfflineAudioCompletionEvent {
+    fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -90,9 +91,7 @@ impl OfflineAudioCompletionEvent {
             can_gc,
         ))
     }
-}
 
-impl OfflineAudioCompletionEventMethods for OfflineAudioCompletionEvent {
     // https://webaudio.github.io/web-audio-api/#dom-offlineaudiocompletionevent-renderedbuffer
     fn RenderedBuffer(&self) -> DomRoot<AudioBuffer> {
         DomRoot::from_ref(&*self.rendered_buffer)

--- a/components/script/dom/offlineaudiocompletionevent.rs
+++ b/components/script/dom/offlineaudiocompletionevent.rs
@@ -72,6 +72,7 @@ impl OfflineAudioCompletionEvent {
 }
 
 impl OfflineAudioCompletionEventMethods for OfflineAudioCompletionEvent {
+    // https://webaudio.github.io/web-audio-api/#dom-offlineaudiocompletionevent-offlineaudiocompletionevent
     fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/offlineaudiocontext.rs
+++ b/components/script/dom/offlineaudiocontext.rs
@@ -44,7 +44,6 @@ pub struct OfflineAudioContext {
     pending_rendering_promise: DomRefCell<Option<Rc<Promise>>>,
 }
 
-#[allow(non_snake_case)]
 impl OfflineAudioContext {
     #[allow(crown::unrooted_must_root)]
     fn new_inherited(
@@ -97,8 +96,10 @@ impl OfflineAudioContext {
             can_gc,
         ))
     }
+}
 
-    pub fn Constructor(
+impl OfflineAudioContextMethods for OfflineAudioContext {
+    fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -114,7 +115,7 @@ impl OfflineAudioContext {
         )
     }
 
-    pub fn Constructor_(
+    fn Constructor_(
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -131,9 +132,7 @@ impl OfflineAudioContext {
             can_gc,
         )
     }
-}
 
-impl OfflineAudioContextMethods for OfflineAudioContext {
     // https://webaudio.github.io/web-audio-api/#dom-offlineaudiocontext-oncomplete
     event_handler!(complete, GetOncomplete, SetOncomplete);
 

--- a/components/script/dom/offlineaudiocontext.rs
+++ b/components/script/dom/offlineaudiocontext.rs
@@ -99,6 +99,7 @@ impl OfflineAudioContext {
 }
 
 impl OfflineAudioContextMethods for OfflineAudioContext {
+    // https://webaudio.github.io/web-audio-api/#dom-offlineaudiocontext-offlineaudiocontext
     fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
@@ -115,6 +116,7 @@ impl OfflineAudioContextMethods for OfflineAudioContext {
         )
     }
 
+    // https://webaudio.github.io/web-audio-api/#dom-offlineaudiocontext-offlineaudiocontext-numberofchannels-length-samplerate
     fn Constructor_(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/offscreencanvas.rs
+++ b/components/script/dom/offscreencanvas.rs
@@ -139,6 +139,7 @@ impl OffscreenCanvas {
 }
 
 impl OffscreenCanvasMethods for OffscreenCanvas {
+    // https://html.spec.whatwg.org/multipage/#dom-offscreencanvas
     fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,

--- a/components/script/dom/offscreencanvas.rs
+++ b/components/script/dom/offscreencanvas.rs
@@ -73,18 +73,6 @@ impl OffscreenCanvas {
         )
     }
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
-        global: &GlobalScope,
-        proto: Option<HandleObject>,
-        can_gc: CanGc,
-        width: u64,
-        height: u64,
-    ) -> Fallible<DomRoot<OffscreenCanvas>> {
-        let offscreencanvas = OffscreenCanvas::new(global, proto, width, height, None, can_gc);
-        Ok(offscreencanvas)
-    }
-
     pub fn get_size(&self) -> Size2D<u64> {
         Size2D::new(self.Width(), self.Height())
     }
@@ -151,6 +139,17 @@ impl OffscreenCanvas {
 }
 
 impl OffscreenCanvasMethods for OffscreenCanvas {
+    fn Constructor(
+        global: &GlobalScope,
+        proto: Option<HandleObject>,
+        can_gc: CanGc,
+        width: u64,
+        height: u64,
+    ) -> Fallible<DomRoot<OffscreenCanvas>> {
+        let offscreencanvas = OffscreenCanvas::new(global, proto, width, height, None, can_gc);
+        Ok(offscreencanvas)
+    }
+
     // https://html.spec.whatwg.org/multipage/#dom-offscreencanvas-getcontext
     fn GetContext(
         &self,

--- a/components/script/dom/oscillatornode.rs
+++ b/components/script/dom/oscillatornode.rs
@@ -114,6 +114,7 @@ impl OscillatorNode {
 }
 
 impl OscillatorNodeMethods for OscillatorNode {
+    // https://webaudio.github.io/web-audio-api/#dom-oscillatornode-oscillatornode
     fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/oscillatornode.rs
+++ b/components/script/dom/oscillatornode.rs
@@ -111,9 +111,10 @@ impl OscillatorNode {
             can_gc,
         ))
     }
+}
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+impl OscillatorNodeMethods for OscillatorNode {
+    fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -122,9 +123,7 @@ impl OscillatorNode {
     ) -> Fallible<DomRoot<OscillatorNode>> {
         OscillatorNode::new_with_proto(window, proto, context, options, can_gc)
     }
-}
 
-impl OscillatorNodeMethods for OscillatorNode {
     // https://webaudio.github.io/web-audio-api/#dom-oscillatornode-frequency
     fn Frequency(&self) -> DomRoot<AudioParam> {
         DomRoot::from_ref(&self.frequency)

--- a/components/script/dom/pagetransitionevent.rs
+++ b/components/script/dom/pagetransitionevent.rs
@@ -83,9 +83,10 @@ impl PageTransitionEvent {
         }
         ev
     }
+}
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+impl PageTransitionEventMethods for PageTransitionEvent {
+    fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -102,9 +103,7 @@ impl PageTransitionEvent {
             can_gc,
         ))
     }
-}
 
-impl PageTransitionEventMethods for PageTransitionEvent {
     // https://html.spec.whatwg.org/multipage/#dom-pagetransitionevent-persisted
     fn Persisted(&self) -> bool {
         self.persisted.get()

--- a/components/script/dom/pagetransitionevent.rs
+++ b/components/script/dom/pagetransitionevent.rs
@@ -86,6 +86,7 @@ impl PageTransitionEvent {
 }
 
 impl PageTransitionEventMethods for PageTransitionEvent {
+    // https://html.spec.whatwg.org/multipage/#pagetransitionevent
     fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/pannernode.rs
+++ b/components/script/dom/pannernode.rs
@@ -204,9 +204,10 @@ impl PannerNode {
             can_gc,
         ))
     }
+}
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+impl PannerNodeMethods for PannerNode {
+    fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -215,9 +216,7 @@ impl PannerNode {
     ) -> Fallible<DomRoot<PannerNode>> {
         PannerNode::new_with_proto(window, proto, context, options, can_gc)
     }
-}
 
-impl PannerNodeMethods for PannerNode {
     // https://webaudio.github.io/web-audio-api/#dom-pannernode-positionx
     fn PositionX(&self) -> DomRoot<AudioParam> {
         DomRoot::from_ref(&self.position_x)

--- a/components/script/dom/pannernode.rs
+++ b/components/script/dom/pannernode.rs
@@ -207,6 +207,7 @@ impl PannerNode {
 }
 
 impl PannerNodeMethods for PannerNode {
+    // https://webaudio.github.io/web-audio-api/#dom-pannernode-pannernode
     fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/performanceobserver.rs
+++ b/components/script/dom/performanceobserver.rs
@@ -119,6 +119,7 @@ impl PerformanceObserver {
 }
 
 impl PerformanceObserverMethods for PerformanceObserver {
+    // https://w3c.github.io/performance-timeline/#dom-performanceobserver-constructor
     fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,

--- a/components/script/dom/performanceobserver.rs
+++ b/components/script/dom/performanceobserver.rs
@@ -86,22 +86,6 @@ impl PerformanceObserver {
         reflect_dom_object_with_proto(Box::new(observer), global, proto, can_gc)
     }
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
-        global: &GlobalScope,
-        proto: Option<HandleObject>,
-        can_gc: CanGc,
-        callback: Rc<PerformanceObserverCallback>,
-    ) -> Fallible<DomRoot<PerformanceObserver>> {
-        Ok(PerformanceObserver::new_with_proto(
-            global,
-            proto,
-            callback,
-            Vec::new(),
-            can_gc,
-        ))
-    }
-
     /// Buffer a new performance entry.
     pub fn queue_entry(&self, entry: &PerformanceEntry) {
         self.entries.borrow_mut().push(DomRoot::from_ref(entry));
@@ -132,17 +116,31 @@ impl PerformanceObserver {
     pub fn set_entries(&self, entries: DOMPerformanceEntryList) {
         *self.entries.borrow_mut() = entries;
     }
+}
+
+impl PerformanceObserverMethods for PerformanceObserver {
+    fn Constructor(
+        global: &GlobalScope,
+        proto: Option<HandleObject>,
+        can_gc: CanGc,
+        callback: Rc<PerformanceObserverCallback>,
+    ) -> Fallible<DomRoot<PerformanceObserver>> {
+        Ok(PerformanceObserver::new_with_proto(
+            global,
+            proto,
+            callback,
+            Vec::new(),
+            can_gc,
+        ))
+    }
 
     // https://w3c.github.io/performance-timeline/#supportedentrytypes-attribute
-    #[allow(non_snake_case)]
-    pub fn SupportedEntryTypes(cx: JSContext, global: &GlobalScope) -> JSVal {
+    fn SupportedEntryTypes(cx: JSContext, global: &GlobalScope) -> JSVal {
         // While this is exposed through a method of PerformanceObserver,
         // it is specified as associated with the global scope.
         global.supported_performance_entry_types(cx)
     }
-}
 
-impl PerformanceObserverMethods for PerformanceObserver {
     // https://w3c.github.io/performance-timeline/#dom-performanceobserver-observe()
     fn Observe(&self, options: &PerformanceObserverInit) -> Fallible<()> {
         // Step 1 is self

--- a/components/script/dom/popstateevent.rs
+++ b/components/script/dom/popstateevent.rs
@@ -84,6 +84,7 @@ impl PopStateEvent {
 }
 
 impl PopStateEventMethods for PopStateEvent {
+    // https://html.spec.whatwg.org/multipage/#popstateevent
     fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/popstateevent.rs
+++ b/components/script/dom/popstateevent.rs
@@ -69,8 +69,22 @@ impl PopStateEvent {
         ev
     }
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+    pub fn dispatch_jsval(target: &EventTarget, window: &Window, state: HandleValue) {
+        let event = PopStateEvent::new(
+            window,
+            None,
+            atom!("popstate"),
+            false,
+            false,
+            state,
+            CanGc::note(),
+        );
+        event.upcast::<Event>().fire(target);
+    }
+}
+
+impl PopStateEventMethods for PopStateEvent {
+    fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -88,21 +102,6 @@ impl PopStateEvent {
         ))
     }
 
-    pub fn dispatch_jsval(target: &EventTarget, window: &Window, state: HandleValue) {
-        let event = PopStateEvent::new(
-            window,
-            None,
-            atom!("popstate"),
-            false,
-            false,
-            state,
-            CanGc::note(),
-        );
-        event.upcast::<Event>().fire(target);
-    }
-}
-
-impl PopStateEventMethods for PopStateEvent {
     // https://html.spec.whatwg.org/multipage/#dom-popstateevent-state
     fn State(&self, _cx: JSContext) -> JSVal {
         self.state.get()

--- a/components/script/dom/progressevent.rs
+++ b/components/script/dom/progressevent.rs
@@ -89,6 +89,7 @@ impl ProgressEvent {
 }
 
 impl ProgressEventMethods for ProgressEvent {
+    // https://xhr.spec.whatwg.org/#dom-progressevent-progressevent
     fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,

--- a/components/script/dom/progressevent.rs
+++ b/components/script/dom/progressevent.rs
@@ -86,9 +86,10 @@ impl ProgressEvent {
         }
         ev
     }
+}
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+impl ProgressEventMethods for ProgressEvent {
+    fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -110,9 +111,7 @@ impl ProgressEvent {
         );
         Ok(ev)
     }
-}
 
-impl ProgressEventMethods for ProgressEvent {
     // https://xhr.spec.whatwg.org/#dom-progressevent-lengthcomputable
     fn LengthComputable(&self) -> bool {
         self.length_computable

--- a/components/script/dom/promiserejectionevent.rs
+++ b/components/script/dom/promiserejectionevent.rs
@@ -92,9 +92,10 @@ impl PromiseRejectionEvent {
         }
         ev
     }
+}
 
-    #[allow(crown::unrooted_must_root, non_snake_case)]
-    pub fn Constructor(
+impl PromiseRejectionEventMethods for PromiseRejectionEvent {
+    fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -117,9 +118,7 @@ impl PromiseRejectionEvent {
         );
         Ok(event)
     }
-}
 
-impl PromiseRejectionEventMethods for PromiseRejectionEvent {
     // https://html.spec.whatwg.org/multipage/#dom-promiserejectionevent-promise
     fn Promise(&self, _cx: JSContext) -> NonNull<JSObject> {
         NonNull::new(self.promise.get()).unwrap()

--- a/components/script/dom/promiserejectionevent.rs
+++ b/components/script/dom/promiserejectionevent.rs
@@ -95,6 +95,7 @@ impl PromiseRejectionEvent {
 }
 
 impl PromiseRejectionEventMethods for PromiseRejectionEvent {
+    // https://html.spec.whatwg.org/multipage/#promiserejectionevent
     fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,

--- a/components/script/dom/radionodelist.rs
+++ b/components/script/dom/radionodelist.rs
@@ -61,16 +61,15 @@ impl RadioNodeList {
             NodeListType::Radio(RadioList::new(form, RadioListMode::Images, name.clone())),
         )
     }
-
-    // https://dom.spec.whatwg.org/#dom-nodelist-length
-    // https://github.com/servo/servo/issues/5875
-    #[allow(non_snake_case)]
-    pub fn Length(&self) -> u32 {
-        self.node_list.Length()
-    }
 }
 
 impl RadioNodeListMethods for RadioNodeList {
+    // https://dom.spec.whatwg.org/#dom-nodelist-length
+    // https://github.com/servo/servo/issues/5875
+    fn Length(&self) -> u32 {
+        self.node_list.Length()
+    }
+
     // https://html.spec.whatwg.org/multipage/#dom-radionodelist-value
     fn Value(&self) -> DOMString {
         self.upcast::<NodeList>()

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -127,17 +127,6 @@ impl Range {
         range
     }
 
-    /// <https://dom.spec.whatwg.org/#dom-range>
-    #[allow(non_snake_case)]
-    pub fn Constructor(
-        window: &Window,
-        proto: Option<HandleObject>,
-        can_gc: CanGc,
-    ) -> Fallible<DomRoot<Range>> {
-        let document = window.Document();
-        Ok(Range::new_with_doc(&document, proto, can_gc))
-    }
-
     /// <https://dom.spec.whatwg.org/#contained>
     fn contains(&self, node: &Node) -> bool {
         matches!(
@@ -338,6 +327,16 @@ impl Range {
 }
 
 impl RangeMethods for Range {
+    /// <https://dom.spec.whatwg.org/#dom-range>
+    fn Constructor(
+        window: &Window,
+        proto: Option<HandleObject>,
+        can_gc: CanGc,
+    ) -> Fallible<DomRoot<Range>> {
+        let document = window.Document();
+        Ok(Range::new_with_doc(&document, proto, can_gc))
+    }
+
     /// <https://dom.spec.whatwg.org/#dom-range-commonancestorcontainer>
     fn CommonAncestorContainer(&self) -> DomRoot<Node> {
         self.end_container()

--- a/components/script/dom/request.rs
+++ b/components/script/dom/request.rs
@@ -74,9 +74,89 @@ impl Request {
         )
     }
 
+    fn from_net_request(
+        global: &GlobalScope,
+        proto: Option<HandleObject>,
+        net_request: NetTraitsRequest,
+        can_gc: CanGc,
+    ) -> DomRoot<Request> {
+        let r = Request::new(global, proto, net_request.current_url(), can_gc);
+        *r.request.borrow_mut() = net_request;
+        r
+    }
+
+    fn clone_from(r: &Request, can_gc: CanGc) -> Fallible<DomRoot<Request>> {
+        let req = r.request.borrow();
+        let url = req.url();
+        let headers_guard = r.Headers().get_guard();
+        let r_clone = Request::new(&r.global(), None, url, can_gc);
+        r_clone.request.borrow_mut().pipeline_id = req.pipeline_id;
+        {
+            let mut borrowed_r_request = r_clone.request.borrow_mut();
+            borrowed_r_request.origin = req.origin.clone();
+        }
+        *r_clone.request.borrow_mut() = req.clone();
+        r_clone.Headers().copy_from_headers(r.Headers())?;
+        r_clone.Headers().set_guard(headers_guard);
+        Ok(r_clone)
+    }
+
+    pub fn get_request(&self) -> NetTraitsRequest {
+        self.request.borrow().clone()
+    }
+}
+
+fn net_request_from_global(global: &GlobalScope, url: ServoUrl) -> NetTraitsRequest {
+    let origin = Origin::Origin(global.get_url().origin());
+    let https_state = global.get_https_state();
+    let pipeline_id = global.pipeline_id();
+    let referrer = global.get_referrer();
+    NetTraitsRequest::new(url, Some(origin), referrer, Some(pipeline_id), https_state)
+}
+
+// https://fetch.spec.whatwg.org/#concept-method-normalize
+fn normalize_method(m: &str) -> Result<HttpMethod, InvalidMethod> {
+    match_ignore_ascii_case! { m,
+        "delete" => return Ok(HttpMethod::DELETE),
+        "get" => return Ok(HttpMethod::GET),
+        "head" => return Ok(HttpMethod::HEAD),
+        "options" => return Ok(HttpMethod::OPTIONS),
+        "post" => return Ok(HttpMethod::POST),
+        "put" => return Ok(HttpMethod::PUT),
+        _ => (),
+    }
+    debug!("Method: {:?}", m);
+    HttpMethod::from_str(m)
+}
+
+// https://fetch.spec.whatwg.org/#concept-method
+fn is_method(m: &ByteString) -> bool {
+    m.as_str().is_some()
+}
+
+// https://fetch.spec.whatwg.org/#cors-safelisted-method
+fn is_cors_safelisted_method(m: &HttpMethod) -> bool {
+    m == HttpMethod::GET || m == HttpMethod::HEAD || m == HttpMethod::POST
+}
+
+// https://url.spec.whatwg.org/#include-credentials
+fn includes_credentials(input: &ServoUrl) -> bool {
+    !input.username().is_empty() || input.password().is_some()
+}
+
+// https://fetch.spec.whatwg.org/#concept-body-disturbed
+fn request_is_disturbed(input: &Request) -> bool {
+    input.is_disturbed()
+}
+
+// https://fetch.spec.whatwg.org/#concept-body-locked
+fn request_is_locked(input: &Request) -> bool {
+    input.is_locked()
+}
+
+impl RequestMethods for Request {
     // https://fetch.spec.whatwg.org/#dom-request
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+    fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -441,90 +521,7 @@ impl Request {
         // Step 42
         Ok(r)
     }
-}
 
-impl Request {
-    fn from_net_request(
-        global: &GlobalScope,
-        proto: Option<HandleObject>,
-        net_request: NetTraitsRequest,
-        can_gc: CanGc,
-    ) -> DomRoot<Request> {
-        let r = Request::new(global, proto, net_request.current_url(), can_gc);
-        *r.request.borrow_mut() = net_request;
-        r
-    }
-
-    fn clone_from(r: &Request, can_gc: CanGc) -> Fallible<DomRoot<Request>> {
-        let req = r.request.borrow();
-        let url = req.url();
-        let headers_guard = r.Headers().get_guard();
-        let r_clone = Request::new(&r.global(), None, url, can_gc);
-        r_clone.request.borrow_mut().pipeline_id = req.pipeline_id;
-        {
-            let mut borrowed_r_request = r_clone.request.borrow_mut();
-            borrowed_r_request.origin = req.origin.clone();
-        }
-        *r_clone.request.borrow_mut() = req.clone();
-        r_clone.Headers().copy_from_headers(r.Headers())?;
-        r_clone.Headers().set_guard(headers_guard);
-        Ok(r_clone)
-    }
-
-    pub fn get_request(&self) -> NetTraitsRequest {
-        self.request.borrow().clone()
-    }
-}
-
-fn net_request_from_global(global: &GlobalScope, url: ServoUrl) -> NetTraitsRequest {
-    let origin = Origin::Origin(global.get_url().origin());
-    let https_state = global.get_https_state();
-    let pipeline_id = global.pipeline_id();
-    let referrer = global.get_referrer();
-    NetTraitsRequest::new(url, Some(origin), referrer, Some(pipeline_id), https_state)
-}
-
-// https://fetch.spec.whatwg.org/#concept-method-normalize
-fn normalize_method(m: &str) -> Result<HttpMethod, InvalidMethod> {
-    match_ignore_ascii_case! { m,
-        "delete" => return Ok(HttpMethod::DELETE),
-        "get" => return Ok(HttpMethod::GET),
-        "head" => return Ok(HttpMethod::HEAD),
-        "options" => return Ok(HttpMethod::OPTIONS),
-        "post" => return Ok(HttpMethod::POST),
-        "put" => return Ok(HttpMethod::PUT),
-        _ => (),
-    }
-    debug!("Method: {:?}", m);
-    HttpMethod::from_str(m)
-}
-
-// https://fetch.spec.whatwg.org/#concept-method
-fn is_method(m: &ByteString) -> bool {
-    m.as_str().is_some()
-}
-
-// https://fetch.spec.whatwg.org/#cors-safelisted-method
-fn is_cors_safelisted_method(m: &HttpMethod) -> bool {
-    m == HttpMethod::GET || m == HttpMethod::HEAD || m == HttpMethod::POST
-}
-
-// https://url.spec.whatwg.org/#include-credentials
-fn includes_credentials(input: &ServoUrl) -> bool {
-    !input.username().is_empty() || input.password().is_some()
-}
-
-// https://fetch.spec.whatwg.org/#concept-body-disturbed
-fn request_is_disturbed(input: &Request) -> bool {
-    input.is_disturbed()
-}
-
-// https://fetch.spec.whatwg.org/#concept-body-locked
-fn request_is_locked(input: &Request) -> bool {
-    input.is_locked()
-}
-
-impl RequestMethods for Request {
     // https://fetch.spec.whatwg.org/#dom-request-method
     fn Method(&self) -> ByteString {
         let r = self.request.borrow();

--- a/components/script/dom/resizeobserver.rs
+++ b/components/script/dom/resizeobserver.rs
@@ -68,20 +68,6 @@ impl ResizeObserver {
         reflect_dom_object_with_proto(observer, window, proto, can_gc)
     }
 
-    /// <https://drafts.csswg.org/resize-observer/#dom-resizeobserver-resizeobserver>
-    #[allow(non_snake_case)]
-    pub fn Constructor(
-        window: &Window,
-        proto: Option<HandleObject>,
-        can_gc: CanGc,
-        callback: Rc<ResizeObserverCallback>,
-    ) -> DomRoot<ResizeObserver> {
-        let rooted_observer = ResizeObserver::new(window, proto, callback, can_gc);
-        let document = window.Document();
-        document.add_resize_observer(&rooted_observer);
-        rooted_observer
-    }
-
     /// <https://drafts.csswg.org/resize-observer/#gather-active-observations-h>
     /// <https://drafts.csswg.org/resize-observer/#has-active-resize-observations>
     pub fn gather_active_resize_observations_at_depth(
@@ -169,6 +155,19 @@ impl ResizeObserver {
 }
 
 impl ResizeObserverMethods for ResizeObserver {
+    /// <https://drafts.csswg.org/resize-observer/#dom-resizeobserver-resizeobserver>
+    fn Constructor(
+        window: &Window,
+        proto: Option<HandleObject>,
+        can_gc: CanGc,
+        callback: Rc<ResizeObserverCallback>,
+    ) -> DomRoot<ResizeObserver> {
+        let rooted_observer = ResizeObserver::new(window, proto, callback, can_gc);
+        let document = window.Document();
+        document.add_resize_observer(&rooted_observer);
+        rooted_observer
+    }
+
     /// <https://drafts.csswg.org/resize-observer/#dom-resizeobserver-observe>
     fn Observe(&self, target: &Element, options: &ResizeObserverOptions) {
         let is_present = self

--- a/components/script/dom/rtcdatachannelevent.rs
+++ b/components/script/dom/rtcdatachannelevent.rs
@@ -76,6 +76,7 @@ impl RTCDataChannelEvent {
 }
 
 impl RTCDataChannelEventMethods for RTCDataChannelEvent {
+    // https://www.w3.org/TR/webrtc/#dom-rtcdatachannelevent-constructor
     fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/rtcdatachannelevent.rs
+++ b/components/script/dom/rtcdatachannelevent.rs
@@ -73,9 +73,10 @@ impl RTCDataChannelEvent {
         }
         event
     }
+}
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+impl RTCDataChannelEventMethods for RTCDataChannelEvent {
+    fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -92,9 +93,7 @@ impl RTCDataChannelEvent {
             can_gc,
         )
     }
-}
 
-impl RTCDataChannelEventMethods for RTCDataChannelEvent {
     // https://www.w3.org/TR/webrtc/#dom-datachannelevent-channel
     fn Channel(&self) -> DomRoot<RTCDataChannel> {
         DomRoot::from_ref(&*self.channel)

--- a/components/script/dom/rtcerror.rs
+++ b/components/script/dom/rtcerror.rs
@@ -61,9 +61,10 @@ impl RTCError {
             can_gc,
         )
     }
+}
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+impl RTCErrorMethods for RTCError {
+    fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -72,9 +73,7 @@ impl RTCError {
     ) -> DomRoot<RTCError> {
         RTCError::new_with_proto(&window.global(), proto, init, message, can_gc)
     }
-}
 
-impl RTCErrorMethods for RTCError {
     // https://www.w3.org/TR/webrtc/#dom-rtcerror-errordetail
     fn ErrorDetail(&self) -> RTCErrorDetailType {
         self.error_detail

--- a/components/script/dom/rtcerror.rs
+++ b/components/script/dom/rtcerror.rs
@@ -64,6 +64,7 @@ impl RTCError {
 }
 
 impl RTCErrorMethods for RTCError {
+    // https://www.w3.org/TR/webrtc/#dom-rtcerror-constructor
     fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/rtcerrorevent.rs
+++ b/components/script/dom/rtcerrorevent.rs
@@ -76,6 +76,7 @@ impl RTCErrorEvent {
 }
 
 impl RTCErrorEventMethods for RTCErrorEvent {
+    // https://www.w3.org/TR/webrtc/#dom-rtcerrorevent-constructor
     fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/rtcerrorevent.rs
+++ b/components/script/dom/rtcerrorevent.rs
@@ -73,9 +73,10 @@ impl RTCErrorEvent {
         }
         event
     }
+}
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+impl RTCErrorEventMethods for RTCErrorEvent {
+    fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -92,9 +93,7 @@ impl RTCErrorEvent {
             can_gc,
         )
     }
-}
 
-impl RTCErrorEventMethods for RTCErrorEvent {
     // https://www.w3.org/TR/webrtc/#dom-rtcerrorevent-error
     fn Error(&self) -> DomRoot<RTCError> {
         DomRoot::from_ref(&*self.error)

--- a/components/script/dom/rtcicecandidate.rs
+++ b/components/script/dom/rtcicecandidate.rs
@@ -83,6 +83,7 @@ impl RTCIceCandidate {
 }
 
 impl RTCIceCandidateMethods for RTCIceCandidate {
+    /// <https://w3c.github.io/webrtc-pc/#dom-rtcicecandidate-constructor>
     fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/rtcicecandidate.rs
+++ b/components/script/dom/rtcicecandidate.rs
@@ -80,9 +80,10 @@ impl RTCIceCandidate {
             can_gc,
         )
     }
+}
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+impl RTCIceCandidateMethods for RTCIceCandidate {
+    fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -103,9 +104,7 @@ impl RTCIceCandidate {
             can_gc,
         ))
     }
-}
 
-impl RTCIceCandidateMethods for RTCIceCandidate {
     /// <https://w3c.github.io/webrtc-pc/#dom-rtcicecandidate-candidate>
     fn Candidate(&self) -> DOMString {
         self.candidate.clone()

--- a/components/script/dom/rtcpeerconnection.rs
+++ b/components/script/dom/rtcpeerconnection.rs
@@ -26,7 +26,7 @@ use crate::dom::bindings::codegen::Bindings::RTCPeerConnectionBinding::{
     RTCSignalingState,
 };
 use crate::dom::bindings::codegen::Bindings::RTCSessionDescriptionBinding::{
-    RTCSdpType, RTCSessionDescriptionInit,
+    RTCSdpType, RTCSessionDescriptionInit, RTCSessionDescriptionMethods,
 };
 use crate::dom::bindings::codegen::UnionTypes::{MediaStreamTrackOrString, StringOrStringSequence};
 use crate::dom::bindings::error::{Error, Fallible};
@@ -229,21 +229,6 @@ impl RTCPeerConnection {
             }
         }
         this
-    }
-
-    #[allow(non_snake_case)]
-    pub fn Constructor(
-        window: &Window,
-        proto: Option<HandleObject>,
-        can_gc: CanGc,
-        config: &RTCConfiguration,
-    ) -> Fallible<DomRoot<RTCPeerConnection>> {
-        Ok(RTCPeerConnection::new(
-            &window.global(),
-            proto,
-            config,
-            can_gc,
-        ))
     }
 
     pub fn get_webrtc_controller(&self) -> &DomRefCell<Option<WebRtcController>> {
@@ -525,6 +510,20 @@ impl RTCPeerConnection {
 }
 
 impl RTCPeerConnectionMethods for RTCPeerConnection {
+    fn Constructor(
+        window: &Window,
+        proto: Option<HandleObject>,
+        can_gc: CanGc,
+        config: &RTCConfiguration,
+    ) -> Fallible<DomRoot<RTCPeerConnection>> {
+        Ok(RTCPeerConnection::new(
+            &window.global(),
+            proto,
+            config,
+            can_gc,
+        ))
+    }
+
     // https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnection-icecandidate
     event_handler!(icecandidate, GetOnicecandidate, SetOnicecandidate);
 

--- a/components/script/dom/rtcpeerconnection.rs
+++ b/components/script/dom/rtcpeerconnection.rs
@@ -510,6 +510,7 @@ impl RTCPeerConnection {
 }
 
 impl RTCPeerConnectionMethods for RTCPeerConnection {
+    // https://w3c.github.io/webrtc-pc/#dom-peerconnection
     fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/rtcpeerconnectioniceevent.rs
+++ b/components/script/dom/rtcpeerconnectioniceevent.rs
@@ -73,6 +73,7 @@ impl RTCPeerConnectionIceEvent {
 }
 
 impl RTCPeerConnectionIceEventMethods for RTCPeerConnectionIceEvent {
+    /// <https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnectioniceevent-constructor>
     fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/rtcpeerconnectioniceevent.rs
+++ b/components/script/dom/rtcpeerconnectioniceevent.rs
@@ -70,9 +70,10 @@ impl RTCPeerConnectionIceEvent {
         evt.set_trusted(trusted);
         e
     }
+}
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+impl RTCPeerConnectionIceEventMethods for RTCPeerConnectionIceEvent {
+    fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -92,9 +93,7 @@ impl RTCPeerConnectionIceEvent {
             can_gc,
         ))
     }
-}
 
-impl RTCPeerConnectionIceEventMethods for RTCPeerConnectionIceEvent {
     /// <https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnectioniceevent-candidate>
     fn GetCandidate(&self) -> Option<DomRoot<RTCIceCandidate>> {
         self.candidate.as_ref().map(|x| DomRoot::from_ref(&**x))

--- a/components/script/dom/rtcsessiondescription.rs
+++ b/components/script/dom/rtcsessiondescription.rs
@@ -46,9 +46,10 @@ impl RTCSessionDescription {
             can_gc,
         )
     }
+}
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+impl RTCSessionDescriptionMethods for RTCSessionDescription {
+    fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -62,9 +63,7 @@ impl RTCSessionDescription {
             can_gc,
         ))
     }
-}
 
-impl RTCSessionDescriptionMethods for RTCSessionDescription {
     /// <https://w3c.github.io/webrtc-pc/#dom-rtcsessiondescription-type>
     fn Type(&self) -> RTCSdpType {
         self.ty

--- a/components/script/dom/rtcsessiondescription.rs
+++ b/components/script/dom/rtcsessiondescription.rs
@@ -49,6 +49,7 @@ impl RTCSessionDescription {
 }
 
 impl RTCSessionDescriptionMethods for RTCSessionDescription {
+    /// <https://w3c.github.io/webrtc-pc/#dom-sessiondescription>
     fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/rtctrackevent.rs
+++ b/components/script/dom/rtctrackevent.rs
@@ -76,6 +76,7 @@ impl RTCTrackEvent {
 }
 
 impl RTCTrackEventMethods for RTCTrackEvent {
+    // https://w3c.github.io/webrtc-pc/#dom-rtctrackevent-constructor
     fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/rtctrackevent.rs
+++ b/components/script/dom/rtctrackevent.rs
@@ -73,9 +73,10 @@ impl RTCTrackEvent {
         }
         trackevent
     }
+}
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+impl RTCTrackEventMethods for RTCTrackEvent {
+    fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -92,9 +93,7 @@ impl RTCTrackEvent {
             can_gc,
         ))
     }
-}
 
-impl RTCTrackEventMethods for RTCTrackEvent {
     // https://w3c.github.io/webrtc-pc/#dom-rtctrackevent-track
     fn Track(&self) -> DomRoot<MediaStreamTrack> {
         DomRoot::from_ref(&*self.track)

--- a/components/script/dom/securitypolicyviolationevent.rs
+++ b/components/script/dom/securitypolicyviolationevent.rs
@@ -104,9 +104,11 @@ impl SecurityPolicyViolationEvent {
             CanGc::note(),
         )
     }
+}
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+#[allow(non_snake_case)]
+impl SecurityPolicyViolationEventMethods for SecurityPolicyViolationEvent {
+    fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -123,10 +125,7 @@ impl SecurityPolicyViolationEvent {
             can_gc,
         )
     }
-}
 
-#[allow(non_snake_case)]
-impl SecurityPolicyViolationEventMethods for SecurityPolicyViolationEvent {
     /// <https://w3c.github.io/webappsec-csp/#dom-securitypolicyviolationevent-documenturi>
     fn DocumentURI(&self) -> USVString {
         self.document_uri.clone()

--- a/components/script/dom/securitypolicyviolationevent.rs
+++ b/components/script/dom/securitypolicyviolationevent.rs
@@ -108,6 +108,7 @@ impl SecurityPolicyViolationEvent {
 
 #[allow(non_snake_case)]
 impl SecurityPolicyViolationEventMethods for SecurityPolicyViolationEvent {
+    /// <https://w3c.github.io/webappsec-csp/#dom-securitypolicyviolationevent-securitypolicyviolationevent>
     fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,

--- a/components/script/dom/stereopannernode.rs
+++ b/components/script/dom/stereopannernode.rs
@@ -101,6 +101,7 @@ impl StereoPannerNode {
 }
 
 impl StereoPannerNodeMethods for StereoPannerNode {
+    // https://webaudio.github.io/web-audio-api/#dom-stereopannernode-stereopannernode
     fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/stereopannernode.rs
+++ b/components/script/dom/stereopannernode.rs
@@ -98,9 +98,10 @@ impl StereoPannerNode {
             can_gc,
         ))
     }
+}
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+impl StereoPannerNodeMethods for StereoPannerNode {
+    fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -109,9 +110,7 @@ impl StereoPannerNode {
     ) -> Fallible<DomRoot<StereoPannerNode>> {
         StereoPannerNode::new_with_proto(window, proto, context, options, can_gc)
     }
-}
 
-impl StereoPannerNodeMethods for StereoPannerNode {
     // https://webaudio.github.io/web-audio-api/#dom-stereopannernode-pan
     fn Pan(&self) -> DomRoot<AudioParam> {
         DomRoot::from_ref(&self.pan)

--- a/components/script/dom/storageevent.rs
+++ b/components/script/dom/storageevent.rs
@@ -126,8 +126,11 @@ impl StorageEvent {
         }
         ev
     }
+}
 
-    pub fn Constructor(
+#[allow(non_snake_case)]
+impl StorageEventMethods for StorageEvent {
+    fn Constructor(
         global: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -156,10 +159,7 @@ impl StorageEvent {
         );
         Ok(event)
     }
-}
 
-#[allow(non_snake_case)]
-impl StorageEventMethods for StorageEvent {
     // https://html.spec.whatwg.org/multipage/#dom-storageevent-key
     fn GetKey(&self) -> Option<DOMString> {
         self.key.borrow().clone()

--- a/components/script/dom/storageevent.rs
+++ b/components/script/dom/storageevent.rs
@@ -130,6 +130,7 @@ impl StorageEvent {
 
 #[allow(non_snake_case)]
 impl StorageEventMethods for StorageEvent {
+    // https://html.spec.whatwg.org/multipage/#storageevent
     fn Constructor(
         global: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/submitevent.rs
+++ b/components/script/dom/submitevent.rs
@@ -73,9 +73,10 @@ impl SubmitEvent {
         }
         ev
     }
+}
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+impl SubmitEventMethods for SubmitEvent {
+    fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -92,9 +93,7 @@ impl SubmitEvent {
             can_gc,
         )
     }
-}
 
-impl SubmitEventMethods for SubmitEvent {
     /// <https://dom.spec.whatwg.org/#dom-event-istrusted>
     fn IsTrusted(&self) -> bool {
         self.event.IsTrusted()

--- a/components/script/dom/submitevent.rs
+++ b/components/script/dom/submitevent.rs
@@ -76,6 +76,7 @@ impl SubmitEvent {
 }
 
 impl SubmitEventMethods for SubmitEvent {
+    /// <https://html.spec.whatwg.org/multipage/#submitevent>
     fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/testbinding.rs
+++ b/components/script/dom/testbinding.rs
@@ -79,8 +79,10 @@ impl TestBinding {
             can_gc,
         )
     }
+}
 
-    pub fn Constructor(
+impl TestBindingMethods for TestBinding {
+    fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -89,7 +91,7 @@ impl TestBinding {
     }
 
     #[allow(unused_variables)]
-    pub fn Constructor_(
+    fn Constructor_(
         global: &GlobalScope,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -99,7 +101,7 @@ impl TestBinding {
     }
 
     #[allow(unused_variables)]
-    pub fn Constructor__(
+    fn Constructor__(
         global: &GlobalScope,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -107,9 +109,7 @@ impl TestBinding {
     ) -> Fallible<DomRoot<TestBinding>> {
         Ok(TestBinding::new(global, proto, can_gc))
     }
-}
 
-impl TestBindingMethods for TestBinding {
     fn BooleanAttribute(&self) -> bool {
         false
     }
@@ -1108,42 +1108,36 @@ impl TestBindingMethods for TestBinding {
     fn MethodInternalThrowToRejectPromise(&self, _arg: u64) -> Rc<Promise> {
         unreachable!("Method should already throw")
     }
-}
 
-#[allow(non_snake_case)]
-impl TestBinding {
-    pub fn StaticThrowToRejectPromise(_: &GlobalScope) -> Fallible<Rc<Promise>> {
+    fn StaticThrowToRejectPromise(_: &GlobalScope) -> Fallible<Rc<Promise>> {
         Err(Error::Type("test".to_string()))
     }
 
-    pub fn StaticInternalThrowToRejectPromise(_: &GlobalScope, _arg: u64) -> Rc<Promise> {
+    fn StaticInternalThrowToRejectPromise(_: &GlobalScope, _arg: u64) -> Rc<Promise> {
         unreachable!("Method should already throw")
     }
-}
 
-#[allow(non_snake_case)]
-impl TestBinding {
-    pub fn BooleanAttributeStatic(_: &GlobalScope) -> bool {
+    fn BooleanAttributeStatic(_: &GlobalScope) -> bool {
         false
     }
-    pub fn SetBooleanAttributeStatic(_: &GlobalScope, _: bool) {}
-    pub fn ReceiveVoidStatic(_: &GlobalScope) {}
-    pub fn PrefControlledStaticAttributeDisabled(_: &GlobalScope) -> bool {
+    fn SetBooleanAttributeStatic(_: &GlobalScope, _: bool) {}
+    fn ReceiveVoidStatic(_: &GlobalScope) {}
+    fn PrefControlledStaticAttributeDisabled(_: &GlobalScope) -> bool {
         false
     }
-    pub fn PrefControlledStaticAttributeEnabled(_: &GlobalScope) -> bool {
+    fn PrefControlledStaticAttributeEnabled(_: &GlobalScope) -> bool {
         false
     }
-    pub fn PrefControlledStaticMethodDisabled(_: &GlobalScope) {}
-    pub fn PrefControlledStaticMethodEnabled(_: &GlobalScope) {}
-    pub fn FuncControlledStaticAttributeDisabled(_: &GlobalScope) -> bool {
+    fn PrefControlledStaticMethodDisabled(_: &GlobalScope) {}
+    fn PrefControlledStaticMethodEnabled(_: &GlobalScope) {}
+    fn FuncControlledStaticAttributeDisabled(_: &GlobalScope) -> bool {
         false
     }
-    pub fn FuncControlledStaticAttributeEnabled(_: &GlobalScope) -> bool {
+    fn FuncControlledStaticAttributeEnabled(_: &GlobalScope) -> bool {
         false
     }
-    pub fn FuncControlledStaticMethodDisabled(_: &GlobalScope) {}
-    pub fn FuncControlledStaticMethodEnabled(_: &GlobalScope) {}
+    fn FuncControlledStaticMethodDisabled(_: &GlobalScope) {}
+    fn FuncControlledStaticMethodEnabled(_: &GlobalScope) {}
 }
 
 impl TestBinding {

--- a/components/script/dom/testbindingiterable.rs
+++ b/components/script/dom/testbindingiterable.rs
@@ -38,18 +38,17 @@ impl TestBindingIterable {
             can_gc,
         )
     }
+}
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+impl TestBindingIterableMethods for TestBindingIterable {
+    fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
         can_gc: CanGc,
     ) -> Fallible<DomRoot<TestBindingIterable>> {
         Ok(TestBindingIterable::new(global, proto, can_gc))
     }
-}
 
-impl TestBindingIterableMethods for TestBindingIterable {
     fn Add(&self, v: DOMString) {
         self.vals.borrow_mut().push(v);
     }

--- a/components/script/dom/testbindingmaplike.rs
+++ b/components/script/dom/testbindingmaplike.rs
@@ -44,18 +44,17 @@ impl TestBindingMaplike {
             can_gc,
         )
     }
+}
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+impl TestBindingMaplikeMethods for TestBindingMaplike {
+    fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
         can_gc: CanGc,
     ) -> Fallible<DomRoot<TestBindingMaplike>> {
         Ok(TestBindingMaplike::new(global, proto, can_gc))
     }
-}
 
-impl TestBindingMaplikeMethods for TestBindingMaplike {
     fn SetInternal(&self, key: DOMString, value: i32) {
         self.internal.set(key, value)
     }

--- a/components/script/dom/testbindingpairiterable.rs
+++ b/components/script/dom/testbindingpairiterable.rs
@@ -58,18 +58,17 @@ impl TestBindingPairIterable {
             can_gc,
         )
     }
+}
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+impl TestBindingPairIterableMethods for TestBindingPairIterable {
+    fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
         can_gc: CanGc,
     ) -> Fallible<DomRoot<TestBindingPairIterable>> {
         Ok(TestBindingPairIterable::new(global, proto, can_gc))
     }
-}
 
-impl TestBindingPairIterableMethods for TestBindingPairIterable {
     fn Add(&self, key: DOMString, value: u32) {
         self.map.borrow_mut().push((key, value));
     }

--- a/components/script/dom/testbindingsetlike.rs
+++ b/components/script/dom/testbindingsetlike.rs
@@ -43,18 +43,17 @@ impl TestBindingSetlike {
             can_gc,
         )
     }
+}
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+impl TestBindingSetlikeMethods for TestBindingSetlike {
+    fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
         can_gc: CanGc,
     ) -> Fallible<DomRoot<TestBindingSetlike>> {
         Ok(TestBindingSetlike::new(global, proto, can_gc))
     }
-}
 
-impl TestBindingSetlikeMethods for TestBindingSetlike {
     fn Size(&self) -> u32 {
         self.internal.size()
     }

--- a/components/script/dom/testworklet.rs
+++ b/components/script/dom/testworklet.rs
@@ -46,18 +46,17 @@ impl TestWorklet {
             can_gc,
         )
     }
+}
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+impl TestWorkletMethods for TestWorklet {
+    fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
     ) -> Fallible<DomRoot<TestWorklet>> {
         Ok(TestWorklet::new(window, proto, can_gc))
     }
-}
 
-impl TestWorkletMethods for TestWorklet {
     #[allow(non_snake_case)]
     fn AddModule(
         &self,

--- a/components/script/dom/text.rs
+++ b/components/script/dom/text.rs
@@ -51,6 +51,7 @@ impl Text {
 }
 
 impl TextMethods for Text {
+    // https://dom.spec.whatwg.org/#dom-text-text
     fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/text.rs
+++ b/components/script/dom/text.rs
@@ -48,9 +48,10 @@ impl Text {
             proto,
         )
     }
+}
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+impl TextMethods for Text {
+    fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
         _can_gc: CanGc,
@@ -59,9 +60,7 @@ impl Text {
         let document = window.Document();
         Ok(Text::new_with_proto(text, &document, proto))
     }
-}
 
-impl TextMethods for Text {
     // https://dom.spec.whatwg.org/#dom-text-splittext
     // https://dom.spec.whatwg.org/#concept-text-split
     fn SplitText(&self, offset: u32) -> Fallible<DomRoot<Text>> {

--- a/components/script/dom/textdecoder.rs
+++ b/components/script/dom/textdecoder.rs
@@ -75,9 +75,11 @@ impl TextDecoder {
             can_gc,
         )
     }
+}
 
+impl TextDecoderMethods for TextDecoder {
     /// <https://encoding.spec.whatwg.org/#dom-textdecoder>
-    pub fn Constructor(
+    fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -97,9 +99,7 @@ impl TextDecoder {
             can_gc,
         ))
     }
-}
 
-impl TextDecoderMethods for TextDecoder {
     // https://encoding.spec.whatwg.org/#dom-textdecoder-encoding
     fn Encoding(&self) -> DOMString {
         DOMString::from(self.encoding.name().to_ascii_lowercase())

--- a/components/script/dom/textencoder.rs
+++ b/components/script/dom/textencoder.rs
@@ -46,19 +46,18 @@ impl TextEncoder {
             can_gc,
         )
     }
+}
 
+impl TextEncoderMethods for TextEncoder {
     /// <https://encoding.spec.whatwg.org/#dom-textencoder>
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+    fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
         can_gc: CanGc,
     ) -> Fallible<DomRoot<TextEncoder>> {
         Ok(TextEncoder::new(global, proto, can_gc))
     }
-}
 
-impl TextEncoderMethods for TextEncoder {
     /// <https://encoding.spec.whatwg.org/#dom-textencoder-encoding>
     fn Encoding(&self) -> DOMString {
         DOMString::from("utf-8")

--- a/components/script/dom/trackevent.rs
+++ b/components/script/dom/trackevent.rs
@@ -101,6 +101,7 @@ impl TrackEvent {
 }
 
 impl TrackEventMethods for TrackEvent {
+    // https://html.spec.whatwg.org/multipage/#trackevent
     fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/trackevent.rs
+++ b/components/script/dom/trackevent.rs
@@ -37,9 +37,8 @@ pub struct TrackEvent {
     track: Option<MediaTrack>,
 }
 
-#[allow(non_snake_case)]
 impl TrackEvent {
-    #[allow(crown::unrooted_must_root)]
+    #[allow(crown::unrooted_must_root, non_snake_case)]
     fn new_inherited(track: &Option<VideoTrackOrAudioTrackOrTextTrack>) -> TrackEvent {
         let media_track = match track {
             Some(VideoTrackOrAudioTrackOrTextTrack::VideoTrack(VideoTrack)) => {
@@ -99,8 +98,10 @@ impl TrackEvent {
         }
         te
     }
+}
 
-    pub fn Constructor(
+impl TrackEventMethods for TrackEvent {
+    fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -117,11 +118,9 @@ impl TrackEvent {
             can_gc,
         ))
     }
-}
 
-#[allow(non_snake_case)]
-impl TrackEventMethods for TrackEvent {
     // https://html.spec.whatwg.org/multipage/#dom-trackevent-track
+    #[allow(non_snake_case)]
     fn GetTrack(&self) -> Option<VideoTrackOrAudioTrackOrTextTrack> {
         match &self.track {
             Some(MediaTrack::Video(VideoTrack)) => Some(

--- a/components/script/dom/transitionevent.rs
+++ b/components/script/dom/transitionevent.rs
@@ -69,6 +69,7 @@ impl TransitionEvent {
 }
 
 impl TransitionEventMethods for TransitionEvent {
+    // https://drafts.csswg.org/css-transitions/#dom-transitionevent-transitionevent
     fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/transitionevent.rs
+++ b/components/script/dom/transitionevent.rs
@@ -66,9 +66,10 @@ impl TransitionEvent {
         }
         ev
     }
+}
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+impl TransitionEventMethods for TransitionEvent {
+    fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -83,9 +84,7 @@ impl TransitionEvent {
             can_gc,
         ))
     }
-}
 
-impl TransitionEventMethods for TransitionEvent {
     // https://drafts.csswg.org/css-transitions/#Events-TransitionEvent-propertyName
     fn PropertyName(&self) -> DOMString {
         DOMString::from(&*self.property_name)

--- a/components/script/dom/uievent.rs
+++ b/components/script/dom/uievent.rs
@@ -94,6 +94,7 @@ impl UIEvent {
 }
 
 impl UIEventMethods for UIEvent {
+    /// <https://w3c.github.io/uievents/#dom-uievent-uievent>
     fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/uievent.rs
+++ b/components/script/dom/uievent.rs
@@ -91,9 +91,10 @@ impl UIEvent {
         );
         ev
     }
+}
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+impl UIEventMethods for UIEvent {
+    fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -114,9 +115,7 @@ impl UIEvent {
         );
         Ok(event)
     }
-}
 
-impl UIEventMethods for UIEvent {
     // https://w3c.github.io/uievents/#widl-UIEvent-view
     fn GetView(&self) -> Option<DomRoot<Window>> {
         self.view.get()

--- a/components/script/dom/url.rs
+++ b/components/script/dom/url.rs
@@ -77,12 +77,28 @@ impl URL {
                 .extend_pairs(pairs);
         }
     }
+
+    /// <https://w3c.github.io/FileAPI/#unicodeSerializationOfBlobURL>
+    fn unicode_serialization_blob_url(origin: &str, id: &Uuid) -> String {
+        // Step 1, 2
+        let mut result = "blob:".to_string();
+
+        // Step 3
+        result.push_str(origin);
+
+        // Step 4
+        result.push('/');
+
+        // Step 5
+        result.push_str(&id.to_string());
+
+        result
+    }
 }
 
-#[allow(non_snake_case)]
-impl URL {
+impl URLMethods for URL {
     /// <https://url.spec.whatwg.org/#constructors>
-    pub fn Constructor(
+    fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -124,7 +140,7 @@ impl URL {
     }
 
     /// <https://url.spec.whatwg.org/#dom-url-canparse>
-    pub fn CanParse(_global: &GlobalScope, url: USVString, base: Option<USVString>) -> bool {
+    fn CanParse(_global: &GlobalScope, url: USVString, base: Option<USVString>) -> bool {
         // Step 1.
         let parsed_base = match base {
             None => None,
@@ -141,7 +157,7 @@ impl URL {
     }
 
     /// <https://url.spec.whatwg.org/#dom-url-parse>
-    pub fn Parse(
+    fn Parse(
         global: &GlobalScope,
         url: USVString,
         base: Option<USVString>,
@@ -163,7 +179,7 @@ impl URL {
     }
 
     /// <https://w3c.github.io/FileAPI/#dfn-createObjectURL>
-    pub fn CreateObjectURL(global: &GlobalScope, blob: &Blob) -> DOMString {
+    fn CreateObjectURL(global: &GlobalScope, blob: &Blob) -> DOMString {
         // XXX: Second field is an unicode-serialized Origin, it is a temporary workaround
         //      and should not be trusted. See issue https://github.com/servo/servo/issues/11722
         let origin = get_blob_origin(&global.get_url());
@@ -174,7 +190,7 @@ impl URL {
     }
 
     /// <https://w3c.github.io/FileAPI/#dfn-revokeObjectURL>
-    pub fn RevokeObjectURL(global: &GlobalScope, url: DOMString) {
+    fn RevokeObjectURL(global: &GlobalScope, url: DOMString) {
         // If the value provided for the url argument is not a Blob URL OR
         // if the value provided for the url argument does not have an entry in the Blob URL Store,
         // this method call does nothing. User agents may display a message on the error console.
@@ -194,26 +210,6 @@ impl URL {
         }
     }
 
-    /// <https://w3c.github.io/FileAPI/#unicodeSerializationOfBlobURL>
-    fn unicode_serialization_blob_url(origin: &str, id: &Uuid) -> String {
-        // Step 1, 2
-        let mut result = "blob:".to_string();
-
-        // Step 3
-        result.push_str(origin);
-
-        // Step 4
-        result.push('/');
-
-        // Step 5
-        result.push_str(&id.to_string());
-
-        result
-    }
-}
-
-#[allow(non_snake_case)]
-impl URLMethods for URL {
     /// <https://url.spec.whatwg.org/#dom-url-hash>
     fn Hash(&self) -> USVString {
         UrlHelper::Hash(&self.url.borrow())

--- a/components/script/dom/urlsearchparams.rs
+++ b/components/script/dom/urlsearchparams.rs
@@ -56,9 +56,14 @@ impl URLSearchParams {
         )
     }
 
+    pub fn set_list(&self, list: Vec<(String, String)>) {
+        *self.list.borrow_mut() = list;
+    }
+}
+
+impl URLSearchParamsMethods for URLSearchParams {
     /// <https://url.spec.whatwg.org/#dom-urlsearchparams-urlsearchparams>
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+    fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -104,12 +109,6 @@ impl URLSearchParams {
         Ok(query)
     }
 
-    pub fn set_list(&self, list: Vec<(String, String)>) {
-        *self.list.borrow_mut() = list;
-    }
-}
-
-impl URLSearchParamsMethods for URLSearchParams {
     /// <https://url.spec.whatwg.org/#dom-urlsearchparams-size>
     fn Size(&self) -> u32 {
         self.list.borrow().len() as u32

--- a/components/script/dom/vttcue.rs
+++ b/components/script/dom/vttcue.rs
@@ -79,6 +79,7 @@ impl VTTCue {
 }
 
 impl VTTCueMethods for VTTCue {
+    // https://w3c.github.io/webvtt/#dom-vttcue-vttcue
     fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/vttcue.rs
+++ b/components/script/dom/vttcue.rs
@@ -76,9 +76,10 @@ impl VTTCue {
             can_gc,
         )
     }
+}
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+impl VTTCueMethods for VTTCue {
+    fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -95,9 +96,7 @@ impl VTTCue {
             can_gc,
         )
     }
-}
 
-impl VTTCueMethods for VTTCue {
     // https://w3c.github.io/webvtt/#dom-vttcue-region
     fn GetRegion(&self) -> Option<DomRoot<VTTRegion>> {
         self.region

--- a/components/script/dom/vttregion.rs
+++ b/components/script/dom/vttregion.rs
@@ -52,6 +52,7 @@ impl VTTRegion {
 }
 
 impl VTTRegionMethods for VTTRegion {
+    // https://w3c.github.io/webvtt/#dom-vttregion-vttregion
     fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/vttregion.rs
+++ b/components/script/dom/vttregion.rs
@@ -49,18 +49,17 @@ impl VTTRegion {
     fn new(global: &GlobalScope, proto: Option<HandleObject>, can_gc: CanGc) -> DomRoot<Self> {
         reflect_dom_object_with_proto(Box::new(Self::new_inherited()), global, proto, can_gc)
     }
+}
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+impl VTTRegionMethods for VTTRegion {
+    fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
     ) -> Fallible<DomRoot<Self>> {
         Ok(VTTRegion::new(&window.global(), proto, can_gc))
     }
-}
 
-impl VTTRegionMethods for VTTRegion {
     // https://w3c.github.io/webvtt/#dom-vttregion-id
     fn Id(&self) -> DOMString {
         self.id.borrow().clone()

--- a/components/script/dom/webglcontextevent.rs
+++ b/components/script/dom/webglcontextevent.rs
@@ -26,6 +26,33 @@ pub struct WebGLContextEvent {
 }
 
 impl WebGLContextEventMethods for WebGLContextEvent {
+    fn Constructor(
+        window: &Window,
+        proto: Option<HandleObject>,
+        can_gc: CanGc,
+        type_: DOMString,
+        init: &WebGLContextEventInit,
+    ) -> Fallible<DomRoot<WebGLContextEvent>> {
+        let status_message = match init.statusMessage.as_ref() {
+            Some(message) => message.clone(),
+            None => DOMString::new(),
+        };
+
+        let bubbles = EventBubbles::from(init.parent.bubbles);
+
+        let cancelable = EventCancelable::from(init.parent.cancelable);
+
+        Ok(WebGLContextEvent::new_with_proto(
+            window,
+            proto,
+            Atom::from(type_),
+            bubbles,
+            cancelable,
+            status_message,
+            can_gc,
+        ))
+    }
+
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.15
     fn StatusMessage(&self) -> DOMString {
         self.status_message.clone()
@@ -85,33 +112,5 @@ impl WebGLContextEvent {
         }
 
         event
-    }
-
-    #[allow(non_snake_case)]
-    pub fn Constructor(
-        window: &Window,
-        proto: Option<HandleObject>,
-        can_gc: CanGc,
-        type_: DOMString,
-        init: &WebGLContextEventInit,
-    ) -> Fallible<DomRoot<WebGLContextEvent>> {
-        let status_message = match init.statusMessage.as_ref() {
-            Some(message) => message.clone(),
-            None => DOMString::new(),
-        };
-
-        let bubbles = EventBubbles::from(init.parent.bubbles);
-
-        let cancelable = EventCancelable::from(init.parent.cancelable);
-
-        Ok(WebGLContextEvent::new_with_proto(
-            window,
-            proto,
-            Atom::from(type_),
-            bubbles,
-            cancelable,
-            status_message,
-            can_gc,
-        ))
     }
 }

--- a/components/script/dom/webglcontextevent.rs
+++ b/components/script/dom/webglcontextevent.rs
@@ -26,6 +26,7 @@ pub struct WebGLContextEvent {
 }
 
 impl WebGLContextEventMethods for WebGLContextEvent {
+    // https://registry.khronos.org/webgl/specs/latest/1.0/#5.15
     fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/websocket.rs
+++ b/components/script/dom/websocket.rs
@@ -144,9 +144,56 @@ impl WebSocket {
         )
     }
 
+    // https://html.spec.whatwg.org/multipage/#dom-websocket-send
+    fn send_impl(&self, data_byte_len: u64) -> Fallible<bool> {
+        let return_after_buffer = match self.ready_state.get() {
+            WebSocketRequestState::Connecting => {
+                return Err(Error::InvalidState);
+            },
+            WebSocketRequestState::Open => false,
+            WebSocketRequestState::Closing | WebSocketRequestState::Closed => true,
+        };
+
+        let address = Trusted::new(self);
+
+        match data_byte_len.checked_add(self.buffered_amount.get()) {
+            None => panic!(),
+            Some(new_amount) => self.buffered_amount.set(new_amount),
+        };
+
+        if return_after_buffer {
+            return Ok(false);
+        }
+
+        if !self.clearing_buffer.get() && self.ready_state.get() == WebSocketRequestState::Open {
+            self.clearing_buffer.set(true);
+
+            let task = Box::new(BufferedAmountTask { address });
+
+            let pipeline_id = self.global().pipeline_id();
+            self.global()
+                .script_chan()
+                // TODO: Use a dedicated `websocket-task-source` task source instead.
+                .send(CommonScriptMsg::Task(
+                    WebSocketEvent,
+                    task,
+                    Some(pipeline_id),
+                    WebsocketTaskSource::NAME,
+                ))
+                .unwrap();
+        }
+
+        Ok(true)
+    }
+
+    pub fn origin(&self) -> ImmutableOrigin {
+        self.url.origin()
+    }
+}
+
+impl WebSocketMethods for WebSocket {
     /// <https://html.spec.whatwg.org/multipage/#dom-websocket>
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+    fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -257,54 +304,6 @@ impl WebSocket {
         Ok(ws)
     }
 
-    // https://html.spec.whatwg.org/multipage/#dom-websocket-send
-    fn send_impl(&self, data_byte_len: u64) -> Fallible<bool> {
-        let return_after_buffer = match self.ready_state.get() {
-            WebSocketRequestState::Connecting => {
-                return Err(Error::InvalidState);
-            },
-            WebSocketRequestState::Open => false,
-            WebSocketRequestState::Closing | WebSocketRequestState::Closed => true,
-        };
-
-        let address = Trusted::new(self);
-
-        match data_byte_len.checked_add(self.buffered_amount.get()) {
-            None => panic!(),
-            Some(new_amount) => self.buffered_amount.set(new_amount),
-        };
-
-        if return_after_buffer {
-            return Ok(false);
-        }
-
-        if !self.clearing_buffer.get() && self.ready_state.get() == WebSocketRequestState::Open {
-            self.clearing_buffer.set(true);
-
-            let task = Box::new(BufferedAmountTask { address });
-
-            let pipeline_id = self.global().pipeline_id();
-            self.global()
-                .script_chan()
-                // TODO: Use a dedicated `websocket-task-source` task source instead.
-                .send(CommonScriptMsg::Task(
-                    WebSocketEvent,
-                    task,
-                    Some(pipeline_id),
-                    WebsocketTaskSource::NAME,
-                ))
-                .unwrap();
-        }
-
-        Ok(true)
-    }
-
-    pub fn origin(&self) -> ImmutableOrigin {
-        self.url.origin()
-    }
-}
-
-impl WebSocketMethods for WebSocket {
     // https://html.spec.whatwg.org/multipage/#handler-websocket-onopen
     event_handler!(open, GetOnopen, SetOnopen);
 

--- a/components/script/dom/wheelevent.rs
+++ b/components/script/dom/wheelevent.rs
@@ -111,6 +111,7 @@ impl WheelEvent {
 }
 
 impl WheelEventMethods for WheelEvent {
+    // https://w3c.github.io/uievents/#dom-wheelevent-wheelevent
     fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/wheelevent.rs
+++ b/components/script/dom/wheelevent.rs
@@ -108,9 +108,10 @@ impl WheelEvent {
 
         ev
     }
+}
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+impl WheelEventMethods for WheelEvent {
+    fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -134,9 +135,7 @@ impl WheelEvent {
 
         Ok(event)
     }
-}
 
-impl WheelEventMethods for WheelEvent {
     // https://w3c.github.io/uievents/#widl-WheelEvent-deltaX
     fn DeltaX(&self) -> Finite<f64> {
         self.delta_x.get()

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -232,16 +232,6 @@ impl XMLHttpRequest {
         )
     }
 
-    #[allow(non_snake_case)]
-    /// <https://xhr.spec.whatwg.org/#constructors>
-    pub fn Constructor(
-        global: &GlobalScope,
-        proto: Option<HandleObject>,
-        can_gc: CanGc,
-    ) -> Fallible<DomRoot<XMLHttpRequest>> {
-        Ok(XMLHttpRequest::new(global, proto, can_gc))
-    }
-
     fn sync_in_window(&self) -> bool {
         self.sync.get() && self.global().is::<Window>()
     }
@@ -338,6 +328,15 @@ impl XMLHttpRequest {
 }
 
 impl XMLHttpRequestMethods for XMLHttpRequest {
+    /// <https://xhr.spec.whatwg.org/#constructors>
+    fn Constructor(
+        global: &GlobalScope,
+        proto: Option<HandleObject>,
+        can_gc: CanGc,
+    ) -> Fallible<DomRoot<XMLHttpRequest>> {
+        Ok(XMLHttpRequest::new(global, proto, can_gc))
+    }
+
     // https://xhr.spec.whatwg.org/#handler-xhr-onreadystatechange
     event_handler!(
         readystatechange,

--- a/components/script/dom/xmlserializer.rs
+++ b/components/script/dom/xmlserializer.rs
@@ -41,18 +41,17 @@ impl XMLSerializer {
             can_gc,
         )
     }
+}
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+impl XMLSerializerMethods for XMLSerializer {
+    fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
     ) -> Fallible<DomRoot<XMLSerializer>> {
         Ok(XMLSerializer::new(window, proto, can_gc))
     }
-}
 
-impl XMLSerializerMethods for XMLSerializer {
     // https://w3c.github.io/DOM-Parsing/#the-xmlserializer-interface
     fn SerializeToString(&self, root: &Node) -> Fallible<DOMString> {
         let mut writer = vec![];

--- a/components/script/dom/xmlserializer.rs
+++ b/components/script/dom/xmlserializer.rs
@@ -44,6 +44,7 @@ impl XMLSerializer {
 }
 
 impl XMLSerializerMethods for XMLSerializer {
+    // https://w3c.github.io/DOM-Parsing/#dom-xmlserializer
     fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/xrinputsourceevent.rs
+++ b/components/script/dom/xrinputsourceevent.rs
@@ -85,6 +85,7 @@ impl XRInputSourceEvent {
 }
 
 impl XRInputSourceEventMethods for XRInputSourceEvent {
+    // https://immersive-web.github.io/webxr/#dom-xrinputsourceevent-xrinputsourceevent
     fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/xrinputsourceevent.rs
+++ b/components/script/dom/xrinputsourceevent.rs
@@ -82,9 +82,10 @@ impl XRInputSourceEvent {
         }
         trackevent
     }
+}
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+impl XRInputSourceEventMethods for XRInputSourceEvent {
+    fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -102,9 +103,7 @@ impl XRInputSourceEvent {
             can_gc,
         ))
     }
-}
 
-impl XRInputSourceEventMethods for XRInputSourceEvent {
     // https://immersive-web.github.io/webxr/#dom-xrinputsourceeventinit-frame
     fn Frame(&self) -> DomRoot<XRFrame> {
         DomRoot::from_ref(&*self.frame)

--- a/components/script/dom/xrinputsourceschangeevent.rs
+++ b/components/script/dom/xrinputsourceschangeevent.rs
@@ -107,6 +107,7 @@ impl XRInputSourcesChangeEvent {
 }
 
 impl XRInputSourcesChangeEventMethods for XRInputSourcesChangeEvent {
+    // https://immersive-web.github.io/webxr/#dom-xrinputsourceschangeevent-xrinputsourceschangeevent
     fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/xrinputsourceschangeevent.rs
+++ b/components/script/dom/xrinputsourceschangeevent.rs
@@ -104,9 +104,10 @@ impl XRInputSourcesChangeEvent {
 
         changeevent
     }
+}
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+impl XRInputSourcesChangeEventMethods for XRInputSourcesChangeEvent {
+    fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -125,9 +126,7 @@ impl XRInputSourcesChangeEvent {
             can_gc,
         )
     }
-}
 
-impl XRInputSourcesChangeEventMethods for XRInputSourcesChangeEvent {
     // https://immersive-web.github.io/webxr/#dom-xrinputsourceschangeevent-session
     fn Session(&self) -> DomRoot<XRSession> {
         DomRoot::from_ref(&*self.session)

--- a/components/script/dom/xrlayerevent.rs
+++ b/components/script/dom/xrlayerevent.rs
@@ -46,9 +46,10 @@ impl XRLayerEvent {
             can_gc,
         )
     }
+}
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+impl XRLayerEventMethods for XRLayerEvent {
+    fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -62,9 +63,7 @@ impl XRLayerEvent {
         event.event.init_event(type_, bubbles, cancelable);
         event
     }
-}
 
-impl XRLayerEventMethods for XRLayerEvent {
     // https://immersive-web.github.io/layers/#dom-xrlayerevent-layer
     fn Layer(&self) -> DomRoot<XRLayer> {
         DomRoot::from_ref(&self.layer)

--- a/components/script/dom/xrlayerevent.rs
+++ b/components/script/dom/xrlayerevent.rs
@@ -49,6 +49,7 @@ impl XRLayerEvent {
 }
 
 impl XRLayerEventMethods for XRLayerEvent {
+    // https://immersive-web.github.io/layers/#dom-xrlayerevent-xrlayerevent
     fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/xrmediabinding.rs
+++ b/components/script/dom/xrmediabinding.rs
@@ -45,9 +45,10 @@ impl XRMediaBinding {
             can_gc,
         )
     }
+}
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+impl XRMediaBindingMethods for XRMediaBinding {
+    fn Constructor(
         global: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -66,9 +67,7 @@ impl XRMediaBinding {
         // Steps 3-5.
         Ok(XRMediaBinding::new(global, proto, session, can_gc))
     }
-}
 
-impl XRMediaBindingMethods for XRMediaBinding {
     /// <https://immersive-web.github.io/layers/#dom-xrmediabinding-createquadlayer>
     fn CreateQuadLayer(
         &self,

--- a/components/script/dom/xrmediabinding.rs
+++ b/components/script/dom/xrmediabinding.rs
@@ -48,6 +48,7 @@ impl XRMediaBinding {
 }
 
 impl XRMediaBindingMethods for XRMediaBinding {
+    /// <https://immersive-web.github.io/layers/#dom-xrmediabinding-xrmediabinding>
     fn Constructor(
         global: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/xrray.rs
+++ b/components/script/dom/xrray.rs
@@ -48,9 +48,14 @@ impl XRRay {
         reflect_dom_object_with_proto(Box::new(XRRay::new_inherited(ray)), global, proto, can_gc)
     }
 
-    #[allow(non_snake_case)]
+    pub fn ray(&self) -> Ray<ApiSpace> {
+        self.ray
+    }
+}
+
+impl XRRayMethods for XRRay {
     /// <https://immersive-web.github.io/hit-test/#dom-xrray-xrray>
-    pub fn Constructor(
+    fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -85,9 +90,8 @@ impl XRRay {
         ))
     }
 
-    #[allow(non_snake_case)]
     /// <https://immersive-web.github.io/hit-test/#dom-xrray-xrray-transform>
-    pub fn Constructor_(
+    fn Constructor_(
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -107,12 +111,6 @@ impl XRRay {
         ))
     }
 
-    pub fn ray(&self) -> Ray<ApiSpace> {
-        self.ray
-    }
-}
-
-impl XRRayMethods for XRRay {
     /// <https://immersive-web.github.io/hit-test/#dom-xrray-origin>
     fn Origin(&self) -> DomRoot<DOMPointReadOnly> {
         DOMPointReadOnly::new(

--- a/components/script/dom/xrreferencespaceevent.rs
+++ b/components/script/dom/xrreferencespaceevent.rs
@@ -85,9 +85,10 @@ impl XRReferenceSpaceEvent {
         }
         trackevent
     }
+}
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+impl XRReferenceSpaceEventMethods for XRReferenceSpaceEvent {
+    fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -105,9 +106,7 @@ impl XRReferenceSpaceEvent {
             can_gc,
         ))
     }
-}
 
-impl XRReferenceSpaceEventMethods for XRReferenceSpaceEvent {
     /// <https://www.w3.org/TR/webxr/#dom-xrreferencespaceeventinit-session>
     fn ReferenceSpace(&self) -> DomRoot<XRReferenceSpace> {
         DomRoot::from_ref(&*self.space)

--- a/components/script/dom/xrreferencespaceevent.rs
+++ b/components/script/dom/xrreferencespaceevent.rs
@@ -88,6 +88,7 @@ impl XRReferenceSpaceEvent {
 }
 
 impl XRReferenceSpaceEventMethods for XRReferenceSpaceEvent {
+    /// <https://www.w3.org/TR/webxr/#dom-xrreferencespaceevent-xrreferencespaceevent>
     fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/xrrigidtransform.rs
+++ b/components/script/dom/xrrigidtransform.rs
@@ -66,10 +66,11 @@ impl XRRigidTransform {
         let transform = RigidTransform3D::identity();
         XRRigidTransform::new(window, transform)
     }
+}
 
+impl XRRigidTransformMethods for XRRigidTransform {
     // https://immersive-web.github.io/webxr/#dom-xrrigidtransform-xrrigidtransform
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+    fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -124,9 +125,7 @@ impl XRRigidTransform {
             can_gc,
         ))
     }
-}
 
-impl XRRigidTransformMethods for XRRigidTransform {
     // https://immersive-web.github.io/webxr/#dom-xrrigidtransform-position
     fn Position(&self) -> DomRoot<DOMPointReadOnly> {
         self.position.or_init(|| {

--- a/components/script/dom/xrsessionevent.rs
+++ b/components/script/dom/xrsessionevent.rs
@@ -76,6 +76,7 @@ impl XRSessionEvent {
 }
 
 impl XRSessionEventMethods for XRSessionEvent {
+    // https://immersive-web.github.io/webxr/#dom-xrsessionevent-xrsessionevent
     fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/xrsessionevent.rs
+++ b/components/script/dom/xrsessionevent.rs
@@ -73,9 +73,10 @@ impl XRSessionEvent {
         }
         trackevent
     }
+}
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+impl XRSessionEventMethods for XRSessionEvent {
+    fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -92,9 +93,7 @@ impl XRSessionEvent {
             can_gc,
         ))
     }
-}
 
-impl XRSessionEventMethods for XRSessionEvent {
     // https://immersive-web.github.io/webxr/#dom-xrsessioneventinit-session
     fn Session(&self) -> DomRoot<XRSession> {
         DomRoot::from_ref(&*self.session)

--- a/components/script/dom/xrwebglbinding.rs
+++ b/components/script/dom/xrwebglbinding.rs
@@ -59,9 +59,10 @@ impl XRWebGLBinding {
             can_gc,
         )
     }
+}
 
-    #[allow(non_snake_case)]
-    pub fn Constructor(
+impl XRWebGLBindingMethods for XRWebGLBinding {
+    fn Constructor(
         global: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -76,9 +77,7 @@ impl XRWebGLBinding {
         };
         XRWebGLBinding::new(global, proto, session, &context, can_gc)
     }
-}
 
-impl XRWebGLBindingMethods for XRWebGLBinding {
     /// <https://immersive-web.github.io/layers/#dom-xrwebglbinding-createprojectionlayer>
     fn CreateProjectionLayer(
         &self,

--- a/components/script/dom/xrwebglbinding.rs
+++ b/components/script/dom/xrwebglbinding.rs
@@ -62,6 +62,7 @@ impl XRWebGLBinding {
 }
 
 impl XRWebGLBindingMethods for XRWebGLBinding {
+    /// <https://immersive-web.github.io/layers/#dom-xrwebglbinding-xrwebglbinding>
     fn Constructor(
         global: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/xrwebgllayer.rs
+++ b/components/script/dom/xrwebgllayer.rs
@@ -103,74 +103,6 @@ impl XRWebGLLayer {
         )
     }
 
-    /// <https://immersive-web.github.io/webxr/#dom-xrwebgllayer-xrwebgllayer>
-    #[allow(non_snake_case)]
-    pub fn Constructor(
-        global: &Window,
-        proto: Option<HandleObject>,
-        can_gc: CanGc,
-        session: &XRSession,
-        context: XRWebGLRenderingContext,
-        init: &XRWebGLLayerInit,
-    ) -> Fallible<DomRoot<Self>> {
-        let context = match context {
-            XRWebGLRenderingContext::WebGLRenderingContext(ctx) => ctx,
-            XRWebGLRenderingContext::WebGL2RenderingContext(ctx) => ctx.base_context(),
-        };
-
-        // Step 2
-        if session.is_ended() {
-            return Err(Error::InvalidState);
-        }
-        // XXXManishearth step 3: throw error if context is lost
-        // XXXManishearth step 4: check XR compat flag for immersive sessions
-
-        let (framebuffer, layer_id) = if session.is_immersive() {
-            // Step 9.2. "Initialize layer’s framebuffer to a new opaque framebuffer created with context."
-            let size = session
-                .with_session(|session| session.recommended_framebuffer_resolution())
-                .ok_or(Error::Operation)?;
-            let framebuffer = WebGLFramebuffer::maybe_new_webxr(session, &context, size)
-                .ok_or(Error::Operation)?;
-
-            // Step 9.3. "Allocate and initialize resources compatible with session’s XR device,
-            // including GPU accessible memory buffers, as required to support the compositing of layer."
-            let context_id = WebXRContextId::from(context.context_id());
-            let layer_init = LayerInit::from(init);
-            let layer_id = session
-                .with_session(|session| session.create_layer(context_id, layer_init))
-                .map_err(|_| Error::Operation)?;
-
-            // Step 9.4: "If layer’s resources were unable to be created for any reason,
-            // throw an OperationError and abort these steps."
-            (Some(framebuffer), Some(layer_id))
-        } else {
-            (None, None)
-        };
-
-        // Ensure that we finish setting up this layer before continuing.
-        context.Finish();
-
-        // Step 10. "Return layer."
-        Ok(XRWebGLLayer::new(
-            &global.global(),
-            proto,
-            session,
-            &context,
-            init,
-            framebuffer.as_deref(),
-            layer_id,
-            can_gc,
-        ))
-    }
-
-    /// <https://www.w3.org/TR/webxr/#dom-xrwebgllayer-getnativeframebufferscalefactor>
-    #[allow(non_snake_case)]
-    pub fn GetNativeFramebufferScaleFactor(_window: &Window, session: &XRSession) -> Finite<f64> {
-        let value: f64 = if session.is_ended() { 0.0 } else { 1.0 };
-        Finite::wrap(value)
-    }
-
     pub fn layer_id(&self) -> Option<LayerId> {
         self.xr_layer.layer_id()
     }
@@ -306,6 +238,72 @@ impl XRWebGLLayer {
 }
 
 impl XRWebGLLayerMethods for XRWebGLLayer {
+    /// <https://immersive-web.github.io/webxr/#dom-xrwebgllayer-xrwebgllayer>
+    fn Constructor(
+        global: &Window,
+        proto: Option<HandleObject>,
+        can_gc: CanGc,
+        session: &XRSession,
+        context: XRWebGLRenderingContext,
+        init: &XRWebGLLayerInit,
+    ) -> Fallible<DomRoot<Self>> {
+        let context = match context {
+            XRWebGLRenderingContext::WebGLRenderingContext(ctx) => ctx,
+            XRWebGLRenderingContext::WebGL2RenderingContext(ctx) => ctx.base_context(),
+        };
+
+        // Step 2
+        if session.is_ended() {
+            return Err(Error::InvalidState);
+        }
+        // XXXManishearth step 3: throw error if context is lost
+        // XXXManishearth step 4: check XR compat flag for immersive sessions
+
+        let (framebuffer, layer_id) = if session.is_immersive() {
+            // Step 9.2. "Initialize layer’s framebuffer to a new opaque framebuffer created with context."
+            let size = session
+                .with_session(|session| session.recommended_framebuffer_resolution())
+                .ok_or(Error::Operation)?;
+            let framebuffer = WebGLFramebuffer::maybe_new_webxr(session, &context, size)
+                .ok_or(Error::Operation)?;
+
+            // Step 9.3. "Allocate and initialize resources compatible with session’s XR device,
+            // including GPU accessible memory buffers, as required to support the compositing of layer."
+            let context_id = WebXRContextId::from(context.context_id());
+            let layer_init = LayerInit::from(init);
+            let layer_id = session
+                .with_session(|session| session.create_layer(context_id, layer_init))
+                .map_err(|_| Error::Operation)?;
+
+            // Step 9.4: "If layer’s resources were unable to be created for any reason,
+            // throw an OperationError and abort these steps."
+            (Some(framebuffer), Some(layer_id))
+        } else {
+            (None, None)
+        };
+
+        // Ensure that we finish setting up this layer before continuing.
+        context.Finish();
+
+        // Step 10. "Return layer."
+        Ok(XRWebGLLayer::new(
+            &global.global(),
+            proto,
+            session,
+            &context,
+            init,
+            framebuffer.as_deref(),
+            layer_id,
+            can_gc,
+        ))
+    }
+
+    /// <https://www.w3.org/TR/webxr/#dom-xrwebgllayer-getnativeframebufferscalefactor>
+    fn GetNativeFramebufferScaleFactor(_window: &Window, session: &XRSession) -> Finite<f64> {
+        let value: f64 = if session.is_ended() { 0.0 } else { 1.0 };
+        Finite::wrap(value)
+    }
+
     /// <https://immersive-web.github.io/webxr/#dom-xrwebgllayer-antialias>
     fn Antialias(&self) -> bool {
         self.antialias

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -19,7 +19,9 @@ use net_traits::{
 };
 use servo_url::ServoUrl;
 
-use crate::dom::bindings::codegen::Bindings::RequestBinding::{RequestInfo, RequestInit};
+use crate::dom::bindings::codegen::Bindings::RequestBinding::{
+    RequestInfo, RequestInit, RequestMethods,
+};
 use crate::dom::bindings::codegen::Bindings::ResponseBinding::ResponseType as DOMResponseType;
 use crate::dom::bindings::codegen::Bindings::ResponseBinding::Response_Binding::ResponseMethods;
 use crate::dom::bindings::error::Error;


### PR DESCRIPTION
As part of #1799, we need the ability to call these methods from a separate crate. That means they need to be part of the generated trait, and that requires moving a lot of methods out of bare impl blocks and into the trait implementation. The second commit is hand-written and contains no changes except code motion and removing redundant `#[allow(non_snake_case)]` attributes.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #32921 
- [x] These changes do not require tests because it is moving existing code around