### PR TITLE
Drop support for '--no-minibrowser' mode

### DIFF
--- a/components/config/opts.rs
+++ b/components/config/opts.rs
@@ -128,9 +128,6 @@ pub struct Opts {
 
     /// Print Progressive Web Metrics to console.
     pub print_pwm: bool,
-
-    /// True to enable minibrowser
-    pub minibrowser: bool,
 }
 
 fn print_usage(app: &str, opts: &Options) {
@@ -425,7 +422,6 @@ pub fn default_opts() -> Opts {
         unminify_js: false,
         local_script_source: None,
         print_pwm: false,
-        minibrowser: true,
     }
 }
 
@@ -564,7 +560,6 @@ pub fn from_cmdline_args(mut opts: Options, args: &[String]) -> ArgumentParsingR
         "Directory root with unminified scripts",
         "",
     );
-    opts.optflag("", "no-minibrowser", "Open minibrowser");
 
     let opt_match = match opts.parse(args) {
         Ok(m) => m,
@@ -767,7 +762,6 @@ pub fn from_cmdline_args(mut opts: Options, args: &[String]) -> ArgumentParsingR
         unminify_js: opt_match.opt_present("unminify-js"),
         local_script_source: opt_match.opt_str("local-script-source"),
         print_pwm: opt_match.opt_present("print-pwm"),
-        minibrowser: !opt_match.opt_present("no-minibrowser"),
     };
 
     set_options(opts);

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -101,7 +101,7 @@ impl App {
             minibrowser: None,
         };
 
-        if opts::get().minibrowser && window.winit_window().is_some() {
+        if window.winit_window().is_some() {
             // Make sure the gl context is made current.
             let rendering_context = window.rendering_context();
             let webrender_gl = match rendering_context.connection().gl_api() {

--- a/ports/servoshell/desktop/webview.rs
+++ b/ports/servoshell/desktop/webview.rs
@@ -38,7 +38,6 @@ use tinyfiledialogs::{self, MessageBoxIcon, OkCancel, YesNo};
 use super::keyutils::{CMD_OR_ALT, CMD_OR_CONTROL};
 use super::window_trait::{WindowPortsMethods, LINE_HEIGHT};
 use crate::desktop::tracing::{trace_embedder_event, trace_embedder_msg};
-use crate::parser::location_bar_input_to_url;
 
 pub struct WebViewManager<Window: WindowPortsMethods + ?Sized> {
     status_text: Option<String>,
@@ -431,7 +430,6 @@ where
             .shortcut(CMD_OR_CONTROL, 'R', || {
                 self.focused_webview_id.map(EmbedderEvent::Reload)
             })
-            .shortcut(CMD_OR_CONTROL, 'L', || None)
             // Select the first 8 tabs via shortcuts
             .shortcut(CMD_OR_CONTROL, '1', || self.focus_webview_by_index(0))
             .shortcut(CMD_OR_CONTROL, '2', || self.focus_webview_by_index(1))

--- a/ports/servoshell/desktop/webview.rs
+++ b/ports/servoshell/desktop/webview.rs
@@ -431,29 +431,7 @@ where
             .shortcut(CMD_OR_CONTROL, 'R', || {
                 self.focused_webview_id.map(EmbedderEvent::Reload)
             })
-            .shortcut(CMD_OR_CONTROL, 'L', || {
-                if !opts::get().minibrowser {
-                    let url = match self.focused_webview() {
-                        Some(webview) => webview
-                            .url
-                            .as_ref()
-                            .map(|url| url.to_string())
-                            .unwrap_or_else(String::default),
-                        None => String::default(),
-                    };
-
-                    let title = "URL or search query";
-                    let input = tinyfiledialogs::input_box(title, title, &tiny_dialog_escape(&url));
-                    input.and_then(|input| {
-                        location_bar_input_to_url(&input).and_then(|url| {
-                            self.focused_webview_id
-                                .map(|id| EmbedderEvent::LoadUrl(id, url))
-                        })
-                    })
-                } else {
-                    None
-                }
-            })
+            .shortcut(CMD_OR_CONTROL, 'L', || None)
             // Select the first 8 tabs via shortcuts
             .shortcut(CMD_OR_CONTROL, '1', || self.focus_webview_by_index(0))
             .shortcut(CMD_OR_CONTROL, '2', || self.focus_webview_by_index(1))


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #33626

<!-- Either: -->
- [x]  these changes do not require tests because changes were made to ServoShell.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
