### PR TITLE
layout: Avoid double negation in `CellLayout::is_empty_for_empty_cells()`

### DIFF
--- a/components/layout_2020/table/layout.rs
+++ b/components/layout_2020/table/layout.rs
@@ -78,7 +78,7 @@ impl CellLayout {
             .layout
             .fragments
             .iter()
-            .any(|fragment| !matches!(fragment, Fragment::AbsoluteOrFixedPositioned(_)))
+            .all(|fragment| matches!(fragment, Fragment::AbsoluteOrFixedPositioned(_)))
     }
 }
 

--- a/components/layout_2020/table/layout.rs
+++ b/components/layout_2020/table/layout.rs
@@ -74,7 +74,7 @@ impl CellLayout {
 
     /// Whether the cell is considered empty for the purpose of the 'empty-cells' property.
     fn is_empty_for_empty_cells(&self) -> bool {
-        !self
+        self
             .layout
             .fragments
             .iter()

--- a/components/layout_2020/table/layout.rs
+++ b/components/layout_2020/table/layout.rs
@@ -74,8 +74,7 @@ impl CellLayout {
 
     /// Whether the cell is considered empty for the purpose of the 'empty-cells' property.
     fn is_empty_for_empty_cells(&self) -> bool {
-        self
-            .layout
+        self.layout
             .fragments
             .iter()
             .all(|fragment| matches!(fragment, Fragment::AbsoluteOrFixedPositioned(_)))


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #33678 

<!-- Either: -->
- [x] These changes do not require tests because there is no behavior change.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
