### PR TITLE
clippy: Fix some clippy warnings in `components/script` and `components/devtools`

### DIFF
--- a/components/devtools/actors/inspector/style_rule.rs
+++ b/components/devtools/actors/inspector/style_rule.rs
@@ -185,8 +185,8 @@ impl StyleRuleActor {
             css_text: "".into(), // TODO: Specify the css text
             declarations: style
                 .into_iter()
-                .filter_map(|decl| {
-                    Some(AppliedDeclaration {
+                .map(|decl| {
+                    AppliedDeclaration {
                         colon_offsets: vec![],
                         is_name_valid: true,
                         is_used: IsUsed { used: true },
@@ -196,7 +196,7 @@ impl StyleRuleActor {
                         priority: decl.priority,
                         terminator: "".into(),
                         value: decl.value,
-                    })
+                    }
                 })
                 .collect(),
             href: node.base_uri.clone(),

--- a/components/script/dom/identityhub.rs
+++ b/components/script/dom/identityhub.rs
@@ -38,12 +38,6 @@ pub struct IdentityHub {
 
 impl Default for IdentityHub {
     fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl IdentityHub {
-    pub fn new() -> Self {
         IdentityHub {
             adapters: IdentityManager::new(),
             devices: IdentityManager::new(),

--- a/components/script/dom/serviceworkerglobalscope.rs
+++ b/components/script/dom/serviceworkerglobalscope.rs
@@ -241,7 +241,7 @@ impl ServiceWorkerGlobalScope {
                 runtime,
                 from_devtools_receiver,
                 closing,
-                Arc::new(IdentityHub::new()),
+                Arc::new(IdentityHub::default()),
             ),
             task_queue: TaskQueue::new(receiver, own_sender.clone()),
             own_sender,

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1417,7 +1417,7 @@ impl ScriptThread {
 
             node_ids: Default::default(),
             is_user_interacting: Cell::new(false),
-            gpu_id_hub: Arc::new(IdentityHub::new()),
+            gpu_id_hub: Arc::new(IdentityHub::default()),
             webgpu_port: RefCell::new(None),
             inherited_secure_context: state.inherited_secure_context,
             layout_factory,


### PR DESCRIPTION
This PR fixes some clippy warnings by;

- Creating default implementations
- Replacing ```.filter_map ``` with ```.map```
- Collapsing ``` if let ``` ``` mach``` with ```if let```
---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #31500
- [X] These changes do not require tests because they do not touch functionality.

