### PR TITLE
clippy: Fix large size difference between variants of `ScriptToCompositorMsg`

### DIFF
--- a/components/shared/webrender/lib.rs
+++ b/components/shared/webrender/lib.rs
@@ -228,7 +228,7 @@ pub enum ScriptToCompositorMsg {
     /// Inform WebRender of a new display list for the given pipeline.
     SendDisplayList {
         /// The [CompositorDisplayListInfo] that describes the display list being sent.
-        display_list_info: CompositorDisplayListInfo,
+        display_list_info: Box<CompositorDisplayListInfo>,
         /// A descriptor of this display list used to construct this display list from raw data.
         display_list_descriptor: BuiltDisplayListDescriptor,
         /// An [ipc::IpcBytesReceiver] used to send the raw data of the display list.
@@ -337,13 +337,12 @@ impl WebRenderScriptApi {
         let (display_list_data, display_list_descriptor) = list.into_data();
         let (display_list_sender, display_list_receiver) = ipc::bytes_channel().unwrap();
         if let Err(e) = self.0.send(ScriptToCompositorMsg::SendDisplayList {
-            display_list_info,
+            display_list_info: Box::new(display_list_info),
             display_list_descriptor,
             display_list_receiver,
         }) {
             warn!("Error sending display list: {}", e);
         }
-
         if let Err(error) = display_list_sender.send(&display_list_data.items_data) {
             warn!("Error sending display list items: {}", error);
         }

--- a/components/shared/webrender/lib.rs
+++ b/components/shared/webrender/lib.rs
@@ -343,7 +343,6 @@ impl WebRenderScriptApi {
         }) {
             warn!("Error sending display list: {}", e);
         }
-        
         if let Err(error) = display_list_sender.send(&display_list_data.items_data) {
             warn!("Error sending display list items: {}", error);
         }

--- a/components/shared/webrender/lib.rs
+++ b/components/shared/webrender/lib.rs
@@ -343,6 +343,7 @@ impl WebRenderScriptApi {
         }) {
             warn!("Error sending display list: {}", e);
         }
+        
         if let Err(error) = display_list_sender.send(&display_list_data.items_data) {
             warn!("Error sending display list items: {}", error);
         }


### PR DESCRIPTION
**file**: components/shared/webrender/lib.rs

**PR Description**
**Issue**: Clippy warned about `ScriptToCompositorMsg` having a big size difference between variants.

**Change**:  
        1. Made `display_list_info` a `Box<CompositorDisplayListInfo>` in the `SendDisplayList` variant.
        2. Adjusted how `SendDisplayList` is constructed.

**Impact**: One extra heap allocation, but improves performance when using the enum. Functionality stays the same.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [X] These changes are part of https://github.com/servo/servo/issues/31500

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because they do not touch functionality.


