### PR TITLE
Replace CanGc::note() calls with arguments in `components/script/dom`

### DIFF
--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -40,6 +40,7 @@ use crate::dom::node::{stylesheets_owner_from_node, window_from_node, Node, Shad
 use crate::dom::types::HTMLElement;
 use crate::realms::enter_realm;
 use crate::script_module::ScriptFetchOptions;
+use crate::script_runtime::CanGc;
 use crate::script_thread::Documents;
 
 #[allow(unsafe_code)]
@@ -336,7 +337,7 @@ pub fn handle_get_layout(
     let elem = node
         .downcast::<Element>()
         .expect("should be getting layout of element");
-    let rect = elem.GetBoundingClientRect();
+    let rect = elem.GetBoundingClientRect(CanGc::note());
     let width = rect.Width() as f32;
     let height = rect.Height() as f32;
 

--- a/components/script/dom/bindings/codegen/Bindings.conf
+++ b/components/script/dom/bindings/codegen/Bindings.conf
@@ -118,7 +118,7 @@ DOMInterfaces = {
 },
 
 'MediaDevices': {
-    'inRealms': ['GetUserMedia'],
+    'inRealms': ['GetUserMedia', 'GetClientRects', 'GetBoundingClientRect'],
 },
 
 'MediaQueryList': {

--- a/components/script/dom/bindings/codegen/Bindings.conf
+++ b/components/script/dom/bindings/codegen/Bindings.conf
@@ -71,7 +71,7 @@ DOMInterfaces = {
 },
 
 'Element': {
-    'canGc': ['InsertAdjacentHTML', 'SetInnerHTML', 'SetOuterHTML'],
+    'canGc': ['SetInnerHTML', 'SetOuterHTML', 'InsertAdjacentHTML', 'GetClientRects', 'GetBoundingClientRect'],
 },
 
 'EventSource': {

--- a/components/script/dom/bindings/codegen/Bindings.conf
+++ b/components/script/dom/bindings/codegen/Bindings.conf
@@ -23,7 +23,7 @@ DOMInterfaces = {
 },
 
 'BaseAudioContext': {
-    'inRealms': ['DecodeAudioData', 'Resume'],
+    'inRealms': ['DecodeAudioData', 'Resume', 'ParseFromString', 'GetBounds', 'GetClientRects'],
 },
 
 'Blob': {

--- a/components/script/dom/domparser.rs
+++ b/components/script/dom/domparser.rs
@@ -90,7 +90,7 @@ impl DOMParserMethods for DOMParser {
                     Default::default(),
                     can_gc,
                 );
-                ServoParser::parse_html_document(&document, Some(s), url, CanGc::note());
+                ServoParser::parse_html_document(&document, Some(s), url, can_gc);
                 document.set_ready_state(DocumentReadyState::Complete);
                 Ok(document)
             },
@@ -112,7 +112,7 @@ impl DOMParserMethods for DOMParser {
                     Default::default(),
                     can_gc,
                 );
-                ServoParser::parse_xml_document(&document, Some(s), url, CanGc::note());
+                ServoParser::parse_xml_document(&document, Some(s), url, can_gc);
                 document.set_ready_state(DocumentReadyState::Complete);
                 Ok(document)
             },

--- a/components/script/dom/domquad.rs
+++ b/components/script/dom/domquad.rs
@@ -162,6 +162,13 @@ impl DOMQuadMethods for DOMQuad {
             .max(self.p3.Y())
             .max(self.p4.Y());
 
-        DOMRect::new(&self.global(), left, top, right - left, bottom - top)
+        DOMRect::new(
+            &self.global(),
+            left,
+            top,
+            right - left,
+            bottom - top,
+            CanGc::note(),
+        )
     }
 }

--- a/components/script/dom/domrect.rs
+++ b/components/script/dom/domrect.rs
@@ -26,8 +26,15 @@ impl DOMRect {
         }
     }
 
-    pub fn new(global: &GlobalScope, x: f64, y: f64, width: f64, height: f64) -> DomRoot<DOMRect> {
-        Self::new_with_proto(global, None, x, y, width, height, CanGc::note())
+    pub fn new(
+        global: &GlobalScope,
+        x: f64,
+        y: f64,
+        width: f64,
+        height: f64,
+        can_gc: CanGc,
+    ) -> DomRoot<DOMRect> {
+        Self::new_with_proto(global, None, x, y, width, height, can_gc)
     }
 
     fn new_with_proto(

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -2341,7 +2341,7 @@ impl ElementMethods for Element {
     }
 
     // https://drafts.csswg.org/cssom-view/#dom-element-getclientrects
-    fn GetClientRects(&self) -> Vec<DomRoot<DOMRect>> {
+    fn GetClientRects(&self, can_gc: CanGc) -> Vec<DomRoot<DOMRect>> {
         let win = window_from_node(self);
         let raw_rects = self.upcast::<Node>().content_boxes();
         raw_rects
@@ -2353,14 +2353,14 @@ impl ElementMethods for Element {
                     rect.origin.y.to_f64_px(),
                     rect.size.width.to_f64_px(),
                     rect.size.height.to_f64_px(),
-                    CanGc::note(),
+                    can_gc,
                 )
             })
             .collect()
     }
 
     // https://drafts.csswg.org/cssom-view/#dom-element-getboundingclientrect
-    fn GetBoundingClientRect(&self) -> DomRoot<DOMRect> {
+    fn GetBoundingClientRect(&self, can_gc: CanGc) -> DomRoot<DOMRect> {
         let win = window_from_node(self);
         let rect = self.upcast::<Node>().bounding_content_box_or_zero();
         DOMRect::new(
@@ -2369,7 +2369,7 @@ impl ElementMethods for Element {
             rect.origin.y.to_f64_px(),
             rect.size.width.to_f64_px(),
             rect.size.height.to_f64_px(),
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -2353,6 +2353,7 @@ impl ElementMethods for Element {
                     rect.origin.y.to_f64_px(),
                     rect.size.width.to_f64_px(),
                     rect.size.height.to_f64_px(),
+                    CanGc::note(),
                 )
             })
             .collect()
@@ -2368,6 +2369,7 @@ impl ElementMethods for Element {
             rect.origin.y.to_f64_px(),
             rect.size.width.to_f64_px(),
             rect.size.height.to_f64_px(),
+            CanGc::note(),
         )
     }
 

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -1823,7 +1823,9 @@ impl VirtualMethods for HTMLImageElement {
             mouse_event.ClientX().to_f32().unwrap(),
             mouse_event.ClientY().to_f32().unwrap(),
         );
-        let bcr = self.upcast::<Element>().GetBoundingClientRect();
+        let bcr = self
+            .upcast::<Element>()
+            .GetBoundingClientRect(CanGc::note());
         let bcr_p = Point2D::new(bcr.X() as f32, bcr.Y() as f32);
 
         // Walk HTMLAreaElements

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -382,28 +382,31 @@ fn get_element_in_view_center_point(element: &Element) -> Option<Point2D<i64>> {
         .and_then(|body| {
             // Step 1: Let rectangle be the first element of the DOMRect sequence
             // returned by calling getClientRects() on element.
-            element.GetClientRects().first().map(|rectangle| {
-                let x = rectangle.X().round() as i64;
-                let y = rectangle.Y().round() as i64;
-                let width = rectangle.Width().round() as i64;
-                let height = rectangle.Height().round() as i64;
+            element
+                .GetClientRects(CanGc::note())
+                .first()
+                .map(|rectangle| {
+                    let x = rectangle.X().round() as i64;
+                    let y = rectangle.Y().round() as i64;
+                    let width = rectangle.Width().round() as i64;
+                    let height = rectangle.Height().round() as i64;
 
-                let client_width = body.ClientWidth() as i64;
-                let client_height = body.ClientHeight() as i64;
+                    let client_width = body.ClientWidth() as i64;
+                    let client_height = body.ClientHeight() as i64;
 
-                // Steps 2 - 5
-                let left = cmp::max(0, cmp::min(x, x + width));
-                let right = cmp::min(client_width, cmp::max(x, x + width));
-                let top = cmp::max(0, cmp::min(y, y + height));
-                let bottom = cmp::min(client_height, cmp::max(y, y + height));
+                    // Steps 2 - 5
+                    let left = cmp::max(0, cmp::min(x, x + width));
+                    let right = cmp::min(client_width, cmp::max(x, x + width));
+                    let top = cmp::max(0, cmp::min(y, y + height));
+                    let bottom = cmp::min(client_height, cmp::max(y, y + height));
 
-                // Steps 6 - 7
-                let x = (left + right) / 2;
-                let y = (top + bottom) / 2;
+                    // Steps 6 - 7
+                    let x = (left + right) / 2;
+                    let y = (top + bottom) / 2;
 
-                // Step 8
-                Point2D::new(x, y)
-            })
+                    // Step 8
+                    Point2D::new(x, y)
+                })
         })
 }
 
@@ -930,7 +933,7 @@ pub fn handle_get_bounding_client_rect(
                 .downcast::<Element>(
             ) {
                 Some(element) => {
-                    let rect = element.GetBoundingClientRect();
+                    let rect = element.GetBoundingClientRect(CanGc::note());
                     Ok(Rect::new(
                         Point2D::new(rect.X() as f32, rect.Y() as f32),
                         Size2D::new(rect.Width() as f32, rect.Height() as f32),


### PR DESCRIPTION
Replaces `CanGc::note()` calls with arguments passed by callers as defined in #33683 


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are a part of #33683 
- [X] These changes do not require tests because they do not modify functionality

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
