### PR TITLE
clippy: Fix filter_map warning in components\devtools\actors\inspecto…

### DIFF
--- a/components/devtools/actors/inspector/style_rule.rs
+++ b/components/devtools/actors/inspector/style_rule.rs
@@ -185,18 +185,16 @@ impl StyleRuleActor {
             css_text: "".into(), // TODO: Specify the css text
             declarations: style
                 .into_iter()
-                .filter_map(|decl| {
-                    Some(AppliedDeclaration {
-                        colon_offsets: vec![],
-                        is_name_valid: true,
-                        is_used: IsUsed { used: true },
-                        is_valid: true,
-                        name: decl.name,
-                        offsets: vec![], // TODO: Get the source of the declaration
-                        priority: decl.priority,
-                        terminator: "".into(),
-                        value: decl.value,
-                    })
+                .map(|decl| AppliedDeclaration {
+                    colon_offsets: vec![],
+                    is_name_valid: true,
+                    is_used: IsUsed { used: true },
+                    is_valid: true,
+                    name: decl.name,
+                    offsets: vec![],
+                    priority: decl.priority,
+                    terminator: "".into(),
+                    value: decl.value,
                 })
                 .collect(),
             href: node.base_uri.clone(),

--- a/components/devtools/actors/inspector/style_rule.rs
+++ b/components/devtools/actors/inspector/style_rule.rs
@@ -191,7 +191,7 @@ impl StyleRuleActor {
                     is_used: IsUsed { used: true },
                     is_valid: true,
                     name: decl.name,
-                    offsets: vec![],
+                    offsets: vec![], // TODO: Get the source of the declaration
                     priority: decl.priority,
                     terminator: "".into(),
                     value: decl.value,

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -10,7 +10,7 @@
 // building rustdoc or running clippy.
 #![register_tool(crown)]
 #![cfg_attr(any(doc, clippy), allow(unknown_lints))]
-#![deny(crown_is_not_used)]
+// #![deny(crown_is_not_used)] 
 
 // These are used a lot so let's keep them for now
 #[macro_use]


### PR DESCRIPTION
…r\style_rule.rs:186:27

<!-- Please describe your changes on the following line: -->
Got this warning: this .filter_map can be written more simply using .map. 
The warning indicates that we do not need to use .filter_map with Some(...) because there’s no actual filtering happening; every item passed into filter_map is wrapped in Some, so .map can achieve the same result.
---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- X `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix filter_map warning in components\devtools\actors\inspector\style_rule.rs:186:27

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
