### PR TITLE
Remove dead (and incorrect) logic about vertical overconstrainment

### DIFF
--- a/components/layout_2020/fragment_tree/box_fragment.rs
+++ b/components/layout_2020/fragment_tree/box_fragment.rs
@@ -96,15 +96,6 @@ impl BoxFragment {
         clearance: Option<Au>,
         block_margins_collapsed_with_children: CollapsedBlockMargins,
     ) -> BoxFragment {
-        let position = style.get_box().position;
-        let insets = style.get_position();
-        let width_overconstrained = position == ComputedPosition::Relative &&
-            !insets.left.is_auto() &&
-            !insets.right.is_auto();
-        let height_overconstrained = position == ComputedPosition::Relative &&
-            !insets.left.is_auto() &&
-            !insets.bottom.is_auto();
-
         Self::new_with_overconstrained(
             base_fragment_info,
             style,
@@ -115,7 +106,7 @@ impl BoxFragment {
             margin,
             clearance,
             block_margins_collapsed_with_children,
-            PhysicalSize::new(width_overconstrained, height_overconstrained),
+            PhysicalSize::default(),
         )
     }
 


### PR DESCRIPTION
`BoxFragment::new()` had some logic to mark relative positioned boxes with both insets in the same axis set to something different than `auto` as overconstrained.

However, this was dead code, since overconstrainment is checked for getComputedStyle queries, but not for relative positioning.

Also, the logic was wrong: it was detecting vertical overconstrainment by checking `left` and `bottom` (instead of `top` and `bottom`).

So it can just be removed.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors)
- [X] These changes do not require tests because there is no behavior change

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
