### PR TITLE
Fix clamp-like pattern warning in font.rs

### DIFF
--- a/components/fonts/platform/windows/font.rs
+++ b/components/fonts/platform/windows/font.rs
@@ -167,7 +167,7 @@ impl PlatformFontMethods for PlatformFont {
         };
 
         let weight = StyleFontWeight::from_float(weight_val as f32);
-        let stretch = match min(9, max(1, width_val)) {
+        let stretch = match width_val.clamp(1, 9) {
             1 => StyleFontStretch::ULTRA_CONDENSED,
             2 => StyleFontStretch::EXTRA_CONDENSED,
             3 => StyleFontStretch::CONDENSED,


### PR DESCRIPTION
**File**: components/fonts/platform/windows/font.rs

**PR Description**
**Issue**: Clippy warned about a clamp-like pattern without using the clamp function in the stretch calculation.

---
**Change**:
Updated `let stretch = match min(9, max(1, width_val))` to `let stretch = match width_val.clamp(1, 9)` in the stretch calculation.

**Impact**:
Improved code readability.

---

- [X] ./mach build -d does not report any errors
- [X] ./mach test-tidy does not report any errors
- [X] These changes are part of Fix as many clippy problems as possible #31500
- [X] These changes do not require tests because they do not alter functionality.

