### PR TITLE
Improve `Au(0)` constructions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2050,6 +2050,7 @@ dependencies = [
  "malloc_size_of",
  "malloc_size_of_derive",
  "net_traits",
+ "num-traits",
  "parking_lot",
  "range",
  "serde",

--- a/components/fonts/Cargo.toml
+++ b/components/fonts/Cargo.toml
@@ -32,6 +32,7 @@ log = { workspace = true }
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
 net_traits = { workspace = true }
+num-traits = { workspace = true }
 parking_lot = { workspace = true }
 range = { path = "../range" }
 serde = { workspace = true }

--- a/components/fonts/font.rs
+++ b/components/fonts/font.rs
@@ -441,7 +441,7 @@ impl Font {
             let offset = prev_glyph_id.map(|prev| {
                 let h_kerning = Au::from_f64_px(self.glyph_h_kerning(prev, glyph_id));
                 advance += h_kerning;
-                Point2D::new(h_kerning, Au(0))
+                Point2D::new(h_kerning, Au::zero())
             });
 
             let glyph = GlyphData::new(glyph_id, advance, offset, true, true);
@@ -818,7 +818,7 @@ pub struct RunMetrics {
 impl RunMetrics {
     pub fn new(advance: Au, ascent: Au, descent: Au) -> RunMetrics {
         let bounds = Rect::new(
-            Point2D::new(Au(0), -ascent),
+            Point2D::new(Au::zero(), -ascent),
             Size2D::new(advance, ascent + descent),
         );
 

--- a/components/fonts/glyph.rs
+++ b/components/fonts/glyph.rs
@@ -10,6 +10,7 @@ use std::{fmt, mem};
 
 use app_units::Au;
 use euclid::default::Point2D;
+use euclid::num::Zero;
 pub use fonts_traits::ByteIndex;
 use itertools::Either;
 use log::debug;
@@ -97,7 +98,7 @@ fn is_simple_glyph_id(id: GlyphId) -> bool {
 }
 
 fn is_simple_advance(advance: Au) -> bool {
-    advance >= Au(0) && {
+    advance >= Au::zero() && {
         let unsigned_au = advance.0 as u32;
         (unsigned_au & (GLYPH_ADVANCE_MASK >> GLYPH_ADVANCE_SHIFT)) == unsigned_au
     }
@@ -474,7 +475,7 @@ impl GlyphStore {
         GlyphStore {
             entry_buffer: vec![GlyphEntry::initial(); length],
             detail_store: DetailedGlyphStore::new(),
-            total_advance: Au(0),
+            total_advance: Au::zero(),
             total_word_separators: 0,
             has_detailed_glyphs: false,
             is_whitespace,
@@ -516,7 +517,7 @@ impl GlyphStore {
 
     #[inline(never)]
     fn cache_total_advance_and_word_separators(&mut self) {
-        let mut total_advance = Au(0);
+        let mut total_advance = Au::zero();
         let mut total_word_separators = 0;
         for glyph in self.iter_glyphs_for_byte_range(&Range::new(ByteIndex(0), self.len())) {
             total_advance += glyph.advance();
@@ -651,7 +652,7 @@ impl GlyphStore {
         extra_word_spacing: Au,
     ) -> (usize, Au) {
         let mut index = 0;
-        let mut current_advance = Au(0);
+        let mut current_advance = Au::zero();
         for glyph in self.iter_glyphs_for_byte_range(range) {
             if glyph.char_is_word_separator() {
                 current_advance += glyph.advance() + extra_word_spacing
@@ -682,7 +683,7 @@ impl GlyphStore {
         extra_word_spacing: Au,
     ) -> Au {
         self.iter_glyphs_for_byte_range(range)
-            .fold(Au(0), |advance, glyph| {
+            .fold(Au::zero(), |advance, glyph| {
                 if glyph.char_is_word_separator() {
                     advance + glyph.advance() + extra_word_spacing
                 } else {

--- a/components/fonts/shaper.rs
+++ b/components/fonts/shaper.rs
@@ -26,6 +26,7 @@ use harfbuzz_sys::{
     HB_OT_LAYOUT_BASELINE_TAG_ROMAN,
 };
 use log::debug;
+use num_traits::Zero;
 
 use crate::platform::font::FontTable;
 use crate::{
@@ -107,11 +108,11 @@ impl ShapedGlyphData {
             let x_advance = Au::from_f64_px(x_advance);
             let y_advance = Au::from_f64_px(y_advance);
 
-            let offset = if x_offset == Au(0) && y_offset == Au(0) && y_advance == Au(0) {
+            let offset = if x_offset.is_zero() && y_offset.is_zero() && y_advance.is_zero() {
                 None
             } else {
                 // adjust the pen..
-                if y_advance > Au(0) {
+                if y_advance > Au::zero() {
                     *y_pos -= y_advance;
                 }
 
@@ -466,7 +467,7 @@ impl Shaper {
         let mut glyph_span = 0..0;
         let mut byte_range = 0..0;
 
-        let mut y_pos = Au(0);
+        let mut y_pos = Au::zero();
 
         // main loop over each glyph. each iteration usually processes 1 glyph and 1+ chars.
         // in cases with complex glyph-character associations, 2+ glyphs and 1+ chars can be

--- a/components/layout_2020/table/layout.rs
+++ b/components/layout_2020/table/layout.rs
@@ -1041,10 +1041,10 @@ impl<'a> TableLayout<'a> {
             |column_index: &usize| self.column_measures[*column_index].percentage.0 > 0.;
         let has_percent_zero = |column_index: &usize| !has_percent_greater_than_zero(column_index);
         let has_max_content = |column_index: &usize| {
-            self.column_measures[*column_index]
+            !self.column_measures[*column_index]
                 .content_sizes
-                .max_content !=
-                Au(0)
+                .max_content
+                .is_zero()
         };
 
         let max_content_sum =
@@ -2862,8 +2862,8 @@ fn get_outer_sizes_for_measurement(
     let min_size = style.min_box_size(writing_mode);
     let max_size = style.max_box_size(writing_mode);
     (
-        outer_size(size.map(|v| get_size_for_axis(v).unwrap_or(Au(0)))),
-        outer_size(min_size.map(|v| get_size_for_axis(v).unwrap_or(Au(0)))),
+        outer_size(size.map(|v| get_size_for_axis(v).unwrap_or_else(Au::zero))),
+        outer_size(min_size.map(|v| get_size_for_axis(v).unwrap_or_else(Au::zero))),
         outer_size(max_size.map(|v| get_size_for_axis(v).unwrap_or(MAX_AU))),
         size.inline.is_keyword(),
         get_size_percentage_contribution(&size, &max_size),

--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -875,7 +875,7 @@ impl LayoutThread {
                         root_flow.overflow.scroll.size
                     };
 
-                    let origin = Rect::new(Point2D::new(Au(0), Au(0)), root_size).to_layout();
+                    let origin = Rect::new(Point2D::zero(), root_size).to_layout();
                     build_state.root_stacking_context.bounds = origin;
                     build_state.root_stacking_context.overflow = origin;
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

I replaced all `Au(0)` constructions to `Au::zero()` (or other utility functions when possible), except in the legacy layout. This ended up changing some line lengths enough that I had to re-run `./mach fmt` which is the cause for the few formatting changes in the commit.

Upsides:
 - Unify all `Au(0)`s down to a single implementation
 - More readable code (imo)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because no logic has been modified

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
