### PR TITLE
Attempt to link to MPL-2.0 license page in Windows installer

### DIFF
--- a/support/windows/Servo.wxs
+++ b/support/windows/Servo.wxs
@@ -1,9 +1,13 @@
 <?xml version="1.0"?>
-<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:bal="http://schemas.microsoft.com/wix/BalExtension">
   <Bundle Name="Servo"
           Version="1.0"
           UpgradeCode="91b09c7e-6c0d-4166-b806-1dc724acf728">
-    <BootstrapperApplicationRef Id="WixStandardBootstrapperApplication.RtfLicense" />
+    <BootstrapperApplicationRef Id="WixStandardBootstrapperApplication.HyperlinkLicense">
+      <bal:WixStandardBootstrapperApplication
+        LicenseUrl="https://www.mozilla.org/en-US/MPL/2.0/"
+        />
+    </BootstrapperApplicationRef>
     <Chain>
       <MsiPackage
           SourceFile="Installer.msi"


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
I do not have experience working with WiX but according to this doc page https://wixtoolset.org/docs/v3/bundle/wixstdba/wixstdba_license/ this should have the installer link to the license page instead of displaying placeholder text in the Windows installer.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix (hopefully) #21720 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
