### PR TITLE
Fix test timing for all tests using xr_promise_test

### DIFF
--- a/tests/wpt/meta/webxr/__dir__.ini
+++ b/tests/wpt/meta/webxr/__dir__.ini
@@ -1,1 +1,1 @@
-prefs: [dom.webxr.test: true, dom.webgl2.enabled: true]
+prefs: [dom.webxr.test: true, dom.webgl2.enabled: true, dom.webxr.layers.enabled: true]

--- a/tests/wpt/meta/webxr/depth-sensing/cpu/depth_sensing_cpu_dataUnavailable.https.html.ini
+++ b/tests/wpt/meta/webxr/depth-sensing/cpu/depth_sensing_cpu_dataUnavailable.https.html.ini
@@ -1,7 +1,7 @@
 [depth_sensing_cpu_dataUnavailable.https.html]
+  expected: ERROR
   [Ensures depth data is not available when cleared in the controller, `cpu-optimized` - webgl]
     expected: FAIL
 
   [Ensures depth data is not available when cleared in the controller, `cpu-optimized` - webgl2]
     expected: FAIL
-

--- a/tests/wpt/meta/webxr/depth-sensing/cpu/depth_sensing_cpu_inactiveFrame.https.html.ini
+++ b/tests/wpt/meta/webxr/depth-sensing/cpu/depth_sensing_cpu_inactiveFrame.https.html.ini
@@ -1,7 +1,7 @@
 [depth_sensing_cpu_inactiveFrame.https.html]
+  expected: ERROR
   [Ensures getDepthInformation() throws when not run in an active frame, `cpu-optimized` - webgl]
     expected: FAIL
 
   [Ensures getDepthInformation() throws when not run in an active frame, `cpu-optimized` - webgl2]
     expected: FAIL
-

--- a/tests/wpt/meta/webxr/depth-sensing/cpu/depth_sensing_cpu_incorrectUsage.https.html.ini
+++ b/tests/wpt/meta/webxr/depth-sensing/cpu/depth_sensing_cpu_incorrectUsage.https.html.ini
@@ -1,7 +1,7 @@
 [depth_sensing_cpu_incorrectUsage.https.html]
+  expected: ERROR
   [Ensures XRWebGLDepthInformation is not obtainable in `cpu-optimized` usage mode - webgl]
     expected: FAIL
 
   [Ensures XRWebGLDepthInformation is not obtainable in `cpu-optimized` usage mode - webgl2]
     expected: FAIL
-

--- a/tests/wpt/meta/webxr/depth-sensing/cpu/depth_sensing_cpu_staleView.https.html.ini
+++ b/tests/wpt/meta/webxr/depth-sensing/cpu/depth_sensing_cpu_staleView.https.html.ini
@@ -1,7 +1,7 @@
 [depth_sensing_cpu_staleView.https.html]
+  expected: ERROR
   [Ensures getDepthInformation() throws when run with stale XRView, `cpu-optimized` - webgl]
     expected: FAIL
 
   [Ensures getDepthInformation() throws when run with stale XRView, `cpu-optimized` - webgl2]
     expected: FAIL
-

--- a/tests/wpt/meta/webxr/depth-sensing/gpu/depth_sensing_gpu_dataUnavailable.https.html.ini
+++ b/tests/wpt/meta/webxr/depth-sensing/gpu/depth_sensing_gpu_dataUnavailable.https.html.ini
@@ -1,7 +1,7 @@
 [depth_sensing_gpu_dataUnavailable.https.html]
+  expected: ERROR
   [Ensures depth data is not available when cleared in the controller, `gpu-optimized` - webgl]
     expected: FAIL
 
   [Ensures depth data is not available when cleared in the controller, `gpu-optimized` - webgl2]
     expected: FAIL
-

--- a/tests/wpt/meta/webxr/depth-sensing/gpu/depth_sensing_gpu_staleView.https.html.ini
+++ b/tests/wpt/meta/webxr/depth-sensing/gpu/depth_sensing_gpu_staleView.https.html.ini
@@ -1,7 +1,7 @@
 [depth_sensing_gpu_staleView.https.html]
+  expected: ERROR
   [Ensures getDepthInformation() throws when not run with stale XRView, `gpu-optimized` - webgl]
     expected: FAIL
 
   [Ensures getDepthInformation() throws when not run with stale XRView, `gpu-optimized` - webgl2]
     expected: FAIL
-

--- a/tests/wpt/meta/webxr/light-estimation/xrWebGLBinding_getReflectionCubeMap.https.html.ini
+++ b/tests/wpt/meta/webxr/light-estimation/xrWebGLBinding_getReflectionCubeMap.https.html.ini
@@ -1,7 +1,3 @@
 [xrWebGLBinding_getReflectionCubeMap.https.html]
   [Test that getReflectionCubeMap returns or throws appropriately without a reflection map. - webgl]
     expected: FAIL
-
-  [Test that getReflectionCubeMap returns or throws appropriately without a reflection map. - webgl2]
-    expected: FAIL
-

--- a/tests/wpt/meta/webxr/render_state_update.https.html.ini
+++ b/tests/wpt/meta/webxr/render_state_update.https.html.ini
@@ -1,2 +1,0 @@
-[render_state_update.https.html]
-  expected: ERROR

--- a/tests/wpt/meta/webxr/xrWebGLLayer_constructor.https.html.ini
+++ b/tests/wpt/meta/webxr/xrWebGLLayer_constructor.https.html.ini
@@ -1,7 +1,7 @@
 [xrWebGLLayer_constructor.https.html]
+  expected: ERROR
   [Ensure that XRWebGLLayer's constructor throws appropriate errors using webgl2]
-    expected: FAIL
+    expected: NOTRUN
 
   [Ensure that XRWebGLLayer's constructor throws appropriate errors using webgl]
-    expected: FAIL
-
+    expected: TIMEOUT

--- a/tests/wpt/tests/webxr/resources/webxr_util.js
+++ b/tests/wpt/tests/webxr/resources/webxr_util.js
@@ -13,6 +13,8 @@
 // override this.
 var xr_debug = function(name, msg) {};
 
+let loaded = new Promise(resolve => document.addEventListener('DOMContentLoaded', resolve));
+
 function xr_promise_test(name, func, properties, glContextType, glContextProperties) {
   promise_test(async (t) => {
     if (glContextType === 'webgl2') {
@@ -60,6 +62,7 @@ function xr_promise_test(name, func, properties, glContextType, glContextPropert
     let canvas = null;
     if (glContextType) {
       canvas = document.createElement('canvas');
+      await loaded;
       document.body.appendChild(canvas);
       gl = canvas.getContext(glContextType, glContextProperties);
     }
@@ -161,22 +164,20 @@ function xr_session_promise_test(
         }));
   }
 
-  document.addEventListener('DOMContentLoaded', () => {
-    xr_promise_test(
-      name + ' - webgl',
-      runTest,
-      properties,
-      'webgl',
-      {alpha: false, antialias: false, ...glcontextProperties}
-    );
-    xr_promise_test(
-      name + ' - webgl2',
-      runTest,
-      properties,
-      'webgl2',
-      {alpha: false, antialias: false, ...glcontextProperties}
-    );
-  });
+  xr_promise_test(
+    name + ' - webgl',
+    runTest,
+    properties,
+    'webgl',
+    {alpha: false, antialias: false, ...glcontextProperties}
+  );
+  xr_promise_test(
+    name + ' - webgl2',
+    runTest,
+    properties,
+    'webgl2',
+    {alpha: false, antialias: false, ...glcontextProperties}
+  );
 }
 
 


### PR DESCRIPTION
#33112 addressed all tests that used xr_session_promise_test, but the actual timing issue resides in xr_promise_test and there are a bunch of files that call that instead. These changes ensure that xr_promise_test waits for the DOMContentLoaded event to be fired before attempting to access the document's body element.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes