### PR TITLE
ohos: pin version of setup-ohos-sdk action to fix CI

### DIFF
--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -52,7 +52,11 @@ jobs:
         run: sudo apt update && python3 ./mach bootstrap --skip-lints
       - name: Setup OpenHarmony SDK
         id: setup_sdk
-        uses: openharmony-rs/setup-ohos-sdk@v0.1
+        # FIXME: We pin the exact patch version to the LKG version of the
+        # action to address bugs in the most recent 0.1.2 release. Once that
+        # has been addresssed upstream, we can revert to specifying only the
+        # major.minor tag.
+        uses: openharmony-rs/setup-ohos-sdk@v0.1.2
         with:
           version: "4.1"
           components: "native;toolchains;ets;js;previewer"


### PR DESCRIPTION
The most recent [v0.1.3] release seems to not set the expected
OHOS_SDK_NATIVE and OHOS_BASE_SDK_HOME environment variables.

This is causing the OHOS builds to fail in CI and blocking the merge
queue. This change pins the action to the last known good version until
the error can be addressed upstream.

[v0.1.3]: https://github.com/openharmony-rs/setup-ohos-sdk/releases/tag/v0.1.3

Fixes #33712.

Signed-off-by: Mukilan Thiyagarajan <mukilan@igalia.com>

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #33712
- [x] These changes do not require tests because they fix CI build issue.

