### PR TITLE
clippy: Add Safety docs for unsafe init_reflector function in components/script/dom/bindings/reflector.rs). 

### DIFF
--- a/components/script/dom/bindings/reflector.rs
+++ b/components/script/dom/bindings/reflector.rs
@@ -123,6 +123,12 @@ impl DomObject for Reflector {
 /// A trait to initialize the `Reflector` for a DOM object.
 pub trait MutDomObject: DomObject {
     /// Initializes the Reflector
+    /// 
+    /// # Safety 
+    /// This Function is 'unsafe' because it takes a raw pointer to a 'JSObject'
+    /// The caller must ensure that the pointer is valid and properly aligned.
+    /// Undefined behavior may occur if the pointer is null or if it points to
+    /// an invalid memory location.
     unsafe fn init_reflector(&self, obj: *mut JSObject);
 }
 


### PR DESCRIPTION
This PR fixes some clippy warnings by: 
Adding a `# Safety` documentation section for the unsafe `init_reflector` function in `components/script/dom/bindings/reflector.rs` to address the missing safety documentation warning from Clippy.


- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of Fix as many clippy problems as possible #31500

- [X] These changes do not require tests because the modification is documentation only.