### PR TITLE
clippy: Add safety documentation to CustomTraceable trait

### DIFF
--- a/components/script/dom/bindings/reflector.rs
+++ b/components/script/dom/bindings/reflector.rs
@@ -123,6 +123,12 @@ impl DomObject for Reflector {
 /// A trait to initialize the `Reflector` for a DOM object.
 pub trait MutDomObject: DomObject {
     /// Initializes the Reflector
+    /// 
+    /// # Safety 
+    /// This Function is 'unsafe' because it takes a raw pointer to a 'JSObject'
+    /// The caller must ensure that the pointer is valid and properly aligned.
+    /// Undefined behavior may occur if the pointer is null or if it points to
+    /// an invalid memory location.
     unsafe fn init_reflector(&self, obj: *mut JSObject);
 }
 

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -69,6 +69,12 @@ use crate::script_thread::IncompleteParserContexts;
 use crate::task::TaskBox;
 
 /// A trait to allow tracing only DOM sub-objects.
+/// 
+/// # Safety
+/// - Before calling `trace`, `self` must be valid and properly initialized.
+/// - The `trace` method must not cause data races or access invalid memory.
+/// - For `Box<T>` and `DomRefCell<T>`, ensure the underlying data is valid during tracing.
+/// - Avoid multiple mutable borrows when using `DomRefCell`. 
 pub unsafe trait CustomTraceable {
     /// Trace `self`.
     unsafe fn trace(&self, trc: *mut JSTracer);


### PR DESCRIPTION
Added safety documentation to the `CustomTraceable` trait and its implementations to comply with Clippy's requirements.

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of Fix as many clippy problems as possible Fix as many clippy problems as possible #31500

- [X] These changes do not require tests because the changes are only documentation-related.