### PR TITLE
clippy:Use `map` instead of `filter_map` in `components/devtools`

### DIFF
--- a/components/devtools/actors/inspector/page_style.rs
+++ b/components/devtools/actors/inspector/page_style.rs
@@ -151,7 +151,7 @@ impl PageStyleActor {
         )
         .unwrap_or_default()
         .into_iter()
-        .filter_map(|node| {
+        .map(|node| {
             let inherited = (node.actor != target).then(|| node.actor.clone());
             let node_actor = registry.find::<NodeActor>(&node.actor);
 
@@ -207,7 +207,7 @@ impl PageStyleActor {
                             inherited: inherited.clone(),
                         })
                     });
-            Some(entries)
+            entries
         })
         .flatten()
         .collect();


### PR DESCRIPTION
**File**: components/devtools/actors/inspector/page_style.rs
<!-- Please describe your changes on the following line: -->
**PR Description**
Issue: Clippy warned about unnecessary use of .filter_map() in the PageStyleActor implementation. The .filter_map() operation was not actually filtering out any elements, making it equivalent to a .map() operation.

**Changes**
Replaced .filter_map(|node| { ... }) with .map(|node| { ... }) in the get_applied method of PageStyleActor.
Removed the Some(...) wrapper from the return value of the closure inside the mapping operation.

Impact: Improved code clarity and efficiency by using the appropriate iterator method. This change resolves a Clippy warning, contributing to better code quality without affecting the functionality of the code.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #31500

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
