### PR TITLE
clippy: Use `flat_map` instead of `map` in `components/devtools`

### DIFF
--- a/components/devtools/actors/inspector/page_style.rs
+++ b/components/devtools/actors/inspector/page_style.rs
@@ -151,7 +151,7 @@ impl PageStyleActor {
         )
         .unwrap_or_default()
         .into_iter()
-        .map(|node| {
+        .flat_map(|node| {
             let inherited = (node.actor != target).then(|| node.actor.clone());
             let node_actor = registry.find::<NodeActor>(&node.actor);
 
@@ -209,7 +209,6 @@ impl PageStyleActor {
                     });
             entries
         })
-        .flatten()
         .collect();
         let msg = GetAppliedReply {
             entries,

--- a/components/devtools/actors/inspector/page_style.rs
+++ b/components/devtools/actors/inspector/page_style.rs
@@ -151,7 +151,7 @@ impl PageStyleActor {
         )
         .unwrap_or_default()
         .into_iter()
-        .filter_map(|node| {
+        .map(|node| {
             let inherited = (node.actor != target).then(|| node.actor.clone());
             let node_actor = registry.find::<NodeActor>(&node.actor);
 
@@ -207,7 +207,7 @@ impl PageStyleActor {
                             inherited: inherited.clone(),
                         })
                     });
-            Some(entries)
+            entries
         })
         .flatten()
         .collect();


### PR DESCRIPTION
**PR Description**
Issue: Clippy suggested replacing .map() with .flat_map() in the PageStyleActor implementation. The .map().flatten() operation was being used in a way that could be more efficiently expressed using .flat_map().

**Changes**
Replaced .map(|node| { ... }) with .flat_map(|node| { ... }) in the get_applied method of PageStyleActor.
Removed the Some(...) wrapper from the return value of the closure, changing Some(entries) to just entries.

**Impact**: Improved code readability by using the more appropriate .flat_map() method. This change resolves a Clippy suggestion, potentially improving performance and maintaining better code quality without altering the functionality of the code.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #31500

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->