### PR TITLE
clippy: Fix `type_complexity` warning in `components/script/dom`

### DIFF
--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -583,9 +583,11 @@ impl RangeMethods for Range {
         }
 
         // Steps 5-12.
-        let first_contained_child = self.contained_children()?.first_partially_contained_child;
-        let last_contained_child = self.contained_children()?.last_partially_contained_child;
-        let contained_children = self.contained_children()?.contained_children;
+        let ContainedChildren {
+            first_partially_contained_child: first_contained_child,
+            last_partially_contained_child: last_contained_child,
+            contained_children,
+        } = self.contained_children()?;
 
         if let Some(child) = first_contained_child {
             // Step 13.
@@ -698,9 +700,11 @@ impl RangeMethods for Range {
         }
 
         // Steps 5-12.
-        let first_contained_child = self.contained_children()?.first_partially_contained_child;
-        let last_contained_child = self.contained_children()?.last_partially_contained_child;
-        let contained_children = self.contained_children()?.contained_children;
+        let ContainedChildren {
+            first_partially_contained_child: first_contained_child,
+            last_partially_contained_child: last_contained_child,
+            contained_children,
+        } = self.contained_children()?;
 
         let (new_node, new_offset) = if start_node.is_inclusive_ancestor_of(&end_node) {
             // Step 13.

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -52,6 +52,12 @@ pub struct Range {
     associated_selections: DomRefCell<Vec<Dom<Selection>>>,
 }
 
+pub struct ContainedChildren {
+    first_partially_contained_child: Option<DomRoot<Node>>,
+    last_partially_contained_child: Option<DomRoot<Node>>,
+    contained_children: Vec<DomRoot<Node>>,
+}
+
 impl Range {
     fn new_inherited(
         start_container: &Node,
@@ -149,13 +155,7 @@ impl Range {
     }
 
     /// <https://dom.spec.whatwg.org/#concept-range-clone>
-    fn contained_children(
-        &self,
-    ) -> Fallible<(
-        Option<DomRoot<Node>>,
-        Option<DomRoot<Node>>,
-        Vec<DomRoot<Node>>,
-    )> {
+    fn contained_children(&self) -> Fallible<ContainedChildren> {
         let start_node = self.start_container();
         let end_node = self.end_container();
         // Steps 5-6.
@@ -192,11 +192,11 @@ impl Range {
             return Err(Error::HierarchyRequest);
         }
 
-        Ok((
-            first_contained_child,
-            last_contained_child,
+        Ok(ContainedChildren {
+            first_partially_contained_child: first_contained_child,
+            last_partially_contained_child: last_contained_child,
             contained_children,
-        ))
+        })
     }
 
     /// <https://dom.spec.whatwg.org/#concept-range-bp-set>
@@ -583,8 +583,9 @@ impl RangeMethods for Range {
         }
 
         // Steps 5-12.
-        let (first_contained_child, last_contained_child, contained_children) =
-            self.contained_children()?;
+        let first_contained_child = self.contained_children()?.first_partially_contained_child;
+        let last_contained_child = self.contained_children()?.last_partially_contained_child;
+        let contained_children = self.contained_children()?.contained_children;
 
         if let Some(child) = first_contained_child {
             // Step 13.
@@ -697,8 +698,9 @@ impl RangeMethods for Range {
         }
 
         // Steps 5-12.
-        let (first_contained_child, last_contained_child, contained_children) =
-            self.contained_children()?;
+        let first_contained_child = self.contained_children()?.first_partially_contained_child;
+        let last_contained_child = self.contained_children()?.last_partially_contained_child;
+        let contained_children = self.contained_children()?.contained_children;
 
         let (new_node, new_offset) = if start_node.is_inclusive_ancestor_of(&end_node) {
             // Step 13.


### PR DESCRIPTION
Fixes `type_complexity` warning in `components/script/dom/range.rs` as a part of #31500  


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are a part of #31500 
- [X] These changes do not require tests because because they do not modify functionality, they only fix lint warnings.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
