### PR TITLE
Fix: Add missing transmute annotations in `Castable` trait

### DIFF
--- a/components/script/dom/bindings/inheritance.rs
+++ b/components/script/dom/bindings/inheritance.rs
@@ -37,7 +37,7 @@ pub trait Castable: IDLInterface + DomObject + Sized {
         T: Castable,
         Self: DerivedFrom<T>,
     {
-        unsafe { mem::transmute(self) }
+        unsafe { mem::transmute::<&Self, &T>(self) }
     }
 
     /// Cast a DOM object downwards to one of the interfaces it might implement.


### PR DESCRIPTION
**File**: components/script/dom/bindings/inheritance.rs

**PR Description**
**Issue**: Clippy warned about transmute usage without annotations in the `Castable` trait implementation.

**Change**:
Added explicit type annotations to the `transmute` calls in both the `upcast` and `downcast` methods:

1. `transmute::<&Self, &T>(self)` in `upcast`
2. `transmute::<&Self, &T>(self)` in `downcast`

**Impact**: Least invasive change that improves type safety and clarity in type casting while maintaining the existing functionality. 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of https://github.com/servo/servo/issues/31500

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because they are not part of functionality.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
