### PR TITLE
clippy: fix `clone_on_copy` warning in `components/script/dom/cryptokey.rs`

### DIFF
--- a/components/script/dom/cryptokey.rs
+++ b/components/script/dom/cryptokey.rs
@@ -93,7 +93,7 @@ impl CryptoKey {
 impl CryptoKeyMethods for CryptoKey {
     /// <https://w3c.github.io/webcrypto/#cryptokey-interface-members>
     fn Type(&self) -> KeyType {
-        self.key_type.clone()
+        self.key_type
     }
 
     /// <https://w3c.github.io/webcrypto/#cryptokey-interface-members>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Removed clone implementation for a copy type

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #31500 
- [X] These changes do not require tests because they do not change functionality.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
