### PR TITLE
Implement keyword sizes on atomic inlines

### DIFF
--- a/tests/wpt/meta/css/css-sizing/animation/height-interpolation.html.ini
+++ b/tests/wpt/meta/css/css-sizing/animation/height-interpolation.html.ini
@@ -478,3 +478,21 @@
 
   [Web Animations: property <height> from neutral to [fit-content\] at (1.5) should be [fit-content\]]
     expected: FAIL
+
+  [CSS Transitions with transition-behavior:allow-discrete: property <height> from [max-content\] to [stretch\] at (-0.3) should be [max-content\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-behavior:allow-discrete: property <height> from [max-content\] to [stretch\] at (0) should be [max-content\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-behavior:allow-discrete: property <height> from [max-content\] to [stretch\] at (0.3) should be [max-content\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <height> from [max-content\] to [stretch\] at (-0.3) should be [max-content\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <height> from [max-content\] to [stretch\] at (0) should be [max-content\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <height> from [max-content\] to [stretch\] at (0.3) should be [max-content\]]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/hori-block-size-small-or-larger-than-container-with-min-or-max-content-1.html.ini
+++ b/tests/wpt/meta/css/css-sizing/hori-block-size-small-or-larger-than-container-with-min-or-max-content-1.html.ini
@@ -1,2 +1,0 @@
-[hori-block-size-small-or-larger-than-container-with-min-or-max-content-1.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/vert-block-size-small-or-larger-than-container-with-min-or-max-content-2a.html.ini
+++ b/tests/wpt/meta/css/css-sizing/vert-block-size-small-or-larger-than-container-with-min-or-max-content-2a.html.ini
@@ -1,0 +1,2 @@
+[vert-block-size-small-or-larger-than-container-with-min-or-max-content-2a.html]
+  expected: FAIL

--- a/tests/wpt/tests/css/css-sizing/keyword-sizes-on-inline-block.html
+++ b/tests/wpt/tests/css/css-sizing/keyword-sizes-on-inline-block.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<title>Keyword sizes on floated element</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-3/#sizing-values">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#sizing-values">
+<link rel="help" href="https://drafts.csswg.org/css2/#value-def-inline-block">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/11006">
+<meta assert="The various keyword sizes work as expected on inline-blocks.">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+
+<style>
+.wrapper {
+  display: inline-block;
+  vertical-align: top;
+  margin-right: 150px;
+}
+
+.test {
+  display: inline-block;
+  margin: 5px;
+  border: 3px solid;
+  padding: 2px;
+  font: 20px/1 Ahem;
+}
+
+/* Set the preferred size to small amount, to test that the min size works */
+.test.min-width  { width:  0px }
+.test.min-height { height: 0px }
+
+/* Set the preferred size to big amount, to test that the max size works */
+.test.max-width  { width:  500px }
+.test.max-height { height: 500px }
+
+/* stretch isn't widely supported, fall back to vendor-prefixed alternatives */
+.width.stretch      {      width: -moz-available;      width: -webkit-fill-available;      width: stretch }
+.min-width.stretch  {  min-width: -moz-available;  min-width: -webkit-fill-available;  min-width: stretch }
+.max-width.stretch  {  max-width: -moz-available;  max-width: -webkit-fill-available;  max-width: stretch }
+.height.stretch     {     height: -moz-available;     height: -webkit-fill-available;     height: stretch }
+.min-height.stretch { min-height: -moz-available; min-height: -webkit-fill-available; min-height: stretch }
+.max-height.stretch { max-height: -moz-available; max-height: -webkit-fill-available; max-height: stretch }
+</style>
+<div id="log"></div>
+
+<!-- Intrinsic keywords -->
+<div class="wrapper" style="width: 100px; height: 100px">
+  <div class="test width" style="width: min-content" data-expected-width="30">X X</div>
+  <div class="test width" style="width: fit-content" data-expected-width="70">X X</div>
+  <div class="test width" style="width: max-content" data-expected-width="70">X X</div>
+
+  <div class="test width" style="width: min-content" data-expected-width="70">XXX XXX</div>
+  <div class="test width" style="width: fit-content" data-expected-width="90">XXX XXX</div>
+  <div class="test width" style="width: max-content" data-expected-width="150">XXX XXX</div>
+
+  <div class="test width" style="width: min-content" data-expected-width="110">XXXXX XXXXX</div>
+  <div class="test width" style="width: fit-content" data-expected-width="110">XXXXX XXXXX</div>
+  <div class="test width" style="width: max-content" data-expected-width="230">XXXXX XXXXX</div>
+
+  <br>
+
+  <div class="test min-width" style="min-width: min-content" data-expected-width="30">X X</div>
+  <div class="test min-width" style="min-width: fit-content" data-expected-width="70">X X</div>
+  <div class="test min-width" style="min-width: max-content" data-expected-width="70">X X</div>
+
+  <div class="test min-width" style="min-width: min-content" data-expected-width="70">XXX XXX</div>
+  <div class="test min-width" style="min-width: fit-content" data-expected-width="90">XXX XXX</div>
+  <div class="test min-width" style="min-width: max-content" data-expected-width="150">XXX XXX</div>
+
+  <div class="test min-width" style="min-width: min-content" data-expected-width="110">XXXXX XXXXX</div>
+  <div class="test min-width" style="min-width: fit-content" data-expected-width="110">XXXXX XXXXX</div>
+  <div class="test min-width" style="min-width: max-content" data-expected-width="230">XXXXX XXXXX</div>
+
+  <br>
+
+  <div class="test max-width" style="max-width: min-content" data-expected-width="30">X X</div>
+  <div class="test max-width" style="max-width: fit-content" data-expected-width="70">X X</div>
+  <div class="test max-width" style="max-width: max-content" data-expected-width="70">X X</div>
+
+  <div class="test max-width" style="max-width: min-content" data-expected-width="70">XXX XXX</div>
+  <div class="test max-width" style="max-width: fit-content" data-expected-width="90">XXX XXX</div>
+  <div class="test max-width" style="max-width: max-content" data-expected-width="150">XXX XXX</div>
+
+  <div class="test max-width" style="max-width: min-content" data-expected-width="110">XXXXX XXXXX</div>
+  <div class="test max-width" style="max-width: fit-content" data-expected-width="110">XXXXX XXXXX</div>
+  <div class="test max-width" style="max-width: max-content" data-expected-width="230">XXXXX XXXXX</div>
+
+  <br>
+
+  <div class="test height" style="height: min-content" data-expected-height="30">X X</div>
+  <div class="test height" style="height: fit-content" data-expected-height="30">X X</div>
+  <div class="test height" style="height: max-content" data-expected-height="30">X X</div>
+
+  <div class="test min-height" style="min-height: min-content" data-expected-height="30">X X</div>
+  <div class="test min-height" style="min-height: fit-content" data-expected-height="30">X X</div>
+  <div class="test min-height" style="min-height: max-content" data-expected-height="30">X X</div>
+
+  <div class="test max-height" style="max-height: min-content" data-expected-height="30">X X</div>
+  <div class="test max-height" style="max-height: fit-content" data-expected-height="30">X X</div>
+  <div class="test max-height" style="max-height: max-content" data-expected-height="30">X X</div>
+</div>
+
+<!-- Definite stretch -->
+<div class="wrapper" style="width: 100px; height: 100px">
+  <div class="test width stretch" data-expected-width="90">X X</div>
+  <div class="test width stretch" data-expected-width="90">XXX XXX</div>
+  <div class="test width stretch" data-expected-width="90">XXXXX XXXXX</div>
+
+  <div class="test min-width stretch" data-expected-width="90">X X</div>
+  <div class="test min-width stretch" data-expected-width="90">XXX XXX</div>
+  <div class="test min-width stretch" data-expected-width="90">XXXXX XXXXX</div>
+
+  <div class="test max-width stretch" data-expected-width="90">X X</div>
+  <div class="test max-width stretch" data-expected-width="90">XXX XXX</div>
+  <div class="test max-width stretch" data-expected-width="90">XXXXX XXXXX</div>
+
+  <div class="test height stretch" data-expected-height="90">X X</div>
+  <div class="test height stretch" data-expected-height="90">XXX XXX<</div>
+  <div class="test height stretch" data-expected-height="90">XXXXX XXXXX</div>
+
+  <div class="test min-height stretch" data-expected-height="90">X X</div>
+  <div class="test min-height stretch" data-expected-height="90">XXX XXX</div>
+  <div class="test min-height stretch" data-expected-height="90">XXXXX XXXXX</div>
+
+  <div class="test max-height stretch" data-expected-height="90">X X</div>
+  <div class="test max-height stretch" data-expected-height="90">XXX XXX</div>
+  <div class="test max-height stretch" data-expected-height="90">XXXXX XXXXX</div>
+</div>
+
+<!-- Indefinite stretch -->
+<div class="wrapper" style="width: 100px; max-height: 100px">
+  <div class="test height stretch indefinite" data-expected-height="30">X X</div>
+  <div class="test height stretch indefinite" data-expected-height="50">XXX XXX</div>
+  <div class="test height stretch indefinite" data-expected-height="50">XXXXX XXXXX</div>
+
+  <div class="test min-height stretch indefinite" data-expected-height="30">X X</div>
+  <div class="test min-height stretch indefinite" data-expected-height="50">XXX XXX</div>
+  <div class="test min-height stretch indefinite" data-expected-height="50">XXXXX XXXXX</div>
+
+  <div class="test max-height stretch indefinite" data-expected-height="30">X X</div>
+  <div class="test max-height stretch indefinite" data-expected-height="50">XXX XXX</div>
+  <div class="test max-height stretch indefinite" data-expected-height="50">XXXXX XXXXX</div>
+</div>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<script>
+checkLayout(".test");
+</script>


### PR DESCRIPTION
Adds support for min-content, max-content, fit-content and stretch, for atomic inlines.

There are some new test failures because we don't support vertical writing modes nor `transition-behavior:allow-discrete`.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #32853
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
