### PR TITLE
CI: Bump setup-ohos-sdk to v0.1.4

### DIFF
--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -59,7 +59,7 @@ jobs:
         run: sudo apt update && python3 ./mach bootstrap --skip-lints
       - name: Setup OpenHarmony SDK
         id: setup_sdk
-        uses: openharmony-rs/setup-ohos-sdk@v0.1.4
+        uses: openharmony-rs/setup-ohos-sdk@v0.1
         with:
           version: "4.1"
           fixup-path: true

--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -59,14 +59,9 @@ jobs:
         run: sudo apt update && python3 ./mach bootstrap --skip-lints
       - name: Setup OpenHarmony SDK
         id: setup_sdk
-        # FIXME: We pin the exact patch version to the LKG version of the
-        # action to address bugs in the most recent 0.1.3 release. Once that
-        # has been addresssed upstream, we can revert to specifying only the
-        # major.minor tag.
-        uses: openharmony-rs/setup-ohos-sdk@v0.1.2
+        uses: openharmony-rs/setup-ohos-sdk@v0.1.4
         with:
           version: "4.1"
-          components: "native;toolchains;ets;js;previewer"
           fixup-path: true
       - name: Install node for hvigor
         uses: actions/setup-node@v4


### PR DESCRIPTION
v0.1.3 had [a bug](https://github.com/servo/servo/issues/33712) when the SDK was restored from cache. This was fixed upstream, and cache-hit behavior is now also tested in upstream CI.


---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
