### PR TITLE
Fix clippy warning: slow zero-filling initialization

### DIFF
--- a/components/script/dom/subtlecrypto.rs
+++ b/components/script/dom/subtlecrypto.rs
@@ -295,8 +295,7 @@ impl SubtleCrypto {
             return Err(Error::Syntax);
         }
 
-        let mut rand = Vec::new();
-        rand.resize(key_gen_params.length as usize, 0);
+        let mut rand = vec![0; key_gen_params.length as usize];
         self.rng.borrow_mut().fill_bytes(&mut rand);
         let handle = match key_gen_params.length {
             128 => Handle::Aes128(rand),


### PR DESCRIPTION
**File**: components/script/dom/subtlecrypto.rs

**PR Description**
**Issue**: Issue: Clippy warned about slow vector initialization in SubtleCrypto, suggesting the use of the vec! macro for optimization.

**Changes**:
Replaced `Vec::new()` and `resize()` with `vec![0; key_gen_params.length as usize]` in the `generate_key_aes_cbc` function.

**Impact**:
Improves performance by optimizing vector initialization, enhancing code readability and maintainability.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of https://github.com/servo/servo/issues/31500

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because they do not touch functionality.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
