### PR TITLE
Fix Clippy warning: Replace map().flatten() with and_then() in http_l…

### DIFF
--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -1142,8 +1142,7 @@ async fn http_network_or_cache_fetch(
     let content_length = http_request
         .body
         .as_ref()
-        .map(|body| body.len().map(|size| size as u64))
-        .flatten();
+        .and_then(|body| body.len().map(|size| size as u64));
 
     // Step 8.6 Let contentLengthHeaderValue be null.
     let mut content_length_header_value = None;


### PR DESCRIPTION
**File**: components/net/http_loader.rs

**PR Description**

**Issue**: Clippy warned about the use of `map(..).flatten()` on `Option`.

**Change**:
Replaced the `map(...).flatten()` chain with a single `and_then()` call.

**Impact**:
Improves code readability and resolves the Clippy warning without altering the existing functionality.

---

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of https://github.com/servo/servo/issues/31500

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because they do not touch functionality.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
