### PR TITLE
Remove most usage of ReentrantMutex in font code

### DIFF
--- a/components/fonts/font_context.rs
+++ b/components/fonts/font_context.rs
@@ -17,7 +17,7 @@ use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 use malloc_size_of_derive::MallocSizeOf;
 use net_traits::request::{Destination, Referrer, RequestBuilder};
 use net_traits::{fetch_async, CoreResourceThread, FetchResponseMsg, ResourceThreads};
-use parking_lot::{Mutex, ReentrantMutex, RwLock};
+use parking_lot::{Mutex, RwLock};
 use servo_arc::Arc as ServoArc;
 use servo_url::ServoUrl;
 use style::computed_values::font_variant_caps::T as FontVariantCaps;
@@ -49,10 +49,10 @@ static SMALL_CAPS_SCALE_FACTOR: f32 = 0.8; // Matches FireFox (see gfxFont.h)
 /// required.
 pub struct FontContext {
     system_font_service_proxy: Arc<SystemFontServiceProxy>,
-    resource_threads: ReentrantMutex<CoreResourceThread>,
+    resource_threads: Mutex<CoreResourceThread>,
 
     /// A sender that can send messages and receive replies from the compositor.
-    compositor_api: ReentrantMutex<CrossProcessCompositorApi>,
+    compositor_api: Mutex<CrossProcessCompositorApi>,
 
     /// The actual instances of fonts ie a [`FontTemplate`] combined with a size and
     /// other font properties, along with the font data and a platform font instance.
@@ -106,8 +106,8 @@ impl FontContext {
         #[allow(clippy::default_constructed_unit_structs)]
         Self {
             system_font_service_proxy,
-            resource_threads: ReentrantMutex::new(resource_threads.core_thread),
-            compositor_api: ReentrantMutex::new(compositor_api),
+            resource_threads: Mutex::new(resource_threads.core_thread),
+            compositor_api: Mutex::new(compositor_api),
             fonts: Default::default(),
             resolved_font_groups: Default::default(),
             web_fonts: Arc::new(RwLock::default()),

--- a/components/fonts/platform/freetype/font.rs
+++ b/components/fonts/platform/freetype/font.rs
@@ -150,7 +150,6 @@ impl PlatformFontMethods for PlatformFont {
             FontStyle::NORMAL
         };
 
-        let face = self.face.lock();
         let os2_table = face.os2_table();
         let weight = os2_table
             .as_ref()

--- a/components/fonts/system_font_service.rs
+++ b/components/fonts/system_font_service.rs
@@ -14,7 +14,7 @@ use atomic_refcell::AtomicRefCell;
 use ipc_channel::ipc::{self, IpcReceiver, IpcSender};
 use log::debug;
 use malloc_size_of_derive::MallocSizeOf;
-use parking_lot::{ReentrantMutex, RwLock};
+use parking_lot::{Mutex, RwLock};
 use serde::{Deserialize, Serialize};
 use servo_config::pref;
 use servo_url::ServoUrl;
@@ -121,7 +121,7 @@ pub struct SystemFontServiceProxySender(pub IpcSender<SystemFontServiceMessage>)
 impl SystemFontServiceProxySender {
     pub fn to_proxy(&self) -> SystemFontServiceProxy {
         SystemFontServiceProxy {
-            sender: ReentrantMutex::new(self.0.clone()),
+            sender: Mutex::new(self.0.clone()),
             templates: Default::default(),
             data_cache: Default::default(),
         }
@@ -384,7 +384,7 @@ struct FontTemplateCacheKey {
 /// `FontContext` instances.
 #[derive(Debug)]
 pub struct SystemFontServiceProxy {
-    sender: ReentrantMutex<IpcSender<SystemFontServiceMessage>>,
+    sender: Mutex<IpcSender<SystemFontServiceMessage>>,
     templates: RwLock<HashMap<FontTemplateCacheKey, Vec<FontTemplateRef>>>,
     data_cache: RwLock<HashMap<FontIdentifier, Arc<FontData>>>,
 }


### PR DESCRIPTION
ReentrantMutex is unnecessary complexity when we're only locking it for the duration of calling `.send(..)` on channel types, because there is no way for us to accidentally invoke code on the same thread that will attempt to lock the mutex again.

I was hoping to remove all usage of ReentrantMutex, but the font code in platform/freetype looks like we would double-panic if we ever panicked while the font mutex was locked, since we would then run the Drop implementation that attempts to lock the mutex again.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes