### PR TITLE
clippy: Add safety documentation and clean up unsafe methods

### DIFF
--- a/components/canvas/canvas_data.rs
+++ b/components/canvas/canvas_data.rs
@@ -656,7 +656,7 @@ impl<'a> CanvasData<'a> {
             ideographic_baseline,
             alphabetic_baseline,
             hanging_baseline,
-        } = match font.get_baseline() {
+        } = match font.baseline() {
             Some(baseline) => baseline,
             None => FontBaseline {
                 hanging_baseline: ascent * HANGING_BASELINE_DEFAULT,

--- a/components/fonts/font.rs
+++ b/components/fonts/font.rs
@@ -543,10 +543,10 @@ impl Font {
         self.handle.typographic_bounds(glyph_id)
     }
 
-    #[allow(unsafe_code)]
-    pub fn get_baseline(&self) -> Option<FontBaseline> {
+    /// Get the [`FontBaseline`] for this font.
+    pub fn baseline(&self) -> Option<FontBaseline> {
         let this = self as *const Font;
-        unsafe { self.shaper.get_or_init(|| Shaper::new(this)).get_baseline() }
+        self.shaper.get_or_init(|| Shaper::new(this)).baseline()
     }
 }
 

--- a/components/fonts/shaper.rs
+++ b/components/fonts/shaper.rs
@@ -619,39 +619,41 @@ impl Shaper {
         advance
     }
 
-    pub unsafe fn get_baseline(&self) -> Option<FontBaseline> {
-        (*self.font).table_for_tag(BASE)?;
+    pub fn baseline(&self) -> Option<FontBaseline> {
+        unsafe { (*self.font).table_for_tag(BASE)? };
 
         let mut hanging_baseline = 0;
         let mut alphabetic_baseline = 0;
         let mut ideographic_baseline = 0;
 
-        hb_ot_layout_get_baseline(
-            self.hb_font,
-            HB_OT_LAYOUT_BASELINE_TAG_ROMAN,
-            HB_DIRECTION_LTR,
-            HB_OT_TAG_DEFAULT_SCRIPT,
-            HB_OT_TAG_DEFAULT_LANGUAGE,
-            &mut alphabetic_baseline as *mut _,
-        );
+        unsafe {
+            hb_ot_layout_get_baseline(
+                self.hb_font,
+                HB_OT_LAYOUT_BASELINE_TAG_ROMAN,
+                HB_DIRECTION_LTR,
+                HB_OT_TAG_DEFAULT_SCRIPT,
+                HB_OT_TAG_DEFAULT_LANGUAGE,
+                &mut alphabetic_baseline as *mut _,
+            );
 
-        hb_ot_layout_get_baseline(
-            self.hb_font,
-            HB_OT_LAYOUT_BASELINE_TAG_HANGING,
-            HB_DIRECTION_LTR,
-            HB_OT_TAG_DEFAULT_SCRIPT,
-            HB_OT_TAG_DEFAULT_LANGUAGE,
-            &mut hanging_baseline as *mut _,
-        );
+            hb_ot_layout_get_baseline(
+                self.hb_font,
+                HB_OT_LAYOUT_BASELINE_TAG_HANGING,
+                HB_DIRECTION_LTR,
+                HB_OT_TAG_DEFAULT_SCRIPT,
+                HB_OT_TAG_DEFAULT_LANGUAGE,
+                &mut hanging_baseline as *mut _,
+            );
 
-        hb_ot_layout_get_baseline(
-            self.hb_font,
-            HB_OT_LAYOUT_BASELINE_TAG_IDEO_EMBOX_BOTTOM_OR_LEFT,
-            HB_DIRECTION_LTR,
-            HB_OT_TAG_DEFAULT_SCRIPT,
-            HB_OT_TAG_DEFAULT_LANGUAGE,
-            &mut ideographic_baseline as *mut _,
-        );
+            hb_ot_layout_get_baseline(
+                self.hb_font,
+                HB_OT_LAYOUT_BASELINE_TAG_IDEO_EMBOX_BOTTOM_OR_LEFT,
+                HB_DIRECTION_LTR,
+                HB_OT_TAG_DEFAULT_SCRIPT,
+                HB_OT_TAG_DEFAULT_LANGUAGE,
+                &mut ideographic_baseline as *mut _,
+            );
+        }
 
         Some(FontBaseline {
             ideographic_baseline: Shaper::fixed_to_float(ideographic_baseline) as f32,

--- a/components/script/dom/bindings/reflector.rs
+++ b/components/script/dom/bindings/reflector.rs
@@ -76,6 +76,10 @@ impl Reflector {
     }
 
     /// Initialize the reflector. (May be called only once.)
+    ///
+    /// # Safety
+    ///
+    /// The provided [`JSObject`] pointer must point to a valid [`JSObject`].
     pub unsafe fn set_jsobject(&self, object: *mut JSObject) {
         assert!(self.object.get().is_null());
         assert!(!object.is_null());
@@ -123,6 +127,10 @@ impl DomObject for Reflector {
 /// A trait to initialize the `Reflector` for a DOM object.
 pub trait MutDomObject: DomObject {
     /// Initializes the Reflector
+    ///
+    /// # Safety
+    ///
+    /// The provided [`JSObject`] pointer must point to a valid [`JSObject`].
     unsafe fn init_reflector(&self, obj: *mut JSObject);
 }
 

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -69,8 +69,19 @@ use crate::script_thread::IncompleteParserContexts;
 use crate::task::TaskBox;
 
 /// A trait to allow tracing only DOM sub-objects.
+///
+/// # Safety
+///
+/// This trait is unsafe; if it is implemented incorrectly, the GC may end up collecting objects
+/// that are still reachable.
 pub unsafe trait CustomTraceable {
     /// Trace `self`.
+    ///
+    /// # Safety
+    ///
+    /// The `JSTracer` argument must point to a valid `JSTracer` in memory. In addition,
+    /// implementors of this method must ensure that all active objects are properly traced
+    /// or else the garbage collector may end up collecting objects that are still reachable.
     unsafe fn trace(&self, trc: *mut JSTracer);
 }
 

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -55,8 +55,8 @@ use crate::fetch::load_whole_resource;
 use crate::realms::{enter_realm, AlreadyInRealm, InRealm};
 use crate::script_runtime::ScriptThreadEventCategory::WorkerEvent;
 use crate::script_runtime::{
-    new_child_runtime, CanGc, CommonScriptMsg, JSContext as SafeJSContext, Runtime, ScriptChan,
-    ScriptPort, ThreadSafeJSContext,
+    CanGc, CommonScriptMsg, JSContext as SafeJSContext, Runtime, ScriptChan, ScriptPort,
+    ThreadSafeJSContext,
 };
 use crate::task_queue::{QueuedTask, QueuedTaskConversion, TaskQueue};
 use crate::task_source::networking::NetworkingTaskSource;
@@ -381,7 +381,7 @@ impl DedicatedWorkerGlobalScope {
                         }),
                         pipeline_id,
                     );
-                    new_child_runtime(parent, Some(task_source))
+                    Runtime::new_with_parent(Some(parent), Some(task_source))
                 };
 
                 let context_for_interrupt = runtime.thread_safe_js_context();

--- a/components/script/dom/serviceworkerglobalscope.rs
+++ b/components/script/dom/serviceworkerglobalscope.rs
@@ -45,8 +45,7 @@ use crate::dom::workerglobalscope::WorkerGlobalScope;
 use crate::fetch::load_whole_resource;
 use crate::realms::{enter_realm, AlreadyInRealm, InRealm};
 use crate::script_runtime::{
-    new_rt_and_cx, CanGc, CommonScriptMsg, JSContext as SafeJSContext, Runtime, ScriptChan,
-    ThreadSafeJSContext,
+    CanGc, CommonScriptMsg, JSContext as SafeJSContext, Runtime, ScriptChan, ThreadSafeJSContext,
 };
 use crate::task_queue::{QueuedTask, QueuedTaskConversion, TaskQueue};
 use crate::task_source::TaskSourceName;
@@ -310,7 +309,7 @@ impl ServiceWorkerGlobalScope {
             .name(format!("SW:{}", script_url.debug_compact()))
             .spawn(move || {
                 thread_state::initialize(ThreadState::SCRIPT | ThreadState::IN_WORKER);
-                let runtime = new_rt_and_cx(None);
+                let runtime = Runtime::new(None);
                 let context_for_interrupt = runtime.thread_safe_js_context();
                 let _ = context_sender.send(context_for_interrupt);
 

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -54,9 +54,7 @@ use crate::dom::workerlocation::WorkerLocation;
 use crate::dom::workernavigator::WorkerNavigator;
 use crate::fetch;
 use crate::realms::{enter_realm, InRealm};
-use crate::script_runtime::{
-    get_reports, CanGc, CommonScriptMsg, JSContext, Runtime, ScriptChan, ScriptPort,
-};
+use crate::script_runtime::{CanGc, CommonScriptMsg, JSContext, Runtime, ScriptChan, ScriptPort};
 use crate::task::TaskCanceller;
 use crate::task_source::dom_manipulation::DOMManipulationTaskSource;
 use crate::task_source::file_reading::FileReadingTaskSource;
@@ -539,8 +537,7 @@ impl WorkerGlobalScope {
             CommonScriptMsg::Task(_, task, _, _) => task.run_box(),
             CommonScriptMsg::CollectReports(reports_chan) => {
                 let cx = self.get_cx();
-                let path_seg = format!("url({})", self.get_url());
-                let reports = unsafe { get_reports(*cx, path_seg) };
+                let reports = cx.get_reports(format!("url({})", self.get_url()));
                 reports_chan.send(reports);
             },
         }

--- a/components/script/dom/worklet.rs
+++ b/components/script/dom/worklet.rs
@@ -49,7 +49,7 @@ use crate::dom::workletglobalscope::{
 };
 use crate::fetch::load_whole_resource;
 use crate::realms::InRealm;
-use crate::script_runtime::{new_rt_and_cx, CommonScriptMsg, Runtime, ScriptThreadEventCategory};
+use crate::script_runtime::{CommonScriptMsg, Runtime, ScriptThreadEventCategory};
 use crate::script_thread::{MainThreadScriptMsg, ScriptThread};
 use crate::task::TaskBox;
 use crate::task_source::TaskSourceName;
@@ -490,7 +490,7 @@ impl WorkletThread {
                     global_init: init.global_init,
                     global_scopes: HashMap::new(),
                     control_buffer: None,
-                    runtime: new_rt_and_cx(None),
+                    runtime: Runtime::new(None),
                     should_gc: false,
                     gc_threshold: MIN_GC_THRESHOLD,
                 });

--- a/components/script/layout_dom/element.rs
+++ b/components/script/layout_dom/element.rs
@@ -89,12 +89,24 @@ impl<'dom> ServoLayoutElement<'dom> {
         self.as_node().style_data()
     }
 
+    /// Unset the snapshot flags on the underlying DOM object for this element.
+    ///
+    /// # Safety
+    ///
+    /// This function accesses and modifies the underlying DOM object and should
+    /// not be used by more than a single thread at once.
     pub unsafe fn unset_snapshot_flags(&self) {
         self.as_node()
             .node
             .set_flag(NodeFlags::HAS_SNAPSHOT | NodeFlags::HANDLED_SNAPSHOT, false);
     }
 
+    /// Unset the snapshot flags on the underlying DOM object for this element.
+    ///
+    /// # Safety
+    ///
+    /// This function accesses and modifies the underlying DOM object and should
+    /// not be used by more than a single thread at once.
     pub unsafe fn set_has_snapshot(&self) {
         self.as_node().node.set_flag(NodeFlags::HAS_SNAPSHOT, true);
     }

--- a/components/script/layout_dom/node.rs
+++ b/components/script/layout_dom/node.rs
@@ -76,6 +76,11 @@ impl<'dom> ServoLayoutNode<'dom> {
         ServoLayoutNode { node: n }
     }
 
+    /// Create a new [`ServoLayoutNode`] for this given [`TrustedNodeAddress`].
+    ///
+    /// # Safety
+    ///
+    /// The address pointed to by `address` should point to a valid node in memory.
     pub unsafe fn new(address: &TrustedNodeAddress) -> Self {
         ServoLayoutNode::from_layout_js(LayoutDom::from_trusted_node_address(*address))
     }

--- a/components/script/layout_dom/shadow_root.rs
+++ b/components/script/layout_dom/shadow_root.rs
@@ -48,6 +48,12 @@ impl<'dom> ServoShadowRoot<'dom> {
         ServoShadowRoot { shadow_root }
     }
 
+    /// Flush the stylesheets for the underlying shadow root.
+    ///
+    /// # Safety
+    ///
+    /// This modifies a DOM object, so should care should be taken that only one
+    /// thread has a reference to this object.
     pub unsafe fn flush_stylesheets(
         &self,
         stylist: &mut Stylist,


### PR DESCRIPTION
This change:

1. Adds safety documentation where it was missing.
2. Limits the scope of unsafe code in some cases to where it is actually
   unsafe.
3. Converts some free functions to associated functions and methods,
   thereby making them more likely to be called safely.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because it should not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
