### PR TITLE
Use `--break-system-packages` when running pip in the WPT export job

### DIFF
--- a/.github/workflows/pull-request-wpt-export.yml
+++ b/.github/workflows/pull-request-wpt-export.yml
@@ -29,7 +29,7 @@ jobs:
           # See https://github.com/actions/checkout/issues/162.
           token: ${{ secrets.WPT_SYNC_TOKEN }}
       - name: Install requirements
-        run: pip install -r servo/python/requirements.txt
+        run: pip install --break-system-packages -r servo/python/requirements.txt
       - name: Process pull request
         run: servo/python/wpt/export.py
         env:


### PR DESCRIPTION
This seems to be necessary now, in much the same way it is necessary on
a normal Ubuntu system. I'm not sure what changed that this is now
required.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because this just fixes a CI job.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
