### PR TITLE
tidy: check that `graphs` field is non empty in `cargo-deny` output

### DIFF
--- a/python/tidy/tidy.py
+++ b/python/tidy/tidy.py
@@ -470,7 +470,7 @@ def validate_dependency_licenses():
         error_fields = error['fields']
         if error['type'] == 'summary':
             num_license_errors = error_fields['licenses']['errors']
-        elif 'graphs' in error_fields:
+        elif 'graphs' in error_fields and error_fields['graphs']:
             crate = error_fields['graphs'][0]['Krate']
             license_name = error_fields['notes'][0]
             message = f'Rejected license "{license_name}". Run `cargo deny` for more details'


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This is something that happened to me, the graphs field in one of the error was empty.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [X] These changes do not require tests because no new features

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
