### PR TITLE
Use `content_box_sizes_and_padding_border_margin_deprecated()` in `FlexItem::new()`

### DIFF
--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -1012,6 +1012,8 @@ fn allocate_free_cross_space_for_flex_line(
 impl<'a> FlexItem<'a> {
     fn new(flex_context: &FlexContext, box_: &'a mut FlexItemBox) -> Self {
         let containing_block = flex_context.containing_block;
+        let indefinite_containing_block: IndefiniteContainingBlock =
+            IndefiniteContainingBlock::from(containing_block);
         let parent_writing_mode = containing_block.style.writing_mode;
         let item_writing_mode = box_.style().writing_mode;
 
@@ -1024,18 +1026,9 @@ impl<'a> FlexItem<'a> {
         );
 
         let pbm = box_.style().padding_border_margin(containing_block);
-        let content_box_size = box_
+        let (content_box_size, min_size, max_size, pbm) = box_
             .style()
-            .content_box_size_deprecated(containing_block, &pbm)
-            .map(|v| v.map(Au::from));
-        let max_size = box_
-            .style()
-            .content_max_box_size_deprecated(containing_block, &pbm)
-            .map(|v| v.map(Au::from));
-        let min_size = box_
-            .style()
-            .content_min_box_size_deprecated(containing_block, &pbm)
-            .map(|v| v.map(Au::from));
+            .content_box_sizes_and_padding_border_margin_deprecated(&indefinite_containing_block);
 
         let margin_auto_is_zero = flex_context.sides_to_flex_relative(pbm.margin.auto_is(Au::zero));
         let padding = flex_context.sides_to_flex_relative(pbm.padding);

--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -1012,8 +1012,6 @@ fn allocate_free_cross_space_for_flex_line(
 impl<'a> FlexItem<'a> {
     fn new(flex_context: &FlexContext, box_: &'a mut FlexItemBox) -> Self {
         let containing_block = flex_context.containing_block;
-        let indefinite_containing_block: IndefiniteContainingBlock =
-            IndefiniteContainingBlock::from(containing_block);
         let parent_writing_mode = containing_block.style.writing_mode;
         let item_writing_mode = box_.style().writing_mode;
 
@@ -1028,7 +1026,7 @@ impl<'a> FlexItem<'a> {
         let pbm = box_.style().padding_border_margin(containing_block);
         let (content_box_size, min_size, max_size, pbm) = box_
             .style()
-            .content_box_sizes_and_padding_border_margin_deprecated(&indefinite_containing_block);
+            .content_box_sizes_and_padding_border_margin_deprecated(&containing_block.into());
 
         let margin_auto_is_zero = flex_context.sides_to_flex_relative(pbm.margin.auto_is(Au::zero));
         let padding = flex_context.sides_to_flex_relative(pbm.padding);

--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -1023,7 +1023,6 @@ impl<'a> FlexItem<'a> {
             flex_context.config.flex_axis,
         );
 
-        let pbm = box_.style().padding_border_margin(containing_block);
         let (content_box_size, min_size, max_size, pbm) = box_
             .style()
             .content_box_sizes_and_padding_border_margin_deprecated(&containing_block.into());


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #33736 

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because there is no behavior change.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
