### PR TITLE
ci: pin the ubuntu runner version in lint job.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         if: github.event_name != 'pull_request_target'


### PR DESCRIPTION
Github has updated the `ubuntu-latest` label to use 24.04, but that
breaks the lint job. Since the build job (github hosted and self hosted
runners) still explicitly use 22.04, pin the same version for lint job
until we upgrade all the workflows together.

Try run on my fork: https://github.com/mukilan/servo/actions/runs/11252639087/job/31286207004

Signed-off-by: Mukilan Thiyagarajan <mukilan@igalia.com>

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #33752
- [x] These changes do not require tests because they change only the CI code.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
