### PR TITLE
Fixed some clippy warnings in components/script/dom

### DIFF
--- a/components/script/dom/domexception.rs
+++ b/components/script/dom/domexception.rs
@@ -18,6 +18,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::script_runtime::CanGc;
 
 #[repr(u16)]
+#[allow(clippy::enum_variant_names)]
 #[derive(Clone, Copy, Debug, Eq, JSTraceable, MallocSizeOf, Ord, PartialEq, PartialOrd)]
 pub enum DOMErrorName {
     IndexSizeError = DOMExceptionConstants::INDEX_SIZE_ERR,


### PR DESCRIPTION

In this PR;
Enum-variation clippy warnings have been fixed in files  components/script/dom/eventtarget.rs and  components/script/dom/domexception.rs

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #31500 
- [X] These changes do not require tests because they do not touch functionality

