### PR TITLE
clippy: Rename various methods and members to conform to naming guidelines

### DIFF
--- a/components/script/dom/testbinding.rs
+++ b/components/script/dom/testbinding.rs
@@ -1017,8 +1017,8 @@ impl TestBindingMethods for TestBinding {
         let global = self.global();
         let handler = PromiseNativeHandler::new(
             &global,
-            resolve.map(SimpleHandler::new),
-            reject.map(SimpleHandler::new),
+            resolve.map(SimpleHandler::new_boxed),
+            reject.map(SimpleHandler::new_boxed),
         );
         let p = Promise::new_in_current_realm(comp);
         p.append_native_handler(&handler, comp);
@@ -1030,7 +1030,7 @@ impl TestBindingMethods for TestBinding {
             handler: Rc<SimpleCallback>,
         }
         impl SimpleHandler {
-            fn new(callback: Rc<SimpleCallback>) -> Box<dyn Callback> {
+            fn new_boxed(callback: Rc<SimpleCallback>) -> Box<dyn Callback> {
                 Box::new(SimpleHandler { handler: callback })
             }
         }

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -115,15 +115,14 @@ pub struct WorkerGlobalScope {
 
     #[ignore_malloc_size_of = "Defined in ipc-channel"]
     #[no_trace]
-    /// Optional `IpcSender` for sending the `DevtoolScriptControlMsg`
-    /// to the server from within the worker
-    from_devtools_sender: Option<IpcSender<DevtoolScriptControlMsg>>,
+    /// A `Sender` for sending messages to devtools. This is unused but is stored here to
+    /// keep the channel alive.
+    _devtools_sender: Option<IpcSender<DevtoolScriptControlMsg>>,
 
-    #[ignore_malloc_size_of = "Defined in std"]
+    #[ignore_malloc_size_of = "Defined in crossbeam"]
     #[no_trace]
-    /// This `Receiver` will be ignored later if the corresponding
-    /// `IpcSender` doesn't exist
-    from_devtools_receiver: Receiver<DevtoolScriptControlMsg>,
+    /// A `Receiver` for receiving messages from devtools.
+    devtools_receiver: Option<Receiver<DevtoolScriptControlMsg>>,
 
     #[no_trace]
     navigation_start: CrossProcessInstant,
@@ -138,12 +137,18 @@ impl WorkerGlobalScope {
         worker_type: WorkerType,
         worker_url: ServoUrl,
         runtime: Runtime,
-        from_devtools_receiver: Receiver<DevtoolScriptControlMsg>,
+        devtools_receiver: Receiver<DevtoolScriptControlMsg>,
         closing: Arc<AtomicBool>,
         gpu_id_hub: Arc<IdentityHub>,
     ) -> Self {
         // Install a pipeline-namespace in the current thread.
         PipelineNamespace::auto_install();
+
+        let devtools_receiver = match init.from_devtools_sender {
+            Some(..) => Some(devtools_receiver),
+            None => None,
+        };
+
         Self {
             globalscope: GlobalScope::new_inherited(
                 init.pipeline_id,
@@ -169,8 +174,8 @@ impl WorkerGlobalScope {
             runtime: DomRefCell::new(Some(runtime)),
             location: Default::default(),
             navigator: Default::default(),
-            from_devtools_sender: init.from_devtools_sender,
-            from_devtools_receiver,
+            devtools_receiver,
+            _devtools_sender: init.from_devtools_sender,
             navigation_start: CrossProcessInstant::now(),
             performance: Default::default(),
         }
@@ -197,12 +202,8 @@ impl WorkerGlobalScope {
             .prepare_for_new_child()
     }
 
-    pub fn from_devtools_sender(&self) -> Option<IpcSender<DevtoolScriptControlMsg>> {
-        self.from_devtools_sender.clone()
-    }
-
-    pub fn from_devtools_receiver(&self) -> &Receiver<DevtoolScriptControlMsg> {
-        &self.from_devtools_receiver
+    pub fn devtools_receiver(&self) -> Option<&Receiver<DevtoolScriptControlMsg>> {
+        self.devtools_receiver.as_ref()
     }
 
     #[allow(unsafe_code)]

--- a/components/script/dom/worklet.rs
+++ b/components/script/dom/worklet.rs
@@ -611,7 +611,8 @@ impl WorkletThread {
             hash_map::Entry::Vacant(entry) => {
                 debug!("Creating new worklet global scope.");
                 let executor = WorkletExecutor::new(worklet_id, self.primary_sender.clone());
-                let result = global_type.new(
+                let result = WorkletGlobalScope::new(
+                    global_type,
                     &self.runtime,
                     pipeline_id,
                     base_url,

--- a/components/script/dom/workletglobalscope.rs
+++ b/components/script/dom/workletglobalscope.rs
@@ -47,6 +47,33 @@ pub struct WorkletGlobalScope {
 }
 
 impl WorkletGlobalScope {
+    /// Create a new heap-allocated `WorkletGlobalScope`.
+    pub fn new(
+        scope_type: WorkletGlobalScopeType,
+        runtime: &Runtime,
+        pipeline_id: PipelineId,
+        base_url: ServoUrl,
+        executor: WorkletExecutor,
+        init: &WorkletGlobalScopeInit,
+    ) -> DomRoot<WorkletGlobalScope> {
+        match scope_type {
+            WorkletGlobalScopeType::Test => DomRoot::upcast(TestWorkletGlobalScope::new(
+                runtime,
+                pipeline_id,
+                base_url,
+                executor,
+                init,
+            )),
+            WorkletGlobalScopeType::Paint => DomRoot::upcast(PaintWorkletGlobalScope::new(
+                runtime,
+                pipeline_id,
+                base_url,
+                executor,
+                init,
+            )),
+        }
+    }
+
     /// Create a new stack-allocated `WorkletGlobalScope`.
     pub fn new_inherited(
         pipeline_id: PipelineId,
@@ -176,35 +203,6 @@ pub enum WorkletGlobalScopeType {
     Test,
     /// A paint worklet
     Paint,
-}
-
-impl WorkletGlobalScopeType {
-    /// Create a new heap-allocated `WorkletGlobalScope`.
-    pub fn new(
-        &self,
-        runtime: &Runtime,
-        pipeline_id: PipelineId,
-        base_url: ServoUrl,
-        executor: WorkletExecutor,
-        init: &WorkletGlobalScopeInit,
-    ) -> DomRoot<WorkletGlobalScope> {
-        match *self {
-            WorkletGlobalScopeType::Test => DomRoot::upcast(TestWorkletGlobalScope::new(
-                runtime,
-                pipeline_id,
-                base_url,
-                executor,
-                init,
-            )),
-            WorkletGlobalScopeType::Paint => DomRoot::upcast(PaintWorkletGlobalScope::new(
-                runtime,
-                pipeline_id,
-                base_url,
-                executor,
-                init,
-            )),
-        }
-    }
 }
 
 /// A task which can be performed in the context of a worklet global.

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -347,7 +347,7 @@ impl ModuleTree {
 
         let handler = PromiseNativeHandler::new(
             &owner.global(),
-            Some(ModuleHandler::new(Box::new(
+            Some(ModuleHandler::new_boxed(Box::new(
                 task!(fetched_resolve: move || {
                     this.notify_owner_to_finish(identity, options);
                 }),
@@ -383,7 +383,7 @@ impl ModuleTree {
 
         let handler = PromiseNativeHandler::new(
             &owner.global(),
-            Some(ModuleHandler::new(Box::new(
+            Some(ModuleHandler::new_boxed(Box::new(
                 task!(fetched_resolve: move || {
                     this.finish_dynamic_module(identity, module_id);
                 }),
@@ -858,7 +858,7 @@ struct ModuleHandler {
 }
 
 impl ModuleHandler {
-    pub fn new(task: Box<dyn TaskBox>) -> Box<dyn Callback> {
+    pub fn new_boxed(task: Box<dyn TaskBox>) -> Box<dyn Callback> {
         Box::new(Self {
             task: DomRefCell::new(Some(task)),
         })


### PR DESCRIPTION
This ensure that methods named `new()` do not take `&self` or return
`Box<Self>`. In addition, method are renamed (or removed when not
necessary) to avoid being prefixed with `from_`.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because this should not change any behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
