### PR TITLE
Fix writing mode in `content_box_sizes_and_padding_border_margin()`

### DIFF
--- a/components/layout_2020/style_ext.rs
+++ b/components/layout_2020/style_ext.rs
@@ -508,7 +508,7 @@ impl ComputedValuesExt for ComputedValues {
         let containing_block_size = containing_block.size.map(|value| value.non_auto());
         let containing_block_size_auto_is_zero =
             containing_block_size.map(|value| value.unwrap_or_else(Au::zero));
-        let writing_mode = self.writing_mode;
+        let writing_mode = containing_block.style.writing_mode;
         let pbm = self.padding_border_margin_with_writing_mode_and_containing_block_inline_size(
             writing_mode,
             containing_block.size.inline.auto_is(Au::zero),


### PR DESCRIPTION
This method should use the writing mode from the containing block,
not the one of the current style.

Note this currently has no observable behavior change, because we don't
support vertical writing modes yet, and all current consumers only use
the padding/border/margin sums per axis (so `direction` is irrelevant).
However, this will matter after #33754.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because currently there is no change in behavior

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
