### PR TITLE
doc(resources): `Preferences`, `HstsPreloadList`, `RippyPNG`

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -9,7 +9,7 @@ use std::sync::LazyLock;
 
 use embedder_traits::resources::{self, Resource};
 use gen::Prefs;
-use log::warn;
+use log::{error, warn};
 use serde_json::{self, Value};
 
 use crate::pref_util::Preferences;
@@ -18,7 +18,7 @@ pub use crate::pref_util::{PrefError, PrefValue};
 static PREFS: LazyLock<Preferences<'static, Prefs>> = LazyLock::new(|| {
     let def_prefs: Prefs = serde_json::from_str(&resources::read_string(Resource::Preferences))
         .unwrap_or_else(|_| {
-            warn!("Preference json file is invalid. Setting Preference to default values");
+            error!("Preference json file is invalid. Setting Preference to default values");
             Prefs::default()
         });
     let result = Preferences::new(def_prefs, &gen::PREF_ACCESSORS);

--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -16,8 +16,11 @@ use crate::pref_util::Preferences;
 pub use crate::pref_util::{PrefError, PrefValue};
 
 static PREFS: LazyLock<Preferences<'static, Prefs>> = LazyLock::new(|| {
-    let def_prefs: Prefs =
-        serde_json::from_str(&resources::read_string(Resource::Preferences)).unwrap_or_default();
+    let def_prefs: Prefs = serde_json::from_str(&resources::read_string(Resource::Preferences))
+        .unwrap_or_else(|_| {
+            warn!("Preference json file is invalid. Setting Preference to default values");
+            Prefs::default()
+        });
     let result = Preferences::new(def_prefs, &gen::PREF_ACCESSORS);
     for (key, value) in result.iter() {
         set_stylo_pref_ref(&key, &value);

--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -16,8 +16,8 @@ use crate::pref_util::Preferences;
 pub use crate::pref_util::{PrefError, PrefValue};
 
 static PREFS: LazyLock<Preferences<'static, Prefs>> = LazyLock::new(|| {
-    let def_prefs: Prefs = serde_json::from_str(&resources::read_string(Resource::Preferences))
-        .expect("Failed to initialize config preferences.");
+    let def_prefs: Prefs =
+        serde_json::from_str(&resources::read_string(Resource::Preferences)).unwrap_or_default();
     let result = Preferences::new(def_prefs, &gen::PREF_ACCESSORS);
     for (key, value) in result.iter() {
         set_stylo_pref_ref(&key, &value);

--- a/components/net/hsts.rs
+++ b/components/net/hsts.rs
@@ -88,7 +88,7 @@ impl HstsList {
 
     pub fn from_servo_preload() -> HstsList {
         let list = resources::read_string(Resource::HstsPreloadList);
-        HstsList::from_preload(&list).expect("Servo HSTS preload file is invalid")
+        HstsList::from_preload(&list).unwrap_or_default()
     }
 
     pub fn is_host_secure(&self, host: &str) -> bool {

--- a/components/net/hsts.rs
+++ b/components/net/hsts.rs
@@ -10,7 +10,7 @@ use base::cross_process_instant::CrossProcessInstant;
 use embedder_traits::resources::{self, Resource};
 use headers::{HeaderMapExt, StrictTransportSecurity};
 use http::HeaderMap;
-use log::info;
+use log::{error, info};
 use net_traits::pub_domains::reg_suffix;
 use net_traits::IncludeSubdomains;
 use serde::{Deserialize, Serialize};
@@ -88,7 +88,10 @@ impl HstsList {
 
     pub fn from_servo_preload() -> HstsList {
         let list = resources::read_string(Resource::HstsPreloadList);
-        HstsList::from_preload(&list).unwrap_or_default()
+        HstsList::from_preload(&list).unwrap_or_else(|| {
+            error!("HSTS preload file is invalid. Setting HSTS list to default values");
+            HstsList::default()
+        })
     }
 
     pub fn is_host_secure(&self, host: &str) -> bool {

--- a/components/shared/embedder/resources.rs
+++ b/components/shared/embedder/resources.rs
@@ -60,7 +60,7 @@ pub enum Resource {
     Preferences,
     BluetoothBlocklist,
     DomainList,
-    /// A preload list of HTTP Strict Transport Security. It can be an empty list and
+    /// A preloaded list of HTTP Strict Transport Security. It can be an empty list and
     /// [`HstsList::default()`](net::hsts::HstsList) will be called.
     HstsPreloadList,
     BadCertHTML,
@@ -69,7 +69,7 @@ pub enum Resource {
     ServoCSS,
     PresentationalHintsCSS,
     QuirksModeCSS,
-    /// A place holder image to display if we couldn't get the requested image.
+    /// A placeholder image to display if we couldn't get the requested image.
     ///
     /// ## Safety
     ///

--- a/components/shared/embedder/resources.rs
+++ b/components/shared/embedder/resources.rs
@@ -55,9 +55,13 @@ pub fn sandbox_access_files_dirs() -> Vec<PathBuf> {
 }
 
 pub enum Resource {
+    /// A json file of [`Preferences`](servo_config::pref_util::Preferences) configuration.
+    /// It can be empty but lots of features will be disabled.
     Preferences,
     BluetoothBlocklist,
     DomainList,
+    /// A preload list of HTTP Strict Transport Security. It can be an empty list and
+    /// [`HstsList::default()`](net::hsts::HstsList) will be called.
     HstsPreloadList,
     BadCertHTML,
     NetErrorHTML,
@@ -65,6 +69,12 @@ pub enum Resource {
     ServoCSS,
     PresentationalHintsCSS,
     QuirksModeCSS,
+    /// A place holder image to display if we couldn't get the requested image.
+    ///
+    /// ## Safety
+    ///
+    /// Servo will crash if this is an invalid image. Check `resources/rippy.png` in Servo codebase to see what
+    /// a default rippy png should look like.
     RippyPNG,
     MediaControlsCSS,
     MediaControlsJS,


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Add documentation to `Preferences`, `HstsPreloadList`, `RippyPNG` variants of `Resource` enum.
This PR also allow `Preferences` and `HstsPreloadList` to be default instead of panic.

part of #33756

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
