### PR TITLE
Fix use of deprecated function in font.rs

### DIFF
--- a/components/fonts/platform/windows/font.rs
+++ b/components/fonts/platform/windows/font.rs
@@ -101,7 +101,7 @@ impl PlatformFontMethods for PlatformFont {
         face_index: u32,
         pt_size: Option<Au>,
     ) -> Result<Self, &'static str> {
-        let font_file = FontFile::new_from_data(data.clone()).ok_or("Could not create FontFile")?;
+        let font_file = FontFile::new_from_buffer(data.clone()).ok_or("Could not create FontFile")?;
         let face = font_file
             .create_face(face_index, dwrote::DWRITE_FONT_SIMULATIONS_NONE)
             .map_err(|_| "Could not create FontFace")?;


### PR DESCRIPTION
**File**: components\fonts\platform\windows\font.rs

**PR Description**

**Issue**: Clippy warning about the use of deprecated associated function `dwrote::FontFile::new_from_data`. The recommended alternative is to use `new_from_buffer` instead.

**Change**:
Updated the instantiation of `FontFile` to use `new_from_buffer` instead of `new_from_data`.

**Impact**:
Eliminates the use of a deprecated method, ensures compatibility with future versions of the `dwrote` library.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of Fix as many clippy problems as possible #31500

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because they do not touch functionality.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
