### PR TITLE
layout: Handle inline margins in `layout_for_block_content_size()`

### DIFF
--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -2512,7 +2512,9 @@ impl FlexItemBox {
                     .auto_is(|| {
                         let containing_block_inline_size_minus_pbm =
                             flex_context.containing_block.inline_size -
-                                padding_border_margin.padding_border_sums.inline;
+                                padding_border_margin.padding_border_sums.inline -
+                                padding_border_margin.margin.inline_start.auto_is(Au::zero) -
+                                padding_border_margin.margin.inline_end.auto_is(Au::zero);
 
                         if item_with_auto_cross_size_stretches_to_container_size {
                             containing_block_inline_size_minus_pbm

--- a/tests/wpt/meta/css/css-flexbox/flex-basis-item-margins-001.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-basis-item-margins-001.html.ini
@@ -1,2 +1,0 @@
-[flex-basis-item-margins-001.html]
-  expected: FAIL


### PR DESCRIPTION
Adds inline margins to `layout_for_block_content_size()` in `components/layout_2020/flexbox/layout.rs`


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #33779 
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
