### PR TITLE
clippy: Fix warnings in generated DOM bindings introduced by #33614

### DIFF
--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -2761,7 +2761,7 @@ class CGAbstractMethod(CGThing):
             if self.returnType == "void":
                 pre = "wrap_panic(&mut || {\n"
                 post = "\n})"
-            elif "return" not in body.define():
+            elif "return" not in body.define() or self.name.startswith("_constructor"):
                 pre = (
                     "let mut result = false;\n"
                     "wrap_panic(&mut || result = {\n"
@@ -6254,7 +6254,7 @@ let global = GlobalScope::from_object(JS_CALLEE(*cx, vp).to_object());
                 ]
             else:
                 args = [
-                    "&global",
+                    "global",
                     "Some(desired_proto.handle())",
                     "CanGc::note()"
                 ]


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
I didn't notice that the changes I introduced in pull request #33614 resulted in warnings from clippy, this patch fixes those.
I used startswith and not checked for equality, because for some interfaces (the ones annotated with `LegacyFactoryFunction`) more than one constructor is generated.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [X] These changes do not require tests because no functionality changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
