### PR TITLE
clippy: Fix `type_complexity` warnings in `components/script/dom`

### DIFF
--- a/components/script/dom/gpucomputepipeline.rs
+++ b/components/script/dom/gpucomputepipeline.rs
@@ -76,7 +76,12 @@ impl GPUComputePipeline {
     ) -> WebGPUComputePipeline {
         let compute_pipeline_id = device.global().wgpu_id_hub().create_compute_pipeline_id();
 
-        let (layout, implicit_ids, _) = device.get_pipeline_layout_data(&descriptor.parent.layout);
+        let layout = device
+            .get_pipeline_layout_data(&descriptor.parent.layout)
+            .explicit();
+        let implicit_ids = device
+            .get_pipeline_layout_data(&descriptor.parent.layout)
+            .implicit();
 
         let desc = ComputePipelineDescriptor {
             label: (&descriptor.parent.parent).into(),

--- a/components/script/dom/gpucomputepipeline.rs
+++ b/components/script/dom/gpucomputepipeline.rs
@@ -76,16 +76,11 @@ impl GPUComputePipeline {
     ) -> WebGPUComputePipeline {
         let compute_pipeline_id = device.global().wgpu_id_hub().create_compute_pipeline_id();
 
-        let layout = device
-            .get_pipeline_layout_data(&descriptor.parent.layout)
-            .explicit();
-        let implicit_ids = device
-            .get_pipeline_layout_data(&descriptor.parent.layout)
-            .implicit();
+        let pipeline_layout = device.get_pipeline_layout_data(&descriptor.parent.layout);
 
         let desc = ComputePipelineDescriptor {
             label: (&descriptor.parent.parent).into(),
-            layout,
+            layout: pipeline_layout.explicit(),
             stage: (&descriptor.compute).into(),
             cache: None,
         };
@@ -97,7 +92,7 @@ impl GPUComputePipeline {
                 device_id: device.id().0,
                 compute_pipeline_id,
                 descriptor: desc,
-                implicit_ids,
+                implicit_ids: pipeline_layout.implicit(),
                 async_sender,
             })
             .expect("Failed to create WebGPU ComputePipeline");

--- a/components/script/dom/gpudevice.rs
+++ b/components/script/dom/gpudevice.rs
@@ -87,7 +87,7 @@ pub struct GPUDevice {
 }
 
 pub enum PipelineLayout {
-    Implicit((PipelineLayoutId, Vec<BindGroupLayoutId>)),
+    Implicit(PipelineLayoutId, Vec<BindGroupLayoutId>),
     Explicit(PipelineLayoutId),
 }
 
@@ -101,7 +101,7 @@ impl PipelineLayout {
 
     pub fn implicit(self) -> Option<(PipelineLayoutId, Vec<BindGroupLayoutId>)> {
         match self {
-            PipelineLayout::Implicit((layout_id, bind_group_layout_ids)) => {
+            PipelineLayout::Implicit(layout_id, bind_group_layout_ids) => {
                 Some((layout_id, bind_group_layout_ids))
             },
             _ => None,
@@ -249,7 +249,7 @@ impl GPUDevice {
                 bgls.push(webgpu::WebGPUBindGroupLayout(bgl));
                 bgl_ids.push(bgl);
             }
-            PipelineLayout::Implicit((layout_id, bgl_ids))
+            PipelineLayout::Implicit(layout_id, bgl_ids)
         }
     }
 
@@ -365,10 +365,7 @@ impl GPUDevice {
             },
             multiview: None,
         };
-        Ok((
-            PipelineLayout::Implicit(pipeline_layout.implicit().unwrap()),
-            desc,
-        ))
+        Ok((pipeline_layout, desc))
     }
 
     /// <https://gpuweb.github.io/gpuweb/#lose-the-device>
@@ -496,13 +493,8 @@ impl GPUDeviceMethods for GPUDevice {
         &self,
         descriptor: &GPURenderPipelineDescriptor,
     ) -> Fallible<DomRoot<GPURenderPipeline>> {
-        let (implicit_ids, desc) = self.parse_render_pipeline(descriptor)?;
-        let render_pipeline = GPURenderPipeline::create(
-            self,
-            PipelineLayout::Implicit(implicit_ids.implicit().unwrap()),
-            desc,
-            None,
-        )?;
+        let (pipeline_layout, desc) = self.parse_render_pipeline(descriptor)?;
+        let render_pipeline = GPURenderPipeline::create(self, pipeline_layout, desc, None)?;
         Ok(GPURenderPipeline::new(
             &self.global(),
             render_pipeline,

--- a/components/script/dom/gpudevice.rs
+++ b/components/script/dom/gpudevice.rs
@@ -242,11 +242,9 @@ impl GPUDevice {
         } else {
             let layout_id = self.global().wgpu_id_hub().create_pipeline_layout_id();
             let max_bind_grps = self.limits.MaxBindGroups();
-            let mut bgls = Vec::with_capacity(max_bind_grps as usize);
             let mut bgl_ids = Vec::with_capacity(max_bind_grps as usize);
             for _ in 0..max_bind_grps {
                 let bgl = self.global().wgpu_id_hub().create_bind_group_layout_id();
-                bgls.push(webgpu::WebGPUBindGroupLayout(bgl));
                 bgl_ids.push(bgl);
             }
             PipelineLayout::Implicit(layout_id, bgl_ids)

--- a/components/script/dom/gpurenderpipeline.rs
+++ b/components/script/dom/gpurenderpipeline.rs
@@ -69,7 +69,7 @@ impl GPURenderPipeline {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createrenderpipeline>
     pub fn create(
         device: &GPUDevice,
-        implicit_ids: PipelineLayout,
+        pipeline_layout: PipelineLayout,
         descriptor: RenderPipelineDescriptor<'static>,
         async_sender: Option<IpcSender<WebGPUResponse>>,
     ) -> Fallible<WebGPURenderPipeline> {
@@ -82,7 +82,7 @@ impl GPURenderPipeline {
                 device_id: device.id().0,
                 render_pipeline_id,
                 descriptor,
-                implicit_ids: implicit_ids.implicit(),
+                implicit_ids: pipeline_layout.implicit(),
                 async_sender,
             })
             .expect("Failed to create WebGPU render pipeline");

--- a/components/script/dom/gpurenderpipeline.rs
+++ b/components/script/dom/gpurenderpipeline.rs
@@ -4,7 +4,6 @@
 
 use dom_struct::dom_struct;
 use ipc_channel::ipc::IpcSender;
-use webgpu::wgc::id::{BindGroupLayoutId, PipelineLayoutId};
 use webgpu::wgc::pipeline::RenderPipelineDescriptor;
 use webgpu::{WebGPU, WebGPUBindGroupLayout, WebGPURenderPipeline, WebGPURequest, WebGPUResponse};
 
@@ -16,7 +15,7 @@ use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::USVString;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::gpubindgrouplayout::GPUBindGroupLayout;
-use crate::dom::gpudevice::GPUDevice;
+use crate::dom::gpudevice::{GPUDevice, PipelineLayout};
 
 #[dom_struct]
 pub struct GPURenderPipeline {
@@ -70,7 +69,7 @@ impl GPURenderPipeline {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createrenderpipeline>
     pub fn create(
         device: &GPUDevice,
-        implicit_ids: Option<(PipelineLayoutId, Vec<BindGroupLayoutId>)>,
+        implicit_ids: PipelineLayout,
         descriptor: RenderPipelineDescriptor<'static>,
         async_sender: Option<IpcSender<WebGPUResponse>>,
     ) -> Fallible<WebGPURenderPipeline> {
@@ -83,7 +82,7 @@ impl GPURenderPipeline {
                 device_id: device.id().0,
                 render_pipeline_id,
                 descriptor,
-                implicit_ids,
+                implicit_ids: implicit_ids.implicit(),
                 async_sender,
             })
             .expect("Failed to create WebGPU render pipeline");


### PR DESCRIPTION
Fixes `type_complexity` warnings in `components/script/dom/gpudevice.rs` as a part of #31500 


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are a part of #31500 
- [X] These changes do not require tests because they only fix lint warnings

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
