### PR TITLE
Implement DOMRect::FromRect

### DIFF
--- a/components/script/dom/domrect.rs
+++ b/components/script/dom/domrect.rs
@@ -74,6 +74,7 @@ impl DOMRectMethods for DOMRect {
     }
 
     // https://drafts.fxtf.org/geometry/#dom-domrect-fromrect
+    #[allow(crown::unrooted_must_root)]
     fn FromRect(global: &GlobalScope, other: &DOMRectInit) -> DomRoot<DOMRect> {
         let rect = create_a_domrectreadonly_from_the_dictionary(other);
 

--- a/components/script/dom/domrect.rs
+++ b/components/script/dom/domrect.rs
@@ -6,11 +6,13 @@ use dom_struct::dom_struct;
 use js::rust::HandleObject;
 
 use crate::dom::bindings::codegen::Bindings::DOMRectBinding::DOMRectMethods;
-use crate::dom::bindings::codegen::Bindings::DOMRectReadOnlyBinding::DOMRectReadOnlyMethods;
+use crate::dom::bindings::codegen::Bindings::DOMRectReadOnlyBinding::{
+    DOMRectInit, DOMRectReadOnlyMethods,
+};
 use crate::dom::bindings::error::Fallible;
-use crate::dom::bindings::reflector::reflect_dom_object_with_proto;
+use crate::dom::bindings::reflector::{reflect_dom_object, reflect_dom_object_with_proto};
 use crate::dom::bindings::root::DomRoot;
-use crate::dom::domrectreadonly::DOMRectReadOnly;
+use crate::dom::domrectreadonly::{create_a_domrectreadonly_from_the_dictionary, DOMRectReadOnly};
 use crate::dom::globalscope::GlobalScope;
 use crate::script_runtime::CanGc;
 
@@ -69,6 +71,13 @@ impl DOMRectMethods for DOMRect {
         Ok(DOMRect::new_with_proto(
             global, proto, x, y, width, height, can_gc,
         ))
+    }
+
+    // https://drafts.fxtf.org/geometry/#dom-domrect-fromrect
+    fn FromRect(global: &GlobalScope, other: &DOMRectInit) -> DomRoot<DOMRect> {
+        let rect = create_a_domrectreadonly_from_the_dictionary(other);
+
+        reflect_dom_object(Box::new(Self { rect }), global)
     }
 
     // https://drafts.fxtf.org/geometry/#dom-domrect-x

--- a/components/script/dom/domrectreadonly.rs
+++ b/components/script/dom/domrectreadonly.rs
@@ -7,9 +7,13 @@ use std::cell::Cell;
 use dom_struct::dom_struct;
 use js::rust::HandleObject;
 
-use crate::dom::bindings::codegen::Bindings::DOMRectReadOnlyBinding::DOMRectReadOnlyMethods;
+use crate::dom::bindings::codegen::Bindings::DOMRectReadOnlyBinding::{
+    DOMRectInit, DOMRectReadOnlyMethods,
+};
 use crate::dom::bindings::error::Fallible;
-use crate::dom::bindings::reflector::{reflect_dom_object_with_proto, Reflector};
+use crate::dom::bindings::reflector::{
+    reflect_dom_object, reflect_dom_object_with_proto, Reflector,
+};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::globalscope::GlobalScope;
 use crate::script_runtime::CanGc;
@@ -84,6 +88,13 @@ impl DOMRectReadOnlyMethods for DOMRectReadOnly {
         ))
     }
 
+    // https://drafts.fxtf.org/geometry/#dom-domrectreadonly-fromrect
+    fn FromRect(global: &GlobalScope, other: &DOMRectInit) -> DomRoot<DOMRectReadOnly> {
+        let dom_rect = create_a_domrectreadonly_from_the_dictionary(other);
+
+        reflect_dom_object(Box::new(dom_rect), global)
+    }
+
     // https://drafts.fxtf.org/geometry/#dom-domrectreadonly-x
     fn X(&self) -> f64 {
         self.x.get()
@@ -142,5 +153,26 @@ impl DOMRectReadOnlyMethods for DOMRectReadOnly {
         } else {
             self.x.get() + width
         }
+    }
+}
+
+/// <https://drafts.fxtf.org/geometry/#ref-for-create-a-domrectreadonly-from-the-dictionary>
+pub(super) fn create_a_domrectreadonly_from_the_dictionary(other: &DOMRectInit) -> DOMRectReadOnly {
+    // NOTE: We trivially combine all three steps into one
+
+    // Step 1. Let rect be a new DOMRectReadOnly or DOMRect as appropriate.
+
+    // Step 2. Set rect’s variables x coordinate to other’s x dictionary member, y coordinate to other’s y
+    // dictionary member, width dimension to other’s width dictionary member and height dimension to
+    // other’s height dictionary member.
+
+    // Step 3. Return rect.
+
+    DOMRectReadOnly {
+        reflector_: Reflector::new(),
+        x: Cell::new(other.x),
+        y: Cell::new(other.y),
+        width: Cell::new(other.width),
+        height: Cell::new(other.height),
     }
 }

--- a/components/script/dom/domrectreadonly.rs
+++ b/components/script/dom/domrectreadonly.rs
@@ -89,6 +89,7 @@ impl DOMRectReadOnlyMethods for DOMRectReadOnly {
     }
 
     // https://drafts.fxtf.org/geometry/#dom-domrectreadonly-fromrect
+    #[allow(crown::unrooted_must_root)]
     fn FromRect(global: &GlobalScope, other: &DOMRectInit) -> DomRoot<DOMRectReadOnly> {
         let dom_rect = create_a_domrectreadonly_from_the_dictionary(other);
 
@@ -157,6 +158,7 @@ impl DOMRectReadOnlyMethods for DOMRectReadOnly {
 }
 
 /// <https://drafts.fxtf.org/geometry/#ref-for-create-a-domrectreadonly-from-the-dictionary>
+#[allow(crown::unrooted_must_root)]
 pub(super) fn create_a_domrectreadonly_from_the_dictionary(other: &DOMRectInit) -> DOMRectReadOnly {
     // NOTE: We trivially combine all three steps into one
 

--- a/components/script/dom/webidls/DOMRect.webidl
+++ b/components/script/dom/webidls/DOMRect.webidl
@@ -2,11 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-[Exposed=(Window,Worker)]
 // https://drafts.fxtf.org/geometry/#domrect
+
+[Exposed=(Window,Worker),
+ Serializable,
+ LegacyWindowAlias=SVGRect]
 interface DOMRect : DOMRectReadOnly {
     [Throws] constructor(optional unrestricted double x = 0, optional unrestricted double y = 0,
                 optional unrestricted double width = 0, optional unrestricted double height = 0);
+
+    [NewObject] static DOMRect fromRect(optional DOMRectInit other = {});
+
     inherit attribute unrestricted double x;
     inherit attribute unrestricted double y;
     inherit attribute unrestricted double width;

--- a/components/script/dom/webidls/DOMRectReadOnly.webidl
+++ b/components/script/dom/webidls/DOMRectReadOnly.webidl
@@ -2,12 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-[Exposed=(Window,Worker)]
 // https://drafts.fxtf.org/geometry/#domrect
+
+[Exposed=(Window,Worker),
+ Serializable]
 interface DOMRectReadOnly {
   [Throws] constructor(optional unrestricted double x = 0, optional unrestricted double y = 0,
               optional unrestricted double width = 0, optional unrestricted double height = 0);
-  // [NewObject] static DOMRectReadOnly fromRect(optional DOMRectInit other);
+
+  [NewObject] static DOMRectReadOnly fromRect(optional DOMRectInit other = {});
 
   readonly attribute unrestricted double x;
   readonly attribute unrestricted double y;

--- a/tests/wpt/meta/css/geometry/DOMRect-002.html.ini
+++ b/tests/wpt/meta/css/geometry/DOMRect-002.html.ini
@@ -1,6 +1,0 @@
-[DOMRect-002.html]
-  [DOMRect.fromRect]
-    expected: FAIL
-
-  [DOMRectReadOnly.fromRect]
-    expected: FAIL

--- a/tests/wpt/meta/css/geometry/idlharness.any.js.ini
+++ b/tests/wpt/meta/css/geometry/idlharness.any.js.ini
@@ -1,26 +1,11 @@
 [idlharness.any.worker.html]
-  [DOMRectReadOnly interface: operation fromRect(optional DOMRectInit)]
-    expected: FAIL
-
   [DOMPointReadOnly interface: calling matrixTransform(optional DOMMatrixInit) on new DOMPoint() with too few arguments must throw TypeError]
     expected: FAIL
 
   [DOMPointReadOnly interface: operation matrixTransform(optional DOMMatrixInit)]
     expected: FAIL
 
-  [DOMRect interface: operation fromRect(optional DOMRectInit)]
-    expected: FAIL
-
   [DOMPointReadOnly interface: new DOMPoint() must inherit property "matrixTransform(optional DOMMatrixInit)" with the proper type]
-    expected: FAIL
-
-  [DOMRectReadOnly interface: calling fromRect(optional DOMRectInit) on new DOMRect() with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [DOMRect interface: calling fromRect(optional DOMRectInit) on new DOMRect() with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [DOMRectReadOnly interface: calling fromRect(optional DOMRectInit) on new DOMRectReadOnly() with too few arguments must throw TypeError]
     expected: FAIL
 
   [DOMPointReadOnly interface: new DOMPointReadOnly() must inherit property "matrixTransform(optional DOMMatrixInit)" with the proper type]
@@ -31,9 +16,6 @@
 
 
 [idlharness.any.html]
-  [DOMRectReadOnly interface: operation fromRect(optional DOMRectInit)]
-    expected: FAIL
-
   [DOMPointReadOnly interface: calling matrixTransform(optional DOMMatrixInit) on new DOMPoint() with too few arguments must throw TypeError]
     expected: FAIL
 
@@ -47,9 +29,6 @@
     expected: FAIL
 
   [DOMRectList interface: [object DOMRect\] must inherit property "length" with the proper type]
-    expected: FAIL
-
-  [DOMRect interface: operation fromRect(optional DOMRectInit)]
     expected: FAIL
 
   [DOMRectList interface: operation item(unsigned long)]
@@ -73,16 +52,7 @@
   [DOMMatrix interface: operation setMatrixValue(DOMString)]
     expected: FAIL
 
-  [DOMRectReadOnly interface: calling fromRect(optional DOMRectInit) on new DOMRect() with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [DOMRect interface: calling fromRect(optional DOMRectInit) on new DOMRect() with too few arguments must throw TypeError]
-    expected: FAIL
-
   [DOMPoint interface: legacy window alias]
-    expected: FAIL
-
-  [DOMRectReadOnly interface: calling fromRect(optional DOMRectInit) on new DOMRectReadOnly() with too few arguments must throw TypeError]
     expected: FAIL
 
   [DOMRectList interface object length]
@@ -92,9 +62,6 @@
     expected: FAIL
 
   [DOMPointReadOnly interface: new DOMPointReadOnly() must inherit property "matrixTransform(optional DOMMatrixInit)" with the proper type]
-    expected: FAIL
-
-  [DOMRect interface: legacy window alias]
     expected: FAIL
 
   [DOMRectList interface: calling item(unsigned long) on [object DOMRect\] with too few arguments must throw TypeError]

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -13495,7 +13495,7 @@
      ]
     ],
     "interfaces.https.html": [
-     "94f1102da478919d2948ebb96f81450f5d545635",
+     "bfe16e7de02b6c95f3aaf274510633f029ad682a",
      [
       null,
       {}

--- a/tests/wpt/mozilla/tests/mozilla/interfaces.https.html
+++ b/tests/wpt/mozilla/tests/mozilla/interfaces.https.html
@@ -240,6 +240,7 @@ test_interfaces([
   "StyleSheet",
   "StyleSheetList",
   "SubmitEvent",
+  "SVGRect",
   "Text",
   "TextTrack",
   "TextTrackCue",


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This implements the [`DOMRect::FromRect`](https://drafts.fxtf.org/geometry/#dom-domrect-fromrect) method, fixing 13 WPT subtests.

Currently, the [try run](https://github.com/simonwuelker/servo/actions/runs/11283722336/job/31383934623) is failing with the following message
```
Stable unexpected results (1): 
  ▶ OK /_mozilla/mozilla/interfaces.https.html
  │   ▶ FAIL [expected PASS] Interfaces exposed on the window
  │   │   → assert_true: If this is failing: DANGER, are you sure you want to expose the new interface SVGRect to all webpages as a property on the global? Do not make a change to this file without review from jdm or Ms2ger for that specific change! expected true got false
 ```

Given that the new interface is only an alias  this doesn't seem particularly dangerous to me. Is it fine to modify the test file or do we not want to expose SVG-related interfaces given that there's no svg support?

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes
