### PR TITLE
ohos: publish nightly builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -73,6 +73,7 @@ jobs:
       - upload-win
       - upload-mac
       - upload-android
+      - upload-ohos
 
   upload-win:
     # This job is only useful when run on upstream servo.
@@ -123,6 +124,22 @@ jobs:
       id-token: write
       attestations: write
     uses: ./.github/workflows/android.yml
+    with:
+      profile: "release"
+      upload: true
+      github-release-id: ${{ needs.create-draft-release.outputs.release-id }}
+    secrets: inherit
+
+  upload-ohos:
+    # This job is only useful when run on upstream servo.
+    if: github.repository == 'servo/servo' || github.event_name == 'workflow_dispatch'
+    name: Upload nightly (OpenHarmony)
+    needs:
+      - create-draft-release
+    permissions:
+      id-token: write
+      attestations: write
+    uses: ./.github/workflows/ohos.yml
     with:
       profile: "release"
       upload: true

--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -6,6 +6,13 @@ on:
         required: false
         default: "release"
         type: string
+      upload:
+        required: false
+        default: false
+        type: boolean
+      github-release-id:
+        required: false
+        type: string
   workflow_dispatch:
     inputs:
       profile:
@@ -29,7 +36,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        arch: ['aarch64-unknown-linux-ohos', 'x86_64-unknown-linux-ohos']
+        target: ['aarch64-unknown-linux-ohos', 'x86_64-unknown-linux-ohos']
     steps:
       - uses: actions/checkout@v4
         if: github.event_name != 'pull_request_target'
@@ -53,7 +60,7 @@ jobs:
       - name: Setup OpenHarmony SDK
         id: setup_sdk
         # FIXME: We pin the exact patch version to the LKG version of the
-        # action to address bugs in the most recent 0.1.2 release. Once that
+        # action to address bugs in the most recent 0.1.3 release. Once that
         # has been addresssed upstream, we can revert to specifying only the
         # major.minor tag.
         uses: openharmony-rs/setup-ohos-sdk@v0.1.2
@@ -75,34 +82,49 @@ jobs:
       - name: "Setup HAP signing config"
         env:
           SIGNING_MATERIAL: ${{ secrets.SERVO_OHOS_SIGNING_MATERIAL }}
-        if: ${{ env.SIGNING_MATERIAL != '' }} # Allows the build to pass on forks.
+        if: ${{ inputs.upload || env.SIGNING_MATERIAL != '' }} # Allows the build to pass on forks.
         run: |
           cd ~
           echo "${SIGNING_MATERIAL}" | base64 -d > servo-ohos-material.zip
           unzip servo-ohos-material.zip
           echo "SERVO_OHOS_SIGNING_CONFIG=${PWD}/servo-ohos-material/signing-configs.json" >> $GITHUB_ENV
-      - name: Build (arch ${{ matrix.arch }} profile ${{ inputs.profile }})
+      - name: Build (arch ${{ matrix.target }} profile ${{ inputs.profile }})
         env:
           OHOS_SDK_NATIVE: ${{ steps.setup_sdk.outputs.ohos_sdk_native }}
           OHOS_BASE_SDK_HOME: ${{ steps.setup_sdk.outputs.ohos-base-sdk-home }}
         run: |
-          python3 ./mach build --locked --target ${{ matrix.arch }} --${{ inputs.profile }}
-          cp -r target/cargo-timings target/cargo-timings-ohos-${{ matrix.arch }}
+          python3 ./mach build --locked --target ${{ matrix.target }} --${{ inputs.profile }}
+          cp -r target/cargo-timings target/cargo-timings-ohos-${{ matrix.target }}
       - name: Archive build timing
         uses: actions/upload-artifact@v4
         with:
-          name: cargo-timings-ohos-${{ matrix.arch }}
+          name: cargo-timings-ohos-${{ matrix.target }}
           # Using a wildcard here ensures that the archive includes the path.
           path: target/cargo-timings-*
+      - name: Upload nightly
+        if: ${{ inputs.upload && contains(matrix.target, 'aarch64') }}
+        run: |
+          python3 ./mach upload-nightly ohos \
+            --secret-from-environment \
+            --github-release-id ${{ inputs.github-release-id }}
+        env:
+          S3_UPLOAD_CREDENTIALS: ${{ secrets.S3_UPLOAD_CREDENTIALS }}
+          NIGHTLY_REPO_TOKEN: ${{ secrets.NIGHTLY_REPO_TOKEN }}
+          NIGHTLY_REPO: ${{ github.repository_owner }}/servo-nightly-builds
+      - name: Generate artifact attestation for HAP
+        if: ${{ inputs.upload }}
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: target/openharmony/${{ matrix.target }}/${{ inputs.profile }}/entry/build/default/outputs/default/servoshell-default-signed.hap
       - name: Upload signed HAP artifact
         if: ${{ env.SERVO_OHOS_SIGNING_CONFIG != '' }} # Build output has different name if not signed.
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.profile }}-binary-ohos-${{ matrix.arch }}
-          path: target/openharmony/${{ matrix.arch }}/${{ inputs.profile }}/entry/build/default/outputs/default/servoshell-default-signed.hap
+          name: ${{ inputs.profile }}-binary-ohos-${{ matrix.target }}
+          path: target/openharmony/${{ matrix.target }}/${{ inputs.profile }}/entry/build/default/outputs/default/servoshell-default-signed.hap
       - name: Upload unsigned HAP artifact
         if: ${{ env.SERVO_OHOS_SIGNING_CONFIG == '' }} # Build output has different name if not signed.
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.profile }}-binary-ohos-${{ matrix.arch }}
-          path: target/openharmony/${{ matrix.arch }}/${{ inputs.profile }}/entry/build/default/outputs/default/servoshell-default-unsigned.hap
+          name: ${{ inputs.profile }}-binary-ohos-${{ matrix.target }}
+          path: target/openharmony/${{ matrix.target }}/${{ inputs.profile }}/entry/build/default/outputs/default/servoshell-default-unsigned.hap

--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -56,6 +56,10 @@ PACKAGES = {
         r'production\msi\Servo.exe',
         r'production\msi\Servo.zip',
     ],
+    'ohos': [
+        ('openharmony/aarch64-unknown-linux-ohos/release/entry/build/'
+            'default/outputs/default/servoshell-default-signed.hap')
+    ],
 }
 
 


### PR DESCRIPTION
Add OpenHarmony nightly builds so that we can make them available for download
at servo.org. As discussed on Zulip, only the OHOS variant for aarch64
architecture is published.

Signed-off-by: Mukilan Thiyagarajan <mukilan@igalia.com>

---

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they only add new CI jobs.

