### PR TITLE
Throw NotSupported error and update expected results for XRSession::UpdateRenderState

### DIFF
--- a/components/script/dom/xrsession.rs
+++ b/components/script/dom/xrsession.rs
@@ -676,16 +676,8 @@ impl XRSessionMethods for XRSession {
 
         // https://immersive-web.github.io/layers/#updaterenderstatechanges
         // Step 1.
-        if init.baseLayer.is_some() {
-            if self.has_layers_feature() {
-                return Err(Error::NotSupported);
-            }
-            // https://github.com/immersive-web/layers/issues/189
-            if init.layers.is_some() {
-                return Err(Error::Type(String::from(
-                    "Cannot set WebXR layers and baseLayer",
-                )));
-            }
+        if init.baseLayer.is_some() && (self.has_layers_feature() || init.layers.is_some()) {
+            return Err(Error::NotSupported);
         }
 
         if let Some(Some(ref layers)) = init.layers {

--- a/tests/wpt/meta/webxr/layers/xrSession_updateRenderState.https.html.ini
+++ b/tests/wpt/meta/webxr/layers/xrSession_updateRenderState.https.html.ini
@@ -4,9 +4,3 @@
 
   [Ensure XRSession throws appropriate errors when updating render state without layers feature enabled - webgl2]
     expected: FAIL
-
-  [Ensure XRSession throws appropriate errors when updating render state with layers feature enabled - webgl]
-    expected: FAIL
-
-  [Ensure XRSession throws appropriate errors when updating render state with layers feature enabled - webgl2]
-    expected: FAIL

--- a/update.log
+++ b/update.log
@@ -1,0 +1,5 @@
+{"action": "log", "time": 1728636225985, "thread": "MainThread", "pid": 25068, "source": "web-platform-tests", "component": "vcs", "message": "git rev-parse --show-toplevel", "level": "DEBUG"}
+{"action": "log", "time": 1728636226023, "thread": "MainThread", "pid": 25068, "source": "web-platform-tests", "component": "vcs", "message": "git rev-parse --show-cdup", "level": "DEBUG"}
+{"action": "log", "time": 1728636226054, "thread": "MainThread", "pid": 25068, "source": "web-platform-tests", "component": "vcs", "message": "git rev-parse HEAD", "level": "DEBUG"}
+{"action": "log", "time": 1728636268025, "thread": "MainThread", "pid": 25068, "source": "web-platform-tests", "message": "Closing logging queue", "level": "INFO"}
+{"action": "log", "time": 1728636268026, "thread": "MainThread", "pid": 25068, "source": "web-platform-tests", "message": "queue closed", "level": "INFO"}

--- a/update.log
+++ b/update.log
@@ -1,5 +1,0 @@
-{"action": "log", "time": 1728636225985, "thread": "MainThread", "pid": 25068, "source": "web-platform-tests", "component": "vcs", "message": "git rev-parse --show-toplevel", "level": "DEBUG"}
-{"action": "log", "time": 1728636226023, "thread": "MainThread", "pid": 25068, "source": "web-platform-tests", "component": "vcs", "message": "git rev-parse --show-cdup", "level": "DEBUG"}
-{"action": "log", "time": 1728636226054, "thread": "MainThread", "pid": 25068, "source": "web-platform-tests", "component": "vcs", "message": "git rev-parse HEAD", "level": "DEBUG"}
-{"action": "log", "time": 1728636268025, "thread": "MainThread", "pid": 25068, "source": "web-platform-tests", "message": "Closing logging queue", "level": "INFO"}
-{"action": "log", "time": 1728636268026, "thread": "MainThread", "pid": 25068, "source": "web-platform-tests", "message": "queue closed", "level": "INFO"}


### PR DESCRIPTION
**File**: servo/components/script/dom/xrsession.rs

**PR Description**

**Issue**: Update expected results for xrSession_updateRenderState.https.html after passing tests

**Changes**:
- Changed the error type returned to a NotSupported error in XRSession::UpdateRenderState.
- Tests pass with unexpected passes.
- Updated the expected results using:
     -  `./mach test-wpt tests/wpt/tests/webxr/layers/xrSession_updateRenderState.https.html --log-raw /tmp/servo.log`
     - `./mach update-wpt /tmp/servo.log`

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #33714

<!-- Either: -->
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
