### PR TITLE
content: Replace uses of `downcast`+`is_some`/`is_none` with `is`

### DIFF
--- a/components/script/dom/dommatrix.rs
+++ b/components/script/dom/dommatrix.rs
@@ -76,7 +76,7 @@ impl DOMMatrixMethods for DOMMatrix {
         }
         match init.unwrap() {
             StringOrUnrestrictedDoubleSequence::String(ref s) => {
-                if global.downcast::<Window>().is_none() {
+                if !global.is::<Window>() {
                     return Err(error::Error::Type(
                         "String constructor is only supported in the main thread.".to_owned(),
                     ));

--- a/components/script/dom/dommatrixreadonly.rs
+++ b/components/script/dom/dommatrixreadonly.rs
@@ -447,7 +447,7 @@ impl DOMMatrixReadOnlyMethods for DOMMatrixReadOnly {
         }
         match init.unwrap() {
             StringOrUnrestrictedDoubleSequence::String(ref s) => {
-                if global.downcast::<Window>().is_none() {
+                if !global.is::<Window>() {
                     return Err(error::Error::Type(
                         "String constructor is only supported in the main thread.".to_owned(),
                     ));

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -2909,7 +2909,7 @@ impl GlobalScope {
     /// Returns a boolean indicating whether the event-loop
     /// where this global is running on can continue running JS.
     pub fn can_continue_running(&self) -> bool {
-        if self.downcast::<Window>().is_some() {
+        if !self.is::<Window>() {
             return ScriptThread::can_continue_running();
         }
         if let Some(worker) = self.downcast::<WorkerGlobalScope>() {

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -2909,7 +2909,7 @@ impl GlobalScope {
     /// Returns a boolean indicating whether the event-loop
     /// where this global is running on can continue running JS.
     pub fn can_continue_running(&self) -> bool {
-        if !self.is::<Window>() {
+        if self.is::<Window>() {
             return ScriptThread::can_continue_running();
         }
         if let Some(worker) = self.downcast::<WorkerGlobalScope>() {

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -1102,7 +1102,7 @@ impl HTMLFormElement {
             let child = child.upcast::<Node>();
 
             // Step 5.1: The field element has a datalist element ancestor.
-            if child.ancestors().any(|a| !a.is::<HTMLDataListElement>()) {
+            if child.ancestors().any(|a| a.is::<HTMLDataListElement>()) {
                 continue;
             }
             if let NodeTypeId::Element(ElementTypeId::HTMLElement(element)) = child.type_id() {

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -1102,10 +1102,7 @@ impl HTMLFormElement {
             let child = child.upcast::<Node>();
 
             // Step 5.1: The field element has a datalist element ancestor.
-            if child
-                .ancestors()
-                .any(|a| DomRoot::downcast::<HTMLDataListElement>(a).is_some())
-            {
+            if child.ancestors().any(|a| !a.is::<HTMLDataListElement>()) {
                 continue;
             }
             if let NodeTypeId::Element(ElementTypeId::HTMLElement(element)) = child.type_id() {

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -181,7 +181,7 @@ pub fn Fetch(
 
     // Step 6. If globalObject is a ServiceWorkerGlobalScope object, then set request’s
     //         service-workers mode to "none".
-    if global.downcast::<ServiceWorkerGlobalScope>().is_some() {
+    if !global.is::<ServiceWorkerGlobalScope>() {
         request_init.service_workers_mode = ServiceWorkersMode::None;
     }
 

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -181,7 +181,7 @@ pub fn Fetch(
 
     // Step 6. If globalObject is a ServiceWorkerGlobalScope object, then set request’s
     //         service-workers mode to "none".
-    if !global.is::<ServiceWorkerGlobalScope>() {
+    if global.is::<ServiceWorkerGlobalScope>() {
         request_init.service_workers_mode = ServiceWorkersMode::None;
     }
 


### PR DESCRIPTION
Replaces uses of `downcast`+`is_some`/`is_none` with `is` in `components/script` and `components/script/dom`


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #33797 
- [X] These changes do not require tests because they do not modify functionality

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
