### PR TITLE
Avoid recomputing inline_content_sizes() when not needed

### DIFF
--- a/components/layout_2020/flexbox/construct.rs
+++ b/components/layout_2020/flexbox/construct.rs
@@ -171,7 +171,7 @@ where
                     let non_replaced = NonReplacedFormattingContext {
                         base_fragment_info: info.into(),
                         style: info.style.clone(),
-                        content_sizes: None,
+                        content_sizes_result: None,
                         contents: NonReplacedFormattingContextContents::Flow(
                             block_formatting_context,
                         ),

--- a/components/layout_2020/formatting_contexts.rs
+++ b/components/layout_2020/formatting_contexts.rs
@@ -18,7 +18,7 @@ use crate::fragment_tree::{BaseFragmentInfo, BoxFragment, Fragment, FragmentFlag
 use crate::geom::LogicalSides;
 use crate::positioned::PositioningContext;
 use crate::replaced::ReplacedContent;
-use crate::sizing::{self, ContentSizes};
+use crate::sizing::{self, InlineContentSizesResult};
 use crate::style_ext::{AspectRatio, DisplayInside};
 use crate::table::Table;
 use crate::{AuOrAuto, ContainingBlock, IndefiniteContainingBlock, LogicalVec2};
@@ -36,7 +36,7 @@ pub(crate) struct NonReplacedFormattingContext {
     #[serde(skip_serializing)]
     pub style: Arc<ComputedValues>,
     /// If it was requested during construction
-    pub content_sizes: Option<(AuOrAuto, ContentSizes)>,
+    pub content_sizes_result: Option<(AuOrAuto, InlineContentSizesResult)>,
     pub contents: NonReplacedFormattingContextContents,
 }
 
@@ -152,7 +152,7 @@ impl IndependentFormattingContext {
                 Self::NonReplaced(NonReplacedFormattingContext {
                     style: Arc::clone(&node_and_style_info.style),
                     base_fragment_info,
-                    content_sizes: None,
+                    content_sizes_result: None,
                     contents,
                 })
             },
@@ -187,7 +187,7 @@ impl IndependentFormattingContext {
         layout_context: &LayoutContext,
         containing_block_for_children: &IndefiniteContainingBlock,
         containing_block: &IndefiniteContainingBlock,
-    ) -> ContentSizes {
+    ) -> InlineContentSizesResult {
         match self {
             Self::NonReplaced(inner) => {
                 inner.inline_content_sizes(layout_context, containing_block_for_children)
@@ -206,7 +206,7 @@ impl IndependentFormattingContext {
         containing_block: &IndefiniteContainingBlock,
         auto_minimum: &LogicalVec2<Au>,
         auto_block_size_stretches_to_containing_block: bool,
-    ) -> ContentSizes {
+    ) -> InlineContentSizesResult {
         match self {
             Self::NonReplaced(non_replaced) => non_replaced.outer_inline_content_sizes(
                 layout_context,
@@ -274,20 +274,22 @@ impl NonReplacedFormattingContext {
         &mut self,
         layout_context: &LayoutContext,
         containing_block_for_children: &IndefiniteContainingBlock,
-    ) -> ContentSizes {
+    ) -> InlineContentSizesResult {
         assert_eq!(
             containing_block_for_children.size.inline,
             AuOrAuto::Auto,
             "inline_content_sizes() got non-auto containing block inline-size",
         );
-        if let Some((previous_cb_block_size, result)) = self.content_sizes {
-            if previous_cb_block_size == containing_block_for_children.size.block {
+        if let Some((previous_cb_block_size, result)) = self.content_sizes_result {
+            if !result.depends_on_block_constraints ||
+                previous_cb_block_size == containing_block_for_children.size.block
+            {
                 return result;
             }
             // TODO: Should we keep multiple caches for various block sizes?
         }
 
-        self.content_sizes
+        self.content_sizes_result
             .insert((
                 containing_block_for_children.size.block,
                 self.contents
@@ -302,7 +304,7 @@ impl NonReplacedFormattingContext {
         containing_block: &IndefiniteContainingBlock,
         auto_minimum: &LogicalVec2<Au>,
         auto_block_size_stretches_to_containing_block: bool,
-    ) -> ContentSizes {
+    ) -> InlineContentSizesResult {
         sizing::outer_inline(
             &self.style.clone(),
             containing_block,
@@ -320,7 +322,7 @@ impl NonReplacedFormattingContextContents {
         &mut self,
         layout_context: &LayoutContext,
         containing_block_for_children: &IndefiniteContainingBlock,
-    ) -> ContentSizes {
+    ) -> InlineContentSizesResult {
         match self {
             Self::Flow(inner) => inner
                 .contents

--- a/components/layout_2020/lib.rs
+++ b/components/layout_2020/lib.rs
@@ -65,7 +65,7 @@ impl<'a> IndefiniteContainingBlock<'a> {
         style: &'a ComputedValues,
         auto_minimum: &LogicalVec2<Au>,
     ) -> Self {
-        let (content_box_size, content_min_size, content_max_size, _) =
+        let (content_box_size, content_min_size, content_max_size, _, _) =
             style.content_box_sizes_and_padding_border_margin_deprecated(self);
         let block_size = content_box_size.block.map(|v| {
             v.clamp_between_extremums(

--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -587,6 +587,7 @@ impl HoistedAbsolutelyPositionedBox {
                                 );
                         non_replaced
                             .inline_content_sizes(layout_context, &containing_block_for_children)
+                            .sizes
                             .shrink_to_fit(available_size)
                     });
 

--- a/components/layout_2020/sizing.rs
+++ b/components/layout_2020/sizing.rs
@@ -118,10 +118,15 @@ pub(crate) fn outer_inline(
     containing_block: &IndefiniteContainingBlock,
     auto_minimum: &LogicalVec2<Au>,
     auto_block_size_stretches_to_containing_block: bool,
-    get_content_size: impl FnOnce(&IndefiniteContainingBlock) -> ContentSizes,
-) -> ContentSizes {
-    let (content_box_size, content_min_size, content_max_size, pbm) =
-        style.content_box_sizes_and_padding_border_margin_deprecated(containing_block);
+    get_content_size: impl FnOnce(&IndefiniteContainingBlock) -> InlineContentSizesResult,
+) -> InlineContentSizesResult {
+    let (
+        content_box_size,
+        content_min_size,
+        content_max_size,
+        pbm,
+        mut depends_on_block_constraints,
+    ) = style.content_box_sizes_and_padding_border_margin_deprecated(containing_block);
     let content_min_size = LogicalVec2 {
         inline: content_min_size.inline.auto_is(|| auto_minimum.inline),
         block: content_min_size.block.auto_is(|| auto_minimum.block),
@@ -132,11 +137,15 @@ pub(crate) fn outer_inline(
         v.clamp_between_extremums(content_min_size.inline, content_max_size.inline) + pbm_inline_sum
     };
     match content_box_size.inline {
-        AuOrAuto::LengthPercentage(inline_size) => adjust(inline_size).into(),
+        AuOrAuto::LengthPercentage(inline_size) => InlineContentSizesResult {
+            sizes: adjust(inline_size).into(),
+            depends_on_block_constraints: false,
+        },
         AuOrAuto::Auto => {
             let block_size = if content_box_size.block.is_auto() &&
                 auto_block_size_stretches_to_containing_block
             {
+                depends_on_block_constraints = true;
                 let outer_block_size = containing_block.size.block;
                 outer_block_size.map(|v| v - pbm.padding_border_sums.block - margin.block_sum())
             } else {
@@ -145,7 +154,18 @@ pub(crate) fn outer_inline(
             .map(|v| v.clamp_between_extremums(content_min_size.block, content_max_size.block));
             let containing_block_for_children =
                 IndefiniteContainingBlock::new_for_style_and_block_size(style, block_size);
-            get_content_size(&containing_block_for_children).map(adjust)
+            let content_result = get_content_size(&containing_block_for_children);
+            InlineContentSizesResult {
+                sizes: content_result.sizes.map(adjust),
+                depends_on_block_constraints: content_result.depends_on_block_constraints &&
+                    depends_on_block_constraints,
+            }
         },
     }
+}
+
+#[derive(Clone, Copy, Debug, Serialize)]
+pub(crate) struct InlineContentSizesResult {
+    pub sizes: ContentSizes,
+    pub depends_on_block_constraints: bool,
 }

--- a/components/layout_2020/table/construct.rs
+++ b/components/layout_2020/table/construct.rs
@@ -137,7 +137,7 @@ impl Table {
         IndependentFormattingContext::NonReplaced(NonReplacedFormattingContext {
             base_fragment_info: (&anonymous_info).into(),
             style: grid_and_wrapper_style,
-            content_sizes: None,
+            content_sizes_result: None,
             contents: NonReplacedFormattingContextContents::Table(table),
         })
     }
@@ -858,7 +858,7 @@ where
                         context: ArcRefCell::new(NonReplacedFormattingContext {
                             style: info.style.clone(),
                             base_fragment_info: info.into(),
-                            content_sizes: None,
+                            content_sizes_result: None,
                             contents,
                         }),
                     };


### PR DESCRIPTION
The result of `inline_content_sizes()` may depend on the block size of the containing block, so we were always recomputing in case we got a different block size.

However, if no content has a vertical percentage or stretches vertically, then we don't need to recompute: the result will be the same anyways.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because there shouldn't be any behavior change

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
