### PR TITLE
Simplify structured cloning infrastructure and make DOMPointReadOnly serializable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1787,6 +1787,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-iterator"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c280b9e6b3ae19e152d8e31cf47f18389781e119d4013a2a2bb0180e5facc635"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1ab991c1362ac86c61ab6f556cff143daa22e5a15e4e189df818b2fd19fe65b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "env_filter"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4051,7 +4071,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5877,6 +5897,7 @@ dependencies = [
  "domobject_derive",
  "embedder_traits",
  "encoding_rs",
+ "enum-iterator",
  "euclid",
  "fnv",
  "fonts",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5903,6 +5903,7 @@ dependencies = [
  "mozangle",
  "mozjs",
  "net_traits",
+ "num-derive",
  "num-traits",
  "num_cpus",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ devtools_traits = { path = "components/shared/devtools" }
 embedder_traits = { path = "components/shared/embedder" }
 encoding_rs = "0.8"
 env_logger = "0.10"
+enum-iterator = "2"
 euclid = "0.22"
 fnv = "1.0"
 freetype-sys = "0.20"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ mime_guess = "2.0.5"
 mozangle = "0.5.1"
 net_traits = { path = "components/shared/net" }
 nix = "0.29"
+num-derive = "0.4"
 num-traits = "0.2"
 num_cpus = "1.1.0"
 parking_lot = "0.12"

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -50,6 +50,7 @@ dom_struct = { path = "../dom_struct" }
 domobject_derive = { path = "../domobject_derive" }
 embedder_traits = { workspace = true }
 encoding_rs = { workspace = true }
+enum-iterator = { workspace = true }
 euclid = { workspace = true }
 fnv = { workspace = true }
 fxhash = { workspace = true }

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -76,6 +76,7 @@ mime = { workspace = true }
 mime_guess = { workspace = true }
 net_traits = { workspace = true }
 num_cpus = { workspace = true }
+num-derive = { workspace = true }
 num-traits = { workspace = true }
 parking_lot = { workspace = true }
 percent-encoding = { workspace = true }

--- a/components/script/dom/bindings/serializable.rs
+++ b/components/script/dom/bindings/serializable.rs
@@ -9,7 +9,7 @@ use js::jsapi::{JSStructuredCloneReader, JS_ReadUint32Pair};
 
 use crate::dom::bindings::reflector::DomObject;
 use crate::dom::bindings::root::DomRoot;
-use crate::dom::bindings::structuredclone::{CloneableObject, StructuredDataHolder};
+use crate::dom::bindings::structuredclone::{CloneableObject, StructuredWriteDataHolder, StructuredReadDataHolder};
 use crate::dom::globalscope::GlobalScope;
 
 /// The key corresponding to the storage location
@@ -72,11 +72,11 @@ pub trait Serializable: DomObject + Sized {
     const TAG: CloneableObject;
 
     /// <https://html.spec.whatwg.org/multipage/#serialization-steps>
-    fn serialize(&self, sc_holder: &mut StructuredDataHolder) -> Result<Self::Data, ()>;
+    fn serialize(&self, sc_holder: &mut StructuredWriteDataHolder) -> Result<Self::Data, ()>;
     /// <https://html.spec.whatwg.org/multipage/#deserialization-steps>
     fn deserialize(
         owner: &GlobalScope,
-        sc_holder: &mut StructuredDataHolder,
+        sc_holder: &mut StructuredReadDataHolder,
         extra_data: Self::Data,
     ) -> Result<DomRoot<Self>, ()>;
 }

--- a/components/script/dom/bindings/serializable.rs
+++ b/components/script/dom/bindings/serializable.rs
@@ -5,41 +5,13 @@
 //! Trait representing the concept of [serializable objects]
 //! (<https://html.spec.whatwg.org/multipage/#serializable-objects>).
 
-use js::jsapi::{JSStructuredCloneReader, JS_ReadUint32Pair};
+use js::jsapi::JSStructuredCloneReader;
 
 use crate::dom::bindings::reflector::DomObject;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::structuredclone::{CloneableObject, StructuredWriteDataHolder, StructuredReadDataHolder};
 use crate::dom::globalscope::GlobalScope;
 
-/// The key corresponding to the storage location
-/// of a serialized platform object stored in a StructuredDataHolder.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub struct StorageKey {
-    pub index: u32,
-    pub name_space: u32,
-}
-
-impl ToSerializeOperations for StorageKey {
-    fn to_serialize_operations(&self) -> Vec<SerializeOperation> {
-        vec![SerializeOperation::Uint32Pair(self.name_space, self.index)]
-    }
-}
-
-impl FromStructuredClone for StorageKey {
-    unsafe fn from_structured_clone(r: *mut JSStructuredCloneReader) -> StorageKey {
-        let mut key = StorageKey {
-            name_space: 0,
-            index: 0,
-        };
-        assert!(JS_ReadUint32Pair(
-            r,
-            &mut key.name_space,
-            &mut key.index,
-        ));
-        key
-     }
-}
 
 /// An interface to construct a stream of serialization operations that will be
 /// evaluated as part of serializing a DOM object.

--- a/components/script/dom/bindings/serializable.rs
+++ b/components/script/dom/bindings/serializable.rs
@@ -6,6 +6,7 @@
 //! (<https://html.spec.whatwg.org/multipage/#serializable-objects>).
 
 use crate::dom::bindings::reflector::DomObject;
+use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::structuredclone::{CloneableObject, StructuredDataHolder};
 use crate::dom::globalscope::GlobalScope;
 
@@ -33,7 +34,7 @@ pub enum SerializeOperation {
 
 /// Interface for serializable platform objects.
 /// <https://html.spec.whatwg.org/multipage/#serializable>
-pub trait Serializable: DomObject {
+pub trait Serializable: DomObject + Sized {
     type Data: ToSerializeOperations;
     const TAG: CloneableObject;
 
@@ -44,5 +45,5 @@ pub trait Serializable: DomObject {
         owner: &GlobalScope,
         sc_holder: &mut StructuredDataHolder,
         extra_data: Self::Data,
-    ) -> Result<(), ()>;
+    ) -> Result<DomRoot<Self>, ()>;
 }

--- a/components/script/dom/bindings/serializable.rs
+++ b/components/script/dom/bindings/serializable.rs
@@ -9,9 +9,10 @@ use js::jsapi::JSStructuredCloneReader;
 
 use crate::dom::bindings::reflector::DomObject;
 use crate::dom::bindings::root::DomRoot;
-use crate::dom::bindings::structuredclone::{CloneableObject, StructuredWriteDataHolder, StructuredReadDataHolder};
+use crate::dom::bindings::structuredclone::{
+    CloneableObject, StructuredReadDataHolder, StructuredWriteDataHolder,
+};
 use crate::dom::globalscope::GlobalScope;
-
 
 /// An interface to construct a stream of serialization operations that will be
 /// evaluated as part of serializing a DOM object.

--- a/components/script/dom/bindings/serializable.rs
+++ b/components/script/dom/bindings/serializable.rs
@@ -60,6 +60,7 @@ pub trait FromStructuredClone: Sized {
 /// during serialization of DOM objects.
 pub enum SerializeOperation {
     Uint32Pair(u32, u32),
+    Double(f64),
 }
 
 /// Interface for serializable platform objects.

--- a/components/script/dom/bindings/structuredclone.rs
+++ b/components/script/dom/bindings/structuredclone.rs
@@ -112,9 +112,10 @@ type DomObjectWriteCallback = unsafe fn(
 ) -> Result<bool, ()>;
 
 #[derive(FromPrimitive, enum_iterator::Sequence)]
+#[repr(u32)]
 pub enum CloneableObject {
-    Blob = StructuredCloneTags::DomBlob as isize,
-    DomPointReadonly = StructuredCloneTags::DomPointReadonly as isize,
+    Blob = StructuredCloneTags::DomBlob as u32,
+    DomPointReadonly = StructuredCloneTags::DomPointReadonly as u32,
 }
 
 impl CloneableObject {

--- a/components/script/dom/bindings/transferable.rs
+++ b/components/script/dom/bindings/transferable.rs
@@ -8,14 +8,14 @@
 use js::jsapi::MutableHandleObject;
 
 use crate::dom::bindings::reflector::DomObject;
-use crate::dom::bindings::structuredclone::StructuredDataHolder;
+use crate::dom::bindings::structuredclone::{StructuredReadDataHolder, StructuredWriteDataHolder};
 use crate::dom::globalscope::GlobalScope;
 
 pub trait Transferable: DomObject {
-    fn transfer(&self, sc_holder: &mut StructuredDataHolder) -> Result<u64, ()>;
+    fn transfer(&self, sc_holder: &mut StructuredWriteDataHolder) -> Result<u64, ()>;
     fn transfer_receive(
         owner: &GlobalScope,
-        sc_holder: &mut StructuredDataHolder,
+        sc_holder: &mut StructuredReadDataHolder,
         extra_data: u64,
         return_object: MutableHandleObject,
     ) -> Result<(), ()>;

--- a/components/script/dom/blob.rs
+++ b/components/script/dom/blob.rs
@@ -25,7 +25,7 @@ use crate::dom::bindings::reflector::{reflect_dom_object_with_proto, DomObject, 
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::serializable::{Serializable, StorageKey};
 use crate::dom::bindings::str::DOMString;
-use crate::dom::bindings::structuredclone::StructuredDataHolder;
+use crate::dom::bindings::structuredclone::{CloneableObject, StructuredDataHolder};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
 use crate::dom::readablestream::ReadableStream;
@@ -115,6 +115,9 @@ impl Blob {
 }
 
 impl Serializable for Blob {
+    type Data = StorageKey;
+    const TAG: CloneableObject = CloneableObject::Blob;
+
     /// <https://w3c.github.io/FileAPI/#ref-for-serialization-steps>
     fn serialize(&self, sc_holder: &mut StructuredDataHolder) -> Result<StorageKey, ()> {
         let blob_impls = match sc_holder {

--- a/components/script/dom/blob.rs
+++ b/components/script/dom/blob.rs
@@ -158,7 +158,7 @@ impl Serializable for Blob {
         owner: &GlobalScope,
         sc_holder: &mut StructuredDataHolder,
         storage_key: StorageKey,
-    ) -> Result<(), ()> {
+    ) -> Result<DomRoot<Blob>, ()> {
         // 1. Re-build the key for the storage location
         // of the serialized object.
         let namespace_id = PipelineNamespaceId(storage_key.name_space);
@@ -170,10 +170,10 @@ impl Serializable for Blob {
             index,
         };
 
-        let (blobs, blob_impls) = match sc_holder {
+        let blob_impls = match sc_holder {
             StructuredDataHolder::Read {
-                blobs, blob_impls, ..
-            } => (blobs, blob_impls),
+                blob_impls, ..
+            } => blob_impls,
             _ => panic!("Unexpected variant of StructuredDataHolder"),
         };
 
@@ -190,10 +190,7 @@ impl Serializable for Blob {
 
         let deserialized_blob = Blob::new(owner, blob_impl);
 
-        let blobs = blobs.get_or_insert_with(HashMap::new);
-        blobs.insert(storage_key, deserialized_blob);
-
-        Ok(())
+        Ok(deserialized_blob)
     }
 }
 

--- a/components/script/dom/blob.rs
+++ b/components/script/dom/blob.rs
@@ -27,7 +27,9 @@ use crate::dom::bindings::serializable::{
     FromStructuredClone, Serializable, SerializeOperation, ToSerializeOperations,
 };
 use crate::dom::bindings::str::DOMString;
-use crate::dom::bindings::structuredclone::{CloneableObject, StructuredReadDataHolder, StructuredWriteDataHolder};
+use crate::dom::bindings::structuredclone::{
+    CloneableObject, StructuredReadDataHolder, StructuredWriteDataHolder,
+};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
 use crate::dom::readablestream::ReadableStream;
@@ -135,13 +137,9 @@ impl FromStructuredClone for StorageKey {
             name_space: 0,
             index: 0,
         };
-        assert!(JS_ReadUint32Pair(
-            r,
-            &mut key.name_space,
-            &mut key.index,
-        ));
+        assert!(JS_ReadUint32Pair(r, &mut key.name_space, &mut key.index,));
         key
-     }
+    }
 }
 
 impl Serializable for Blob {

--- a/components/script/dom/dompointreadonly.rs
+++ b/components/script/dom/dompointreadonly.rs
@@ -5,6 +5,7 @@
 use std::cell::Cell;
 
 use dom_struct::dom_struct;
+use js::jsapi::{JS_ReadDouble, JSStructuredCloneReader};
 use js::rust::HandleObject;
 
 use crate::dom::bindings::codegen::Bindings::DOMPointBinding::DOMPointInit;
@@ -12,6 +13,8 @@ use crate::dom::bindings::codegen::Bindings::DOMPointReadOnlyBinding::DOMPointRe
 use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::reflector::{reflect_dom_object_with_proto, Reflector};
 use crate::dom::bindings::root::DomRoot;
+use crate::dom::bindings::serializable::{Serializable, SerializeOperation, ToSerializeOperations, FromStructuredClone};
+use crate::dom::bindings::structuredclone::{CloneableObject, StructuredReadDataHolder, StructuredWriteDataHolder};
 use crate::dom::globalscope::GlobalScope;
 use crate::script_runtime::CanGc;
 
@@ -124,5 +127,64 @@ impl DOMPointWriteMethods for DOMPointReadOnly {
 
     fn SetW(&self, value: f64) {
         self.w.set(value);
+    }
+}
+
+pub struct Coordinates {
+    x: f64,
+    y: f64,
+    z: f64,
+    w: f64,
+}
+
+impl ToSerializeOperations for Coordinates {
+    fn to_serialize_operations(&self) -> Vec<SerializeOperation> {
+        vec![
+            SerializeOperation::Double(self.x),
+            SerializeOperation::Double(self.y),
+            SerializeOperation::Double(self.z),
+            SerializeOperation::Double(self.w),
+        ]
+    }
+}
+
+impl FromStructuredClone for Coordinates {
+    #[allow(unsafe_code)]
+    unsafe fn from_structured_clone(r: *mut JSStructuredCloneReader) -> Coordinates {
+        let mut coordinates = Coordinates {
+            x: 0.0,
+            y: 0.0,
+            z: 0.0,
+            w: 0.0,
+        };
+        assert!(JS_ReadDouble(r, &mut coordinates.x));
+        assert!(JS_ReadDouble(r, &mut coordinates.y));
+        assert!(JS_ReadDouble(r, &mut coordinates.z));
+        assert!(JS_ReadDouble(r, &mut coordinates.w));
+        coordinates
+    }
+}
+
+impl Serializable for DOMPointReadOnly {
+    type Data = Coordinates;
+    const TAG: CloneableObject = CloneableObject::DomPointReadonly;
+
+    /// <https://drafts.fxtf.org/geometry-1/#structured-serialization>
+    fn serialize(&self, _sc_holder: &mut StructuredWriteDataHolder) -> Result<Coordinates, ()> {
+        Ok(Coordinates {
+            x: self.x.get(),
+            y: self.y.get(),
+            z: self.z.get(),
+            w: self.w.get(),
+        })
+    }
+
+    /// <https://drafts.fxtf.org/geometry-1/#structured-serialization>
+    fn deserialize(
+        owner: &GlobalScope,
+        _sc_holder: &mut StructuredReadDataHolder,
+        coordinates: Coordinates,
+    ) -> Result<DomRoot<DOMPointReadOnly>, ()> {
+        Ok(Self::new(owner, coordinates.x, coordinates.y, coordinates.z, coordinates.w))
     }
 }

--- a/components/script/dom/dompointreadonly.rs
+++ b/components/script/dom/dompointreadonly.rs
@@ -5,7 +5,7 @@
 use std::cell::Cell;
 
 use dom_struct::dom_struct;
-use js::jsapi::{JS_ReadDouble, JSStructuredCloneReader};
+use js::jsapi::{JSStructuredCloneReader, JS_ReadDouble};
 use js::rust::HandleObject;
 
 use crate::dom::bindings::codegen::Bindings::DOMPointBinding::DOMPointInit;
@@ -13,8 +13,12 @@ use crate::dom::bindings::codegen::Bindings::DOMPointReadOnlyBinding::DOMPointRe
 use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::reflector::{reflect_dom_object_with_proto, Reflector};
 use crate::dom::bindings::root::DomRoot;
-use crate::dom::bindings::serializable::{Serializable, SerializeOperation, ToSerializeOperations, FromStructuredClone};
-use crate::dom::bindings::structuredclone::{CloneableObject, StructuredReadDataHolder, StructuredWriteDataHolder};
+use crate::dom::bindings::serializable::{
+    FromStructuredClone, Serializable, SerializeOperation, ToSerializeOperations,
+};
+use crate::dom::bindings::structuredclone::{
+    CloneableObject, StructuredReadDataHolder, StructuredWriteDataHolder,
+};
 use crate::dom::globalscope::GlobalScope;
 use crate::script_runtime::CanGc;
 
@@ -185,6 +189,12 @@ impl Serializable for DOMPointReadOnly {
         _sc_holder: &mut StructuredReadDataHolder,
         coordinates: Coordinates,
     ) -> Result<DomRoot<DOMPointReadOnly>, ()> {
-        Ok(Self::new(owner, coordinates.x, coordinates.y, coordinates.z, coordinates.w))
+        Ok(Self::new(
+            owner,
+            coordinates.x,
+            coordinates.y,
+            coordinates.z,
+            coordinates.w,
+        ))
     }
 }

--- a/components/script/dom/messageport.rs
+++ b/components/script/dom/messageport.rs
@@ -23,7 +23,9 @@ use crate::dom::bindings::error::{Error, ErrorResult};
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::{reflect_dom_object, DomObject};
 use crate::dom::bindings::root::DomRoot;
-use crate::dom::bindings::structuredclone::{self, StructuredReadDataHolder, StructuredWriteDataHolder};
+use crate::dom::bindings::structuredclone::{
+    self, StructuredReadDataHolder, StructuredWriteDataHolder,
+};
 use crate::dom::bindings::trace::RootedTraceableBox;
 use crate::dom::bindings::transferable::Transferable;
 use crate::dom::eventtarget::EventTarget;

--- a/tests/wpt/meta/css/geometry/structured-serialization.html.ini
+++ b/tests/wpt/meta/css/geometry/structured-serialization.html.ini
@@ -1,26 +1,5 @@
 [structured-serialization.html]
-  [DOMPointReadOnly clone: basic]
-    expected: FAIL
-
-  [DOMPointReadOnly clone: custom property]
-    expected: FAIL
-
-  [DOMPointReadOnly clone: throwing getters]
-    expected: FAIL
-
-  [DOMPointReadOnly clone: non-initial values]
-    expected: FAIL
-
   [DOMPoint clone: basic]
-    expected: FAIL
-
-  [DOMPoint clone: custom property]
-    expected: FAIL
-
-  [DOMPoint clone: throwing getters]
-    expected: FAIL
-
-  [DOMPoint clone: non-initial values]
     expected: FAIL
 
   [DOMRectReadOnly clone: basic]


### PR DESCRIPTION
I started looking at what it would take to implement this missing serialization for various DOM interfaces, and the existing structured clone code does not make it easy. This PR is a series of refactorings to reduce the opportunity for errors when adding support for new interfaces, and adds serialization for DOMPointReadOnly as a demonstration of how straightforward it now is as a result.

There are a few reasons why the existing code was complex:
* lots of potential for duplicated code when extending it
* enums with multiple variants that need to be ignored, so exhaustive matches aren't possible
* an enum with Read/Write variants where only one variant was ever used for a read or write operation, leading to lots of matches with unreachable panics
* confusing control flow that stored data in temporary fields in StructuredDataHolder then pulled it out again right afterwards
* requiring data types needed by blobs in the general serializable trait interface

The refactoring attempt to address these by:
* creating an enum that only contains interfaces that are serializable, allowing exhaustive matching against it
* splitting StructuredDataHolder into two separate types for reading and writing to reduce unnecessary enum matching
* extracting interface-specific serialization logic out of the general-purpose serialization logic, hoisting it into a type-safe representation that is part of the serialization trait interface
* creating type-safe abstractions for serializing and deserializing all known serializable DOM interfaces, minimizing code changes that need to be made to the general-purpose logic when adding support for new interfaces

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes