### PR TITLE
Fix headless mode on Windows

### DIFF
--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -978,25 +978,25 @@ fn create_compositor_channel(
 
     let (compositor_ipc_sender, compositor_ipc_receiver) =
         ipc::channel().expect("ipc channel failure");
-    let sender_clone = sender.clone();
+
+    let cross_process_compositor_api = CrossProcessCompositorApi(compositor_ipc_sender);
+    let compositor_proxy = CompositorProxy {
+        sender,
+        cross_process_compositor_api,
+        event_loop_waker,
+    };
+
+    let compositor_proxy_clone = compositor_proxy.clone();
     ROUTER.add_route(
         compositor_ipc_receiver.to_opaque(),
         Box::new(move |message| {
-            let _ = sender_clone.send(CompositorMsg::CrossProcess(
+            let _ = compositor_proxy_clone.send(CompositorMsg::CrossProcess(
                 message.to().expect("Could not convert Compositor message"),
             ));
         }),
     );
-    let cross_process_compositor_api = CrossProcessCompositorApi(compositor_ipc_sender);
 
-    (
-        CompositorProxy {
-            sender,
-            cross_process_compositor_api,
-            event_loop_waker,
-        },
-        CompositorReceiver { receiver },
-    )
+    (compositor_proxy, CompositorReceiver { receiver })
 }
 
 fn get_layout_factory(legacy_layout: bool) -> Arc<dyn LayoutFactory> {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
After #33660 headless mode stopped working on Windows. With these changes the messages are sent to `compositor` through `CompositorProxy` which wakes the event loop after a message is sent.

Linux and MacOS weren't fully affected because in headless mode the event loop processes messages every 5 milliseconds when not woken
https://github.com/servo/servo/blob/a86dcfc6e7e163ebc084d69fedc32a368ef7e202/ports/servoshell/desktop/events_loop.rs#L89-L138

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [X] There are tests for these changes but WPT is not run on Windows yet

[try run](https://github.com/crbrz/servo/actions/runs/11298073966/job/31427636494)

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
