### PR TITLE
CanGc fixes starting from blob.rs, mediastream.rs, custom_event.rs

### DIFF
--- a/components/script/dom/audiocontext.rs
+++ b/components/script/dom/audiocontext.rs
@@ -292,10 +292,13 @@ impl AudioContextMethods for AudioContext {
     }
 
     /// <https://webaudio.github.io/web-audio-api/#dom-audiocontext-createmediastreamdestination>
-    fn CreateMediaStreamDestination(&self) -> Fallible<DomRoot<MediaStreamAudioDestinationNode>> {
+    fn CreateMediaStreamDestination(
+        &self,
+        can_gc: CanGc,
+    ) -> Fallible<DomRoot<MediaStreamAudioDestinationNode>> {
         let global = self.global();
         let window = global.as_window();
-        MediaStreamAudioDestinationNode::new(window, self, &AudioNodeOptions::empty())
+        MediaStreamAudioDestinationNode::new(window, self, &AudioNodeOptions::empty(), can_gc)
     }
 }
 

--- a/components/script/dom/bindings/codegen/Bindings.conf
+++ b/components/script/dom/bindings/codegen/Bindings.conf
@@ -20,6 +20,7 @@ DOMInterfaces = {
 
 'AudioContext': {
     'inRealms': ['Close', 'Suspend'],
+    'canGc':['CreateMediaStreamDestination'],
 },
 
 'BaseAudioContext': {
@@ -28,6 +29,7 @@ DOMInterfaces = {
 
 'Blob': {
     'weakReferenceable': True,
+    'canGc': ['Slice'], 
 },
 
 'Bluetooth': {
@@ -63,7 +65,7 @@ DOMInterfaces = {
 },
 
 'Document': {
-    'canGc': ['Close', 'CreateElement', 'CreateElementNS', 'ImportNode', 'SetTitle', 'Write', 'Writeln'],
+    'canGc': ['Close', 'CreateElement', 'CreateElementNS', 'ImportNode', 'SetTitle', 'Write', 'Writeln', 'CreateEvent', 'CreateRange', 'Open', 'Open_'],
 },
 
 'DynamicModuleOwner': {
@@ -113,12 +115,21 @@ DOMInterfaces = {
     'inRealms': ['Play'],
 },
 
+'HTMLCanvasElement': {
+    'canGc': ['CaptureStream'],
+},
+
 'HTMLTemplateElement': {
     'canGc': ['Content'],
 },
 
 'MediaDevices': {
+    'canGc': ['GetUserMedia'],
     'inRealms': ['GetUserMedia', 'GetClientRects', 'GetBoundingClientRect'],
+},
+
+'MediaStream': {
+    'canGc': ['Clone'],
 },
 
 'MediaQueryList': {

--- a/components/script/dom/blob.rs
+++ b/components/script/dom/blob.rs
@@ -246,12 +246,13 @@ impl BlobMethods for Blob {
         start: Option<i64>,
         end: Option<i64>,
         content_type: Option<DOMString>,
+        can_gc: CanGc,
     ) -> DomRoot<Blob> {
         let type_string =
             normalize_type_string(content_type.unwrap_or(DOMString::from("")).as_ref());
         let rel_pos = RelativePos::from_opts(start, end);
         let blob_impl = BlobImpl::new_sliced(rel_pos, self.blob_id, type_string);
-        Blob::new(&self.global(), blob_impl, CanGc::note())
+        Blob::new(&self.global(), blob_impl, can_gc)
     }
 
     // https://w3c.github.io/FileAPI/#text-method-algo

--- a/components/script/dom/customevent.rs
+++ b/components/script/dom/customevent.rs
@@ -36,8 +36,8 @@ impl CustomEvent {
         }
     }
 
-    pub fn new_uninitialized(global: &GlobalScope) -> DomRoot<CustomEvent> {
-        Self::new_uninitialized_with_proto(global, None, CanGc::note())
+    pub fn new_uninitialized(global: &GlobalScope, can_gc: CanGc) -> DomRoot<CustomEvent> {
+        Self::new_uninitialized_with_proto(global, None, can_gc)
     }
 
     fn new_uninitialized_with_proto(

--- a/components/script/dom/htmlcanvaselement.rs
+++ b/components/script/dom/htmlcanvaselement.rs
@@ -48,7 +48,7 @@ use crate::dom::node::{window_from_node, Node};
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::dom::webgl2renderingcontext::WebGL2RenderingContext;
 use crate::dom::webglrenderingcontext::WebGLRenderingContext;
-use crate::script_runtime::JSContext;
+use crate::script_runtime::{CanGc, JSContext};
 
 const DEFAULT_WIDTH: u32 = 300;
 const DEFAULT_HEIGHT: u32 = 150;
@@ -424,9 +424,13 @@ impl HTMLCanvasElementMethods for HTMLCanvasElement {
     }
 
     /// <https://w3c.github.io/mediacapture-fromelement/#dom-htmlcanvaselement-capturestream>
-    fn CaptureStream(&self, _frame_request_rate: Option<Finite<f64>>) -> DomRoot<MediaStream> {
+    fn CaptureStream(
+        &self,
+        _frame_request_rate: Option<Finite<f64>>,
+        can_gc: CanGc,
+    ) -> DomRoot<MediaStream> {
         let global = self.global();
-        let stream = MediaStream::new(&global);
+        let stream = MediaStream::new(&global, can_gc);
         let track = MediaStreamTrack::new(&global, MediaStreamId::new(), MediaStreamType::Video);
         stream.AddTrack(&track);
         stream

--- a/components/script/dom/mediadevices.rs
+++ b/components/script/dom/mediadevices.rs
@@ -25,6 +25,7 @@ use crate::dom::mediastream::MediaStream;
 use crate::dom::mediastreamtrack::MediaStreamTrack;
 use crate::dom::promise::Promise;
 use crate::realms::{AlreadyInRealm, InRealm};
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct MediaDevices {
@@ -46,10 +47,15 @@ impl MediaDevices {
 impl MediaDevicesMethods for MediaDevices {
     /// <https://w3c.github.io/mediacapture-main/#dom-mediadevices-getusermedia>
     #[allow(unsafe_code)]
-    fn GetUserMedia(&self, constraints: &MediaStreamConstraints, comp: InRealm) -> Rc<Promise> {
+    fn GetUserMedia(
+        &self,
+        constraints: &MediaStreamConstraints,
+        comp: InRealm,
+        can_gc: CanGc,
+    ) -> Rc<Promise> {
         let p = Promise::new_in_current_realm(comp);
         let media = ServoMedia::get().unwrap();
-        let stream = MediaStream::new(&self.global());
+        let stream = MediaStream::new(&self.global(), can_gc);
         if let Some(constraints) = convert_constraints(&constraints.audio) {
             if let Some(audio) = media.create_audioinput_stream(constraints) {
                 let track = MediaStreamTrack::new(&self.global(), audio, MediaStreamType::Audio);

--- a/components/script/dom/mediastream.rs
+++ b/components/script/dom/mediastream.rs
@@ -33,8 +33,8 @@ impl MediaStream {
         }
     }
 
-    pub fn new(global: &GlobalScope) -> DomRoot<MediaStream> {
-        Self::new_with_proto(global, None, CanGc::note())
+    pub fn new(global: &GlobalScope, can_gc: CanGc) -> DomRoot<MediaStream> {
+        Self::new_with_proto(global, None, can_gc)
     }
 
     fn new_with_proto(
@@ -54,8 +54,9 @@ impl MediaStream {
         global: &GlobalScope,
         id: MediaStreamId,
         ty: MediaStreamType,
+        can_gc: CanGc,
     ) -> DomRoot<MediaStream> {
-        let this = Self::new(global);
+        let this = Self::new(global, can_gc);
         let track = MediaStreamTrack::new(global, id, ty);
         this.AddTrack(&track);
         this
@@ -160,8 +161,8 @@ impl MediaStreamMethods for MediaStream {
     }
 
     /// <https://w3c.github.io/mediacapture-main/#dom-mediastream-clone>
-    fn Clone(&self) -> DomRoot<MediaStream> {
-        self.clone_with_proto(None, CanGc::note())
+    fn Clone(&self, can_gc: CanGc) -> DomRoot<MediaStream> {
+        self.clone_with_proto(None, can_gc)
     }
 }
 

--- a/components/script/dom/mediastreamaudiodestinationnode.rs
+++ b/components/script/dom/mediastreamaudiodestinationnode.rs
@@ -33,10 +33,11 @@ impl MediaStreamAudioDestinationNode {
     pub fn new_inherited(
         context: &AudioContext,
         options: &AudioNodeOptions,
+        can_gc: CanGc,
     ) -> Fallible<MediaStreamAudioDestinationNode> {
         let media = ServoMedia::get().unwrap();
         let (socket, id) = media.create_stream_and_socket(MediaStreamType::Audio);
-        let stream = MediaStream::new_single(&context.global(), id, MediaStreamType::Audio);
+        let stream = MediaStream::new_single(&context.global(), id, MediaStreamType::Audio, can_gc);
         let node_options = options.unwrap_or(
             2,
             ChannelCountMode::Explicit,
@@ -59,8 +60,9 @@ impl MediaStreamAudioDestinationNode {
         window: &Window,
         context: &AudioContext,
         options: &AudioNodeOptions,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<MediaStreamAudioDestinationNode>> {
-        Self::new_with_proto(window, None, context, options, CanGc::note())
+        Self::new_with_proto(window, None, context, options, can_gc)
     }
 
     #[allow(crown::unrooted_must_root)]
@@ -71,7 +73,7 @@ impl MediaStreamAudioDestinationNode {
         options: &AudioNodeOptions,
         can_gc: CanGc,
     ) -> Fallible<DomRoot<MediaStreamAudioDestinationNode>> {
-        let node = MediaStreamAudioDestinationNode::new_inherited(context, options)?;
+        let node = MediaStreamAudioDestinationNode::new_inherited(context, options, can_gc)?;
         Ok(reflect_dom_object_with_proto(
             Box::new(node),
             window,


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

**File Changes**: 
Replaced `CanGc::note()` calls in these files + made required entries in Bindings.conf
1. `components/script/dom/audiocontext.rs`
2. `components/script/dom/bindings/codegen/Bindings.conf`
3. `components/script/dom/blob.rs`
4. `components/script/dom/customevent.rs`
5. `components/script/dom/document.rs`
6. `components/script/dom/htmlcanvaselement.rs`
7. `components/script/dom/mediadevices.rs`
8. `components/script/dom/mediastream.rs`
9. `components/script/dom/mediastreamaudiodestinationnode.rs`

**Note**:
In Blob.rs, the `CanGc::note()` call in `fn deserialize()` could not be changed because it triggered a series of changes that ultimately required modifying a function defined by the SpiderMonkey JavaScript engine.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #33683

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because they do not modify functionality

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
