### PR TITLE
Remove some fixed `FIXME` comments

### DIFF
--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -1075,14 +1075,12 @@ impl HTMLMediaElement {
         self.error.get().is_some()
     }
 
-    // https://html.spec.whatwg.org/multipage/#potentially-playing
+    /// <https://html.spec.whatwg.org/multipage/#potentially-playing>
     fn is_potentially_playing(&self) -> bool {
         !self.paused.get() &&
-        // FIXME: We need https://github.com/servo/servo/pull/22348
-        //              to know whether playback has ended or not
-        // !self.Ended() &&
-        self.error.get().is_none() &&
-        !self.is_blocked_media_element()
+            !self.Ended() &&
+            self.error.get().is_none() &&
+            !self.is_blocked_media_element()
     }
 
     // https://html.spec.whatwg.org/multipage/#blocked-media-element

--- a/components/script/dom/webidls/ServiceWorker.webidl
+++ b/components/script/dom/webidls/ServiceWorker.webidl
@@ -14,7 +14,6 @@ interface ServiceWorker : EventTarget {
   attribute EventHandler onstatechange;
 };
 
-// FIXME: use `includes` instead of `implements` after #22539 is fixed.
 ServiceWorker includes AbstractWorker;
 
 enum ServiceWorkerState {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Removes confusing `// FIXME` comments. 

There is a small change to `HtmlMediaElment::is_potentially_playing` but this does not appear to have any impact on tests.

[Try run](https://github.com/shanehandley/servo/actions/runs/11190515932)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because the single functional change made is not covered by existing WPTs

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
