### PR TITLE
Refactor WorkletGlobalScopeType to Suppress Clippy Warning

### DIFF
--- a/components/devtools/actors/inspector/page_style.rs
+++ b/components/devtools/actors/inspector/page_style.rs
@@ -172,7 +172,7 @@ impl PageStyleActor {
 
             // For each selector (plus an empty one that represents the style attribute)
             // get all of the rules associated with it.
-            let entries =
+            let entries: Vec<AppliedEntry> =
                 once(("".into(), usize::MAX))
                     .chain(selectors)
                     .filter_map(move |selector| {
@@ -206,7 +206,8 @@ impl PageStyleActor {
                             is_system: false,
                             inherited: inherited.clone(),
                         })
-                    });
+                    })
+                    .collect();
             Some(entries)
         })
         .flatten()

--- a/components/script/dom/bindings/reflector.rs
+++ b/components/script/dom/bindings/reflector.rs
@@ -123,6 +123,12 @@ impl DomObject for Reflector {
 /// A trait to initialize the `Reflector` for a DOM object.
 pub trait MutDomObject: DomObject {
     /// Initializes the Reflector
+    /// 
+    /// # Safety 
+    /// This Function is 'unsafe' because it takes a raw pointer to a 'JSObject'
+    /// The caller must ensure that the pointer is valid and properly aligned.
+    /// Undefined behavior may occur if the pointer is null or if it points to
+    /// an invalid memory location.
     unsafe fn init_reflector(&self, obj: *mut JSObject);
 }
 

--- a/components/script/dom/bindings/reflector.rs
+++ b/components/script/dom/bindings/reflector.rs
@@ -120,15 +120,16 @@ impl DomObject for Reflector {
     }
 }
 
-/// A trait to initialize the `Reflector` for a DOM object.
+
+// FIXME: Add safety documentation.
+// See Github Issue Number:#33725
+#[allow(clippy::missing_safety_doc)]
+
+// Brief description of the trait
+/// A trait to initialize the `Reflector` for a DOM object. 
 pub trait MutDomObject: DomObject {
-    /// Initializes the Reflector
-    /// 
-    /// # Safety 
-    /// This Function is 'unsafe' because it takes a raw pointer to a 'JSObject'
-    /// The caller must ensure that the pointer is valid and properly aligned.
-    /// Undefined behavior may occur if the pointer is null or if it points to
-    /// an invalid memory location.
+    /// Initializes the `Reflector` for the DOM object.
+    #[allow(clippy::missing_safety_doc)]
     unsafe fn init_reflector(&self, obj: *mut JSObject);
 }
 

--- a/components/script/dom/bindings/reflector.rs
+++ b/components/script/dom/bindings/reflector.rs
@@ -121,15 +121,12 @@ impl DomObject for Reflector {
 }
 
 
-// FIXME: Add safety documentation.
-// See Github Issue Number:#33725
-#[allow(clippy::missing_safety_doc)]
-
-// Brief description of the trait
 /// A trait to initialize the `Reflector` for a DOM object. 
 pub trait MutDomObject: DomObject {
-    /// Initializes the `Reflector` for the DOM object.
+    // FIXME: Add Safety Documentation
+    // See Github Issue #33725.
     #[allow(clippy::missing_safety_doc)]
+    /// Initializes the `Reflector` for the DOM object.
     unsafe fn init_reflector(&self, obj: *mut JSObject);
 }
 

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -69,6 +69,12 @@ use crate::script_thread::IncompleteParserContexts;
 use crate::task::TaskBox;
 
 /// A trait to allow tracing only DOM sub-objects.
+/// 
+/// # Safety
+/// - Before calling `trace`, `self` must be valid and properly initialized.
+/// - The `trace` method must not cause data races or access invalid memory.
+/// - For `Box<T>` and `DomRefCell<T>`, ensure the underlying data is valid during tracing.
+/// - Avoid multiple mutable borrows when using `DomRefCell`. 
 pub unsafe trait CustomTraceable {
     /// Trace `self`.
     unsafe fn trace(&self, trc: *mut JSTracer);

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -68,17 +68,19 @@ use crate::script_runtime::{ContextForRequestInterrupt, StreamConsumer};
 use crate::script_thread::IncompleteParserContexts;
 use crate::task::TaskBox;
 
-/// A trait to allow tracing only DOM sub-objects.
-/// 
-/// # Safety
-/// - Before calling `trace`, `self` must be valid and properly initialized.
-/// - The `trace` method must not cause data races or access invalid memory.
-/// - For `Box<T>` and `DomRefCell<T>`, ensure the underlying data is valid during tracing.
-/// - Avoid multiple mutable borrows when using `DomRefCell`. 
+
+// Allow missing safety documentation warning temporarily
+// Link to the issue regarding Documentation 
+// Warning Line: https://github.com/rexbrown21/servo/blob/457d8a8a5c720fbf5624a95d86ac53f2aee342e8/components/script/dom/bindings/trace.rs#L72
+#[allow(clippy::missing_safety_doc)] 
+
+// Brief description of the trait
+/// This trait defines a method for tracing objects in the context of garbage collection.
 pub unsafe trait CustomTraceable {
     /// Trace `self`.
     unsafe fn trace(&self, trc: *mut JSTracer);
 }
+
 
 unsafe impl<T: CustomTraceable> CustomTraceable for Box<T> {
     #[inline]

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -69,9 +69,8 @@ use crate::script_thread::IncompleteParserContexts;
 use crate::task::TaskBox;
 
 
-// Allow missing safety documentation warning temporarily
-// Link to the issue regarding Documentation 
-// Warning Line: https://github.com/rexbrown21/servo/blob/457d8a8a5c720fbf5624a95d86ac53f2aee342e8/components/script/dom/bindings/trace.rs#L72
+// FIXME: Add safety documentation.
+// See Github Issue Number: #33722
 #[allow(clippy::missing_safety_doc)] 
 
 // Brief description of the trait

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -73,13 +73,11 @@ use crate::task::TaskBox;
 // See Github Issue Number: #33722
 #[allow(clippy::missing_safety_doc)] 
 
-// Brief description of the trait
-/// This trait defines a method for tracing objects in the context of garbage collection.
+/// A trait to allow tracing only DOM sub-objects.
 pub unsafe trait CustomTraceable {
     /// Trace `self`.
     unsafe fn trace(&self, trc: *mut JSTracer);
 }
-
 
 unsafe impl<T: CustomTraceable> CustomTraceable for Box<T> {
     #[inline]

--- a/components/script/dom/workletglobalscope.rs
+++ b/components/script/dom/workletglobalscope.rs
@@ -180,6 +180,7 @@ pub enum WorkletGlobalScopeType {
 
 impl WorkletGlobalScopeType {
     /// Create a new heap-allocated `WorkletGlobalScope`.
+    #[allow(clippy::new_ret_no_self)]
     pub fn new(
         &self,
         runtime: &Runtime,


### PR DESCRIPTION
This PR suppresses the Clippy warning for the new function in WorkletGlobalScopeType by adding the #[allow(clippy::new_ret_no_self)] attribute to the module. This change helps prevent unnecessary linting errors while keeping the existing behavior intact. 

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

