### PR TITLE
Refactor WorkletGlobalScopeType to Suppress Clippy Warning (2)

### DIFF
--- a/components/script/dom/bindings/reflector.rs
+++ b/components/script/dom/bindings/reflector.rs
@@ -123,6 +123,12 @@ impl DomObject for Reflector {
 /// A trait to initialize the `Reflector` for a DOM object.
 pub trait MutDomObject: DomObject {
     /// Initializes the Reflector
+    /// 
+    /// # Safety 
+    /// This Function is 'unsafe' because it takes a raw pointer to a 'JSObject'
+    /// The caller must ensure that the pointer is valid and properly aligned.
+    /// Undefined behavior may occur if the pointer is null or if it points to
+    /// an invalid memory location.
     unsafe fn init_reflector(&self, obj: *mut JSObject);
 }
 

--- a/components/script/dom/workletglobalscope.rs
+++ b/components/script/dom/workletglobalscope.rs
@@ -180,6 +180,7 @@ pub enum WorkletGlobalScopeType {
 
 impl WorkletGlobalScopeType {
     /// Create a new heap-allocated `WorkletGlobalScope`.
+    #[allow(clippy::new_ret_no_self)]
     pub fn new(
         &self,
         runtime: &Runtime,


### PR DESCRIPTION
This PR suppresses the Clippy warning for the new function in WorkletGlobalScopeType by adding the #[allow(clippy::new_ret_no_self)] attribute to the module. This change helps prevent unnecessary linting errors while keeping the existing behavior intact.

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors