### PR TITLE
README: Add python3-setuptools to ubuntu apt install line

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ For more detailed build instructions, see the Servo book under [Setting up your 
 
 - Install `curl` and `python`:
   - Arch: `sudo pacman -S --needed curl python python-pip`
-  - Debian, Ubuntu: `sudo apt install curl python3-pip python3-venv`
+  - Debian, Ubuntu: `sudo apt install curl python3-pip python3-venv python3-setuptools`
   - Fedora: `sudo dnf install curl python3 python3-pip python3-devel`
   - Gentoo: `sudo emerge net-misc/curl dev-python/pip`
 - Install `rustup`: `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`


### PR DESCRIPTION
This was needed on my clean installed ubuntu 24.10.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because it's only docs

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
