### PR TITLE
CI: temporarily disable self-hosted runners for nightly.yml

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -28,6 +28,10 @@ on:
       github-release-id:
         required: false
         type: string
+      force-github-hosted-runner:
+        required: false
+        type: boolean
+        default: false
   workflow_dispatch:
     inputs:
       profile:
@@ -55,6 +59,10 @@ on:
         required: false
         default: false
         type: boolean
+      force-github-hosted-runner:
+        required: false
+        type: boolean
+        default: false
 
 env:
   RUST_BACKTRACE: 1
@@ -72,7 +80,7 @@ jobs:
       # runners which still use 20.04.
       github-hosted-runner-label: ubuntu-${{ inputs.upload && '20.04' || '22.04' }}
       self-hosted-image-name: servo-ubuntu2204
-      force-github-hosted-runner: ${{ inputs.upload }}
+      force-github-hosted-runner: ${{ inputs.upload || inputs.force-github-hosted-runner }}
   runner-timeout:
     needs:
       - runner-select

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -86,6 +86,7 @@ jobs:
       profile: "production"
       upload: true
       github-release-id: ${{ needs.create-draft-release.outputs.release-id }}
+      force-github-hosted-runner: true  # <https://github.com/servo/servo/issues/33296>
     secrets: inherit
 
   upload-mac:
@@ -112,6 +113,7 @@ jobs:
       profile: "production"
       upload: true
       github-release-id: ${{ needs.create-draft-release.outputs.release-id }}
+      force-github-hosted-runner: true  # <https://github.com/servo/servo/issues/33296>
     secrets: inherit
 
   upload-android:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -18,6 +18,10 @@ on:
       github-release-id:
         required: false
         type: string
+      force-github-hosted-runner:
+        required: false
+        type: boolean
+        default: false
   workflow_dispatch:
     inputs:
       profile:
@@ -33,6 +37,10 @@ on:
         required: false
         default: false
         type: boolean
+      force-github-hosted-runner:
+        required: false
+        type: boolean
+        default: false
 
 env:
   RUST_BACKTRACE: 1
@@ -54,6 +62,7 @@ jobs:
     with:
       github-hosted-runner-label: windows-2022
       self-hosted-image-name: servo-windows10
+      force-github-hosted-runner: ${{ inputs.force-github-hosted-runner }}
   runner-timeout:
     needs:
       - runner-select


### PR DESCRIPTION
This should unblock the nightly release builds while we investigate.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are related to #33296

<!-- Either: -->
- [x] CI test runs
  - [x] [nightly.yml Windows job](https://github.com/delan/servo/actions/runs/11327126386/job/31497532363#step:2:58) selects GitHub-hosted runner
  - [x] [nightly.yml Linux job](https://github.com/delan/servo/actions/runs/11327126386/job/31497531919#step:2:58) selects GitHub-hosted runner
  - [x] [main.yml Windows job](https://github.com/delan/servo/actions/runs/11327095942/job/31497438737#step:2:59) selects self-hosted runner (but fails because my fork can’t use our prod runners)
  - [x] [main.yml Linux job](https://github.com/delan/servo/actions/runs/11327095942/job/31497438296#step:2:59) selects self-hosted runner (but fails because my fork can’t use our prod runners)