### PR TITLE
Fix Clippy warning: remove unneeded late initialization of string

### DIFF
--- a/components/script/dom/dommatrixreadonly.rs
+++ b/components/script/dom/dommatrixreadonly.rs
@@ -822,8 +822,6 @@ impl DOMMatrixReadOnlyMethods for DOMMatrixReadOnly {
             return Err(error::Error::InvalidState);
         }
 
-        // Step 2. Let string be the empty string.
-        // Step 3. If is 2D is true, then:
         let cx = GlobalScope::get_cx();
         let to_string = |f: f64| {
             let value = jsval::DoubleValue(f);
@@ -837,6 +835,9 @@ impl DOMMatrixReadOnlyMethods for DOMMatrixReadOnly {
                 )
             }
         };
+
+        // Step 2. Let string be the empty string.
+        // Step 3. If is 2D is true, then:
         let string = if self.is2D() {
             // Step 3.1 Append "matrix(" to string.
             // Step 3.2 Append ! ToString(m11 element) to string.

--- a/components/script/dom/dommatrixreadonly.rs
+++ b/components/script/dom/dommatrixreadonly.rs
@@ -823,8 +823,6 @@ impl DOMMatrixReadOnlyMethods for DOMMatrixReadOnly {
         }
 
         // Step 2. Let string be the empty string.
-        let string;
-
         // Step 3. If is 2D is true, then:
         let cx = GlobalScope::get_cx();
         let to_string = |f: f64| {
@@ -839,7 +837,7 @@ impl DOMMatrixReadOnlyMethods for DOMMatrixReadOnly {
                 )
             }
         };
-        if self.is2D() {
+        let string = if self.is2D() {
             // Step 3.1 Append "matrix(" to string.
             // Step 3.2 Append ! ToString(m11 element) to string.
             // Step 3.3 Append ", " to string.
@@ -853,7 +851,7 @@ impl DOMMatrixReadOnlyMethods for DOMMatrixReadOnly {
             // Step 3.11 Append ", " to string.
             // Step 3.12 Append ! ToString(m42 element) to string.
             // Step 3.13 Append ")" to string.
-            string = format!(
+            format!(
                 "matrix({}, {}, {}, {}, {}, {})",
                 to_string(mat.m11),
                 to_string(mat.m12),
@@ -862,7 +860,7 @@ impl DOMMatrixReadOnlyMethods for DOMMatrixReadOnly {
                 to_string(mat.m41),
                 to_string(mat.m42)
             )
-            .into();
+            .into()
         }
         // Step 4. Otherwise:
         else {
@@ -894,7 +892,7 @@ impl DOMMatrixReadOnlyMethods for DOMMatrixReadOnly {
 
             // NOTE: The spec is wrong and missing the m3* elements.
             // (https://github.com/w3c/fxtf-drafts/issues/574)
-            string = format!(
+            format!(
                 "matrix3d({}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {})",
                 to_string(mat.m11),
                 to_string(mat.m12),
@@ -913,8 +911,8 @@ impl DOMMatrixReadOnlyMethods for DOMMatrixReadOnly {
                 to_string(mat.m43),
                 to_string(mat.m44)
             )
-            .into();
-        }
+            .into()
+        };
 
         Ok(string)
     }


### PR DESCRIPTION
**File**: `components/script/dom/dommatrixreadonly.rs`

**PR Description**
**Issue:** 
Clippy warning for unnecessary late initialization (`needless_late_init`).

**Changes:** 
Moved the declaration of `string` to directly initialize it based on the 2D condition, removing the need for a separate declaration.

**Impact:** 
Improves code clarity and complies with Clippy suggestions, eliminating the warning.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of https://github.com/servo/servo/issues/31500.

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because they do not modify functionality, they only fix lint errors.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
