### PR TITLE
CanGc fixes in `components/script/dom`

### DIFF
--- a/components/script/animations.rs
+++ b/components/script/animations.rs
@@ -508,7 +508,7 @@ impl Animations {
                     elapsedTime: elapsed_time,
                     pseudoElement: pseudo_element,
                 };
-                TransitionEvent::new(&window, event_atom, &event_init)
+                TransitionEvent::new(&window, event_atom, &event_init, can_gc)
                     .upcast::<Event>()
                     .fire(node.upcast());
             } else {

--- a/components/script/dom/bindings/codegen/Bindings.conf
+++ b/components/script/dom/bindings/codegen/Bindings.conf
@@ -245,7 +245,7 @@ DOMInterfaces = {
 },
 
 'XMLHttpRequest': {
-    'canGc': ['GetResponseXML', 'Response'],
+    'canGc': ['Abort', 'GetResponseXML', 'Response'],
 },
 
 'XRSession': {

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -1666,6 +1666,7 @@ impl Document {
         delta: WheelDelta,
         client_point: Point2D<f32>,
         node_address: Option<UntrustedNodeAddress>,
+        can_gc: CanGc,
     ) {
         let wheel_event_type_string = "wheel".to_owned();
         debug!("{}: at {:?}", wheel_event_type_string, client_point);
@@ -1697,6 +1698,7 @@ impl Document {
             Finite::wrap(delta.y),
             Finite::wrap(delta.z),
             delta.mode as u32,
+            can_gc,
         );
 
         let event = event.upcast::<Event>();

--- a/components/script/dom/gpudevice.rs
+++ b/components/script/dom/gpudevice.rs
@@ -597,6 +597,7 @@ impl AsyncWGPUListener for GPUDevice {
                         &self.global(),
                         msg.into(),
                         GPUPipelineErrorReason::Validation,
+                        can_gc,
                     ))
                 },
                 Err(webgpu::Error::OutOfMemory(msg) | webgpu::Error::Internal(msg)) => promise
@@ -604,6 +605,7 @@ impl AsyncWGPUListener for GPUDevice {
                         &self.global(),
                         msg.into(),
                         GPUPipelineErrorReason::Internal,
+                        can_gc,
                     )),
             },
             WebGPUResponse::RenderPipeline(result) => match result {
@@ -618,6 +620,7 @@ impl AsyncWGPUListener for GPUDevice {
                         &self.global(),
                         msg.into(),
                         GPUPipelineErrorReason::Validation,
+                        can_gc,
                     ))
                 },
                 Err(webgpu::Error::OutOfMemory(msg) | webgpu::Error::Internal(msg)) => promise
@@ -625,6 +628,7 @@ impl AsyncWGPUListener for GPUDevice {
                         &self.global(),
                         msg.into(),
                         GPUPipelineErrorReason::Internal,
+                        can_gc,
                     )),
             },
             _ => unreachable!("Wrong response received on AsyncWGPUListener for GPUDevice"),

--- a/components/script/dom/gpupipelineerror.rs
+++ b/components/script/dom/gpupipelineerror.rs
@@ -49,8 +49,9 @@ impl GPUPipelineError {
         global: &GlobalScope,
         message: DOMString,
         reason: GPUPipelineErrorReason,
+        can_gc: CanGc,
     ) -> DomRoot<Self> {
-        Self::new_with_proto(global, None, message, reason, CanGc::note())
+        Self::new_with_proto(global, None, message, reason, can_gc)
     }
 }
 

--- a/components/script/dom/transitionevent.rs
+++ b/components/script/dom/transitionevent.rs
@@ -43,8 +43,9 @@ impl TransitionEvent {
         window: &Window,
         type_: Atom,
         init: &TransitionEventInit,
+        can_gc: CanGc,
     ) -> DomRoot<TransitionEvent> {
-        Self::new_with_proto(window, None, type_, init, CanGc::note())
+        Self::new_with_proto(window, None, type_, init, can_gc)
     }
 
     fn new_with_proto(

--- a/components/script/dom/wheelevent.rs
+++ b/components/script/dom/wheelevent.rs
@@ -61,20 +61,11 @@ impl WheelEvent {
         delta_y: Finite<f64>,
         delta_z: Finite<f64>,
         delta_mode: u32,
+        can_gc: CanGc,
     ) -> DomRoot<WheelEvent> {
         Self::new_with_proto(
-            window,
-            None,
-            type_,
-            can_bubble,
-            cancelable,
-            view,
-            detail,
-            delta_x,
-            delta_y,
-            delta_z,
-            delta_mode,
-            CanGc::note(),
+            window, None, type_, can_bubble, cancelable, view, detail, delta_x, delta_y, delta_z,
+            delta_mode, can_gc,
         )
     }
 

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -803,7 +803,7 @@ impl XMLHttpRequestMethods for XMLHttpRequest {
     }
 
     /// <https://xhr.spec.whatwg.org/#the-abort()-method>
-    fn Abort(&self) {
+    fn Abort(&self, can_gc: CanGc) {
         // Step 1
         self.terminate_ongoing_fetch();
         // Step 2
@@ -813,10 +813,7 @@ impl XMLHttpRequestMethods for XMLHttpRequest {
             state == XMLHttpRequestState::Loading
         {
             let gen_id = self.generation_id.get();
-            self.process_partial_response(
-                XHRProgress::Errored(gen_id, Error::Abort),
-                CanGc::note(),
-            );
+            self.process_partial_response(XHRProgress::Errored(gen_id, Error::Abort), can_gc);
             // If open was called in one of the handlers invoked by the
             // above call then we should terminate the abort sequence
             if self.generation_id.get() != gen_id {
@@ -825,7 +822,7 @@ impl XMLHttpRequestMethods for XMLHttpRequest {
         }
         // Step 3
         if self.ready_state.get() == XMLHttpRequestState::Done {
-            self.change_ready_state(XMLHttpRequestState::Unsent, CanGc::note());
+            self.change_ready_state(XMLHttpRequestState::Unsent, can_gc);
             self.response_status.set(Err(()));
             self.response.borrow_mut().clear();
             self.response_headers.borrow_mut().clear();

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1613,7 +1613,7 @@ impl ScriptThread {
                 },
 
                 CompositorEvent::WheelEvent(delta, point, node_address) => {
-                    self.handle_wheel_event(pipeline_id, delta, point, node_address);
+                    self.handle_wheel_event(pipeline_id, delta, point, node_address, can_gc);
                 },
 
                 CompositorEvent::KeyboardEvent(key_event) => {
@@ -3944,12 +3944,13 @@ impl ScriptThread {
         wheel_delta: WheelDelta,
         point: Point2D<f32>,
         node_address: Option<UntrustedNodeAddress>,
+        can_gc: CanGc,
     ) {
         let Some(document) = self.documents.borrow().find_document(pipeline_id) else {
             warn!("Message sent to closed pipeline {pipeline_id}.");
             return;
         };
-        unsafe { document.handle_wheel_event(wheel_delta, point, node_address) };
+        unsafe { document.handle_wheel_event(wheel_delta, point, node_address, can_gc) };
     }
 
     /// Handle a "navigate an iframe" message from the constellation.


### PR DESCRIPTION
Replaces CanGc::note() calls with arguments passed by callers in `components/script/dom/xmlhttprequest.rs`, `components/script/dom/wheelevent.rs`, `components/script/dom/gpupipelineerror.rs` and `components/script/dom/transitionevent.rs`


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are a part of #33683 
- [X] These changes do not require tests because they do not modify functionailty

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
