### PR TITLE
Avoid wrapping line at the start of text run with `text-wrap-mode: nowrap`

### DIFF
--- a/components/layout_2020/flow/inline/mod.rs
+++ b/components/layout_2020/flow/inline/mod.rs
@@ -2245,17 +2245,17 @@ impl<'layout_data> ContentSizesComputation<'layout_data> {
             },
             InlineItem::TextRun(text_run) => {
                 for segment in text_run.shaped_text.iter() {
+                    let style_text = text_run.parent_style.get_inherited_text();
+                    let can_wrap = style_text.text_wrap_mode == TextWrapMode::Wrap;
+
                     // TODO: This should take account whether or not the first and last character prevent
                     // linebreaks after atomics as in layout.
-                    if segment.break_at_start {
+                    if can_wrap && segment.break_at_start {
                         self.line_break_opportunity()
                     }
 
                     for run in segment.runs.iter() {
                         let advance = run.glyph_store.total_advance();
-                        let style_text = text_run.parent_style.get_inherited_text();
-                        let can_wrap = style_text.text_wrap_mode == TextWrapMode::Wrap;
-
                         if run.glyph_store.is_whitespace() {
                             // If this run is a forced line break, we *must* break the line
                             // and start measuring from the inline origin once more.

--- a/tests/wpt/tests/css/css-text/white-space/white-space-intrinsic-size-021.html
+++ b/tests/wpt/tests/css/css-text/white-space/white-space-intrinsic-size-021.html
@@ -166,6 +166,16 @@ x-br::before {
   <div class="break-spaces wrap"      data-expected-client-width="20" data-expected-client-height="20">X <x-br></x-br>É</div>
   <div class="break-spaces nowrap"    data-expected-client-width="20" data-expected-client-height="20">X <x-br></x-br>É</div>
 </div>
+<div class="container narrow">
+  <div class="collapse wrap"          data-expected-client-width="10" data-expected-client-height="20">X <a>É</a></div>
+  <div class="collapse nowrap"        data-expected-client-width="30" data-expected-client-height="10">X <a>É</a></div>
+  <div class="preserve wrap"          data-expected-client-width="10" data-expected-client-height="20">X <a>É</a></div>
+  <div class="preserve nowrap"        data-expected-client-width="30" data-expected-client-height="10">X <a>É</a></div>
+  <div class="preserve-breaks wrap"   data-expected-client-width="10" data-expected-client-height="20">X <a>É</a></div>
+  <div class="preserve-breaks nowrap" data-expected-client-width="30" data-expected-client-height="10">X <a>É</a></div>
+  <div class="break-spaces wrap"      data-expected-client-width="20" data-expected-client-height="20">X <a>É</a></div>
+  <div class="break-spaces nowrap"    data-expected-client-width="30" data-expected-client-height="10">X <a>É</a></div>
+</div>
 
 <hr>
 
@@ -278,6 +288,16 @@ x-br::before {
   <div class="preserve-breaks nowrap" data-expected-client-width="10" data-expected-client-height="20">X <x-br></x-br>É</div>
   <div class="break-spaces wrap"      data-expected-client-width="20" data-expected-client-height="20">X <x-br></x-br>É</div>
   <div class="break-spaces nowrap"    data-expected-client-width="20" data-expected-client-height="20">X <x-br></x-br>É</div>
+</div>
+<div class="container wide">
+  <div class="collapse wrap"          data-expected-client-width="30" data-expected-client-height="10">X <a>É</a></div>
+  <div class="collapse nowrap"        data-expected-client-width="30" data-expected-client-height="10">X <a>É</a></div>
+  <div class="preserve wrap"          data-expected-client-width="30" data-expected-client-height="10">X <a>É</a></div>
+  <div class="preserve nowrap"        data-expected-client-width="30" data-expected-client-height="10">X <a>É</a></div>
+  <div class="preserve-breaks wrap"   data-expected-client-width="30" data-expected-client-height="10">X <a>É</a></div>
+  <div class="preserve-breaks nowrap" data-expected-client-width="30" data-expected-client-height="10">X <a>É</a></div>
+  <div class="break-spaces wrap"      data-expected-client-width="30" data-expected-client-height="10">X <a>É</a></div>
+  <div class="break-spaces nowrap"    data-expected-client-width="30" data-expected-client-height="10">X <a>É</a></div>
 </div>
 
 <hr>


### PR DESCRIPTION
When computing the min-content size of an inline formatting context, we could allow a soft wrap opportunity at the start of a text run. This shouldn't happen with `text-wrap-mode: nowrap`.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #33847
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
