### PR TITLE
clippy: fix clippy warnings in `components/script`

### DIFF
--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -122,9 +122,9 @@ impl fmt::Debug for CommonScriptMsg {
 }
 
 /// A cloneable interface for communicating with an event loop.
-#[allow(clippy::result_unit_err)]
 pub trait ScriptChan: JSTraceable {
     /// Send a message to the associated event loop.
+    #[allow(clippy::result_unit_err)]
     fn send(&self, msg: CommonScriptMsg) -> Result<(), ()>;
     /// Clone this handle.
     fn clone(&self) -> Box<dyn ScriptChan + Send>;
@@ -164,8 +164,8 @@ pub enum ScriptThreadEventCategory {
 /// An interface for receiving ScriptMsg values in an event loop. Used for synchronous DOM
 /// APIs that need to abstract over multiple kinds of event loops (worker/main thread) with
 /// different Receiver interfaces.
-#[allow(clippy::result_unit_err)]
 pub trait ScriptPort {
+    #[allow(clippy::result_unit_err)]
     fn recv(&self) -> Result<CommonScriptMsg, ()>;
 }
 

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -122,6 +122,7 @@ impl fmt::Debug for CommonScriptMsg {
 }
 
 /// A cloneable interface for communicating with an event loop.
+#[allow(clippy::result_unit_err)]
 pub trait ScriptChan: JSTraceable {
     /// Send a message to the associated event loop.
     fn send(&self, msg: CommonScriptMsg) -> Result<(), ()>;
@@ -163,6 +164,7 @@ pub enum ScriptThreadEventCategory {
 /// An interface for receiving ScriptMsg values in an event loop. Used for synchronous DOM
 /// APIs that need to abstract over multiple kinds of event loops (worker/main thread) with
 /// different Receiver interfaces.
+#[allow(clippy::result_unit_err)]
 pub trait ScriptPort {
     fn recv(&self) -> Result<CommonScriptMsg, ()>;
 }

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -257,6 +257,7 @@ impl InProgressLoad {
 }
 
 #[derive(Debug)]
+#[allow(clippy::enum_variant_names)]
 enum MixedMessage {
     FromConstellation(ConstellationControlMsg),
     FromScript(MainThreadScriptMsg),


### PR DESCRIPTION
This PR contains clippy fixes for files components/script/script_runtime.rs and components/script/script_thread.rs"

---

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #31500 
- [X] These changes do not require tests because they do not touch functionality.

