### PR TITLE
clippy: Fix warnings in `components/script/dom` & `components/servo`

### DIFF
--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -88,6 +88,7 @@ use crate::task_source::TaskSource;
 #[derive(Clone, Copy, JSTraceable, MallocSizeOf, PartialEq)]
 pub struct GenerationId(u32);
 
+#[allow(clippy::type_complexity)]
 #[dom_struct]
 pub struct HTMLFormElement {
     htmlelement: HTMLElement,

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -97,8 +97,10 @@ pub struct HTMLFormElement {
     elements: DomOnceCell<HTMLFormControlsCollection>,
     generation_id: Cell<GenerationId>,
     controls: DomRefCell<Vec<Dom<Element>>>,
+
     #[allow(clippy::type_complexity)]
     past_names_map: DomRefCell<HashMapTracedValues<Atom, (Dom<Element>, NoTrace<Instant>)>>,
+    
     firing_submission_events: Cell<bool>,
     rel_list: MutNullableDom<DOMTokenList>,
 

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -100,7 +100,7 @@ pub struct HTMLFormElement {
 
     #[allow(clippy::type_complexity)]
     past_names_map: DomRefCell<HashMapTracedValues<Atom, (Dom<Element>, NoTrace<Instant>)>>,
-    
+
     firing_submission_events: Cell<bool>,
     rel_list: MutNullableDom<DOMTokenList>,
 

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -88,7 +88,6 @@ use crate::task_source::TaskSource;
 #[derive(Clone, Copy, JSTraceable, MallocSizeOf, PartialEq)]
 pub struct GenerationId(u32);
 
-#[allow(clippy::type_complexity)]
 #[dom_struct]
 pub struct HTMLFormElement {
     htmlelement: HTMLElement,
@@ -98,6 +97,7 @@ pub struct HTMLFormElement {
     elements: DomOnceCell<HTMLFormControlsCollection>,
     generation_id: Cell<GenerationId>,
     controls: DomRefCell<Vec<Dom<Element>>>,
+    #[allow(clippy::type_complexity)]
     past_names_map: DomRefCell<HashMapTracedValues<Atom, (Dom<Element>, NoTrace<Instant>)>>,
     firing_submission_events: Cell<bool>,
     rel_list: MutNullableDom<DOMTokenList>,

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -344,6 +344,7 @@ pub struct HTMLMediaElement {
     #[ignore_malloc_size_of = "promises are hard"]
     pending_play_promises: DomRefCell<Vec<Rc<Promise>>>,
     /// Play promises which are soon to be fulfilled by a queued task.
+    #[allow(clippy::type_complexity)]
     #[ignore_malloc_size_of = "promises are hard"]
     in_flight_play_promises_queue: DomRefCell<VecDeque<(Box<[Rc<Promise>]>, ErrorResult)>>,
     #[ignore_malloc_size_of = "servo_media"]

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -993,7 +993,7 @@ fn create_compositor_channel(
     ROUTER.add_route(
         compositor_ipc_receiver.to_opaque(),
         Box::new(move |message| {
-            let _ = compositor_proxy_clone.send(CompositorMsg::CrossProcess(
+            compositor_proxy_clone.send(CompositorMsg::CrossProcess(
                 message.to().expect("Could not convert Compositor message"),
             ));
         }),


### PR DESCRIPTION
Fixes warnings in `components/script/dom` & `components/servo` as a part of #31500 


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are a part of #31500 
- [X] These changes do not require tests because they do not modify functionality

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
