### PR TITLE
clippy: fix docs miss `# Safety` in components\script\script_runtime.…

### DIFF
--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -757,7 +757,22 @@ unsafe extern "C" fn get_size(obj: *mut JSObject) -> usize {
         Err(_e) => 0,
     }
 }
-
+/// Retrieves memory reports from the given JavaScript context.
+///
+/// # Safety
+/// This function is unsafe because it takes a raw pointer to a `RawJSContext`.
+/// The caller must ensure that:
+/// - `cx` is a valid, non-null pointer to a `RawJSContext`.
+/// - The memory pointed to by `cx` remains valid for the duration of the function call.
+/// - The function should not be called from multiple threads simultaneously unless
+///   appropriate synchronization is used.
+///
+/// # Arguments
+/// * `cx` - A mutable pointer to a `RawJSContext`.
+/// * `path_seg` - A string segment to append to the report paths.
+///
+/// # Returns
+/// A vector of `Report` containing the collected memory statistics.
 #[allow(unsafe_code)]
 pub unsafe fn get_reports(cx: *mut RawJSContext, path_seg: String) -> Vec<Report> {
     let mut reports = vec![];


### PR DESCRIPTION
…rs:777:1

<!-- Please describe your changes on the following line: -->
I got this warning - unsafe function's docs miss `# Safety` section
   --> components\script\script_runtime.rs:756:1
    |
756 | pub unsafe fn get_reports(cx: *mut RawJSContext, path_seg: String) -> Vec<Report> { 
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#missing_safety_doc
which indicates that the 'get_reports' is missing a # Safety section in its documentation. 
I added these comments to solve the issue:
/// Retrieves memory reports from the given JavaScript context.
///
/// # Safety
/// This function is unsafe because it takes a raw pointer to a `RawJSContext`.
/// The caller must ensure that:
/// - `cx` is a valid, non-null pointer to a `RawJSContext`.
/// - The memory pointed to by `cx` remains valid for the duration of the function call.
/// - The function should not be called from multiple threads simultaneously unless
///   appropriate synchronization is used.
///
/// # Arguments
/// * `cx` - A mutable pointer to a `RawJSContext`.
/// * `path_seg` - A string segment to append to the report paths.
///
/// # Returns
/// A vector of `Report` containing the collected memory statistics.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- X `./mach build -d` does not report any errors
- X `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
