### PR TITLE
clippy: Fix warnings in `components/script/dom`

### DIFF
--- a/components/script/dom/bindings/reflector.rs
+++ b/components/script/dom/bindings/reflector.rs
@@ -141,9 +141,9 @@ impl MutDomObject for Reflector {
 }
 
 /// A trait to provide a function pointer to wrap function for DOM objects.
-#[allow(clippy::type_complexity)]
 pub trait DomObjectWrap: Sized + DomObject {
     /// Function pointer to the general wrap function type
+    #[allow(clippy::type_complexity)]
     const WRAP: unsafe fn(
         JSContext,
         &GlobalScope,
@@ -155,9 +155,9 @@ pub trait DomObjectWrap: Sized + DomObject {
 
 /// A trait to provide a function pointer to wrap function for
 /// DOM iterator interfaces.
-#[allow(clippy::type_complexity)]
 pub trait DomObjectIteratorWrap: DomObjectWrap + JSTraceable + Iterable {
     /// Function pointer to the wrap function for `IterableIterator<T>`
+    #[allow(clippy::type_complexity)]
     const ITER_WRAP: unsafe fn(
         JSContext,
         &GlobalScope,

--- a/components/script/dom/bindings/reflector.rs
+++ b/components/script/dom/bindings/reflector.rs
@@ -141,6 +141,7 @@ impl MutDomObject for Reflector {
 }
 
 /// A trait to provide a function pointer to wrap function for DOM objects.
+#[allow(clippy::type_complexity)]
 pub trait DomObjectWrap: Sized + DomObject {
     /// Function pointer to the general wrap function type
     const WRAP: unsafe fn(
@@ -154,6 +155,7 @@ pub trait DomObjectWrap: Sized + DomObject {
 
 /// A trait to provide a function pointer to wrap function for
 /// DOM iterator interfaces.
+#[allow(clippy::type_complexity)]
 pub trait DomObjectIteratorWrap: DomObjectWrap + JSTraceable + Iterable {
     /// Function pointer to the wrap function for `IterableIterator<T>`
     const ITER_WRAP: unsafe fn(

--- a/components/script/dom/xrinputsourceschangeevent.rs
+++ b/components/script/dom/xrinputsourceschangeevent.rs
@@ -46,6 +46,7 @@ impl XRInputSourcesChangeEvent {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         global: &GlobalScope,
         type_: Atom,


### PR DESCRIPTION
Fixes clippy warnings in `components/script/dom` as a part of #31500 


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are a part of #31500 
- [X] These changes do not require tests because they do not modify functionality
<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
