### PR TITLE
CanGc fixes in `components/script/dom`

### DIFF
--- a/components/script/dom/audiocontext.rs
+++ b/components/script/dom/audiocontext.rs
@@ -276,20 +276,22 @@ impl AudioContextMethods for AudioContext {
     fn CreateMediaStreamSource(
         &self,
         stream: &MediaStream,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<MediaStreamAudioSourceNode>> {
         let global = self.global();
         let window = global.as_window();
-        MediaStreamAudioSourceNode::new(window, self, stream)
+        MediaStreamAudioSourceNode::new(window, self, stream, can_gc)
     }
 
     /// <https://webaudio.github.io/web-audio-api/#dom-audiocontext-createmediastreamtracksource>
     fn CreateMediaStreamTrackSource(
         &self,
         track: &MediaStreamTrack,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<MediaStreamTrackAudioSourceNode>> {
         let global = self.global();
         let window = global.as_window();
-        MediaStreamTrackAudioSourceNode::new(window, self, track)
+        MediaStreamTrackAudioSourceNode::new(window, self, track, can_gc)
     }
 
     /// <https://webaudio.github.io/web-audio-api/#dom-audiocontext-createmediastreamdestination>

--- a/components/script/dom/baseaudiocontext.rs
+++ b/components/script/dom/baseaudiocontext.rs
@@ -577,13 +577,14 @@ impl BaseAudioContextMethods for BaseAudioContext {
         &self,
         feedforward: Vec<Finite<f64>>,
         feedback: Vec<Finite<f64>>,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<IIRFilterNode>> {
         let opts = IIRFilterOptions {
             parent: AudioNodeOptions::empty(),
             feedback,
             feedforward,
         };
-        IIRFilterNode::new(self.global().as_window(), self, &opts)
+        IIRFilterNode::new(self.global().as_window(), self, &opts, can_gc)
     }
 }
 

--- a/components/script/dom/bindings/codegen/Bindings.conf
+++ b/components/script/dom/bindings/codegen/Bindings.conf
@@ -20,12 +20,12 @@ DOMInterfaces = {
 
 'AudioContext': {
     'inRealms': ['Close', 'Suspend'],
-    'canGc':['CreateMediaStreamDestination', 'CreateMediaElementSource'],
+    'canGc':['CreateMediaStreamDestination', 'CreateMediaElementSource', 'CreateMediaStreamSource', 'CreateMediaStreamTrackSource'],
 },
 
 'BaseAudioContext': {
     'inRealms': ['DecodeAudioData', 'Resume', 'ParseFromString', 'GetBounds', 'GetClientRects'],
-    'canGc': ['CreateOscillator', 'CreateStereoPanner', 'CreateGain'],
+    'canGc': ['CreateOscillator', 'CreateStereoPanner', 'CreateGain', 'CreateIIRFilter'],
 },
 
 'Blob': {

--- a/components/script/dom/iirfilternode.rs
+++ b/components/script/dom/iirfilternode.rs
@@ -72,8 +72,9 @@ impl IIRFilterNode {
         window: &Window,
         context: &BaseAudioContext,
         options: &IIRFilterOptions,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<IIRFilterNode>> {
-        Self::new_with_proto(window, None, context, options, CanGc::note())
+        Self::new_with_proto(window, None, context, options, can_gc)
     }
 
     #[allow(crown::unrooted_must_root)]

--- a/components/script/dom/mediastreamaudiosourcenode.rs
+++ b/components/script/dom/mediastreamaudiosourcenode.rs
@@ -55,8 +55,9 @@ impl MediaStreamAudioSourceNode {
         window: &Window,
         context: &AudioContext,
         stream: &MediaStream,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<MediaStreamAudioSourceNode>> {
-        Self::new_with_proto(window, None, context, stream, CanGc::note())
+        Self::new_with_proto(window, None, context, stream, can_gc)
     }
 
     #[allow(crown::unrooted_must_root)]

--- a/components/script/dom/mediastreamtrackaudiosourcenode.rs
+++ b/components/script/dom/mediastreamtrackaudiosourcenode.rs
@@ -48,8 +48,9 @@ impl MediaStreamTrackAudioSourceNode {
         window: &Window,
         context: &AudioContext,
         track: &MediaStreamTrack,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<MediaStreamTrackAudioSourceNode>> {
-        Self::new_with_proto(window, None, context, track, CanGc::note())
+        Self::new_with_proto(window, None, context, track, can_gc)
     }
 
     #[allow(crown::unrooted_must_root)]

--- a/components/script/dom/promise.rs
+++ b/components/script/dom/promise.rs
@@ -37,7 +37,7 @@ use crate::dom::bindings::settings_stack::AutoEntryScript;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::promisenativehandler::PromiseNativeHandler;
 use crate::realms::{enter_realm, AlreadyInRealm, InRealm};
-use crate::script_runtime::JSContext as SafeJSContext;
+use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
 use crate::script_thread::ScriptThread;
 
 #[dom_struct]
@@ -320,11 +320,13 @@ unsafe extern "C" fn native_handler_callback(
             *cx,
             HandleValue::from_raw(args.get(0)),
             InRealm::Already(&in_realm_proof),
+            CanGc::note(),
         ),
         v if v == NativeHandlerTask::Reject as i32 => handler.rejected_callback(
             *cx,
             HandleValue::from_raw(args.get(0)),
             InRealm::Already(&in_realm_proof),
+            CanGc::note(),
         ),
         _ => panic!("unexpected native handler task value"),
     };

--- a/components/script/dom/promisenativehandler.rs
+++ b/components/script/dom/promisenativehandler.rs
@@ -47,18 +47,31 @@ impl PromiseNativeHandler {
         cx: *mut JSContext,
         v: HandleValue,
         realm: InRealm,
+        can_gc: CanGc,
     ) {
         let cx = unsafe { SafeJSContext::from_ptr(cx) };
         if let Some(ref callback) = *callback {
-            callback.callback(cx, v, realm, CanGc::note())
+            callback.callback(cx, v, realm, can_gc)
         }
     }
 
-    pub fn resolved_callback(&self, cx: *mut JSContext, v: HandleValue, realm: InRealm) {
-        PromiseNativeHandler::callback(&self.resolve, cx, v, realm)
+    pub fn resolved_callback(
+        &self,
+        cx: *mut JSContext,
+        v: HandleValue,
+        realm: InRealm,
+        can_gc: CanGc,
+    ) {
+        PromiseNativeHandler::callback(&self.resolve, cx, v, realm, can_gc)
     }
 
-    pub fn rejected_callback(&self, cx: *mut JSContext, v: HandleValue, realm: InRealm) {
-        PromiseNativeHandler::callback(&self.reject, cx, v, realm)
+    pub fn rejected_callback(
+        &self,
+        cx: *mut JSContext,
+        v: HandleValue,
+        realm: InRealm,
+        can_gc: CanGc,
+    ) {
+        PromiseNativeHandler::callback(&self.reject, cx, v, realm, can_gc)
     }
 }

--- a/components/script/dom/resizeobserver.rs
+++ b/components/script/dom/resizeobserver.rs
@@ -118,7 +118,7 @@ impl ResizeObserver {
                 box_size.origin.y.to_f64_px(),
                 width,
                 height,
-                CanGc::note(),
+                can_gc,
             );
             let entry = ResizeObserverEntry::new(
                 &window,

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -361,7 +361,7 @@ impl ServoParser {
             input.push_back(String::from(chunk).into());
         }
 
-        self.tokenize(|tokenizer| tokenizer.feed(&input, can_gc));
+        self.tokenize(|tokenizer| tokenizer.feed(&input, can_gc), can_gc);
 
         if self.suspended.get() {
             // Parser got suspended, insert remaining input at end of
@@ -546,7 +546,10 @@ impl ServoParser {
                 }
             }
         }
-        self.tokenize(|tokenizer| tokenizer.feed(&self.network_input, can_gc));
+        self.tokenize(
+            |tokenizer| tokenizer.feed(&self.network_input, can_gc),
+            can_gc,
+        );
 
         if self.suspended.get() {
             return;
@@ -576,7 +579,7 @@ impl ServoParser {
         }
     }
 
-    fn tokenize<F>(&self, feed: F)
+    fn tokenize<F>(&self, feed: F, can_gc: CanGc)
     where
         F: Fn(&Tokenizer) -> TokenizerResult<DomRoot<HTMLScriptElement>>,
     {
@@ -600,7 +603,7 @@ impl ServoParser {
                 self.document
                     .window()
                     .upcast::<GlobalScope>()
-                    .perform_a_microtask_checkpoint(CanGc::note());
+                    .perform_a_microtask_checkpoint(can_gc);
             }
 
             let script_nesting_level = self.script_nesting_level.get();


### PR DESCRIPTION
Replaces CanGc::note() calls with arguments passed by callers in `components/script/dom/resizeobserver.rs`, `components/script/dom/iirfilternode.rs`, `components/script/dom/promisenativehandler.rs`, `components/script/dom/servoparser/mod.rs`, `components/script/dom/mediastreamaudiosourcenode.rs` and `components/script/dom/mediastreamtrackaudiosourcenode.rs`

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are a part of #33683 
- [X] These changes do not require tests because they do not modify functionality

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
