### PR TITLE
net: Start reducing number of IPCs channels used for fetch with a `FetchThread`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4718,6 +4718,7 @@ dependencies = [
  "base",
  "content-security-policy",
  "cookie 0.18.1",
+ "crossbeam-channel",
  "embedder_traits",
  "headers",
  "http",

--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -581,9 +581,9 @@ impl ImageCache for ImageCacheImpl {
     /// Inform the image cache about a response for a pending request.
     fn notify_pending_response(&self, id: PendingImageId, action: FetchResponseMsg) {
         match (action, id) {
-            (FetchResponseMsg::ProcessRequestBody, _) |
-            (FetchResponseMsg::ProcessRequestEOF, _) => (),
-            (FetchResponseMsg::ProcessResponse(response), _) => {
+            (FetchResponseMsg::ProcessRequestBody(..), _) |
+            (FetchResponseMsg::ProcessRequestEOF(..), _) => (),
+            (FetchResponseMsg::ProcessResponse(_, response), _) => {
                 debug!("Received {:?} for {:?}", response.as_ref().map(|_| ()), id);
                 let mut store = self.store.lock().unwrap();
                 let pending_load = store.pending_loads.get_by_key_mut(&id).unwrap();
@@ -608,7 +608,7 @@ impl ImageCache for ImageCacheImpl {
                 pending_load.final_url = final_url;
                 pending_load.cors_status = cors_status;
             },
-            (FetchResponseMsg::ProcessResponseChunk(data), _) => {
+            (FetchResponseMsg::ProcessResponseChunk(_, data), _) => {
                 debug!("Got some data for {:?}", id);
                 let mut store = self.store.lock().unwrap();
                 let pending_load = store.pending_loads.get_by_key_mut(&id).unwrap();
@@ -627,7 +627,7 @@ impl ImageCache for ImageCacheImpl {
                     pending_load.metadata = Some(img_metadata);
                 }
             },
-            (FetchResponseMsg::ProcessResponseEOF(result), key) => {
+            (FetchResponseMsg::ProcessResponseEOF(_, result), key) => {
                 debug!("Received EOF for {:?}", key);
                 match result {
                     Ok(_) => {

--- a/components/net/tests/data_loader.rs
+++ b/components/net/tests/data_loader.rs
@@ -7,8 +7,8 @@ use std::ops::Deref;
 use headers::{ContentType, HeaderMapExt};
 use hyper_serde::Serde;
 use mime::{self, Mime};
-use net_traits::request::{Origin, Referrer, Request};
-use net_traits::response::{HttpsState, ResponseBody};
+use net_traits::request::Referrer;
+use net_traits::response::ResponseBody;
 use net_traits::{FetchMetadata, FilteredMetadata, NetworkError};
 use servo_url::ServoUrl;
 
@@ -21,15 +21,13 @@ fn assert_parse(
     charset: Option<&str>,
     data: Option<&[u8]>,
 ) {
+    use net_traits::request::RequestBuilder;
+
     let url = ServoUrl::parse(url).unwrap();
-    let origin = Origin::Origin(url.origin());
-    let mut request = Request::new(
-        url,
-        Some(origin),
-        Referrer::NoReferrer,
-        None,
-        HttpsState::None,
-    );
+    let mut request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
+        .origin(url.origin())
+        .pipeline_id(None)
+        .build();
 
     let response = fetch(&mut request, None);
 

--- a/components/net/tests/http_cache.rs
+++ b/components/net/tests/http_cache.rs
@@ -6,8 +6,8 @@ use base::id::TEST_PIPELINE_ID;
 use http::header::{HeaderValue, EXPIRES};
 use http::StatusCode;
 use net::http_cache::HttpCache;
-use net_traits::request::{Origin, Referrer, Request};
-use net_traits::response::{HttpsState, Response, ResponseBody};
+use net_traits::request::{Referrer, RequestBuilder};
+use net_traits::response::{Response, ResponseBody};
 use net_traits::{ResourceFetchTiming, ResourceTimingType};
 use servo_url::ServoUrl;
 use tokio::sync::mpsc::unbounded_channel as unbounded;
@@ -20,13 +20,10 @@ fn test_refreshing_resource_sets_done_chan_the_appropriate_value() {
         ResponseBody::Done(vec![]),
     ];
     let url = ServoUrl::parse("https://servo.org").unwrap();
-    let request = Request::new(
-        url.clone(),
-        Some(Origin::Origin(url.clone().origin())),
-        Referrer::NoReferrer,
-        Some(TEST_PIPELINE_ID),
-        HttpsState::None,
-    );
+    let request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
+        .pipeline_id(Some(TEST_PIPELINE_ID))
+        .origin(url.origin())
+        .build();
     let timing = ResourceFetchTiming::new(ResourceTimingType::Navigation);
     let mut response = Response::new(url.clone(), timing);
     // Expires header makes the response cacheable.

--- a/components/net/tests/http_loader.rs
+++ b/components/net/tests/http_loader.rs
@@ -1390,12 +1390,12 @@ fn test_fetch_compressed_response_update_count() {
     impl FetchTaskTarget for FetchResponseCollector {
         fn process_request_body(&mut self, _: &Request) {}
         fn process_request_eof(&mut self, _: &Request) {}
-        fn process_response(&mut self, _: &Response) {}
-        fn process_response_chunk(&mut self, _: Vec<u8>) {
+        fn process_response(&mut self, _: &Request, _: &Response) {}
+        fn process_response_chunk(&mut self, _: &Request, _: Vec<u8>) {
             self.update_count += 1;
         }
         /// Fired when the response is fully fetched
-        fn process_response_eof(&mut self, _: &Response) {
+        fn process_response_eof(&mut self, _: &Request, _: &Response) {
             let _ = self.sender.send(self.update_count);
         }
     }

--- a/components/net/tests/main.rs
+++ b/components/net/tests/main.rs
@@ -121,10 +121,10 @@ fn new_fetch_context(
 impl FetchTaskTarget for FetchResponseCollector {
     fn process_request_body(&mut self, _: &Request) {}
     fn process_request_eof(&mut self, _: &Request) {}
-    fn process_response(&mut self, _: &Response) {}
-    fn process_response_chunk(&mut self, _: Vec<u8>) {}
+    fn process_response(&mut self, _: &Request, _: &Response) {}
+    fn process_response_chunk(&mut self, _: &Request, _: Vec<u8>) {}
     /// Fired when the response is fully fetched
-    fn process_response_eof(&mut self, response: &Response) {
+    fn process_response_eof(&mut self, _: &Request, response: &Response) {
         let _ = self.sender.send(response.clone());
     }
 }

--- a/components/script/document_loader.rs
+++ b/components/script/document_loader.rs
@@ -6,9 +6,9 @@
 //!
 //! <https://html.spec.whatwg.org/multipage/#the-end>
 
-use ipc_channel::ipc::IpcSender;
+use ipc_channel::ipc;
 use net_traits::request::RequestBuilder;
-use net_traits::{CoreResourceMsg, FetchChannels, FetchResponseMsg, IpcSend, ResourceThreads};
+use net_traits::{fetch_async, BoxedFetchCallback, ResourceThreads};
 use servo_url::ServoUrl;
 
 use crate::dom::bindings::root::Dom;
@@ -111,33 +111,37 @@ impl DocumentLoader {
         self.blocking_loads.push(load);
     }
 
-    /// Initiate a new fetch.
-    pub fn fetch_async(
+    /// Initiate a new fetch given a response callback.
+    pub fn fetch_async_with_callback(
         &mut self,
         load: LoadType,
         request: RequestBuilder,
-        fetch_target: IpcSender<FetchResponseMsg>,
+        callback: BoxedFetchCallback,
     ) {
         self.add_blocking_load(load);
-        self.fetch_async_background(request, fetch_target);
+        self.fetch_async_background(request, callback, None);
     }
 
     /// Initiate a new fetch that does not block the document load event.
     pub fn fetch_async_background(
         &mut self,
         request: RequestBuilder,
-        fetch_target: IpcSender<FetchResponseMsg>,
+        callback: BoxedFetchCallback,
+        cancel_override: Option<ipc::IpcReceiver<()>>,
     ) {
-        let mut canceller = FetchCanceller::new();
-        let cancel_receiver = canceller.initialize();
-        self.cancellers.push(canceller);
-        self.resource_threads
-            .sender()
-            .send(CoreResourceMsg::Fetch(
-                request,
-                FetchChannels::ResponseMsg(fetch_target, Some(cancel_receiver)),
-            ))
-            .unwrap();
+        let canceller = cancel_override.unwrap_or_else(|| {
+            let mut canceller = FetchCanceller::new();
+            let cancel_receiver = canceller.initialize();
+            self.cancellers.push(canceller);
+            cancel_receiver
+        });
+
+        fetch_async(
+            &self.resource_threads.core_thread,
+            request,
+            Some(canceller),
+            callback,
+        );
     }
 
     /// Mark an in-progress network request complete.

--- a/components/script/dom/eventsource.rs
+++ b/components/script/dom/eventsource.rs
@@ -17,7 +17,7 @@ use js::conversions::ToJSValConvertible;
 use js::jsval::UndefinedValue;
 use js::rust::HandleObject;
 use mime::{self, Mime};
-use net_traits::request::{CacheMode, CorsSettings, Destination, RequestBuilder};
+use net_traits::request::{CacheMode, CorsSettings, Destination, RequestBuilder, RequestId};
 use net_traits::{
     CoreResourceMsg, FetchChannels, FetchMetadata, FetchResponseListener, FetchResponseMsg,
     FilteredMetadata, NetworkError, ResourceFetchTiming, ResourceTimingType,
@@ -336,15 +336,15 @@ impl EventSourceContext {
 }
 
 impl FetchResponseListener for EventSourceContext {
-    fn process_request_body(&mut self) {
+    fn process_request_body(&mut self, _: RequestId) {
         // TODO
     }
 
-    fn process_request_eof(&mut self) {
+    fn process_request_eof(&mut self, _: RequestId) {
         // TODO
     }
 
-    fn process_response(&mut self, metadata: Result<FetchMetadata, NetworkError>) {
+    fn process_response(&mut self, _: RequestId, metadata: Result<FetchMetadata, NetworkError>) {
         match metadata {
             Ok(fm) => {
                 let meta = match fm {
@@ -378,7 +378,7 @@ impl FetchResponseListener for EventSourceContext {
         }
     }
 
-    fn process_response_chunk(&mut self, chunk: Vec<u8>) {
+    fn process_response_chunk(&mut self, _: RequestId, chunk: Vec<u8>) {
         let mut input = &*chunk;
         if let Some(mut incomplete) = self.incomplete_utf8.take() {
             match incomplete.try_complete(input) {
@@ -417,7 +417,11 @@ impl FetchResponseListener for EventSourceContext {
         }
     }
 
-    fn process_response_eof(&mut self, _response: Result<ResourceFetchTiming, NetworkError>) {
+    fn process_response_eof(
+        &mut self,
+        _: RequestId,
+        _response: Result<ResourceFetchTiming, NetworkError>,
+    ) {
         if self.incomplete_utf8.take().is_some() {
             self.parse("\u{FFFD}".chars());
         }

--- a/components/script/dom/htmlvideoelement.rs
+++ b/components/script/dom/htmlvideoelement.rs
@@ -3,22 +3,21 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::cell::Cell;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use dom_struct::dom_struct;
 use euclid::default::Size2D;
 use html5ever::{local_name, LocalName, Prefix};
 use ipc_channel::ipc;
-use ipc_channel::router::ROUTER;
 use js::rust::HandleObject;
 use net_traits::image_cache::{
     ImageCache, ImageCacheResult, ImageOrMetadataAvailable, ImageResponse, PendingImageId,
     UsePlaceholder,
 };
-use net_traits::request::{CredentialsMode, Destination, RequestBuilder};
+use net_traits::request::{CredentialsMode, Destination, RequestBuilder, RequestId};
 use net_traits::{
-    CoreResourceMsg, FetchChannels, FetchMetadata, FetchResponseListener, FetchResponseMsg,
-    NetworkError, ResourceFetchTiming, ResourceTimingType,
+    FetchMetadata, FetchResponseListener, FetchResponseMsg, NetworkError, ResourceFetchTiming,
+    ResourceTimingType,
 };
 use servo_media::player::video::VideoFrame;
 use servo_url::ServoUrl;
@@ -41,7 +40,7 @@ use crate::dom::performanceresourcetiming::InitiatorType;
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::fetch::FetchCanceller;
 use crate::image_listener::{generate_cache_listener_for_element, ImageCacheListener};
-use crate::network_listener::{self, NetworkListener, PreInvoke, ResourceTimingListener};
+use crate::network_listener::{self, PreInvoke, ResourceTimingListener};
 use crate::script_runtime::CanGc;
 
 const DEFAULT_WIDTH: u32 = 300;
@@ -213,34 +212,11 @@ impl HTMLVideoElement {
             LoadType::Image(poster_url.clone()),
         ));
 
-        let window = window_from_node(self);
-        let context = Arc::new(Mutex::new(PosterFrameFetchContext::new(
-            self, poster_url, id,
-        )));
+        let context = PosterFrameFetchContext::new(self, poster_url, id);
 
-        let (action_sender, action_receiver) = ipc::channel().unwrap();
-        let (task_source, canceller) = window
-            .task_manager()
-            .networking_task_source_with_canceller();
-        let listener = NetworkListener {
-            context,
-            task_source,
-            canceller: Some(canceller),
-        };
-        ROUTER.add_route(
-            action_receiver.to_opaque(),
-            Box::new(move |message| {
-                listener.notify_fetch(message.to().unwrap());
-            }),
-        );
-        let global = self.global();
-        global
-            .core_resource_thread()
-            .send(CoreResourceMsg::Fetch(
-                request,
-                FetchChannels::ResponseMsg(action_sender, Some(cancel_receiver)),
-            ))
-            .unwrap();
+        // TODO: If this is supposed to to be a "fetch" as defined in the specification
+        // this should probably be integrated into the Document's list of cancellable fetches.
+        document_from_node(self).fetch_background(request, context, Some(cancel_receiver));
     }
 }
 
@@ -326,12 +302,18 @@ struct PosterFrameFetchContext {
 }
 
 impl FetchResponseListener for PosterFrameFetchContext {
-    fn process_request_body(&mut self) {}
-    fn process_request_eof(&mut self) {}
+    fn process_request_body(&mut self, _: RequestId) {}
+    fn process_request_eof(&mut self, _: RequestId) {}
 
-    fn process_response(&mut self, metadata: Result<FetchMetadata, NetworkError>) {
-        self.image_cache
-            .notify_pending_response(self.id, FetchResponseMsg::ProcessResponse(metadata.clone()));
+    fn process_response(
+        &mut self,
+        request_id: RequestId,
+        metadata: Result<FetchMetadata, NetworkError>,
+    ) {
+        self.image_cache.notify_pending_response(
+            self.id,
+            FetchResponseMsg::ProcessResponse(request_id, metadata.clone()),
+        );
 
         let metadata = metadata.ok().map(|meta| match meta {
             FetchMetadata::Unfiltered(m) => m,
@@ -352,19 +334,27 @@ impl FetchResponseListener for PosterFrameFetchContext {
         }
     }
 
-    fn process_response_chunk(&mut self, payload: Vec<u8>) {
+    fn process_response_chunk(&mut self, request_id: RequestId, payload: Vec<u8>) {
         if self.cancelled {
             // An error was received previously, skip processing the payload.
             return;
         }
 
-        self.image_cache
-            .notify_pending_response(self.id, FetchResponseMsg::ProcessResponseChunk(payload));
+        self.image_cache.notify_pending_response(
+            self.id,
+            FetchResponseMsg::ProcessResponseChunk(request_id, payload),
+        );
     }
 
-    fn process_response_eof(&mut self, response: Result<ResourceFetchTiming, NetworkError>) {
-        self.image_cache
-            .notify_pending_response(self.id, FetchResponseMsg::ProcessResponseEOF(response));
+    fn process_response_eof(
+        &mut self,
+        request_id: RequestId,
+        response: Result<ResourceFetchTiming, NetworkError>,
+    ) {
+        self.image_cache.notify_pending_response(
+            self.id,
+            FetchResponseMsg::ProcessResponseEOF(request_id, response),
+        );
     }
 
     fn resource_timing_mut(&mut self) -> &mut ResourceFetchTiming {

--- a/components/script/dom/request.rs
+++ b/components/script/dom/request.rs
@@ -17,7 +17,7 @@ use net_traits::fetch::headers::is_forbidden_method;
 use net_traits::request::{
     CacheMode as NetTraitsRequestCache, CredentialsMode as NetTraitsRequestCredentials,
     Destination as NetTraitsRequestDestination, Origin, RedirectMode as NetTraitsRequestRedirect,
-    Referrer as NetTraitsRequestReferrer, Request as NetTraitsRequest,
+    Referrer as NetTraitsRequestReferrer, Request as NetTraitsRequest, RequestBuilder,
     RequestMode as NetTraitsRequestMode, Window,
 };
 use net_traits::ReferrerPolicy as MsgReferrerPolicy;
@@ -107,11 +107,11 @@ impl Request {
 }
 
 fn net_request_from_global(global: &GlobalScope, url: ServoUrl) -> NetTraitsRequest {
-    let origin = Origin::Origin(global.get_url().origin());
-    let https_state = global.get_https_state();
-    let pipeline_id = global.pipeline_id();
-    let referrer = global.get_referrer();
-    NetTraitsRequest::new(url, Some(origin), referrer, Some(pipeline_id), https_state)
+    RequestBuilder::new(url, global.get_referrer())
+        .origin(global.get_url().origin())
+        .pipeline_id(Some(global.pipeline_id()))
+        .https_state(global.get_https_state())
+        .build()
 }
 
 // https://fetch.spec.whatwg.org/#concept-method-normalize

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -21,6 +21,7 @@ use html5ever::tree_builder::{ElementFlags, NextParserState, NodeOrText, QuirksM
 use html5ever::{local_name, namespace_url, ns, Attribute, ExpandedName, LocalName, QualName};
 use hyper_serde::Serde;
 use mime::{self, Mime};
+use net_traits::request::RequestId;
 use net_traits::{
     FetchMetadata, FetchResponseListener, Metadata, NetworkError, ResourceFetchTiming,
     ResourceTimingType,
@@ -756,11 +757,11 @@ impl ParserContext {
 }
 
 impl FetchResponseListener for ParserContext {
-    fn process_request_body(&mut self) {}
+    fn process_request_body(&mut self, _: RequestId) {}
 
-    fn process_request_eof(&mut self) {}
+    fn process_request_eof(&mut self, _: RequestId) {}
 
-    fn process_response(&mut self, meta_result: Result<FetchMetadata, NetworkError>) {
+    fn process_response(&mut self, _: RequestId, meta_result: Result<FetchMetadata, NetworkError>) {
         let (metadata, error) = match meta_result {
             Ok(meta) => (
                 Some(match meta {
@@ -911,7 +912,7 @@ impl FetchResponseListener for ParserContext {
         }
     }
 
-    fn process_response_chunk(&mut self, payload: Vec<u8>) {
+    fn process_response_chunk(&mut self, _: RequestId, payload: Vec<u8>) {
         if self.is_synthesized_document {
             return;
         }
@@ -929,7 +930,11 @@ impl FetchResponseListener for ParserContext {
     // This method is called via script_thread::handle_fetch_eof, so we must call
     // submit_resource_timing in this function
     // Resource listeners are called via net_traits::Action::process, which handles submission for them
-    fn process_response_eof(&mut self, status: Result<ResourceFetchTiming, NetworkError>) {
+    fn process_response_eof(
+        &mut self,
+        _: RequestId,
+        status: Result<ResourceFetchTiming, NetworkError>,
+    ) {
         let parser = match self.parser.as_ref() {
             Some(parser) => parser.root(),
             None => return,

--- a/components/script/network_listener.rs
+++ b/components/script/network_listener.rs
@@ -5,7 +5,8 @@
 use std::sync::{Arc, Mutex};
 
 use net_traits::{
-    Action, FetchResponseListener, FetchResponseMsg, ResourceFetchTiming, ResourceTimingType,
+    Action, BoxedFetchCallback, FetchResponseListener, FetchResponseMsg, ResourceFetchTiming,
+    ResourceTimingType,
 };
 use servo_url::ServoUrl;
 
@@ -88,6 +89,10 @@ impl<Listener: PreInvoke + Send + 'static> NetworkListener<Listener> {
 impl<Listener: FetchResponseListener + PreInvoke + Send + 'static> NetworkListener<Listener> {
     pub fn notify_fetch(&self, action: FetchResponseMsg) {
         self.notify(action);
+    }
+
+    pub fn to_callback(self) -> BoxedFetchCallback {
+        Box::new(move |response_msg| self.notify_fetch(response_msg))
     }
 }
 

--- a/components/script/stylesheet_loader.rs
+++ b/components/script/stylesheet_loader.rs
@@ -3,15 +3,12 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::sync::atomic::AtomicBool;
-use std::sync::Mutex;
 
 use base::id::PipelineId;
 use cssparser::SourceLocation;
 use encoding_rs::UTF_8;
-use ipc_channel::ipc;
-use ipc_channel::router::ROUTER;
 use mime::{self, Mime};
-use net_traits::request::{CorsSettings, Destination, Referrer, RequestBuilder};
+use net_traits::request::{CorsSettings, Destination, Referrer, RequestBuilder, RequestId};
 use net_traits::{
     FetchMetadata, FetchResponseListener, FilteredMetadata, Metadata, NetworkError, ReferrerPolicy,
     ResourceFetchTiming, ResourceTimingType,
@@ -43,7 +40,7 @@ use crate::dom::node::{containing_shadow_root, document_from_node, window_from_n
 use crate::dom::performanceresourcetiming::InitiatorType;
 use crate::dom::shadowroot::ShadowRoot;
 use crate::fetch::create_a_potential_cors_request;
-use crate::network_listener::{self, NetworkListener, PreInvoke, ResourceTimingListener};
+use crate::network_listener::{self, PreInvoke, ResourceTimingListener};
 use crate::script_runtime::CanGc;
 
 pub trait StylesheetOwner {
@@ -94,11 +91,11 @@ pub struct StylesheetContext {
 impl PreInvoke for StylesheetContext {}
 
 impl FetchResponseListener for StylesheetContext {
-    fn process_request_body(&mut self) {}
+    fn process_request_body(&mut self, _: RequestId) {}
 
-    fn process_request_eof(&mut self) {}
+    fn process_request_eof(&mut self, _: RequestId) {}
 
-    fn process_response(&mut self, metadata: Result<FetchMetadata, NetworkError>) {
+    fn process_response(&mut self, _: RequestId, metadata: Result<FetchMetadata, NetworkError>) {
         if let Ok(FetchMetadata::Filtered {
             filtered: FilteredMetadata::Opaque | FilteredMetadata::OpaqueRedirect(_),
             ..
@@ -113,11 +110,15 @@ impl FetchResponseListener for StylesheetContext {
         });
     }
 
-    fn process_response_chunk(&mut self, mut payload: Vec<u8>) {
+    fn process_response_chunk(&mut self, _: RequestId, mut payload: Vec<u8>) {
         self.data.append(&mut payload);
     }
 
-    fn process_response_eof(&mut self, status: Result<ResourceFetchTiming, NetworkError>) {
+    fn process_response_eof(
+        &mut self,
+        _: RequestId,
+        status: Result<ResourceFetchTiming, NetworkError>,
+    ) {
         let elem = self.elem.root();
         let document = self.document.root();
         let mut successful = false;
@@ -279,7 +280,7 @@ impl<'a> StylesheetLoader<'a> {
             .elem
             .downcast::<HTMLLinkElement>()
             .map(HTMLLinkElement::get_request_generation_id);
-        let context = ::std::sync::Arc::new(Mutex::new(StylesheetContext {
+        let context = StylesheetContext {
             elem: Trusted::new(self.elem),
             source,
             url: url.clone(),
@@ -290,24 +291,7 @@ impl<'a> StylesheetLoader<'a> {
             origin_clean: true,
             request_generation_id: gen,
             resource_timing: ResourceFetchTiming::new(ResourceTimingType::Resource),
-        }));
-
-        let (action_sender, action_receiver) = ipc::channel().unwrap();
-        let (task_source, canceller) = document
-            .window()
-            .task_manager()
-            .networking_task_source_with_canceller();
-        let listener = NetworkListener {
-            context,
-            task_source,
-            canceller: Some(canceller),
         };
-        ROUTER.add_route(
-            action_receiver.to_opaque(),
-            Box::new(move |message| {
-                listener.notify_fetch(message.to().unwrap());
-            }),
-        );
 
         let owner = self
             .elem
@@ -331,8 +315,9 @@ impl<'a> StylesheetLoader<'a> {
             referrer_policy,
             integrity_metadata,
         );
+        let request = document.prepare_request(request);
 
-        document.fetch_async(LoadType::Stylesheet(url), request, action_sender);
+        document.fetch(LoadType::Stylesheet(url), request, context);
     }
 }
 

--- a/components/shared/net/Cargo.toml
+++ b/components/shared/net/Cargo.toml
@@ -17,6 +17,7 @@ doctest = false
 base = { workspace = true }
 content-security-policy = { workspace = true }
 cookie = { workspace = true }
+crossbeam-channel = { workspace = true }
 embedder_traits = { workspace = true }
 headers = { workspace = true }
 http = { workspace = true }

--- a/components/shared/net/request.rs
+++ b/components/shared/net/request.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
 use base::id::PipelineId;
@@ -16,6 +17,17 @@ use servo_url::{ImmutableOrigin, ServoUrl};
 
 use crate::response::HttpsState;
 use crate::{ReferrerPolicy, ResourceTimingType};
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, MallocSizeOf, PartialEq, Serialize)]
+/// An id to differeniate one network request from another.
+pub struct RequestId(usize);
+
+impl RequestId {
+    pub fn new() -> Self {
+        static NEXT_REQUEST_ID: AtomicUsize = AtomicUsize::new(0);
+        Self(NEXT_REQUEST_ID.fetch_add(1, Ordering::Relaxed))
+    }
+}
 
 /// An [initiator](https://fetch.spec.whatwg.org/#concept-request-initiator)
 #[derive(Clone, Copy, Debug, Deserialize, MallocSizeOf, PartialEq, Serialize)]
@@ -223,6 +235,7 @@ impl RequestBody {
 
 #[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
 pub struct RequestBuilder {
+    pub id: RequestId,
     #[serde(
         deserialize_with = "::hyper_serde::deserialize",
         serialize_with = "::hyper_serde::serialize"
@@ -272,6 +285,7 @@ pub struct RequestBuilder {
 impl RequestBuilder {
     pub fn new(url: ServoUrl, referrer: Referrer) -> RequestBuilder {
         RequestBuilder {
+            id: RequestId::new(),
             method: Method::GET,
             url,
             headers: HeaderMap::new(),
@@ -396,6 +410,11 @@ impl RequestBuilder {
         self
     }
 
+    pub fn csp_list(mut self, csp_list: Option<CspList>) -> RequestBuilder {
+        self.csp_list = csp_list;
+        self
+    }
+
     pub fn crash(mut self, crash: Option<String>) -> Self {
         self.crash = crash;
         self
@@ -403,6 +422,7 @@ impl RequestBuilder {
 
     pub fn build(self) -> Request {
         let mut request = Request::new(
+            self.id,
             self.url.clone(),
             Some(Origin::Origin(self.origin)),
             self.referrer,
@@ -443,6 +463,9 @@ impl RequestBuilder {
 /// the Fetch spec.
 #[derive(Clone, MallocSizeOf)]
 pub struct Request {
+    /// The id of this request so that the task that triggered it can route
+    /// messages to the correct listeners.
+    pub id: RequestId,
     /// <https://fetch.spec.whatwg.org/#concept-request-method>
     #[ignore_malloc_size_of = "Defined in hyper"]
     pub method: Method,
@@ -514,6 +537,7 @@ pub struct Request {
 
 impl Request {
     pub fn new(
+        id: RequestId,
         url: ServoUrl,
         origin: Option<Origin>,
         referrer: Referrer,
@@ -521,6 +545,7 @@ impl Request {
         https_state: HttpsState,
     ) -> Request {
         Request {
+            id,
             method: Method::GET,
             local_urls_only: false,
             sandboxed_storage_area_urls: false,


### PR DESCRIPTION
Instead of creating a `ROUTER` route for each fetch, create a fetch thread
which handles all incoming and outcoming fetch traffic. Now messages
involving fetches carry a "request id" which indicates which fetch is
being addressed by the message. This greatly reduces the number of file
descriptors used by fetch.

In addition, the interface for kicking off fetches is simplified when
using the `Listener` with `Document`s and the `GlobalScope`.

This does not fix all leaked file descriptors / mach ports, but greatly
eliminates the number used. Now tests can be run without limiting
procesess on modern macOS systems.

Followup work:

1. There are more instances where fetch is done using the old method.
   Some of these require more changes in order to be converted to the
   `FetchThread` approach.
2. Eliminate usage of IPC channels when doing redirects.
3. Also eliminate the IPC channel used for cancel handling.
4. This change opens up the possiblity of controlling the priority of
   fetch requests.

Fixes #29834.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because it theoretically should not change observable behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
