### PR TITLE
Some CanGc Fixes

### DIFF
--- a/components/script/dom/bindings/codegen/Bindings.conf
+++ b/components/script/dom/bindings/codegen/Bindings.conf
@@ -235,6 +235,7 @@ DOMInterfaces = {
 
 'URL': {
     'weakReferenceable': True,
+    'canGc': ['Parse'],
 },
 
 'VRDisplay': {

--- a/components/script/dom/url.rs
+++ b/components/script/dom/url.rs
@@ -162,6 +162,7 @@ impl URLMethods for URL {
         global: &GlobalScope,
         url: USVString,
         base: Option<USVString>,
+        can_gc: CanGc,
     ) -> Option<DomRoot<URL>> {
         // Step 1: Let parsedURL be the result of running the API URL parser on url with base,
         // if given.
@@ -176,7 +177,7 @@ impl URLMethods for URL {
         // These steps are all handled while mapping the Result to an Option<ServoUrl>.
         // Regarding initialization, the same condition should apply here as stated in the comments
         // in Self::Constructor above - construct it on-demand inside `URL::SearchParams`.
-        Some(URL::new(global, None, parsed_url.ok()?, CanGc::note()))
+        Some(URL::new(global, None, parsed_url.ok()?, can_gc))
     }
 
     /// <https://w3c.github.io/FileAPI/#dfn-createObjectURL>


### PR DESCRIPTION
Replaces CanGc::note() calls with arguments passed by callers in components/script/do/url.rs

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #33683 
- [X] These changes do not require tests because do not touch functionality

