### PR TITLE
Use `ROUTER::add_typed_route` instead of `ROUTER::add_route` everywhere

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ dependencies = [
  "backtrace",
  "base",
  "crossbeam-channel",
- "ipc-channel 0.19.0",
+ "ipc-channel",
  "libc",
  "log",
  "mach2",
@@ -341,7 +341,7 @@ name = "background_hang_monitor_api"
 version = "0.0.1"
 dependencies = [
  "base",
- "ipc-channel 0.19.0",
+ "ipc-channel",
  "malloc_size_of",
  "malloc_size_of_derive",
  "parking_lot",
@@ -370,7 +370,7 @@ name = "base"
 version = "0.0.1"
 dependencies = [
  "crossbeam-channel",
- "ipc-channel 0.19.0",
+ "ipc-channel",
  "libc",
  "mach2",
  "malloc_size_of",
@@ -490,7 +490,7 @@ dependencies = [
  "blurmock",
  "blurz",
  "embedder_traits",
- "ipc-channel 0.19.0",
+ "ipc-channel",
  "log",
  "servo_config",
  "servo_rand",
@@ -502,7 +502,7 @@ name = "bluetooth_traits"
 version = "0.0.1"
 dependencies = [
  "embedder_traits",
- "ipc-channel 0.19.0",
+ "ipc-channel",
  "regex",
  "serde",
 ]
@@ -667,7 +667,7 @@ dependencies = [
  "font-kit",
  "fonts",
  "half",
- "ipc-channel 0.19.0",
+ "ipc-channel",
  "log",
  "lyon_geom",
  "net_traits",
@@ -697,7 +697,7 @@ dependencies = [
  "base",
  "crossbeam-channel",
  "euclid",
- "ipc-channel 0.19.0",
+ "ipc-channel",
  "malloc_size_of",
  "malloc_size_of_derive",
  "pixels",
@@ -989,7 +989,7 @@ dependencies = [
  "fonts_traits",
  "gleam",
  "image",
- "ipc-channel 0.19.0",
+ "ipc-channel",
  "keyboard-types",
  "libc",
  "log",
@@ -1020,7 +1020,7 @@ dependencies = [
  "embedder_traits",
  "euclid",
  "fonts_traits",
- "ipc-channel 0.19.0",
+ "ipc-channel",
  "keyboard-types",
  "log",
  "pixels",
@@ -1059,7 +1059,7 @@ dependencies = [
  "fonts_traits",
  "gaol",
  "http",
- "ipc-channel 0.19.0",
+ "ipc-channel",
  "keyboard-types",
  "log",
  "media",
@@ -1464,7 +1464,7 @@ dependencies = [
  "embedder_traits",
  "headers",
  "http",
- "ipc-channel 0.19.0",
+ "ipc-channel",
  "log",
  "net_traits",
  "serde",
@@ -1482,7 +1482,7 @@ dependencies = [
  "base",
  "bitflags 2.6.0",
  "http",
- "ipc-channel 0.19.0",
+ "ipc-channel",
  "malloc_size_of",
  "malloc_size_of_derive",
  "net_traits",
@@ -1765,7 +1765,7 @@ dependencies = [
  "base",
  "cfg-if",
  "crossbeam-channel",
- "ipc-channel 0.19.0",
+ "ipc-channel",
  "keyboard-types",
  "log",
  "num-derive",
@@ -2046,7 +2046,7 @@ dependencies = [
  "fontsan",
  "freetype-sys",
  "harfbuzz-sys",
- "ipc-channel 0.19.0",
+ "ipc-channel",
  "itertools 0.13.0",
  "libc",
  "log",
@@ -2083,7 +2083,7 @@ dependencies = [
 name = "fonts_traits"
 version = "0.0.1"
 dependencies = [
- "ipc-channel 0.19.0",
+ "ipc-channel",
  "malloc_size_of",
  "malloc_size_of_derive",
  "range",
@@ -3693,25 +3693,6 @@ dependencies = [
 
 [[package]]
 name = "ipc-channel"
-version = "0.18.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f4c80f2df4fc64fb7fc2cff69fc034af26e6e6617ea9f1313131af464b9ca0"
-dependencies = [
- "bincode",
- "crossbeam-channel",
- "fnv",
- "lazy_static",
- "libc",
- "mio",
- "rand",
- "serde",
- "tempfile",
- "uuid",
- "windows",
-]
-
-[[package]]
-name = "ipc-channel"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fb8251fb7bcd9ccd3725ed8deae9fe7db8e586495c9eb5b0c52e6233e5e75ea"
@@ -3865,7 +3846,7 @@ dependencies = [
  "fonts",
  "fonts_traits",
  "html5ever",
- "ipc-channel 0.19.0",
+ "ipc-channel",
  "log",
  "malloc_size_of",
  "malloc_size_of_derive",
@@ -3913,7 +3894,7 @@ dependencies = [
  "fxhash",
  "html5ever",
  "icu_segmenter",
- "ipc-channel 0.19.0",
+ "ipc-channel",
  "itertools 0.13.0",
  "log",
  "net_traits",
@@ -3954,7 +3935,7 @@ dependencies = [
  "fonts",
  "fonts_traits",
  "fxhash",
- "ipc-channel 0.19.0",
+ "ipc-channel",
  "layout_2013",
  "log",
  "malloc_size_of",
@@ -3992,7 +3973,7 @@ dependencies = [
  "fonts",
  "fonts_traits",
  "fxhash",
- "ipc-channel 0.19.0",
+ "ipc-channel",
  "layout_2020",
  "log",
  "malloc_size_of",
@@ -4083,7 +4064,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -4128,7 +4109,7 @@ dependencies = [
  "gaol",
  "gleam",
  "gstreamer",
- "ipc-channel 0.19.0",
+ "ipc-channel",
  "keyboard-types",
  "layout_thread_2013",
  "layout_thread_2020",
@@ -4329,7 +4310,7 @@ version = "0.0.1"
 dependencies = [
  "euclid",
  "fnv",
- "ipc-channel 0.19.0",
+ "ipc-channel",
  "log",
  "serde",
  "servo-media",
@@ -4397,7 +4378,7 @@ version = "0.0.1"
 dependencies = [
  "base",
  "fonts_traits",
- "ipc-channel 0.19.0",
+ "ipc-channel",
  "log",
  "malloc_size_of",
  "malloc_size_of_derive",
@@ -4413,7 +4394,7 @@ version = "0.0.1"
 dependencies = [
  "base",
  "fonts_traits",
- "ipc-channel 0.19.0",
+ "ipc-channel",
  "metrics",
  "profile_traits",
  "servo_url",
@@ -4684,7 +4665,7 @@ dependencies = [
  "hyper-rustls",
  "hyper_serde",
  "imsz",
- "ipc-channel 0.19.0",
+ "ipc-channel",
  "log",
  "malloc_size_of",
  "malloc_size_of_derive",
@@ -4732,7 +4713,7 @@ dependencies = [
  "hyper",
  "hyper_serde",
  "image",
- "ipc-channel 0.19.0",
+ "ipc-channel",
  "log",
  "malloc_size_of",
  "malloc_size_of_derive",
@@ -5451,7 +5432,7 @@ dependencies = [
  "criterion",
  "euclid",
  "image",
- "ipc-channel 0.19.0",
+ "ipc-channel",
  "log",
  "malloc_size_of",
  "malloc_size_of_derive",
@@ -5592,7 +5573,7 @@ name = "profile"
 version = "0.0.1"
 dependencies = [
  "base",
- "ipc-channel 0.19.0",
+ "ipc-channel",
  "libc",
  "profile_traits",
  "regex",
@@ -5608,7 +5589,7 @@ dependencies = [
 name = "profile_tests"
 version = "0.0.1"
 dependencies = [
- "ipc-channel 0.19.0",
+ "ipc-channel",
  "profile",
  "profile_traits",
  "servo_config",
@@ -5621,7 +5602,7 @@ version = "0.0.1"
 dependencies = [
  "base",
  "crossbeam-channel",
- "ipc-channel 0.19.0",
+ "ipc-channel",
  "log",
  "serde",
  "servo_config",
@@ -6082,7 +6063,7 @@ dependencies = [
  "hyper_serde",
  "image",
  "indexmap",
- "ipc-channel 0.19.0",
+ "ipc-channel",
  "itertools 0.13.0",
  "jstraceable_derive",
  "keyboard-types",
@@ -6156,7 +6137,7 @@ dependencies = [
  "fonts",
  "fonts_traits",
  "html5ever",
- "ipc-channel 0.19.0",
+ "ipc-channel",
  "libc",
  "malloc_size_of",
  "malloc_size_of_derive",
@@ -6204,7 +6185,7 @@ dependencies = [
  "fonts_traits",
  "http",
  "hyper_serde",
- "ipc-channel 0.19.0",
+ "ipc-channel",
  "keyboard-types",
  "libc",
  "log",
@@ -6363,7 +6344,7 @@ dependencies = [
 [[package]]
 name = "servo-media"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#ed1d4c7c11c93e7e66afc0224fc15f70d6b1fe83"
+source = "git+https://github.com/servo/media#12dfb35619520eb6e78e25e9a975d625f6484a13"
 dependencies = [
  "once_cell",
  "servo-media-audio",
@@ -6376,7 +6357,7 @@ dependencies = [
 [[package]]
 name = "servo-media-audio"
 version = "0.2.0"
-source = "git+https://github.com/servo/media#ed1d4c7c11c93e7e66afc0224fc15f70d6b1fe83"
+source = "git+https://github.com/servo/media#12dfb35619520eb6e78e25e9a975d625f6484a13"
 dependencies = [
  "byte-slice-cast",
  "euclid",
@@ -6397,7 +6378,7 @@ dependencies = [
 [[package]]
 name = "servo-media-derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#ed1d4c7c11c93e7e66afc0224fc15f70d6b1fe83"
+source = "git+https://github.com/servo/media#12dfb35619520eb6e78e25e9a975d625f6484a13"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6407,9 +6388,9 @@ dependencies = [
 [[package]]
 name = "servo-media-dummy"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#ed1d4c7c11c93e7e66afc0224fc15f70d6b1fe83"
+source = "git+https://github.com/servo/media#12dfb35619520eb6e78e25e9a975d625f6484a13"
 dependencies = [
- "ipc-channel 0.18.3",
+ "ipc-channel",
  "servo-media",
  "servo-media-audio",
  "servo-media-player",
@@ -6421,7 +6402,7 @@ dependencies = [
 [[package]]
 name = "servo-media-gstreamer"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#ed1d4c7c11c93e7e66afc0224fc15f70d6b1fe83"
+source = "git+https://github.com/servo/media#12dfb35619520eb6e78e25e9a975d625f6484a13"
 dependencies = [
  "byte-slice-cast",
  "glib",
@@ -6435,7 +6416,7 @@ dependencies = [
  "gstreamer-sys",
  "gstreamer-video",
  "gstreamer-webrtc",
- "ipc-channel 0.18.3",
+ "ipc-channel",
  "lazy_static",
  "log",
  "mime",
@@ -6455,7 +6436,7 @@ dependencies = [
 [[package]]
 name = "servo-media-gstreamer-render"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#ed1d4c7c11c93e7e66afc0224fc15f70d6b1fe83"
+source = "git+https://github.com/servo/media#12dfb35619520eb6e78e25e9a975d625f6484a13"
 dependencies = [
  "gstreamer",
  "gstreamer-video",
@@ -6465,7 +6446,7 @@ dependencies = [
 [[package]]
 name = "servo-media-gstreamer-render-android"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#ed1d4c7c11c93e7e66afc0224fc15f70d6b1fe83"
+source = "git+https://github.com/servo/media#12dfb35619520eb6e78e25e9a975d625f6484a13"
 dependencies = [
  "glib",
  "gstreamer",
@@ -6479,7 +6460,7 @@ dependencies = [
 [[package]]
 name = "servo-media-gstreamer-render-unix"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#ed1d4c7c11c93e7e66afc0224fc15f70d6b1fe83"
+source = "git+https://github.com/servo/media#12dfb35619520eb6e78e25e9a975d625f6484a13"
 dependencies = [
  "glib",
  "gstreamer",
@@ -6494,9 +6475,9 @@ dependencies = [
 [[package]]
 name = "servo-media-player"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#ed1d4c7c11c93e7e66afc0224fc15f70d6b1fe83"
+source = "git+https://github.com/servo/media#12dfb35619520eb6e78e25e9a975d625f6484a13"
 dependencies = [
- "ipc-channel 0.18.3",
+ "ipc-channel",
  "serde",
  "serde_derive",
  "servo-media-streams",
@@ -6506,7 +6487,7 @@ dependencies = [
 [[package]]
 name = "servo-media-streams"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#ed1d4c7c11c93e7e66afc0224fc15f70d6b1fe83"
+source = "git+https://github.com/servo/media#12dfb35619520eb6e78e25e9a975d625f6484a13"
 dependencies = [
  "lazy_static",
  "uuid",
@@ -6515,12 +6496,12 @@ dependencies = [
 [[package]]
 name = "servo-media-traits"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#ed1d4c7c11c93e7e66afc0224fc15f70d6b1fe83"
+source = "git+https://github.com/servo/media#12dfb35619520eb6e78e25e9a975d625f6484a13"
 
 [[package]]
 name = "servo-media-webrtc"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#ed1d4c7c11c93e7e66afc0224fc15f70d6b1fe83"
+source = "git+https://github.com/servo/media#12dfb35619520eb6e78e25e9a975d625f6484a13"
 dependencies = [
  "lazy_static",
  "log",
@@ -6647,7 +6628,7 @@ dependencies = [
  "hitrace",
  "http",
  "image",
- "ipc-channel 0.19.0",
+ "ipc-channel",
  "jni",
  "keyboard-types",
  "libc",
@@ -8193,7 +8174,7 @@ dependencies = [
  "euclid",
  "http",
  "image",
- "ipc-channel 0.19.0",
+ "ipc-channel",
  "keyboard-types",
  "log",
  "net_traits",
@@ -8215,7 +8196,7 @@ dependencies = [
  "arrayvec",
  "base",
  "euclid",
- "ipc-channel 0.19.0",
+ "ipc-channel",
  "log",
  "malloc_size_of",
  "serde",
@@ -8304,7 +8285,7 @@ dependencies = [
  "crossbeam-channel",
  "embedder_traits",
  "euclid",
- "ipc-channel 0.19.0",
+ "ipc-channel",
  "libc",
  "log",
  "serde",
@@ -8315,7 +8296,7 @@ dependencies = [
 [[package]]
 name = "webxr"
 version = "0.0.1"
-source = "git+https://github.com/servo/webxr#e3249c3df967f16fab9928d053708bfb43487af3"
+source = "git+https://github.com/servo/webxr#2094e041f6b59ca8a2aa3ab572e69e3cf7fae6ab"
 dependencies = [
  "crossbeam-channel",
  "euclid",
@@ -8332,10 +8313,10 @@ dependencies = [
 [[package]]
 name = "webxr-api"
 version = "0.0.1"
-source = "git+https://github.com/servo/webxr#e3249c3df967f16fab9928d053708bfb43487af3"
+source = "git+https://github.com/servo/webxr#2094e041f6b59ca8a2aa3ab572e69e3cf7fae6ab"
 dependencies = [
  "euclid",
- "ipc-channel 0.18.3",
+ "ipc-channel",
  "log",
  "serde",
 ]
@@ -8459,7 +8440,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ dependencies = [
  "backtrace",
  "base",
  "crossbeam-channel",
- "ipc-channel",
+ "ipc-channel 0.19.0",
  "libc",
  "log",
  "mach2",
@@ -341,7 +341,7 @@ name = "background_hang_monitor_api"
 version = "0.0.1"
 dependencies = [
  "base",
- "ipc-channel",
+ "ipc-channel 0.19.0",
  "malloc_size_of",
  "malloc_size_of_derive",
  "parking_lot",
@@ -370,7 +370,7 @@ name = "base"
 version = "0.0.1"
 dependencies = [
  "crossbeam-channel",
- "ipc-channel",
+ "ipc-channel 0.19.0",
  "libc",
  "mach2",
  "malloc_size_of",
@@ -490,7 +490,7 @@ dependencies = [
  "blurmock",
  "blurz",
  "embedder_traits",
- "ipc-channel",
+ "ipc-channel 0.19.0",
  "log",
  "servo_config",
  "servo_rand",
@@ -502,7 +502,7 @@ name = "bluetooth_traits"
 version = "0.0.1"
 dependencies = [
  "embedder_traits",
- "ipc-channel",
+ "ipc-channel 0.19.0",
  "regex",
  "serde",
 ]
@@ -667,7 +667,7 @@ dependencies = [
  "font-kit",
  "fonts",
  "half",
- "ipc-channel",
+ "ipc-channel 0.19.0",
  "log",
  "lyon_geom",
  "net_traits",
@@ -697,7 +697,7 @@ dependencies = [
  "base",
  "crossbeam-channel",
  "euclid",
- "ipc-channel",
+ "ipc-channel 0.19.0",
  "malloc_size_of",
  "malloc_size_of_derive",
  "pixels",
@@ -989,7 +989,7 @@ dependencies = [
  "fonts_traits",
  "gleam",
  "image",
- "ipc-channel",
+ "ipc-channel 0.19.0",
  "keyboard-types",
  "libc",
  "log",
@@ -1020,7 +1020,7 @@ dependencies = [
  "embedder_traits",
  "euclid",
  "fonts_traits",
- "ipc-channel",
+ "ipc-channel 0.19.0",
  "keyboard-types",
  "log",
  "pixels",
@@ -1059,7 +1059,7 @@ dependencies = [
  "fonts_traits",
  "gaol",
  "http",
- "ipc-channel",
+ "ipc-channel 0.19.0",
  "keyboard-types",
  "log",
  "media",
@@ -1464,7 +1464,7 @@ dependencies = [
  "embedder_traits",
  "headers",
  "http",
- "ipc-channel",
+ "ipc-channel 0.19.0",
  "log",
  "net_traits",
  "serde",
@@ -1482,7 +1482,7 @@ dependencies = [
  "base",
  "bitflags 2.6.0",
  "http",
- "ipc-channel",
+ "ipc-channel 0.19.0",
  "malloc_size_of",
  "malloc_size_of_derive",
  "net_traits",
@@ -1765,7 +1765,7 @@ dependencies = [
  "base",
  "cfg-if",
  "crossbeam-channel",
- "ipc-channel",
+ "ipc-channel 0.19.0",
  "keyboard-types",
  "log",
  "num-derive",
@@ -2046,7 +2046,7 @@ dependencies = [
  "fontsan",
  "freetype-sys",
  "harfbuzz-sys",
- "ipc-channel",
+ "ipc-channel 0.19.0",
  "itertools 0.13.0",
  "libc",
  "log",
@@ -2083,7 +2083,7 @@ dependencies = [
 name = "fonts_traits"
 version = "0.0.1"
 dependencies = [
- "ipc-channel",
+ "ipc-channel 0.19.0",
  "malloc_size_of",
  "malloc_size_of_derive",
  "range",
@@ -3711,6 +3711,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipc-channel"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fb8251fb7bcd9ccd3725ed8deae9fe7db8e586495c9eb5b0c52e6233e5e75ea"
+dependencies = [
+ "bincode",
+ "crossbeam-channel",
+ "fnv",
+ "lazy_static",
+ "libc",
+ "mio",
+ "rand",
+ "serde",
+ "tempfile",
+ "uuid",
+ "windows",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3846,7 +3865,7 @@ dependencies = [
  "fonts",
  "fonts_traits",
  "html5ever",
- "ipc-channel",
+ "ipc-channel 0.19.0",
  "log",
  "malloc_size_of",
  "malloc_size_of_derive",
@@ -3894,7 +3913,7 @@ dependencies = [
  "fxhash",
  "html5ever",
  "icu_segmenter",
- "ipc-channel",
+ "ipc-channel 0.19.0",
  "itertools 0.13.0",
  "log",
  "net_traits",
@@ -3935,7 +3954,7 @@ dependencies = [
  "fonts",
  "fonts_traits",
  "fxhash",
- "ipc-channel",
+ "ipc-channel 0.19.0",
  "layout_2013",
  "log",
  "malloc_size_of",
@@ -3973,7 +3992,7 @@ dependencies = [
  "fonts",
  "fonts_traits",
  "fxhash",
- "ipc-channel",
+ "ipc-channel 0.19.0",
  "layout_2020",
  "log",
  "malloc_size_of",
@@ -4109,7 +4128,7 @@ dependencies = [
  "gaol",
  "gleam",
  "gstreamer",
- "ipc-channel",
+ "ipc-channel 0.19.0",
  "keyboard-types",
  "layout_thread_2013",
  "layout_thread_2020",
@@ -4310,7 +4329,7 @@ version = "0.0.1"
 dependencies = [
  "euclid",
  "fnv",
- "ipc-channel",
+ "ipc-channel 0.19.0",
  "log",
  "serde",
  "servo-media",
@@ -4378,7 +4397,7 @@ version = "0.0.1"
 dependencies = [
  "base",
  "fonts_traits",
- "ipc-channel",
+ "ipc-channel 0.19.0",
  "log",
  "malloc_size_of",
  "malloc_size_of_derive",
@@ -4394,7 +4413,7 @@ version = "0.0.1"
 dependencies = [
  "base",
  "fonts_traits",
- "ipc-channel",
+ "ipc-channel 0.19.0",
  "metrics",
  "profile_traits",
  "servo_url",
@@ -4665,7 +4684,7 @@ dependencies = [
  "hyper-rustls",
  "hyper_serde",
  "imsz",
- "ipc-channel",
+ "ipc-channel 0.19.0",
  "log",
  "malloc_size_of",
  "malloc_size_of_derive",
@@ -4713,7 +4732,7 @@ dependencies = [
  "hyper",
  "hyper_serde",
  "image",
- "ipc-channel",
+ "ipc-channel 0.19.0",
  "log",
  "malloc_size_of",
  "malloc_size_of_derive",
@@ -5432,7 +5451,7 @@ dependencies = [
  "criterion",
  "euclid",
  "image",
- "ipc-channel",
+ "ipc-channel 0.19.0",
  "log",
  "malloc_size_of",
  "malloc_size_of_derive",
@@ -5573,7 +5592,7 @@ name = "profile"
 version = "0.0.1"
 dependencies = [
  "base",
- "ipc-channel",
+ "ipc-channel 0.19.0",
  "libc",
  "profile_traits",
  "regex",
@@ -5589,7 +5608,7 @@ dependencies = [
 name = "profile_tests"
 version = "0.0.1"
 dependencies = [
- "ipc-channel",
+ "ipc-channel 0.19.0",
  "profile",
  "profile_traits",
  "servo_config",
@@ -5602,7 +5621,7 @@ version = "0.0.1"
 dependencies = [
  "base",
  "crossbeam-channel",
- "ipc-channel",
+ "ipc-channel 0.19.0",
  "log",
  "serde",
  "servo_config",
@@ -6063,7 +6082,7 @@ dependencies = [
  "hyper_serde",
  "image",
  "indexmap",
- "ipc-channel",
+ "ipc-channel 0.19.0",
  "itertools 0.13.0",
  "jstraceable_derive",
  "keyboard-types",
@@ -6137,7 +6156,7 @@ dependencies = [
  "fonts",
  "fonts_traits",
  "html5ever",
- "ipc-channel",
+ "ipc-channel 0.19.0",
  "libc",
  "malloc_size_of",
  "malloc_size_of_derive",
@@ -6185,7 +6204,7 @@ dependencies = [
  "fonts_traits",
  "http",
  "hyper_serde",
- "ipc-channel",
+ "ipc-channel 0.19.0",
  "keyboard-types",
  "libc",
  "log",
@@ -6390,7 +6409,7 @@ name = "servo-media-dummy"
 version = "0.1.0"
 source = "git+https://github.com/servo/media#ed1d4c7c11c93e7e66afc0224fc15f70d6b1fe83"
 dependencies = [
- "ipc-channel",
+ "ipc-channel 0.18.3",
  "servo-media",
  "servo-media-audio",
  "servo-media-player",
@@ -6416,7 +6435,7 @@ dependencies = [
  "gstreamer-sys",
  "gstreamer-video",
  "gstreamer-webrtc",
- "ipc-channel",
+ "ipc-channel 0.18.3",
  "lazy_static",
  "log",
  "mime",
@@ -6477,7 +6496,7 @@ name = "servo-media-player"
 version = "0.1.0"
 source = "git+https://github.com/servo/media#ed1d4c7c11c93e7e66afc0224fc15f70d6b1fe83"
 dependencies = [
- "ipc-channel",
+ "ipc-channel 0.18.3",
  "serde",
  "serde_derive",
  "servo-media-streams",
@@ -6628,7 +6647,7 @@ dependencies = [
  "hitrace",
  "http",
  "image",
- "ipc-channel",
+ "ipc-channel 0.19.0",
  "jni",
  "keyboard-types",
  "libc",
@@ -8174,7 +8193,7 @@ dependencies = [
  "euclid",
  "http",
  "image",
- "ipc-channel",
+ "ipc-channel 0.19.0",
  "keyboard-types",
  "log",
  "net_traits",
@@ -8196,7 +8215,7 @@ dependencies = [
  "arrayvec",
  "base",
  "euclid",
- "ipc-channel",
+ "ipc-channel 0.19.0",
  "log",
  "malloc_size_of",
  "serde",
@@ -8285,7 +8304,7 @@ dependencies = [
  "crossbeam-channel",
  "embedder_traits",
  "euclid",
- "ipc-channel",
+ "ipc-channel 0.19.0",
  "libc",
  "log",
  "serde",
@@ -8316,7 +8335,7 @@ version = "0.0.1"
 source = "git+https://github.com/servo/webxr#e3249c3df967f16fab9928d053708bfb43487af3"
 dependencies = [
  "euclid",
- "ipc-channel",
+ "ipc-channel 0.18.3",
  "log",
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ icu_segmenter = "1.5.0"
 image = "0.24"
 imsz = "0.2"
 indexmap = { version = "2.5.0", features = ["std"] }
-ipc-channel = "0.18"
+ipc-channel = "0.19"
 itertools = "0.13"
 tikv-jemalloc-sys = "0.6.0"
 tikv-jemallocator = "0.6.0"
@@ -145,6 +145,8 @@ webpki-roots = "0.25"
 webrender = { git = "https://github.com/servo/webrender", branch = "0.65", features = ["capture"] }
 webrender_api = { git = "https://github.com/servo/webrender", branch = "0.65" }
 webrender_traits = { path = "components/shared/webrender" }
+webxr = { git = "https://github.com/servo/webxr" }
+webxr-api = { git = "https://github.com/servo/webxr" }
 wgpu-core = { git = "https://github.com/gfx-rs/wgpu", rev = "2b15a2b24b69e105ebdbb5e8a859e2df75e441c1" }
 wgpu-types = { git = "https://github.com/gfx-rs/wgpu", rev = "2b15a2b24b69e105ebdbb5e8a859e2df75e441c1" }
 windows-sys = "0.59"

--- a/components/canvas/Cargo.toml
+++ b/components/canvas/Cargo.toml
@@ -45,5 +45,5 @@ unicode-script = { workspace = true }
 webrender = { workspace = true }
 webrender_api = { workspace = true }
 webrender_traits = { workspace = true }
-webxr = { git = "https://github.com/servo/webxr", features = ["ipc"] }
-webxr-api = { git = "https://github.com/servo/webxr", features = ["ipc"] }
+webxr = { workspace = true, features = ["ipc"] }
+webxr-api = { workspace = true, features = ["ipc"] }

--- a/components/compositing/Cargo.toml
+++ b/components/compositing/Cargo.toml
@@ -46,7 +46,7 @@ tracing = { workspace = true, optional = true }
 webrender = { workspace = true }
 webrender_api = { workspace = true }
 webrender_traits = { workspace = true }
-webxr = { git = "https://github.com/servo/webxr" }
+webxr = { workspace = true }
 
 [dev-dependencies]
 surfman = { workspace = true }

--- a/components/constellation/Cargo.toml
+++ b/components/constellation/Cargo.toml
@@ -51,7 +51,7 @@ webgpu = { path = "../webgpu" }
 webrender = { workspace = true }
 webrender_api = { workspace = true }
 webrender_traits = { workspace = true }
-webxr-api = { git = "https://github.com/servo/webxr", features = ["ipc"] }
+webxr-api = { workspace = true, features = ["ipc"] }
 
 [target.'cfg(any(target_os="macos", all(not(target_os = "windows"), not(target_os = "ios"), not(target_os="android"), not(target_arch="arm"), not(target_arch="aarch64"))))'.dependencies]
 gaol = "0.2.1"

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -594,9 +594,11 @@ where
     T: for<'de> Deserialize<'de> + Serialize + Send + 'static,
 {
     let (crossbeam_sender, crossbeam_receiver) = unbounded();
-    ROUTER.add_route(
-        ipc_receiver.to_opaque(),
-        Box::new(move |message| drop(crossbeam_sender.send(message.to::<T>()))),
+    ROUTER.add_typed_route(
+        ipc_receiver,
+        Box::new(move |message| {
+            let _ = crossbeam_sender.send(message);
+        }),
     );
     crossbeam_receiver
 }

--- a/components/constellation/network_listener.rs
+++ b/components/constellation/network_listener.rs
@@ -86,11 +86,10 @@ impl NetworkListener {
             },
         };
 
-        ROUTER.add_route(
-            ipc_receiver.to_opaque(),
+        ROUTER.add_typed_route(
+            ipc_receiver,
             Box::new(move |message| {
-                let msg = message.to();
-                match msg {
+                match message {
                     Ok(FetchResponseMsg::ProcessResponse(request_id, res)) => {
                         listener.check_redirect(request_id, res)
                     },

--- a/components/media/media_channel/mod.rs
+++ b/components/media/media_channel/mod.rs
@@ -69,9 +69,9 @@ where
     }
 
     #[allow(clippy::wrong_self_convention)] // It is an alias to the underlying module
-    pub fn to_opaque(self) -> ipc_channel::ipc::OpaqueIpcReceiver {
+    pub fn to_ipc_receiver(self) -> ipc_channel::ipc::IpcReceiver<T> {
         match self {
-            GLPlayerReceiver::Ipc(receiver) => receiver.to_opaque(),
+            GLPlayerReceiver::Ipc(receiver) => receiver,
             _ => unreachable!(),
         }
     }

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -560,11 +560,11 @@ async fn obtain_response(
             let devtools_bytes = devtools_bytes.clone();
             let chunk_requester2 = chunk_requester.clone();
 
-            ROUTER.add_route(
-                body_port.to_opaque(),
+            ROUTER.add_typed_route(
+                body_port,
                 Box::new(move |message| {
                     info!("Received message");
-                    let bytes: Vec<u8> = match message.to().unwrap() {
+                    let bytes: Vec<u8> = match message.unwrap() {
                         BodyChunkResponse::Chunk(bytes) => bytes,
                         BodyChunkResponse::Done => {
                             // Step 3, abort these parallel steps.

--- a/components/net/tests/http_loader.rs
+++ b/components/net/tests/http_loader.rs
@@ -98,10 +98,10 @@ fn create_request_body_with_content(content: Vec<u8>) -> RequestBody {
     let content_len = content.len();
 
     let (chunk_request_sender, chunk_request_receiver) = ipc::channel().unwrap();
-    ROUTER.add_route(
-        chunk_request_receiver.to_opaque(),
+    ROUTER.add_typed_route(
+        chunk_request_receiver,
         Box::new(move |message| {
-            let request = message.to().unwrap();
+            let request = message.unwrap();
             if let BodyChunkRequest::Connect(sender) = request {
                 let _ = sender.send(BodyChunkResponse::Chunk(content.clone()));
                 let _ = sender.send(BodyChunkResponse::Done);

--- a/components/net/websocket_loader.rs
+++ b/components/net/websocket_loader.rs
@@ -157,10 +157,10 @@ fn setup_dom_listener(
 ) -> UnboundedReceiver<DomMsg> {
     let (sender, receiver) = unbounded_channel();
 
-    ROUTER.add_route(
-        dom_action_receiver.to_opaque(),
+    ROUTER.add_typed_route(
+        dom_action_receiver,
         Box::new(move |message| {
-            let dom_action = message.to().expect("Ws dom_action message to deserialize");
+            let dom_action = message.expect("Ws dom_action message to deserialize");
             trace!("handling WS DOM action: {:?}", dom_action);
             match dom_action {
                 WebSocketDomAction::SendMessage(MessageData::Text(data)) => {

--- a/components/profile/mem.rs
+++ b/components/profile/mem.rs
@@ -65,10 +65,10 @@ impl Profiler {
         // be unregistered, because as long as the memory profiler is running the system memory
         // reporter can make measurements.
         let (system_reporter_sender, system_reporter_receiver) = ipc::channel().unwrap();
-        ROUTER.add_route(
-            system_reporter_receiver.to_opaque(),
+        ROUTER.add_typed_route(
+            system_reporter_receiver,
             Box::new(|message| {
-                let request: ReporterRequest = message.to().unwrap();
+                let request: ReporterRequest = message.unwrap();
                 system_reporter::collect_reports(request)
             }),
         );

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -116,7 +116,7 @@ webdriver = { workspace = true }
 webgpu = { path = "../webgpu" }
 webrender_api = { workspace = true }
 webrender_traits = { workspace = true }
-webxr-api = { git = "https://github.com/servo/webxr", features = ["ipc"] }
+webxr-api = { workspace = true, features = ["ipc"] }
 xml5ever = { workspace = true }
 
 [target.'cfg(not(target_os = "ios"))'.dependencies]

--- a/components/script/body.rs
+++ b/components/script/body.rs
@@ -114,10 +114,10 @@ impl TransmitBodyConnectHandler {
         let mut body_handler = self.clone();
         body_handler.reset_in_memory_done();
 
-        ROUTER.add_route(
-            chunk_request_receiver.to_opaque(),
+        ROUTER.add_typed_route(
+            chunk_request_receiver,
             Box::new(move |message| {
-                let request = message.to().unwrap();
+                let request = message.unwrap();
                 match request {
                     BodyChunkRequest::Connect(sender) => {
                         body_handler.start_reading(sender);
@@ -397,11 +397,10 @@ impl ExtractedBody {
             source,
         );
 
-        ROUTER.add_route(
-            chunk_request_receiver.to_opaque(),
+        ROUTER.add_typed_route(
+            chunk_request_receiver,
             Box::new(move |message| {
-                let request = message.to().unwrap();
-                match request {
+                match message.unwrap() {
                     BodyChunkRequest::Connect(sender) => {
                         body_handler.start_reading(sender);
                     },

--- a/components/script/dom/analysernode.rs
+++ b/components/script/dom/analysernode.rs
@@ -116,14 +116,14 @@ impl AnalyserNode {
             .dom_manipulation_task_source_with_canceller();
         let this = Trusted::new(&*object);
 
-        ROUTER.add_route(
-            recv.to_opaque(),
+        ROUTER.add_typed_route(
+            recv,
             Box::new(move |block| {
                 let this = this.clone();
                 let _ = source.queue_with_canceller(
                     task!(append_analysis_block: move || {
                         let this = this.root();
-                        this.push_block(block.to().unwrap())
+                        this.push_block(block.unwrap())
                     }),
                     &canceller,
                 );

--- a/components/script/dom/bluetooth.rs
+++ b/components/script/dom/bluetooth.rs
@@ -245,8 +245,8 @@ pub fn response_async<T: AsyncBluetoothListener + DomObject + 'static>(
         promise: Some(TrustedPromise::new(promise.clone())),
         receiver: Trusted::new(receiver),
     }));
-    ROUTER.add_route(
-        action_receiver.to_opaque(),
+    ROUTER.add_typed_route(
+        action_receiver,
         Box::new(move |message| {
             struct ListenerTask<T: AsyncBluetoothListener + DomObject> {
                 context: Arc<Mutex<BluetoothContext<T>>>,
@@ -265,7 +265,7 @@ pub fn response_async<T: AsyncBluetoothListener + DomObject + 'static>(
 
             let task = ListenerTask {
                 context: context.clone(),
-                action: message.to().unwrap(),
+                action: message.unwrap(),
             };
 
             let result = task_source.queue_unconditionally(task);

--- a/components/script/dom/eventsource.rs
+++ b/components/script/dom/eventsource.rs
@@ -607,10 +607,10 @@ impl EventSourceMethods for EventSource {
             task_source: global.networking_task_source(),
             canceller: Some(global.task_canceller(TaskSourceName::Networking)),
         };
-        ROUTER.add_route(
-            action_receiver.to_opaque(),
+        ROUTER.add_typed_route(
+            action_receiver,
             Box::new(move |message| {
-                listener.notify_fetch(message.to().unwrap());
+                listener.notify_fetch(message.unwrap());
             }),
         );
         let cancel_receiver = ev.canceller.borrow_mut().initialize();

--- a/components/script/dom/fakexrdevice.rs
+++ b/components/script/dom/fakexrdevice.rs
@@ -306,8 +306,9 @@ impl FakeXRDeviceMethods for FakeXRDevice {
             .task_manager()
             .dom_manipulation_task_source_with_canceller();
         let (sender, receiver) = ipc::channel(global.time_profiler_chan().clone()).unwrap();
-        ROUTER.add_route(
-            receiver.to_opaque(),
+
+        ROUTER.add_typed_route(
+            receiver.to_ipc_receiver(),
             Box::new(move |_| {
                 let trusted = trusted
                     .take()

--- a/components/script/dom/gamepadhapticactuator.rs
+++ b/components/script/dom/gamepadhapticactuator.rs
@@ -229,14 +229,11 @@ impl GamepadHapticActuatorMethods for GamepadHapticActuator {
             context,
         };
 
-        ROUTER.add_route(
-            effect_complete_receiver.to_opaque(),
-            Box::new(move |message| {
-                let msg = message.to::<bool>();
-                match msg {
-                    Ok(msg) => listener.handle_completed(msg),
-                    Err(err) => warn!("Error receiving a GamepadMsg: {:?}", err),
-                }
+        ROUTER.add_typed_route(
+            effect_complete_receiver,
+            Box::new(move |message| match message {
+                Ok(msg) => listener.handle_completed(msg),
+                Err(err) => warn!("Error receiving a GamepadMsg: {:?}", err),
             }),
         );
 
@@ -301,14 +298,11 @@ impl GamepadHapticActuatorMethods for GamepadHapticActuator {
             context,
         };
 
-        ROUTER.add_route(
-            effect_stop_receiver.to_opaque(),
-            Box::new(move |message| {
-                let msg = message.to::<bool>();
-                match msg {
-                    Ok(msg) => listener.handle_stopped(msg),
-                    Err(err) => warn!("Error receiving a GamepadMsg: {:?}", err),
-                }
+        ROUTER.add_typed_route(
+            effect_stop_receiver,
+            Box::new(move |message| match message {
+                Ok(msg) => listener.handle_stopped(msg),
+                Err(err) => warn!("Error receiving a GamepadMsg: {:?}", err),
             }),
         );
 

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -847,10 +847,10 @@ impl GlobalScope {
             task_source,
             canceller,
         };
-        ROUTER.add_route(
-            timer_ipc_port.to_opaque(),
+        ROUTER.add_typed_route(
+            timer_ipc_port,
             Box::new(move |message| {
-                let event = message.to().unwrap();
+                let event = message.unwrap();
                 timer_listener.handle(event);
             }),
         );
@@ -1435,14 +1435,11 @@ impl GlobalScope {
                 task_source,
                 context,
             };
-            ROUTER.add_route(
-                broadcast_control_receiver.to_opaque(),
-                Box::new(move |message| {
-                    let msg = message.to();
-                    match msg {
-                        Ok(msg) => listener.handle(msg),
-                        Err(err) => warn!("Error receiving a BroadcastMsg: {:?}", err),
-                    }
+            ROUTER.add_typed_route(
+                broadcast_control_receiver,
+                Box::new(move |message| match message {
+                    Ok(msg) => listener.handle(msg),
+                    Err(err) => warn!("Error receiving a BroadcastMsg: {:?}", err),
                 }),
             );
             let router_id = BroadcastChannelRouterId::new();
@@ -1491,14 +1488,11 @@ impl GlobalScope {
                 task_source,
                 context,
             };
-            ROUTER.add_route(
-                port_control_receiver.to_opaque(),
-                Box::new(move |message| {
-                    let msg = message.to();
-                    match msg {
-                        Ok(msg) => listener.notify(msg),
-                        Err(err) => warn!("Error receiving a MessagePortMsg: {:?}", err),
-                    }
+            ROUTER.add_typed_route(
+                port_control_receiver,
+                Box::new(move |message| match message {
+                    Ok(msg) => listener.notify(msg),
+                    Err(err) => warn!("Error receiving a MessagePortMsg: {:?}", err),
                 }),
             );
             let router_id = MessagePortRouterId::new();
@@ -2021,13 +2015,10 @@ impl GlobalScope {
             task_canceller,
         };
 
-        ROUTER.add_route(
-            recv.to_opaque(),
+        ROUTER.add_typed_route(
+            recv.to_ipc_receiver(),
             Box::new(move |msg| {
-                file_listener.handle(
-                    msg.to()
-                        .expect("Deserialization of file listener msg failed."),
-                );
+                file_listener.handle(msg.expect("Deserialization of file listener msg failed."));
             }),
         );
 
@@ -2050,13 +2041,10 @@ impl GlobalScope {
             task_canceller,
         };
 
-        ROUTER.add_route(
-            recv.to_opaque(),
+        ROUTER.add_typed_route(
+            recv.to_ipc_receiver(),
             Box::new(move |msg| {
-                file_listener.handle(
-                    msg.to()
-                        .expect("Deserialization of file listener msg failed."),
-                );
+                file_listener.handle(msg.expect("Deserialization of file listener msg failed."));
             }),
         );
     }

--- a/components/script/dom/gpu.rs
+++ b/components/script/dom/gpu.rs
@@ -76,8 +76,8 @@ pub fn response_async<T: AsyncWGPUListener + DomObject + 'static>(
         .task_canceller(TaskSourceName::DOMManipulation);
     let mut trusted: Option<TrustedPromise> = Some(TrustedPromise::new(promise.clone()));
     let trusted_receiver = Trusted::new(receiver);
-    ROUTER.add_route(
-        action_receiver.to_opaque(),
+    ROUTER.add_typed_route(
+        action_receiver,
         Box::new(move |message| {
             let trusted = if let Some(trusted) = trusted.take() {
                 trusted
@@ -92,7 +92,7 @@ pub fn response_async<T: AsyncWGPUListener + DomObject + 'static>(
             };
             let result = task_source.queue_with_canceller(
                 task!(process_webgpu_task: move|| {
-                    context.response(message.to().unwrap(), CanGc::note());
+                    context.response(message.unwrap(), CanGc::note());
                 }),
                 &canceller,
             );

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -1077,14 +1077,15 @@ impl HTMLImageElement {
                 .task_manager()
                 .networking_task_source_with_canceller();
             let generation = elem.generation.get();
-            ROUTER.add_route(
-                responder_receiver.to_opaque(),
+
+            ROUTER.add_typed_route(
+                responder_receiver,
                 Box::new(move |message| {
                     debug!("Got image {:?}", message);
                     // Return the image via a message to the script thread, which marks
                     // the element as dirty and triggers a reflow.
                     let element = trusted_node.clone();
-                    let image: PendingImageResponse = message.to().unwrap();
+                    let image: PendingImageResponse = message.unwrap();
                     let selected_source_clone = selected_source.clone();
                     let _ = task_source.queue_with_canceller(
                         task!(process_image_response_for_environment_change: move || {

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -1372,10 +1372,10 @@ impl HTMLMediaElement {
         let (task_source, canceller) = window
             .task_manager()
             .media_element_task_source_with_canceller();
-        ROUTER.add_route(
-            action_receiver.to_opaque(),
+        ROUTER.add_typed_route(
+            action_receiver,
             Box::new(move |message| {
-                let event = message.to().unwrap();
+                let event = message.unwrap();
                 trace!("Player event {:?}", event);
                 let this = trusted_node.clone();
                 if let Err(err) = task_source.queue_with_canceller(
@@ -1415,10 +1415,10 @@ impl HTMLMediaElement {
             let (task_source, canceller) = window
                 .task_manager()
                 .media_element_task_source_with_canceller();
-            ROUTER.add_route(
-                image_receiver.to_opaque(),
+            ROUTER.add_typed_route(
+                image_receiver.to_ipc_receiver(),
                 Box::new(move |message| {
-                    let msg = message.to().unwrap();
+                    let msg = message.unwrap();
                     let this = trusted_node.clone();
                     if let Err(err) = task_source.queue_with_canceller(
                         task!(handle_glplayer_message: move || {

--- a/components/script/dom/serviceworkercontainer.rs
+++ b/components/script/dom/serviceworkercontainer.rs
@@ -153,14 +153,11 @@ impl ServiceWorkerContainerMethods for ServiceWorkerContainer {
 
         let (job_result_sender, job_result_receiver) = ipc::channel().expect("ipc channel failure");
 
-        ROUTER.add_route(
-            job_result_receiver.to_opaque(),
-            Box::new(move |message| {
-                let msg = message.to();
-                match msg {
-                    Ok(msg) => handler.handle(msg),
-                    Err(err) => warn!("Error receiving a JobResult: {:?}", err),
-                }
+        ROUTER.add_typed_route(
+            job_result_receiver,
+            Box::new(move |message| match message {
+                Ok(msg) => handler.handle(msg),
+                Err(err) => warn!("Error receiving a JobResult: {:?}", err),
             }),
         );
 

--- a/components/script/dom/websocket.rs
+++ b/components/script/dom/websocket.rs
@@ -268,9 +268,9 @@ impl WebSocketMethods for WebSocket {
 
         let task_source = global.websocket_task_source();
         let canceller = global.task_canceller(WebsocketTaskSource::NAME);
-        ROUTER.add_route(
-            dom_event_receiver.to_opaque(),
-            Box::new(move |message| match message.to().unwrap() {
+        ROUTER.add_typed_route(
+            dom_event_receiver.to_ipc_receiver(),
+            Box::new(move |message| match message.unwrap() {
                 WebSocketNetworkEvent::ConnectionEstablished { protocol_in_use } => {
                     let open_thread = ConnectionEstablishedTask {
                         address: address.clone(),

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1934,10 +1934,10 @@ impl Window {
                 let (responder, responder_listener) =
                     ProfiledIpc::channel(self.global().time_profiler_chan().clone()).unwrap();
                 let image_cache_chan = self.image_cache_chan.clone();
-                ROUTER.add_route(
-                    responder_listener.to_opaque(),
+                ROUTER.add_typed_route(
+                    responder_listener.to_ipc_receiver(),
                     Box::new(move |message| {
-                        let _ = image_cache_chan.send((pipeline_id, message.to().unwrap()));
+                        let _ = image_cache_chan.send((pipeline_id, message.unwrap()));
                     }),
                 );
                 self.image_cache

--- a/components/script/dom/xrsystem.rs
+++ b/components/script/dom/xrsystem.rs
@@ -121,8 +121,8 @@ impl XRSystemMethods for XRSystem {
             .task_manager()
             .dom_manipulation_task_source_with_canceller();
         let (sender, receiver) = ipc::channel(global.time_profiler_chan().clone()).unwrap();
-        ROUTER.add_route(
-            receiver.to_opaque(),
+        ROUTER.add_typed_route(
+            receiver.to_ipc_receiver(),
             Box::new(move |message| {
                 // router doesn't know this is only called once
                 let trusted = if let Some(trusted) = trusted.take() {
@@ -131,7 +131,7 @@ impl XRSystemMethods for XRSystem {
                     error!("supportsSession callback called twice!");
                     return;
                 };
-                let message: Result<(), webxr_api::Error> = if let Ok(message) = message.to() {
+                let message: Result<(), webxr_api::Error> = if let Ok(message) = message {
                     message
                 } else {
                     error!("supportsSession callback given incorrect payload");
@@ -242,14 +242,14 @@ impl XRSystemMethods for XRSystem {
         let (sender, receiver) = ipc::channel(global.time_profiler_chan().clone()).unwrap();
         let (frame_sender, frame_receiver) = ipc_crate::channel().unwrap();
         let mut frame_receiver = Some(frame_receiver);
-        ROUTER.add_route(
-            receiver.to_opaque(),
+        ROUTER.add_typed_route(
+            receiver.to_ipc_receiver(),
             Box::new(move |message| {
                 // router doesn't know this is only called once
                 let trusted = trusted.take().unwrap();
                 let this = this.clone();
                 let frame_receiver = frame_receiver.take().unwrap();
-                let message: Result<Session, webxr_api::Error> = if let Ok(message) = message.to() {
+                let message: Result<Session, webxr_api::Error> = if let Ok(message) = message {
                     message
                 } else {
                     error!("requestSession callback given incorrect payload");

--- a/components/script/dom/xrtest.rs
+++ b/components/script/dom/xrtest.rs
@@ -154,16 +154,16 @@ impl XRTestMethods for XRTest {
             .task_manager()
             .dom_manipulation_task_source_with_canceller();
         let (sender, receiver) = ipc::channel(global.time_profiler_chan().clone()).unwrap();
-        ROUTER.add_route(
-            receiver.to_opaque(),
+
+        ROUTER.add_typed_route(
+            receiver.to_ipc_receiver(),
             Box::new(move |message| {
                 let trusted = trusted
                     .take()
                     .expect("SimulateDeviceConnection callback called twice");
                 let this = this.clone();
-                let message = message
-                    .to()
-                    .expect("SimulateDeviceConnection callback given incorrect payload");
+                let message =
+                    message.expect("SimulateDeviceConnection callback given incorrect payload");
 
                 let _ = task_source.queue_with_canceller(
                     task!(request_session: move || {
@@ -209,8 +209,8 @@ impl XRTestMethods for XRTest {
                 .task_manager()
                 .dom_manipulation_task_source_with_canceller();
 
-            ROUTER.add_route(
-                receiver.to_opaque(),
+            ROUTER.add_typed_route(
+                receiver.to_ipc_receiver(),
                 Box::new(move |_| {
                     len -= 1;
                     if len == 0 {

--- a/components/script/image_listener.rs
+++ b/components/script/image_listener.rs
@@ -32,11 +32,12 @@ pub fn generate_cache_listener_for_element<
         .task_manager()
         .networking_task_source_with_canceller();
     let generation = elem.generation_id();
-    ROUTER.add_route(
-        responder_receiver.to_opaque(),
+
+    ROUTER.add_typed_route(
+        responder_receiver,
         Box::new(move |message| {
             let element = trusted_node.clone();
-            let image: PendingImageResponse = message.to().unwrap();
+            let image: PendingImageResponse = message.unwrap();
             debug!("Got image {:?}", image);
             let _ = task_source.queue_with_canceller(
                 task!(process_image_response: move || {

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -83,8 +83,8 @@ webgpu = { path = "../webgpu" }
 webrender = { workspace = true }
 webrender_api = { workspace = true }
 webrender_traits = { workspace = true }
-webxr = { git = "https://github.com/servo/webxr" }
-webxr-api = { git = "https://github.com/servo/webxr" }
+webxr = { workspace = true }
+webxr-api = { workspace = true }
 
 [target.'cfg(all(not(target_os = "windows"), not(target_os = "ios"), not(target_os = "android"), not(target_arch = "arm"), not(target_arch = "aarch64")))'.dependencies]
 gaol = "0.2.1"

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -990,11 +990,11 @@ fn create_compositor_channel(
     };
 
     let compositor_proxy_clone = compositor_proxy.clone();
-    ROUTER.add_route(
-        compositor_ipc_receiver.to_opaque(),
+    ROUTER.add_typed_route(
+        compositor_ipc_receiver,
         Box::new(move |message| {
             compositor_proxy_clone.send(CompositorMsg::CrossProcess(
-                message.to().expect("Could not convert Compositor message"),
+                message.expect("Could not convert Compositor message"),
             ));
         }),
     );

--- a/components/shared/canvas/Cargo.toml
+++ b/components/shared/canvas/Cargo.toml
@@ -28,4 +28,4 @@ servo_config = { path = "../../config" }
 sparkle = { workspace = true }
 style = { workspace = true }
 webrender_api = { workspace = true }
-webxr-api = { git = "https://github.com/servo/webxr", features = ["ipc"] }
+webxr-api = { workspace = true, features = ["ipc"] }

--- a/components/shared/embedder/Cargo.toml
+++ b/components/shared/embedder/Cargo.toml
@@ -23,4 +23,4 @@ num-traits = { workspace = true }
 serde = { workspace = true }
 servo_url = { path = "../../url" }
 webrender_api = { workspace = true }
-webxr-api = { git = "https://github.com/servo/webxr", features = ["ipc"] }
+webxr-api = { workspace = true, features = ["ipc"] }

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -532,10 +532,10 @@ impl FetchThread {
         let (to_fetch_sender, from_fetch_sender) = ipc::channel().unwrap();
 
         let sender_clone = sender.clone();
-        ROUTER.add_route(
-            from_fetch_sender.to_opaque(),
+        ROUTER.add_typed_route(
+            from_fetch_sender,
             Box::new(move |message| {
-                let message: FetchResponseMsg = message.to().unwrap();
+                let message: FetchResponseMsg = message.unwrap();
                 let _ = sender_clone.send(ToFetchThreadMessage::FetchResponse(message));
             }),
         );

--- a/components/shared/profile/ipc.rs
+++ b/components/shared/profile/ipc.rs
@@ -35,8 +35,8 @@ where
         self.ipc_receiver.try_recv()
     }
 
-    pub fn to_opaque(self) -> ipc::OpaqueIpcReceiver {
-        self.ipc_receiver.to_opaque()
+    pub fn to_ipc_receiver(self) -> ipc::IpcReceiver<T> {
+        self.ipc_receiver
     }
 }
 

--- a/components/shared/profile/mem.rs
+++ b/components/shared/profile/mem.rs
@@ -75,11 +75,11 @@ impl ProfilerChan {
     {
         // Register the memory reporter.
         let (reporter_sender, reporter_receiver) = ipc::channel().unwrap();
-        ROUTER.add_route(
-            reporter_receiver.to_opaque(),
+        ROUTER.add_typed_route(
+            reporter_receiver,
             Box::new(move |message| {
                 // Just injects an appropriate event into the paint thread's queue.
-                let request: ReporterRequest = message.to().unwrap();
+                let request: ReporterRequest = message.unwrap();
                 channel_for_reporter.send(msg(request.reports_channel));
             }),
         );

--- a/components/shared/script/Cargo.toml
+++ b/components/shared/script/Cargo.toml
@@ -45,4 +45,4 @@ webdriver = { workspace = true }
 webgpu = { path = "../../webgpu" }
 webrender_api = { workspace = true }
 webrender_traits = { workspace = true }
-webxr-api = { git = "https://github.com/servo/webxr", features = ["ipc"] }
+webxr-api = { workspace = true, features = ["ipc"] }

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -95,7 +95,7 @@ ohos-vsync = "0.1"
 nix = { workspace = true, features = ["fs"] }
 surfman = { workspace = true, features = ["sm-angle-default"] }
 serde_json = { workspace = true }
-webxr = { git = "https://github.com/servo/webxr" }
+webxr = { workspace = true }
 
 
 [target.'cfg(not(any(target_os = "android", target_env = "ohos")))'.dependencies]
@@ -118,7 +118,7 @@ raw-window-handle = "0.6"
 shellwords = "1.0.0"
 surfman = { workspace = true, features = ["sm-x11", "sm-raw-window-handle-06"] }
 tinyfiledialogs = "3.0"
-webxr = { git = "https://github.com/servo/webxr", features = ["ipc", "glwindow", "headless"] }
+webxr = { workspace = true, features = ["ipc", "glwindow", "headless"] }
 winit = "0.30.5"
 
 [target.'cfg(any(all(target_os = "linux", not(target_env = "ohos")), target_os = "windows"))'.dependencies]
@@ -128,6 +128,6 @@ image = { workspace = true }
 sig = "1.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-webxr = { git = "https://github.com/servo/webxr", features = ["ipc", "glwindow", "headless", "openxr-api"] }
+webxr = { workspace = true, features = ["ipc", "glwindow", "headless", "openxr-api"] }
 windows-sys = { workspace = true, features = ["Win32_Graphics_Gdi"] }
 libservo = { path = "../../components/servo", features = ["no-wgl"] }


### PR DESCRIPTION
This updates the `ipc-channel`, `webxr` and `servo-media` dependencies to the latest version and uses `ROUTER::add_typed_route` to make our routes more typesafe. You can read more about `ROUTER::add_typed_route` in https://github.com/servo/ipc-channel/issues/242.

This revealed *two* issues where we accidentally abuse https://github.com/servo/ipc-channel/issues/239, one of which was previously described in https://github.com/servo/servo/issues/23818.
These were fixed in https://github.com/servo/servo/pull/33882.

I also made `webxr` and `webxr-api` workspace dependencies, because every crate in `components/` used the same versions anyways, and doing so made it easier to patch them while testing.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because they do not change behaviour

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
