### PR TITLE
Handle multibyte characters in img srcset

### DIFF
--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -2011,8 +2011,8 @@ pub fn parse_a_srcset_attribute(input: &str) -> Vec<ImageSource> {
         // > that position is past the end of input.
         let mut characters = descriptors_string.chars();
         let mut character = characters.next();
-        if character.is_some() {
-            current_index += 1;
+        if let Some(character) = character {
+            current_index += character.len_utf8();
         }
 
         loop {
@@ -2086,8 +2086,8 @@ pub fn parse_a_srcset_attribute(input: &str) -> Vec<ImageSource> {
             }
 
             character = characters.next();
-            if character.is_some() {
-                current_index += 1;
+            if let Some(character) = character {
+                current_index += character.len_utf8();
             }
         }
 

--- a/tests/wpt/meta/html/semantics/embedded-content/the-img-element/srcset/parse-a-srcset-attribute.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/the-img-element/srcset/parse-a-srcset-attribute.html.ini
@@ -1,2 +1,165 @@
 [parse-a-srcset-attribute.html]
-  expected: CRASH
+  ["data:,a,, , "]
+    expected: FAIL
+
+  [",,,data:,a"]
+    expected: FAIL
+
+  [" , ,,data:,a"]
+    expected: FAIL
+
+  ["data:,a 1.0w"]
+    expected: FAIL
+
+  ["data:,a 1e0w"]
+    expected: FAIL
+
+  ["data:,a 1www"]
+    expected: FAIL
+
+  ["data:,a +1w"]
+    expected: FAIL
+
+  ["data:,a 1\\x01w" (trailing U+0001)]
+    expected: FAIL
+
+  ["data:,a 1 w" (trailing U+00A0)]
+    expected: FAIL
+
+  ["data:,a 1 w" (trailing U+1680)]
+    expected: FAIL
+
+  ["data:,a 1 w" (trailing U+2000)]
+    expected: FAIL
+
+  ["data:,a 1 w" (trailing U+2001)]
+    expected: FAIL
+
+  ["data:,a 1 w" (trailing U+2002)]
+    expected: FAIL
+
+  ["data:,a 1 w" (trailing U+2003)]
+    expected: FAIL
+
+  ["data:,a 1 w" (trailing U+2004)]
+    expected: FAIL
+
+  ["data:,a 1 w" (trailing U+2005)]
+    expected: FAIL
+
+  ["data:,a 1 w" (trailing U+2006)]
+    expected: FAIL
+
+  ["data:,a 1 w" (trailing U+2007)]
+    expected: FAIL
+
+  ["data:,a 1 w" (trailing U+2008)]
+    expected: FAIL
+
+  ["data:,a 1 w" (trailing U+2009)]
+    expected: FAIL
+
+  ["data:,a 1 w" (trailing U+200A)]
+    expected: FAIL
+
+  ["data:,a 1‌w" (trailing U+200C)]
+    expected: FAIL
+
+  ["data:,a 1‍w" (trailing U+200D)]
+    expected: FAIL
+
+  ["data:,a 1 w" (trailing U+202F)]
+    expected: FAIL
+
+  ["data:,a 1 w" (trailing U+205F)]
+    expected: FAIL
+
+  ["data:,a 1　w" (trailing U+3000)]
+    expected: FAIL
+
+  ["data:,a 1﻿w" (trailing U+FEFF)]
+    expected: FAIL
+
+  ["data:,a 0x"]
+    expected: FAIL
+
+  ["data:,a -0x"]
+    expected: FAIL
+
+  ["data:,a 1.x"]
+    expected: FAIL
+
+  ["data:,a +1x"]
+    expected: FAIL
+
+  ["data:,a 1w 1.0h"]
+    expected: FAIL
+
+  ["data:,a 1w 1e0h"]
+    expected: FAIL
+
+  ["data:,a 1w 1hhh"]
+    expected: FAIL
+
+  ["data:,a 1w +1h"]
+    expected: FAIL
+
+  ["data:,a 1w 1\\x01h" (trailing U+0001)]
+    expected: FAIL
+
+  ["data:,a 1w 1 h" (trailing U+00A0)]
+    expected: FAIL
+
+  ["data:,a 1w 1 h" (trailing U+1680)]
+    expected: FAIL
+
+  ["data:,a 1w 1 h" (trailing U+2000)]
+    expected: FAIL
+
+  ["data:,a 1w 1 h" (trailing U+2001)]
+    expected: FAIL
+
+  ["data:,a 1w 1 h" (trailing U+2002)]
+    expected: FAIL
+
+  ["data:,a 1w 1 h" (trailing U+2003)]
+    expected: FAIL
+
+  ["data:,a 1w 1 h" (trailing U+2004)]
+    expected: FAIL
+
+  ["data:,a 1w 1 h" (trailing U+2005)]
+    expected: FAIL
+
+  ["data:,a 1w 1 h" (trailing U+2006)]
+    expected: FAIL
+
+  ["data:,a 1w 1 h" (trailing U+2007)]
+    expected: FAIL
+
+  ["data:,a 1w 1 h" (trailing U+2008)]
+    expected: FAIL
+
+  ["data:,a 1w 1 h" (trailing U+2009)]
+    expected: FAIL
+
+  ["data:,a 1w 1 h" (trailing U+200A)]
+    expected: FAIL
+
+  ["data:,a 1w 1‌h" (trailing U+200C)]
+    expected: FAIL
+
+  ["data:,a 1w 1‍h" (trailing U+200D)]
+    expected: FAIL
+
+  ["data:,a 1w 1 h" (trailing U+202F)]
+    expected: FAIL
+
+  ["data:,a 1w 1 h" (trailing U+205F)]
+    expected: FAIL
+
+  ["data:,a 1w 1　h" (trailing U+3000)]
+    expected: FAIL
+
+  ["data:,a 1w 1﻿h" (trailing U+FEFF)]
+    expected: FAIL


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Handle multi-bytes character in the `srcset` attribute.

This was causing this web platform test to crash:
https://wpt.fyi/results/html/semantics/embedded-content/the-img-element/srcset/parse-a-srcset-attribute.html

I wasn't sure about writing tests for this, since WPT already covered this issue. I'll add tests if necessary.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they fix a crash in WPT.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
