### PR TITLE
ci: Fix the WPT export job again by removing `--break-system-packages`

### DIFF
--- a/.github/workflows/pull-request-wpt-export.yml
+++ b/.github/workflows/pull-request-wpt-export.yml
@@ -29,7 +29,7 @@ jobs:
           # See https://github.com/actions/checkout/issues/162.
           token: ${{ secrets.WPT_SYNC_TOKEN }}
       - name: Install requirements
-        run: pip install --break-system-packages -r servo/python/requirements.txt
+        run: pip install -r servo/python/requirements.txt
       - name: Process pull request
         run: servo/python/wpt/export.py
         env:


### PR DESCRIPTION
Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
