### PR TITLE
CanGc fixes in `components/script/dom`

### DIFF
--- a/components/script/body.rs
+++ b/components/script/body.rs
@@ -878,7 +878,7 @@ fn run_form_data_algorithm(
     // ... is not fully determined yet.
     if mime.type_() == mime::APPLICATION && mime.subtype() == mime::WWW_FORM_URLENCODED {
         let entries = form_urlencoded::parse(&bytes);
-        let formdata = FormData::new(None, root);
+        let formdata = FormData::new(None, root, CanGc::note());
         for (k, e) in entries {
             formdata.Append(USVString(k.into_owned()), USVString(e.into_owned()));
         }

--- a/components/script/dom/bindings/codegen/Bindings.conf
+++ b/components/script/dom/bindings/codegen/Bindings.conf
@@ -132,6 +132,10 @@ DOMInterfaces = {
     'inRealms': ['PlayEffect', 'Reset']
 },
 
+'HTMLFormElement': {
+    'canGc': ['RequestSubmit'],
+},
+
 'HTMLMediaElement': {
     'canGc': ['Load', 'Pause', 'Play', 'SetSrcObject'],
     'inRealms': ['Play'],

--- a/components/script/dom/extendableevent.rs
+++ b/components/script/dom/extendableevent.rs
@@ -40,8 +40,9 @@ impl ExtendableEvent {
         type_: Atom,
         bubbles: bool,
         cancelable: bool,
+        can_gc: CanGc,
     ) -> DomRoot<ExtendableEvent> {
-        Self::new_with_proto(worker, None, type_, bubbles, cancelable, CanGc::note())
+        Self::new_with_proto(worker, None, type_, bubbles, cancelable, can_gc)
     }
 
     fn new_with_proto(

--- a/components/script/dom/formdata.rs
+++ b/components/script/dom/formdata.rs
@@ -45,8 +45,12 @@ impl FormData {
         }
     }
 
-    pub fn new(form_datums: Option<Vec<FormDatum>>, global: &GlobalScope) -> DomRoot<FormData> {
-        Self::new_with_proto(form_datums, global, None, CanGc::note())
+    pub fn new(
+        form_datums: Option<Vec<FormDatum>>,
+        global: &GlobalScope,
+        can_gc: CanGc,
+    ) -> DomRoot<FormData> {
+        Self::new_with_proto(form_datums, global, None, can_gc)
     }
 
     fn new_with_proto(
@@ -73,7 +77,7 @@ impl FormDataMethods for FormData {
         form: Option<&HTMLFormElement>,
     ) -> Fallible<DomRoot<FormData>> {
         if let Some(opt_form) = form {
-            return match opt_form.get_form_dataset(None, None) {
+            return match opt_form.get_form_dataset(None, None, can_gc) {
                 Some(form_datums) => Ok(FormData::new_with_proto(
                     Some(form_datums),
                     global,

--- a/components/script/dom/htmlbuttonelement.rs
+++ b/components/script/dom/htmlbuttonelement.rs
@@ -31,6 +31,7 @@ use crate::dom::nodelist::NodeList;
 use crate::dom::validation::{is_barred_by_datalist_ancestor, Validatable};
 use crate::dom::validitystate::{ValidationFlags, ValidityState};
 use crate::dom::virtualmethods::VirtualMethods;
+use crate::script_runtime::CanGc;
 
 #[derive(Clone, Copy, JSTraceable, MallocSizeOf, PartialEq)]
 enum ButtonType {
@@ -352,6 +353,7 @@ impl Activatable for HTMLButtonElement {
                     owner.submit(
                         SubmittedFrom::NotFromForm,
                         FormSubmitterElement::Button(self),
+                        CanGc::note(),
                     );
                 }
             },

--- a/components/script/dom/rtcpeerconnectioniceevent.rs
+++ b/components/script/dom/rtcpeerconnectioniceevent.rs
@@ -46,8 +46,9 @@ impl RTCPeerConnectionIceEvent {
         candidate: Option<&RTCIceCandidate>,
         url: Option<DOMString>,
         trusted: bool,
+        can_gc: CanGc,
     ) -> DomRoot<RTCPeerConnectionIceEvent> {
-        Self::new_with_proto(global, None, ty, candidate, url, trusted, CanGc::note())
+        Self::new_with_proto(global, None, ty, candidate, url, trusted, can_gc)
     }
 
     fn new_with_proto(

--- a/components/script/dom/serviceworkerglobalscope.rs
+++ b/components/script/dom/serviceworkerglobalscope.rs
@@ -384,7 +384,7 @@ impl ServiceWorkerGlobalScope {
                     scope.execute_script(DOMString::from(source));
                 }
 
-                global.dispatch_activate();
+                global.dispatch_activate(can_gc);
                 let reporter_name = format!("service-worker-reporter-{}", random::<u64>());
                 scope
                     .upcast::<GlobalScope>()
@@ -478,8 +478,8 @@ impl ServiceWorkerGlobalScope {
         })
     }
 
-    fn dispatch_activate(&self) {
-        let event = ExtendableEvent::new(self, atom!("activate"), false, false);
+    fn dispatch_activate(&self, can_gc: CanGc) {
+        let event = ExtendableEvent::new(self, atom!("activate"), false, false, can_gc);
         let event = (*event).upcast::<Event>();
         self.upcast::<EventTarget>().dispatch_event(event);
     }

--- a/components/script/dom/xrsession.rs
+++ b/components/script/dom/xrsession.rs
@@ -297,7 +297,8 @@ impl XRSession {
                     promise.resolve_native(&());
                 }
                 // Step 7
-                let event = XRSessionEvent::new(&self.global(), atom!("end"), false, false, self);
+                let event =
+                    XRSessionEvent::new(&self.global(), atom!("end"), false, false, self, can_gc);
                 event.upcast::<Event>().fire(self.upcast());
             },
             XREvent::Select(input, kind, ty, frame) => {
@@ -360,6 +361,7 @@ impl XRSession {
                     false,
                     false,
                     self,
+                    can_gc,
                 );
                 event.upcast::<Event>().fire(self.upcast());
                 // The page may be visible again, dirty the layers
@@ -607,6 +609,7 @@ impl XRSession {
             false,
             false,
             self,
+            CanGc::note(),
         );
         event.upcast::<Event>().fire(self.upcast());
     }

--- a/components/script/dom/xrsessionevent.rs
+++ b/components/script/dom/xrsessionevent.rs
@@ -40,16 +40,9 @@ impl XRSessionEvent {
         bubbles: bool,
         cancelable: bool,
         session: &XRSession,
+        can_gc: CanGc,
     ) -> DomRoot<XRSessionEvent> {
-        Self::new_with_proto(
-            global,
-            None,
-            type_,
-            bubbles,
-            cancelable,
-            session,
-            CanGc::note(),
-        )
+        Self::new_with_proto(global, None, type_, bubbles, cancelable, session, can_gc)
     }
 
     fn new_with_proto(


### PR DESCRIPTION
Replaces CanGc::note() calls with arguments passed by callers in `components/script/dom/rtcpeerconnectioniceevent.rs`, `components/script/dom/xrsessionevent.rs`, `components/script/dom/extendableevent.rs` and `components/script/dom/formdata.rs`

Some files couldn't be changed:
`components/script/dom/promiserejectionevent.rs`
`omponents/script/dom/websocket.rs`
`components/script/document_loader.rs`


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are a part of #33683 
- [X] These changes do not require tests because they do not modify functionality

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
