### PR TITLE
clippy: Rename `RequestId::new()` to `RequestId::next()` and fix one more issue in `servo/lib.rs`

### DIFF
--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -345,7 +345,6 @@ pub fn load_whole_resource(
     loop {
         match action_receiver.recv().unwrap() {
             FetchResponseMsg::ProcessRequestBody(..) | FetchResponseMsg::ProcessRequestEOF(..) => {
-                ()
             },
             FetchResponseMsg::ProcessResponse(_, Ok(m)) => {
                 metadata = Some(match m {

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -4185,7 +4185,7 @@ impl ScriptThread {
             None => vec![],
         };
 
-        let dummy_request_id = RequestId::new();
+        let dummy_request_id = RequestId::default();
         context.process_response(dummy_request_id, Ok(FetchMetadata::Unfiltered(meta)));
         context.process_response_chunk(dummy_request_id, chunk);
         context.process_response_eof(
@@ -4209,7 +4209,7 @@ impl ScriptThread {
 
         let chunk = load_data.srcdoc.into_bytes();
 
-        let dummy_request_id = RequestId::new();
+        let dummy_request_id = RequestId::default();
         context.process_response(dummy_request_id, Ok(FetchMetadata::Unfiltered(meta)));
         context.process_response_chunk(dummy_request_id, chunk);
         context.process_response_eof(

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -4185,7 +4185,7 @@ impl ScriptThread {
             None => vec![],
         };
 
-        let dummy_request_id = RequestId::default();
+        let dummy_request_id = RequestId::next();
         context.process_response(dummy_request_id, Ok(FetchMetadata::Unfiltered(meta)));
         context.process_response_chunk(dummy_request_id, chunk);
         context.process_response_eof(
@@ -4209,7 +4209,7 @@ impl ScriptThread {
 
         let chunk = load_data.srcdoc.into_bytes();
 
-        let dummy_request_id = RequestId::default();
+        let dummy_request_id = RequestId::next();
         context.process_response(dummy_request_id, Ok(FetchMetadata::Unfiltered(meta)));
         context.process_response_chunk(dummy_request_id, chunk);
         context.process_response_eof(

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -228,6 +228,7 @@ where
         feature = "tracing",
         tracing::instrument(skip(embedder, window), fields(servo_profiling = true))
     )]
+    #[allow(clippy::new_ret_no_self)]
     pub fn new(
         mut embedder: Box<dyn EmbedderMethods>,
         window: Rc<Window>,

--- a/components/shared/net/request.rs
+++ b/components/shared/net/request.rs
@@ -22,8 +22,8 @@ use crate::{ReferrerPolicy, ResourceTimingType};
 /// An id to differeniate one network request from another.
 pub struct RequestId(usize);
 
-impl Default for RequestId {
-    fn default() -> Self {
+impl RequestId {
+    pub fn next() -> Self {
         static NEXT_REQUEST_ID: AtomicUsize = AtomicUsize::new(0);
         Self(NEXT_REQUEST_ID.fetch_add(1, Ordering::Relaxed))
     }
@@ -285,7 +285,7 @@ pub struct RequestBuilder {
 impl RequestBuilder {
     pub fn new(url: ServoUrl, referrer: Referrer) -> RequestBuilder {
         RequestBuilder {
-            id: RequestId::default(),
+            id: RequestId::next(),
             method: Method::GET,
             url,
             headers: HeaderMap::new(),

--- a/components/shared/net/request.rs
+++ b/components/shared/net/request.rs
@@ -22,8 +22,8 @@ use crate::{ReferrerPolicy, ResourceTimingType};
 /// An id to differeniate one network request from another.
 pub struct RequestId(usize);
 
-impl RequestId {
-    pub fn new() -> Self {
+impl Default for RequestId {
+    fn default() -> Self {
         static NEXT_REQUEST_ID: AtomicUsize = AtomicUsize::new(0);
         Self(NEXT_REQUEST_ID.fetch_add(1, Ordering::Relaxed))
     }
@@ -285,7 +285,7 @@ pub struct RequestBuilder {
 impl RequestBuilder {
     pub fn new(url: ServoUrl, referrer: Referrer) -> RequestBuilder {
         RequestBuilder {
-            id: RequestId::new(),
+            id: RequestId::default(),
             method: Method::GET,
             url,
             headers: HeaderMap::new(),


### PR DESCRIPTION
This PR addresses clippy warnings in files; 
- components/servo/lib.rs 
- components/shared/net/request.rs
- components/script/fetch.rs


---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of  #31500
- [X] These changes do not require tests because they do not touch functionality.

