### PR TITLE
Several CanGc fixes in `components/script/dom`

### DIFF
--- a/components/script/dom/abstractworkerglobalscope.rs
+++ b/components/script/dom/abstractworkerglobalscope.rs
@@ -89,7 +89,7 @@ pub trait WorkerEventLoopMethods {
     type ControlMsg;
     type Event;
     fn task_queue(&self) -> &TaskQueue<Self::WorkerMsg>;
-    fn handle_event(&self, event: Self::Event) -> bool;
+    fn handle_event(&self, event: Self::Event, can_gc: CanGc) -> bool;
     fn handle_worker_post_event(&self, worker: &TrustedWorkerAddress) -> Option<AutoWorkerReset>;
     fn from_control_msg(msg: Self::ControlMsg) -> Self::Event;
     fn from_worker_msg(msg: Self::WorkerMsg) -> Self::Event;
@@ -143,7 +143,7 @@ pub fn run_worker_event_loop<T, WorkerMsg, Event>(
     // Step 3
     for event in sequential {
         let _realm = enter_realm(worker_scope);
-        if !worker_scope.handle_event(event) {
+        if !worker_scope.handle_event(event, can_gc) {
             // Shutdown
             return;
         }

--- a/components/script/dom/baseaudiocontext.rs
+++ b/components/script/dom/baseaudiocontext.rs
@@ -367,8 +367,13 @@ impl BaseAudioContextMethods for BaseAudioContext {
     }
 
     /// <https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createpanner>
-    fn CreatePanner(&self) -> Fallible<DomRoot<PannerNode>> {
-        PannerNode::new(self.global().as_window(), self, &PannerOptions::empty())
+    fn CreatePanner(&self, can_gc: CanGc) -> Fallible<DomRoot<PannerNode>> {
+        PannerNode::new(
+            self.global().as_window(),
+            self,
+            &PannerOptions::empty(),
+            can_gc,
+        )
     }
 
     /// <https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createanalyser>
@@ -411,10 +416,14 @@ impl BaseAudioContextMethods for BaseAudioContext {
     }
 
     /// <https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createchannelmerger>
-    fn CreateChannelMerger(&self, count: u32) -> Fallible<DomRoot<ChannelMergerNode>> {
+    fn CreateChannelMerger(
+        &self,
+        count: u32,
+        can_gc: CanGc,
+    ) -> Fallible<DomRoot<ChannelMergerNode>> {
         let mut opts = ChannelMergerOptions::empty();
         opts.numberOfInputs = count;
-        ChannelMergerNode::new(self.global().as_window(), self, &opts)
+        ChannelMergerNode::new(self.global().as_window(), self, &opts, can_gc)
     }
 
     /// <https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createchannelsplitter>

--- a/components/script/dom/bindings/codegen/Bindings.conf
+++ b/components/script/dom/bindings/codegen/Bindings.conf
@@ -25,7 +25,7 @@ DOMInterfaces = {
 
 'BaseAudioContext': {
     'inRealms': ['DecodeAudioData', 'Resume', 'ParseFromString', 'GetBounds', 'GetClientRects'],
-    'canGc': ['CreateOscillator', 'CreateStereoPanner', 'CreateGain', 'CreateIIRFilter', 'CreateBiquadFilter', 'CreateBufferSource', 'CreateAnalyser'],
+    'canGc': ['CreateChannelMerger', 'CreateOscillator', 'CreateStereoPanner', 'CreateGain', 'CreateIIRFilter', 'CreateBiquadFilter', 'CreateBufferSource', 'CreateAnalyser', 'CreatePanner'],
 },
 
 'Blob': {

--- a/components/script/dom/channelmergernode.rs
+++ b/components/script/dom/channelmergernode.rs
@@ -61,8 +61,9 @@ impl ChannelMergerNode {
         window: &Window,
         context: &BaseAudioContext,
         options: &ChannelMergerOptions,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<ChannelMergerNode>> {
-        Self::new_with_proto(window, None, context, options, CanGc::note())
+        Self::new_with_proto(window, None, context, options, can_gc)
     }
 
     #[allow(crown::unrooted_must_root)]

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -212,7 +212,7 @@ impl WorkerEventLoopMethods for DedicatedWorkerGlobalScope {
         &self.task_queue
     }
 
-    fn handle_event(&self, event: MixedMessage) -> bool {
+    fn handle_event(&self, event: MixedMessage, _can_gc: CanGc) -> bool {
         self.handle_mixed_message(event)
     }
 

--- a/components/script/dom/extendablemessageevent.rs
+++ b/components/script/dom/extendablemessageevent.rs
@@ -75,6 +75,7 @@ impl ExtendableMessageEvent {
         origin: DOMString,
         lastEventId: DOMString,
         ports: Vec<DomRoot<MessagePort>>,
+        can_gc: CanGc,
     ) -> DomRoot<ExtendableMessageEvent> {
         Self::new_with_proto(
             global,
@@ -86,7 +87,7 @@ impl ExtendableMessageEvent {
             origin,
             lastEventId,
             ports,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -126,6 +127,7 @@ impl ExtendableMessageEvent {
         scope: &GlobalScope,
         message: HandleValue,
         ports: Vec<DomRoot<MessagePort>>,
+        can_gc: CanGc,
     ) {
         let Extendablemessageevent = ExtendableMessageEvent::new(
             scope,
@@ -136,11 +138,12 @@ impl ExtendableMessageEvent {
             DOMString::new(),
             DOMString::new(),
             ports,
+            can_gc,
         );
         Extendablemessageevent.upcast::<Event>().fire(target);
     }
 
-    pub fn dispatch_error(target: &EventTarget, scope: &GlobalScope) {
+    pub fn dispatch_error(target: &EventTarget, scope: &GlobalScope, can_gc: CanGc) {
         let init = ExtendableMessageEventBinding::ExtendableMessageEventInit::empty();
         let ExtendableMsgEvent = ExtendableMessageEvent::new(
             scope,
@@ -151,6 +154,7 @@ impl ExtendableMessageEvent {
             init.origin.clone(),
             init.lastEventId.clone(),
             init.ports.clone(),
+            can_gc,
         );
         ExtendableMsgEvent.upcast::<Event>().fire(target);
     }

--- a/components/script/dom/gpu.rs
+++ b/components/script/dom/gpu.rs
@@ -143,7 +143,7 @@ impl GPUMethods for GPU {
 }
 
 impl AsyncWGPUListener for GPU {
-    fn handle_response(&self, response: WebGPUResponse, promise: &Rc<Promise>, _can_gc: CanGc) {
+    fn handle_response(&self, response: WebGPUResponse, promise: &Rc<Promise>, can_gc: CanGc) {
         match response {
             WebGPUResponse::Adapter(Ok(adapter)) => {
                 let adapter = GPUAdapter::new(
@@ -158,6 +158,7 @@ impl AsyncWGPUListener for GPU {
                     adapter.limits,
                     adapter.adapter_info,
                     adapter.adapter_id,
+                    can_gc,
                 );
                 promise.resolve_native(&adapter);
             },

--- a/components/script/dom/gpudevice.rs
+++ b/components/script/dom/gpudevice.rs
@@ -148,10 +148,11 @@ impl GPUDevice {
         device: webgpu::WebGPUDevice,
         queue: webgpu::WebGPUQueue,
         label: String,
+        can_gc: CanGc,
     ) -> DomRoot<Self> {
         let queue = GPUQueue::new(global, channel.clone(), queue);
         let limits = GPUSupportedLimits::new(global, limits);
-        let features = GPUSupportedFeatures::Constructor(global, None, features).unwrap();
+        let features = GPUSupportedFeatures::Constructor(global, None, features, can_gc).unwrap();
         let lost_promise = Promise::new(global);
         let device = reflect_dom_object(
             Box::new(GPUDevice::new_inherited(

--- a/components/script/dom/gpusupportedfeatures.rs
+++ b/components/script/dom/gpusupportedfeatures.rs
@@ -50,6 +50,7 @@ impl GPUSupportedFeatures {
         global: &GlobalScope,
         proto: Option<HandleObject>,
         features: Features,
+        can_gc: CanGc,
     ) -> DomRoot<GPUSupportedFeatures> {
         let mut set = IndexSet::new();
         if features.contains(Features::DEPTH_CLIP_CONTROL) {
@@ -103,7 +104,7 @@ impl GPUSupportedFeatures {
             }),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -112,8 +113,9 @@ impl GPUSupportedFeatures {
         global: &GlobalScope,
         proto: Option<HandleObject>,
         features: Features,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<GPUSupportedFeatures>> {
-        Ok(GPUSupportedFeatures::new(global, proto, features))
+        Ok(GPUSupportedFeatures::new(global, proto, features, can_gc))
     }
 }
 

--- a/components/script/dom/pannernode.rs
+++ b/components/script/dom/pannernode.rs
@@ -184,8 +184,9 @@ impl PannerNode {
         window: &Window,
         context: &BaseAudioContext,
         options: &PannerOptions,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<PannerNode>> {
-        Self::new_with_proto(window, None, context, options, CanGc::note())
+        Self::new_with_proto(window, None, context, options, can_gc)
     }
 
     #[allow(crown::unrooted_must_root)]

--- a/components/script/dom/performanceobserver.rs
+++ b/components/script/dom/performanceobserver.rs
@@ -70,8 +70,9 @@ impl PerformanceObserver {
         global: &GlobalScope,
         callback: Rc<PerformanceObserverCallback>,
         entries: DOMPerformanceEntryList,
+        can_gc: CanGc,
     ) -> DomRoot<PerformanceObserver> {
-        Self::new_with_proto(global, None, callback, entries, CanGc::note())
+        Self::new_with_proto(global, None, callback, entries, can_gc)
     }
 
     #[allow(crown::unrooted_must_root)]


### PR DESCRIPTION
Replaces CanGc::note() calls with arguments passed by callers in `components/script/dom/pannernode.rs`, `components/script/dom/performanceobserver.rs`, `components/script/dom/extendablemessageevent.rs`, `components/script/dom/channelmergernode.rs`, and `components/script/dom/gpusupportedfeatures.rs`

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are a part of #33683 
- [X] These changes do not require tests because they do not modify functionality

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
