### PR TITLE
More files with CanGc fixes

### DIFF
--- a/components/script/dom/bindings/codegen/Bindings.conf
+++ b/components/script/dom/bindings/codegen/Bindings.conf
@@ -97,10 +97,6 @@ DOMInterfaces = {
     'inRealms': ['PromiseAttribute'],
 },
 
-'DedicatedWorkerGlobalScope': {
-    'canGc': ['PostMessage', 'PostMessage_'],
-},
-
 'Element': {
     'canGc': ['SetInnerHTML', 'SetOuterHTML', 'InsertAdjacentHTML', 'GetClientRects', 'GetBoundingClientRect'],
 },

--- a/components/script/dom/bindings/codegen/Bindings.conf
+++ b/components/script/dom/bindings/codegen/Bindings.conf
@@ -97,6 +97,10 @@ DOMInterfaces = {
     'inRealms': ['PromiseAttribute'],
 },
 
+'DedicatedWorkerGlobalScope': {
+    'canGc': ['PostMessage', 'PostMessage_'],
+},
+
 'Element': {
     'canGc': ['SetInnerHTML', 'SetOuterHTML', 'InsertAdjacentHTML', 'GetClientRects', 'GetBoundingClientRect'],
 },
@@ -145,7 +149,7 @@ DOMInterfaces = {
 },
 
 'HTMLCanvasElement': {
-    'canGc': ['CaptureStream'],
+    'canGc': ['CaptureStream', 'GetContext'],
 },
 
 'HTMLTemplateElement': {
@@ -242,7 +246,7 @@ DOMInterfaces = {
 
 'URL': {
     'weakReferenceable': True,
-    'canGc': ['Parse'],
+    'canGc': ['Parse', 'SearchParams'],
 },
 
 'VRDisplay': {
@@ -273,7 +277,7 @@ DOMInterfaces = {
 
 'XRSession': {
     'inRealms': ['RequestReferenceSpace', 'UpdateRenderState', 'UpdateTargetFrameRate'],
-    'canGc': ['End'],
+    'canGc': ['End', 'RequestReferenceSpace'],
 },
 
 'XRSystem': {
@@ -289,7 +293,19 @@ DOMInterfaces = {
 },
 
 'XRRigidTransform': {
-    'canGc': ['Position', 'Orientation'],
+    'canGc': ['Position', 'Orientation', 'Inverse'],
+},
+
+'XRReferenceSpace': {
+    'canGc': ['GetOffsetReferenceSpace'],
+},
+
+'XRFrame': {
+    'canGc': ['GetViewerPose', 'GetPose', 'GetJointPose'],
+},
+
+'XRHitTestResult': {
+    'canGc': ['GetPose'],
 },
 
 'SubtleCrypto': {

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -212,8 +212,8 @@ impl WorkerEventLoopMethods for DedicatedWorkerGlobalScope {
         &self.task_queue
     }
 
-    fn handle_event(&self, event: MixedMessage, _can_gc: CanGc) -> bool {
-        self.handle_mixed_message(event)
+    fn handle_event(&self, event: MixedMessage, can_gc: CanGc) -> bool {
+        self.handle_mixed_message(event, can_gc)
     }
 
     fn handle_worker_post_event(&self, worker: &TrustedWorkerAddress) -> Option<AutoWorkerReset> {
@@ -512,7 +512,7 @@ impl DedicatedWorkerGlobalScope {
         (chan, Box::new(rx))
     }
 
-    fn handle_script_event(&self, msg: WorkerScriptMsg) {
+    fn handle_script_event(&self, msg: WorkerScriptMsg, can_gc: CanGc) {
         match msg {
             WorkerScriptMsg::DOMMessage { origin, data } => {
                 let scope = self.upcast::<WorkerGlobalScope>();
@@ -528,9 +528,10 @@ impl DedicatedWorkerGlobalScope {
                         Some(&origin.ascii_serialization()),
                         None,
                         ports,
+                        can_gc,
                     );
                 } else {
-                    MessageEvent::dispatch_error(target, scope.upcast());
+                    MessageEvent::dispatch_error(target, scope.upcast(), can_gc);
                 }
             },
             WorkerScriptMsg::Common(msg) => {
@@ -539,7 +540,7 @@ impl DedicatedWorkerGlobalScope {
         }
     }
 
-    fn handle_mixed_message(&self, msg: MixedMessage) -> bool {
+    fn handle_mixed_message(&self, msg: MixedMessage, can_gc: CanGc) -> bool {
         // FIXME(#26324): `self.worker` is None in devtools messages.
         match msg {
             MixedMessage::Devtools(msg) => match msg {
@@ -553,7 +554,7 @@ impl DedicatedWorkerGlobalScope {
             },
             MixedMessage::Worker(DedicatedWorkerScriptMsg::CommonWorker(linked_worker, msg)) => {
                 let _ar = AutoWorkerReset::new(self, linked_worker);
-                self.handle_script_event(msg);
+                self.handle_script_event(msg, can_gc);
             },
             MixedMessage::Worker(DedicatedWorkerScriptMsg::WakeUp) => {},
             MixedMessage::Control(DedicatedWorkerControlMsg::Exit) => {
@@ -608,13 +609,14 @@ impl DedicatedWorkerGlobalScope {
         cx: SafeJSContext,
         message: HandleValue,
         transfer: CustomAutoRooterGuard<Vec<*mut JSObject>>,
+        can_gc: CanGc,
     ) -> ErrorResult {
         let data = structuredclone::write(cx, message, Some(transfer))?;
         let worker = self.worker.borrow().as_ref().unwrap().clone();
         let global_scope = self.upcast::<GlobalScope>();
         let pipeline_id = global_scope.pipeline_id();
         let task = Box::new(task!(post_worker_message: move || {
-            Worker::handle_message(worker, data);
+            Worker::handle_message(worker, data, can_gc);
         }));
         self.parent_sender
             .send(CommonScriptMsg::Task(
@@ -651,8 +653,9 @@ impl DedicatedWorkerGlobalScopeMethods for DedicatedWorkerGlobalScope {
         cx: SafeJSContext,
         message: HandleValue,
         transfer: CustomAutoRooterGuard<Vec<*mut JSObject>>,
+        can_gc: CanGc,
     ) -> ErrorResult {
-        self.post_message_impl(cx, message, transfer)
+        self.post_message_impl(cx, message, transfer, can_gc)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-dedicatedworkerglobalscope-postmessage>
@@ -661,6 +664,7 @@ impl DedicatedWorkerGlobalScopeMethods for DedicatedWorkerGlobalScope {
         cx: SafeJSContext,
         message: HandleValue,
         options: RootedTraceableBox<StructuredSerializeOptions>,
+        can_gc: CanGc,
     ) -> ErrorResult {
         let mut rooted = CustomAutoRooter::new(
             options
@@ -670,7 +674,7 @@ impl DedicatedWorkerGlobalScopeMethods for DedicatedWorkerGlobalScope {
                 .collect(),
         );
         let guard = CustomAutoRooterGuard::new(*cx, &mut rooted);
-        self.post_message_impl(cx, message, guard)
+        self.post_message_impl(cx, message, guard, can_gc)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-dedicatedworkerglobalscope-close

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -4680,6 +4680,7 @@ impl DocumentMethods for Document {
             ))),
             "messageevent" => Ok(DomRoot::upcast(MessageEvent::new_uninitialized(
                 self.window.upcast(),
+                can_gc,
             ))),
             "mouseevent" | "mouseevents" => Ok(DomRoot::upcast(MouseEvent::new_uninitialized(
                 &self.window,

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -759,6 +759,7 @@ impl HTMLFormElement {
                 true,
                 true,
                 submitter_button.map(DomRoot::from_ref),
+                can_gc,
             );
             let event = event.upcast::<Event>();
             event.fire(self.upcast::<EventTarget>());

--- a/components/script/dom/messageevent.rs
+++ b/components/script/dom/messageevent.rs
@@ -91,8 +91,8 @@ impl MessageEvent {
         }
     }
 
-    pub fn new_uninitialized(global: &GlobalScope) -> DomRoot<MessageEvent> {
-        Self::new_uninitialized_with_proto(global, None, CanGc::note())
+    pub fn new_uninitialized(global: &GlobalScope, can_gc: CanGc) -> DomRoot<MessageEvent> {
+        Self::new_uninitialized_with_proto(global, None, can_gc)
     }
 
     fn new_uninitialized_with_proto(
@@ -146,6 +146,7 @@ impl MessageEvent {
         source: Option<&WindowProxyOrMessagePortOrServiceWorker>,
         lastEventId: DOMString,
         ports: Vec<DomRoot<MessagePort>>,
+        can_gc: CanGc,
     ) -> DomRoot<MessageEvent> {
         Self::new_with_proto(
             global,
@@ -158,7 +159,7 @@ impl MessageEvent {
             source,
             lastEventId,
             ports,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -200,6 +201,7 @@ impl MessageEvent {
         origin: Option<&str>,
         source: Option<&WindowProxy>,
         ports: Vec<DomRoot<MessagePort>>,
+        can_gc: CanGc,
     ) {
         let messageevent = MessageEvent::new(
             scope,
@@ -215,11 +217,12 @@ impl MessageEvent {
                 .as_ref(),
             DOMString::new(),
             ports,
+            can_gc,
         );
         messageevent.upcast::<Event>().fire(target);
     }
 
-    pub fn dispatch_error(target: &EventTarget, scope: &GlobalScope) {
+    pub fn dispatch_error(target: &EventTarget, scope: &GlobalScope, can_gc: CanGc) {
         let init = MessageEventBinding::MessageEventInit::empty();
         let messageevent = MessageEvent::new(
             scope,
@@ -231,6 +234,7 @@ impl MessageEvent {
             init.source.as_ref(),
             init.lastEventId.clone(),
             init.ports.clone(),
+            can_gc,
         );
         messageevent.upcast::<Event>().fire(target);
     }

--- a/components/script/dom/rtcdatachannel.rs
+++ b/components/script/dom/rtcdatachannel.rs
@@ -199,6 +199,7 @@ impl RTCDataChannel {
                 Some(&global.origin().immutable().ascii_serialization()),
                 None,
                 vec![],
+                can_gc,
             );
         }
     }

--- a/components/script/dom/rtcdatachannelevent.rs
+++ b/components/script/dom/rtcdatachannelevent.rs
@@ -40,16 +40,9 @@ impl RTCDataChannelEvent {
         bubbles: bool,
         cancelable: bool,
         channel: &RTCDataChannel,
+        can_gc: CanGc,
     ) -> DomRoot<RTCDataChannelEvent> {
-        Self::new_with_proto(
-            global,
-            None,
-            type_,
-            bubbles,
-            cancelable,
-            channel,
-            CanGc::note(),
-        )
+        Self::new_with_proto(global, None, type_, bubbles, cancelable, channel, can_gc)
     }
 
     fn new_with_proto(

--- a/components/script/dom/rtcicecandidate.rs
+++ b/components/script/dom/rtcicecandidate.rs
@@ -47,6 +47,7 @@ impl RTCIceCandidate {
         sdp_m_id: Option<DOMString>,
         sdp_m_line_index: Option<u16>,
         username_fragment: Option<DOMString>,
+        can_gc: CanGc,
     ) -> DomRoot<RTCIceCandidate> {
         Self::new_with_proto(
             global,
@@ -55,7 +56,7 @@ impl RTCIceCandidate {
             sdp_m_id,
             sdp_m_line_index,
             username_fragment,
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/rtcpeerconnection.rs
+++ b/components/script/dom/rtcpeerconnection.rs
@@ -259,6 +259,7 @@ impl RTCPeerConnection {
             None,
             Some(candidate.sdp_mline_index as u16),
             None,
+            can_gc,
         );
         let event = RTCPeerConnectionIceEvent::new(
             &self.global(),
@@ -320,6 +321,7 @@ impl RTCPeerConnection {
                     false,
                     false,
                     &channel,
+                    can_gc,
                 );
                 event.upcast::<Event>().fire(self.upcast());
             },

--- a/components/script/dom/submitevent.rs
+++ b/components/script/dom/submitevent.rs
@@ -40,16 +40,9 @@ impl SubmitEvent {
         bubbles: bool,
         cancelable: bool,
         submitter: Option<DomRoot<HTMLElement>>,
+        can_gc: CanGc,
     ) -> DomRoot<SubmitEvent> {
-        Self::new_with_proto(
-            global,
-            None,
-            type_,
-            bubbles,
-            cancelable,
-            submitter,
-            CanGc::note(),
-        )
+        Self::new_with_proto(global, None, type_, bubbles, cancelable, submitter, can_gc)
     }
 
     fn new_with_proto(

--- a/components/script/dom/url.rs
+++ b/components/script/dom/url.rs
@@ -318,9 +318,9 @@ impl URLMethods for URL {
     }
 
     /// <https://url.spec.whatwg.org/#dom-url-searchparams>
-    fn SearchParams(&self) -> DomRoot<URLSearchParams> {
+    fn SearchParams(&self, can_gc: CanGc) -> DomRoot<URLSearchParams> {
         self.search_params
-            .or_init(|| URLSearchParams::new(&self.global(), Some(self)))
+            .or_init(|| URLSearchParams::new(&self.global(), Some(self), can_gc))
     }
 
     /// <https://url.spec.whatwg.org/#dom-url-username>

--- a/components/script/dom/urlsearchparams.rs
+++ b/components/script/dom/urlsearchparams.rs
@@ -38,8 +38,8 @@ impl URLSearchParams {
         }
     }
 
-    pub fn new(global: &GlobalScope, url: Option<&URL>) -> DomRoot<URLSearchParams> {
-        Self::new_with_proto(global, None, url, CanGc::note())
+    pub fn new(global: &GlobalScope, url: Option<&URL>, can_gc: CanGc) -> DomRoot<URLSearchParams> {
+        Self::new_with_proto(global, None, url, can_gc)
     }
 
     pub fn new_with_proto(

--- a/components/script/dom/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl2renderingcontext.rs
@@ -69,7 +69,7 @@ use crate::dom::webgluniformlocation::WebGLUniformLocation;
 use crate::dom::webglvertexarrayobject::WebGLVertexArrayObject;
 use crate::dom::window::Window;
 use crate::js::conversions::ToJSValConvertible;
-use crate::script_runtime::JSContext;
+use crate::script_runtime::{CanGc, JSContext};
 
 #[crown::unrooted_must_root_lint::must_root]
 #[derive(JSTraceable, MallocSizeOf)]
@@ -143,8 +143,10 @@ impl WebGL2RenderingContext {
         canvas: &HTMLCanvasElementOrOffscreenCanvas,
         size: Size2D<u32>,
         attrs: GLContextAttributes,
+        can_gc: CanGc,
     ) -> Option<WebGL2RenderingContext> {
-        let base = WebGLRenderingContext::new(window, canvas, WebGLVersion::WebGL2, size, attrs)?;
+        let base =
+            WebGLRenderingContext::new(window, canvas, WebGLVersion::WebGL2, size, attrs, can_gc)?;
 
         let samplers = (0..base.limits().max_combined_texture_image_units)
             .map(|_| Default::default())
@@ -190,8 +192,9 @@ impl WebGL2RenderingContext {
         canvas: &HTMLCanvasElementOrOffscreenCanvas,
         size: Size2D<u32>,
         attrs: GLContextAttributes,
+        can_gc: CanGc,
     ) -> Option<DomRoot<WebGL2RenderingContext>> {
-        WebGL2RenderingContext::new_inherited(window, canvas, size, attrs)
+        WebGL2RenderingContext::new_inherited(window, canvas, size, attrs, can_gc)
             .map(|ctx| reflect_dom_object(Box::new(ctx), window))
     }
 

--- a/components/script/dom/webglcontextevent.rs
+++ b/components/script/dom/webglcontextevent.rs
@@ -79,6 +79,7 @@ impl WebGLContextEvent {
         bubbles: EventBubbles,
         cancelable: EventCancelable,
         status_message: DOMString,
+        can_gc: CanGc,
     ) -> DomRoot<WebGLContextEvent> {
         Self::new_with_proto(
             window,
@@ -87,7 +88,7 @@ impl WebGLContextEvent {
             bubbles,
             cancelable,
             status_message,
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -87,7 +87,7 @@ use crate::dom::webgluniformlocation::WebGLUniformLocation;
 use crate::dom::webglvertexarrayobject::WebGLVertexArrayObject;
 use crate::dom::webglvertexarrayobjectoes::WebGLVertexArrayObjectOES;
 use crate::dom::window::Window;
-use crate::script_runtime::JSContext as SafeJSContext;
+use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
 
 // From the GLES 2.0.25 spec, page 85:
 //
@@ -288,6 +288,7 @@ impl WebGLRenderingContext {
         webgl_version: WebGLVersion,
         size: Size2D<u32>,
         attrs: GLContextAttributes,
+        can_gc: CanGc,
     ) -> Option<DomRoot<WebGLRenderingContext>> {
         match WebGLRenderingContext::new_inherited(window, canvas, webgl_version, size, attrs) {
             Ok(ctx) => Some(reflect_dom_object(Box::new(ctx), window)),
@@ -299,6 +300,7 @@ impl WebGLRenderingContext {
                     EventBubbles::DoesNotBubble,
                     EventCancelable::Cancelable,
                     DOMString::from(msg),
+                    can_gc,
                 );
                 match canvas {
                     HTMLCanvasElementOrOffscreenCanvas::HTMLCanvasElement(canvas) => {

--- a/components/script/dom/websocket.rs
+++ b/components/script/dom/websocket.rs
@@ -603,6 +603,7 @@ impl TaskOnce for MessageReceivedTask {
                 Some(&ws.origin().ascii_serialization()),
                 None,
                 vec![],
+                CanGc::note(),
             );
         }
     }

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2782,12 +2782,14 @@ impl Window {
                     Some(&source_origin.ascii_serialization()),
                     Some(&*source),
                     ports,
+                    CanGc::note()
                 );
             } else {
                 // Step 4, fire messageerror.
                 MessageEvent::dispatch_error(
                     this.upcast(),
                     this.upcast(),
+                    CanGc::note()
                 );
             }
         });

--- a/components/script/dom/xrboundedreferencespace.rs
+++ b/components/script/dom/xrboundedreferencespace.rs
@@ -39,8 +39,12 @@ impl XRBoundedReferenceSpace {
     }
 
     #[allow(unused)]
-    pub fn new(global: &GlobalScope, session: &XRSession) -> DomRoot<XRBoundedReferenceSpace> {
-        let offset = XRRigidTransform::identity(global);
+    pub fn new(
+        global: &GlobalScope,
+        session: &XRSession,
+        can_gc: CanGc,
+    ) -> DomRoot<XRBoundedReferenceSpace> {
+        let offset = XRRigidTransform::identity(global, can_gc);
         Self::new_offset(global, session, &offset)
     }
 

--- a/components/script/dom/xrframe.rs
+++ b/components/script/dom/xrframe.rs
@@ -25,6 +25,7 @@ use crate::dom::xrreferencespace::XRReferenceSpace;
 use crate::dom::xrsession::{ApiPose, XRSession};
 use crate::dom::xrspace::XRSpace;
 use crate::dom::xrviewerpose::XRViewerPose;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct XRFrame {
@@ -92,6 +93,7 @@ impl XRFrameMethods for XRFrame {
     fn GetViewerPose(
         &self,
         reference: &XRReferenceSpace,
+        can_gc: CanGc,
     ) -> Result<Option<DomRoot<XRViewerPose>>, Error> {
         if self.session != reference.upcast::<XRSpace>().session() {
             return Err(Error::InvalidState);
@@ -116,6 +118,7 @@ impl XRFrameMethods for XRFrame {
             &self.session,
             to_base,
             viewer_pose,
+            can_gc,
         )))
     }
 
@@ -124,6 +127,7 @@ impl XRFrameMethods for XRFrame {
         &self,
         space: &XRSpace,
         base_space: &XRSpace,
+        can_gc: CanGc,
     ) -> Result<Option<DomRoot<XRPose>>, Error> {
         if self.session != space.session() || self.session != base_space.session() {
             return Err(Error::InvalidState);
@@ -142,7 +146,7 @@ impl XRFrameMethods for XRFrame {
             return Ok(None);
         };
         let pose = space.then(&base_space.inverse());
-        Ok(Some(XRPose::new(&self.global(), pose)))
+        Ok(Some(XRPose::new(&self.global(), pose, can_gc)))
     }
 
     /// <https://immersive-web.github.io/webxr/#dom-xrframe-getpose>
@@ -150,6 +154,7 @@ impl XRFrameMethods for XRFrame {
         &self,
         space: &XRJointSpace,
         base_space: &XRSpace,
+        can_gc: CanGc,
     ) -> Result<Option<DomRoot<XRJointPose>>, Error> {
         if self.session != space.upcast::<XRSpace>().session() ||
             self.session != base_space.session()
@@ -174,6 +179,7 @@ impl XRFrameMethods for XRFrame {
             &self.global(),
             pose.cast_unit(),
             Some(joint_frame.radius),
+            can_gc,
         )))
     }
 

--- a/components/script/dom/xrhittestresult.rs
+++ b/components/script/dom/xrhittestresult.rs
@@ -12,6 +12,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::xrframe::XRFrame;
 use crate::dom::xrpose::XRPose;
 use crate::dom::xrspace::XRSpace;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct XRHitTestResult {
@@ -45,9 +46,9 @@ impl XRHitTestResult {
 
 impl XRHitTestResultMethods for XRHitTestResult {
     // https://immersive-web.github.io/hit-test/#dom-xrhittestresult-getpose
-    fn GetPose(&self, base: &XRSpace) -> Option<DomRoot<XRPose>> {
+    fn GetPose(&self, base: &XRSpace, can_gc: CanGc) -> Option<DomRoot<XRPose>> {
         let base = self.frame.get_pose(base)?;
         let pose = self.result.space.then(&base.inverse());
-        Some(XRPose::new(&self.global(), pose.cast_unit()))
+        Some(XRPose::new(&self.global(), pose.cast_unit(), can_gc))
     }
 }

--- a/components/script/dom/xrjointpose.rs
+++ b/components/script/dom/xrjointpose.rs
@@ -12,6 +12,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::xrpose::XRPose;
 use crate::dom::xrrigidtransform::XRRigidTransform;
 use crate::dom::xrsession::ApiRigidTransform;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct XRJointPose {
@@ -32,8 +33,9 @@ impl XRJointPose {
         global: &GlobalScope,
         pose: ApiRigidTransform,
         radius: Option<f32>,
+        can_gc: CanGc,
     ) -> DomRoot<XRJointPose> {
-        let transform = XRRigidTransform::new(global, pose);
+        let transform = XRRigidTransform::new(global, pose, can_gc);
         reflect_dom_object(
             Box::new(XRJointPose::new_inherited(&transform, radius)),
             global,

--- a/components/script/dom/xrpose.rs
+++ b/components/script/dom/xrpose.rs
@@ -11,6 +11,7 @@ use crate::dom::dompointreadonly::DOMPointReadOnly;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::xrrigidtransform::XRRigidTransform;
 use crate::dom::xrsession::ApiRigidTransform;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct XRPose {
@@ -27,8 +28,12 @@ impl XRPose {
     }
 
     #[allow(unused)]
-    pub fn new(global: &GlobalScope, transform: ApiRigidTransform) -> DomRoot<XRPose> {
-        let transform = XRRigidTransform::new(global, transform);
+    pub fn new(
+        global: &GlobalScope,
+        transform: ApiRigidTransform,
+        can_gc: CanGc,
+    ) -> DomRoot<XRPose> {
+        let transform = XRRigidTransform::new(global, transform, can_gc);
         reflect_dom_object(Box::new(XRPose::new_inherited(&transform)), global)
     }
 }

--- a/components/script/dom/xrreferencespace.rs
+++ b/components/script/dom/xrreferencespace.rs
@@ -16,6 +16,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::xrrigidtransform::XRRigidTransform;
 use crate::dom::xrsession::{cast_transform, ApiPose, BaseTransform, XRSession};
 use crate::dom::xrspace::XRSpace;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct XRReferenceSpace {
@@ -42,8 +43,9 @@ impl XRReferenceSpace {
         global: &GlobalScope,
         session: &XRSession,
         ty: XRReferenceSpaceType,
+        can_gc: CanGc,
     ) -> DomRoot<XRReferenceSpace> {
-        let offset = XRRigidTransform::identity(global);
+        let offset = XRRigidTransform::identity(global, can_gc);
         Self::new_offset(global, session, ty, &offset)
     }
 
@@ -79,9 +81,9 @@ impl XRReferenceSpace {
 
 impl XRReferenceSpaceMethods for XRReferenceSpace {
     /// <https://immersive-web.github.io/webxr/#dom-xrreferencespace-getoffsetreferencespace>
-    fn GetOffsetReferenceSpace(&self, new: &XRRigidTransform) -> DomRoot<Self> {
+    fn GetOffsetReferenceSpace(&self, new: &XRRigidTransform, can_gc: CanGc) -> DomRoot<Self> {
         let offset = new.transform().then(&self.offset.transform());
-        let offset = XRRigidTransform::new(&self.global(), offset);
+        let offset = XRRigidTransform::new(&self.global(), offset, can_gc);
         Self::new_offset(
             &self.global(),
             self.upcast::<XRSpace>().session(),

--- a/components/script/dom/xrrigidtransform.rs
+++ b/components/script/dom/xrrigidtransform.rs
@@ -44,8 +44,12 @@ impl XRRigidTransform {
         }
     }
 
-    pub fn new(global: &GlobalScope, transform: ApiRigidTransform) -> DomRoot<XRRigidTransform> {
-        Self::new_with_proto(global, None, transform, CanGc::note())
+    pub fn new(
+        global: &GlobalScope,
+        transform: ApiRigidTransform,
+        can_gc: CanGc,
+    ) -> DomRoot<XRRigidTransform> {
+        Self::new_with_proto(global, None, transform, can_gc)
     }
 
     fn new_with_proto(
@@ -62,9 +66,9 @@ impl XRRigidTransform {
         )
     }
 
-    pub fn identity(window: &GlobalScope) -> DomRoot<XRRigidTransform> {
+    pub fn identity(window: &GlobalScope, can_gc: CanGc) -> DomRoot<XRRigidTransform> {
         let transform = RigidTransform3D::identity();
-        XRRigidTransform::new(window, transform)
+        XRRigidTransform::new(window, transform, can_gc)
     }
 }
 
@@ -155,9 +159,9 @@ impl XRRigidTransformMethods for XRRigidTransform {
         })
     }
     // https://immersive-web.github.io/webxr/#dom-xrrigidtransform-inverse
-    fn Inverse(&self) -> DomRoot<XRRigidTransform> {
+    fn Inverse(&self, can_gc: CanGc) -> DomRoot<XRRigidTransform> {
         self.inverse.or_init(|| {
-            let transform = XRRigidTransform::new(&self.global(), self.transform.inverse());
+            let transform = XRRigidTransform::new(&self.global(), self.transform.inverse(), can_gc);
             transform.inverse.set(Some(self));
             transform
         })

--- a/components/script/dom/xrsession.rs
+++ b/components/script/dom/xrsession.rs
@@ -401,7 +401,7 @@ impl XRSession {
                         base == base_space
                     })
                     .for_each(|space| {
-                        let offset = XRRigidTransform::new(&self.global(), transform);
+                        let offset = XRRigidTransform::new(&self.global(), transform, can_gc);
                         let event = XRReferenceSpaceEvent::new(
                             &self.global(),
                             atom!("reset"),
@@ -824,7 +824,12 @@ impl XRSessionMethods for XRSession {
     }
 
     /// <https://immersive-web.github.io/webxr/#dom-xrsession-requestreferencespace>
-    fn RequestReferenceSpace(&self, ty: XRReferenceSpaceType, comp: InRealm) -> Rc<Promise> {
+    fn RequestReferenceSpace(
+        &self,
+        ty: XRReferenceSpaceType,
+        comp: InRealm,
+        can_gc: CanGc,
+    ) -> Rc<Promise> {
         let p = Promise::new_in_current_realm(comp);
 
         // https://immersive-web.github.io/webxr/#create-a-reference-space
@@ -861,13 +866,13 @@ impl XRSessionMethods for XRSession {
                     }
                 }
                 if ty == XRReferenceSpaceType::Bounded_floor {
-                    let space = XRBoundedReferenceSpace::new(&self.global(), self);
+                    let space = XRBoundedReferenceSpace::new(&self.global(), self, can_gc);
                     self.reference_spaces
                         .borrow_mut()
                         .push(Dom::from_ref(space.reference_space()));
                     p.resolve_native(&space);
                 } else {
-                    let space = XRReferenceSpace::new(&self.global(), self, ty);
+                    let space = XRReferenceSpace::new(&self.global(), self, ty, can_gc);
                     self.reference_spaces
                         .borrow_mut()
                         .push(Dom::from_ref(&*space));

--- a/components/script/dom/xrview.rs
+++ b/components/script/dom/xrview.rs
@@ -17,7 +17,7 @@ use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::xrrigidtransform::XRRigidTransform;
 use crate::dom::xrsession::{cast_transform, BaseSpace, BaseTransform, XRSession};
-use crate::script_runtime::JSContext;
+use crate::script_runtime::{CanGc, JSContext};
 
 #[dom_struct]
 pub struct XRView {
@@ -61,9 +61,10 @@ impl XRView {
         eye: XREye,
         viewport_index: usize,
         to_base: &BaseTransform,
+        can_gc: CanGc,
     ) -> DomRoot<XRView> {
         let transform: RigidTransform3D<f32, V, BaseSpace> = view.transform.then(to_base);
-        let transform = XRRigidTransform::new(global, cast_transform(transform));
+        let transform = XRRigidTransform::new(global, cast_transform(transform), can_gc);
 
         reflect_dom_object(
             Box::new(XRView::new_inherited(

--- a/components/script/dom/xrviewerpose.rs
+++ b/components/script/dom/xrviewerpose.rs
@@ -19,7 +19,7 @@ use crate::dom::xrrigidtransform::XRRigidTransform;
 use crate::dom::xrsession::{cast_transform, BaseSpace, BaseTransform, XRSession};
 use crate::dom::xrview::XRView;
 use crate::realms::enter_realm;
-use crate::script_runtime::JSContext;
+use crate::script_runtime::{CanGc, JSContext};
 
 #[dom_struct]
 pub struct XRViewerPose {
@@ -42,6 +42,7 @@ impl XRViewerPose {
         session: &XRSession,
         to_base: BaseTransform,
         viewer_pose: &ViewerPose,
+        can_gc: CanGc,
     ) -> DomRoot<XRViewerPose> {
         let _ac = enter_realm(global);
         rooted_vec!(let mut views);
@@ -53,12 +54,27 @@ impl XRViewerPose {
                 XREye::None,
                 0,
                 &to_base,
+                can_gc,
             )),
-            Views::Mono(view) => {
-                views.push(XRView::new(global, session, view, XREye::None, 0, &to_base))
-            },
+            Views::Mono(view) => views.push(XRView::new(
+                global,
+                session,
+                view,
+                XREye::None,
+                0,
+                &to_base,
+                can_gc,
+            )),
             Views::Stereo(left, right) => {
-                views.push(XRView::new(global, session, left, XREye::Left, 0, &to_base));
+                views.push(XRView::new(
+                    global,
+                    session,
+                    left,
+                    XREye::Left,
+                    0,
+                    &to_base,
+                    can_gc,
+                ));
                 views.push(XRView::new(
                     global,
                     session,
@@ -66,10 +82,19 @@ impl XRViewerPose {
                     XREye::Right,
                     1,
                     &to_base,
+                    can_gc,
                 ));
             },
             Views::StereoCapture(left, right, third_eye) => {
-                views.push(XRView::new(global, session, left, XREye::Left, 0, &to_base));
+                views.push(XRView::new(
+                    global,
+                    session,
+                    left,
+                    XREye::Left,
+                    0,
+                    &to_base,
+                    can_gc,
+                ));
                 views.push(XRView::new(
                     global,
                     session,
@@ -77,6 +102,7 @@ impl XRViewerPose {
                     XREye::Right,
                     1,
                     &to_base,
+                    can_gc,
                 ));
                 views.push(XRView::new(
                     global,
@@ -85,6 +111,7 @@ impl XRViewerPose {
                     XREye::None,
                     2,
                     &to_base,
+                    can_gc,
                 ));
             },
             Views::Cubemap(front, left, right, top, bottom, back) => {
@@ -95,8 +122,17 @@ impl XRViewerPose {
                     XREye::None,
                     0,
                     &to_base,
+                    can_gc,
                 ));
-                views.push(XRView::new(global, session, left, XREye::None, 1, &to_base));
+                views.push(XRView::new(
+                    global,
+                    session,
+                    left,
+                    XREye::None,
+                    1,
+                    &to_base,
+                    can_gc,
+                ));
                 views.push(XRView::new(
                     global,
                     session,
@@ -104,8 +140,17 @@ impl XRViewerPose {
                     XREye::None,
                     2,
                     &to_base,
+                    can_gc,
                 ));
-                views.push(XRView::new(global, session, top, XREye::None, 3, &to_base));
+                views.push(XRView::new(
+                    global,
+                    session,
+                    top,
+                    XREye::None,
+                    3,
+                    &to_base,
+                    can_gc,
+                ));
                 views.push(XRView::new(
                     global,
                     session,
@@ -113,13 +158,22 @@ impl XRViewerPose {
                     XREye::None,
                     4,
                     &to_base,
+                    can_gc,
                 ));
-                views.push(XRView::new(global, session, back, XREye::None, 5, &to_base));
+                views.push(XRView::new(
+                    global,
+                    session,
+                    back,
+                    XREye::None,
+                    5,
+                    &to_base,
+                    can_gc,
+                ));
             },
         };
         let transform: RigidTransform3D<f32, Viewer, BaseSpace> =
             viewer_pose.transform.then(&to_base);
-        let transform = XRRigidTransform::new(global, cast_transform(transform));
+        let transform = XRRigidTransform::new(global, cast_transform(transform), can_gc);
         let pose = reflect_dom_object(Box::new(XRViewerPose::new_inherited(&transform)), global);
 
         let cx = GlobalScope::get_cx();


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

**File Changes**: 
Replaced `CanGc::note()` calls in these files + made required entries in `Bindings.conf`

1. `components/script/dom/urlsearchparams.rs`
2. `components/script/dom/submitevent.rs`
3. `components/script/dom/webglcontextevent.rs`
4. `components/script/dom/rtcdatachannelevent.rs`
5. `components/script/dom/rtcicecandidate.rs`
6. `components/script/dom/xrrigidtransform.rs`
7. `components/script/dom/messageevent.rs`

**Files that couldn't be changed**:
1. `components/script/dom/htmlmediaelement.rs` - all inside `VirtualMethods`
2. `components/script/dom/globalscope.rs` - inside `!task`
3. `components/script/dom/htmlsourceelement.rs`- all inside `VirtualMethods` or `FetchResponseListener`

**Note**:
I'm not so sure about this PR please check the fixes made through the propagation of the CanGc fix from `messageevent.rs` line 161 `CanGc::note()`, while fixing that there were changes that led to adding few `CanGc::note()` inside `!task` and in calls within `FetchResponseListener` (NO FUNCTION PARAMETERS WERE ADDED/MODIFIED)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #33683

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because they do not modify functionality

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
