### PR TITLE
Some CanGc fixes in `components/script/dom`

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -1817,7 +1817,11 @@ impl Document {
     }
 
     /// The entry point for all key processing for web content
-    pub fn dispatch_key_event(&self, keyboard_event: ::keyboard_types::KeyboardEvent) {
+    pub fn dispatch_key_event(
+        &self,
+        keyboard_event: ::keyboard_types::KeyboardEvent,
+        can_gc: CanGc,
+    ) {
         let focused = self.get_focused_element();
         let body = self.GetBody();
 
@@ -1842,6 +1846,7 @@ impl Document {
             keyboard_event.modifiers,
             0,
             keyboard_event.key.legacy_keycode(),
+            can_gc,
         );
         let event = keyevent.upcast::<Event>();
         event.fire(target);
@@ -1869,6 +1874,7 @@ impl Document {
                 keyboard_event.modifiers,
                 keyboard_event.key.legacy_charcode(),
                 0,
+                can_gc,
             );
             let ev = event.upcast::<Event>();
             ev.fire(target);
@@ -4677,6 +4683,7 @@ impl DocumentMethods for Document {
             ))),
             "keyboardevent" => Ok(DomRoot::upcast(KeyboardEvent::new_uninitialized(
                 &self.window,
+                can_gc,
             ))),
             "messageevent" => Ok(DomRoot::upcast(MessageEvent::new_uninitialized(
                 self.window.upcast(),

--- a/components/script/dom/keyboardevent.rs
+++ b/components/script/dom/keyboardevent.rs
@@ -54,8 +54,8 @@ impl KeyboardEvent {
         }
     }
 
-    pub fn new_uninitialized(window: &Window) -> DomRoot<KeyboardEvent> {
-        Self::new_uninitialized_with_proto(window, None, CanGc::note())
+    pub fn new_uninitialized(window: &Window, can_gc: CanGc) -> DomRoot<KeyboardEvent> {
+        Self::new_uninitialized_with_proto(window, None, can_gc)
     }
 
     fn new_uninitialized_with_proto(
@@ -87,6 +87,7 @@ impl KeyboardEvent {
         modifiers: Modifiers,
         char_code: u32,
         key_code: u32,
+        can_gc: CanGc,
     ) -> DomRoot<KeyboardEvent> {
         Self::new_with_proto(
             window,
@@ -104,7 +105,7 @@ impl KeyboardEvent {
             modifiers,
             char_code,
             key_code,
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/rtcpeerconnection.rs
+++ b/components/script/dom/rtcpeerconnection.rs
@@ -290,7 +290,14 @@ impl RTCPeerConnection {
             return;
         }
         let track = MediaStreamTrack::new(&self.global(), id, ty);
-        let event = RTCTrackEvent::new(&self.global(), atom!("track"), false, false, &track);
+        let event = RTCTrackEvent::new(
+            &self.global(),
+            atom!("track"),
+            false,
+            false,
+            &track,
+            CanGc::note(),
+        );
         event.upcast::<Event>().fire(self.upcast());
     }
 

--- a/components/script/dom/rtctrackevent.rs
+++ b/components/script/dom/rtctrackevent.rs
@@ -40,16 +40,9 @@ impl RTCTrackEvent {
         bubbles: bool,
         cancelable: bool,
         track: &MediaStreamTrack,
+        can_gc: CanGc,
     ) -> DomRoot<RTCTrackEvent> {
-        Self::new_with_proto(
-            global,
-            None,
-            type_,
-            bubbles,
-            cancelable,
-            track,
-            CanGc::note(),
-        )
+        Self::new_with_proto(global, None, type_, bubbles, cancelable, track, can_gc)
     }
 
     fn new_with_proto(

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1624,7 +1624,7 @@ impl ScriptThread {
                 },
 
                 CompositorEvent::KeyboardEvent(key_event) => {
-                    document.dispatch_key_event(key_event);
+                    document.dispatch_key_event(key_event, can_gc);
                 },
 
                 CompositorEvent::IMEDismissedEvent => {


### PR DESCRIPTION
Replaces CanGc::note() calls with arguments passed by callers in `components/script/dom/rtctrackevent.rs` and `components/script/dom/keyboardevent.rs`


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are a part of #33683 
- [X] These changes do not require tests because they do not modify functionality

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
