### PR TITLE
Prevent moving CanGc values between threads/tasks

### DIFF
--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -333,7 +333,6 @@ impl DedicatedWorkerGlobalScope {
         gpu_id_hub: Arc<IdentityHub>,
         control_receiver: Receiver<DedicatedWorkerControlMsg>,
         context_sender: Sender<ThreadSafeJSContext>,
-        can_gc: CanGc,
     ) -> JoinHandle<()> {
         let serialized_worker_url = worker_url.to_string();
         let top_level_browsing_context_id = TopLevelBrowsingContextId::installed();
@@ -479,7 +478,7 @@ impl DedicatedWorkerGlobalScope {
                             // until the event loop is destroyed,
                             // which happens after the closing flag is set to true.
                             while !scope.is_closing() {
-                                run_worker_event_loop(&*global, Some(&worker), can_gc);
+                                run_worker_event_loop(&*global, Some(&worker), CanGc::note());
                             }
                         },
                         reporter_name,

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -694,7 +694,7 @@ impl Document {
         self.activity.get() != DocumentActivity::Inactive
     }
 
-    pub fn set_activity(&self, activity: DocumentActivity, can_gc: CanGc) {
+    pub fn set_activity(&self, activity: DocumentActivity) {
         // This function should only be called on documents with a browsing context
         assert!(self.has_browsing_context);
         if activity == self.activity.get() {
@@ -752,7 +752,7 @@ impl Document {
                         false, // bubbles
                         false, // cancelable
                         true, // persisted
-                        can_gc,
+                        CanGc::note(),
                     );
                     let event = event.upcast::<Event>();
                     event.set_trusted(true);
@@ -2379,7 +2379,7 @@ impl Document {
     }
 
     // https://html.spec.whatwg.org/multipage/#the-end
-    pub fn maybe_queue_document_completion(&self, can_gc: CanGc) {
+    pub fn maybe_queue_document_completion(&self) {
         // https://html.spec.whatwg.org/multipage/#delaying-load-events-mode
         let is_in_delaying_load_events_mode = match self.window.undiscarded_window_proxy() {
             Some(window_proxy) => window_proxy.is_delaying_load_events_mode(),
@@ -2429,7 +2429,7 @@ impl Document {
                         atom!("load"),
                         EventBubbles::DoesNotBubble,
                         EventCancelable::NotCancelable,
-                        can_gc,
+                        CanGc::note(),
                     );
                     event.set_trusted(true);
 
@@ -2472,7 +2472,7 @@ impl Document {
                             false, // bubbles
                             false, // cancelable
                             false, // persisted
-                            can_gc,
+                            CanGc::note(),
                         );
                         let event = event.upcast::<Event>();
                         event.set_trusted(true);

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -3185,7 +3185,7 @@ impl GlobalScope {
         }
     }
 
-    pub fn handle_gamepad_event(&self, gamepad_event: GamepadEvent, can_gc: CanGc) {
+    pub fn handle_gamepad_event(&self, gamepad_event: GamepadEvent) {
         match gamepad_event {
             GamepadEvent::Connected(index, name, bounds, supported_haptic_effects) => {
                 self.handle_gamepad_connect(
@@ -3194,7 +3194,6 @@ impl GlobalScope {
                     bounds.axis_bounds,
                     bounds.button_bounds,
                     supported_haptic_effects,
-                    can_gc,
                 );
             },
             GamepadEvent::Disconnected(index) => {
@@ -3207,7 +3206,7 @@ impl GlobalScope {
     }
 
     /// <https://www.w3.org/TR/gamepad/#dfn-gamepadconnected>
-    pub fn handle_gamepad_connect(
+    fn handle_gamepad_connect(
         &self,
         // As the spec actually defines how to set the gamepad index, the GilRs index
         // is currently unused, though in practice it will almost always be the same.
@@ -3217,7 +3216,6 @@ impl GlobalScope {
         axis_bounds: (f64, f64),
         button_bounds: (f64, f64),
         supported_haptic_effects: GamepadSupportedHapticEffects,
-        can_gc: CanGc,
     ) {
         // TODO: 2. If document is not null and is not allowed to use the "gamepad" permission,
         //          then abort these steps.
@@ -3239,7 +3237,7 @@ impl GlobalScope {
                             button_bounds,
                             supported_haptic_effects,
                             false,
-                            can_gc,
+                            CanGc::note(),
                         );
                         navigator.set_gamepad(selected_index as usize, &gamepad);
                     }

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -516,12 +516,7 @@ impl HTMLImageElement {
                 });
                 self.pending_request.borrow_mut().final_url = Some(url);
                 self.pending_request.borrow_mut().image = Some(image);
-                self.finish_reacting_to_environment_change(
-                    src,
-                    generation,
-                    selected_pixel_density,
-                    can_gc,
-                );
+                self.finish_reacting_to_environment_change(src, generation, selected_pixel_density);
             },
             ImageResponse::MetadataLoaded(meta) => {
                 self.pending_request.borrow_mut().metadata = Some(meta);
@@ -1067,7 +1062,6 @@ impl HTMLImageElement {
             elem: &HTMLImageElement,
             selected_source: String,
             selected_pixel_density: f64,
-            can_gc: CanGc,
         ) -> IpcSender<PendingImageResponse> {
             let trusted_node = Trusted::new(elem);
             let (responder_sender, responder_receiver) = ipc::channel().unwrap();
@@ -1094,7 +1088,7 @@ impl HTMLImageElement {
                             if generation == element.generation.get() {
                                 element.process_image_response_for_environment_change(image.response,
                                     USVString::from(selected_source_clone), generation,
-                                    selected_pixel_density, can_gc);
+                                    selected_pixel_density, CanGc::note());
                             }
                         }),
                         &canceller,
@@ -1160,7 +1154,6 @@ impl HTMLImageElement {
             self,
             selected_source.0.clone(),
             selected_pixel_density,
-            can_gc,
         );
         let cache_result = image_cache.track_image(
             img_url.clone(),
@@ -1177,7 +1170,6 @@ impl HTMLImageElement {
                     selected_source,
                     generation,
                     selected_pixel_density,
-                    can_gc,
                 )
             },
             ImageCacheResult::Available(ImageOrMetadataAvailable::MetadataAvailable(m)) => {
@@ -1251,7 +1243,6 @@ impl HTMLImageElement {
         src: USVString,
         generation: u32,
         selected_pixel_density: f64,
-        can_gc: CanGc,
     ) {
         let this = Trusted::new(self);
         let window = window_from_node(self);
@@ -1262,7 +1253,7 @@ impl HTMLImageElement {
                 let relevant_mutation = this.generation.get() != generation;
                 // Step 15.1
                 if relevant_mutation {
-                    this.abort_request(State::Unavailable, ImageRequestPhase::Pending, can_gc);
+                    this.abort_request(State::Unavailable, ImageRequestPhase::Pending, CanGc::note());
                     return;
                 }
                 // Step 15.2
@@ -1280,7 +1271,7 @@ impl HTMLImageElement {
 
                     // Step 15.5
                     mem::swap(&mut this.current_request.borrow_mut(), &mut pending_request);
-                    this.abort_request(State::Unavailable, ImageRequestPhase::Pending, can_gc);
+                    this.abort_request(State::Unavailable, ImageRequestPhase::Pending, CanGc::note());
                 }
 
                 // Step 15.6

--- a/components/script/dom/serviceworkerglobalscope.rs
+++ b/components/script/dom/serviceworkerglobalscope.rs
@@ -294,7 +294,6 @@ impl ServiceWorkerGlobalScope {
         control_receiver: Receiver<ServiceWorkerControlMsg>,
         context_sender: Sender<ThreadSafeJSContext>,
         closing: Arc<AtomicBool>,
-        can_gc: CanGc,
     ) -> JoinHandle<()> {
         let ScopeThings {
             script_url,
@@ -384,7 +383,7 @@ impl ServiceWorkerGlobalScope {
                     scope.execute_script(DOMString::from(source));
                 }
 
-                global.dispatch_activate(can_gc);
+                global.dispatch_activate(CanGc::note());
                 let reporter_name = format!("service-worker-reporter-{}", random::<u64>());
                 scope
                     .upcast::<GlobalScope>()
@@ -398,7 +397,7 @@ impl ServiceWorkerGlobalScope {
                             // which happens after the closing flag is set to true,
                             // or until the worker has run beyond its allocated time.
                             while !scope.is_closing() && !global.has_timed_out() {
-                                run_worker_event_loop(&*global, None, can_gc);
+                                run_worker_event_loop(&*global, None, CanGc::note());
                             }
                         },
                         reporter_name,

--- a/components/script/dom/worker.rs
+++ b/components/script/dom/worker.rs
@@ -232,7 +232,6 @@ impl WorkerMethods for Worker {
             global.wgpu_id_hub(),
             control_receiver,
             context_sender,
-            can_gc,
         );
 
         let context = context_receiver

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -1115,10 +1115,17 @@ impl Runnable {
 }
 
 #[derive(Clone, Copy, Debug)]
-pub struct CanGc(());
+/// A compile-time marker that there are operations that could trigger a JS garbage collection
+/// operation within the current stack frame. It is trivially copyable, so it should be passed
+/// as a function argument and reused when calling other functions whenever possible. Since it
+/// is only meaningful within the current stack frame, it is impossible to move it to a different
+/// thread or into a task that will execute asynchronously.
+pub struct CanGc(std::marker::PhantomData<*mut ()>);
 
 impl CanGc {
+    /// Create a new CanGc value, representing that a GC operation is possible within the
+    /// current stack frame.
     pub fn note() -> CanGc {
-        CanGc(())
+        CanGc(std::marker::PhantomData)
     }
 }

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1637,7 +1637,7 @@ impl ScriptThread {
 
                 CompositorEvent::GamepadEvent(gamepad_event) => {
                     let global = window.upcast::<GlobalScope>();
-                    global.handle_gamepad_event(gamepad_event, can_gc);
+                    global.handle_gamepad_event(gamepad_event);
                 },
             }
         }
@@ -2034,7 +2034,7 @@ impl ScriptThread {
             let mut docs = self.docs_with_no_blocking_loads.borrow_mut();
             for document in docs.iter() {
                 let _realm = enter_realm(&**document);
-                document.maybe_queue_document_completion(can_gc);
+                document.maybe_queue_document_completion();
 
                 // Document load is a rendering opportunity.
                 ScriptThread::note_rendering_opportunity(document.window().pipeline_id());
@@ -2331,7 +2331,7 @@ impl ScriptThread {
                 self.handle_get_title_msg(pipeline_id)
             },
             ConstellationControlMsg::SetDocumentActivity(pipeline_id, activity) => {
-                self.handle_set_document_activity_msg(pipeline_id, activity, can_gc)
+                self.handle_set_document_activity_msg(pipeline_id, activity)
             },
             ConstellationControlMsg::SetThrottled(pipeline_id, throttled) => {
                 self.handle_set_throttled_msg(pipeline_id, throttled)
@@ -3003,12 +3003,7 @@ impl ScriptThread {
     }
 
     /// Handles activity change message
-    fn handle_set_document_activity_msg(
-        &self,
-        id: PipelineId,
-        activity: DocumentActivity,
-        can_gc: CanGc,
-    ) {
+    fn handle_set_document_activity_msg(&self, id: PipelineId, activity: DocumentActivity) {
         debug!(
             "Setting activity of {} to be {:?} in {:?}.",
             id,
@@ -3017,7 +3012,7 @@ impl ScriptThread {
         );
         let document = self.documents.borrow().find_document(id);
         if let Some(document) = document {
-            document.set_activity(activity, can_gc);
+            document.set_activity(activity);
             return;
         }
         let mut loads = self.incomplete_loads.borrow_mut();


### PR DESCRIPTION
This change prevents a common misuse of CanGc. If the only use of a value is within a queued task or inside of a spawned thread, it should start a new propagated chain within that context instead of reusing a value from the initiator.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they are compile-time only.