### PR TITLE
Fix GC borrow hazard in HTMLImageElement::finish_reacting_to_environment_change

### DIFF
--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -1272,7 +1272,7 @@ impl HTMLImageElement {
                     // Step 15.5
                     mem::swap(&mut this.current_request.borrow_mut(), &mut pending_request);
                 }
-                this.abort_request(State::Unavailable, ImageRequestPhase::Pending, can_gc);
+                this.abort_request(State::Unavailable, ImageRequestPhase::Pending, CanGc::note());
 
                 // Step 15.6
                 this.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -1280,8 +1280,8 @@ impl HTMLImageElement {
 
                     // Step 15.5
                     mem::swap(&mut this.current_request.borrow_mut(), &mut pending_request);
-                    this.abort_request(State::Unavailable, ImageRequestPhase::Pending, can_gc);
                 }
+                this.abort_request(State::Unavailable, ImageRequestPhase::Pending, can_gc);
 
                 // Step 15.6
                 this.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);


### PR DESCRIPTION
**File:** `components/script/dom/htmlimageelement.rs`

**PR Description**


**Issue:** 
We’re holding a field of `HTMLImageElement` at [line 1272](https://github.com/servo/servo/blob/main/components/script/dom/htmlimageelement.rs#L1272), then calling a method at [line 1283](https://github.com/servo/servo/blob/main/components/script/dom/htmlimageelement.rs#L1283) that could trigger garbage collection while still using it. To fix this, we should move the `abort_request` call outside the existing block to shorten the borrow time.

**Changes:** 
Moved the `abort_request` call outside of the existing block to reduce the duration of the mutable borrow.  

**Impact:** 
This change prevents potential issues with memory safety during garbage collection.



---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix https://github.com/servo/servo/issues/33903

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because they do not touch functionality.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
