### PR TITLE
Remove BoxFragment::overconstrained

### DIFF
--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -533,10 +533,6 @@ impl HoistedAbsolutelyPositionedBox {
             alignment: block_alignment,
             flip_anchor: false,
         };
-        let overconstrained = LogicalVec2 {
-            inline: inline_axis_solver.is_overconstrained_for_size(computed_size.inline),
-            block: block_axis_solver.is_overconstrained_for_size(computed_size.block),
-        };
 
         let mut inline_axis = inline_axis_solver.solve_for_size(computed_size.inline);
         let mut block_axis = block_axis_solver.solve_for_size(computed_size.block);
@@ -739,10 +735,7 @@ impl HoistedAbsolutelyPositionedBox {
             block_axis_solver.solve_alignment(margin_box_rect, &mut content_rect);
             inline_axis_solver.solve_alignment(margin_box_rect, &mut content_rect);
 
-            let physical_overconstrained =
-                overconstrained.to_physical_size(containing_block.style.writing_mode);
-
-            BoxFragment::new_with_overconstrained(
+            BoxFragment::new(
                 absolutely_positioned_box.context.base_fragment_info(),
                 style,
                 fragments,
@@ -754,7 +747,6 @@ impl HoistedAbsolutelyPositionedBox {
                 // We do not set the baseline offset, because absolutely positioned
                 // elements are not inflow.
                 CollapsedBlockMargins::zero(),
-                physical_overconstrained,
             )
         };
         positioning_context.layout_collected_children(layout_context, &mut new_fragment);
@@ -804,10 +796,6 @@ struct AbsoluteBoxOffsets<'a> {
 }
 
 impl AbsoluteBoxOffsets<'_> {
-    pub(crate) fn both_specified(&self) -> bool {
-        !self.start.is_auto() && !self.end.is_auto()
-    }
-
     pub(crate) fn either_specified(&self) -> bool {
         !self.start.is_auto() || !self.end.is_auto()
     }
@@ -929,13 +917,6 @@ impl<'a> AbsoluteAxisSolver<'a> {
                 }
             },
         }
-    }
-
-    fn is_overconstrained_for_size(&self, computed_size: AuOrAuto) -> bool {
-        !computed_size.is_auto() &&
-            self.box_offsets.both_specified() &&
-            !self.computed_margin_start.is_auto() &&
-            !self.computed_margin_end.is_auto()
     }
 
     fn origin_for_alignment_or_justification(&self, margin_box_axis: RectAxis) -> Option<Au> {

--- a/tests/wpt/meta/css/cssom/getComputedStyle-insets-absolute.html.ini
+++ b/tests/wpt/meta/css/cssom/getComputedStyle-insets-absolute.html.ini
@@ -2,46 +2,19 @@
   [vertical-lr ltr inside vertical-lr ltr - If opposite sides are 'auto', they resolve to used value]
     expected: FAIL
 
-  [horizontal-tb rtl inside vertical-rl rtl - Percentages absolutize the computed value when overconstrained]
-    expected: FAIL
-
-  [horizontal-tb ltr inside vertical-lr rtl - Percentages absolutize the computed value when overconstrained]
-    expected: FAIL
-
-  [vertical-rl rtl inside vertical-lr rtl - Percentages absolutize the computed value when overconstrained]
-    expected: FAIL
-
   [vertical-lr rtl inside vertical-rl ltr - If opposite sides are 'auto', they resolve to used value]
-    expected: FAIL
-
-  [vertical-lr rtl inside horizontal-tb rtl - Percentages absolutize the computed value when overconstrained]
     expected: FAIL
 
   [vertical-lr ltr inside horizontal-tb rtl - If opposite sides are 'auto', they resolve to used value]
     expected: FAIL
 
-  [vertical-rl rtl inside vertical-lr ltr - Percentages absolutize the computed value when overconstrained]
-    expected: FAIL
-
   [vertical-lr rtl inside horizontal-tb rtl - If opposite sides are 'auto', they resolve to used value]
-    expected: FAIL
-
-  [vertical-rl rtl inside vertical-rl ltr - Percentages absolutize the computed value when overconstrained]
-    expected: FAIL
-
-  [horizontal-tb ltr inside horizontal-tb rtl - Percentages absolutize the computed value when overconstrained]
     expected: FAIL
 
   [horizontal-tb rtl inside vertical-rl ltr - If opposite sides are 'auto', they resolve to used value]
     expected: FAIL
 
-  [vertical-lr rtl inside vertical-lr rtl - Percentages absolutize the computed value when overconstrained]
-    expected: FAIL
-
   [horizontal-tb ltr inside vertical-rl ltr - If opposite sides are 'auto', they resolve to used value]
-    expected: FAIL
-
-  [horizontal-tb rtl inside vertical-lr rtl - Percentages absolutize the computed value when overconstrained]
     expected: FAIL
 
   [vertical-rl ltr inside vertical-rl ltr - If opposite sides are 'auto', they resolve to used value]
@@ -53,34 +26,16 @@
   [vertical-rl ltr inside horizontal-tb rtl - If opposite sides are 'auto', they resolve to used value]
     expected: FAIL
 
-  [vertical-lr ltr inside horizontal-tb ltr - Percentages absolutize the computed value when overconstrained]
-    expected: FAIL
-
   [vertical-rl rtl inside vertical-lr ltr - If opposite sides are 'auto', they resolve to used value]
     expected: FAIL
 
-  [vertical-lr ltr inside vertical-lr rtl - Percentages absolutize the computed value when overconstrained]
-    expected: FAIL
-
   [vertical-lr ltr inside vertical-rl rtl - If opposite sides are 'auto', they resolve to used value]
-    expected: FAIL
-
-  [vertical-rl ltr inside vertical-rl rtl - Percentages absolutize the computed value when overconstrained]
-    expected: FAIL
-
-  [vertical-rl ltr inside vertical-lr rtl - Percentages absolutize the computed value when overconstrained]
-    expected: FAIL
-
-  [vertical-lr ltr inside horizontal-tb rtl - Percentages absolutize the computed value when overconstrained]
     expected: FAIL
 
   [horizontal-tb ltr inside horizontal-tb rtl - If opposite sides are 'auto', they resolve to used value]
     expected: FAIL
 
   [horizontal-tb ltr inside horizontal-tb ltr - If opposite sides are 'auto', they resolve to used value]
-    expected: FAIL
-
-  [vertical-rl ltr inside vertical-lr ltr - Percentages absolutize the computed value when overconstrained]
     expected: FAIL
 
   [vertical-rl ltr inside vertical-lr rtl - If opposite sides are 'auto', they resolve to used value]
@@ -92,13 +47,7 @@
   [horizontal-tb rtl inside vertical-lr ltr - If opposite sides are 'auto', they resolve to used value]
     expected: FAIL
 
-  [vertical-lr rtl inside vertical-lr ltr - Percentages absolutize the computed value when overconstrained]
-    expected: FAIL
-
   [vertical-rl ltr inside vertical-rl rtl - If opposite sides are 'auto', they resolve to used value]
-    expected: FAIL
-
-  [vertical-rl ltr inside horizontal-tb ltr - Percentages absolutize the computed value when overconstrained]
     expected: FAIL
 
   [horizontal-tb rtl inside vertical-lr rtl - If opposite sides are 'auto', they resolve to used value]
@@ -107,40 +56,16 @@
   [horizontal-tb rtl inside horizontal-tb ltr - If opposite sides are 'auto', they resolve to used value]
     expected: FAIL
 
-  [vertical-rl rtl inside vertical-rl rtl - Percentages absolutize the computed value when overconstrained]
-    expected: FAIL
-
-  [vertical-lr ltr inside vertical-rl ltr - Percentages absolutize the computed value when overconstrained]
-    expected: FAIL
-
   [horizontal-tb ltr inside vertical-rl rtl - If opposite sides are 'auto', they resolve to used value]
     expected: FAIL
 
-  [vertical-lr ltr inside vertical-rl rtl - Percentages absolutize the computed value when overconstrained]
-    expected: FAIL
-
   [vertical-lr ltr inside horizontal-tb ltr - If opposite sides are 'auto', they resolve to used value]
-    expected: FAIL
-
-  [vertical-rl rtl inside horizontal-tb ltr - Percentages absolutize the computed value when overconstrained]
-    expected: FAIL
-
-  [vertical-rl rtl inside horizontal-tb rtl - Percentages absolutize the computed value when overconstrained]
-    expected: FAIL
-
-  [horizontal-tb rtl inside vertical-rl ltr - Percentages absolutize the computed value when overconstrained]
     expected: FAIL
 
   [vertical-lr ltr inside vertical-rl ltr - If opposite sides are 'auto', they resolve to used value]
     expected: FAIL
 
   [vertical-lr rtl inside horizontal-tb ltr - If opposite sides are 'auto', they resolve to used value]
-    expected: FAIL
-
-  [vertical-lr rtl inside vertical-rl ltr - Percentages absolutize the computed value when overconstrained]
-    expected: FAIL
-
-  [vertical-rl ltr inside vertical-rl ltr - Percentages absolutize the computed value when overconstrained]
     expected: FAIL
 
   [vertical-rl rtl inside horizontal-tb rtl - If opposite sides are 'auto', they resolve to used value]
@@ -152,22 +77,10 @@
   [vertical-lr rtl inside vertical-lr ltr - If opposite sides are 'auto', they resolve to used value]
     expected: FAIL
 
-  [horizontal-tb ltr inside vertical-lr ltr - Percentages absolutize the computed value when overconstrained]
-    expected: FAIL
-
   [vertical-rl rtl inside horizontal-tb ltr - If opposite sides are 'auto', they resolve to used value]
     expected: FAIL
 
-  [vertical-lr ltr inside vertical-lr ltr - Percentages absolutize the computed value when overconstrained]
-    expected: FAIL
-
-  [vertical-lr rtl inside vertical-rl rtl - Percentages absolutize the computed value when overconstrained]
-    expected: FAIL
-
   [vertical-rl rtl inside vertical-rl ltr - If opposite sides are 'auto', they resolve to used value]
-    expected: FAIL
-
-  [vertical-rl ltr inside horizontal-tb rtl - Percentages absolutize the computed value when overconstrained]
     expected: FAIL
 
   [vertical-lr ltr inside vertical-lr rtl - If opposite sides are 'auto', they resolve to used value]
@@ -176,25 +89,13 @@
   [horizontal-tb ltr inside vertical-lr ltr - If opposite sides are 'auto', they resolve to used value]
     expected: FAIL
 
-  [vertical-lr rtl inside horizontal-tb ltr - Percentages absolutize the computed value when overconstrained]
-    expected: FAIL
-
   [vertical-rl ltr inside vertical-lr ltr - If opposite sides are 'auto', they resolve to used value]
     expected: FAIL
 
   [vertical-lr rtl inside vertical-rl rtl - If opposite sides are 'auto', they resolve to used value]
     expected: FAIL
 
-  [horizontal-tb rtl inside horizontal-tb rtl - Percentages absolutize the computed value when overconstrained]
-    expected: FAIL
-
-  [horizontal-tb ltr inside horizontal-tb ltr - Percentages absolutize the computed value when overconstrained]
-    expected: FAIL
-
   [horizontal-tb ltr inside vertical-lr rtl - If opposite sides are 'auto', they resolve to used value]
-    expected: FAIL
-
-  [horizontal-tb rtl inside vertical-lr ltr - Percentages absolutize the computed value when overconstrained]
     expected: FAIL
 
   [vertical-rl rtl inside vertical-lr rtl - If opposite sides are 'auto', they resolve to used value]
@@ -203,14 +104,5 @@
   [vertical-rl rtl inside vertical-rl rtl - If opposite sides are 'auto', they resolve to used value]
     expected: FAIL
 
-  [horizontal-tb ltr inside vertical-rl rtl - Percentages absolutize the computed value when overconstrained]
-    expected: FAIL
-
-  [horizontal-tb rtl inside horizontal-tb ltr - Percentages absolutize the computed value when overconstrained]
-    expected: FAIL
-
   [horizontal-tb rtl inside horizontal-tb rtl - If opposite sides are 'auto', they resolve to used value]
-    expected: FAIL
-
-  [horizontal-tb ltr inside vertical-rl ltr - Percentages absolutize the computed value when overconstrained]
     expected: FAIL

--- a/tests/wpt/meta/css/cssom/getComputedStyle-insets-fixed.html.ini
+++ b/tests/wpt/meta/css/cssom/getComputedStyle-insets-fixed.html.ini
@@ -2,46 +2,19 @@
   [vertical-lr ltr inside vertical-lr ltr - If opposite sides are 'auto', they resolve to used value]
     expected: FAIL
 
-  [horizontal-tb rtl inside vertical-rl rtl - Percentages absolutize the computed value when overconstrained]
-    expected: FAIL
-
-  [horizontal-tb ltr inside vertical-lr rtl - Percentages absolutize the computed value when overconstrained]
-    expected: FAIL
-
-  [vertical-rl rtl inside vertical-lr rtl - Percentages absolutize the computed value when overconstrained]
-    expected: FAIL
-
   [vertical-lr rtl inside vertical-rl ltr - If opposite sides are 'auto', they resolve to used value]
-    expected: FAIL
-
-  [vertical-lr rtl inside horizontal-tb rtl - Percentages absolutize the computed value when overconstrained]
     expected: FAIL
 
   [vertical-lr ltr inside horizontal-tb rtl - If opposite sides are 'auto', they resolve to used value]
     expected: FAIL
 
-  [vertical-rl rtl inside vertical-lr ltr - Percentages absolutize the computed value when overconstrained]
-    expected: FAIL
-
   [vertical-lr rtl inside horizontal-tb rtl - If opposite sides are 'auto', they resolve to used value]
-    expected: FAIL
-
-  [vertical-rl rtl inside vertical-rl ltr - Percentages absolutize the computed value when overconstrained]
-    expected: FAIL
-
-  [horizontal-tb ltr inside horizontal-tb rtl - Percentages absolutize the computed value when overconstrained]
     expected: FAIL
 
   [horizontal-tb rtl inside vertical-rl ltr - If opposite sides are 'auto', they resolve to used value]
     expected: FAIL
 
-  [vertical-lr rtl inside vertical-lr rtl - Percentages absolutize the computed value when overconstrained]
-    expected: FAIL
-
   [horizontal-tb ltr inside vertical-rl ltr - If opposite sides are 'auto', they resolve to used value]
-    expected: FAIL
-
-  [horizontal-tb rtl inside vertical-lr rtl - Percentages absolutize the computed value when overconstrained]
     expected: FAIL
 
   [vertical-rl ltr inside vertical-rl ltr - If opposite sides are 'auto', they resolve to used value]
@@ -53,34 +26,16 @@
   [vertical-rl ltr inside horizontal-tb rtl - If opposite sides are 'auto', they resolve to used value]
     expected: FAIL
 
-  [vertical-lr ltr inside horizontal-tb ltr - Percentages absolutize the computed value when overconstrained]
-    expected: FAIL
-
   [vertical-rl rtl inside vertical-lr ltr - If opposite sides are 'auto', they resolve to used value]
     expected: FAIL
 
-  [vertical-lr ltr inside vertical-lr rtl - Percentages absolutize the computed value when overconstrained]
-    expected: FAIL
-
   [vertical-lr ltr inside vertical-rl rtl - If opposite sides are 'auto', they resolve to used value]
-    expected: FAIL
-
-  [vertical-rl ltr inside vertical-rl rtl - Percentages absolutize the computed value when overconstrained]
-    expected: FAIL
-
-  [vertical-rl ltr inside vertical-lr rtl - Percentages absolutize the computed value when overconstrained]
-    expected: FAIL
-
-  [vertical-lr ltr inside horizontal-tb rtl - Percentages absolutize the computed value when overconstrained]
     expected: FAIL
 
   [horizontal-tb ltr inside horizontal-tb rtl - If opposite sides are 'auto', they resolve to used value]
     expected: FAIL
 
   [horizontal-tb ltr inside horizontal-tb ltr - If opposite sides are 'auto', they resolve to used value]
-    expected: FAIL
-
-  [vertical-rl ltr inside vertical-lr ltr - Percentages absolutize the computed value when overconstrained]
     expected: FAIL
 
   [vertical-rl ltr inside vertical-lr rtl - If opposite sides are 'auto', they resolve to used value]
@@ -92,13 +47,7 @@
   [horizontal-tb rtl inside vertical-lr ltr - If opposite sides are 'auto', they resolve to used value]
     expected: FAIL
 
-  [vertical-lr rtl inside vertical-lr ltr - Percentages absolutize the computed value when overconstrained]
-    expected: FAIL
-
   [vertical-rl ltr inside vertical-rl rtl - If opposite sides are 'auto', they resolve to used value]
-    expected: FAIL
-
-  [vertical-rl ltr inside horizontal-tb ltr - Percentages absolutize the computed value when overconstrained]
     expected: FAIL
 
   [horizontal-tb rtl inside vertical-lr rtl - If opposite sides are 'auto', they resolve to used value]
@@ -107,40 +56,16 @@
   [horizontal-tb rtl inside horizontal-tb ltr - If opposite sides are 'auto', they resolve to used value]
     expected: FAIL
 
-  [vertical-rl rtl inside vertical-rl rtl - Percentages absolutize the computed value when overconstrained]
-    expected: FAIL
-
-  [vertical-lr ltr inside vertical-rl ltr - Percentages absolutize the computed value when overconstrained]
-    expected: FAIL
-
   [horizontal-tb ltr inside vertical-rl rtl - If opposite sides are 'auto', they resolve to used value]
     expected: FAIL
 
-  [vertical-lr ltr inside vertical-rl rtl - Percentages absolutize the computed value when overconstrained]
-    expected: FAIL
-
   [vertical-lr ltr inside horizontal-tb ltr - If opposite sides are 'auto', they resolve to used value]
-    expected: FAIL
-
-  [vertical-rl rtl inside horizontal-tb ltr - Percentages absolutize the computed value when overconstrained]
-    expected: FAIL
-
-  [vertical-rl rtl inside horizontal-tb rtl - Percentages absolutize the computed value when overconstrained]
-    expected: FAIL
-
-  [horizontal-tb rtl inside vertical-rl ltr - Percentages absolutize the computed value when overconstrained]
     expected: FAIL
 
   [vertical-lr ltr inside vertical-rl ltr - If opposite sides are 'auto', they resolve to used value]
     expected: FAIL
 
   [vertical-lr rtl inside horizontal-tb ltr - If opposite sides are 'auto', they resolve to used value]
-    expected: FAIL
-
-  [vertical-lr rtl inside vertical-rl ltr - Percentages absolutize the computed value when overconstrained]
-    expected: FAIL
-
-  [vertical-rl ltr inside vertical-rl ltr - Percentages absolutize the computed value when overconstrained]
     expected: FAIL
 
   [vertical-rl rtl inside horizontal-tb rtl - If opposite sides are 'auto', they resolve to used value]
@@ -152,22 +77,10 @@
   [vertical-lr rtl inside vertical-lr ltr - If opposite sides are 'auto', they resolve to used value]
     expected: FAIL
 
-  [horizontal-tb ltr inside vertical-lr ltr - Percentages absolutize the computed value when overconstrained]
-    expected: FAIL
-
   [vertical-rl rtl inside horizontal-tb ltr - If opposite sides are 'auto', they resolve to used value]
     expected: FAIL
 
-  [vertical-lr ltr inside vertical-lr ltr - Percentages absolutize the computed value when overconstrained]
-    expected: FAIL
-
-  [vertical-lr rtl inside vertical-rl rtl - Percentages absolutize the computed value when overconstrained]
-    expected: FAIL
-
   [vertical-rl rtl inside vertical-rl ltr - If opposite sides are 'auto', they resolve to used value]
-    expected: FAIL
-
-  [vertical-rl ltr inside horizontal-tb rtl - Percentages absolutize the computed value when overconstrained]
     expected: FAIL
 
   [vertical-lr ltr inside vertical-lr rtl - If opposite sides are 'auto', they resolve to used value]
@@ -176,25 +89,13 @@
   [horizontal-tb ltr inside vertical-lr ltr - If opposite sides are 'auto', they resolve to used value]
     expected: FAIL
 
-  [vertical-lr rtl inside horizontal-tb ltr - Percentages absolutize the computed value when overconstrained]
-    expected: FAIL
-
   [vertical-rl ltr inside vertical-lr ltr - If opposite sides are 'auto', they resolve to used value]
     expected: FAIL
 
   [vertical-lr rtl inside vertical-rl rtl - If opposite sides are 'auto', they resolve to used value]
     expected: FAIL
 
-  [horizontal-tb rtl inside horizontal-tb rtl - Percentages absolutize the computed value when overconstrained]
-    expected: FAIL
-
-  [horizontal-tb ltr inside horizontal-tb ltr - Percentages absolutize the computed value when overconstrained]
-    expected: FAIL
-
   [horizontal-tb ltr inside vertical-lr rtl - If opposite sides are 'auto', they resolve to used value]
-    expected: FAIL
-
-  [horizontal-tb rtl inside vertical-lr ltr - Percentages absolutize the computed value when overconstrained]
     expected: FAIL
 
   [vertical-rl rtl inside vertical-lr rtl - If opposite sides are 'auto', they resolve to used value]
@@ -203,14 +104,5 @@
   [vertical-rl rtl inside vertical-rl rtl - If opposite sides are 'auto', they resolve to used value]
     expected: FAIL
 
-  [horizontal-tb ltr inside vertical-rl rtl - Percentages absolutize the computed value when overconstrained]
-    expected: FAIL
-
-  [horizontal-tb rtl inside horizontal-tb ltr - Percentages absolutize the computed value when overconstrained]
-    expected: FAIL
-
   [horizontal-tb rtl inside horizontal-tb rtl - If opposite sides are 'auto', they resolve to used value]
-    expected: FAIL
-
-  [horizontal-tb ltr inside vertical-rl ltr - Percentages absolutize the computed value when overconstrained]
     expected: FAIL


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This was only used for serializing inset properties in getComputedStyle,
but it was unnecessary and the logic was wrong anyways: an `auto` size
doesn't imply that we won't be overconstrained, because it won't become
negative even if the insets are big enough.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
