### PR TITLE
remove sparkle from components/servo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4142,7 +4142,6 @@ dependencies = [
  "servo_config",
  "servo_geometry",
  "servo_url",
- "sparkle",
  "style",
  "style_traits",
  "surfman",

--- a/components/canvas/webgl_mode/inprocess.rs
+++ b/components/canvas/webgl_mode/inprocess.rs
@@ -5,11 +5,10 @@
 use std::default::Default;
 use std::sync::{Arc, Mutex};
 
-use canvas_traits::webgl::{webgl_channel, WebGLContextId, WebGLMsg, WebGLThreads};
+use canvas_traits::webgl::{webgl_channel, GlType, WebGLContextId, WebGLMsg, WebGLThreads};
 use euclid::default::Size2D;
 use fnv::FnvHashMap;
 use log::debug;
-use sparkle::gl::GlType;
 use surfman::chains::{SwapChainAPI, SwapChains, SwapChainsAPI};
 use surfman::{Device, SurfaceInfo, SurfaceTexture};
 use webrender::RenderApiSender;

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -73,7 +73,6 @@ servo-media-gstreamer = { workspace = true, optional = true }
 servo_config = { path = "../config" }
 servo_geometry = { path = "../geometry" }
 servo_url = { path = "../url" }
-sparkle = { workspace = true }
 style = { workspace = true }
 style_traits = { workspace = true }
 surfman = { workspace = true }

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -30,7 +30,7 @@ use bluetooth::BluetoothThreadFactory;
 use bluetooth_traits::BluetoothRequest;
 use canvas::canvas_paint_thread::CanvasPaintThread;
 use canvas::WebGLComm;
-use canvas_traits::webgl::WebGLThreads;
+use canvas_traits::webgl::{GlType, WebGLThreads};
 use compositing::webview::UnknownWebView;
 use compositing::windowing::{EmbedderEvent, EmbedderMethods, WindowMethods};
 use compositing::{CompositeTarget, IOCompositor, InitialCompositorState, ShutdownState};
@@ -387,8 +387,8 @@ where
 
         // Create the webgl thread
         let gl_type = match webrender_gl.get_type() {
-            gleam::gl::GlType::Gl => sparkle::gl::GlType::Gl,
-            gleam::gl::GlType::Gles => sparkle::gl::GlType::Gles,
+            gleam::gl::GlType::Gl => GlType::Gl,
+            gleam::gl::GlType::Gles => GlType::Gles,
         };
 
         let (external_image_handlers, external_images) = WebrenderExternalImageHandlers::new();


### PR DESCRIPTION
This is done by replacing sparkle's GlType with canvas_traits's GlType.

Part of https://github.com/servo/servo/issues/33539

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because it's simple refactor

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
