### PR TITLE
Update dependabot.yml to only contain one group key

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,6 @@ updates:
          - "glib*"
          - "gobject*"
          - "gstreamer*"
-  groups:
     egui-related:
        patterns:
          - "ecolor"


### PR DESCRIPTION
I think this will resolve problem observed in https://github.com/servo/servo/pull/33896#issuecomment-2422930003 (as currently second group definition override first one).


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because it's dependabot config

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
