### PR TITLE
CanGc fixes through `focusevent.rs` & `hashchangeevent.rs`

### DIFF
--- a/components/script/dom/bindings/codegen/Bindings.conf
+++ b/components/script/dom/bindings/codegen/Bindings.conf
@@ -101,6 +101,10 @@ DOMInterfaces = {
     'canGc': ['SetInnerHTML', 'SetOuterHTML', 'InsertAdjacentHTML', 'GetClientRects', 'GetBoundingClientRect'],
 },
 
+'ElementInternals': {
+    'canGc': ['ReportValidity'],
+},
+
 'EventSource': {
     'weakReferenceable': True,
 },
@@ -135,8 +139,24 @@ DOMInterfaces = {
     'inRealms': ['PlayEffect', 'Reset']
 },
 
+'HTMLButtonElement': {
+    'canGc': ['ReportValidity'],
+},
+
+'HTMLElement': {
+    'canGc': ['Focus', 'Blur'],
+},
+
+'HTMLFieldSetElement': {
+    'canGc': ['ReportValidity'],
+},
+
 'HTMLFormElement': {
-    'canGc': ['RequestSubmit'],
+    'canGc': ['RequestSubmit', 'ReportValidity'],
+},
+
+'HTMLInputElement': {
+    'canGc': ['ReportValidity'],
 },
 
 'HTMLMediaElement': {
@@ -144,12 +164,28 @@ DOMInterfaces = {
     'inRealms': ['Play'],
 },
 
+'HTMLObjectElement': {
+    'canGc': ['ReportValidity'],
+},
+
+'HTMLOutputElement': {
+    'canGc': ['ReportValidity'],
+},
+
 'HTMLCanvasElement': {
     'canGc': ['CaptureStream', 'GetContext'],
 },
 
+'HTMLSelectElement': {
+    'canGc': ['ReportValidity'],
+},
+
 'HTMLTemplateElement': {
     'canGc': ['Content'],
+},
+
+'HTMLTextAreaElement': {
+    'canGc': ['ReportValidity'],
 },
 
 'MediaDevices': {

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -2002,7 +2002,7 @@ impl Element {
         }
     }
 
-    pub(crate) fn update_sequentially_focusable_status(&self) {
+    pub(crate) fn update_sequentially_focusable_status(&self, can_gc: CanGc) {
         let node = self.upcast::<Node>();
         let is_sequentially_focusable = self.is_sequentially_focusable();
         node.set_flag(NodeFlags::SEQUENTIALLY_FOCUSABLE, is_sequentially_focusable);
@@ -2010,7 +2010,7 @@ impl Element {
         // https://html.spec.whatwg.org/multipage/#focus-fixup-rule
         if !is_sequentially_focusable {
             let document = document_from_node(self);
-            document.perform_focus_fixup_rule(self);
+            document.perform_focus_fixup_rule(self, can_gc);
         }
     }
 
@@ -3327,7 +3327,7 @@ impl VirtualMethods for Element {
         let doc = node.owner_doc();
         match attr.local_name() {
             &local_name!("tabindex") | &local_name!("draggable") | &local_name!("hidden") => {
-                self.update_sequentially_focusable_status()
+                self.update_sequentially_focusable_status(CanGc::note())
             },
             &local_name!("style") => {
                 // Modifying the `style` attribute might change style.
@@ -3493,7 +3493,7 @@ impl VirtualMethods for Element {
             return;
         }
 
-        self.update_sequentially_focusable_status();
+        self.update_sequentially_focusable_status(CanGc::note());
 
         if let Some(ref id) = *self.id_attribute.borrow() {
             if let Some(shadow_root) = self.upcast::<Node>().containing_shadow_root() {
@@ -3526,7 +3526,7 @@ impl VirtualMethods for Element {
             return;
         }
 
-        self.update_sequentially_focusable_status();
+        self.update_sequentially_focusable_status(CanGc::note());
 
         let doc = document_from_node(self);
 

--- a/components/script/dom/elementinternals.rs
+++ b/components/script/dom/elementinternals.rs
@@ -25,6 +25,7 @@ use crate::dom::node::{window_from_node, Node};
 use crate::dom::nodelist::NodeList;
 use crate::dom::validation::{is_barred_by_datalist_ancestor, Validatable};
 use crate::dom::validitystate::{ValidationFlags, ValidityState};
+use crate::script_runtime::CanGc;
 
 #[derive(Clone, JSTraceable, MallocSizeOf)]
 enum SubmissionValue {
@@ -324,11 +325,11 @@ impl ElementInternalsMethods for ElementInternals {
     }
 
     /// <https://html.spec.whatwg.org/multipage#dom-elementinternals-reportvalidity>
-    fn ReportValidity(&self) -> Fallible<bool> {
+    fn ReportValidity(&self, can_gc: CanGc) -> Fallible<bool> {
         if !self.is_target_form_associated() {
             return Err(Error::NotSupported);
         }
-        Ok(self.report_validity())
+        Ok(self.report_validity(can_gc))
     }
 }
 

--- a/components/script/dom/focusevent.rs
+++ b/components/script/dom/focusevent.rs
@@ -55,6 +55,7 @@ impl FocusEvent {
         view: Option<&Window>,
         detail: i32,
         related_target: Option<&EventTarget>,
+        can_gc: CanGc,
     ) -> DomRoot<FocusEvent> {
         Self::new_with_proto(
             window,
@@ -65,7 +66,7 @@ impl FocusEvent {
             view,
             detail,
             related_target,
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/hashchangeevent.rs
+++ b/components/script/dom/hashchangeevent.rs
@@ -35,19 +35,20 @@ impl HashChangeEvent {
         }
     }
 
-    pub fn new_uninitialized(window: &Window) -> DomRoot<HashChangeEvent> {
-        Self::new_uninitialized_with_proto(window, None)
+    pub fn new_uninitialized(window: &Window, can_gc: CanGc) -> DomRoot<HashChangeEvent> {
+        Self::new_uninitialized_with_proto(window, None, can_gc)
     }
 
     fn new_uninitialized_with_proto(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HashChangeEvent> {
         reflect_dom_object_with_proto(
             Box::new(HashChangeEvent::new_inherited(String::new(), String::new())),
             window,
             proto,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -58,16 +59,10 @@ impl HashChangeEvent {
         cancelable: bool,
         old_url: String,
         new_url: String,
+        can_gc: CanGc,
     ) -> DomRoot<HashChangeEvent> {
         Self::new_with_proto(
-            window,
-            None,
-            type_,
-            bubbles,
-            cancelable,
-            old_url,
-            new_url,
-            CanGc::note(),
+            window, None, type_, bubbles, cancelable, old_url, new_url, can_gc,
         )
     }
 

--- a/components/script/dom/history.rs
+++ b/components/script/dom/history.rs
@@ -152,6 +152,7 @@ impl History {
                 false,
                 old_url.into_string(),
                 url.into_string(),
+                can_gc,
             );
             event
                 .upcast::<Event>()

--- a/components/script/dom/htmlbuttonelement.rs
+++ b/components/script/dom/htmlbuttonelement.rs
@@ -175,8 +175,8 @@ impl HTMLButtonElementMethods for HTMLButtonElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-cva-reportvalidity
-    fn ReportValidity(&self) -> bool {
-        self.report_validity()
+    fn ReportValidity(&self, can_gc: CanGc) -> bool {
+        self.report_validity(can_gc)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-cva-validationmessage
@@ -245,7 +245,7 @@ impl VirtualMethods for HTMLButtonElement {
                         el.check_ancestors_disabled_state_for_form_control();
                     },
                 }
-                el.update_sequentially_focusable_status();
+                el.update_sequentially_focusable_status(CanGc::note());
                 self.validity_state()
                     .perform_validation_and_update(ValidationFlags::all());
             },

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -51,6 +51,7 @@ use crate::dom::node::{
 };
 use crate::dom::text::Text;
 use crate::dom::virtualmethods::VirtualMethods;
+use crate::script_runtime::CanGc;
 use crate::script_thread::ScriptThread;
 
 #[dom_struct]
@@ -399,22 +400,22 @@ impl HTMLElementMethods for HTMLElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-focus
-    fn Focus(&self) {
+    fn Focus(&self, can_gc: CanGc) {
         // TODO: Mark the element as locked for focus and run the focusing steps.
         // https://html.spec.whatwg.org/multipage/#focusing-steps
         let document = document_from_node(self);
-        document.request_focus(Some(self.upcast()), FocusType::Element);
+        document.request_focus(Some(self.upcast()), FocusType::Element, can_gc);
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-blur
-    fn Blur(&self) {
+    fn Blur(&self, can_gc: CanGc) {
         // TODO: Run the unfocusing steps.
         if !self.as_element().focus_state() {
             return;
         }
         // https://html.spec.whatwg.org/multipage/#unfocusing-steps
         let document = document_from_node(self);
-        document.request_focus(None, FocusType::Element);
+        document.request_focus(None, FocusType::Element, can_gc);
     }
 
     // https://drafts.csswg.org/cssom-view/#dom-htmlelement-offsetparent
@@ -1077,7 +1078,7 @@ impl VirtualMethods for HTMLElement {
             super_type.bind_to_tree(context);
         }
         let element = self.as_element();
-        element.update_sequentially_focusable_status();
+        element.update_sequentially_focusable_status(CanGc::note());
 
         // Binding to a tree can disable a form control if one of the new
         // ancestors is a fieldset.

--- a/components/script/dom/htmlfieldsetelement.rs
+++ b/components/script/dom/htmlfieldsetelement.rs
@@ -25,6 +25,7 @@ use crate::dom::node::{window_from_node, Node, ShadowIncluding};
 use crate::dom::validation::Validatable;
 use crate::dom::validitystate::ValidityState;
 use crate::dom::virtualmethods::VirtualMethods;
+use crate::script_runtime::CanGc;
 use crate::script_thread::ScriptThread;
 
 #[dom_struct]
@@ -131,8 +132,8 @@ impl HTMLFieldSetElementMethods for HTMLFieldSetElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-cva-reportvalidity
-    fn ReportValidity(&self) -> bool {
-        self.report_validity()
+    fn ReportValidity(&self, can_gc: CanGc) -> bool {
+        self.report_validity(can_gc)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-cva-validationmessage
@@ -219,7 +220,7 @@ impl VirtualMethods for HTMLFieldSetElement {
                                 );
                             }
                         }
-                        element.update_sequentially_focusable_status();
+                        element.update_sequentially_focusable_status(CanGc::note());
                     }
                 } else {
                     for field in fields {
@@ -240,10 +241,10 @@ impl VirtualMethods for HTMLFieldSetElement {
                                 );
                             }
                         }
-                        element.update_sequentially_focusable_status();
+                        element.update_sequentially_focusable_status(CanGc::note());
                     }
                 }
-                element.update_sequentially_focusable_status();
+                element.update_sequentially_focusable_status(CanGc::note());
             },
             local_name!("form") => {
                 self.form_attribute_mutated(mutation);

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -634,8 +634,8 @@ impl HTMLFormElementMethods for HTMLFormElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-form-reportvalidity>
-    fn ReportValidity(&self) -> bool {
-        self.interactive_validation().is_ok()
+    fn ReportValidity(&self, can_gc: CanGc) -> bool {
+        self.interactive_validation(can_gc).is_ok()
     }
 }
 
@@ -733,7 +733,7 @@ impl HTMLFormElement {
             // Step 6.2
             self.firing_submission_events.set(true);
             // Step 6.3
-            if !submitter.no_validate(self) && self.interactive_validation().is_err() {
+            if !submitter.no_validate(self) && self.interactive_validation(can_gc).is_err() {
                 self.firing_submission_events.set(false);
                 return;
             }
@@ -1029,7 +1029,7 @@ impl HTMLFormElement {
 
     /// Interactively validate the constraints of form elements
     /// <https://html.spec.whatwg.org/multipage/#interactively-validate-the-constraints>
-    fn interactive_validation(&self) -> Result<(), ()> {
+    fn interactive_validation(&self, can_gc: CanGc) -> Result<(), ()> {
         // Step 1-2
         let unhandled_invalid_controls = match self.static_validation() {
             Ok(()) => return Ok(()),
@@ -1045,7 +1045,7 @@ impl HTMLFormElement {
             }
             if first {
                 if let Some(html_elem) = elem.downcast::<HTMLElement>() {
-                    html_elem.Focus();
+                    html_elem.Focus(can_gc);
                     first = false;
                 }
             }

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -1591,8 +1591,8 @@ impl HTMLInputElementMethods for HTMLInputElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-cva-reportvalidity
-    fn ReportValidity(&self) -> bool {
-        self.report_validity()
+    fn ReportValidity(&self, can_gc: CanGc) -> bool {
+        self.report_validity(can_gc)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-cva-validationmessage
@@ -2267,7 +2267,7 @@ impl VirtualMethods for HTMLInputElement {
                     el.set_read_write_state(read_write);
                 }
 
-                el.update_sequentially_focusable_status();
+                el.update_sequentially_focusable_status(CanGc::note());
             },
             local_name!("checked") if !self.checked_changed.get() => {
                 let checked_state = match mutation {

--- a/components/script/dom/htmlobjectelement.rs
+++ b/components/script/dom/htmlobjectelement.rs
@@ -24,6 +24,7 @@ use crate::dom::node::{window_from_node, Node};
 use crate::dom::validation::Validatable;
 use crate::dom::validitystate::ValidityState;
 use crate::dom::virtualmethods::VirtualMethods;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct HTMLObjectElement {
@@ -114,8 +115,8 @@ impl HTMLObjectElementMethods for HTMLObjectElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-cva-reportvalidity
-    fn ReportValidity(&self) -> bool {
-        self.report_validity()
+    fn ReportValidity(&self, can_gc: CanGc) -> bool {
+        self.report_validity(can_gc)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-cva-validationmessage

--- a/components/script/dom/htmloutputelement.rs
+++ b/components/script/dom/htmloutputelement.rs
@@ -21,6 +21,7 @@ use crate::dom::nodelist::NodeList;
 use crate::dom::validation::Validatable;
 use crate::dom::validitystate::ValidityState;
 use crate::dom::virtualmethods::VirtualMethods;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct HTMLOutputElement {
@@ -136,8 +137,8 @@ impl HTMLOutputElementMethods for HTMLOutputElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-cva-reportvalidity
-    fn ReportValidity(&self) -> bool {
-        self.report_validity()
+    fn ReportValidity(&self, can_gc: CanGc) -> bool {
+        self.report_validity(can_gc)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-cva-validationmessage

--- a/components/script/dom/htmlselectelement.rs
+++ b/components/script/dom/htmlselectelement.rs
@@ -39,6 +39,7 @@ use crate::dom::nodelist::NodeList;
 use crate::dom::validation::{is_barred_by_datalist_ancestor, Validatable};
 use crate::dom::validitystate::{ValidationFlags, ValidityState};
 use crate::dom::virtualmethods::VirtualMethods;
+use crate::script_runtime::CanGc;
 
 #[derive(JSTraceable, MallocSizeOf)]
 struct OptionsFilter;
@@ -395,8 +396,8 @@ impl HTMLSelectElementMethods for HTMLSelectElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-cva-reportvalidity
-    fn ReportValidity(&self) -> bool {
-        self.report_validity()
+    fn ReportValidity(&self, can_gc: CanGc) -> bool {
+        self.report_validity(can_gc)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-cva-validationmessage

--- a/components/script/dom/htmltextareaelement.rs
+++ b/components/script/dom/htmltextareaelement.rs
@@ -42,6 +42,7 @@ use crate::dom::textcontrol::{TextControlElement, TextControlSelection};
 use crate::dom::validation::{is_barred_by_datalist_ancestor, Validatable};
 use crate::dom::validitystate::{ValidationFlags, ValidityState};
 use crate::dom::virtualmethods::VirtualMethods;
+use crate::script_runtime::CanGc;
 use crate::textinput::{
     Direction, KeyReaction, Lines, SelectionDirection, TextInput, UTF16CodeUnits, UTF8Bytes,
 };
@@ -428,8 +429,8 @@ impl HTMLTextAreaElementMethods for HTMLTextAreaElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-cva-reportvalidity
-    fn ReportValidity(&self) -> bool {
-        self.report_validity()
+    fn ReportValidity(&self, can_gc: CanGc) -> bool {
+        self.report_validity(can_gc)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-cva-validationmessage
@@ -484,7 +485,7 @@ impl VirtualMethods for HTMLTextAreaElement {
                         }
                     },
                 }
-                el.update_sequentially_focusable_status();
+                el.update_sequentially_focusable_status(CanGc::note());
             },
             local_name!("maxlength") => match *attr.value() {
                 AttrValue::Int(_, value) => {

--- a/components/script/dom/validation.rs
+++ b/components/script/dom/validation.rs
@@ -12,6 +12,7 @@ use crate::dom::htmldatalistelement::HTMLDataListElement;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::node::Node;
 use crate::dom::validitystate::{ValidationFlags, ValidityState};
+use crate::script_runtime::CanGc;
 
 /// Trait for elements with constraint validation support
 pub trait Validatable {
@@ -46,7 +47,7 @@ pub trait Validatable {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#report-validity-steps>
-    fn report_validity(&self) -> bool {
+    fn report_validity(&self, can_gc: CanGc) -> bool {
         // Step 1.
         if !self.is_instance_validatable() {
             return true;
@@ -70,7 +71,7 @@ pub trait Validatable {
                 validation_message_for_flags(&self.validity_state(), flags)
             );
             if let Some(html_elem) = self.as_element().downcast::<HTMLElement>() {
-                html_elem.Focus();
+                html_elem.Focus(can_gc);
             }
         }
 

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2262,7 +2262,8 @@ impl Window {
                         false,
                         false,
                         old_url,
-                        new_url);
+                        new_url,
+                        CanGc::note());
                     event.upcast::<Event>().fire(this.upcast::<EventTarget>());
                 });
                 // FIXME(nox): Why are errors silenced here?

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -677,6 +677,7 @@ pub fn handle_focus_element(
     pipeline: PipelineId,
     element_id: String,
     reply: IpcSender<Result<(), ErrorStatus>>,
+    can_gc: CanGc,
 ) {
     reply
         .send(
@@ -684,7 +685,7 @@ pub fn handle_focus_element(
                 match node.downcast::<HTMLElement>() {
                     Some(element) => {
                         // Need a way to find if this actually succeeded
-                        element.Focus();
+                        element.Focus(can_gc);
                         Ok(())
                     },
                     None => Err(ErrorStatus::UnknownError),
@@ -1072,6 +1073,7 @@ pub fn handle_element_click(
     pipeline: PipelineId,
     element_id: String,
     reply: IpcSender<Result<Option<String>, ErrorStatus>>,
+    can_gc: CanGc,
 ) {
     reply
         .send(
@@ -1122,7 +1124,7 @@ pub fn handle_element_click(
 
                         // Step 8.5
                         match parent_node.downcast::<HTMLElement>() {
-                            Some(html_element) => html_element.Focus(),
+                            Some(html_element) => html_element.Focus(can_gc),
                             None => return Err(ErrorStatus::UnknownError),
                         }
 


### PR DESCRIPTION
Replaces CanGc::note() calls with arguments passed by callers in `components/script/dom/focusevent.rs` and `components/script/dom/hashchangeevent.rs`


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are a part of #33683 
- [X] These changes do not require tests because they do not modify funtionality

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
