### PR TITLE
Refactor positioned layout

### DIFF
--- a/components/layout_2020/lib.rs
+++ b/components/layout_2020/lib.rs
@@ -30,7 +30,6 @@ pub use flow::BoxTree;
 pub use fragment_tree::FragmentTree;
 use geom::AuOrAuto;
 use style::properties::ComputedValues;
-use style_ext::{Clamp, ComputedValuesExt};
 
 use crate::geom::LogicalVec2;
 
@@ -58,22 +57,6 @@ impl<'a> IndefiniteContainingBlock<'a> {
             },
             style,
         }
-    }
-
-    fn new_for_intrinsic_inline_size_of_child(
-        &self,
-        style: &'a ComputedValues,
-        auto_minimum: &LogicalVec2<Au>,
-    ) -> Self {
-        let (content_box_size, content_min_size, content_max_size, _, _) =
-            style.content_box_sizes_and_padding_border_margin_deprecated(self);
-        let block_size = content_box_size.block.map(|v| {
-            v.clamp_between_extremums(
-                content_min_size.block.auto_is(|| auto_minimum.block),
-                content_max_size.block,
-            )
-        });
-        IndefiniteContainingBlock::new_for_style_and_block_size(style, block_size)
     }
 }
 

--- a/tests/wpt/meta/css/css-position/position-absolute-center-006.html.ini
+++ b/tests/wpt/meta/css/css-position/position-absolute-center-006.html.ini
@@ -1,2 +1,0 @@
-[position-absolute-center-006.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-position/position-absolute-center-007.html.ini
+++ b/tests/wpt/meta/css/css-position/position-absolute-center-007.html.ini
@@ -1,2 +1,0 @@
-[position-absolute-center-007.html]
-  expected: FAIL


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This unifies the size resolution into AbsoluteAxisSolver, since it needs
to know the size in order to resolve auto margins correctly anyways.
This will allow adding support for sizing keywords in a follow-up patch.

Also, this avoids doing multiple layouts due to min and max constraints,
improving performance.

Additionally, tables may end up having a custom size, different than
what we would expect by just looking at the sizing properties. This
patch ensures that we resolve margins correctly with the final size,
resulting in 2 tests now passing.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
