### PR TITLE
Multiple CanGc fixes in `components/script/dom`

### DIFF
--- a/components/script/dom/activation.rs
+++ b/components/script/dom/activation.rs
@@ -10,6 +10,7 @@ use crate::dom::eventtarget::EventTarget;
 use crate::dom::htmlinputelement::InputActivationState;
 use crate::dom::node::window_from_node;
 use crate::dom::window::ReflowReason;
+use crate::script_runtime::CanGc;
 
 /// Trait for elements with defined activation behavior
 pub trait Activatable {
@@ -29,7 +30,7 @@ pub trait Activatable {
     // https://dom.spec.whatwg.org/#eventtarget-activation-behavior
     // event and target are used only by HTMLAnchorElement, in the case
     // where the target is an <img ismap> so the href gets coordinates appended
-    fn activation_behavior(&self, event: &Event, target: &EventTarget);
+    fn activation_behavior(&self, event: &Event, target: &EventTarget, can_gc: CanGc);
 
     // https://html.spec.whatwg.org/multipage/#concept-selector-active
     fn enter_formal_activation_state(&self) {

--- a/components/script/dom/audiobuffer.rs
+++ b/components/script/dom/audiobuffer.rs
@@ -81,6 +81,7 @@ impl AudioBuffer {
         length: u32,
         sample_rate: f32,
         initial_data: Option<&[Vec<f32>]>,
+        can_gc: CanGc,
     ) -> DomRoot<AudioBuffer> {
         Self::new_with_proto(
             global,
@@ -89,7 +90,7 @@ impl AudioBuffer {
             length,
             sample_rate,
             initial_data,
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/baseaudiocontext.rs
+++ b/components/script/dom/baseaudiocontext.rs
@@ -443,6 +443,7 @@ impl BaseAudioContextMethods for BaseAudioContext {
         number_of_channels: u32,
         length: u32,
         sample_rate: Finite<f32>,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<AudioBuffer>> {
         if number_of_channels == 0 ||
             number_of_channels > MAX_CHANNEL_COUNT ||
@@ -457,6 +458,7 @@ impl BaseAudioContextMethods for BaseAudioContext {
             length,
             *sample_rate,
             None,
+            can_gc,
         ))
     }
 
@@ -547,7 +549,8 @@ impl BaseAudioContextMethods for BaseAudioContext {
                                 decoded_audio.len() as u32 /* number of channels */,
                                 length as u32,
                                 this.sample_rate,
-                                Some(decoded_audio.as_slice()));
+                                Some(decoded_audio.as_slice()),
+                                CanGc::note());
                             let mut resolvers = this.decode_resolvers.borrow_mut();
                             assert!(resolvers.contains_key(&uuid_));
                             let resolver = resolvers.remove(&uuid_).unwrap();

--- a/components/script/dom/bindings/codegen/Bindings.conf
+++ b/components/script/dom/bindings/codegen/Bindings.conf
@@ -25,7 +25,7 @@ DOMInterfaces = {
 
 'BaseAudioContext': {
     'inRealms': ['DecodeAudioData', 'Resume', 'ParseFromString', 'GetBounds', 'GetClientRects'],
-    'canGc': ['CreateChannelMerger', 'CreateOscillator', 'CreateStereoPanner', 'CreateGain', 'CreateIIRFilter', 'CreateBiquadFilter', 'CreateBufferSource', 'CreateAnalyser', 'CreatePanner', 'CreateChannelSplitter'],
+    'canGc': ['CreateChannelMerger', 'CreateOscillator', 'CreateStereoPanner', 'CreateGain', 'CreateIIRFilter', 'CreateBiquadFilter', 'CreateBufferSource', 'CreateAnalyser', 'CreatePanner', 'CreateChannelSplitter', 'CreateBuffer'],
 },
 
 'Blob': {
@@ -109,6 +109,10 @@ DOMInterfaces = {
     'weakReferenceable': True,
 },
 
+'EventTarget': {
+    'canGc': ['DispatchEvent'],
+},
+
 'File': {
     'weakReferenceable': True,
 },
@@ -144,7 +148,7 @@ DOMInterfaces = {
 },
 
 'HTMLElement': {
-    'canGc': ['Focus', 'Blur'],
+    'canGc': ['Focus', 'Blur', 'Click'],
 },
 
 'HTMLFieldSetElement': {

--- a/components/script/dom/bindings/serializable.rs
+++ b/components/script/dom/bindings/serializable.rs
@@ -8,6 +8,7 @@
 use crate::dom::bindings::reflector::DomObject;
 use crate::dom::bindings::structuredclone::StructuredDataHolder;
 use crate::dom::globalscope::GlobalScope;
+use crate::script_runtime::CanGc;
 
 /// The key corresponding to the storage location
 /// of a serialized platform object stored in a StructuredDataHolder.
@@ -27,5 +28,6 @@ pub trait Serializable: DomObject {
         owner: &GlobalScope,
         sc_holder: &mut StructuredDataHolder,
         extra_data: StorageKey,
+        can_gc: CanGc,
     ) -> Result<(), ()>;
 }

--- a/components/script/dom/blob.rs
+++ b/components/script/dom/blob.rs
@@ -132,6 +132,7 @@ impl Serializable for Blob {
         owner: &GlobalScope,
         sc_holder: &mut StructuredDataHolder,
         storage_key: StorageKey,
+        can_gc: CanGc,
     ) -> Result<(), ()> {
         // 1. Re-build the key for the storage location
         // of the serialized object.
@@ -162,7 +163,7 @@ impl Serializable for Blob {
             *blob_impls = None;
         }
 
-        let deserialized_blob = Blob::new(owner, blob_impl, CanGc::note());
+        let deserialized_blob = Blob::new(owner, blob_impl, can_gc);
 
         let blobs = blobs.get_or_insert_with(HashMap::new);
         blobs.insert(storage_key, deserialized_blob);

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -1365,6 +1365,7 @@ impl Document {
             pressed_mouse_buttons,
             None,
             point_in_node,
+            can_gc,
         );
         let event = event.upcast::<Event>();
 
@@ -1398,7 +1399,7 @@ impl Document {
 
         if let MouseEventType::Click = mouse_event_type {
             self.commit_focus_transaction(FocusType::Element, can_gc);
-            self.maybe_fire_dblclick(client_point, node, pressed_mouse_buttons);
+            self.maybe_fire_dblclick(client_point, node, pressed_mouse_buttons, can_gc);
         }
     }
 
@@ -1407,6 +1408,7 @@ impl Document {
         click_pos: Point2D<f32>,
         target: &Node,
         pressed_mouse_buttons: u16,
+        can_gc: CanGc,
     ) {
         // https://w3c.github.io/uievents/#event-type-dblclick
         let now = Instant::now();
@@ -1449,6 +1451,7 @@ impl Document {
                     pressed_mouse_buttons,
                     None,
                     None,
+                    can_gc,
                 );
                 event.upcast::<Event>().fire(target.upcast());
 
@@ -1470,6 +1473,7 @@ impl Document {
         can_bubble: EventBubbles,
         cancelable: EventCancelable,
         pressed_mouse_buttons: u16,
+        can_gc: CanGc,
     ) {
         let client_x = client_point.x.to_i32().unwrap_or(0);
         let client_y = client_point.y.to_i32().unwrap_or(0);
@@ -1493,6 +1497,7 @@ impl Document {
             pressed_mouse_buttons,
             None,
             None,
+            can_gc,
         );
         let event = mouse_event.upcast::<Event>();
         event.fire(target);
@@ -1505,6 +1510,7 @@ impl Document {
         prev_mouse_over_target: &MutNullableDom<Element>,
         node_address: Option<UntrustedNodeAddress>,
         pressed_mouse_buttons: u16,
+        can_gc: CanGc,
     ) {
         let maybe_new_target = node_address.and_then(|address| {
             let node = node::from_untrusted_node_address(address);
@@ -1552,6 +1558,7 @@ impl Document {
                     EventBubbles::Bubbles,
                     EventCancelable::Cancelable,
                     pressed_mouse_buttons,
+                    can_gc,
                 );
 
                 if !old_target_is_ancestor_of_new_target {
@@ -1563,6 +1570,7 @@ impl Document {
                         moving_into,
                         event_target,
                         pressed_mouse_buttons,
+                        can_gc,
                     );
                 }
             }
@@ -1586,6 +1594,7 @@ impl Document {
                 EventBubbles::Bubbles,
                 EventCancelable::Cancelable,
                 pressed_mouse_buttons,
+                can_gc,
             );
 
             let moving_from = prev_mouse_over_target
@@ -1598,6 +1607,7 @@ impl Document {
                 moving_from,
                 event_target,
                 pressed_mouse_buttons,
+                can_gc,
             );
         }
 
@@ -1610,6 +1620,7 @@ impl Document {
             EventBubbles::Bubbles,
             EventCancelable::Cancelable,
             pressed_mouse_buttons,
+            can_gc,
         );
 
         // If the target has changed then store the current mouse over target for next frame.
@@ -1625,6 +1636,7 @@ impl Document {
         related_target: Option<DomRoot<Node>>,
         event_target: DomRoot<Node>,
         pressed_mouse_buttons: u16,
+        can_gc: CanGc,
     ) {
         assert!(matches!(
             event_type,
@@ -1664,6 +1676,7 @@ impl Document {
                 EventBubbles::DoesNotBubble,
                 EventCancelable::NotCancelable,
                 pressed_mouse_buttons,
+                can_gc,
             );
         }
     }
@@ -1902,7 +1915,7 @@ impl Document {
             {
                 if let Some(elem) = target.downcast::<Element>() {
                     elem.upcast::<Node>()
-                        .fire_synthetic_mouse_event_not_trusted(DOMString::from("click"));
+                        .fire_synthetic_mouse_event_not_trusted(DOMString::from("click"), can_gc);
                 }
             }
         }

--- a/components/script/dom/event.rs
+++ b/components/script/dom/event.rs
@@ -168,6 +168,7 @@ impl Event {
         &self,
         target: &EventTarget,
         legacy_target_override: bool,
+        can_gc: CanGc,
         // TODO legacy_did_output_listeners_throw_flag for indexeddb
     ) -> EventStatus {
         // Step 1.
@@ -333,7 +334,7 @@ impl Event {
             if self.DefaultPrevented() {
                 activation_target.legacy_canceled_activation_behavior(pre_activation_result);
             } else {
-                activation_target.activation_behavior(self, target);
+                activation_target.activation_behavior(self, target, can_gc);
             }
         }
 
@@ -380,7 +381,7 @@ impl Event {
     /// <https://html.spec.whatwg.org/multipage/#fire-a-simple-event>
     pub fn fire(&self, target: &EventTarget) -> EventStatus {
         self.set_trusted(true);
-        target.dispatch_event(self)
+        target.dispatch_event(self, CanGc::note())
     }
 }
 

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -397,8 +397,8 @@ impl EventTarget {
             })
     }
 
-    pub fn dispatch_event(&self, event: &Event) -> EventStatus {
-        event.dispatch(self, false)
+    pub fn dispatch_event(&self, event: &Event, can_gc: CanGc) -> EventStatus {
+        event.dispatch(self, false, can_gc)
     }
 
     pub fn remove_all_listeners(&self) {
@@ -779,12 +779,12 @@ impl EventTargetMethods for EventTarget {
     }
 
     // https://dom.spec.whatwg.org/#dom-eventtarget-dispatchevent
-    fn DispatchEvent(&self, event: &Event) -> Fallible<bool> {
+    fn DispatchEvent(&self, event: &Event, can_gc: CanGc) -> Fallible<bool> {
         if event.dispatching() || !event.initialized() {
             return Err(Error::InvalidState);
         }
         event.set_trusted(false);
-        Ok(match self.dispatch_event(event) {
+        Ok(match self.dispatch_event(event, can_gc) {
             EventStatus::Canceled => false,
             EventStatus::NotCanceled => true,
         })

--- a/components/script/dom/gpudevice.rs
+++ b/components/script/dom/gpudevice.rs
@@ -206,7 +206,7 @@ impl GPUDevice {
             },
             can_gc,
         );
-        let _ = self.eventtarget.DispatchEvent(ev.event());
+        let _ = self.eventtarget.DispatchEvent(ev.event(), can_gc);
     }
 
     /// <https://gpuweb.github.io/gpuweb/#abstract-opdef-validate-texture-format-required-features>

--- a/components/script/dom/htmlanchorelement.rs
+++ b/components/script/dom/htmlanchorelement.rs
@@ -34,6 +34,7 @@ use crate::dom::node::{document_from_node, BindContext, Node};
 use crate::dom::urlhelper::UrlHelper;
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::links::{follow_hyperlink, LinkRelations};
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct HTMLAnchorElement {
@@ -593,7 +594,7 @@ impl Activatable for HTMLAnchorElement {
     }
 
     //https://html.spec.whatwg.org/multipage/#the-a-element:activation-behaviour
-    fn activation_behavior(&self, event: &Event, target: &EventTarget) {
+    fn activation_behavior(&self, event: &Event, target: &EventTarget, _can_gc: CanGc) {
         let element = self.as_element();
         let mouse_event = event.downcast::<MouseEvent>().unwrap();
         let mut ismap_suffix = None;

--- a/components/script/dom/htmlareaelement.rs
+++ b/components/script/dom/htmlareaelement.rs
@@ -29,6 +29,7 @@ use crate::dom::htmlelement::HTMLElement;
 use crate::dom::node::{BindContext, Node};
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::links::{follow_hyperlink, LinkRelations};
+use crate::script_runtime::CanGc;
 
 #[derive(Debug, PartialEq)]
 pub enum Area {
@@ -371,7 +372,7 @@ impl Activatable for HTMLAreaElement {
         self.as_element().has_attribute(&local_name!("href"))
     }
 
-    fn activation_behavior(&self, _event: &Event, _target: &EventTarget) {
+    fn activation_behavior(&self, _event: &Event, _target: &EventTarget, _can_gc: CanGc) {
         follow_hyperlink(self.as_element(), self.relations.get(), None);
     }
 }

--- a/components/script/dom/htmlbuttonelement.rs
+++ b/components/script/dom/htmlbuttonelement.rs
@@ -343,7 +343,7 @@ impl Activatable for HTMLButtonElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#run-post-click-activation-steps
-    fn activation_behavior(&self, _event: &Event, _target: &EventTarget) {
+    fn activation_behavior(&self, _event: &Event, _target: &EventTarget, _can_gc: CanGc) {
         let ty = self.button_type.get();
         match ty {
             //https://html.spec.whatwg.org/multipage/#attr-button-type-submit-state

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -384,7 +384,7 @@ impl HTMLElementMethods for HTMLElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-click
-    fn Click(&self) {
+    fn Click(&self, can_gc: CanGc) {
         let element = self.as_element();
         if element.disabled_state() {
             return;
@@ -395,7 +395,7 @@ impl HTMLElementMethods for HTMLElement {
         element.set_click_in_progress(true);
 
         self.upcast::<Node>()
-            .fire_synthetic_mouse_event_not_trusted(DOMString::from("click"));
+            .fire_synthetic_mouse_event_not_trusted(DOMString::from("click"), can_gc);
         element.set_click_in_progress(false);
     }
 
@@ -1139,7 +1139,7 @@ impl Activatable for HTMLElement {
     }
 
     // Basically used to make the HTMLSummaryElement activatable (which has no IDL definition)
-    fn activation_behavior(&self, _event: &Event, _target: &EventTarget) {
+    fn activation_behavior(&self, _event: &Event, _target: &EventTarget, _can_gc: CanGc) {
         self.summary_activation_behavior();
     }
 }

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -1825,7 +1825,7 @@ impl VirtualMethods for HTMLImageElement {
                 None => return,
             };
             if shp.hit_test(&point) {
-                element.activation_behavior(event, self.upcast());
+                element.activation_behavior(event, self.upcast(), CanGc::note());
                 return;
             }
         }

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -2072,7 +2072,7 @@ impl HTMLInputElement {
                     // but we can get here from synthetic keydown events
                     button
                         .upcast::<Node>()
-                        .fire_synthetic_mouse_event_not_trusted(DOMString::from("click"));
+                        .fire_synthetic_mouse_event_not_trusted(DOMString::from("click"), can_gc);
                 }
             },
             None => {
@@ -2801,7 +2801,7 @@ impl Activatable for HTMLInputElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#run-post-click-activation-steps
-    fn activation_behavior(&self, _event: &Event, _target: &EventTarget) {
+    fn activation_behavior(&self, _event: &Event, _target: &EventTarget, _can_gc: CanGc) {
         let ty = self.input_type();
         match ty {
             InputType::Submit => {

--- a/components/script/dom/htmllabelelement.rs
+++ b/components/script/dom/htmllabelelement.rs
@@ -25,6 +25,7 @@ use crate::dom::htmlelement::HTMLElement;
 use crate::dom::htmlformelement::{FormControl, FormControlElementHelpers, HTMLFormElement};
 use crate::dom::node::{Node, ShadowIncluding};
 use crate::dom::virtualmethods::VirtualMethods;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct HTMLLabelElement {
@@ -73,9 +74,9 @@ impl Activatable for HTMLLabelElement {
     // at all, we are free to do an implementation-dependent thing;
     // firing a click event is an example, and the precise details of that
     // click event (e.g. isTrusted) are not specified.
-    fn activation_behavior(&self, _event: &Event, _target: &EventTarget) {
+    fn activation_behavior(&self, _event: &Event, _target: &EventTarget, can_gc: CanGc) {
         if let Some(e) = self.GetControl() {
-            e.Click();
+            e.Click(can_gc);
         }
     }
 }

--- a/components/script/dom/mouseevent.rs
+++ b/components/script/dom/mouseevent.rs
@@ -107,6 +107,7 @@ impl MouseEvent {
         buttons: u16,
         related_target: Option<&EventTarget>,
         point_in_target: Option<Point2D<f32>>,
+        can_gc: CanGc,
     ) -> DomRoot<MouseEvent> {
         Self::new_with_proto(
             window,
@@ -128,7 +129,7 @@ impl MouseEvent {
             buttons,
             related_target,
             point_in_target,
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -390,7 +390,7 @@ impl Node {
     }
 
     /// <https://html.spec.whatg.org/#fire_a_synthetic_mouse_event>
-    pub fn fire_synthetic_mouse_event_not_trusted(&self, name: DOMString) {
+    pub fn fire_synthetic_mouse_event_not_trusted(&self, name: DOMString, can_gc: CanGc) {
         // Spec says the choice of which global to create
         // the mouse event on is not well-defined,
         // and refers to heycam/webidl#135
@@ -415,6 +415,7 @@ impl Node {
             0,     // buttons uninitialized (and therefore none)
             None,  // related_target uninitialized,
             None,  // point_in_target uninitialized,
+            can_gc,
         );
 
         // Step 4: TODO composed flag for shadow root
@@ -426,7 +427,7 @@ impl Node {
 
         mouse_event
             .upcast::<Event>()
-            .dispatch(self.upcast::<EventTarget>(), false);
+            .dispatch(self.upcast::<EventTarget>(), false, can_gc);
     }
 
     pub fn parent_directionality(&self) -> String {

--- a/components/script/dom/offlineaudiocontext.rs
+++ b/components/script/dom/offlineaudiocontext.rs
@@ -197,7 +197,8 @@ impl OfflineAudioContextMethods for OfflineAudioContext {
                             this.channel_count,
                             this.length,
                             *this.context.SampleRate(),
-                            Some(processed_audio.as_slice()));
+                            Some(processed_audio.as_slice()),
+                            CanGc::note());
                         (*this.pending_rendering_promise.borrow_mut()).take().unwrap().resolve_native(&buffer);
                         let global = &this.global();
                         let window = global.as_window();

--- a/components/script/dom/promiserejectionevent.rs
+++ b/components/script/dom/promiserejectionevent.rs
@@ -51,6 +51,7 @@ impl PromiseRejectionEvent {
         cancelable: EventCancelable,
         promise: Rc<Promise>,
         reason: HandleValue,
+        can_gc: CanGc,
     ) -> DomRoot<Self> {
         Self::new_with_proto(
             global,
@@ -60,7 +61,7 @@ impl PromiseRejectionEvent {
             cancelable,
             promise.promise_obj(),
             reason,
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/serviceworkerglobalscope.rs
+++ b/components/script/dom/serviceworkerglobalscope.rs
@@ -481,7 +481,7 @@ impl ServiceWorkerGlobalScope {
     fn dispatch_activate(&self, can_gc: CanGc) {
         let event = ExtendableEvent::new(self, atom!("activate"), false, false, can_gc);
         let event = (*event).upcast::<Event>();
-        self.upcast::<EventTarget>().dispatch_event(event);
+        self.upcast::<EventTarget>().dispatch_event(event, can_gc);
     }
 }
 

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -548,7 +548,7 @@ impl Window {
 
     // see note at https://dom.spec.whatwg.org/#concept-event-dispatch step 2
     pub fn dispatch_event_with_target_override(&self, event: &Event) -> EventStatus {
-        event.dispatch(self.upcast(), true)
+        event.dispatch(self.upcast(), true, CanGc::note())
     }
 }
 

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -302,7 +302,8 @@ unsafe extern "C" fn promise_rejection_tracker(
                         EventBubbles::DoesNotBubble,
                         EventCancelable::Cancelable,
                         root_promise,
-                        reason.handle()
+                        reason.handle(),
+                        CanGc::note()
                     );
 
                     event.upcast::<Event>().fire(&target);
@@ -419,7 +420,8 @@ pub fn notify_about_rejected_promises(global: &GlobalScope) {
                             EventBubbles::DoesNotBubble,
                             EventCancelable::Cancelable,
                             promise.clone(),
-                            reason.handle()
+                            reason.handle(),
+                            CanGc::note()
                         );
 
                         let event_status = event.upcast::<Event>().fire(&target);

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1484,6 +1484,7 @@ impl ScriptThread {
         point: Point2D<f32>,
         node_address: Option<UntrustedNodeAddress>,
         pressed_mouse_buttons: u16,
+        can_gc: CanGc,
     ) {
         // Get the previous target temporarily
         let prev_mouse_over_target = self.topmost_mouse_over_target.get();
@@ -1494,6 +1495,7 @@ impl ScriptThread {
                 &self.topmost_mouse_over_target,
                 node_address,
                 pressed_mouse_buttons,
+                can_gc,
             )
         }
 
@@ -1592,6 +1594,7 @@ impl ScriptThread {
                         point,
                         node_address,
                         pressed_mouse_buttons,
+                        can_gc,
                     );
                 },
 


### PR DESCRIPTION
Replaces CanGc::note() calls with arguments passed by callers in `components/script/dom/promiserejectionevent.rs`, `components/script/dom/audiobuffer.rs`, `components/script/dom/blob.rs`, and `components/script/dom/mouseevent.rs`

Left a `CanGc::note()` in `event.rs` at line 384 and in `window.rs` at line 551 to be worked on in a separate PR.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are a part of #33683 
- [X] These changes do not require tests because they do not modify funtionality

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
