### PR TITLE
Fix GC borrow hazard in XRSession::UpdateTargetFrameRate

### DIFF
--- a/components/script/dom/xrsession.rs
+++ b/components/script/dom/xrsession.rs
@@ -1025,6 +1025,7 @@ impl XRSessionMethods for XRSession {
     }
 
     /// <https://www.w3.org/TR/webxr/#dom-xrsession-updatetargetframerate>
+<<<<<<< HEAD
     fn UpdateTargetFrameRate(
         &self,
         rate: Finite<f32>,
@@ -1032,6 +1033,10 @@ impl XRSessionMethods for XRSession {
         can_gc: CanGc,
     ) -> Rc<Promise> {
         let mut session = self.session.borrow_mut();
+=======
+    fn UpdateTargetFrameRate(&self, rate: Finite<f32>, comp: InRealm) -> Rc<Promise> {
+        let session = self.session.borrow();
+>>>>>>> ebe5ea76a5 (Fix GC borrow hazard in XRSession::UpdateTargetFrameRate)
         let supported_frame_rates = session.supported_frame_rates();
         let promise = Promise::new_in_current_realm(comp, can_gc);
 
@@ -1075,7 +1080,7 @@ impl XRSessionMethods for XRSession {
             }),
         );
 
-        session.update_frame_rate(*rate, sender);
+        self.session.borrow_mut().update_frame_rate(*rate, sender);
 
         promise
     }

--- a/components/script/dom/xrsession.rs
+++ b/components/script/dom/xrsession.rs
@@ -1025,32 +1025,29 @@ impl XRSessionMethods for XRSession {
     }
 
     /// <https://www.w3.org/TR/webxr/#dom-xrsession-updatetargetframerate>
-<<<<<<< HEAD
     fn UpdateTargetFrameRate(
         &self,
         rate: Finite<f32>,
         comp: InRealm,
         can_gc: CanGc,
     ) -> Rc<Promise> {
-        let mut session = self.session.borrow_mut();
-=======
-    fn UpdateTargetFrameRate(&self, rate: Finite<f32>, comp: InRealm) -> Rc<Promise> {
-        let session = self.session.borrow();
->>>>>>> ebe5ea76a5 (Fix GC borrow hazard in XRSession::UpdateTargetFrameRate)
-        let supported_frame_rates = session.supported_frame_rates();
         let promise = Promise::new_in_current_realm(comp, can_gc);
-
-        if self.mode == XRSessionMode::Inline ||
-            supported_frame_rates.is_empty() ||
-            self.ended.get()
         {
-            promise.reject_error(Error::InvalidState);
-            return promise;
-        }
+            let session = self.session.borrow();
+            let supported_frame_rates = session.supported_frame_rates();
 
-        if !supported_frame_rates.contains(&*rate) {
-            promise.reject_error(Error::Type("Provided framerate not supported".into()));
-            return promise;
+            if self.mode == XRSessionMode::Inline ||
+                supported_frame_rates.is_empty() ||
+                self.ended.get()
+            {
+                promise.reject_error(Error::InvalidState);
+                return promise;
+            }
+
+            if !supported_frame_rates.contains(&*rate) {
+                promise.reject_error(Error::Type("Provided framerate not supported".into()));
+                return promise;
+            }
         }
 
         *self.update_framerate_promise.borrow_mut() = Some(promise.clone());


### PR DESCRIPTION
Fix GC borrow hazard in XRSession::UpdateTargetFrameRate in `components/script/dom/xrsession.rs`


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #33925 
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
