### PR TITLE
CanGc fixes from `constantsourcenode.rs` & `window.rs`

### DIFF
--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -486,9 +486,9 @@ pub fn handle_request_animation_frame(documents: &Documents, id: PipelineId, act
     }
 }
 
-pub fn handle_reload(documents: &Documents, id: PipelineId) {
+pub fn handle_reload(documents: &Documents, id: PipelineId, can_gc: CanGc) {
     if let Some(win) = documents.find_window(id) {
-        win.Location().reload_without_origin_check();
+        win.Location().reload_without_origin_check(can_gc);
     }
 }
 

--- a/components/script/dom/baseaudiocontext.rs
+++ b/components/script/dom/baseaudiocontext.rs
@@ -407,11 +407,12 @@ impl BaseAudioContextMethods for BaseAudioContext {
     }
 
     /// <https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createconstantsource>
-    fn CreateConstantSource(&self) -> Fallible<DomRoot<ConstantSourceNode>> {
+    fn CreateConstantSource(&self, can_gc: CanGc) -> Fallible<DomRoot<ConstantSourceNode>> {
         ConstantSourceNode::new(
             self.global().as_window(),
             self,
             &ConstantSourceOptions::empty(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/bindings/codegen/Bindings.conf
+++ b/components/script/dom/bindings/codegen/Bindings.conf
@@ -25,7 +25,7 @@ DOMInterfaces = {
 
 'BaseAudioContext': {
     'inRealms': ['DecodeAudioData', 'Resume', 'ParseFromString', 'GetBounds', 'GetClientRects'],
-    'canGc': ['CreateChannelMerger', 'CreateOscillator', 'CreateStereoPanner', 'CreateGain', 'CreateIIRFilter', 'CreateBiquadFilter', 'CreateBufferSource', 'CreateAnalyser', 'CreatePanner', 'CreateChannelSplitter', 'CreateBuffer'],
+    'canGc': ['CreateChannelMerger', 'CreateOscillator', 'CreateStereoPanner', 'CreateGain', 'CreateIIRFilter', 'CreateBiquadFilter', 'CreateBufferSource', 'CreateAnalyser', 'CreatePanner', 'CreateChannelSplitter', 'CreateBuffer', 'CreateConstantSource'],
 },
 
 'Blob': {
@@ -143,6 +143,10 @@ DOMInterfaces = {
     'inRealms': ['PlayEffect', 'Reset']
 },
 
+'History': {
+    'canGc': ['Go'],
+},
+
 'HTMLButtonElement': {
     'canGc': ['ReportValidity'],
 },
@@ -190,6 +194,10 @@ DOMInterfaces = {
 
 'HTMLTextAreaElement': {
     'canGc': ['ReportValidity'],
+},
+
+'Location': {
+    'canGc': ['Assign', 'Reload', 'Replace', 'SetHash', 'SetHost', 'SetHostname', 'SetHref', 'SetPathname', 'SetPort', 'SetProtocol', 'SetSearch'],
 },
 
 'MediaDevices': {
@@ -293,7 +301,7 @@ DOMInterfaces = {
 },
 
 'Window': {
-    'canGc': ['Stop', 'Fetch'],
+    'canGc': ['Stop', 'Fetch', 'Open'],
     'inRealms': ['Fetch', 'GetOpener'],
 },
 

--- a/components/script/dom/constantsourcenode.rs
+++ b/components/script/dom/constantsourcenode.rs
@@ -67,8 +67,9 @@ impl ConstantSourceNode {
         window: &Window,
         context: &BaseAudioContext,
         options: &ConstantSourceOptions,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<ConstantSourceNode>> {
-        Self::new_with_proto(window, None, context, options, CanGc::note())
+        Self::new_with_proto(window, None, context, options, can_gc)
     }
 
     #[allow(crown::unrooted_must_root)]

--- a/components/script/dom/focusevent.rs
+++ b/components/script/dom/focusevent.rs
@@ -47,6 +47,7 @@ impl FocusEvent {
         reflect_dom_object_with_proto(Box::new(FocusEvent::new_inherited()), window, proto, can_gc)
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         window: &Window,
         type_: DOMString,

--- a/components/script/dom/history.rs
+++ b/components/script/dom/history.rs
@@ -313,11 +313,11 @@ impl HistoryMethods for History {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-history-go>
-    fn Go(&self, delta: i32) -> ErrorResult {
+    fn Go(&self, delta: i32, can_gc: CanGc) -> ErrorResult {
         let direction = match delta.cmp(&0) {
             Ordering::Greater => TraversalDirection::Forward(delta as usize),
             Ordering::Less => TraversalDirection::Back(-delta as usize),
-            Ordering::Equal => return self.window.Location().Reload(),
+            Ordering::Equal => return self.window.Location().Reload(can_gc),
         };
 
         self.traverse_history(direction)

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -1016,6 +1016,7 @@ impl HTMLFormElement {
                     HistoryEntryReplacement::Disabled,
                     false,
                     load_data,
+                    CanGc::note(),
                 );
         });
 

--- a/components/script/dom/htmlmetaelement.rs
+++ b/components/script/dom/htmlmetaelement.rs
@@ -30,6 +30,7 @@ use crate::dom::location::NavigationType;
 use crate::dom::node::{document_from_node, window_from_node, BindContext, Node, UnbindContext};
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 use crate::timers::OneshotTimerCallback;
 
 #[dom_struct]
@@ -45,11 +46,12 @@ pub struct RefreshRedirectDue {
     pub window: DomRoot<Window>,
 }
 impl RefreshRedirectDue {
-    pub fn invoke(self) {
+    pub fn invoke(self, can_gc: CanGc) {
         self.window.Location().navigate(
             self.url.clone(),
             HistoryEntryReplacement::Enabled,
             NavigationType::DeclarativeRefresh,
+            can_gc,
         );
     }
 }

--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -54,7 +54,7 @@ use crate::dom::element::Element;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::window::Window;
 use crate::realms::{enter_realm, AlreadyInRealm, InRealm};
-use crate::script_runtime::JSContext as SafeJSContext;
+use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
 use crate::script_thread::ScriptThread;
 
 #[dom_struct]
@@ -465,6 +465,7 @@ impl WindowProxy {
         url: USVString,
         target: DOMString,
         features: DOMString,
+        can_gc: CanGc,
     ) -> Fallible<Option<DomRoot<WindowProxy>>> {
         // Step 4.
         let non_empty_target = match target.as_ref() {
@@ -527,7 +528,7 @@ impl WindowProxy {
             } else {
                 HistoryEntryReplacement::Disabled
             };
-            target_window.load_url(replacement_flag, false, load_data);
+            target_window.load_url(replacement_flag, false, load_data, can_gc);
         }
         if noopener {
             // Step 15 (Dis-owning has been done in create_auxiliary_browsing_context).

--- a/components/script/links.rs
+++ b/components/script/links.rs
@@ -21,6 +21,7 @@ use crate::dom::htmlformelement::HTMLFormElement;
 use crate::dom::htmllinkelement::HTMLLinkElement;
 use crate::dom::node::document_from_node;
 use crate::dom::types::{Element, GlobalScope};
+use crate::script_runtime::CanGc;
 use crate::task_source::TaskSource;
 
 bitflags::bitflags! {
@@ -432,7 +433,7 @@ pub fn follow_hyperlink(
         let target = Trusted::new(target_window);
         let task = task!(navigate_follow_hyperlink: move || {
             debug!("following hyperlink to {}", load_data.url);
-            target.root().load_url(replace, false, load_data);
+            target.root().load_url(replace, false, load_data, CanGc::note());
         });
         target_window
             .task_manager()

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2409,7 +2409,7 @@ impl ScriptThread {
             ConstellationControlMsg::ReportCSSError(pipeline_id, filename, line, column, msg) => {
                 self.handle_css_error_reporting(pipeline_id, filename, line, column, msg)
             },
-            ConstellationControlMsg::Reload(pipeline_id) => self.handle_reload(pipeline_id),
+            ConstellationControlMsg::Reload(pipeline_id) => self.handle_reload(pipeline_id, can_gc),
             ConstellationControlMsg::ExitPipeline(pipeline_id, discard_browsing_context) => {
                 self.handle_exit_pipeline_msg(pipeline_id, discard_browsing_context, can_gc)
             },
@@ -2629,7 +2629,7 @@ impl ScriptThread {
             DevtoolScriptControlMsg::RequestAnimationFrame(id, name) => {
                 devtools::handle_request_animation_frame(&documents, id, name)
             },
-            DevtoolScriptControlMsg::Reload(id) => devtools::handle_reload(&documents, id),
+            DevtoolScriptControlMsg::Reload(id) => devtools::handle_reload(&documents, id, can_gc),
             DevtoolScriptControlMsg::GetCssDatabase(reply) => {
                 devtools::handle_get_css_database(reply)
             },
@@ -4259,10 +4259,10 @@ impl ScriptThread {
         }
     }
 
-    fn handle_reload(&self, pipeline_id: PipelineId) {
+    fn handle_reload(&self, pipeline_id: PipelineId, can_gc: CanGc) {
         let window = self.documents.borrow().find_window(pipeline_id);
         if let Some(window) = window {
-            window.Location().reload_without_origin_check();
+            window.Location().reload_without_origin_check(can_gc);
         }
     }
 

--- a/components/script/timers.rs
+++ b/components/script/timers.rs
@@ -96,7 +96,7 @@ impl OneshotTimerCallback {
             OneshotTimerCallback::JsTimer(task) => task.invoke(this, js_timers),
             OneshotTimerCallback::TestBindingCallback(callback) => callback.invoke(),
             OneshotTimerCallback::FakeRequestAnimationFrame(callback) => callback.invoke(),
-            OneshotTimerCallback::RefreshRedirectDue(callback) => callback.invoke(),
+            OneshotTimerCallback::RefreshRedirectDue(callback) => callback.invoke(can_gc),
         }
     }
 }


### PR DESCRIPTION
Replaces CanGc::note() calls with arguments passed by callers in `components/script/dom/constantsourcenode.rs` and `components/script/dom/window.rs`


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are a part of #33683 
- [X] These changes do not require tests because they do not modify funtionality

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
