### PR TITLE
clippy: fix using clone() warning in components\layout_2020\display_l…

### DIFF
--- a/components/layout_2020/display_list/mod.rs
+++ b/components/layout_2020/display_list/mod.rs
@@ -1362,22 +1362,22 @@ pub(super) fn compute_margin_box_radius(
         top_left: compute_margin_radius(
             radius.top_left,
             layout_rect,
-            Size2D::new(margin.left.clone(), margin.top.clone()),
+            Size2D::new(margin.left, margin.top),
         ),
         top_right: compute_margin_radius(
             radius.top_right,
             layout_rect,
-            Size2D::new(margin.right.clone(), margin.top.clone()),
+            Size2D::new(margin.right, margin.top),
         ),
         bottom_left: compute_margin_radius(
             radius.bottom_left,
             layout_rect,
-            Size2D::new(margin.left.clone(), margin.bottom.clone()),
+            Size2D::new(margin.left, margin.bottom),
         ),
         bottom_right: compute_margin_radius(
             radius.bottom_right,
             layout_rect,
-            Size2D::new(margin.right.clone(), margin.bottom.clone()),
+            Size2D::new(margin.right, margin.bottom),
         ),
     }
 }


### PR DESCRIPTION
…ist\mod.rs:1365:25

<!-- Please describe your changes on the following line: -->
Clippy suggests that we remove the clone() calls for margin.left and margin.top. Instead of having this Size2D::new(margin.left.clone(), margin.top.clone()) we can have Size2D::new(margin.left, margin.top)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are a part of #31500

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
