### PR TITLE
clippy: fix explicit lifetime warning layout_2020/style_ext.rs

### DIFF
--- a/components/layout_2020/style_ext.rs
+++ b/components/layout_2020/style_ext.rs
@@ -317,7 +317,7 @@ pub(crate) trait ComputedValuesExt {
 
 impl ComputedValuesExt for ComputedValues {
     fn physical_box_offsets(&self) -> PhysicalSides<LengthPercentageOrAuto<'_>> {
-        fn convert<'a>(inset: &'a Inset) -> LengthPercentageOrAuto<'a> {
+        fn convert(inset: &Inset) -> LengthPercentageOrAuto<'_> {
             match inset {
                 Inset::LengthPercentage(ref v) => LengthPercentageOrAuto::LengthPercentage(v),
                 Inset::Auto => LengthPercentageOrAuto::Auto,
@@ -696,7 +696,7 @@ impl ComputedValuesExt for ComputedValues {
     }
 
     fn physical_margin(&self) -> PhysicalSides<LengthPercentageOrAuto<'_>> {
-        fn convert<'a>(inset: &'a Margin) -> LengthPercentageOrAuto<'a> {
+        fn convert(inset: &Margin) -> LengthPercentageOrAuto<'_> {
             match inset {
                 Margin::LengthPercentage(ref v) => LengthPercentageOrAuto::LengthPercentage(v),
                 Margin::Auto => LengthPercentageOrAuto::Auto,


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Got this warning: the following explicit lifetimes could be elided: 'a
   --> components\layout_2020\style_ext.rs:320:20
    |
320 |         fn convert<'a>(inset: &'a Inset) -> LengthPercentageOrAuto<'a> {
    |                    ^^          ^^                                  ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
which suggests that we do not need to specify the lifetime explicitly. So instead of having this fn convert<'a>(inset: &'a Inset) -> LengthPercentageOrAuto<'a> {}, we can have this fn convert(inset: &Inset) -> LengthPercentageOrAuto<'_> {}

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are a part of #31500

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
