### PR TITLE
Mark CompileFunction as a potential GC operation.

### DIFF
--- a/components/script/dom/event.rs
+++ b/components/script/dom/event.rs
@@ -271,6 +271,7 @@ impl Event {
                 object,
                 self,
                 Some(ListenerPhase::Capturing),
+                can_gc,
             );
         }
 
@@ -290,6 +291,7 @@ impl Event {
                     object,
                     self,
                     Some(ListenerPhase::Bubbling),
+                    can_gc,
                 );
             }
         }
@@ -639,6 +641,7 @@ fn invoke(
     object: &EventTarget,
     event: &Event,
     phase: Option<ListenerPhase>,
+    can_gc: CanGc,
     // TODO legacy_output_did_listeners_throw for indexeddb
 ) {
     // Step 1: Until shadow DOM puts the event path in the
@@ -657,7 +660,7 @@ fn invoke(
     event.current_target.set(Some(object));
 
     // Step 6
-    let listeners = object.get_listeners_for(&event.type_(), phase);
+    let listeners = object.get_listeners_for(&event.type_(), phase, can_gc);
 
     // Step 7.
     let found = inner_invoke(timeline_window, object, event, &listeners);

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -189,7 +189,7 @@ impl HTMLElementMethods for HTMLElement {
             }
         } else {
             self.upcast::<EventTarget>()
-                .get_event_handler_common("error")
+                .get_event_handler_common("error", CanGc::note())
         }
     }
 
@@ -218,7 +218,7 @@ impl HTMLElementMethods for HTMLElement {
             }
         } else {
             self.upcast::<EventTarget>()
-                .get_event_handler_common("load")
+                .get_event_handler_common("load", CanGc::note())
         }
     }
 
@@ -246,7 +246,7 @@ impl HTMLElementMethods for HTMLElement {
             }
         } else {
             self.upcast::<EventTarget>()
-                .get_event_handler_common("blur")
+                .get_event_handler_common("blur", CanGc::note())
         }
     }
 
@@ -274,7 +274,7 @@ impl HTMLElementMethods for HTMLElement {
             }
         } else {
             self.upcast::<EventTarget>()
-                .get_event_handler_common("focus")
+                .get_event_handler_common("focus", CanGc::note())
         }
     }
 
@@ -302,7 +302,7 @@ impl HTMLElementMethods for HTMLElement {
             }
         } else {
             self.upcast::<EventTarget>()
-                .get_event_handler_common("resize")
+                .get_event_handler_common("resize", CanGc::note())
         }
     }
 
@@ -330,7 +330,7 @@ impl HTMLElementMethods for HTMLElement {
             }
         } else {
             self.upcast::<EventTarget>()
-                .get_event_handler_common("scroll")
+                .get_event_handler_common("scroll", CanGc::note())
         }
     }
 

--- a/components/script/dom/macros.rs
+++ b/components/script/dom/macros.rs
@@ -318,8 +318,9 @@ macro_rules! define_event_handler(
         fn $getter(&self) -> Option<::std::rc::Rc<$handler>> {
             use crate::dom::bindings::inheritance::Castable;
             use crate::dom::eventtarget::EventTarget;
+            use crate::script_runtime::CanGc;
             let eventtarget = self.upcast::<EventTarget>();
-            eventtarget.get_event_handler_common(stringify!($event_type))
+            eventtarget.get_event_handler_common(stringify!($event_type), CanGc::note())
         }
 
         fn $setter(&self, listener: Option<::std::rc::Rc<$handler>>) {

--- a/components/script/dom/messageport.rs
+++ b/components/script/dom/messageport.rs
@@ -28,7 +28,7 @@ use crate::dom::bindings::trace::RootedTraceableBox;
 use crate::dom::bindings::transferable::Transferable;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
-use crate::script_runtime::JSContext as SafeJSContext;
+use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
 
 #[dom_struct]
 /// The MessagePort used in the DOM.
@@ -327,7 +327,7 @@ impl MessagePortMethods for MessagePort {
             return None;
         }
         let eventtarget = self.upcast::<EventTarget>();
-        eventtarget.get_event_handler_common("message")
+        eventtarget.get_event_handler_common("message", CanGc::note())
     }
 
     /// <https://html.spec.whatwg.org/multipage/#handler-messageport-onmessage>


### PR DESCRIPTION
This change makes clear the GC hazard reported in #33932.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they have no runtime impact.