### PR TITLE
CI: Fail the lint job when cargo-clippy reports some warnings

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -51,7 +51,6 @@ jobs:
           sudo apt update
           python3 ./mach bootstrap
       # TODO: Do GitHub anotaions
-      # TODO: Fail on warnings
       - name: Clippy
         run: |
           python3 ./mach cargo-clippy --use-crown --locked -- -- --deny warnings

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -54,6 +54,6 @@ jobs:
       # TODO: Fail on warnings
       - name: Clippy
         run: |
-          python3 ./mach cargo-clippy --use-crown --locked
+          python3 ./mach cargo-clippy --use-crown --locked -- -- --deny warnings
       - name: Tidy
         run: python3 ./mach test-tidy --no-progress --all

--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -867,7 +867,7 @@ impl<'a> AbsoluteAxisSolver<'a> {
         // Override sizes
         let old_size = mem::replace(&mut self.computed_size, AuOrAuto::LengthPercentage(size));
         let old_min_size = mem::replace(&mut self.computed_min_size, Au::zero());
-        let old_max_size = mem::replace(&mut self.computed_max_size, None);
+        let old_max_size = self.computed_max_size.take();
 
         let result = self.solve_tentatively();
 


### PR DESCRIPTION
Adds the `-- -- --deny warnings` argument to `./mach cargo-clippy` invocation in `.github/workflows/lint.yml` to fail the lint job when cargo-clippy reports warnings


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #33940 
- [X] These changes do not require tests because they do not modify functionality

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
