### PR TITLE
clippy: fix expression creates a reference which is immediately dereferenced

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -189,14 +189,6 @@ mod gen {
         gen_accessors = PREF_ACCESSORS,
         // tree of structs to generate
         gen_types = Prefs {
-            browser: {
-                display: {
-                    #[serde(default = "white")]
-                    background_color: i64,
-                    #[serde(default = "black")]
-                    foreground_color: i64,
-                }
-            },
             fonts: {
                 #[serde(default)]
                 default: String,
@@ -610,9 +602,6 @@ mod gen {
                 },
                 /// URL string of the homepage.
                 homepage: String,
-                keep_screen_on: {
-                    enabled: bool,
-                },
                 #[serde(rename = "shell.native-orientation")]
                 native_orientation: String,
                 native_titlebar: {

--- a/components/script/dom/subtlecrypto.rs
+++ b/components/script/dom/subtlecrypto.rs
@@ -533,15 +533,15 @@ impl SubtleCrypto {
 
         let ct = match key.handle() {
             Handle::Aes128(data) => {
-                let key_data = GenericArray::from_slice(&data);
+                let key_data = GenericArray::from_slice(data);
                 Aes128CbcEnc::new(key_data, iv).encrypt_padded_vec_mut::<Pkcs7>(&mut plaintext)
             },
             Handle::Aes192(data) => {
-                let key_data = GenericArray::from_slice(&data);
+                let key_data = GenericArray::from_slice(data);
                 Aes192CbcEnc::new(key_data, iv).encrypt_padded_vec_mut::<Pkcs7>(&mut plaintext)
             },
             Handle::Aes256(data) => {
-                let key_data = GenericArray::from_slice(&data);
+                let key_data = GenericArray::from_slice(data);
                 Aes256CbcEnc::new(key_data, iv).encrypt_padded_vec_mut::<Pkcs7>(&mut plaintext)
             },
         };
@@ -570,19 +570,19 @@ impl SubtleCrypto {
 
         let plaintext = match key.handle() {
             Handle::Aes128(data) => {
-                let key_data = GenericArray::from_slice(&data);
+                let key_data = GenericArray::from_slice(data);
                 Aes128CbcDec::new(key_data, iv)
                     .decrypt_padded_mut::<Pkcs7>(ciphertext.as_mut_slice())
                     .map_err(|_| Error::Operation)?
             },
             Handle::Aes192(data) => {
-                let key_data = GenericArray::from_slice(&data);
+                let key_data = GenericArray::from_slice(data);
                 Aes192CbcDec::new(key_data, iv)
                     .decrypt_padded_mut::<Pkcs7>(ciphertext.as_mut_slice())
                     .map_err(|_| Error::Operation)?
             },
             Handle::Aes256(data) => {
-                let key_data = GenericArray::from_slice(&data);
+                let key_data = GenericArray::from_slice(data);
                 Aes256CbcDec::new(key_data, iv)
                     .decrypt_padded_mut::<Pkcs7>(ciphertext.as_mut_slice())
                     .map_err(|_| Error::Operation)?


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Got this warning: this expression creates a reference which is immediately dereferenced by the compiler
   --> components\script\dom\subtlecrypto.rs:579:57
    |
579 |                 let key_data = GenericArray::from_slice(&data);
    |                                                         ^^^^^ help: change this to: `data`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
So i removed & from the CODE

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
