### PR TITLE
Prevent `stretch` from producing a negative size

### DIFF
--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -1969,11 +1969,12 @@ impl IndependentFormattingContext {
                 let max_box_size = style.content_max_box_size(containing_block, &pbm);
                 let min_box_size = style.content_min_box_size(containing_block, &pbm);
 
-                let available_inline_size = containing_block.inline_size - pbm_sums.inline_sum();
+                let available_inline_size =
+                    (containing_block.inline_size - pbm_sums.inline_sum()).max(Au::zero());
                 let available_block_size = containing_block
                     .block_size
                     .non_auto()
-                    .map(|block_size| block_size - pbm_sums.block_sum());
+                    .map(|block_size| (block_size - pbm_sums.block_sum()).max(Au::zero()));
                 let tentative_block_size = box_size
                     .block
                     .maybe_resolve_extrinsic(available_block_size)

--- a/tests/wpt/tests/css/css-sizing/keyword-sizes-on-floated-element.html
+++ b/tests/wpt/tests/css/css-sizing/keyword-sizes-on-floated-element.html
@@ -119,6 +119,12 @@
   <div class="test max-height stretch" data-expected-height="90">XXXXX XXXXX</div>
 </div>
 
+<!-- Stretch sizes can't result in a negative content size -->
+<div class="wrapper" style="width: 0px; height: 0px">
+  <div class="test width min-width max-width stretch" data-expected-width="10"></div>
+  <div class="test height min-height max-height stretch" data-expected-height="10"></div>
+</div>
+
 <!-- Indefinite stretch -->
 <div style="width: 100px; max-height: 100px">
   <div class="test height stretch indefinite" data-expected-height="30">X X</div>

--- a/tests/wpt/tests/css/css-sizing/keyword-sizes-on-inline-block.html
+++ b/tests/wpt/tests/css/css-sizing/keyword-sizes-on-inline-block.html
@@ -125,6 +125,12 @@
   <div class="test max-height stretch" data-expected-height="90">XXXXX XXXXX</div>
 </div>
 
+<!-- Stretch sizes can't result in a negative content size -->
+<div class="wrapper" style="width: 0px; height: 0px">
+  <div class="test width min-width max-width stretch" data-expected-width="10"></div>
+  <div class="test height min-height max-height stretch" data-expected-height="10"></div>
+</div>
+
 <!-- Indefinite stretch -->
 <div class="wrapper" style="width: 100px; max-height: 100px">
   <div class="test height stretch indefinite" data-expected-height="30">X X</div>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #32853
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
