### PR TITLE
Replaced mem::replace with mem::take for old_min_size

### DIFF
--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -866,7 +866,7 @@ impl<'a> AbsoluteAxisSolver<'a> {
     fn solve_with_size(&mut self, size: Au) -> AxisResult {
         // Override sizes
         let old_size = mem::replace(&mut self.computed_size, AuOrAuto::LengthPercentage(size));
-        let old_min_size = mem::replace(&mut self.computed_min_size, Au::zero());
+        let old_min_size = mem::take(&mut self.computed_min_size);
         let old_max_size = self.computed_max_size.take();
 
         let result = self.solve_tentatively();


### PR DESCRIPTION
**Files:** `servo/components/layout_2020/positioned.rs`

**PR Description:**
**Issue:**
Improved the code in `servo/components/layout_2020/positioned.rs` by using `mem::take` instead of `mem::replace` for setting default values. This makes the code cleaner and more idiomatic.

**Changes:**
`let old_min_size = mem::take(&mut self.computed_min_size);`
-This change uses `mem::take`, which automatically provides the default value of `Au`, eliminating the need to specify `Au::zero()` explicitly.

**Impact:**
The change improves code readability and makes it more idiomatic by using `mem::take`.



---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #33945 

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because does not alter functionality.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
