### PR TITLE
CanGc fixes in `errorevent.rs`

### DIFF
--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -44,7 +44,12 @@ use crate::script_runtime::CanGc;
 use crate::script_thread::Documents;
 
 #[allow(unsafe_code)]
-pub fn handle_evaluate_js(global: &GlobalScope, eval: String, reply: IpcSender<EvaluateJSReply>) {
+pub fn handle_evaluate_js(
+    global: &GlobalScope,
+    eval: String,
+    reply: IpcSender<EvaluateJSReply>,
+    can_gc: CanGc,
+) {
     // global.get_cx() returns a valid `JSContext` pointer, so this is safe.
     let result = unsafe {
         let cx = GlobalScope::get_cx();
@@ -58,6 +63,7 @@ pub fn handle_evaluate_js(global: &GlobalScope, eval: String, reply: IpcSender<E
             1,
             ScriptFetchOptions::default_classic_script(global),
             global.api_base_url(),
+            can_gc,
         );
 
         if rval.is_undefined() {

--- a/components/script/dom/bindings/callback.rs
+++ b/components/script/dom/bindings/callback.rs
@@ -27,7 +27,7 @@ use crate::dom::bindings::utils::AsCCharPtrPtr;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::window::Window;
 use crate::realms::{enter_realm, InRealm};
-use crate::script_runtime::JSContext;
+use crate::script_runtime::{CanGc, JSContext};
 
 /// The exception handling used for a call.
 #[derive(Clone, Copy, PartialEq)]
@@ -271,7 +271,7 @@ impl Drop for CallSetup {
             LeaveRealm(*self.cx, self.old_realm);
             if self.handling == ExceptionHandling::Report {
                 let ar = enter_realm(&*self.exception_global);
-                report_pending_exception(*self.cx, true, InRealm::Entered(&ar));
+                report_pending_exception(*self.cx, true, InRealm::Entered(&ar), CanGc::note());
             }
             drop(self.incumbent_script.take());
             drop(self.entry_script.take().unwrap());

--- a/components/script/dom/bindings/error.rs
+++ b/components/script/dom/bindings/error.rs
@@ -29,7 +29,7 @@ use crate::dom::bindings::str::USVString;
 use crate::dom::domexception::{DOMErrorName, DOMException};
 use crate::dom::globalscope::GlobalScope;
 use crate::realms::InRealm;
-use crate::script_runtime::JSContext as SafeJSContext;
+use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
 
 #[cfg(feature = "js_backtrace")]
 thread_local! {
@@ -267,7 +267,12 @@ impl ErrorInfo {
 ///
 /// The `dispatch_event` argument is temporary and non-standard; passing false
 /// prevents dispatching the `error` event.
-pub unsafe fn report_pending_exception(cx: *mut JSContext, dispatch_event: bool, realm: InRealm) {
+pub unsafe fn report_pending_exception(
+    cx: *mut JSContext,
+    dispatch_event: bool,
+    realm: InRealm,
+    can_gc: CanGc,
+) {
     if !JS_IsExceptionPending(cx) {
         return;
     }
@@ -299,7 +304,7 @@ pub unsafe fn report_pending_exception(cx: *mut JSContext, dispatch_event: bool,
     }
 
     if dispatch_event {
-        GlobalScope::from_context(cx, realm).report_an_error(error_info, value.handle());
+        GlobalScope::from_context(cx, realm).report_an_error(error_info, value.handle(), can_gc);
     }
 }
 

--- a/components/script/dom/create.rs
+++ b/components/script/dom/create.rs
@@ -168,7 +168,7 @@ fn create_html_element(
                             unsafe {
                                 let ar = enter_realm(&*global);
                                 throw_dom_exception(cx, &global, error);
-                                report_pending_exception(*cx, true, InRealm::Entered(&ar));
+                                report_pending_exception(*cx, true, InRealm::Entered(&ar), can_gc);
                             }
 
                             // Step 6.1.2

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -844,7 +844,7 @@ pub fn upgrade_element(definition: Rc<CustomElementDefinition>, element: &Elemen
         unsafe {
             let ar = enter_realm(&*global);
             throw_dom_exception(cx, &global, error);
-            report_pending_exception(*cx, true, InRealm::Entered(&ar));
+            report_pending_exception(*cx, true, InRealm::Entered(&ar), can_gc);
         }
 
         return;

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -544,7 +544,7 @@ impl DedicatedWorkerGlobalScope {
         match msg {
             MixedMessage::Devtools(msg) => match msg {
                 DevtoolScriptControlMsg::EvaluateJS(_pipe_id, string, sender) => {
-                    devtools::handle_evaluate_js(self.upcast(), string, sender)
+                    devtools::handle_evaluate_js(self.upcast(), string, sender, can_gc)
                 },
                 DevtoolScriptControlMsg::WantsLiveNotifications(_pipe_id, bool_val) => {
                     devtools::handle_wants_live_notifications(self.upcast(), bool_val)
@@ -583,13 +583,14 @@ impl DedicatedWorkerGlobalScope {
                 error_info.lineno,
                 error_info.column,
                 HandleValue::null(),
+                CanGc::note(),
             );
             let event_status =
                 event.upcast::<Event>().fire(worker.upcast::<EventTarget>());
 
             // Step 2.
             if event_status == EventStatus::NotCanceled {
-                global.report_an_error(error_info, HandleValue::null());
+                global.report_an_error(error_info, HandleValue::null(), CanGc::note());
             }
         }));
         self.parent_sender

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -3097,13 +3097,13 @@ impl Document {
     }
 
     /// <https://drafts.csswg.org/resize-observer/#deliver-resize-loop-error-notification>
-    pub(crate) fn deliver_resize_loop_error_notification(&self) {
+    pub(crate) fn deliver_resize_loop_error_notification(&self, can_gc: CanGc) {
         let global_scope = self.window.upcast::<GlobalScope>();
         let error_info: ErrorInfo = crate::dom::bindings::error::ErrorInfo {
             message: "ResizeObserver loop completed with undelivered notifications.".to_string(),
             ..Default::default()
         };
-        global_scope.report_an_error(error_info, HandleValue::null());
+        global_scope.report_an_error(error_info, HandleValue::null(), can_gc);
     }
 
     pub(crate) fn status_code(&self) -> Option<u16> {

--- a/components/script/dom/errorevent.rs
+++ b/components/script/dom/errorevent.rs
@@ -66,19 +66,11 @@ impl ErrorEvent {
         lineno: u32,
         colno: u32,
         error: HandleValue,
+        can_gc: CanGc,
     ) -> DomRoot<ErrorEvent> {
         Self::new_with_proto(
-            global,
-            None,
-            type_,
-            bubbles,
-            cancelable,
-            message,
-            filename,
-            lineno,
-            colno,
-            error,
-            CanGc::note(),
+            global, None, type_, bubbles, cancelable, message, filename, lineno, colno, error,
+            can_gc,
         )
     }
 

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -486,7 +486,7 @@ impl EventTarget {
         &self,
         handler: InternalRawUncompiledHandler,
         ty: &Atom,
-        _can_gc: CanGc,
+        can_gc: CanGc,
     ) -> Option<CommonEventHandler> {
         // Step 3.1
         let element = self.downcast::<Element>();
@@ -568,7 +568,7 @@ impl EventTarget {
             unsafe {
                 let ar = enter_realm(self);
                 // FIXME(#13152): dispatch error event.
-                report_pending_exception(*cx, false, InRealm::Entered(&ar));
+                report_pending_exception(*cx, false, InRealm::Entered(&ar), can_gc);
             }
             return None;
         }

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -2630,6 +2630,7 @@ impl GlobalScope {
 
     /// Evaluate a JS script on this global scope.
     #[allow(unsafe_code)]
+    #[allow(clippy::too_many_arguments)]
     pub fn evaluate_script_on_global_with_result(
         &self,
         code: &SourceCode,

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -159,7 +159,7 @@ impl HTMLIFrameElement {
                 // TODO: check according to https://w3c.github.io/webappsec-csp/#should-block-navigation-request
                 if ScriptThread::check_load_origin(&load_data.load_origin, &document.url().origin())
                 {
-                    ScriptThread::eval_js_url(&window_proxy.global(), &mut load_data);
+                    ScriptThread::eval_js_url(&window_proxy.global(), &mut load_data, can_gc);
                 }
             }
         }

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -1014,12 +1014,12 @@ impl HTMLScriptElement {
 
         match script.type_ {
             ScriptType::Classic => {
-                self.run_a_classic_script(&script);
+                self.run_a_classic_script(&script, CanGc::note());
                 document.set_current_script(old_script.as_deref());
             },
             ScriptType::Module => {
                 assert!(document.GetCurrentScript().is_none());
-                self.run_a_module_script(&script, false);
+                self.run_a_module_script(&script, false, CanGc::note());
             },
         }
 
@@ -1035,7 +1035,7 @@ impl HTMLScriptElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#run-a-classic-script
-    pub fn run_a_classic_script(&self, script: &ScriptOrigin) {
+    pub fn run_a_classic_script(&self, script: &ScriptOrigin, can_gc: CanGc) {
         // TODO use a settings object rather than this element's document/window
         // Step 2
         let document = document_from_node(self);
@@ -1059,12 +1059,13 @@ impl HTMLScriptElement {
             line_number,
             script.fetch_options.clone(),
             script.url.clone(),
+            can_gc,
         );
     }
 
     #[allow(unsafe_code)]
     /// <https://html.spec.whatwg.org/multipage/#run-a-module-script>
-    pub fn run_a_module_script(&self, script: &ScriptOrigin, _rethrow_errors: bool) {
+    pub fn run_a_module_script(&self, script: &ScriptOrigin, _rethrow_errors: bool, can_gc: CanGc) {
         // TODO use a settings object rather than this element's document/window
         // Step 2
         let document = document_from_node(self);
@@ -1093,7 +1094,7 @@ impl HTMLScriptElement {
                 let module_error = module_tree.get_rethrow_error().borrow();
                 let network_error = module_tree.get_network_error().borrow();
                 if module_error.is_some() && network_error.is_none() {
-                    module_tree.report_error(global);
+                    module_tree.report_error(global, can_gc);
                     return;
                 }
             }
@@ -1111,7 +1112,7 @@ impl HTMLScriptElement {
 
                 if let Err(exception) = evaluated {
                     module_tree.set_rethrow_error(exception);
-                    module_tree.report_error(global);
+                    module_tree.report_error(global, can_gc);
                 }
             }
         }

--- a/components/script/dom/serviceworkerglobalscope.rs
+++ b/components/script/dom/serviceworkerglobalscope.rs
@@ -414,7 +414,7 @@ impl ServiceWorkerGlobalScope {
         match msg {
             MixedMessage::Devtools(msg) => match msg {
                 DevtoolScriptControlMsg::EvaluateJS(_pipe_id, string, sender) => {
-                    devtools::handle_evaluate_js(self.upcast(), string, sender)
+                    devtools::handle_evaluate_js(self.upcast(), string, sender, can_gc)
                 },
                 DevtoolScriptControlMsg::WantsLiveNotifications(_pipe_id, bool_val) => {
                     devtools::handle_wants_live_notifications(self.upcast(), bool_val)

--- a/components/script/dom/userscripts.rs
+++ b/components/script/dom/userscripts.rs
@@ -17,6 +17,7 @@ use crate::dom::htmlheadelement::HTMLHeadElement;
 use crate::dom::htmlscriptelement::SourceCode;
 use crate::dom::node::document_from_node;
 use crate::script_module::ScriptFetchOptions;
+use crate::script_runtime::CanGc;
 
 pub fn load_script(head: &HTMLHeadElement) {
     let doc = document_from_node(head);
@@ -54,6 +55,7 @@ pub fn load_script(head: &HTMLHeadElement) {
                 1,
                 ScriptFetchOptions::default_classic_script(global),
                 global.api_base_url(),
+                CanGc::note(),
             );
         }
     }));

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -466,7 +466,7 @@ impl WorkerGlobalScope {
                     println!("evaluate_script failed");
                     unsafe {
                         let ar = enter_realm(self);
-                        report_pending_exception(cx, true, InRealm::Entered(&ar));
+                        report_pending_exception(cx, true, InRealm::Entered(&ar), CanGc::note());
                     }
                 }
             },

--- a/components/script/dom/worklet.rs
+++ b/components/script/dom/worklet.rs
@@ -49,7 +49,7 @@ use crate::dom::workletglobalscope::{
 };
 use crate::fetch::load_whole_resource;
 use crate::realms::InRealm;
-use crate::script_runtime::{CommonScriptMsg, Runtime, ScriptThreadEventCategory};
+use crate::script_runtime::{CanGc, CommonScriptMsg, Runtime, ScriptThreadEventCategory};
 use crate::script_thread::{MainThreadScriptMsg, ScriptThread};
 use crate::task::TaskBox;
 use crate::task_source::TaskSourceName;
@@ -545,10 +545,10 @@ impl WorkletThread {
             // try to become the cold backup.
             if self.role.is_cold_backup {
                 if let Some(control) = self.control_buffer.take() {
-                    self.process_control(control);
+                    self.process_control(control, CanGc::note());
                 }
                 while let Ok(control) = self.control_receiver.try_recv() {
-                    self.process_control(control);
+                    self.process_control(control, CanGc::note());
                 }
                 self.gc();
             } else if self.control_buffer.is_none() {
@@ -637,6 +637,7 @@ impl WorkletThread {
         credentials: RequestCredentials,
         pending_tasks_struct: PendingTasksStruct,
         promise: TrustedPromise,
+        can_gc: CanGc,
     ) {
         debug!("Fetching from {}.", script_url);
         // Step 1.
@@ -671,7 +672,7 @@ impl WorkletThread {
         // to the main script thread.
         // https://github.com/w3c/css-houdini-drafts/issues/407
         let ok = script
-            .map(|script| global_scope.evaluate_js(&script))
+            .map(|script| global_scope.evaluate_js(&script, can_gc))
             .unwrap_or(false);
 
         if !ok {
@@ -706,7 +707,7 @@ impl WorkletThread {
     }
 
     /// Process a control message.
-    fn process_control(&mut self, control: WorkletControl) {
+    fn process_control(&mut self, control: WorkletControl, can_gc: CanGc) {
         match control {
             WorkletControl::ExitWorklet(worklet_id) => {
                 self.global_scopes.remove(&worklet_id);
@@ -732,6 +733,7 @@ impl WorkletThread {
                     credentials,
                     pending_tasks_struct,
                     promise,
+                    can_gc,
                 )
             },
         }

--- a/components/script/dom/workletglobalscope.rs
+++ b/components/script/dom/workletglobalscope.rs
@@ -27,7 +27,7 @@ use crate::dom::paintworkletglobalscope::{PaintWorkletGlobalScope, PaintWorkletT
 use crate::dom::testworkletglobalscope::{TestWorkletGlobalScope, TestWorkletTask};
 use crate::dom::worklet::WorkletExecutor;
 use crate::script_module::ScriptFetchOptions;
-use crate::script_runtime::JSContext;
+use crate::script_runtime::{CanGc, JSContext};
 use crate::script_thread::MainThreadScriptMsg;
 
 #[dom_struct]
@@ -114,7 +114,7 @@ impl WorkletGlobalScope {
     }
 
     /// Evaluate a JS script in this global.
-    pub fn evaluate_js(&self, script: &str) -> bool {
+    pub fn evaluate_js(&self, script: &str, can_gc: CanGc) -> bool {
         debug!("Evaluating Dom in a worklet.");
         rooted!(in (*GlobalScope::get_cx()) let mut rval = UndefinedValue());
         self.globalscope.evaluate_js_on_global_with_result(
@@ -122,6 +122,7 @@ impl WorkletGlobalScope {
             rval.handle_mut(),
             ScriptFetchOptions::default_classic_script(&self.globalscope),
             self.globalscope.api_base_url(),
+            can_gc,
         )
     }
 

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -539,7 +539,7 @@ impl ModuleTree {
     }
 
     #[allow(unsafe_code)]
-    pub fn report_error(&self, global: &GlobalScope) {
+    pub fn report_error(&self, global: &GlobalScope, can_gc: CanGc) {
         let module_error = self.rethrow_error.borrow();
 
         if let Some(exception) = &*module_error {
@@ -550,7 +550,12 @@ impl ModuleTree {
                     exception.handle(),
                     ExceptionStackBehavior::Capture,
                 );
-                report_pending_exception(*GlobalScope::get_cx(), true, InRealm::Entered(&ar));
+                report_pending_exception(
+                    *GlobalScope::get_cx(),
+                    true,
+                    InRealm::Entered(&ar),
+                    can_gc,
+                );
             }
         }
     }

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1028,7 +1028,7 @@ impl ScriptThread {
                     // TODO: check according to https://w3c.github.io/webappsec-csp/#should-block-navigation-request
                     if let Some(window) = trusted_global.root().downcast::<Window>() {
                         if ScriptThread::check_load_origin(&load_data.load_origin, &window.get_url().origin()) {
-                            ScriptThread::eval_js_url(&trusted_global.root(), &mut load_data);
+                            ScriptThread::eval_js_url(&trusted_global.root(), &mut load_data, CanGc::note());
                             sender
                                 .send((pipeline_id, ScriptMsg::LoadUrl(load_data, replace)))
                                 .unwrap();
@@ -1738,7 +1738,7 @@ impl ScriptThread {
             }
 
             if document.has_skipped_resize_observations() {
-                document.deliver_resize_loop_error_notification();
+                document.deliver_resize_loop_error_notification(can_gc);
             }
 
             // TODO(#31870): Implement step 17: if the focused area of doc is not a focusable area,
@@ -2578,7 +2578,7 @@ impl ScriptThread {
                 Some(window) => {
                     let global = window.upcast::<GlobalScope>();
                     let _aes = AutoEntryScript::new(global);
-                    devtools::handle_evaluate_js(global, s, reply)
+                    devtools::handle_evaluate_js(global, s, reply, can_gc)
                 },
                 None => warn!("Message sent to closed pipeline {}.", id),
             },
@@ -2660,11 +2660,13 @@ impl ScriptThread {
         match msg {
             WebDriverScriptCommand::ExecuteScript(script, reply) => {
                 let window = self.documents.borrow().find_window(pipeline_id);
-                return webdriver_handlers::handle_execute_script(window, script, reply);
+                return webdriver_handlers::handle_execute_script(window, script, reply, can_gc);
             },
             WebDriverScriptCommand::ExecuteAsyncScript(script, reply) => {
                 let window = self.documents.borrow().find_window(pipeline_id);
-                return webdriver_handlers::handle_execute_async_script(window, script, reply);
+                return webdriver_handlers::handle_execute_async_script(
+                    window, script, reply, can_gc,
+                );
             },
             _ => (),
         }
@@ -4007,7 +4009,7 @@ impl ScriptThread {
 
     /// Turn javascript: URL into JS code to eval, according to the steps in
     /// <https://html.spec.whatwg.org/multipage/#javascript-protocol>
-    pub fn eval_js_url(global_scope: &GlobalScope, load_data: &mut LoadData) {
+    pub fn eval_js_url(global_scope: &GlobalScope, load_data: &mut LoadData, can_gc: CanGc) {
         // This slice of the URL’s serialization is equivalent to (5.) to (7.):
         // Start with the scheme data of the parsed URL;
         // append question mark and query component, if any;
@@ -4025,6 +4027,7 @@ impl ScriptThread {
             jsval.handle_mut(),
             ScriptFetchOptions::default_classic_script(global_scope),
             global_scope.api_base_url(),
+            can_gc,
         );
 
         load_data.js_eval_result = if jsval.get().is_string() {

--- a/components/script/timers.rs
+++ b/components/script/timers.rs
@@ -558,6 +558,7 @@ impl JsTimerTask {
                     rval.handle_mut(),
                     ScriptFetchOptions::default_classic_script(&global),
                     global.api_base_url(),
+                    CanGc::note(),
                 );
             },
             InternalTimerCallback::FunctionTimerCallback(ref function, ref arguments) => {

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -289,6 +289,7 @@ pub fn handle_execute_script(
     window: Option<DomRoot<Window>>,
     eval: String,
     reply: IpcSender<WebDriverJSResult>,
+    can_gc: CanGc,
 ) {
     match window {
         Some(window) => {
@@ -301,6 +302,7 @@ pub fn handle_execute_script(
                     rval.handle_mut(),
                     ScriptFetchOptions::default_classic_script(global),
                     global.api_base_url(),
+                    can_gc,
                 );
                 jsval_to_webdriver(*cx, window.upcast::<GlobalScope>(), rval.handle())
             };
@@ -319,6 +321,7 @@ pub fn handle_execute_async_script(
     window: Option<DomRoot<Window>>,
     eval: String,
     reply: IpcSender<WebDriverJSResult>,
+    can_gc: CanGc,
 ) {
     match window {
         Some(window) => {
@@ -331,6 +334,7 @@ pub fn handle_execute_async_script(
                 rval.handle_mut(),
                 ScriptFetchOptions::default_classic_script(global),
                 global.api_base_url(),
+                can_gc,
             );
         },
         None => {


### PR DESCRIPTION
Replaces CanGc::note() calls with arguments passed by callers in `components/script/dom/errorevent.rs`


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are a part of #33683 
- [X] These changes do not require tests because they do not modify functionality

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
