### PR TITLE
layout: Cache content block size contributions

### DIFF
--- a/components/layout_2020/flexbox/construct.rs
+++ b/components/layout_2020/flexbox/construct.rs
@@ -181,6 +181,7 @@ where
                         independent_formatting_context: IndependentFormattingContext::NonReplaced(
                             non_replaced,
                         ),
+                        cached_layout: Default::default(),
                     })))
                 },
                 FlexLevelJob::Element {
@@ -212,6 +213,7 @@ where
                                 contents,
                                 self.text_decoration_line,
                             ),
+                            cached_layout: Default::default(),
                         }))
                     };
                     box_slot.set(LayoutBox::FlexLevel(box_.clone()));

--- a/components/layout_2020/flexbox/mod.rs
+++ b/components/layout_2020/flexbox/mod.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use app_units::Au;
 use geom::{FlexAxis, MainStartCrossStart};
 use serde::Serialize;
 use servo_arc::Arc as ServoArc;
@@ -112,9 +113,17 @@ pub(crate) enum FlexLevelBox {
     OutOfFlowAbsolutelyPositionedBox(ArcRefCell<AbsolutelyPositionedBox>),
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Serialize)]
 pub(crate) struct FlexItemBox {
     independent_formatting_context: IndependentFormattingContext,
+    #[serde(skip)]
+    cached_layout: ArcRefCell<Option<FlexItemLayoutCache>>,
+}
+
+impl std::fmt::Debug for FlexItemBox {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("FlexItemBox")
+    }
 }
 
 impl FlexItemBox {
@@ -125,4 +134,21 @@ impl FlexItemBox {
     fn base_fragment_info(&self) -> BaseFragmentInfo {
         self.independent_formatting_context.base_fragment_info()
     }
+}
+
+#[derive(Debug)]
+struct FlexItemLayoutCacheDescriptor {
+    containing_block_inline_size: Au,
+    content_block_size: Au,
+}
+
+impl FlexItemLayoutCacheDescriptor {
+    fn compatible_with_size(&self, inline: Au) -> bool {
+        inline == self.containing_block_inline_size
+    }
+}
+
+/// A cache to avoid multiple layouts during flexbox layout.
+struct FlexItemLayoutCache {
+    descriptor: FlexItemLayoutCacheDescriptor,
 }


### PR DESCRIPTION
This is the first part of caching intermediary layout during flexbox
layout. A later change will try to reuse these layouts, when possible,
for actual item layout and re-layout due to stretching.

Co-authored-by: Oriol Brufau <obrufau@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they should not change testable behavior. We have no performance tests.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
