### PR TITLE
layout: Avoid flex item relayout sometimes when stretching

### DIFF
--- a/components/layout_2020/flexbox/construct.rs
+++ b/components/layout_2020/flexbox/construct.rs
@@ -181,7 +181,7 @@ where
                         independent_formatting_context: IndependentFormattingContext::NonReplaced(
                             non_replaced,
                         ),
-                        cached_layout: Default::default(),
+                        block_content_size_cache: Default::default(),
                     })))
                 },
                 FlexLevelJob::Element {
@@ -213,7 +213,7 @@ where
                                 contents,
                                 self.text_decoration_line,
                             ),
-                            cached_layout: Default::default(),
+                            block_content_size_cache: Default::default(),
                         }))
                     };
                     box_slot.set(LayoutBox::FlexLevel(box_.clone()));

--- a/components/layout_2020/flexbox/mod.rs
+++ b/components/layout_2020/flexbox/mod.rs
@@ -117,7 +117,7 @@ pub(crate) enum FlexLevelBox {
 pub(crate) struct FlexItemBox {
     independent_formatting_context: IndependentFormattingContext,
     #[serde(skip)]
-    cached_layout: ArcRefCell<Option<FlexItemLayoutCache>>,
+    block_content_size_cache: ArcRefCell<Option<CachedBlockSizeContribution>>,
 }
 
 impl std::fmt::Debug for FlexItemBox {
@@ -136,19 +136,7 @@ impl FlexItemBox {
     }
 }
 
-#[derive(Debug)]
-struct FlexItemLayoutCacheDescriptor {
+struct CachedBlockSizeContribution {
     containing_block_inline_size: Au,
     content_block_size: Au,
-}
-
-impl FlexItemLayoutCacheDescriptor {
-    fn compatible_with_size(&self, inline: Au) -> bool {
-        inline == self.containing_block_inline_size
-    }
-}
-
-/// A cache to avoid multiple layouts during flexbox layout.
-struct FlexItemLayoutCache {
-    descriptor: FlexItemLayoutCacheDescriptor,
 }

--- a/components/layout_2020/formatting_contexts.rs
+++ b/components/layout_2020/formatting_contexts.rs
@@ -90,6 +90,9 @@ pub(crate) struct IndependentLayout {
     /// there was one. This is used to propagate baselines to the ancestors of `display:
     /// inline-block`.
     pub baselines: Baselines,
+
+    /// Whether or not this layout depends on the containing block size.
+    pub depends_on_block_constraints: bool,
 }
 
 pub(crate) struct IndependentLayoutResult {

--- a/components/layout_2020/fragment_tree/base_fragment.rs
+++ b/components/layout_2020/fragment_tree/base_fragment.rs
@@ -104,6 +104,10 @@ bitflags! {
         /// for empty table cells when 'empty-cells' is 'hide' and also table wrappers.  This flag
         /// doesn't avoid hit-testing nor does it prevent the painting outlines.
         const DO_NOT_PAINT = 1 << 6;
+        /// Whether or not the size of this fragment depends on the block size of its container
+        /// and the fragment can be a flex item. This flag is used to cache items during flex
+        /// layout.
+        const SIZE_DEPENDS_ON_BLOCK_CONSTRAINTS_AND_CAN_BE_CHILD_OF_FLEX_ITEM = 1 << 7;
     }
 }
 

--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -459,9 +459,15 @@ impl HoistedAbsolutelyPositionedBox {
             IndependentFormattingContext::Replaced(replaced) => {
                 // https://drafts.csswg.org/css2/visudet.html#abs-replaced-width
                 // https://drafts.csswg.org/css2/visudet.html#abs-replaced-height
+                let content_box_sizes_and_pbm =
+                    style.content_box_sizes_and_padding_border_margin(&containing_block.into());
                 let used_size = replaced
                     .contents
-                    .used_size_as_if_inline_element(containing_block, &style, &pbm)
+                    .used_size_as_if_inline_element(
+                        containing_block,
+                        &style,
+                        &content_box_sizes_and_pbm.into(),
+                    )
                     .map(|size| Size::Numeric(*size));
                 (used_size, Default::default(), Default::default())
             },
@@ -477,7 +483,7 @@ impl HoistedAbsolutelyPositionedBox {
             .static_position_rect
             .to_logical(containing_block);
 
-        let box_offset = style.box_offsets(containing_block);
+        let box_offset = style.box_offsets(containing_block.style.writing_mode);
 
         // When the "static-position rect" doesn't come into play, we do not do any alignment
         // in the inline axis.
@@ -982,7 +988,7 @@ pub(crate) fn relative_adjustement(
     let cbis = containing_block.inline_size;
     let cbbs = containing_block.block_size;
     let box_offsets = style
-        .box_offsets(containing_block)
+        .box_offsets(containing_block.style.writing_mode)
         .map_inline_and_block_axes(
             |value| value.map(|value| value.to_used_value(cbis)),
             |value| match cbbs.non_auto() {

--- a/components/layout_2020/replaced.rs
+++ b/components/layout_2020/replaced.rs
@@ -30,7 +30,7 @@ use crate::dom::NodeExt;
 use crate::fragment_tree::{BaseFragmentInfo, Fragment, IFrameFragment, ImageFragment};
 use crate::geom::{LogicalVec2, PhysicalPoint, PhysicalRect, PhysicalSize};
 use crate::sizing::InlineContentSizesResult;
-use crate::style_ext::{AspectRatio, Clamp, ComputedValuesExt, PaddingBorderMargin};
+use crate::style_ext::{AspectRatio, Clamp, ComputedValuesExt, ContentBoxSizesAndPBMDeprecated};
 use crate::{AuOrAuto, ContainingBlock, IndefiniteContainingBlock};
 
 #[derive(Debug, Serialize)]
@@ -430,24 +430,22 @@ impl ReplacedContent {
         &self,
         containing_block: &ContainingBlock,
         style: &ComputedValues,
-        pbm: &PaddingBorderMargin,
+        content_box_sizes_and_pbm: &ContentBoxSizesAndPBMDeprecated,
     ) -> LogicalVec2<Au> {
-        let box_size = style
-            .content_box_size_deprecated(containing_block, pbm)
-            // We need to clamp to zero here to obtain the proper aspect
-            // ratio when box-sizing is border-box and the inner box size
-            // would otherwise be negative.
+        // We need to clamp to zero here to obtain the proper aspect ratio when box-sizing
+        // is border-box and the inner box size would otherwise be negative.
+        let content_box_size = content_box_sizes_and_pbm
+            .content_box_size
             .map(|value| value.map(|value| value.max(Au::zero())));
-        let min_box_size = style
-            .content_min_box_size_deprecated(containing_block, pbm)
+        let content_min_box_size = content_box_sizes_and_pbm
+            .content_min_box_size
             .auto_is(Au::zero);
-        let max_box_size = style.content_max_box_size_deprecated(containing_block, pbm);
         self.used_size_as_if_inline_element_from_content_box_sizes(
             containing_block,
             style,
-            box_size,
-            min_box_size,
-            max_box_size,
+            content_box_size,
+            content_min_box_size,
+            content_box_sizes_and_pbm.content_max_box_size,
         )
     }
 

--- a/components/layout_2020/table/layout.rs
+++ b/components/layout_2020/table/layout.rs
@@ -1683,11 +1683,18 @@ impl<'a> TableLayout<'a> {
         let offset_from_wrapper = -table_pbm.padding - table_pbm.border;
         let mut current_block_offset = offset_from_wrapper.block_start;
 
+        let depends_on_block_constraints = self
+            .table
+            .style
+            .content_box_sizes_and_padding_border_margin(&containing_block_for_table.into())
+            .depends_on_block_constraints;
+
         let mut table_layout = IndependentLayout {
             fragments: Vec::new(),
             content_block_size: Zero::zero(),
             content_inline_size_for_table: None,
             baselines: Baselines::default(),
+            depends_on_block_constraints,
         };
 
         table_layout


### PR DESCRIPTION
This is the second flexbox caching change. It seeks to detect when a
relayout can be avoided in the case of a stretching flex item. This
heuristic can be combined, because currently we still do relayout
sometimes when we do not need to.

For instance currently we always relayout when a flex child is itself a
column flex. This only needs to happen when the grandchildren themselves
grow or shrink. That optimization is perhaps a lower priority as
`flex-grow: 0 / flex-shrink: 1` is the default behavior for flex.

Fixes #33567.

Co-authored-by: Oriol Brufau <obrufau@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they do not change layout results and there is no way to measure performance with tests yet.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
