### PR TITLE
CanGc fixes from `eventtarget.rs`

### DIFF
--- a/components/script/dom/bindings/codegen/Bindings.conf
+++ b/components/script/dom/bindings/codegen/Bindings.conf
@@ -55,7 +55,7 @@ DOMInterfaces = {
 
 'BluetoothRemoteGATTServer': {
     'inRealms': ['Connect'],
-    'canGc': ['GetPrimaryService', 'GetPrimaryServices', 'Connect'],
+    'canGc': ['GetPrimaryService', 'GetPrimaryServices', 'Connect', 'Disconnect'],
 },
 
 'BluetoothRemoteGATTService': {
@@ -116,7 +116,7 @@ DOMInterfaces = {
 },
 
 'ElementInternals': {
-    'canGc': ['ReportValidity'],
+    'canGc': ['CheckValidity', 'ReportValidity'],
 },
 
 'EventSource': {
@@ -184,11 +184,7 @@ DOMInterfaces = {
 },
 
 'HTMLButtonElement': {
-    'canGc': ['ReportValidity'],
-},
-
-'HTMLCanvasElement': {
-    'canGc': ['CaptureStream', 'GetContext'],
+    'canGc': ['CheckValidity', 'ReportValidity'],
 },
 
 'HTMLElement': {
@@ -196,19 +192,19 @@ DOMInterfaces = {
 },
 
 'HTMLFieldSetElement': {
-    'canGc': ['ReportValidity'],
+    'canGc': ['CheckValidity', 'ReportValidity'],
 },
 
 'HTMLFormElement': {
-    'canGc': ['RequestSubmit', 'ReportValidity', 'Submit'],
-},
-
-'HTMLInputElement': {
-    'canGc': ['ReportValidity', 'SelectFiles'],
+    'canGc': ['CheckValidity', 'RequestSubmit', 'ReportValidity', 'Submit'],
 },
 
 'HTMLImageElement': {
     'canGc': ['Width', 'Height', 'Decode'],
+},
+
+'HTMLInputElement': {
+    'canGc': ['CheckValidity', 'ReportValidity', 'SelectFiles'],
 },
 
 'HTMLMediaElement': {
@@ -217,15 +213,19 @@ DOMInterfaces = {
 },
 
 'HTMLObjectElement': {
-    'canGc': ['ReportValidity'],
+    'canGc': ['CheckValidity', 'ReportValidity'],
 },
 
 'HTMLOutputElement': {
-    'canGc': ['ReportValidity'],
+    'canGc': ['CheckValidity', 'ReportValidity'],
+},
+
+'HTMLCanvasElement': {
+    'canGc': ['CaptureStream', 'GetContext'],
 },
 
 'HTMLSelectElement': {
-    'canGc': ['ReportValidity'],
+    'canGc': ['CheckValidity', 'ReportValidity'],
 },
 
 'HTMLTemplateElement': {
@@ -233,7 +233,7 @@ DOMInterfaces = {
 },
 
 'HTMLTextAreaElement': {
-    'canGc': ['ReportValidity'],
+    'canGc': ['CheckValidity', 'ReportValidity'],
 },
 
 'Location': {
@@ -289,6 +289,10 @@ DOMInterfaces = {
 
 'PaintRenderingContext2D': {
     'canGc': ['GetTransform', 'SetStrokeStyle', 'SetFillStyle', 'SetShadowColor'],
+},
+
+'Permissions': {
+    'canGc': ['Query', 'Request', 'Revoke'],
 },
 
 'Permissions': {

--- a/components/script/dom/bluetoothdevice.rs
+++ b/components/script/dom/bluetoothdevice.rs
@@ -193,7 +193,7 @@ impl BluetoothDevice {
 
     // https://webbluetoothcg.github.io/web-bluetooth/#clean-up-the-disconnected-device
     #[allow(crown::unrooted_must_root)]
-    pub fn clean_up_disconnected_device(&self) {
+    pub fn clean_up_disconnected_device(&self, can_gc: CanGc) {
         // Step 1.
         self.get_gatt().set_connected(false);
 
@@ -224,7 +224,7 @@ impl BluetoothDevice {
 
         // Step 8.
         self.upcast::<EventTarget>()
-            .fire_bubbling_event(atom!("gattserverdisconnected"));
+            .fire_bubbling_event(atom!("gattserverdisconnected"), can_gc);
     }
 
     // https://webbluetoothcg.github.io/web-bluetooth/#garbage-collect-the-connection
@@ -317,7 +317,7 @@ impl BluetoothDeviceMethods for BluetoothDevice {
 }
 
 impl AsyncBluetoothListener for BluetoothDevice {
-    fn handle_response(&self, response: BluetoothResponse, promise: &Rc<Promise>) {
+    fn handle_response(&self, response: BluetoothResponse, promise: &Rc<Promise>, _can_gc: CanGc) {
         match response {
             // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothdevice-unwatchadvertisements
             BluetoothResponse::WatchAdvertisements(_result) => {

--- a/components/script/dom/bluetoothpermissionresult.rs
+++ b/components/script/dom/bluetoothpermissionresult.rs
@@ -25,6 +25,7 @@ use crate::dom::bluetoothdevice::BluetoothDevice;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::permissionstatus::PermissionStatus;
 use crate::dom::promise::Promise;
+use crate::script_runtime::CanGc;
 
 // https://webbluetoothcg.github.io/web-bluetooth/#bluetoothpermissionresult
 #[dom_struct]
@@ -94,7 +95,7 @@ impl BluetoothPermissionResultMethods for BluetoothPermissionResult {
 }
 
 impl AsyncBluetoothListener for BluetoothPermissionResult {
-    fn handle_response(&self, response: BluetoothResponse, promise: &Rc<Promise>) {
+    fn handle_response(&self, response: BluetoothResponse, promise: &Rc<Promise>, _can_gc: CanGc) {
         match response {
             // https://webbluetoothcg.github.io/web-bluetooth/#request-bluetooth-devices
             // Step 3, 11, 13 - 14.

--- a/components/script/dom/bluetoothremotegattcharacteristic.rs
+++ b/components/script/dom/bluetoothremotegattcharacteristic.rs
@@ -298,7 +298,7 @@ impl BluetoothRemoteGATTCharacteristicMethods for BluetoothRemoteGATTCharacteris
 }
 
 impl AsyncBluetoothListener for BluetoothRemoteGATTCharacteristic {
-    fn handle_response(&self, response: BluetoothResponse, promise: &Rc<Promise>) {
+    fn handle_response(&self, response: BluetoothResponse, promise: &Rc<Promise>, can_gc: CanGc) {
         let device = self.Service().Device();
         match response {
             // https://webbluetoothcg.github.io/web-bluetooth/#getgattchildren
@@ -328,7 +328,7 @@ impl AsyncBluetoothListener for BluetoothRemoteGATTCharacteristic {
 
                 // Step 5.5.3.
                 self.upcast::<EventTarget>()
-                    .fire_bubbling_event(atom!("characteristicvaluechanged"));
+                    .fire_bubbling_event(atom!("characteristicvaluechanged"), can_gc);
 
                 // Step 5.5.4.
                 promise.resolve_native(&value);

--- a/components/script/dom/bluetoothremotegattdescriptor.rs
+++ b/components/script/dom/bluetoothremotegattdescriptor.rs
@@ -179,7 +179,7 @@ impl BluetoothRemoteGATTDescriptorMethods for BluetoothRemoteGATTDescriptor {
 }
 
 impl AsyncBluetoothListener for BluetoothRemoteGATTDescriptor {
-    fn handle_response(&self, response: BluetoothResponse, promise: &Rc<Promise>) {
+    fn handle_response(&self, response: BluetoothResponse, promise: &Rc<Promise>, _can_gc: CanGc) {
         match response {
             // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattdescriptor-readvalue
             BluetoothResponse::ReadValue(result) => {

--- a/components/script/dom/bluetoothremotegattserver.rs
+++ b/components/script/dom/bluetoothremotegattserver.rs
@@ -95,7 +95,7 @@ impl BluetoothRemoteGATTServerMethods for BluetoothRemoteGATTServer {
     }
 
     // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattserver-disconnect
-    fn Disconnect(&self) -> ErrorResult {
+    fn Disconnect(&self, can_gc: CanGc) -> ErrorResult {
         // TODO: Step 1: Implement activeAlgorithms internal slot for BluetoothRemoteGATTServer.
 
         // Step 2.
@@ -104,7 +104,7 @@ impl BluetoothRemoteGATTServerMethods for BluetoothRemoteGATTServer {
         }
 
         // Step 3.
-        self.Device().clean_up_disconnected_device();
+        self.Device().clean_up_disconnected_device(can_gc);
 
         // Step 4 - 5:
         self.Device().garbage_collect_the_connection()
@@ -146,7 +146,7 @@ impl BluetoothRemoteGATTServerMethods for BluetoothRemoteGATTServer {
 }
 
 impl AsyncBluetoothListener for BluetoothRemoteGATTServer {
-    fn handle_response(&self, response: BluetoothResponse, promise: &Rc<Promise>) {
+    fn handle_response(&self, response: BluetoothResponse, promise: &Rc<Promise>, _can_gc: CanGc) {
         match response {
             // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattserver-connect
             BluetoothResponse::GATTServerConnect(connected) => {

--- a/components/script/dom/bluetoothremotegattservice.rs
+++ b/components/script/dom/bluetoothremotegattservice.rs
@@ -163,7 +163,7 @@ impl BluetoothRemoteGATTServiceMethods for BluetoothRemoteGATTService {
 }
 
 impl AsyncBluetoothListener for BluetoothRemoteGATTService {
-    fn handle_response(&self, response: BluetoothResponse, promise: &Rc<Promise>) {
+    fn handle_response(&self, response: BluetoothResponse, promise: &Rc<Promise>, _can_gc: CanGc) {
         let device = self.Device();
         match response {
             // https://webbluetoothcg.github.io/web-bluetooth/#getgattchildren

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -746,7 +746,7 @@ impl Document {
                     // Step 4.6.2 Set document's page showing flag to true.
                     document.page_showing.set(true);
                     // Step 4.6.3 Update the visibility state of document to "visible".
-                    document.update_visibility_state(DocumentVisibilityState::Visible);
+                    document.update_visibility_state(DocumentVisibilityState::Visible, CanGc::note());
                     // Step 4.6.4 Fire a page transition event named pageshow at document's relevant
                     // global object with true.
                     let event = PageTransitionEvent::new(
@@ -2360,7 +2360,7 @@ impl Document {
                 .window
                 .dispatch_event_with_target_override(event, can_gc);
             // Step 6 Update the visibility state of oldDocument to "hidden".
-            self.update_visibility_state(DocumentVisibilityState::Hidden);
+            self.update_visibility_state(DocumentVisibilityState::Hidden, can_gc);
         }
         // Step 7
         if !self.fired_unload.get() {
@@ -2721,7 +2721,7 @@ impl Document {
             .queue(
                 task!(fire_dom_content_loaded_event: move || {
                 let document = document.root();
-                document.upcast::<EventTarget>().fire_bubbling_event(atom!("DOMContentLoaded"));
+                document.upcast::<EventTarget>().fire_bubbling_event(atom!("DOMContentLoaded"), CanGc::note());
                 update_with_current_instant(&document.dom_content_loaded_event_end);
                 }),
                 window.upcast(),
@@ -4216,7 +4216,7 @@ impl Document {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#visibility-state>
-    fn update_visibility_state(&self, visibility_state: DocumentVisibilityState) {
+    fn update_visibility_state(&self, visibility_state: DocumentVisibilityState, can_gc: CanGc) {
         // Step 1 If document's visibility state equals visibilityState, then return.
         if self.visibility_state.get() == visibility_state {
             return;
@@ -4255,7 +4255,7 @@ impl Document {
 
         // Step 7 Fire an event named visibilitychange at document, with its bubbles attribute initialized to true.
         self.upcast::<EventTarget>()
-            .fire_bubbling_event(atom!("visibilitychange"));
+            .fire_bubbling_event(atom!("visibilitychange"), can_gc);
     }
 }
 

--- a/components/script/dom/elementinternals.rs
+++ b/components/script/dom/elementinternals.rs
@@ -317,11 +317,11 @@ impl ElementInternalsMethods for ElementInternals {
     }
 
     /// <https://html.spec.whatwg.org/multipage#dom-elementinternals-checkvalidity>
-    fn CheckValidity(&self) -> Fallible<bool> {
+    fn CheckValidity(&self, can_gc: CanGc) -> Fallible<bool> {
         if !self.is_target_form_associated() {
             return Err(Error::NotSupported);
         }
-        Ok(self.check_validity())
+        Ok(self.check_validity(can_gc))
     }
 
     /// <https://html.spec.whatwg.org/multipage#dom-elementinternals-reportvalidity>

--- a/components/script/dom/event.rs
+++ b/components/script/dom/event.rs
@@ -618,7 +618,7 @@ impl TaskOnce for EventTask {
         let target = self.target.root();
         let bubbles = self.bubbles;
         let cancelable = self.cancelable;
-        target.fire_event_with_params(self.name, bubbles, cancelable);
+        target.fire_event_with_params(self.name, bubbles, cancelable, CanGc::note());
     }
 }
 

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -665,26 +665,38 @@ impl EventTarget {
             name,
             EventBubbles::DoesNotBubble,
             EventCancelable::NotCancelable,
+            CanGc::note(),
         )
     }
 
     // https://dom.spec.whatwg.org/#concept-event-fire
-    pub fn fire_bubbling_event(&self, name: Atom) -> DomRoot<Event> {
-        self.fire_event_with_params(name, EventBubbles::Bubbles, EventCancelable::NotCancelable)
+    pub fn fire_bubbling_event(&self, name: Atom, can_gc: CanGc) -> DomRoot<Event> {
+        self.fire_event_with_params(
+            name,
+            EventBubbles::Bubbles,
+            EventCancelable::NotCancelable,
+            can_gc,
+        )
     }
 
     // https://dom.spec.whatwg.org/#concept-event-fire
-    pub fn fire_cancelable_event(&self, name: Atom) -> DomRoot<Event> {
+    pub fn fire_cancelable_event(&self, name: Atom, can_gc: CanGc) -> DomRoot<Event> {
         self.fire_event_with_params(
             name,
             EventBubbles::DoesNotBubble,
             EventCancelable::Cancelable,
+            can_gc,
         )
     }
 
     // https://dom.spec.whatwg.org/#concept-event-fire
-    pub fn fire_bubbling_cancelable_event(&self, name: Atom) -> DomRoot<Event> {
-        self.fire_event_with_params(name, EventBubbles::Bubbles, EventCancelable::Cancelable)
+    pub fn fire_bubbling_cancelable_event(&self, name: Atom, can_gc: CanGc) -> DomRoot<Event> {
+        self.fire_event_with_params(
+            name,
+            EventBubbles::Bubbles,
+            EventCancelable::Cancelable,
+            can_gc,
+        )
     }
 
     // https://dom.spec.whatwg.org/#concept-event-fire
@@ -693,8 +705,9 @@ impl EventTarget {
         name: Atom,
         bubbles: EventBubbles,
         cancelable: EventCancelable,
+        can_gc: CanGc,
     ) -> DomRoot<Event> {
-        let event = Event::new(&self.global(), name, bubbles, cancelable, CanGc::note());
+        let event = Event::new(&self.global(), name, bubbles, cancelable, can_gc);
         event.fire(self);
         event
     }

--- a/components/script/dom/htmlbuttonelement.rs
+++ b/components/script/dom/htmlbuttonelement.rs
@@ -170,8 +170,8 @@ impl HTMLButtonElementMethods for HTMLButtonElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-cva-checkvalidity
-    fn CheckValidity(&self) -> bool {
-        self.check_validity()
+    fn CheckValidity(&self, can_gc: CanGc) -> bool {
+        self.check_validity(can_gc)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-cva-reportvalidity

--- a/components/script/dom/htmlfieldsetelement.rs
+++ b/components/script/dom/htmlfieldsetelement.rs
@@ -127,8 +127,8 @@ impl HTMLFieldSetElementMethods for HTMLFieldSetElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-cva-checkvalidity
-    fn CheckValidity(&self) -> bool {
-        self.check_validity()
+    fn CheckValidity(&self, can_gc: CanGc) -> bool {
+        self.check_validity(can_gc)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-cva-reportvalidity

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -1586,8 +1586,8 @@ impl HTMLInputElementMethods for HTMLInputElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-cva-checkvalidity
-    fn CheckValidity(&self) -> bool {
-        self.check_validity()
+    fn CheckValidity(&self, can_gc: CanGc) -> bool {
+        self.check_validity(can_gc)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-cva-reportvalidity
@@ -1889,8 +1889,8 @@ impl HTMLInputElement {
             let filelist = FileList::new(&window, files);
             self.filelist.set(Some(&filelist));
 
-            target.fire_bubbling_event(atom!("input"));
-            target.fire_bubbling_event(atom!("change"));
+            target.fire_bubbling_event(atom!("input"), can_gc);
+            target.fire_bubbling_event(atom!("change"), can_gc);
         }
     }
 
@@ -2805,7 +2805,7 @@ impl Activatable for HTMLInputElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#run-post-click-activation-steps
-    fn activation_behavior(&self, _event: &Event, _target: &EventTarget, _can_gc: CanGc) {
+    fn activation_behavior(&self, _event: &Event, _target: &EventTarget, can_gc: CanGc) {
         let ty = self.input_type();
         match ty {
             InputType::Submit => {
@@ -2836,8 +2836,8 @@ impl Activatable for HTMLInputElement {
                     return;
                 }
                 let target = self.upcast::<EventTarget>();
-                target.fire_bubbling_event(atom!("input"));
-                target.fire_bubbling_event(atom!("change"));
+                target.fire_bubbling_event(atom!("input"), can_gc);
+                target.fire_bubbling_event(atom!("change"), can_gc);
             },
             InputType::File => self.select_files(None, CanGc::note()),
             _ => (),

--- a/components/script/dom/htmlobjectelement.rs
+++ b/components/script/dom/htmlobjectelement.rs
@@ -110,8 +110,8 @@ impl HTMLObjectElementMethods for HTMLObjectElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-cva-checkvalidity
-    fn CheckValidity(&self) -> bool {
-        self.check_validity()
+    fn CheckValidity(&self, can_gc: CanGc) -> bool {
+        self.check_validity(can_gc)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-cva-reportvalidity

--- a/components/script/dom/htmloutputelement.rs
+++ b/components/script/dom/htmloutputelement.rs
@@ -132,8 +132,8 @@ impl HTMLOutputElementMethods for HTMLOutputElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-cva-checkvalidity
-    fn CheckValidity(&self) -> bool {
-        self.check_validity()
+    fn CheckValidity(&self, can_gc: CanGc) -> bool {
+        self.check_validity(can_gc)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-cva-reportvalidity

--- a/components/script/dom/htmlselectelement.rs
+++ b/components/script/dom/htmlselectelement.rs
@@ -391,8 +391,8 @@ impl HTMLSelectElementMethods for HTMLSelectElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-cva-checkvalidity
-    fn CheckValidity(&self) -> bool {
-        self.check_validity()
+    fn CheckValidity(&self, can_gc: CanGc) -> bool {
+        self.check_validity(can_gc)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-cva-reportvalidity

--- a/components/script/dom/htmltextareaelement.rs
+++ b/components/script/dom/htmltextareaelement.rs
@@ -424,8 +424,8 @@ impl HTMLTextAreaElementMethods for HTMLTextAreaElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-cva-checkvalidity
-    fn CheckValidity(&self) -> bool {
-        self.check_validity()
+    fn CheckValidity(&self, can_gc: CanGc) -> bool {
+        self.check_validity(can_gc)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-cva-reportvalidity

--- a/components/script/dom/permissions.rs
+++ b/components/script/dom/permissions.rs
@@ -46,7 +46,7 @@ pub trait PermissionAlgorithm {
         descriptor: &Self::Descriptor,
         status: &Self::Status,
     );
-    fn permission_revoke(descriptor: &Self::Descriptor, status: &Self::Status);
+    fn permission_revoke(descriptor: &Self::Descriptor, status: &Self::Status, can_gc: CanGc);
 }
 
 enum Operation {
@@ -139,7 +139,7 @@ impl Permissions {
                             .remove(&root_desc.name.to_string());
 
                         // (Revoke) Step 4.
-                        Bluetooth::permission_revoke(&bluetooth_desc, &result)
+                        Bluetooth::permission_revoke(&bluetooth_desc, &result, can_gc)
                     },
                 }
             },
@@ -171,7 +171,7 @@ impl Permissions {
                             .remove(&root_desc.name.to_string());
 
                         // (Revoke) Step 4.
-                        Permissions::permission_revoke(&root_desc, &status);
+                        Permissions::permission_revoke(&root_desc, &status, can_gc);
                     },
                 }
             },
@@ -270,7 +270,12 @@ impl PermissionAlgorithm for Permissions {
         Permissions::permission_query(cx, promise, descriptor, status);
     }
 
-    fn permission_revoke(_descriptor: &PermissionDescriptor, _status: &PermissionStatus) {}
+    fn permission_revoke(
+        _descriptor: &PermissionDescriptor,
+        _status: &PermissionStatus,
+        _can_gc: CanGc,
+    ) {
+    }
 }
 
 // https://w3c.github.io/permissions/#permission-state

--- a/components/script/dom/validation.rs
+++ b/components/script/dom/validation.rs
@@ -35,11 +35,11 @@ pub trait Validatable {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#check-validity-steps>
-    fn check_validity(&self) -> bool {
+    fn check_validity(&self, can_gc: CanGc) -> bool {
         if self.is_instance_validatable() && !self.satisfies_constraints() {
             self.as_element()
                 .upcast::<EventTarget>()
-                .fire_cancelable_event(atom!("invalid"));
+                .fire_cancelable_event(atom!("invalid"), can_gc);
             false
         } else {
             true
@@ -61,7 +61,7 @@ pub trait Validatable {
         let event = self
             .as_element()
             .upcast::<EventTarget>()
-            .fire_cancelable_event(atom!("invalid"));
+            .fire_cancelable_event(atom!("invalid"), can_gc);
 
         // Step 1.2.
         if !event.DefaultPrevented() {

--- a/components/script/dom/xrsystem.rs
+++ b/components/script/dom/xrsystem.rs
@@ -324,7 +324,7 @@ impl XRSystem {
                     let xr = xr.root();
                     let interacting = ScriptThread::is_user_interacting();
                     ScriptThread::set_user_interacting(true);
-                    xr.upcast::<EventTarget>().fire_bubbling_event(atom!("sessionavailable"));
+                    xr.upcast::<EventTarget>().fire_bubbling_event(atom!("sessionavailable"), CanGc::note());
                     ScriptThread::set_user_interacting(interacting);
                 }),
                 window.upcast(),


### PR DESCRIPTION
Replaces CanGc::note() calls with arguments passed by callers in `components/script/dom/eventtarget.rs`

New `CanGc::note()` in EventTarget::fire_event to be picked up later

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are a part of #33683 
- [X] These changes do not require tests because they do not modify functionality

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
