### PR TITLE
Propagate CanGc when interacting with readable streams.

### DIFF
--- a/components/script/dom/bindings/codegen/Bindings.conf
+++ b/components/script/dom/bindings/codegen/Bindings.conf
@@ -30,7 +30,7 @@ DOMInterfaces = {
 
 'Blob': {
     'weakReferenceable': True,
-    'canGc': ['Slice', 'Text', 'ArrayBuffer'], 
+    'canGc': ['Slice', 'Text', 'ArrayBuffer', 'Stream'],
 },
 
 'Bluetooth': {

--- a/components/script/dom/blob.rs
+++ b/components/script/dom/blob.rs
@@ -86,8 +86,8 @@ impl Blob {
     }
 
     /// <https://w3c.github.io/FileAPI/#blob-get-stream>
-    pub fn get_stream(&self) -> DomRoot<ReadableStream> {
-        self.global().get_blob_stream(&self.blob_id)
+    pub fn get_stream(&self, can_gc: CanGc) -> DomRoot<ReadableStream> {
+        self.global().get_blob_stream(&self.blob_id, can_gc)
     }
 }
 
@@ -237,8 +237,8 @@ impl BlobMethods for Blob {
     }
 
     // <https://w3c.github.io/FileAPI/#blob-get-stream>
-    fn Stream(&self, _cx: JSContext) -> NonNull<JSObject> {
-        self.get_stream().get_js_stream()
+    fn Stream(&self, _cx: JSContext, can_gc: CanGc) -> NonNull<JSObject> {
+        self.get_stream(can_gc).get_js_stream()
     }
 
     // https://w3c.github.io/FileAPI/#slice-method-algo

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -870,6 +870,7 @@ impl HTMLFormElement {
                     enctype,
                     encoding,
                     target_window,
+                    can_gc,
                 );
             },
             // https://html.spec.whatwg.org/multipage/#submit-get-action
@@ -920,6 +921,7 @@ impl HTMLFormElement {
         enctype: FormEncType,
         encoding: &'static Encoding,
         target: &Window,
+        can_gc: CanGc,
     ) {
         let boundary = generate_boundary();
         let bytes = match enctype {
@@ -957,7 +959,7 @@ impl HTMLFormElement {
         let global = self.global();
 
         let request_body = bytes
-            .extract(&global)
+            .extract(&global, can_gc)
             .expect("Couldn't extract body.")
             .into_net_request_body()
             .0;

--- a/components/script/dom/request.rs
+++ b/components/script/dom/request.rs
@@ -477,7 +477,7 @@ impl RequestMethods for Request {
             // Step 37.1 TODO "If init["keepalive"] exists and is true..."
 
             // Step 37.2
-            let mut extracted_body = init_body.extract(global)?;
+            let mut extracted_body = init_body.extract(global, can_gc)?;
 
             // Step 37.3
             if let Some(contents) = extracted_body.content_type.take() {

--- a/components/script/dom/response.rs
+++ b/components/script/dom/response.rs
@@ -190,7 +190,7 @@ impl ResponseMethods for Response {
                 total_bytes: _,
                 content_type,
                 source: _,
-            } = body.extract(global)?;
+            } = body.extract(global, can_gc)?;
 
             r.body_stream.set(Some(&*stream));
 
@@ -210,7 +210,7 @@ impl ResponseMethods for Response {
         } else {
             // Reset FetchResponse to an in-memory stream with empty byte sequence here for
             // no-init-body case
-            let stream = ReadableStream::new_from_bytes(global, Vec::with_capacity(0));
+            let stream = ReadableStream::new_from_bytes(global, Vec::with_capacity(0), can_gc);
             r.body_stream.set(Some(&*stream));
         }
 
@@ -444,12 +444,12 @@ impl Response {
         *self.stream_consumer.borrow_mut() = sc;
     }
 
-    pub fn stream_chunk(&self, chunk: Vec<u8>) {
+    pub fn stream_chunk(&self, chunk: Vec<u8>, can_gc: CanGc) {
         // Note, are these two actually mutually exclusive?
         if let Some(stream_consumer) = self.stream_consumer.borrow_mut().as_ref() {
             stream_consumer.consume_chunk(chunk.as_slice());
         } else if let Some(body) = self.body_stream.get() {
-            body.enqueue_native(chunk);
+            body.enqueue_native(chunk, can_gc);
         }
     }
 

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -576,7 +576,7 @@ impl XMLHttpRequestMethods for XMLHttpRequest {
                 };
                 let total_bytes = bytes.len();
                 let global = self.global();
-                let stream = ReadableStream::new_from_bytes(&global, bytes);
+                let stream = ReadableStream::new_from_bytes(&global, bytes, can_gc);
                 Some(ExtractedBody {
                     stream,
                     total_bytes: Some(total_bytes),
@@ -585,7 +585,9 @@ impl XMLHttpRequestMethods for XMLHttpRequest {
                 })
             },
             Some(DocumentOrXMLHttpRequestBodyInit::Blob(ref b)) => {
-                let extracted_body = b.extract(&self.global()).expect("Couldn't extract body.");
+                let extracted_body = b
+                    .extract(&self.global(), can_gc)
+                    .expect("Couldn't extract body.");
                 if !extracted_body.in_memory() && self.sync.get() {
                     warn!("Sync XHR with not in-memory Blob as body not supported");
                     None
@@ -595,22 +597,23 @@ impl XMLHttpRequestMethods for XMLHttpRequest {
             },
             Some(DocumentOrXMLHttpRequestBodyInit::FormData(ref formdata)) => Some(
                 formdata
-                    .extract(&self.global())
+                    .extract(&self.global(), can_gc)
                     .expect("Couldn't extract body."),
             ),
-            Some(DocumentOrXMLHttpRequestBodyInit::String(ref str)) => {
-                Some(str.extract(&self.global()).expect("Couldn't extract body."))
-            },
+            Some(DocumentOrXMLHttpRequestBodyInit::String(ref str)) => Some(
+                str.extract(&self.global(), can_gc)
+                    .expect("Couldn't extract body."),
+            ),
             Some(DocumentOrXMLHttpRequestBodyInit::URLSearchParams(ref urlsp)) => Some(
                 urlsp
-                    .extract(&self.global())
+                    .extract(&self.global(), can_gc)
                     .expect("Couldn't extract body."),
             ),
             Some(DocumentOrXMLHttpRequestBodyInit::ArrayBuffer(ref typedarray)) => {
                 let bytes = typedarray.to_vec();
                 let total_bytes = bytes.len();
                 let global = self.global();
-                let stream = ReadableStream::new_from_bytes(&global, bytes);
+                let stream = ReadableStream::new_from_bytes(&global, bytes, can_gc);
                 Some(ExtractedBody {
                     stream,
                     total_bytes: Some(total_bytes),
@@ -622,7 +625,7 @@ impl XMLHttpRequestMethods for XMLHttpRequest {
                 let bytes = typedarray.to_vec();
                 let total_bytes = bytes.len();
                 let global = self.global();
-                let stream = ReadableStream::new_from_bytes(&global, bytes);
+                let stream = ReadableStream::new_from_bytes(&global, bytes, can_gc);
                 Some(ExtractedBody {
                     stream,
                     total_bytes: Some(total_bytes),

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -277,7 +277,7 @@ impl FetchResponseListener for FetchContext {
 
     fn process_response_chunk(&mut self, _: RequestId, chunk: Vec<u8>) {
         let response = self.response_object.root();
-        response.stream_chunk(chunk);
+        response.stream_chunk(chunk, CanGc::note());
     }
 
     fn process_response_eof(


### PR DESCRIPTION
Identified via #33974.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they are compile-only.