### PR TITLE
Use borrow() to fix GC hazard in stream_chunk

### DIFF
--- a/components/script/dom/response.rs
+++ b/components/script/dom/response.rs
@@ -446,7 +446,7 @@ impl Response {
 
     pub fn stream_chunk(&self, chunk: Vec<u8>) {
         // Note, are these two actually mutually exclusive?
-        if let Some(stream_consumer) = self.stream_consumer.borrow.as_ref() {
+        if let Some(stream_consumer) = self.stream_consumer.borrow().as_ref() {
             stream_consumer.consume_chunk(chunk.as_slice());
         } else if let Some(body) = self.body_stream.get() {
             body.enqueue_native(chunk);

--- a/components/script/dom/response.rs
+++ b/components/script/dom/response.rs
@@ -446,7 +446,7 @@ impl Response {
 
     pub fn stream_chunk(&self, chunk: Vec<u8>) {
         // Note, are these two actually mutually exclusive?
-        if let Some(stream_consumer) = self.stream_consumer.borrow_mut().as_ref() {
+        if let Some(stream_consumer) = self.stream_consumer.borrow.as_ref() {
             stream_consumer.consume_chunk(chunk.as_slice());
         } else if let Some(body) = self.body_stream.get() {
             body.enqueue_native(chunk);


### PR DESCRIPTION
**File:** `servo/components/script/dom/response.rs`

**PR Description**
**Issue**: Addressed a GC borrow hazard in the `Response::stream_chunk` method.

Changes: 
The `borrow_mut()` call in the `if let` statement was replaced with `borrow()`. The original code used `borrow_mut()`, which held a mutable borrow even when the condition evaluated to false. Since mutability was not needed, changing it to `borrow()` resolves the issue and avoids potential borrow conflicts.

**Impact:** 
This change eliminates the borrow hazard in `Response::stream_chunk`, making the code safer without affecting its existing behavior.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #33974

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
