### PR TITLE
Replace CanGC note calls with arguments passed by callers

### DIFF
--- a/components/script/body.rs
+++ b/components/script/body.rs
@@ -708,7 +708,7 @@ impl Callback for ConsumeBodyPromiseHandler {
 
             let realm = enter_realm(&*global);
             let comp = InRealm::Entered(&realm);
-            read_promise.append_native_handler(&handler, comp, CanGc::note());
+            read_promise.append_native_handler(&handler, comp, can_gc);
         }
     }
 }

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2280,7 +2280,7 @@ impl Window {
                     load_data.url.clone(),
                     replace,
                 ));
-                doc.check_and_scroll_fragment(fragment, CanGc::note());
+                doc.check_and_scroll_fragment(fragment, can_gc);
                 let this = Trusted::new(self);
                 let old_url = doc.url().into_string();
                 let new_url = load_data.url.clone().into_string();

--- a/components/script/dom/xrsession.rs
+++ b/components/script/dom/xrsession.rs
@@ -600,7 +600,7 @@ impl XRSession {
     }
 
     /// <https://www.w3.org/TR/webxr/#apply-the-nominal-frame-rate>
-    fn apply_nominal_framerate(&self, rate: f32) {
+    fn apply_nominal_framerate(&self, rate: f32, can_gc: CanGc) {
         if self.framerate.get() == rate || self.ended.get() {
             return;
         }
@@ -613,7 +613,7 @@ impl XRSession {
             false,
             false,
             self,
-            CanGc::note(),
+            can_gc,
         );
         event.upcast::<Event>().fire(self.upcast());
     }
@@ -1067,7 +1067,7 @@ impl XRSessionMethods for XRSession {
                 let _ = task_source.queue_with_canceller(
                     task!(update_session_framerate: move || {
                         let session = this.root();
-                        session.apply_nominal_framerate(message.unwrap());
+                        session.apply_nominal_framerate(message.unwrap(), CanGc::note());
                         if let Some(promise) = session.update_framerate_promise.borrow_mut().take() {
                             promise.resolve_native(&());
                         };


### PR DESCRIPTION
File Changes:
Replaced CanGc::note() calls in these files:
components/script/body.rs
components/script/dom/xrsession.rs
components/script/dom/window.rs

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #33683 ([GitHub issue number if applicable](https://github.com/servo/servo/issues/33683))
- [X] These changes do not require tests because they do not modify functionality

