### PR TITLE
cangc fixes in node.rs

### DIFF
--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -395,6 +395,7 @@ pub fn handle_modify_attribute(
     pipeline: PipelineId,
     node_id: String,
     modifications: Vec<AttrModification>,
+    can_gc: CanGc,
 ) {
     let Some(document) = documents.find_document(pipeline) else {
         return warn!("document for pipeline id {} is not found", &pipeline);
@@ -421,6 +422,7 @@ pub fn handle_modify_attribute(
                 let _ = elem.SetAttribute(
                     DOMString::from(modification.attribute_name),
                     DOMString::from(string),
+                    can_gc,
                 );
             },
             None => elem.RemoveAttribute(DOMString::from(modification.attribute_name)),

--- a/components/script/dom/attr.rs
+++ b/components/script/dom/attr.rs
@@ -23,6 +23,7 @@ use crate::dom::element::{AttributeMutation, Element};
 use crate::dom::mutationobserver::{Mutation, MutationObserver};
 use crate::dom::node::Node;
 use crate::dom::virtualmethods::vtable_for;
+use crate::script_runtime::CanGc;
 use crate::script_thread::ScriptThread;
 
 // https://dom.spec.whatwg.org/#interface-attr
@@ -60,7 +61,7 @@ impl Attr {
             owner: MutNullableDom::new(owner),
         }
     }
-
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         document: &Document,
         local_name: LocalName,
@@ -69,12 +70,14 @@ impl Attr {
         namespace: Namespace,
         prefix: Option<Prefix>,
         owner: Option<&Element>,
+        can_gc: CanGc,
     ) -> DomRoot<Attr> {
         Node::reflect_node(
             Box::new(Attr::new_inherited(
                 document, local_name, value, name, namespace, prefix, owner,
             )),
             document,
+            can_gc,
         )
     }
 

--- a/components/script/dom/bindings/codegen/Bindings.conf
+++ b/components/script/dom/bindings/codegen/Bindings.conf
@@ -66,6 +66,14 @@ DOMInterfaces = {
     'canGc': ['GetTransform','GetImageData', 'CreateImageData', 'CreateImageData_', 'SetFont', 'FillText', 'MeasureText', 'SetStrokeStyle', 'SetFillStyle', 'SetShadowColor'],
 },
 
+'CharacterData': {
+    'canGc': ['Before', 'After', 'ReplaceWith']
+},
+
+'CSSStyleDeclaration': {
+    'canGc': ['RemoveProperty', 'SetCssText']
+},
+
 'CanvasGradient': {
     'canGc': ['AddColorStop'],
 },
@@ -76,7 +84,7 @@ DOMInterfaces = {
 },
 
 'DOMImplementation': {
-    'canGc': ['CreateDocument', 'CreateHTMLDocument'],
+    'canGc': ['CreateDocument', 'CreateHTMLDocument', 'CreateDocumentType'],
 },
 
 'DOMMatrix': {
@@ -104,15 +112,31 @@ DOMInterfaces = {
 },
 
 'Document': {
-    'canGc': ['Close', 'CreateElement', 'CreateElementNS', 'ImportNode', 'SetTitle', 'Write', 'Writeln', 'CreateEvent', 'CreateRange', 'Open', 'Open_', 'Fonts', 'ElementFromPoint', 'ElementsFromPoint', 'ExitFullscreen'],
+    'canGc': ['Close', 'CreateElement', 'CreateElementNS', 'ImportNode', 'SetTitle', 'Write', 'Writeln', 'CreateEvent', 'CreateRange', 'Open', 'Open_', 'CreateComment', 'CreateAttribute', 'CreateAttributeNS', 'CreateDocumentFragment', 'CreateTextNode', 'CreateCDATASection', 'CreateProcessingInstruction', 'Prepend', 'Append', 'ReplaceChildren', 'SetBgColor', 'SetFgColor', 'Fonts', 'ElementFromPoint', 'ElementsFromPoint', 'ExitFullscreen'],
 },
 
 'DynamicModuleOwner': {
     'inRealms': ['PromiseAttribute'],
 },
 
+'DocumentFragment': {
+    'canGc': ['Prepend', 'Append', 'ReplaceChildren']
+},
+
+'DocumentType': {
+    'canGc': ['Before', 'After', 'ReplaceWith']
+},
+
+'DOMStringMap': {
+    'canGc': ['NamedSetter']
+},
+
+"DOMTokenList": {
+     'canGc': ['SetValue', 'Add', 'Remove', 'Toggle', 'Replace']
+},
+
 'Element': {
-    'canGc': ['SetInnerHTML', 'SetOuterHTML', 'InsertAdjacentHTML', 'GetClientRects', 'GetBoundingClientRect', 'SetScrollTop', 'SetScrollLeft', 'Scroll', 'Scroll_', 'ScrollBy', 'ScrollBy_', 'ScrollWidth', 'ScrollHeight', 'ScrollTop', 'ScrollLeft', 'ClientTop', 'ClientLeft', 'ClientWidth', 'ClientHeight', 'RequestFullscreen'],
+    'canGc': ['SetInnerHTML', 'SetOuterHTML', 'InsertAdjacentHTML', 'GetClientRects', 'GetBoundingClientRect', 'InsertAdjacentText', 'ToggleAttribute', 'SetAttribute', 'SetAttributeNS', "SetId","SetClassName","Prepend","Append","ReplaceChildren","Before","After","ReplaceWith", 'SetRole', 'SetAriaAtomic', 'SetAriaAutoComplete', 'SetAriaBrailleLabel', 'SetAriaBrailleRoleDescription', 'SetAriaBusy', 'SetAriaChecked', 'SetAriaColCount', 'SetAriaColIndex', 'SetAriaColIndexText', 'SetAriaColSpan', 'SetAriaCurrent', 'SetAriaDescription', 'SetAriaDisabled', 'SetAriaExpanded', 'SetAriaHasPopup', 'SetAriaHidden', 'SetAriaInvalid', 'SetAriaKeyShortcuts', 'SetAriaLabel', 'SetAriaLevel', 'SetAriaLive', 'SetAriaModal', 'SetAriaMultiLine', 'SetAriaMultiSelectable', 'SetAriaOrientation', 'SetAriaPlaceholder', 'SetAriaPosInSet', 'SetAriaPressed','SetAriaReadOnly', 'SetAriaRelevant', 'SetAriaRequired', 'SetAriaRoleDescription', 'SetAriaRowCount', 'SetAriaRowIndex', 'SetAriaRowIndexText', 'SetAriaRowSpan', 'SetAriaSelected', 'SetAriaSetSize','SetAriaSort', 'SetAriaValueMax', 'SetAriaValueMin', 'SetAriaValueNow', 'SetAriaValueText', 'SetScrollTop', 'SetScrollLeft', 'Scroll', 'Scroll_', 'ScrollBy', 'ScrollBy_', 'ScrollWidth', 'ScrollHeight', 'ScrollTop', 'ScrollLeft', 'ClientTop', 'ClientLeft', 'ClientWidth', 'ClientHeight', 'RequestFullscreen'],
 },
 
 'ElementInternals': {
@@ -184,31 +208,47 @@ DOMInterfaces = {
 },
 
 'HTMLButtonElement': {
-    'canGc': ['CheckValidity', 'ReportValidity'],
+    'canGc': ['CheckValidity', 'ReportValidity','SetBackground'],
 },
 
 'HTMLElement': {
-    'canGc': ['GetOffsetParent', 'OffsetTop', 'OffsetLeft', 'OffsetWidth', 'OffsetHeight', 'InnerText', 'GetOuterText', 'Focus', 'Blur', 'Click'],
+    'canGc': ['Focus', 'Blur', 'Click', 'SetInnerText', 'SetOuterText', "SetTranslate", 'SetAutofocus', 'GetOffsetParent', 'OffsetTop', 'OffsetLeft', 'OffsetWidth', 'OffsetHeight', 'InnerText', 'GetOuterText'],
 },
 
 'HTMLFieldSetElement': {
     'canGc': ['CheckValidity', 'ReportValidity'],
 },
 
+'HTMLDialogElement': {
+    'canGc': ['Show'],
+},
+
 'HTMLFormElement': {
-    'canGc': ['CheckValidity', 'RequestSubmit', 'ReportValidity', 'Submit'],
+    'canGc': ['CheckValidity', 'RequestSubmit', 'ReportValidity', 'Submit', 'Reset', 'SetRel'],
 },
 
 'HTMLImageElement': {
-    'canGc': ['Width', 'Height', 'Decode'],
+    'canGc': ['RequestSubmit', 'ReportValidity', 'Reset','SetRel', 'Width', 'Height', 'Decode', 'SetCrossOrigin', 'SetWidth', 'SetHeight', 'SetReferrerPolicy'],
+},
+
+'HTMLFontElement': {
+    'canGc': ['SetSize']
 },
 
 'HTMLInputElement': {
-    'canGc': ['CheckValidity', 'ReportValidity', 'SelectFiles'],
+    'canGc': ['ReportValidity', 'SetValue', 'SetValueAsNumber', 'SetValueAsDate', 'StepUp', 'StepDown', 'CheckValidity', 'ReportValidity', 'SelectFiles'],
+},
+
+"HTMLAreaElement": {
+     "canGc": ["SetRel"]
+},
+
+"HTMLBodyElement": {
+    "canGc": ["SetBackground"]
 },
 
 'HTMLMediaElement': {
-    'canGc': ['Load', 'Pause', 'Play', 'SetSrcObject'],
+    'canGc': ['Load', 'Pause', 'Play', 'SetSrcObject', 'SetCrossOrigin'],
     'inRealms': ['Play'],
 },
 
@@ -217,7 +257,11 @@ DOMInterfaces = {
 },
 
 'HTMLOutputElement': {
-    'canGc': ['CheckValidity', 'ReportValidity'],
+    'canGc': ['ReportValidity', 'SetDefaultValue', 'SetValue', 'CheckValidity'],
+},
+
+'HTMLMeterElement': {
+    'canGc': ['SetValue', 'SetMin', 'SetMax', 'SetLow', 'SetHigh', 'SetOptimum', 'CheckValidity', 'ReportValidity']
 },
 
 'HTMLCanvasElement': {
@@ -225,15 +269,55 @@ DOMInterfaces = {
 },
 
 'HTMLSelectElement': {
-    'canGc': ['CheckValidity', 'ReportValidity'],
+    'canGc': ['ReportValidity', 'SetLength', 'IndexedSetter', 'CheckValidity'],
 },
 
 'HTMLTemplateElement': {
     'canGc': ['Content'],
 },
 
+'HTMLTitleElement': {
+    'canGc': ['SetText']
+},
+
 'HTMLTextAreaElement': {
-    'canGc': ['CheckValidity', 'ReportValidity'],
+    'canGc': ['ReportValidity', 'SetDefaultValue', 'CheckValidity'],
+},
+
+'HTMLTableElement': {
+    'canGc': ['CreateCaption', 'CreateTBody', 'InsertRow', 'InsertCell', 'InsertRow', 'CreateTHead', 'CreateTFoot']
+},
+
+'HTMLTableRowElement': {
+    'canGc': ['InsertCell']
+},
+
+'HTMLTableSectionElement': {
+    'canGc': ['InsertRow']
+},
+
+'HTMLOptionsCollection': {
+    'canGc': ['IndexedSetter', 'SetLength']
+},
+
+'HTMLOptionElement': {
+    'canGc': ['SetText']
+},
+
+'HTMLProgressElement': {
+    'canGc': ['SetValue', 'SetMax']
+},
+
+'HTMLScriptElement': {
+    'canGc': ['SetAsync', 'SetCrossOrigin', 'SetText']
+},
+
+"HTMLAnchorElement": {
+    "canGc": ["SetText","SetRel","SetHref", 'SetHash', 'SetHost', 'SetHostname', 'SetPassword', 'SetPathname', 'SetPort', 'SetProtocol', 'SetSearch', 'SetUsername']
+},
+
+'HTMLLinkElement': {
+    'canGc': ['SetRel', 'SetCrossOrigin'],
 },
 
 'Location': {
@@ -275,7 +359,7 @@ DOMInterfaces = {
 },
 
 'Node': {
-    'canGc': ['CloneNode'],
+    'canGc': ['CloneNode', 'SetTextContent'],
 },
 
 'OfflineAudioContext': {
@@ -313,7 +397,7 @@ DOMInterfaces = {
 },
 
 'Range': {
-    'canGc': ['CloneContents', 'CloneRange', 'CreateContextualFragment', 'ExtractContents', 'SurroundContents'],
+    'canGc': ['CloneContents', 'CloneRange', 'CreateContextualFragment', 'ExtractContents', 'SurroundContents', 'InsertNode'],
     'weakReferenceable': True,
 },
 
@@ -348,6 +432,10 @@ DOMInterfaces = {
     'canGc': ['Encrypt', 'Decrypt', 'GenerateKey', 'ImportKey', 'ExportKey'],
 },
 
+'SVGElement': {
+    'canGc': ['SetAutofocus']
+},
+
 #FIXME(jdm): This should be 'register': False, but then we don't generate enum types
 'TestBinding': {
     'inRealms': ['PromiseAttribute', 'PromiseNativeHandler'],
@@ -357,6 +445,10 @@ DOMInterfaces = {
 'TestWorklet': {
     'inRealms': ['AddModule'],
     'canGc': ['AddModule'],
+},
+
+'Text': {
+    'canGc': ['SplitText']
 },
 
 'URL': {

--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -6239,6 +6239,7 @@ let global = GlobalScope::from_object(JS_CALLEE(*cx, vp).to_object());
                     &global,
                     PrototypeList::ID::{MakeNativeName(self.descriptor.name)},
                     CreateInterfaceObjects,
+                    CanGc::note()
                 )
                 """
         else:

--- a/components/script/dom/bindings/constructor.rs
+++ b/components/script/dom/bindings/constructor.rs
@@ -63,6 +63,7 @@ unsafe fn html_constructor(
     check_type: fn(&Element) -> bool,
     proto_id: PrototypeList::ID,
     creator: unsafe fn(SafeJSContext, HandleObject, *mut ProtoOrIfaceArray),
+    can_gc: CanGc,
 ) -> Result<(), ()> {
     let window = global.downcast::<Window>().unwrap();
     let document = window.Document();
@@ -157,7 +158,7 @@ unsafe fn html_constructor(
             // Any prototype used to create these elements will be overwritten before returning
             // from this function, so we don't bother overwriting the defaults here.
             let element = if definition.is_autonomous() {
-                DomRoot::upcast(HTMLElement::new(name.local, None, &document, None))
+                DomRoot::upcast(HTMLElement::new(name.local, None, &document, None, can_gc))
             } else {
                 create_native_html_element(
                     name,
@@ -384,6 +385,7 @@ pub unsafe fn call_html_constructor<T: DerivedFrom<Element> + DomObject>(
     global: &GlobalScope,
     proto_id: PrototypeList::ID,
     creator: unsafe fn(SafeJSContext, HandleObject, *mut ProtoOrIfaceArray),
+    can_gc: CanGc,
 ) -> bool {
     fn element_derives_interface<T: DerivedFrom<Element>>(element: &Element) -> bool {
         element.is::<T>()
@@ -396,6 +398,7 @@ pub unsafe fn call_html_constructor<T: DerivedFrom<Element> + DomObject>(
         element_derives_interface::<T>,
         proto_id,
         creator,
+        can_gc,
     )
     .is_ok()
 }

--- a/components/script/dom/cdatasection.rs
+++ b/components/script/dom/cdatasection.rs
@@ -9,6 +9,7 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
 use crate::dom::node::Node;
 use crate::dom::text::Text;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct CDATASection {
@@ -22,10 +23,11 @@ impl CDATASection {
         }
     }
 
-    pub fn new(text: DOMString, document: &Document) -> DomRoot<CDATASection> {
+    pub fn new(text: DOMString, document: &Document, can_gc: CanGc) -> DomRoot<CDATASection> {
         Node::reflect_node(
             Box::new(CDATASection::new_inherited(text, document)),
             document,
+            can_gc,
         )
     }
 }

--- a/components/script/dom/comment.rs
+++ b/components/script/dom/comment.rs
@@ -33,11 +33,13 @@ impl Comment {
         text: DOMString,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<Comment> {
         Node::reflect_node_with_proto(
             Box::new(Comment::new_inherited(text, document)),
             document,
             proto,
+            can_gc,
         )
     }
 }
@@ -47,10 +49,10 @@ impl CommentMethods for Comment {
     fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
-        _can_gc: CanGc,
+        can_gc: CanGc,
         data: DOMString,
     ) -> Fallible<DomRoot<Comment>> {
         let document = window.Document();
-        Ok(Comment::new(data, &document, proto))
+        Ok(Comment::new(data, &document, proto, can_gc))
     }
 }

--- a/components/script/dom/create.rs
+++ b/components/script/dom/create.rs
@@ -99,17 +99,17 @@ fn create_svg_element(
 
     macro_rules! make(
         ($ctor:ident) => ({
-            let obj = $ctor::new(name.local, prefix, document, proto);
+            let obj = $ctor::new(name.local, prefix, document, proto, CanGc::note());
             DomRoot::upcast(obj)
         });
         ($ctor:ident, $($arg:expr),+) => ({
-            let obj = $ctor::new(name.local, prefix, document, proto, $($arg),+);
+            let obj = $ctor::new(name.local, prefix, document, proto, $($arg),+, CanGc::note());
             DomRoot::upcast(obj)
         })
     );
 
     if !pref!(dom.svg.enabled) {
-        return Element::new(name.local, name.ns, prefix, document, proto);
+        return Element::new(name.local, name.ns, prefix, document, proto, CanGc::note());
     }
 
     match name.local {
@@ -145,6 +145,7 @@ fn create_html_element(
                         prefix.clone(),
                         document,
                         proto,
+                        can_gc,
                     ));
                     result.set_custom_element_state(CustomElementState::Undefined);
                     ScriptThread::enqueue_upgrade_reaction(&result, definition);
@@ -173,7 +174,7 @@ fn create_html_element(
 
                             // Step 6.1.2
                             let element = DomRoot::upcast::<Element>(HTMLUnknownElement::new(
-                                local_name, prefix, document, proto,
+                                local_name, prefix, document, proto, can_gc,
                             ));
                             element.set_custom_element_state(CustomElementState::Failed);
                             element
@@ -231,11 +232,11 @@ pub fn create_native_html_element(
 
     macro_rules! make(
         ($ctor:ident) => ({
-            let obj = $ctor::new(name.local, prefix, document, proto);
+            let obj = $ctor::new(name.local, prefix, document, proto, CanGc::note());
             DomRoot::upcast(obj)
         });
         ($ctor:ident, $($arg:expr),+) => ({
-            let obj = $ctor::new(name.local, prefix, document, proto, $($arg),+);
+            let obj = $ctor::new(name.local, prefix, document, proto, $($arg),+, CanGc::note());
             DomRoot::upcast(obj)
         })
     );
@@ -406,6 +407,6 @@ pub fn create_element(
     match name.ns {
         ns!(html) => create_html_element(name, prefix, is, document, creator, mode, proto, can_gc),
         ns!(svg) => create_svg_element(name, prefix, document, proto),
-        _ => Element::new(name.local, name.ns, prefix, document, proto),
+        _ => Element::new(name.local, name.ns, prefix, document, proto, can_gc),
     }
 }

--- a/components/script/dom/documentfragment.rs
+++ b/components/script/dom/documentfragment.rs
@@ -40,18 +40,20 @@ impl DocumentFragment {
         }
     }
 
-    pub fn new(document: &Document) -> DomRoot<DocumentFragment> {
-        Self::new_with_proto(document, None)
+    pub fn new(document: &Document, can_gc: CanGc) -> DomRoot<DocumentFragment> {
+        Self::new_with_proto(document, None, can_gc)
     }
 
     fn new_with_proto(
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<DocumentFragment> {
         Node::reflect_node_with_proto(
             Box::new(DocumentFragment::new_inherited(document)),
             document,
             proto,
+            can_gc,
         )
     }
 
@@ -65,11 +67,11 @@ impl DocumentFragmentMethods for DocumentFragment {
     fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
-        _can_gc: CanGc,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<DocumentFragment>> {
         let document = window.Document();
 
-        Ok(DocumentFragment::new_with_proto(&document, proto))
+        Ok(DocumentFragment::new_with_proto(&document, proto, can_gc))
     }
 
     // https://dom.spec.whatwg.org/#dom-parentnode-children
@@ -106,18 +108,18 @@ impl DocumentFragmentMethods for DocumentFragment {
     }
 
     // https://dom.spec.whatwg.org/#dom-parentnode-prepend
-    fn Prepend(&self, nodes: Vec<NodeOrString>) -> ErrorResult {
-        self.upcast::<Node>().prepend(nodes)
+    fn Prepend(&self, nodes: Vec<NodeOrString>, can_gc: CanGc) -> ErrorResult {
+        self.upcast::<Node>().prepend(nodes, can_gc)
     }
 
     // https://dom.spec.whatwg.org/#dom-parentnode-append
-    fn Append(&self, nodes: Vec<NodeOrString>) -> ErrorResult {
-        self.upcast::<Node>().append(nodes)
+    fn Append(&self, nodes: Vec<NodeOrString>, can_gc: CanGc) -> ErrorResult {
+        self.upcast::<Node>().append(nodes, can_gc)
     }
 
     // https://dom.spec.whatwg.org/#dom-parentnode-replacechildren
-    fn ReplaceChildren(&self, nodes: Vec<NodeOrString>) -> ErrorResult {
-        self.upcast::<Node>().replace_children(nodes)
+    fn ReplaceChildren(&self, nodes: Vec<NodeOrString>, can_gc: CanGc) -> ErrorResult {
+        self.upcast::<Node>().replace_children(nodes, can_gc)
     }
 
     // https://dom.spec.whatwg.org/#dom-parentnode-queryselector

--- a/components/script/dom/documenttype.rs
+++ b/components/script/dom/documenttype.rs
@@ -12,6 +12,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
 use crate::dom::node::Node;
+use crate::script_runtime::CanGc;
 
 // https://dom.spec.whatwg.org/#documenttype
 /// The `DOCTYPE` tag.
@@ -43,12 +44,14 @@ impl DocumentType {
         public_id: Option<DOMString>,
         system_id: Option<DOMString>,
         document: &Document,
+        can_gc: CanGc,
     ) -> DomRoot<DocumentType> {
         Node::reflect_node(
             Box::new(DocumentType::new_inherited(
                 name, public_id, system_id, document,
             )),
             document,
+            can_gc,
         )
     }
 
@@ -85,18 +88,18 @@ impl DocumentTypeMethods for DocumentType {
     }
 
     // https://dom.spec.whatwg.org/#dom-childnode-before
-    fn Before(&self, nodes: Vec<NodeOrString>) -> ErrorResult {
-        self.upcast::<Node>().before(nodes)
+    fn Before(&self, nodes: Vec<NodeOrString>, can_gc: CanGc) -> ErrorResult {
+        self.upcast::<Node>().before(nodes, can_gc)
     }
 
     // https://dom.spec.whatwg.org/#dom-childnode-after
-    fn After(&self, nodes: Vec<NodeOrString>) -> ErrorResult {
-        self.upcast::<Node>().after(nodes)
+    fn After(&self, nodes: Vec<NodeOrString>, can_gc: CanGc) -> ErrorResult {
+        self.upcast::<Node>().after(nodes, can_gc)
     }
 
     // https://dom.spec.whatwg.org/#dom-childnode-replacewith
-    fn ReplaceWith(&self, nodes: Vec<NodeOrString>) -> ErrorResult {
-        self.upcast::<Node>().replace_with(nodes)
+    fn ReplaceWith(&self, nodes: Vec<NodeOrString>, can_gc: CanGc) -> ErrorResult {
+        self.upcast::<Node>().replace_with(nodes, can_gc)
     }
 
     // https://dom.spec.whatwg.org/#dom-childnode-remove

--- a/components/script/dom/domimplementation.rs
+++ b/components/script/dom/domimplementation.rs
@@ -59,6 +59,7 @@ impl DOMImplementationMethods for DOMImplementation {
         qualified_name: DOMString,
         pubid: DOMString,
         sysid: DOMString,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<DocumentType>> {
         validate_qualified_name(&qualified_name)?;
         Ok(DocumentType::new(
@@ -66,6 +67,7 @@ impl DOMImplementationMethods for DOMImplementation {
             Some(pubid),
             Some(sysid),
             &self.document,
+            can_gc,
         ))
     }
 
@@ -165,7 +167,7 @@ impl DOMImplementationMethods for DOMImplementation {
         {
             // Step 3.
             let doc_node = doc.upcast::<Node>();
-            let doc_type = DocumentType::new(DOMString::from("html"), None, None, &doc);
+            let doc_type = DocumentType::new(DOMString::from("html"), None, None, &doc, can_gc);
             doc_node.AppendChild(doc_type.upcast()).unwrap();
         }
 
@@ -177,6 +179,7 @@ impl DOMImplementationMethods for DOMImplementation {
                 None,
                 &doc,
                 None,
+                can_gc,
             ));
             doc_node.AppendChild(&doc_html).expect("Appending failed");
 
@@ -187,6 +190,7 @@ impl DOMImplementationMethods for DOMImplementation {
                     None,
                     &doc,
                     None,
+                    can_gc,
                 ));
                 doc_html.AppendChild(&doc_head).unwrap();
 
@@ -198,17 +202,18 @@ impl DOMImplementationMethods for DOMImplementation {
                         None,
                         &doc,
                         None,
+                        can_gc,
                     ));
                     doc_head.AppendChild(&doc_title).unwrap();
 
                     // Step 6.2.
-                    let title_text = Text::new(title_str, &doc);
+                    let title_text = Text::new(title_str, &doc, can_gc);
                     doc_title.AppendChild(title_text.upcast()).unwrap();
                 }
             }
 
             // Step 7.
-            let doc_body = HTMLBodyElement::new(local_name!("body"), None, &doc, None);
+            let doc_body = HTMLBodyElement::new(local_name!("body"), None, &doc, None, can_gc);
             doc_html.AppendChild(doc_body.upcast()).unwrap();
         }
 

--- a/components/script/dom/domstringmap.rs
+++ b/components/script/dom/domstringmap.rs
@@ -11,6 +11,7 @@ use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::node::window_from_node;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct DOMStringMap {
@@ -40,8 +41,8 @@ impl DOMStringMapMethods for DOMStringMap {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-domstringmap-setitem
-    fn NamedSetter(&self, name: DOMString, value: DOMString) -> ErrorResult {
-        self.element.set_custom_attr(name, value)
+    fn NamedSetter(&self, name: DOMString, value: DOMString, can_gc: CanGc) -> ErrorResult {
+        self.element.set_custom_attr(name, value, can_gc)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-domstringmap-nameditem

--- a/components/script/dom/htmlanchorelement.rs
+++ b/components/script/dom/htmlanchorelement.rs
@@ -67,6 +67,7 @@ impl HTMLAnchorElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLAnchorElement> {
         Node::reflect_node_with_proto(
             Box::new(HTMLAnchorElement::new_inherited(
@@ -74,6 +75,7 @@ impl HTMLAnchorElement {
             )),
             document,
             proto,
+            can_gc,
         )
     }
 
@@ -115,9 +117,9 @@ impl HTMLAnchorElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#update-href
-    fn update_href(&self, url: DOMString) {
+    fn update_href(&self, url: DOMString, can_gc: CanGc) {
         self.upcast::<Element>()
-            .set_string_attribute(&local_name!("href"), url);
+            .set_string_attribute(&local_name!("href"), url, can_gc);
     }
 }
 
@@ -165,17 +167,17 @@ impl HTMLAnchorElementMethods for HTMLAnchorElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-a-text
-    fn SetText(&self, value: DOMString) {
-        self.upcast::<Node>().SetTextContent(Some(value))
+    fn SetText(&self, value: DOMString, can_gc: CanGc) {
+        self.upcast::<Node>().SetTextContent(Some(value), can_gc)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-a-rel
     make_getter!(Rel, "rel");
 
     // https://html.spec.whatwg.org/multipage/#dom-a-rel
-    fn SetRel(&self, rel: DOMString) {
+    fn SetRel(&self, rel: DOMString, can_gc: CanGc) {
         self.upcast::<Element>()
-            .set_tokenlist_attribute(&local_name!("rel"), rel);
+            .set_tokenlist_attribute(&local_name!("rel"), rel, can_gc);
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-a-rellist
@@ -239,7 +241,7 @@ impl HTMLAnchorElementMethods for HTMLAnchorElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-hyperlink-hash
-    fn SetHash(&self, value: USVString) {
+    fn SetHash(&self, value: USVString, can_gc: CanGc) {
         // Step 1.
         self.reinitialize_url();
 
@@ -255,7 +257,7 @@ impl HTMLAnchorElementMethods for HTMLAnchorElement {
             },
         };
         // Step 6.
-        self.update_href(url);
+        self.update_href(url, can_gc);
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-hyperlink-host
@@ -278,7 +280,7 @@ impl HTMLAnchorElementMethods for HTMLAnchorElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-hyperlink-host
-    fn SetHost(&self, value: USVString) {
+    fn SetHost(&self, value: USVString, can_gc: CanGc) {
         // Step 1.
         self.reinitialize_url();
 
@@ -294,7 +296,7 @@ impl HTMLAnchorElementMethods for HTMLAnchorElement {
             },
         };
         // Step 5.
-        self.update_href(url);
+        self.update_href(url, can_gc);
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-hyperlink-hostname
@@ -313,7 +315,7 @@ impl HTMLAnchorElementMethods for HTMLAnchorElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-hyperlink-hostname
-    fn SetHostname(&self, value: USVString) {
+    fn SetHostname(&self, value: USVString, can_gc: CanGc) {
         // Step 1.
         self.reinitialize_url();
 
@@ -329,7 +331,7 @@ impl HTMLAnchorElementMethods for HTMLAnchorElement {
             },
         };
         // Step 5.
-        self.update_href(url);
+        self.update_href(url, can_gc);
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-hyperlink-href
@@ -355,9 +357,12 @@ impl HTMLAnchorElementMethods for HTMLAnchorElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-hyperlink-href
-    fn SetHref(&self, value: USVString) {
-        self.upcast::<Element>()
-            .set_string_attribute(&local_name!("href"), DOMString::from_string(value.0));
+    fn SetHref(&self, value: USVString, can_gc: CanGc) {
+        self.upcast::<Element>().set_string_attribute(
+            &local_name!("href"),
+            DOMString::from_string(value.0),
+            can_gc,
+        );
         self.set_url();
     }
 
@@ -392,7 +397,7 @@ impl HTMLAnchorElementMethods for HTMLAnchorElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-hyperlink-password
-    fn SetPassword(&self, value: USVString) {
+    fn SetPassword(&self, value: USVString, can_gc: CanGc) {
         // Step 1.
         self.reinitialize_url();
 
@@ -408,7 +413,7 @@ impl HTMLAnchorElementMethods for HTMLAnchorElement {
             },
         };
         // Step 5.
-        self.update_href(url);
+        self.update_href(url, can_gc);
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-hyperlink-pathname
@@ -425,7 +430,7 @@ impl HTMLAnchorElementMethods for HTMLAnchorElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-hyperlink-pathname
-    fn SetPathname(&self, value: USVString) {
+    fn SetPathname(&self, value: USVString, can_gc: CanGc) {
         // Step 1.
         self.reinitialize_url();
 
@@ -441,7 +446,7 @@ impl HTMLAnchorElementMethods for HTMLAnchorElement {
             },
         };
         // Step 6.
-        self.update_href(url);
+        self.update_href(url, can_gc);
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-hyperlink-port
@@ -458,7 +463,7 @@ impl HTMLAnchorElementMethods for HTMLAnchorElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-hyperlink-port
-    fn SetPort(&self, value: USVString) {
+    fn SetPort(&self, value: USVString, can_gc: CanGc) {
         // Step 1.
         self.reinitialize_url();
 
@@ -477,7 +482,7 @@ impl HTMLAnchorElementMethods for HTMLAnchorElement {
             },
         };
         // Step 5.
-        self.update_href(url);
+        self.update_href(url, can_gc);
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-hyperlink-protocol
@@ -494,7 +499,7 @@ impl HTMLAnchorElementMethods for HTMLAnchorElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-hyperlink-protocol
-    fn SetProtocol(&self, value: USVString) {
+    fn SetProtocol(&self, value: USVString, can_gc: CanGc) {
         // Step 1.
         self.reinitialize_url();
 
@@ -508,7 +513,7 @@ impl HTMLAnchorElementMethods for HTMLAnchorElement {
             },
         };
         // Step 4.
-        self.update_href(url);
+        self.update_href(url, can_gc);
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-hyperlink-search
@@ -525,7 +530,7 @@ impl HTMLAnchorElementMethods for HTMLAnchorElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-hyperlink-search
-    fn SetSearch(&self, value: USVString) {
+    fn SetSearch(&self, value: USVString, can_gc: CanGc) {
         // Step 1.
         self.reinitialize_url();
 
@@ -542,7 +547,7 @@ impl HTMLAnchorElementMethods for HTMLAnchorElement {
             },
         };
         // Step 6.
-        self.update_href(url);
+        self.update_href(url, can_gc);
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-hyperlink-username
@@ -559,7 +564,7 @@ impl HTMLAnchorElementMethods for HTMLAnchorElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-hyperlink-username
-    fn SetUsername(&self, value: USVString) {
+    fn SetUsername(&self, value: USVString, can_gc: CanGc) {
         // Step 1.
         self.reinitialize_url();
 
@@ -575,7 +580,7 @@ impl HTMLAnchorElementMethods for HTMLAnchorElement {
             },
         };
         // Step 5.
-        self.update_href(url);
+        self.update_href(url, can_gc);
     }
 }
 

--- a/components/script/dom/htmlareaelement.rs
+++ b/components/script/dom/htmlareaelement.rs
@@ -264,11 +264,13 @@ impl HTMLAreaElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLAreaElement> {
         Node::reflect_node_with_proto(
             Box::new(HTMLAreaElement::new_inherited(local_name, prefix, document)),
             document,
             proto,
+            can_gc,
         )
     }
 
@@ -341,9 +343,9 @@ impl HTMLAreaElementMethods for HTMLAreaElement {
     make_getter!(Rel, "rel");
 
     // https://html.spec.whatwg.org/multipage/#dom-a-rel
-    fn SetRel(&self, rel: DOMString) {
+    fn SetRel(&self, rel: DOMString, can_gc: CanGc) {
         self.upcast::<Element>()
-            .set_tokenlist_attribute(&local_name!("rel"), rel);
+            .set_tokenlist_attribute(&local_name!("rel"), rel, can_gc);
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-area-rellist

--- a/components/script/dom/htmlaudioelement.rs
+++ b/components/script/dom/htmlaudioelement.rs
@@ -42,6 +42,7 @@ impl HTMLAudioElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLAudioElement> {
         Node::reflect_node_with_proto(
             Box::new(HTMLAudioElement::new_inherited(
@@ -49,6 +50,7 @@ impl HTMLAudioElement {
             )),
             document,
             proto,
+            can_gc,
         )
     }
 }
@@ -75,12 +77,12 @@ impl HTMLAudioElementMethods for HTMLAudioElement {
 
         audio
             .upcast::<Element>()
-            .SetAttribute(DOMString::from("preload"), DOMString::from("auto"))
+            .SetAttribute(DOMString::from("preload"), DOMString::from("auto"), can_gc)
             .expect("should be infallible");
         if let Some(s) = src {
             audio
                 .upcast::<Element>()
-                .SetAttribute(DOMString::from("src"), s)
+                .SetAttribute(DOMString::from("src"), s, can_gc)
                 .expect("should be infallible");
         }
 

--- a/components/script/dom/htmlbaseelement.rs
+++ b/components/script/dom/htmlbaseelement.rs
@@ -17,6 +17,7 @@ use crate::dom::element::{AttributeMutation, Element};
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::node::{document_from_node, BindContext, Node, UnbindContext};
 use crate::dom::virtualmethods::VirtualMethods;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct HTMLBaseElement {
@@ -40,11 +41,13 @@ impl HTMLBaseElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLBaseElement> {
         Node::reflect_node_with_proto(
             Box::new(HTMLBaseElement::new_inherited(local_name, prefix, document)),
             document,
             proto,
+            can_gc,
         )
     }
 

--- a/components/script/dom/htmlbodyelement.rs
+++ b/components/script/dom/htmlbodyelement.rs
@@ -24,6 +24,7 @@ use crate::dom::eventtarget::EventTarget;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::node::{document_from_node, window_from_node, BindContext, Node};
 use crate::dom::virtualmethods::VirtualMethods;
+use crate::script_runtime::CanGc;
 
 /// How long we should wait before performing the initial reflow after `<body>` is parsed.
 const INITIAL_REFLOW_DELAY: Duration = Duration::from_millis(200);
@@ -50,11 +51,13 @@ impl HTMLBodyElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLBodyElement> {
         Node::reflect_node_with_proto(
             Box::new(HTMLBodyElement::new_inherited(local_name, prefix, document)),
             document,
             proto,
+            can_gc,
         )
     }
 
@@ -87,13 +90,13 @@ impl HTMLBodyElementMethods for HTMLBodyElement {
     make_getter!(Background, "background");
 
     // https://html.spec.whatwg.org/multipage/#dom-body-background
-    fn SetBackground(&self, input: DOMString) {
+    fn SetBackground(&self, input: DOMString, can_gc: CanGc) {
         let value = AttrValue::from_resolved_url(
             &document_from_node(self).base_url().get_arc(),
             input.into(),
         );
         self.upcast::<Element>()
-            .set_attribute(&local_name!("background"), value);
+            .set_attribute(&local_name!("background"), value, can_gc);
     }
 
     // https://html.spec.whatwg.org/multipage/#windoweventhandlers

--- a/components/script/dom/htmlbrelement.rs
+++ b/components/script/dom/htmlbrelement.rs
@@ -10,6 +10,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::document::Document;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::node::Node;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct HTMLBRElement {
@@ -33,11 +34,13 @@ impl HTMLBRElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLBRElement> {
         Node::reflect_node_with_proto(
             Box::new(HTMLBRElement::new_inherited(local_name, prefix, document)),
             document,
             proto,
+            can_gc,
         )
     }
 }

--- a/components/script/dom/htmlbuttonelement.rs
+++ b/components/script/dom/htmlbuttonelement.rs
@@ -75,6 +75,7 @@ impl HTMLButtonElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLButtonElement> {
         Node::reflect_node_with_proto(
             Box::new(HTMLButtonElement::new_inherited(
@@ -82,6 +83,7 @@ impl HTMLButtonElement {
             )),
             document,
             proto,
+            can_gc,
         )
     }
 
@@ -360,7 +362,7 @@ impl Activatable for HTMLButtonElement {
             ButtonType::Reset => {
                 // TODO: is document owner fully active?
                 if let Some(owner) = self.form_owner() {
-                    owner.reset(ResetFrom::NotFromForm);
+                    owner.reset(ResetFrom::NotFromForm, CanGc::note());
                 }
             },
             _ => (),

--- a/components/script/dom/htmlcanvaselement.rs
+++ b/components/script/dom/htmlcanvaselement.rs
@@ -86,6 +86,7 @@ impl HTMLCanvasElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLCanvasElement> {
         Node::reflect_node_with_proto(
             Box::new(HTMLCanvasElement::new_inherited(
@@ -93,6 +94,7 @@ impl HTMLCanvasElement {
             )),
             document,
             proto,
+            can_gc,
         )
     }
 

--- a/components/script/dom/htmldataelement.rs
+++ b/components/script/dom/htmldataelement.rs
@@ -12,6 +12,7 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::node::Node;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct HTMLDataElement {
@@ -35,11 +36,13 @@ impl HTMLDataElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLDataElement> {
         Node::reflect_node_with_proto(
             Box::new(HTMLDataElement::new_inherited(local_name, prefix, document)),
             document,
             proto,
+            can_gc,
         )
     }
 }

--- a/components/script/dom/htmldatalistelement.rs
+++ b/components/script/dom/htmldatalistelement.rs
@@ -15,6 +15,7 @@ use crate::dom::htmlcollection::{CollectionFilter, HTMLCollection};
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::htmloptionelement::HTMLOptionElement;
 use crate::dom::node::{window_from_node, Node};
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct HTMLDataListElement {
@@ -38,6 +39,7 @@ impl HTMLDataListElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLDataListElement> {
         Node::reflect_node_with_proto(
             Box::new(HTMLDataListElement::new_inherited(
@@ -45,6 +47,7 @@ impl HTMLDataListElement {
             )),
             document,
             proto,
+            can_gc,
         )
     }
 }

--- a/components/script/dom/htmldetailselement.rs
+++ b/components/script/dom/htmldetailselement.rs
@@ -19,6 +19,7 @@ use crate::dom::eventtarget::EventTarget;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::node::{window_from_node, Node, NodeDamage};
 use crate::dom::virtualmethods::VirtualMethods;
+use crate::script_runtime::CanGc;
 use crate::task_source::TaskSource;
 
 #[dom_struct]
@@ -45,6 +46,7 @@ impl HTMLDetailsElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLDetailsElement> {
         Node::reflect_node_with_proto(
             Box::new(HTMLDetailsElement::new_inherited(
@@ -52,6 +54,7 @@ impl HTMLDetailsElement {
             )),
             document,
             proto,
+            can_gc,
         )
     }
 

--- a/components/script/dom/htmldialogelement.rs
+++ b/components/script/dom/htmldialogelement.rs
@@ -16,6 +16,7 @@ use crate::dom::element::Element;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::node::{window_from_node, Node};
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct HTMLDialogElement {
@@ -41,6 +42,7 @@ impl HTMLDialogElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLDialogElement> {
         Node::reflect_node_with_proto(
             Box::new(HTMLDialogElement::new_inherited(
@@ -48,6 +50,7 @@ impl HTMLDialogElement {
             )),
             document,
             proto,
+            can_gc,
         )
     }
 }
@@ -71,7 +74,7 @@ impl HTMLDialogElementMethods for HTMLDialogElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-dialog-show>
-    fn Show(&self) {
+    fn Show(&self, can_gc: CanGc) {
         let element = self.upcast::<Element>();
 
         // Step 1 TODO: Check is modal flag is false
@@ -82,7 +85,7 @@ impl HTMLDialogElementMethods for HTMLDialogElement {
         // TODO: Step 2 If this has an open attribute, then throw an "InvalidStateError" DOMException.
 
         // Step 3
-        element.set_bool_attribute(&local_name!("open"), true);
+        element.set_bool_attribute(&local_name!("open"), true, can_gc);
 
         // TODO: Step 4 Set this's previously focused element to the focused element.
 

--- a/components/script/dom/htmldirectoryelement.rs
+++ b/components/script/dom/htmldirectoryelement.rs
@@ -10,6 +10,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::document::Document;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::node::Node;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct HTMLDirectoryElement {
@@ -33,6 +34,7 @@ impl HTMLDirectoryElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLDirectoryElement> {
         Node::reflect_node_with_proto(
             Box::new(HTMLDirectoryElement::new_inherited(
@@ -40,6 +42,7 @@ impl HTMLDirectoryElement {
             )),
             document,
             proto,
+            can_gc,
         )
     }
 }

--- a/components/script/dom/htmldivelement.rs
+++ b/components/script/dom/htmldivelement.rs
@@ -12,6 +12,7 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::node::Node;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct HTMLDivElement {
@@ -35,11 +36,13 @@ impl HTMLDivElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLDivElement> {
         Node::reflect_node_with_proto(
             Box::new(HTMLDivElement::new_inherited(local_name, prefix, document)),
             document,
             proto,
+            can_gc,
         )
     }
 }

--- a/components/script/dom/htmldlistelement.rs
+++ b/components/script/dom/htmldlistelement.rs
@@ -10,6 +10,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::document::Document;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::node::Node;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct HTMLDListElement {
@@ -33,6 +34,7 @@ impl HTMLDListElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLDListElement> {
         Node::reflect_node_with_proto(
             Box::new(HTMLDListElement::new_inherited(
@@ -40,6 +42,7 @@ impl HTMLDListElement {
             )),
             document,
             proto,
+            can_gc,
         )
     }
 }

--- a/components/script/dom/htmlembedelement.rs
+++ b/components/script/dom/htmlembedelement.rs
@@ -10,6 +10,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::document::Document;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::node::Node;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct HTMLEmbedElement {
@@ -33,6 +34,7 @@ impl HTMLEmbedElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLEmbedElement> {
         Node::reflect_node_with_proto(
             Box::new(HTMLEmbedElement::new_inherited(
@@ -40,6 +42,7 @@ impl HTMLEmbedElement {
             )),
             document,
             proto,
+            can_gc,
         )
     }
 }

--- a/components/script/dom/htmlfieldsetelement.rs
+++ b/components/script/dom/htmlfieldsetelement.rs
@@ -59,6 +59,7 @@ impl HTMLFieldSetElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLFieldSetElement> {
         Node::reflect_node_with_proto(
             Box::new(HTMLFieldSetElement::new_inherited(
@@ -66,6 +67,7 @@ impl HTMLFieldSetElement {
             )),
             document,
             proto,
+            can_gc,
         )
     }
 

--- a/components/script/dom/htmlfontelement.rs
+++ b/components/script/dom/htmlfontelement.rs
@@ -24,6 +24,7 @@ use crate::dom::element::{Element, LayoutElementHelpers};
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::node::Node;
 use crate::dom::virtualmethods::VirtualMethods;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct HTMLFontElement {
@@ -47,11 +48,13 @@ impl HTMLFontElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLFontElement> {
         Node::reflect_node_with_proto(
             Box::new(HTMLFontElement::new_inherited(local_name, prefix, document)),
             document,
             proto,
+            can_gc,
         )
     }
 
@@ -104,9 +107,9 @@ impl HTMLFontElementMethods for HTMLFontElement {
     make_getter!(Size, "size");
 
     // https://html.spec.whatwg.org/multipage/#dom-font-size
-    fn SetSize(&self, value: DOMString) {
+    fn SetSize(&self, value: DOMString, can_gc: CanGc) {
         let element = self.upcast::<Element>();
-        element.set_attribute(&local_name!("size"), parse_size(&value));
+        element.set_attribute(&local_name!("size"), parse_size(&value), can_gc);
     }
 }
 

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -140,11 +140,13 @@ impl HTMLFormElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLFormElement> {
         Node::reflect_node_with_proto(
             Box::new(HTMLFormElement::new_inherited(local_name, prefix, document)),
             document,
             proto,
+            can_gc,
         )
     }
 
@@ -339,8 +341,8 @@ impl HTMLFormElementMethods for HTMLFormElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-form-reset
-    fn Reset(&self) {
-        self.reset(ResetFrom::FromForm);
+    fn Reset(&self, can_gc: CanGc) {
+        self.reset(ResetFrom::FromForm, can_gc);
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-form-elements
@@ -474,9 +476,9 @@ impl HTMLFormElementMethods for HTMLFormElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-a-rel
-    fn SetRel(&self, rel: DOMString) {
+    fn SetRel(&self, rel: DOMString, can_gc: CanGc) {
         self.upcast::<Element>()
-            .set_tokenlist_attribute(&local_name!("rel"), rel);
+            .set_tokenlist_attribute(&local_name!("rel"), rel, can_gc);
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-a-rellist
@@ -1230,7 +1232,7 @@ impl HTMLFormElement {
         Some(form_data.datums())
     }
 
-    pub fn reset(&self, _reset_method_flag: ResetFrom) {
+    pub fn reset(&self, _reset_method_flag: ResetFrom, can_gc: CanGc) {
         // https://html.spec.whatwg.org/multipage/#locked-for-reset
         if self.marked_for_reset.get() {
             return;
@@ -1268,7 +1270,7 @@ impl HTMLFormElement {
                 NodeTypeId::Element(ElementTypeId::HTMLElement(
                     HTMLElementTypeId::HTMLOutputElement,
                 )) => {
-                    child.downcast::<HTMLOutputElement>().unwrap().reset();
+                    child.downcast::<HTMLOutputElement>().unwrap().reset(can_gc);
                 },
                 NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLElement)) => {
                     let html_element = child.downcast::<HTMLElement>().unwrap();

--- a/components/script/dom/htmlframeelement.rs
+++ b/components/script/dom/htmlframeelement.rs
@@ -10,6 +10,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::document::Document;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::node::Node;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct HTMLFrameElement {
@@ -33,6 +34,7 @@ impl HTMLFrameElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLFrameElement> {
         Node::reflect_node_with_proto(
             Box::new(HTMLFrameElement::new_inherited(
@@ -40,6 +42,7 @@ impl HTMLFrameElement {
             )),
             document,
             proto,
+            can_gc,
         )
     }
 }

--- a/components/script/dom/htmlframesetelement.rs
+++ b/components/script/dom/htmlframesetelement.rs
@@ -13,6 +13,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::document::Document;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::node::{document_from_node, Node};
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct HTMLFrameSetElement {
@@ -36,6 +37,7 @@ impl HTMLFrameSetElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLFrameSetElement> {
         let n = Node::reflect_node_with_proto(
             Box::new(HTMLFrameSetElement::new_inherited(
@@ -43,6 +45,7 @@ impl HTMLFrameSetElement {
             )),
             document,
             proto,
+            can_gc,
         );
         n.upcast::<Node>().set_weird_parser_insertion_mode();
         n

--- a/components/script/dom/htmlheadelement.rs
+++ b/components/script/dom/htmlheadelement.rs
@@ -17,6 +17,7 @@ use crate::dom::htmlmetaelement::HTMLMetaElement;
 use crate::dom::node::{document_from_node, BindContext, Node, ShadowIncluding};
 use crate::dom::userscripts::load_script;
 use crate::dom::virtualmethods::VirtualMethods;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct HTMLHeadElement {
@@ -40,11 +41,13 @@ impl HTMLHeadElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLHeadElement> {
         let n = Node::reflect_node_with_proto(
             Box::new(HTMLHeadElement::new_inherited(local_name, prefix, document)),
             document,
             proto,
+            can_gc,
         );
 
         n.upcast::<Node>().set_weird_parser_insertion_mode();

--- a/components/script/dom/htmlheadingelement.rs
+++ b/components/script/dom/htmlheadingelement.rs
@@ -10,6 +10,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::document::Document;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::node::Node;
+use crate::script_runtime::CanGc;
 
 #[derive(JSTraceable, MallocSizeOf)]
 pub enum HeadingLevel {
@@ -47,6 +48,7 @@ impl HTMLHeadingElement {
         document: &Document,
         proto: Option<HandleObject>,
         level: HeadingLevel,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLHeadingElement> {
         Node::reflect_node_with_proto(
             Box::new(HTMLHeadingElement::new_inherited(
@@ -54,6 +56,7 @@ impl HTMLHeadingElement {
             )),
             document,
             proto,
+            can_gc,
         )
     }
 }

--- a/components/script/dom/htmlhrelement.rs
+++ b/components/script/dom/htmlhrelement.rs
@@ -17,6 +17,7 @@ use crate::dom::element::{Element, LayoutElementHelpers};
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::node::Node;
 use crate::dom::virtualmethods::VirtualMethods;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct HTMLHRElement {
@@ -40,11 +41,13 @@ impl HTMLHRElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLHRElement> {
         Node::reflect_node_with_proto(
             Box::new(HTMLHRElement::new_inherited(local_name, prefix, document)),
             document,
             proto,
+            can_gc,
         )
     }
 }

--- a/components/script/dom/htmlhtmlelement.rs
+++ b/components/script/dom/htmlhtmlelement.rs
@@ -11,6 +11,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::document::Document;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::node::Node;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct HTMLHtmlElement {
@@ -35,11 +36,13 @@ impl HTMLHtmlElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLHtmlElement> {
         let n = Node::reflect_node_with_proto(
             Box::new(HTMLHtmlElement::new_inherited(localName, prefix, document)),
             document,
             proto,
+            can_gc,
         );
 
         n.upcast::<Node>().set_weird_parser_insertion_mode();

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -456,6 +456,7 @@ impl HTMLIFrameElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLIFrameElement> {
         Node::reflect_node_with_proto(
             Box::new(HTMLIFrameElement::new_inherited(
@@ -463,6 +464,7 @@ impl HTMLIFrameElement {
             )),
             document,
             proto,
+            can_gc,
         )
     }
 

--- a/components/script/dom/htmllabelelement.rs
+++ b/components/script/dom/htmllabelelement.rs
@@ -49,6 +49,7 @@ impl HTMLLabelElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLLabelElement> {
         Node::reflect_node_with_proto(
             Box::new(HTMLLabelElement::new_inherited(
@@ -56,6 +57,7 @@ impl HTMLLabelElement {
             )),
             document,
             proto,
+            can_gc,
         )
     }
 }

--- a/components/script/dom/htmllegendelement.rs
+++ b/components/script/dom/htmllegendelement.rs
@@ -17,6 +17,7 @@ use crate::dom::htmlfieldsetelement::HTMLFieldSetElement;
 use crate::dom::htmlformelement::{FormControl, HTMLFormElement};
 use crate::dom::node::{BindContext, Node, UnbindContext};
 use crate::dom::virtualmethods::VirtualMethods;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct HTMLLegendElement {
@@ -42,6 +43,7 @@ impl HTMLLegendElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLLegendElement> {
         Node::reflect_node_with_proto(
             Box::new(HTMLLegendElement::new_inherited(
@@ -49,6 +51,7 @@ impl HTMLLegendElement {
             )),
             document,
             proto,
+            can_gc,
         )
     }
 }

--- a/components/script/dom/htmllielement.rs
+++ b/components/script/dom/htmllielement.rs
@@ -15,6 +15,7 @@ use crate::dom::document::Document;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::node::Node;
 use crate::dom::virtualmethods::VirtualMethods;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct HTMLLIElement {
@@ -38,11 +39,13 @@ impl HTMLLIElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLLIElement> {
         Node::reflect_node_with_proto(
             Box::new(HTMLLIElement::new_inherited(local_name, prefix, document)),
             document,
             proto,
+            can_gc,
         )
     }
 }

--- a/components/script/dom/htmllinkelement.rs
+++ b/components/script/dom/htmllinkelement.rs
@@ -56,6 +56,7 @@ use crate::dom::virtualmethods::VirtualMethods;
 use crate::fetch::create_a_potential_cors_request;
 use crate::links::LinkRelations;
 use crate::network_listener::{submit_timing, PreInvoke, ResourceTimingListener};
+use crate::script_runtime::CanGc;
 use crate::stylesheet_loader::{StylesheetContextSource, StylesheetLoader, StylesheetOwner};
 
 #[derive(Clone, Copy, JSTraceable, MallocSizeOf, PartialEq)]
@@ -137,6 +138,7 @@ impl HTMLLinkElement {
         document: &Document,
         proto: Option<HandleObject>,
         creator: ElementCreator,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLLinkElement> {
         Node::reflect_node_with_proto(
             Box::new(HTMLLinkElement::new_inherited(
@@ -144,6 +146,7 @@ impl HTMLLinkElement {
             )),
             document,
             proto,
+            can_gc,
         )
     }
 
@@ -522,9 +525,9 @@ impl HTMLLinkElementMethods for HTMLLinkElement {
     make_getter!(Rel, "rel");
 
     // https://html.spec.whatwg.org/multipage/#dom-link-rel
-    fn SetRel(&self, rel: DOMString) {
+    fn SetRel(&self, rel: DOMString, can_gc: CanGc) {
         self.upcast::<Element>()
-            .set_tokenlist_attribute(&local_name!("rel"), rel);
+            .set_tokenlist_attribute(&local_name!("rel"), rel, can_gc);
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-link-media
@@ -602,8 +605,8 @@ impl HTMLLinkElementMethods for HTMLLinkElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-link-crossorigin
-    fn SetCrossOrigin(&self, value: Option<DOMString>) {
-        set_cross_origin_attribute(self.upcast::<Element>(), value);
+    fn SetCrossOrigin(&self, value: Option<DOMString>, can_gc: CanGc) {
+        set_cross_origin_attribute(self.upcast::<Element>(), value, can_gc);
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-link-referrerpolicy

--- a/components/script/dom/htmlmapelement.rs
+++ b/components/script/dom/htmlmapelement.rs
@@ -12,6 +12,7 @@ use crate::dom::document::Document;
 use crate::dom::htmlareaelement::HTMLAreaElement;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::node::{Node, ShadowIncluding};
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct HTMLMapElement {
@@ -35,11 +36,13 @@ impl HTMLMapElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLMapElement> {
         Node::reflect_node_with_proto(
             Box::new(HTMLMapElement::new_inherited(local_name, prefix, document)),
             document,
             proto,
+            can_gc,
         )
     }
 

--- a/components/script/dom/htmlmenuelement.rs
+++ b/components/script/dom/htmlmenuelement.rs
@@ -11,6 +11,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::document::Document;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::node::Node;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct HTMLMenuElement {
@@ -34,11 +35,13 @@ impl HTMLMenuElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLMenuElement> {
         Node::reflect_node_with_proto(
             Box::new(HTMLMenuElement::new_inherited(local_name, prefix, document)),
             document,
             proto,
+            can_gc,
         )
     }
 }

--- a/components/script/dom/htmlmetaelement.rs
+++ b/components/script/dom/htmlmetaelement.rs
@@ -73,11 +73,13 @@ impl HTMLMetaElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLMetaElement> {
         Node::reflect_node_with_proto(
             Box::new(HTMLMetaElement::new_inherited(local_name, prefix, document)),
             document,
             proto,
+            can_gc,
         )
     }
 

--- a/components/script/dom/htmlmeterelement.rs
+++ b/components/script/dom/htmlmeterelement.rs
@@ -18,6 +18,7 @@ use crate::dom::element::Element;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::node::Node;
 use crate::dom::nodelist::NodeList;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct HTMLMeterElement {
@@ -44,6 +45,7 @@ impl HTMLMeterElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLMeterElement> {
         Node::reflect_node_with_proto(
             Box::new(HTMLMeterElement::new_inherited(
@@ -51,6 +53,7 @@ impl HTMLMeterElement {
             )),
             document,
             proto,
+            can_gc,
         )
     }
 }
@@ -75,13 +78,13 @@ impl HTMLMeterElementMethods for HTMLMeterElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-meter-value>
-    fn SetValue(&self, value: Finite<f64>) {
+    fn SetValue(&self, value: Finite<f64>, can_gc: CanGc) {
         let mut string_value = DOMString::from_string((*value).to_string());
 
         string_value.set_best_representation_of_the_floating_point_number();
 
         self.upcast::<Element>()
-            .set_string_attribute(&local_name!("value"), string_value);
+            .set_string_attribute(&local_name!("value"), string_value, can_gc);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#concept-meter-minimum>
@@ -95,13 +98,13 @@ impl HTMLMeterElementMethods for HTMLMeterElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-meter-min>
-    fn SetMin(&self, value: Finite<f64>) {
+    fn SetMin(&self, value: Finite<f64>, can_gc: CanGc) {
         let mut string_value = DOMString::from_string((*value).to_string());
 
         string_value.set_best_representation_of_the_floating_point_number();
 
         self.upcast::<Element>()
-            .set_string_attribute(&local_name!("min"), string_value);
+            .set_string_attribute(&local_name!("min"), string_value, can_gc);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#concept-meter-maximum>
@@ -116,13 +119,13 @@ impl HTMLMeterElementMethods for HTMLMeterElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#concept-meter-maximum>
-    fn SetMax(&self, value: Finite<f64>) {
+    fn SetMax(&self, value: Finite<f64>, can_gc: CanGc) {
         let mut string_value = DOMString::from_string((*value).to_string());
 
         string_value.set_best_representation_of_the_floating_point_number();
 
         self.upcast::<Element>()
-            .set_string_attribute(&local_name!("max"), string_value);
+            .set_string_attribute(&local_name!("max"), string_value, can_gc);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#concept-meter-low>
@@ -141,13 +144,13 @@ impl HTMLMeterElementMethods for HTMLMeterElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-meter-low>
-    fn SetLow(&self, value: Finite<f64>) {
+    fn SetLow(&self, value: Finite<f64>, can_gc: CanGc) {
         let mut string_value = DOMString::from_string((*value).to_string());
 
         string_value.set_best_representation_of_the_floating_point_number();
 
         self.upcast::<Element>()
-            .set_string_attribute(&local_name!("low"), string_value);
+            .set_string_attribute(&local_name!("low"), string_value, can_gc);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#concept-meter-high>
@@ -170,13 +173,13 @@ impl HTMLMeterElementMethods for HTMLMeterElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-meter-high>
-    fn SetHigh(&self, value: Finite<f64>) {
+    fn SetHigh(&self, value: Finite<f64>, can_gc: CanGc) {
         let mut string_value = DOMString::from_string((*value).to_string());
 
         string_value.set_best_representation_of_the_floating_point_number();
 
         self.upcast::<Element>()
-            .set_string_attribute(&local_name!("high"), string_value);
+            .set_string_attribute(&local_name!("high"), string_value, can_gc);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#concept-meter-optimum>
@@ -195,12 +198,15 @@ impl HTMLMeterElementMethods for HTMLMeterElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-meter-optimum>
-    fn SetOptimum(&self, value: Finite<f64>) {
+    fn SetOptimum(&self, value: Finite<f64>, can_gc: CanGc) {
         let mut string_value = DOMString::from_string((*value).to_string());
 
         string_value.set_best_representation_of_the_floating_point_number();
 
-        self.upcast::<Element>()
-            .set_string_attribute(&local_name!("optimum"), string_value);
+        self.upcast::<Element>().set_string_attribute(
+            &local_name!("optimum"),
+            string_value,
+            can_gc,
+        );
     }
 }

--- a/components/script/dom/htmlmodelement.rs
+++ b/components/script/dom/htmlmodelement.rs
@@ -10,6 +10,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::document::Document;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::node::Node;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct HTMLModElement {
@@ -33,11 +34,13 @@ impl HTMLModElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLModElement> {
         Node::reflect_node_with_proto(
             Box::new(HTMLModElement::new_inherited(local_name, prefix, document)),
             document,
             proto,
+            can_gc,
         )
     }
 }

--- a/components/script/dom/htmlobjectelement.rs
+++ b/components/script/dom/htmlobjectelement.rs
@@ -56,6 +56,7 @@ impl HTMLObjectElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLObjectElement> {
         Node::reflect_node_with_proto(
             Box::new(HTMLObjectElement::new_inherited(
@@ -63,6 +64,7 @@ impl HTMLObjectElement {
             )),
             document,
             proto,
+            can_gc,
         )
     }
 }

--- a/components/script/dom/htmlolistelement.rs
+++ b/components/script/dom/htmlolistelement.rs
@@ -10,6 +10,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::document::Document;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::node::Node;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct HTMLOListElement {
@@ -33,6 +34,7 @@ impl HTMLOListElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLOListElement> {
         Node::reflect_node_with_proto(
             Box::new(HTMLOListElement::new_inherited(
@@ -40,6 +42,7 @@ impl HTMLOListElement {
             )),
             document,
             proto,
+            can_gc,
         )
     }
 }

--- a/components/script/dom/htmloptgroupelement.rs
+++ b/components/script/dom/htmloptgroupelement.rs
@@ -20,6 +20,7 @@ use crate::dom::node::{BindContext, Node, ShadowIncluding, UnbindContext};
 use crate::dom::validation::Validatable;
 use crate::dom::validitystate::ValidationFlags;
 use crate::dom::virtualmethods::VirtualMethods;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct HTMLOptGroupElement {
@@ -48,6 +49,7 @@ impl HTMLOptGroupElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLOptGroupElement> {
         Node::reflect_node_with_proto(
             Box::new(HTMLOptGroupElement::new_inherited(
@@ -55,6 +57,7 @@ impl HTMLOptGroupElement {
             )),
             document,
             proto,
+            can_gc,
         )
     }
 

--- a/components/script/dom/htmloptionelement.rs
+++ b/components/script/dom/htmloptionelement.rs
@@ -72,6 +72,7 @@ impl HTMLOptionElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLOptionElement> {
         Node::reflect_node_with_proto(
             Box::new(HTMLOptionElement::new_inherited(
@@ -79,6 +80,7 @@ impl HTMLOptionElement {
             )),
             document,
             proto,
+            can_gc,
         )
     }
 
@@ -196,7 +198,7 @@ impl HTMLOptionElementMethods for HTMLOptionElement {
         let option = DomRoot::downcast::<HTMLOptionElement>(element).unwrap();
 
         if !text.is_empty() {
-            option.upcast::<Node>().SetTextContent(Some(text))
+            option.upcast::<Node>().SetTextContent(Some(text), can_gc)
         }
 
         if let Some(val) = value {
@@ -223,8 +225,8 @@ impl HTMLOptionElementMethods for HTMLOptionElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-option-text
-    fn SetText(&self, value: DOMString) {
-        self.upcast::<Node>().SetTextContent(Some(value))
+    fn SetText(&self, value: DOMString, can_gc: CanGc) {
+        self.upcast::<Node>().SetTextContent(Some(value), can_gc)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-option-form

--- a/components/script/dom/htmloptionscollection.rs
+++ b/components/script/dom/htmloptionscollection.rs
@@ -26,6 +26,7 @@ use crate::dom::htmloptionelement::HTMLOptionElement;
 use crate::dom::htmlselectelement::HTMLSelectElement;
 use crate::dom::node::{document_from_node, Node};
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct HTMLOptionsCollection {
@@ -53,12 +54,13 @@ impl HTMLOptionsCollection {
         )
     }
 
-    fn add_new_elements(&self, count: u32) -> ErrorResult {
+    fn add_new_elements(&self, count: u32, can_gc: CanGc) -> ErrorResult {
         let root = self.upcast().root_node();
         let document = document_from_node(&*root);
 
         for _ in 0..count {
-            let element = HTMLOptionElement::new(local_name!("option"), None, &document, None);
+            let element =
+                HTMLOptionElement::new(local_name!("option"), None, &document, None, can_gc);
             let node = element.upcast::<Node>();
             root.AppendChild(node)?;
         }
@@ -91,7 +93,12 @@ impl HTMLOptionsCollectionMethods for HTMLOptionsCollection {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-htmloptionscollection-setter
-    fn IndexedSetter(&self, index: u32, value: Option<&HTMLOptionElement>) -> ErrorResult {
+    fn IndexedSetter(
+        &self,
+        index: u32,
+        value: Option<&HTMLOptionElement>,
+        can_gc: CanGc,
+    ) -> ErrorResult {
         if let Some(value) = value {
             // Step 2
             let length = self.upcast().Length();
@@ -101,7 +108,7 @@ impl HTMLOptionsCollectionMethods for HTMLOptionsCollection {
 
             // Step 4
             if n > 0 {
-                self.add_new_elements(n as u32)?;
+                self.add_new_elements(n as u32, can_gc)?;
             }
 
             // Step 5
@@ -128,7 +135,7 @@ impl HTMLOptionsCollectionMethods for HTMLOptionsCollection {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-htmloptionscollection-length>
-    fn SetLength(&self, length: u32) {
+    fn SetLength(&self, length: u32, can_gc: CanGc) {
         let current_length = self.upcast().Length();
         let delta = length as i32 - current_length as i32;
         match delta.cmp(&0) {
@@ -140,7 +147,7 @@ impl HTMLOptionsCollectionMethods for HTMLOptionsCollection {
             },
             Ordering::Greater => {
                 // new length is higher - adding new option elements
-                self.add_new_elements(delta as u32).unwrap();
+                self.add_new_elements(delta as u32, can_gc).unwrap();
             },
             _ => {},
         }

--- a/components/script/dom/htmloutputelement.rs
+++ b/components/script/dom/htmloutputelement.rs
@@ -53,6 +53,7 @@ impl HTMLOutputElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLOutputElement> {
         Node::reflect_node_with_proto(
             Box::new(HTMLOutputElement::new_inherited(
@@ -60,11 +61,12 @@ impl HTMLOutputElement {
             )),
             document,
             proto,
+            can_gc,
         )
     }
 
-    pub fn reset(&self) {
-        Node::string_replace_all(self.DefaultValue(), self.upcast::<Node>());
+    pub fn reset(&self, can_gc: CanGc) {
+        Node::string_replace_all(self.DefaultValue(), self.upcast::<Node>(), can_gc);
         *self.default_value_override.borrow_mut() = None;
     }
 }
@@ -89,10 +91,10 @@ impl HTMLOutputElementMethods for HTMLOutputElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-output-defaultvalue
-    fn SetDefaultValue(&self, value: DOMString) {
+    fn SetDefaultValue(&self, value: DOMString, can_gc: CanGc) {
         if self.default_value_override.borrow().is_none() {
             // Step 1 ("and return")
-            Node::string_replace_all(value.clone(), self.upcast::<Node>());
+            Node::string_replace_all(value.clone(), self.upcast::<Node>(), can_gc);
         } else {
             // Step 2, if not returned from step 1
             *self.default_value_override.borrow_mut() = Some(value);
@@ -105,9 +107,9 @@ impl HTMLOutputElementMethods for HTMLOutputElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-output-value
-    fn SetValue(&self, value: DOMString) {
+    fn SetValue(&self, value: DOMString, can_gc: CanGc) {
         *self.default_value_override.borrow_mut() = Some(self.DefaultValue());
-        Node::string_replace_all(value, self.upcast::<Node>());
+        Node::string_replace_all(value, self.upcast::<Node>(), can_gc);
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-output-type

--- a/components/script/dom/htmlparagraphelement.rs
+++ b/components/script/dom/htmlparagraphelement.rs
@@ -10,6 +10,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::document::Document;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::node::Node;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct HTMLParagraphElement {
@@ -33,6 +34,7 @@ impl HTMLParagraphElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLParagraphElement> {
         Node::reflect_node_with_proto(
             Box::new(HTMLParagraphElement::new_inherited(
@@ -40,6 +42,7 @@ impl HTMLParagraphElement {
             )),
             document,
             proto,
+            can_gc,
         )
     }
 }

--- a/components/script/dom/htmlparamelement.rs
+++ b/components/script/dom/htmlparamelement.rs
@@ -10,6 +10,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::document::Document;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::node::Node;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct HTMLParamElement {
@@ -33,6 +34,7 @@ impl HTMLParamElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLParamElement> {
         Node::reflect_node_with_proto(
             Box::new(HTMLParamElement::new_inherited(
@@ -40,6 +42,7 @@ impl HTMLParamElement {
             )),
             document,
             proto,
+            can_gc,
         )
     }
 }

--- a/components/script/dom/htmlpictureelement.rs
+++ b/components/script/dom/htmlpictureelement.rs
@@ -10,6 +10,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::document::Document;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::node::Node;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct HTMLPictureElement {
@@ -33,6 +34,7 @@ impl HTMLPictureElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLPictureElement> {
         Node::reflect_node_with_proto(
             Box::new(HTMLPictureElement::new_inherited(
@@ -40,6 +42,7 @@ impl HTMLPictureElement {
             )),
             document,
             proto,
+            can_gc,
         )
     }
 }

--- a/components/script/dom/htmlpreelement.rs
+++ b/components/script/dom/htmlpreelement.rs
@@ -15,6 +15,7 @@ use crate::dom::document::Document;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::node::Node;
 use crate::dom::virtualmethods::VirtualMethods;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct HTMLPreElement {
@@ -38,11 +39,13 @@ impl HTMLPreElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLPreElement> {
         Node::reflect_node_with_proto(
             Box::new(HTMLPreElement::new_inherited(local_name, prefix, document)),
             document,
             proto,
+            can_gc,
         )
     }
 }

--- a/components/script/dom/htmlprogresselement.rs
+++ b/components/script/dom/htmlprogresselement.rs
@@ -16,6 +16,7 @@ use crate::dom::element::Element;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::node::Node;
 use crate::dom::nodelist::NodeList;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct HTMLProgressElement {
@@ -41,6 +42,7 @@ impl HTMLProgressElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLProgressElement> {
         Node::reflect_node_with_proto(
             Box::new(HTMLProgressElement::new_inherited(
@@ -48,6 +50,7 @@ impl HTMLProgressElement {
             )),
             document,
             proto,
+            can_gc,
         )
     }
 }
@@ -77,14 +80,17 @@ impl HTMLProgressElementMethods for HTMLProgressElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-progress-value>
-    fn SetValue(&self, new_val: Finite<f64>) {
+    fn SetValue(&self, new_val: Finite<f64>, can_gc: CanGc) {
         if *new_val >= 0.0 {
             let mut string_value = DOMString::from_string((*new_val).to_string());
 
             string_value.set_best_representation_of_the_floating_point_number();
 
-            self.upcast::<Element>()
-                .set_string_attribute(&local_name!("value"), string_value);
+            self.upcast::<Element>().set_string_attribute(
+                &local_name!("value"),
+                string_value,
+                can_gc,
+            );
         }
     }
 
@@ -106,14 +112,17 @@ impl HTMLProgressElementMethods for HTMLProgressElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-progress-max>
-    fn SetMax(&self, new_val: Finite<f64>) {
+    fn SetMax(&self, new_val: Finite<f64>, can_gc: CanGc) {
         if *new_val > 0.0 {
             let mut string_value = DOMString::from_string((*new_val).to_string());
 
             string_value.set_best_representation_of_the_floating_point_number();
 
-            self.upcast::<Element>()
-                .set_string_attribute(&local_name!("max"), string_value);
+            self.upcast::<Element>().set_string_attribute(
+                &local_name!("max"),
+                string_value,
+                can_gc,
+            );
         }
     }
 

--- a/components/script/dom/htmlquoteelement.rs
+++ b/components/script/dom/htmlquoteelement.rs
@@ -12,6 +12,7 @@ use crate::dom::bindings::str::USVString;
 use crate::dom::document::Document;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::node::Node;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct HTMLQuoteElement {
@@ -35,6 +36,7 @@ impl HTMLQuoteElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLQuoteElement> {
         Node::reflect_node_with_proto(
             Box::new(HTMLQuoteElement::new_inherited(
@@ -42,6 +44,7 @@ impl HTMLQuoteElement {
             )),
             document,
             proto,
+            can_gc,
         )
     }
 }

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -193,6 +193,7 @@ impl HTMLScriptElement {
         document: &Document,
         proto: Option<HandleObject>,
         creator: ElementCreator,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLScriptElement> {
         Node::reflect_node_with_proto(
             Box::new(HTMLScriptElement::new_inherited(
@@ -200,6 +201,7 @@ impl HTMLScriptElement {
             )),
             document,
             proto,
+            can_gc,
         )
     }
 
@@ -1311,10 +1313,10 @@ impl HTMLScriptElementMethods for HTMLScriptElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-script-async
-    fn SetAsync(&self, value: bool) {
+    fn SetAsync(&self, value: bool, can_gc: CanGc) {
         self.non_blocking.set(false);
         self.upcast::<Element>()
-            .set_bool_attribute(&local_name!("async"), value);
+            .set_bool_attribute(&local_name!("async"), value, can_gc);
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-script-defer
@@ -1348,8 +1350,8 @@ impl HTMLScriptElementMethods for HTMLScriptElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-script-crossorigin
-    fn SetCrossOrigin(&self, value: Option<DOMString>) {
-        set_cross_origin_attribute(self.upcast::<Element>(), value);
+    fn SetCrossOrigin(&self, value: Option<DOMString>, can_gc: CanGc) {
+        set_cross_origin_attribute(self.upcast::<Element>(), value, can_gc);
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-script-referrerpolicy
@@ -1366,8 +1368,8 @@ impl HTMLScriptElementMethods for HTMLScriptElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-script-text
-    fn SetText(&self, value: DOMString) {
-        self.upcast::<Node>().SetTextContent(Some(value))
+    fn SetText(&self, value: DOMString, can_gc: CanGc) {
+        self.upcast::<Node>().SetTextContent(Some(value), can_gc)
     }
 }
 

--- a/components/script/dom/htmlselectelement.rs
+++ b/components/script/dom/htmlselectelement.rs
@@ -98,6 +98,7 @@ impl HTMLSelectElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLSelectElement> {
         let n = Node::reflect_node_with_proto(
             Box::new(HTMLSelectElement::new_inherited(
@@ -105,6 +106,7 @@ impl HTMLSelectElement {
             )),
             document,
             proto,
+            can_gc,
         );
 
         n.upcast::<Node>().set_weird_parser_insertion_mode();
@@ -288,8 +290,8 @@ impl HTMLSelectElementMethods for HTMLSelectElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-select-length
-    fn SetLength(&self, length: u32) {
-        self.Options().SetLength(length)
+    fn SetLength(&self, length: u32, can_gc: CanGc) {
+        self.Options().SetLength(length, can_gc)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-select-item
@@ -303,8 +305,13 @@ impl HTMLSelectElementMethods for HTMLSelectElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-select-setter
-    fn IndexedSetter(&self, index: u32, value: Option<&HTMLOptionElement>) -> ErrorResult {
-        self.Options().IndexedSetter(index, value)
+    fn IndexedSetter(
+        &self,
+        index: u32,
+        value: Option<&HTMLOptionElement>,
+        can_gc: CanGc,
+    ) -> ErrorResult {
+        self.Options().IndexedSetter(index, value, can_gc)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-select-nameditem

--- a/components/script/dom/htmlsourceelement.rs
+++ b/components/script/dom/htmlsourceelement.rs
@@ -43,6 +43,7 @@ impl HTMLSourceElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLSourceElement> {
         Node::reflect_node_with_proto(
             Box::new(HTMLSourceElement::new_inherited(
@@ -50,6 +51,7 @@ impl HTMLSourceElement {
             )),
             document,
             proto,
+            can_gc,
         )
     }
 

--- a/components/script/dom/htmlspanelement.rs
+++ b/components/script/dom/htmlspanelement.rs
@@ -10,6 +10,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::document::Document;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::node::Node;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct HTMLSpanElement {
@@ -33,11 +34,13 @@ impl HTMLSpanElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLSpanElement> {
         Node::reflect_node_with_proto(
             Box::new(HTMLSpanElement::new_inherited(local_name, prefix, document)),
             document,
             proto,
+            can_gc,
         )
     }
 }

--- a/components/script/dom/htmlstyleelement.rs
+++ b/components/script/dom/htmlstyleelement.rs
@@ -30,6 +30,7 @@ use crate::dom::node::{
 };
 use crate::dom::stylesheet::StyleSheet as DOMStyleSheet;
 use crate::dom::virtualmethods::VirtualMethods;
+use crate::script_runtime::CanGc;
 use crate::stylesheet_loader::{StylesheetLoader, StylesheetOwner};
 
 #[dom_struct]
@@ -73,6 +74,7 @@ impl HTMLStyleElement {
         document: &Document,
         proto: Option<HandleObject>,
         creator: ElementCreator,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLStyleElement> {
         Node::reflect_node_with_proto(
             Box::new(HTMLStyleElement::new_inherited(
@@ -80,6 +82,7 @@ impl HTMLStyleElement {
             )),
             document,
             proto,
+            can_gc,
         )
     }
 

--- a/components/script/dom/htmltablecaptionelement.rs
+++ b/components/script/dom/htmltablecaptionelement.rs
@@ -11,6 +11,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::document::Document;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::node::Node;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct HTMLTableCaptionElement {
@@ -34,6 +35,7 @@ impl HTMLTableCaptionElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLTableCaptionElement> {
         let n = Node::reflect_node_with_proto(
             Box::new(HTMLTableCaptionElement::new_inherited(
@@ -41,6 +43,7 @@ impl HTMLTableCaptionElement {
             )),
             document,
             proto,
+            can_gc,
         );
 
         n.upcast::<Node>().set_weird_parser_insertion_mode();

--- a/components/script/dom/htmltablecellelement.rs
+++ b/components/script/dom/htmltablecellelement.rs
@@ -22,6 +22,7 @@ use crate::dom::htmltablerowelement::HTMLTableRowElement;
 use crate::dom::htmltablesectionelement::HTMLTableSectionElement;
 use crate::dom::node::{LayoutNodeHelpers, Node};
 use crate::dom::virtualmethods::VirtualMethods;
+use crate::script_runtime::CanGc;
 
 const DEFAULT_COLSPAN: u32 = 1;
 const DEFAULT_ROWSPAN: u32 = 1;
@@ -48,6 +49,7 @@ impl HTMLTableCellElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLTableCellElement> {
         let n = Node::reflect_node_with_proto(
             Box::new(HTMLTableCellElement::new_inherited(
@@ -55,6 +57,7 @@ impl HTMLTableCellElement {
             )),
             document,
             proto,
+            can_gc,
         );
 
         n.upcast::<Node>().set_weird_parser_insertion_mode();

--- a/components/script/dom/htmltablecolelement.rs
+++ b/components/script/dom/htmltablecolelement.rs
@@ -18,6 +18,7 @@ use crate::dom::element::LayoutElementHelpers;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::node::Node;
 use crate::dom::virtualmethods::VirtualMethods;
+use crate::script_runtime::CanGc;
 
 const DEFAULT_SPAN: u32 = 1;
 
@@ -43,6 +44,7 @@ impl HTMLTableColElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLTableColElement> {
         let n = Node::reflect_node_with_proto(
             Box::new(HTMLTableColElement::new_inherited(
@@ -50,6 +52,7 @@ impl HTMLTableColElement {
             )),
             document,
             proto,
+            can_gc,
         );
 
         n.upcast::<Node>().set_weird_parser_insertion_mode();

--- a/components/script/dom/htmltablerowelement.rs
+++ b/components/script/dom/htmltablerowelement.rs
@@ -25,6 +25,7 @@ use crate::dom::htmltableelement::HTMLTableElement;
 use crate::dom::htmltablesectionelement::HTMLTableSectionElement;
 use crate::dom::node::{window_from_node, Node};
 use crate::dom::virtualmethods::VirtualMethods;
+use crate::script_runtime::CanGc;
 
 #[derive(JSTraceable)]
 struct CellsFilter;
@@ -59,6 +60,7 @@ impl HTMLTableRowElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLTableRowElement> {
         let n = Node::reflect_node_with_proto(
             Box::new(HTMLTableRowElement::new_inherited(
@@ -66,6 +68,7 @@ impl HTMLTableRowElement {
             )),
             document,
             proto,
+            can_gc,
         );
 
         n.upcast::<Node>().set_weird_parser_insertion_mode();
@@ -99,12 +102,12 @@ impl HTMLTableRowElementMethods for HTMLTableRowElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-tr-insertcell
-    fn InsertCell(&self, index: i32) -> Fallible<DomRoot<HTMLElement>> {
+    fn InsertCell(&self, index: i32, can_gc: CanGc) -> Fallible<DomRoot<HTMLElement>> {
         let node = self.upcast::<Node>();
         node.insert_cell_or_row(
             index,
             || self.Cells(),
-            || HTMLTableCellElement::new(local_name!("td"), None, &node.owner_doc(), None),
+            || HTMLTableCellElement::new(local_name!("td"), None, &node.owner_doc(), None, can_gc),
         )
     }
 

--- a/components/script/dom/htmltablesectionelement.rs
+++ b/components/script/dom/htmltablesectionelement.rs
@@ -21,6 +21,7 @@ use crate::dom::htmlelement::HTMLElement;
 use crate::dom::htmltablerowelement::HTMLTableRowElement;
 use crate::dom::node::{window_from_node, Node};
 use crate::dom::virtualmethods::VirtualMethods;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct HTMLTableSectionElement {
@@ -44,6 +45,7 @@ impl HTMLTableSectionElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLTableSectionElement> {
         let n = Node::reflect_node_with_proto(
             Box::new(HTMLTableSectionElement::new_inherited(
@@ -51,6 +53,7 @@ impl HTMLTableSectionElement {
             )),
             document,
             proto,
+            can_gc,
         );
 
         n.upcast::<Node>().set_weird_parser_insertion_mode();
@@ -74,12 +77,12 @@ impl HTMLTableSectionElementMethods for HTMLTableSectionElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-tbody-insertrow
-    fn InsertRow(&self, index: i32) -> Fallible<DomRoot<HTMLElement>> {
+    fn InsertRow(&self, index: i32, can_gc: CanGc) -> Fallible<DomRoot<HTMLElement>> {
         let node = self.upcast::<Node>();
         node.insert_cell_or_row(
             index,
             || self.Rows(),
-            || HTMLTableRowElement::new(local_name!("tr"), None, &node.owner_doc(), None),
+            || HTMLTableRowElement::new(local_name!("tr"), None, &node.owner_doc(), None, can_gc),
         )
     }
 

--- a/components/script/dom/htmltemplateelement.rs
+++ b/components/script/dom/htmltemplateelement.rs
@@ -44,6 +44,7 @@ impl HTMLTemplateElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLTemplateElement> {
         let n = Node::reflect_node_with_proto(
             Box::new(HTMLTemplateElement::new_inherited(
@@ -51,6 +52,7 @@ impl HTMLTemplateElement {
             )),
             document,
             proto,
+            can_gc,
         );
 
         n.upcast::<Node>().set_weird_parser_insertion_mode();
@@ -64,7 +66,7 @@ impl HTMLTemplateElementMethods for HTMLTemplateElement {
         self.contents.or_init(|| {
             let doc = document_from_node(self);
             doc.appropriate_template_contents_owner_document(can_gc)
-                .CreateDocumentFragment()
+                .CreateDocumentFragment(can_gc)
         })
     }
 }

--- a/components/script/dom/htmltextareaelement.rs
+++ b/components/script/dom/htmltextareaelement.rs
@@ -176,6 +176,7 @@ impl HTMLTextAreaElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLTextAreaElement> {
         Node::reflect_node_with_proto(
             Box::new(HTMLTextAreaElement::new_inherited(
@@ -183,6 +184,7 @@ impl HTMLTextAreaElement {
             )),
             document,
             proto,
+            can_gc,
         )
     }
 
@@ -306,8 +308,8 @@ impl HTMLTextAreaElementMethods for HTMLTextAreaElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-textarea-defaultvalue
-    fn SetDefaultValue(&self, value: DOMString) {
-        self.upcast::<Node>().SetTextContent(Some(value));
+    fn SetDefaultValue(&self, value: DOMString, can_gc: CanGc) {
+        self.upcast::<Node>().SetTextContent(Some(value), can_gc);
 
         // if the element's dirty value flag is false, then the element's
         // raw value must be set to the value of the element's textContent IDL attribute

--- a/components/script/dom/htmltimeelement.rs
+++ b/components/script/dom/htmltimeelement.rs
@@ -12,6 +12,7 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::node::Node;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct HTMLTimeElement {
@@ -35,11 +36,13 @@ impl HTMLTimeElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLTimeElement> {
         Node::reflect_node_with_proto(
             Box::new(HTMLTimeElement::new_inherited(local_name, prefix, document)),
             document,
             proto,
+            can_gc,
         )
     }
 }

--- a/components/script/dom/htmltitleelement.rs
+++ b/components/script/dom/htmltitleelement.rs
@@ -17,6 +17,7 @@ use crate::dom::document::Document;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::node::{BindContext, ChildrenMutation, Node};
 use crate::dom::virtualmethods::VirtualMethods;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct HTMLTitleElement {
@@ -42,6 +43,7 @@ impl HTMLTitleElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLTitleElement> {
         Node::reflect_node_with_proto(
             Box::new(HTMLTitleElement::new_inherited(
@@ -49,6 +51,7 @@ impl HTMLTitleElement {
             )),
             document,
             proto,
+            can_gc,
         )
     }
 
@@ -67,8 +70,8 @@ impl HTMLTitleElementMethods for HTMLTitleElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-title-text
-    fn SetText(&self, value: DOMString) {
-        self.upcast::<Node>().SetTextContent(Some(value))
+    fn SetText(&self, value: DOMString, can_gc: CanGc) {
+        self.upcast::<Node>().SetTextContent(Some(value), can_gc)
     }
 }
 

--- a/components/script/dom/htmltrackelement.rs
+++ b/components/script/dom/htmltrackelement.rs
@@ -17,6 +17,7 @@ use crate::dom::element::Element;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::node::Node;
 use crate::dom::texttrack::TextTrack;
+use crate::script_runtime::CanGc;
 
 #[derive(Clone, Copy, JSTraceable, MallocSizeOf, PartialEq)]
 #[repr(u16)]
@@ -54,6 +55,7 @@ impl HTMLTrackElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLTrackElement> {
         let track = TextTrack::new(
             document.window(),
@@ -70,6 +72,7 @@ impl HTMLTrackElement {
             )),
             document,
             proto,
+            can_gc,
         )
     }
 }

--- a/components/script/dom/htmlulistelement.rs
+++ b/components/script/dom/htmlulistelement.rs
@@ -12,6 +12,7 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::node::Node;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct HTMLUListElement {
@@ -35,6 +36,7 @@ impl HTMLUListElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLUListElement> {
         Node::reflect_node_with_proto(
             Box::new(HTMLUListElement::new_inherited(
@@ -42,6 +44,7 @@ impl HTMLUListElement {
             )),
             document,
             proto,
+            can_gc,
         )
     }
 }

--- a/components/script/dom/htmlunknownelement.rs
+++ b/components/script/dom/htmlunknownelement.rs
@@ -10,6 +10,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::document::Document;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::node::Node;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct HTMLUnknownElement {
@@ -33,6 +34,7 @@ impl HTMLUnknownElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLUnknownElement> {
         Node::reflect_node_with_proto(
             Box::new(HTMLUnknownElement::new_inherited(
@@ -40,6 +42,7 @@ impl HTMLUnknownElement {
             )),
             document,
             proto,
+            can_gc,
         )
     }
 }

--- a/components/script/dom/htmlvideoelement.rs
+++ b/components/script/dom/htmlvideoelement.rs
@@ -89,6 +89,7 @@ impl HTMLVideoElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLVideoElement> {
         Node::reflect_node_with_proto(
             Box::new(HTMLVideoElement::new_inherited(
@@ -96,6 +97,7 @@ impl HTMLVideoElement {
             )),
             document,
             proto,
+            can_gc,
         )
     }
 

--- a/components/script/dom/macros.rs
+++ b/components/script/dom/macros.rs
@@ -32,6 +32,7 @@ macro_rules! make_limited_int_setter(
         fn $attr(&self, value: i32) -> $crate::dom::bindings::error::ErrorResult {
             use $crate::dom::bindings::inheritance::Castable;
             use $crate::dom::element::Element;
+            use $crate::script_runtime::CanGc;
 
             let value = if value < 0 {
                 return Err($crate::dom::bindings::error::Error::IndexSize);
@@ -40,7 +41,7 @@ macro_rules! make_limited_int_setter(
             };
 
             let element = self.upcast::<Element>();
-            element.set_int_attribute(&html5ever::local_name!($htmlname), value);
+            element.set_int_attribute(&html5ever::local_name!($htmlname), value, CanGc::note());
             Ok(())
         }
     );
@@ -52,9 +53,10 @@ macro_rules! make_int_setter(
         fn $attr(&self, value: i32) {
             use $crate::dom::bindings::inheritance::Castable;
             use $crate::dom::element::Element;
+            use $crate::script_runtime::CanGc;
 
             let element = self.upcast::<Element>();
-            element.set_int_attribute(&html5ever::local_name!($htmlname), value)
+            element.set_int_attribute(&html5ever::local_name!($htmlname), value, CanGc::note())
         }
     );
     ($attr:ident, $htmlname:tt) => {
@@ -111,9 +113,10 @@ macro_rules! make_url_setter(
         fn $attr(&self, value: USVString) {
             use $crate::dom::bindings::inheritance::Castable;
             use $crate::dom::element::Element;
+            use $crate::script_runtime::CanGc;
             let element = self.upcast::<Element>();
             element.set_url_attribute(&html5ever::local_name!($htmlname),
-                                         value);
+                                         value, CanGc::note());
         }
     );
 );
@@ -181,8 +184,9 @@ macro_rules! make_setter(
         fn $attr(&self, value: DOMString) {
             use $crate::dom::bindings::inheritance::Castable;
             use $crate::dom::element::Element;
+            use $crate::script_runtime::CanGc;
             let element = self.upcast::<Element>();
-            element.set_string_attribute(&html5ever::local_name!($htmlname), value)
+            element.set_string_attribute(&html5ever::local_name!($htmlname), value, CanGc::note())
         }
     );
 );
@@ -193,8 +197,9 @@ macro_rules! make_bool_setter(
         fn $attr(&self, value: bool) {
             use $crate::dom::bindings::inheritance::Castable;
             use $crate::dom::element::Element;
+            use $crate::script_runtime::CanGc;
             let element = self.upcast::<Element>();
-            element.set_bool_attribute(&html5ever::local_name!($htmlname), value)
+            element.set_bool_attribute(&html5ever::local_name!($htmlname), value, CanGc::note())
         }
     );
 );
@@ -206,13 +211,14 @@ macro_rules! make_uint_setter(
             use $crate::dom::bindings::inheritance::Castable;
             use $crate::dom::element::Element;
             use $crate::dom::values::UNSIGNED_LONG_MAX;
+            use $crate::script_runtime::CanGc;
             let value = if value > UNSIGNED_LONG_MAX {
                 $default
             } else {
                 value
             };
             let element = self.upcast::<Element>();
-            element.set_uint_attribute(&html5ever::local_name!($htmlname), value)
+            element.set_uint_attribute(&html5ever::local_name!($htmlname), value, CanGc::note())
         }
     );
     ($attr:ident, $htmlname:tt) => {
@@ -227,6 +233,7 @@ macro_rules! make_limited_uint_setter(
             use $crate::dom::bindings::inheritance::Castable;
             use $crate::dom::element::Element;
             use $crate::dom::values::UNSIGNED_LONG_MAX;
+            use $crate::script_runtime::CanGc;
             let value = if value == 0 {
                 return Err($crate::dom::bindings::error::Error::IndexSize);
             } else if value > UNSIGNED_LONG_MAX {
@@ -235,7 +242,7 @@ macro_rules! make_limited_uint_setter(
                 value
             };
             let element = self.upcast::<Element>();
-            element.set_uint_attribute(&html5ever::local_name!($htmlname), value);
+            element.set_uint_attribute(&html5ever::local_name!($htmlname), value, CanGc::note());
             Ok(())
         }
     );
@@ -250,8 +257,9 @@ macro_rules! make_atomic_setter(
         fn $attr(&self, value: DOMString) {
             use $crate::dom::bindings::inheritance::Castable;
             use $crate::dom::element::Element;
+            use $crate::script_runtime::CanGc;
             let element = self.upcast::<Element>();
-            element.set_atomic_attribute(&html5ever::local_name!($htmlname), value)
+            element.set_atomic_attribute(&html5ever::local_name!($htmlname), value, CanGc::note())
         }
     );
 );
@@ -263,9 +271,10 @@ macro_rules! make_legacy_color_setter(
             use $crate::dom::bindings::inheritance::Castable;
             use $crate::dom::element::Element;
             use style::attr::AttrValue;
+            use $crate::script_runtime::CanGc;
             let element = self.upcast::<Element>();
             let value = AttrValue::from_legacy_color(value.into());
-            element.set_attribute(&html5ever::local_name!($htmlname), value)
+            element.set_attribute(&html5ever::local_name!($htmlname), value, CanGc::note())
         }
     );
 );
@@ -276,9 +285,10 @@ macro_rules! make_dimension_setter(
         fn $attr(&self, value: DOMString) {
             use $crate::dom::bindings::inheritance::Castable;
             use $crate::dom::element::Element;
+            use $crate::script_runtime::CanGc;
             let element = self.upcast::<Element>();
             let value = AttrValue::from_dimension(value.into());
-            element.set_attribute(&html5ever::local_name!($htmlname), value)
+            element.set_attribute(&html5ever::local_name!($htmlname), value, CanGc::note())
         }
     );
 );
@@ -289,9 +299,10 @@ macro_rules! make_nonzero_dimension_setter(
         fn $attr(&self, value: DOMString) {
             use $crate::dom::bindings::inheritance::Castable;
             use $crate::dom::element::Element;
+            use $crate::script_runtime::CanGc;
             let element = self.upcast::<Element>();
             let value = AttrValue::from_nonzero_dimension(value.into());
-            element.set_attribute(&html5ever::local_name!($htmlname), value)
+            element.set_attribute(&html5ever::local_name!($htmlname), value, CanGc::note())
         }
     );
 );

--- a/components/script/dom/processinginstruction.rs
+++ b/components/script/dom/processinginstruction.rs
@@ -10,6 +10,7 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::characterdata::CharacterData;
 use crate::dom::document::Document;
 use crate::dom::node::Node;
+use crate::script_runtime::CanGc;
 
 /// An HTML processing instruction node.
 #[dom_struct]
@@ -34,10 +35,12 @@ impl ProcessingInstruction {
         target: DOMString,
         data: DOMString,
         document: &Document,
+        can_gc: CanGc,
     ) -> DomRoot<ProcessingInstruction> {
         Node::reflect_node(
             Box::new(ProcessingInstruction::new_inherited(target, data, document)),
             document,
+            can_gc,
         )
     }
 }

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -561,7 +561,7 @@ impl RangeMethods for Range {
         let end_offset = self.end_offset();
 
         // Step 1.
-        let fragment = DocumentFragment::new(&start_node.owner_doc());
+        let fragment = DocumentFragment::new(&start_node.owner_doc(), can_gc);
 
         // Step 2.
         if self.start() == self.end() {
@@ -574,7 +574,7 @@ impl RangeMethods for Range {
                 let data = cdata
                     .SubstringData(start_offset, end_offset - start_offset)
                     .unwrap();
-                let clone = cdata.clone_with_data(data, &start_node.owner_doc());
+                let clone = cdata.clone_with_data(data, &start_node.owner_doc(), can_gc);
                 // Step 4.3.
                 fragment.upcast::<Node>().AppendChild(&clone)?;
                 // Step 4.4
@@ -597,7 +597,7 @@ impl RangeMethods for Range {
                 let data = cdata
                     .SubstringData(start_offset, start_node.len() - start_offset)
                     .unwrap();
-                let clone = cdata.clone_with_data(data, &start_node.owner_doc());
+                let clone = cdata.clone_with_data(data, &start_node.owner_doc(), can_gc);
                 // Step 13.3.
                 fragment.upcast::<Node>().AppendChild(&clone)?;
             } else {
@@ -635,7 +635,7 @@ impl RangeMethods for Range {
                 assert!(child == end_node);
                 // Steps 16.1-2.
                 let data = cdata.SubstringData(0, end_offset).unwrap();
-                let clone = cdata.clone_with_data(data, &start_node.owner_doc());
+                let clone = cdata.clone_with_data(data, &start_node.owner_doc(), can_gc);
                 // Step 16.3.
                 fragment.upcast::<Node>().AppendChild(&clone)?;
             } else {
@@ -667,7 +667,7 @@ impl RangeMethods for Range {
         let end_offset = self.end_offset();
 
         // Step 1.
-        let fragment = DocumentFragment::new(&start_node.owner_doc());
+        let fragment = DocumentFragment::new(&start_node.owner_doc(), can_gc);
 
         // Step 2.
         if self.collapsed() {
@@ -807,7 +807,7 @@ impl RangeMethods for Range {
 
     /// <https://dom.spec.whatwg.org/#dom-range-insertnode>
     /// <https://dom.spec.whatwg.org/#concept-range-insert>
-    fn InsertNode(&self, node: &Node) -> ErrorResult {
+    fn InsertNode(&self, node: &Node, can_gc: CanGc) -> ErrorResult {
         let start_node = self.start_container();
         let start_offset = self.start_offset();
 
@@ -848,7 +848,7 @@ impl RangeMethods for Range {
         let split_text;
         let reference_node = match start_node.downcast::<Text>() {
             Some(text) => {
-                split_text = text.SplitText(start_offset)?;
+                split_text = text.SplitText(start_offset, can_gc)?;
                 let new_reference = DomRoot::upcast::<Node>(split_text);
                 assert!(new_reference.GetParentNode().as_deref() == Some(&parent));
                 Some(new_reference)
@@ -1006,7 +1006,7 @@ impl RangeMethods for Range {
         Node::replace_all(None, new_parent);
 
         // Step 5.
-        self.InsertNode(new_parent)?;
+        self.InsertNode(new_parent, can_gc)?;
 
         // Step 6.
         new_parent.AppendChild(fragment.upcast())?;
@@ -1086,7 +1086,7 @@ impl RangeMethods for Range {
         };
 
         // Step 2.
-        let element = Element::fragment_parsing_context(&owner_doc, element.as_deref());
+        let element = Element::fragment_parsing_context(&owner_doc, element.as_deref(), can_gc);
 
         // Step 3.
         let fragment_node = element.parse_fragment(fragment, can_gc)?;

--- a/components/script/dom/servoparser/async_html.rs
+++ b/components/script/dom/servoparser/async_html.rs
@@ -447,7 +447,7 @@ impl Tokenizer {
                 self.insert_node(node, Dom::from_ref(element.upcast()));
             },
             ParseOperation::CreateComment { text, node } => {
-                let comment = Comment::new(DOMString::from(text), document, None);
+                let comment = Comment::new(DOMString::from(text), document, None, can_gc);
                 self.insert_node(node, Dom::from_ref(comment.upcast()));
             },
             ParseOperation::AppendBeforeSibling { sibling, node } => {
@@ -477,6 +477,7 @@ impl Tokenizer {
                     Some(DOMString::from(public_id)),
                     Some(DOMString::from(system_id)),
                     document,
+                    can_gc,
                 );
 
                 document
@@ -490,7 +491,12 @@ impl Tokenizer {
                     .downcast::<Element>()
                     .expect("tried to set attrs on non-Element in HTML parsing");
                 for attr in attrs {
-                    elem.set_attribute_from_parser(attr.name, DOMString::from(attr.value), None);
+                    elem.set_attribute_from_parser(
+                        attr.name,
+                        DOMString::from(attr.value),
+                        None,
+                        can_gc,
+                    );
                 }
             },
             ParseOperation::RemoveFromParent { target } => {
@@ -549,6 +555,7 @@ impl Tokenizer {
                     DOMString::from(target),
                     DOMString::from(data),
                     document,
+                    can_gc,
                 );
                 self.insert_node(node, Dom::from_ref(pi.upcast()));
             },

--- a/components/script/dom/svgelement.rs
+++ b/components/script/dom/svgelement.rs
@@ -15,6 +15,7 @@ use crate::dom::document::Document;
 use crate::dom::element::Element;
 use crate::dom::node::{window_from_node, Node};
 use crate::dom::virtualmethods::VirtualMethods;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct SVGElement {
@@ -48,11 +49,13 @@ impl SVGElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<SVGElement> {
         Node::reflect_node_with_proto(
             Box::new(SVGElement::new_inherited(tag_name, prefix, document)),
             document,
             proto,
+            can_gc,
         )
     }
 }
@@ -83,8 +86,8 @@ impl SVGElementMethods for SVGElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-fe-autofocus
-    fn SetAutofocus(&self, autofocus: bool) {
+    fn SetAutofocus(&self, autofocus: bool, can_gc: CanGc) {
         self.element
-            .set_bool_attribute(&local_name!("autofocus"), autofocus);
+            .set_bool_attribute(&local_name!("autofocus"), autofocus, can_gc);
     }
 }

--- a/components/script/dom/svgsvgelement.rs
+++ b/components/script/dom/svgsvgelement.rs
@@ -17,6 +17,7 @@ use crate::dom::element::{AttributeMutation, Element, LayoutElementHelpers};
 use crate::dom::node::Node;
 use crate::dom::svggraphicselement::SVGGraphicsElement;
 use crate::dom::virtualmethods::VirtualMethods;
+use crate::script_runtime::CanGc;
 
 const DEFAULT_WIDTH: u32 = 300;
 const DEFAULT_HEIGHT: u32 = 150;
@@ -43,11 +44,13 @@ impl SVGSVGElement {
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<SVGSVGElement> {
         Node::reflect_node_with_proto(
             Box::new(SVGSVGElement::new_inherited(local_name, prefix, document)),
             document,
             proto,
+            can_gc,
         )
     }
 }

--- a/components/script/dom/text.rs
+++ b/components/script/dom/text.rs
@@ -33,19 +33,21 @@ impl Text {
         }
     }
 
-    pub fn new(text: DOMString, document: &Document) -> DomRoot<Text> {
-        Self::new_with_proto(text, document, None)
+    pub fn new(text: DOMString, document: &Document, can_gc: CanGc) -> DomRoot<Text> {
+        Self::new_with_proto(text, document, None, can_gc)
     }
 
     fn new_with_proto(
         text: DOMString,
         document: &Document,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<Text> {
         Node::reflect_node_with_proto(
             Box::new(Text::new_inherited(text, document)),
             document,
             proto,
+            can_gc,
         )
     }
 }
@@ -55,16 +57,16 @@ impl TextMethods for Text {
     fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
-        _can_gc: CanGc,
+        can_gc: CanGc,
         text: DOMString,
     ) -> Fallible<DomRoot<Text>> {
         let document = window.Document();
-        Ok(Text::new_with_proto(text, &document, proto))
+        Ok(Text::new_with_proto(text, &document, proto, can_gc))
     }
 
     // https://dom.spec.whatwg.org/#dom-text-splittext
     // https://dom.spec.whatwg.org/#concept-text-split
-    fn SplitText(&self, offset: u32) -> Fallible<DomRoot<Text>> {
+    fn SplitText(&self, offset: u32, can_gc: CanGc) -> Fallible<DomRoot<Text>> {
         let cdata = self.upcast::<CharacterData>();
         // Step 1.
         let length = cdata.Length();
@@ -79,7 +81,7 @@ impl TextMethods for Text {
         // Step 5.
         let node = self.upcast::<Node>();
         let owner_doc = node.owner_doc();
-        let new_node = owner_doc.CreateTextNode(new_data);
+        let new_node = owner_doc.CreateTextNode(new_data, can_gc);
         // Step 6.
         let parent = node.GetParentNode();
         if let Some(ref parent) = parent {

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2613,7 +2613,7 @@ impl ScriptThread {
                 devtools::handle_get_layout(&documents, id, node_id, reply, can_gc)
             },
             DevtoolScriptControlMsg::ModifyAttribute(id, node_id, modifications) => {
-                devtools::handle_modify_attribute(&documents, id, node_id, modifications)
+                devtools::handle_modify_attribute(&documents, id, node_id, modifications, can_gc)
             },
             DevtoolScriptControlMsg::ModifyRule(id, node_id, modifications) => {
                 devtools::handle_modify_rule(&documents, id, node_id, modifications)


### PR DESCRIPTION
**File:** `components\script\dom\node.rs`

**PR Description:**

Replaced `CanGc::note()` calls in `node.rs` and fixed it's corresponding propagations.

**Note:**
Left `CanGc::note()` calls under relevant `TreeSink` trait methods that I could not propagate due to it's external dependencies.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #33683

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because they do not modify functionality

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
