### PR TITLE
add `#allow(non_camel_case_types)` to generated pref structs

### DIFF
--- a/components/config_plugins/lib.rs
+++ b/components/config_plugins/lib.rs
@@ -84,6 +84,7 @@ impl Build {
             .collect::<Result<Vec<_>>>()?;
         self.output.extend(quote! {
             #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+            #[allow(non_camel_case_types)]
             pub struct #struct_name {
                 #(#field_defs), *
             }


### PR DESCRIPTION
Structs related to prefs are autogenerated as of #8539, but the
generated struct names are of the format `Prefs__fonts`, which
rust-analyzer doesn't like (it suggests using `PrefsFonts`).

This generates a LOT of warnings, so silence them by adding a
`#allow(non_camel_case_types)` to the generated code.

NB: the other solution is of course to change the generated
names, but I like the "autogeneratedness" of those names as they
are now.

---

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because it only affects `rust-analyzer`
