### PR TITLE
Consistent resolution of cyclic percentages in min sizing properties

### DIFF
--- a/tests/wpt/meta/css/css-values/calc-min-height-block-1.html.ini
+++ b/tests/wpt/meta/css/css-values/calc-min-height-block-1.html.ini
@@ -1,0 +1,2 @@
+[calc-min-height-block-1.html]
+  expected: FAIL

--- a/tests/wpt/tests/css/css-sizing/intrinsic-percent-non-replaced-006.html
+++ b/tests/wpt/tests/css/css-sizing/intrinsic-percent-non-replaced-006.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Cyclic percentages in min-width and min-height</title>
+<link rel="help" href="https://drafts.csswg.org/css-sizing-3/#cyclic-percentage-contribution">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/10969">
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+
+<style>
+#outer {
+  display: inline-block;
+  border: 5px solid;
+  padding: 3px;
+}
+#inner {
+  min-width: calc(100px + 50%);
+  min-height: calc(100px + 50%);
+  border: 2px solid cyan;
+}
+</style>
+
+<div id="outer">
+  <div id="inner"></div>
+</div>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+const innerBorder = 4;
+const outerPadding = 6;
+const bp = innerBorder + outerPadding;
+
+// Intrinsic contributions should treat cyclic percentages equally in both axes.
+test(
+  () => assert_equals(outer.clientWidth, outer.clientHeight),
+  "Axis consistency of intrinsic contributions",
+);
+
+// The spec says that the intrinsic size contributions should resolve cyclic percentages
+// in min size properties against zero, so here we should expect 110px.
+// However, most browsers just ignore the mininum in that case, resulting in 10px.
+// See https://github.com/w3c/csswg-drafts/issues/10969
+test(
+  () => assert_in_array(outer.clientWidth, [0 + bp, 100 + bp]),
+  "Intrinsic contribution for width",
+);
+test(
+  () => assert_in_array(outer.clientHeight, [0 + bp, 100 + bp]),
+  "Intrinsic contribution for height",
+);
+
+// Regardless of how browsers treat cyclic percentages, once the size of #outer is known,
+// #inner should re-resolve its inline-axis percentage against the containing block,
+// but not re-resolve its block-axis percentage.
+test(
+  () => assert_equals(inner.clientWidth, 100 + 0.5 * (outer.clientWidth - outerPadding)),
+  "Final size for width",
+);
+test(
+  () => assert_equals(inner.clientHeight, outer.clientHeight - bp),
+  "Final size for height",
+);
+</script>


### PR DESCRIPTION
The spec says that cyclic percentages in min sizing properties should be resolved against zero when computing intrinsic contributions. We were already doing that in the inline axis, but we were treating the entire expression as `auto` in the block axis.

With this patch we will follow the spec in both axes. But note that browsers don't follow the spec in either axis, so we may have to revisit (see https://github.com/w3c/csswg-drafts/issues/10969).

calc-min-height-block-1.html now fails because it tests what browsers do instead of what the spec says.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
