### PR TITLE
dom: Stub out the `IntersectionObserver` interface

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -261,6 +261,9 @@ mod gen {
                 imagebitmap: {
                     enabled: bool,
                 },
+                intersection_observer: {
+                    enabled: bool,
+                },
                 microdata: {
                     testing: {
                         enabled: bool,

--- a/components/script/dom/bindings/root.rs
+++ b/components/script/dom/bindings/root.rs
@@ -190,6 +190,17 @@ impl<T: DomObject> DomRoot<T> {
     pub fn from_ref(unrooted: &T) -> DomRoot<T> {
         unsafe { DomRoot::new(Dom::from_ref(unrooted)) }
     }
+
+    /// Create a traced version of this rooted object.
+    ///
+    /// # Safety
+    ///
+    /// This should never be used to create on-stack values. Instead these values should always
+    /// end up as members of other DOM objects.
+    #[allow(crown::unrooted_must_root)]
+    pub(crate) fn as_traced(&self) -> Dom<T> {
+        Dom::from_ref(self)
+    }
 }
 
 impl<T> MallocSizeOf for DomRoot<T>
@@ -359,6 +370,11 @@ impl<T: DomObject> Dom<T> {
         Dom {
             ptr: ptr::NonNull::from(obj),
         }
+    }
+
+    /// Return a rooted version of this DOM object ([`DomRoot<T>`]) suitable for use on the stack.
+    pub(crate) fn as_rooted(&self) -> DomRoot<T> {
+        DomRoot::from_ref(self)
     }
 }
 

--- a/components/script/dom/intersectionobserver.rs
+++ b/components/script/dom/intersectionobserver.rs
@@ -1,0 +1,143 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::rc::Rc;
+
+use dom_struct::dom_struct;
+use js::jsval::{JSVal, NullValue};
+use js::rust::HandleObject;
+
+use super::bindings::codegen::Bindings::IntersectionObserverBinding::{
+    IntersectionObserverCallback, IntersectionObserverMethods,
+};
+use super::bindings::codegen::UnionTypes::ElementOrDocument;
+use super::types::{Element, IntersectionObserverEntry};
+use crate::dom::bindings::codegen::Bindings::IntersectionObserverBinding::IntersectionObserverInit;
+use crate::dom::bindings::reflector::{reflect_dom_object_with_proto, Reflector};
+use crate::dom::bindings::root::DomRoot;
+use crate::dom::bindings::str::DOMString;
+use crate::dom::window::Window;
+use crate::script_runtime::{CanGc, JSContext};
+
+/// The Intersection Observer interface
+///
+/// > The IntersectionObserver interface can be used to observe changes in the intersection
+/// > of an intersection root and one or more target Elements.
+///
+/// <https://w3c.github.io/IntersectionObserver/#intersection-observer-interface>
+#[dom_struct]
+pub struct IntersectionObserver {
+    reflector_: Reflector,
+
+    /// > This callback will be invoked when there are changes to a target’s intersection
+    /// > with the intersection root, as per the processing model.
+    /// <https://w3c.github.io/IntersectionObserver/#intersection-observer-callback>
+    #[ignore_malloc_size_of = "Rc are hard"]
+    callback: Rc<IntersectionObserverCallback>,
+}
+
+impl IntersectionObserver {
+    pub fn new_inherited(
+        callback: Rc<IntersectionObserverCallback>,
+        _init: &IntersectionObserverInit,
+    ) -> Self {
+        Self {
+            reflector_: Reflector::new(),
+            callback,
+        }
+    }
+
+    fn new(
+        window: &Window,
+        proto: Option<HandleObject>,
+        callback: Rc<IntersectionObserverCallback>,
+        init: &IntersectionObserverInit,
+        can_gc: CanGc,
+    ) -> DomRoot<Self> {
+        let observer = Box::new(Self::new_inherited(callback, init));
+        reflect_dom_object_with_proto(observer, window, proto, can_gc)
+    }
+}
+
+impl IntersectionObserverMethods for IntersectionObserver {
+    /// > The root provided to the IntersectionObserver constructor, or null if none was provided.
+    ///
+    /// <https://w3c.github.io/IntersectionObserver/#dom-intersectionobserver-root>
+    fn GetRoot(&self) -> Option<ElementOrDocument> {
+        None
+    }
+
+    /// > Offsets applied to the root intersection rectangle, effectively growing or
+    /// > shrinking the box that is used to calculate intersections. These offsets are only
+    /// > applied when handling same-origin-domain targets; for cross-origin-domain targets
+    /// > they are ignored.
+    ///
+    /// <https://w3c.github.io/IntersectionObserver/#dom-intersectionobserver-rootmargin>
+    fn RootMargin(&self) -> DOMString {
+        DOMString::new()
+    }
+
+    /// > Offsets are applied to scrollports on the path from intersection root to target,
+    /// > effectively growing or shrinking the clip rects used to calculate intersections.
+    ///
+    /// <https://w3c.github.io/IntersectionObserver/#dom-intersectionobserver-scrollmargin>
+    fn ScrollMargin(&self) -> DOMString {
+        DOMString::new()
+    }
+
+    /// > A list of thresholds, sorted in increasing numeric order, where each threshold
+    /// > is a ratio of intersection area to bounding box area of an observed target.
+    /// > Notifications for a target are generated when any of the thresholds are crossed
+    /// > for that target. If no options.threshold was provided to the IntersectionObserver
+    /// > constructor, or the sequence is empty, the value of this attribute will be [0].
+    ///
+    /// <https://w3c.github.io/IntersectionObserver/#dom-intersectionobserver-thresholds>
+    fn Thresholds(&self, _context: JSContext) -> JSVal {
+        NullValue()
+    }
+
+    /// > A number indicating the minimum delay in milliseconds between notifications from
+    /// > this observer for a given target.
+    ///
+    /// <https://w3c.github.io/IntersectionObserver/#dom-intersectionobserver-delay>
+    fn Delay(&self) -> i32 {
+        0
+    }
+
+    /// > A boolean indicating whether this IntersectionObserver will track changes in a target’s visibility.
+    ///
+    /// <https://w3c.github.io/IntersectionObserver/#dom-intersectionobserver-trackvisibility>
+    fn TrackVisibility(&self) -> bool {
+        false
+    }
+
+    /// > Run the observe a target Element algorithm, providing this and target.
+    ///
+    /// <https://w3c.github.io/IntersectionObserver/#dom-intersectionobserver-observe>
+    fn Observe(&self, _target: &Element) {}
+
+    /// > Run the unobserve a target Element algorithm, providing this and target.
+    ///
+    /// <https://w3c.github.io/IntersectionObserver/#dom-intersectionobserver-unobserve>
+    fn Unobserve(&self, _target: &Element) {}
+
+    /// <https://w3c.github.io/IntersectionObserver/#dom-intersectionobserver-disconnect>
+    fn Disconnect(&self) {}
+
+    /// <https://w3c.github.io/IntersectionObserver/#dom-intersectionobserver-takerecords>
+    fn TakeRecords(&self) -> Vec<DomRoot<IntersectionObserverEntry>> {
+        vec![]
+    }
+
+    /// <https://w3c.github.io/IntersectionObserver/#dom-intersectionobserver-intersectionobserver>
+    fn Constructor(
+        window: &Window,
+        proto: Option<HandleObject>,
+        can_gc: CanGc,
+        callback: Rc<IntersectionObserverCallback>,
+        init: &IntersectionObserverInit,
+    ) -> DomRoot<IntersectionObserver> {
+        Self::new(window, proto, callback, init, can_gc)
+    }
+}

--- a/components/script/dom/intersectionobserverentry.rs
+++ b/components/script/dom/intersectionobserverentry.rs
@@ -1,0 +1,128 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use dom_struct::dom_struct;
+use js::rust::HandleObject;
+
+use super::bindings::codegen::Bindings::IntersectionObserverEntryBinding::{
+    IntersectionObserverEntryInit, IntersectionObserverEntryMethods,
+};
+use super::bindings::num::Finite;
+use crate::dom::bindings::reflector::{reflect_dom_object_with_proto, DomObject, Reflector};
+use crate::dom::bindings::root::{Dom, DomRoot};
+use crate::dom::domrectreadonly::DOMRectReadOnly;
+use crate::dom::element::Element;
+use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
+
+/// An individual IntersectionObserver entry.
+///
+/// <https://w3c.github.io/IntersectionObserver/#intersection-observer-entry>
+#[dom_struct]
+pub struct IntersectionObserverEntry {
+    reflector_: Reflector,
+    target: Dom<Element>,
+}
+
+impl IntersectionObserverEntry {
+    pub fn new_inherited(init: &IntersectionObserverEntryInit) -> Self {
+        Self {
+            reflector_: Reflector::new(),
+            target: init.target.as_traced(),
+        }
+    }
+
+    fn new(
+        window: &Window,
+        proto: Option<HandleObject>,
+        init: &IntersectionObserverEntryInit,
+        can_gc: CanGc,
+    ) -> DomRoot<Self> {
+        let observer = Box::new(Self::new_inherited(init));
+        reflect_dom_object_with_proto(observer, window, proto, can_gc)
+    }
+}
+
+impl IntersectionObserverEntryMethods for IntersectionObserverEntry {
+    /// > The attribute must return a DOMHighResTimeStamp that corresponds to the time the
+    /// > intersection was recorded, relative to the time origin of the global object
+    /// > associated with the IntersectionObserver instance that generated the notification.
+    ///
+    /// <https://w3c.github.io/IntersectionObserver/#dom-intersectionobserverentry-time>
+    fn Time(&self) -> Finite<f64> {
+        Finite::new(0.).unwrap()
+    }
+
+    /// > For a same-origin-domain target, this will be the root intersection rectangle.
+    /// > Otherwise, this will be null. Note that if the target is in a different browsing
+    /// > context than the intersection root, this will be in a different coordinate system
+    /// > than boundingClientRect and intersectionRect.
+    ///
+    /// <https://w3c.github.io/IntersectionObserver/#dom-intersectionobserverentry-rootbounds>
+    fn GetRootBounds(&self) -> Option<DomRoot<DOMRectReadOnly>> {
+        None
+    }
+
+    /// > A DOMRectReadOnly obtained by getting the bounding box for target.
+    ///
+    /// <https://w3c.github.io/IntersectionObserver/#dom-intersectionobserverentry-boundingclientrect>
+    fn BoundingClientRect(&self) -> DomRoot<DOMRectReadOnly> {
+        DOMRectReadOnly::new(&self.global(), None, 0., 0., 0., 0., CanGc::note())
+    }
+
+    /// > boundingClientRect, intersected by each of target's ancestors' clip rects (up to
+    /// > but not including root), intersected with the root intersection rectangle. This
+    /// > value represents the portion of target that intersects with the root intersection
+    /// > rectangle.
+    ///
+    /// <https://w3c.github.io/IntersectionObserver/#dom-intersectionobserverentry-intersectionrect>
+    fn IntersectionRect(&self) -> DomRoot<DOMRectReadOnly> {
+        DOMRectReadOnly::new(&self.global(), None, 0., 0., 0., 0., CanGc::note())
+    }
+
+    /// > True if the target intersects with the root; false otherwise. This flag makes it
+    /// > possible to distinguish between an IntersectionObserverEntry signalling the
+    /// > transition from intersecting to not-intersecting; and an IntersectionObserverEntry
+    /// > signalling a transition from not-intersecting to intersecting with a zero-area
+    /// > intersection rect (as will happen with edge-adjacent intersections, or when the
+    /// > boundingClientRect has zero area).
+    ///
+    /// <https://w3c.github.io/IntersectionObserver/#dom-intersectionobserverentry-isintersecting>
+    fn IsIntersecting(&self) -> bool {
+        false
+    }
+
+    /// > Contains the result of running the visibility algorithm on target.
+    ///
+    /// <https://w3c.github.io/IntersectionObserver/#dom-intersectionobserverentry-isvisible>
+    fn IsVisible(&self) -> bool {
+        false
+    }
+
+    /// > If the boundingClientRect has non-zero area, this will be the ratio of
+    /// > intersectionRect area to boundingClientRect area. Otherwise, this will be 1 if the
+    /// > isIntersecting is true, and 0 if not.
+    ///
+    /// <https://w3c.github.io/IntersectionObserver/#dom-intersectionobserverentry-intersectionratio>
+    fn IntersectionRatio(&self) -> Finite<f64> {
+        Finite::new(0.).unwrap()
+    }
+
+    /// > The Element whose intersection with the intersection root changed.
+    ///
+    /// <https://w3c.github.io/IntersectionObserver/#dom-intersectionobserverentry-target>
+    fn Target(&self) -> DomRoot<Element> {
+        self.target.as_rooted()
+    }
+
+    /// <https://w3c.github.io/IntersectionObserver/#dom-intersectionobserverentry-intersectionobserverentry>
+    fn Constructor(
+        window: &Window,
+        proto: Option<HandleObject>,
+        can_gc: CanGc,
+        init: &IntersectionObserverEntryInit,
+    ) -> DomRoot<IntersectionObserverEntry> {
+        Self::new(window, proto, init, can_gc)
+    }
+}

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -445,6 +445,8 @@ pub mod iirfilternode;
 pub mod imagebitmap;
 pub mod imagedata;
 pub mod inputevent;
+pub mod intersectionobserver;
+pub mod intersectionobserverentry;
 pub mod keyboardevent;
 pub mod location;
 pub mod mediadeviceinfo;

--- a/components/script/dom/webidls/IntersectionObserver.webidl
+++ b/components/script/dom/webidls/IntersectionObserver.webidl
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// https://w3c.github.io/IntersectionObserver/#intersection-observer-interface
+
+callback IntersectionObserverCallback =
+  undefined (sequence<IntersectionObserverEntry> entries, IntersectionObserver observer);
+
+dictionary IntersectionObserverInit {
+  (Element or Document)?  root = null;
+  DOMString rootMargin;
+  DOMString scrollMargin;
+  (double or sequence<double>) threshold;
+  long delay;
+  boolean trackVisibility = false;
+};
+
+[Pref="dom.intersection_observer.enabled", Exposed=(Window)]
+interface IntersectionObserver {
+  constructor(IntersectionObserverCallback callback, optional IntersectionObserverInit options = {});
+  readonly attribute (Element or Document)? root;
+  readonly attribute DOMString rootMargin;
+  readonly attribute DOMString scrollMargin;
+  readonly attribute /* FrozenArray<double> */ any thresholds;
+  readonly attribute long delay;
+  readonly attribute boolean trackVisibility;
+  undefined observe(Element target);
+  undefined unobserve(Element target);
+  undefined disconnect();
+  sequence<IntersectionObserverEntry> takeRecords();
+};

--- a/components/script/dom/webidls/IntersectionObserverEntry.webidl
+++ b/components/script/dom/webidls/IntersectionObserverEntry.webidl
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// https://w3c.github.io/IntersectionObserver/#intersection-observer-entry
+
+[Pref="dom.intersection_observer.enabled", Exposed=(Window)]
+interface IntersectionObserverEntry {
+  constructor(IntersectionObserverEntryInit intersectionObserverEntryInit);
+  readonly attribute DOMHighResTimeStamp time;
+  readonly attribute DOMRectReadOnly? rootBounds;
+  readonly attribute DOMRectReadOnly boundingClientRect;
+  readonly attribute DOMRectReadOnly intersectionRect;
+  readonly attribute boolean isIntersecting;
+  readonly attribute boolean isVisible;
+  readonly attribute double intersectionRatio;
+  readonly attribute Element target;
+};
+
+dictionary IntersectionObserverEntryInit {
+  required DOMHighResTimeStamp time;
+  required DOMRectInit rootBounds;
+  required DOMRectInit boundingClientRect;
+  required DOMRectInit intersectionRect;
+  required boolean isIntersecting;
+  required boolean isVisible;
+  required double intersectionRatio;
+  required Element target;
+};

--- a/resources/prefs.json
+++ b/resources/prefs.json
@@ -15,6 +15,7 @@
   "dom.fullscreen.test": false,
   "dom.gamepad.enabled": true,
   "dom.imagebitmap.enabled": false,
+  "dom.intersection_observer.enabled": false,
   "dom.microdata.enabled": false,
   "dom.microdata.testing.enabled": false,
   "dom.mouseevent.which.enabled": false,


### PR DESCRIPTION
This is the first step toward implementing the IntersectionObserver
interface. It adds stubs which are exposed when a preference is turned
on. This is enough to get some sites with `IntersectionObserver` to
start working.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #31021.
- [x] These changes do not require tests this change is still too early to test. Later when we start implementing IntersectionObsersver we can turn on tests.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
