### PR TITLE
Use `Rc<Box<[u8]>>` for queue to optimize get_in_memory_bytes 

### DIFF
--- a/components/script/dom/readablestreamdefaultcontroller.rs
+++ b/components/script/dom/readablestreamdefaultcontroller.rs
@@ -135,7 +135,7 @@ pub struct ValueWithSize {
 #[allow(crown::unrooted_must_root)]
 pub enum EnqueuedValue {
     /// A value enqueued from Rust.
-    Native(Vec<u8>),
+    Native(Rc<Box<[u8]>>),
     /// A Js value.
     Js(ValueWithSize),
 }
@@ -194,7 +194,7 @@ impl QueueWithSizes {
                         "`get_in_memory_bytes` can only be called on a queue with native values."
                     )
                 };
-                chunk.clone()
+                chunk.iter().copied()
             })
             .collect()
     }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Part of https://github.com/servo/servo/issues/32898
---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
