### PR TITLE
CanGc fixes in `messageport.rs` & `workerglobalscope.rs`

### DIFF
--- a/components/script/dom/bindings/codegen/Bindings.conf
+++ b/components/script/dom/bindings/codegen/Bindings.conf
@@ -347,6 +347,7 @@ DOMInterfaces = {
 
 'MessagePort': {
     'weakReferenceable': True,
+    'canGc': ['GetOnmessage'],
 },
 
 'NavigationPreloadManager': {

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -464,7 +464,7 @@ impl DedicatedWorkerGlobalScope {
                 {
                     let _ar = AutoWorkerReset::new(&global, worker.clone());
                     let _ac = enter_realm(scope);
-                    scope.execute_script(DOMString::from(source));
+                    scope.execute_script(DOMString::from(source), CanGc::note());
                 }
 
                 let reporter_name = format!("dedicated-worker-reporter-{}", random::<u64>());

--- a/components/script/dom/messageport.rs
+++ b/components/script/dom/messageport.rs
@@ -322,12 +322,12 @@ impl MessagePortMethods for MessagePort {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#handler-messageport-onmessage>
-    fn GetOnmessage(&self) -> Option<Rc<EventHandlerNonNull>> {
+    fn GetOnmessage(&self, can_gc: CanGc) -> Option<Rc<EventHandlerNonNull>> {
         if self.detached.get() {
             return None;
         }
         let eventtarget = self.upcast::<EventTarget>();
-        eventtarget.get_event_handler_common("message", CanGc::note())
+        eventtarget.get_event_handler_common("message", can_gc)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#handler-messageport-onmessage>

--- a/components/script/dom/serviceworkerglobalscope.rs
+++ b/components/script/dom/serviceworkerglobalscope.rs
@@ -384,7 +384,7 @@ impl ServiceWorkerGlobalScope {
                 {
                     // TODO: use AutoWorkerReset as in dedicated worker?
                     let _ac = enter_realm(scope);
-                    scope.execute_script(DOMString::from(source));
+                    scope.execute_script(DOMString::from(source), CanGc::note());
                 }
 
                 global.dispatch_activate(CanGc::note());

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -447,7 +447,7 @@ impl WorkerGlobalScopeMethods for WorkerGlobalScope {
 
 impl WorkerGlobalScope {
     #[allow(unsafe_code)]
-    pub fn execute_script(&self, source: DOMString) {
+    pub fn execute_script(&self, source: DOMString, can_gc: CanGc) {
         let _aes = AutoEntryScript::new(self.upcast());
         let cx = self.runtime.borrow().as_ref().unwrap().cx();
         rooted!(in(cx) let mut rval = UndefinedValue());
@@ -468,7 +468,7 @@ impl WorkerGlobalScope {
                     println!("evaluate_script failed");
                     unsafe {
                         let ar = enter_realm(self);
-                        report_pending_exception(cx, true, InRealm::Entered(&ar), CanGc::note());
+                        report_pending_exception(cx, true, InRealm::Entered(&ar), can_gc);
                     }
                 }
             },


### PR DESCRIPTION
Replaces CanGc::note() calls with arguments passed by callers in `components/script/dom/messageport.rs` and `components/script/dom/workerglobalscope.rs`


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are a part of #33683 
- [X] These changes do not require tests because they do not modify functionality

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
