### PR TITLE
ServoShell: Don't request redrawing again when processing a RedrawRequested event

### DIFF
--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -278,7 +278,8 @@ impl App {
                                 "Sync WebView size with Window Resize event",
                             );
                         }
-                        if response.repaint {
+                        if response.repaint && *event != winit::event::WindowEvent::RedrawRequested
+                        {
                             // Request a winit redraw event, so we can recomposite, update and paint
                             // the minibrowser, and present the new frame.
                             window.winit_window().unwrap().request_redraw();


### PR DESCRIPTION
Prevents requesting a new redraw when we are already processing that same event kind.

On both Linux and MacOS, this brings cpu usage down from 15%-20% to 0% when loading pages that have no animations, like `https://example.org` or `https://google.com` .


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
