### PR TITLE
ci: pin python to 3.12 for mac workflows

### DIFF
--- a/.github/workflows/mac-wpt.yml
+++ b/.github/workflows/mac-wpt.yml
@@ -41,6 +41,11 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.profile }}-binary-macos
+      # Python 3.13 breaks wptrunner, so pin the version until
+      # web-platform-tests/wpt#48585 is fixed.
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
       - name: Prep test environment
         run: |
           gtar -xzf target.tar.gz

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -77,6 +77,11 @@ jobs:
         if: github.event_name == 'pull_request_target'
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+      # Python 3.13 breaks wptrunner, so pin the version until
+      # web-platform-tests/wpt#48585 is fixed.
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.6
       - name: Install crown


### PR DESCRIPTION
wptrunner breaks macos builds because it doesn't work well with 3.13 due
to two issues:

1. The current version (10.3.0) of the 'pillow' dependency of wptrunner
   breaks with >=3.13 and needs to be upgraded.
2. Python 3.13 has removed the 'cgi' module which was deprecated in 3.11
   and has no direct replacement. There are two files in wptrunner that
   use the cgi module and one of them is the vendored 'html5lib'.

As a quick fix, pin the Python version on MacOS runner until
web-platform-tests/wpt#48585 is addressed.

Signed-off-by: Mukilan Thiyagarajan <mukilan@igalia.com>


---

- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

