### PR TITLE
webgpu: Move supported context format to content timeline

### DIFF
--- a/components/webgpu/wgpu_thread.rs
+++ b/components/webgpu/wgpu_thread.rs
@@ -551,21 +551,7 @@ impl WGPU {
                         {
                             warn!("Unable to send FreeTexture({:?}) ({:?})", texture_id, e);
                         };
-                        if let Some(error) = error {
-                            self.dispatch_error(device_id, Error::from_error(error));
-                            continue;
-                        }
-                        // Supported context formats
-                        // TODO: wgt::TextureFormat::Rgba16Float, when wr supports HDR
-                        if !matches!(
-                            descriptor.format,
-                            wgt::TextureFormat::Bgra8Unorm | wgt::TextureFormat::Rgba8Unorm
-                        ) {
-                            self.dispatch_error(
-                                device_id,
-                                Error::Validation("Unsupported context format".to_string()),
-                            );
-                        }
+                        self.maybe_dispatch_wgpu_error(device_id, error);
                     },
                     WebGPURequest::DestroyContext { context_id } => {
                         self.destroy_context(context_id);


### PR DESCRIPTION
Relevant spec change: https://github.com/gpuweb/gpuweb/pull/4911 (also done by me).

draft because it needs updated expectations


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes in WebGPU CTS (actually I used this commit to create changes for CTS that we now finally got)

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
