### PR TITLE
Devtools: Don't display iframes in the tab list

### DIFF
--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3866,11 +3866,13 @@ impl ScriptThread {
             .unwrap();
 
         // Notify devtools that a new script global exists.
-        self.notify_devtools(
-            document.Title(),
-            final_url.clone(),
-            (incomplete.browsing_context_id, incomplete.pipeline_id, None),
-        );
+        if incomplete.top_level_browsing_context_id.0 == incomplete.browsing_context_id {
+            self.notify_devtools(
+                document.Title(),
+                final_url.clone(),
+                (incomplete.browsing_context_id, incomplete.pipeline_id, None),
+            );
+        }
 
         document.set_https_state(metadata.https_state);
         document.set_navigation_start(incomplete.navigation_start);


### PR DESCRIPTION
Small patch to only show top level browsing contexts in the devtools tab list.

|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/34ecc3b8-4000-4113-846b-d4b4cb36dadf)|![image](https://github.com/user-attachments/assets/0b01af18-928c-4c63-a72d-2235751aa945)|

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #34010
- [x] To manually test devtools changes, follow the instructions in the [book](https://book.servo.org/hacking/using-devtools.html#connecting-to-servo)