### PR TITLE
Add `medium` cargo profile for daily usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,6 +162,14 @@ xml5ever = "0.20"
 opt-level = 3
 debug-assertions = true
 
+# A profile between `dev` and `release` which aims to offer a compromise between
+# fast incremental rebuilds and runtime speed.
+[profile.medium]
+inherits = "release"
+opt-level = 2
+incremental = true
+debug = "line-tables-only"
+
 [profile.production]
 inherits = "release"
 debug-assertions = false

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -678,6 +678,10 @@ class CommandBase(object):
             elif self.config["build"]["mode"] == "release":
                 print("No build type specified, but .servobuild specified `--release`.")
                 return BuildType.release()
+            elif self.config["build"]["mode"] != "":
+                profile = self.config["build"]["mode"]
+                print(f"No build type specified, but .servobuild specified custom profile `{profile}`.")
+                return BuildType.custom(profile)
             else:
                 print("No build type specified so assuming `--dev`.")
                 return BuildType.dev()

--- a/servobuild.example
+++ b/servobuild.example
@@ -14,6 +14,8 @@
 [build]
 # Set "mode = dev" or use `mach build --dev` to build the project with warning.
 # or Set "mode = release" or use `mach build --release` for optimized build.
+# Use `mode = <profile>` or `mach build --profile=<profile>` to build the given
+# profile. Check the `Cargo.toml` manifest for a complete list of custom profiles.
 # Defaults to prompting before building
 #mode = "dev"
 


### PR DESCRIPTION
- The standard `dev` mode is often too slow for daily work on servo
- Increasing the optimization level to 2 improves the performance noticably.
- Build time for opt-level = 1 is slightly higher than 2 on my machine
- Reducing debug info to `line-tables-only` improves link and build times,
  while still keeping relevant info for backtraces.

Also extend .servobuild to allow setting custom cargo profiles instead
of just release and dev.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

