### PR TITLE
servoshell: Allow overriding screen resolution with a command-line argument

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8303,6 +8303,7 @@ dependencies = [
  "libc",
  "log",
  "serde",
+ "servo_geometry",
  "surfman",
  "webrender_api",
 ]

--- a/components/compositing/windowing.rs
+++ b/components/compositing/windowing.rs
@@ -17,7 +17,7 @@ use script_traits::{
     GamepadEvent, MediaSessionActionType, MouseButton, TouchEventType, TouchId, TraversalDirection,
     WheelDelta,
 };
-use servo_geometry::DeviceIndependentPixel;
+use servo_geometry::{DeviceIndependentIntRect, DeviceIndependentIntSize, DeviceIndependentPixel};
 use servo_url::ServoUrl;
 use style_traits::DevicePixel;
 use webrender_api::units::{DeviceIntPoint, DeviceIntRect, DeviceIntSize, DevicePoint, DeviceRect};
@@ -241,11 +241,11 @@ pub struct EmbedderCoordinates {
     /// The pixel density of the display.
     pub hidpi_factor: Scale<f32, DeviceIndependentPixel, DevicePixel>,
     /// Size of the screen.
-    pub screen_size: DeviceIntSize,
+    pub screen_size: DeviceIndependentIntSize,
     /// Size of the available screen space (screen without toolbars and docks).
-    pub available_screen_size: DeviceIntSize,
+    pub available_screen_size: DeviceIndependentIntSize,
     /// Position and size of the native window.
-    pub window_rect: DeviceIntRect,
+    pub window_rect: DeviceIndependentIntRect,
     /// Size of the GL buffer in the window.
     pub framebuffer: DeviceIntSize,
     /// Coordinates of the document within the framebuffer.
@@ -278,23 +278,23 @@ impl EmbedderCoordinates {
 
 #[cfg(test)]
 mod test {
-    use euclid::{Point2D, Scale, Size2D};
+    use euclid::{Box2D, Point2D, Scale, Size2D};
     use webrender_api::units::DeviceIntRect;
 
     use super::EmbedderCoordinates;
 
     #[test]
     fn test() {
-        let pos = Point2D::zero();
-        let viewport = Size2D::new(800, 600);
-        let screen = Size2D::new(1080, 720);
+        let screen_size = Size2D::new(1080, 720);
+        let viewport = Box2D::from_origin_and_size(Point2D::zero(), Size2D::new(800, 600));
+        let window_rect = Box2D::from_origin_and_size(Point2D::zero(), Size2D::new(800, 600));
         let coordinates = EmbedderCoordinates {
             hidpi_factor: Scale::new(1.),
-            screen_size: screen,
-            available_screen_size: screen,
-            window_rect: DeviceIntRect::from_origin_and_size(pos, viewport),
-            framebuffer: viewport,
-            viewport: DeviceIntRect::from_origin_and_size(pos, viewport),
+            screen_size,
+            available_screen_size: screen_size,
+            window_rect,
+            framebuffer: viewport.size(),
+            viewport,
         };
 
         // Check if viewport conversion is correct.

--- a/components/config/opts.rs
+++ b/components/config/opts.rs
@@ -83,6 +83,10 @@ pub struct Opts {
     /// The initial requested size of the window.
     pub initial_window_size: Size2D<u32, DeviceIndependentPixel>,
 
+    /// An override for the screen resolution. This is useful for testing behavior on different screen sizes,
+    /// such as the screen of a mobile device.
+    pub screen_size_override: Option<Size2D<u32, DeviceIndependentPixel>>,
+
     /// Whether we're running in multiprocess mode.
     pub multiprocess: bool,
 
@@ -407,6 +411,7 @@ pub fn default_opts() -> Opts {
         devtools_server_enabled: false,
         webdriver_port: None,
         initial_window_size: Size2D::new(1024, 740),
+        screen_size_override: None,
         multiprocess: false,
         background_hang_monitor: false,
         random_pipeline_closure_probability: None,
@@ -499,7 +504,18 @@ pub fn from_cmdline_args(mut opts: Options, args: &[String]) -> ArgumentParsingR
         "Start remote WebDriver server on port",
         "7000",
     );
-    opts.optopt("", "resolution", "Set window resolution.", "1024x740");
+    opts.optopt(
+        "",
+        "window-size",
+        "Set the initial window size in logical (device independenrt) pixels",
+        "1024x740",
+    );
+    opts.optopt(
+        "",
+        "screen-size",
+        "Override the screen resolution in logical (device independent) pixels",
+        "1024x768",
+    );
     opts.optflag("M", "multiprocess", "Run in multiprocess mode");
     opts.optflag("B", "bhm", "Background Hang Monitor enabled");
     opts.optflag("S", "sandbox", "Run in a sandbox if multiprocess");
@@ -689,20 +705,32 @@ pub fn from_cmdline_args(mut opts: Options, args: &[String]) -> ArgumentParsingR
         })
     });
 
-    let initial_window_size = match opt_match.opt_str("resolution") {
-        Some(res_string) => {
-            let res: Vec<u32> = res_string
-                .split('x')
-                .map(|r| {
-                    r.parse().unwrap_or_else(|err| {
-                        args_fail(&format!("Error parsing option: --resolution ({})", err))
-                    })
+    let parse_resolution_string = |string: String| {
+        let components: Vec<u32> = string
+            .split('x')
+            .map(|component| {
+                component.parse().unwrap_or_else(|error| {
+                    args_fail(&format!("Error parsing resolution '{string}': {error}"));
                 })
-                .collect();
-            Size2D::new(res[0], res[1])
-        },
-        None => Size2D::new(1024, 740),
+            })
+            .collect();
+        Size2D::new(components[0], components[1])
     };
+
+    let screen_size_override = opt_match
+        .opt_str("screen-size")
+        .map(parse_resolution_string);
+
+    // Make sure the default window size is not larger than any provided screen size.
+    let default_window_size = Size2D::new(1024, 740);
+    let default_window_size = screen_size_override
+        .map_or(default_window_size, |screen_size_override| {
+            default_window_size.min(screen_size_override)
+        });
+
+    let initial_window_size = opt_match
+        .opt_str("window-size")
+        .map_or(default_window_size, parse_resolution_string);
 
     if opt_match.opt_present("M") {
         MULTIPROCESS.store(true, Ordering::SeqCst)
@@ -748,6 +776,7 @@ pub fn from_cmdline_args(mut opts: Options, args: &[String]) -> ArgumentParsingR
         devtools_server_enabled,
         webdriver_port,
         initial_window_size,
+        screen_size_override,
         multiprocess: opt_match.opt_present("M"),
         background_hang_monitor: opt_match.opt_present("B"),
         sandbox: opt_match.opt_present("S"),

--- a/components/geometry/lib.rs
+++ b/components/geometry/lib.rs
@@ -5,8 +5,8 @@
 use std::f32;
 
 use app_units::{Au, MAX_AU, MIN_AU};
-use euclid::default::{Point2D, Rect, Size2D};
-use euclid::Length;
+use euclid::default::{Point2D as UntypedPoint2D, Rect as UntypedRect, Size2D as UntypedSize2D};
+use euclid::{Box2D, Length, Point2D, SideOffsets2D, Size2D, Vector2D};
 use malloc_size_of_derive::MallocSizeOf;
 use webrender_api::units::{FramebufferPixel, LayoutPoint, LayoutRect, LayoutSize};
 
@@ -30,6 +30,19 @@ pub type FramebufferUintLength = Length<u32, FramebufferPixel>;
 #[derive(Clone, Copy, Debug, MallocSizeOf)]
 pub enum DeviceIndependentPixel {}
 
+pub type DeviceIndependentIntRect = Box2D<i32, DeviceIndependentPixel>;
+pub type DeviceIndependentIntPoint = Point2D<i32, DeviceIndependentPixel>;
+pub type DeviceIndependentIntSize = Size2D<i32, DeviceIndependentPixel>;
+pub type DeviceIndependentIntLength = Length<i32, DeviceIndependentPixel>;
+pub type DeviceIndependentIntSideOffsets = SideOffsets2D<i32, DeviceIndependentPixel>;
+pub type DeviceIndependentIntVector2D = Vector2D<i32, DeviceIndependentPixel>;
+
+pub type DeviceIndependentRect = Box2D<f32, DeviceIndependentPixel>;
+pub type DeviceIndependentBox2D = Box2D<f32, DeviceIndependentPixel>;
+pub type DeviceIndependentPoint = Point2D<f32, DeviceIndependentPixel>;
+pub type DeviceIndependentVector2D = Vector2D<f32, DeviceIndependentPixel>;
+pub type DeviceIndependentSize = Size2D<f32, DeviceIndependentPixel>;
+
 // An Au is an "App Unit" and represents 1/60th of a CSS pixel.  It was
 // originally proposed in 2002 as a standard unit of measure in Gecko.
 // See https://bugzilla.mozilla.org/show_bug.cgi?id=177805 for more info.
@@ -38,20 +51,20 @@ pub trait MaxRect {
     fn max_rect() -> Self;
 }
 
-impl MaxRect for Rect<Au> {
+impl MaxRect for UntypedRect<Au> {
     #[inline]
-    fn max_rect() -> Rect<Au> {
-        Rect::new(
-            Point2D::new(MIN_AU / 2, MIN_AU / 2),
-            Size2D::new(MAX_AU, MAX_AU),
+    fn max_rect() -> Self {
+        Self::new(
+            UntypedPoint2D::new(MIN_AU / 2, MIN_AU / 2),
+            UntypedSize2D::new(MAX_AU, MAX_AU),
         )
     }
 }
 
 impl MaxRect for LayoutRect {
     #[inline]
-    fn max_rect() -> LayoutRect {
-        LayoutRect::from_origin_and_size(
+    fn max_rect() -> Self {
+        Self::from_origin_and_size(
             LayoutPoint::new(f32::MIN / 2.0, f32::MIN / 2.0),
             LayoutSize::new(f32::MAX, f32::MAX),
         )
@@ -59,8 +72,8 @@ impl MaxRect for LayoutRect {
 }
 
 /// A helper function to convert a rect of `f32` pixels to a rect of app units.
-pub fn f32_rect_to_au_rect(rect: Rect<f32>) -> Rect<Au> {
-    Rect::new(
+pub fn f32_rect_to_au_rect(rect: UntypedRect<f32>) -> UntypedRect<Au> {
+    UntypedRect::new(
         Point2D::new(
             Au::from_f32_px(rect.origin.x),
             Au::from_f32_px(rect.origin.y),
@@ -73,8 +86,8 @@ pub fn f32_rect_to_au_rect(rect: Rect<f32>) -> Rect<Au> {
 }
 
 /// A helper function to convert a rect of `Au` pixels to a rect of f32 units.
-pub fn au_rect_to_f32_rect(rect: Rect<Au>) -> Rect<f32> {
-    Rect::new(
+pub fn au_rect_to_f32_rect(rect: UntypedRect<Au>) -> UntypedRect<f32> {
+    UntypedRect::new(
         Point2D::new(rect.origin.x.to_f32_px(), rect.origin.y.to_f32_px()),
         Size2D::new(rect.size.width.to_f32_px(), rect.size.height.to_f32_px()),
     )

--- a/components/script/dom/screen.rs
+++ b/components/script/dom/screen.rs
@@ -5,8 +5,8 @@
 use dom_struct::dom_struct;
 use euclid::Size2D;
 use profile_traits::ipc;
+use servo_geometry::DeviceIndependentIntSize;
 use style_traits::CSSPixel;
-use webrender_api::units::DeviceIntSize;
 use webrender_traits::CrossProcessCompositorMessage;
 
 use crate::dom::bindings::codegen::Bindings::ScreenBinding::ScreenMethods;
@@ -35,28 +35,28 @@ impl Screen {
 
     fn screen_size(&self) -> Size2D<u32, CSSPixel> {
         let (send, recv) =
-            ipc::channel::<DeviceIntSize>(self.global().time_profiler_chan().clone()).unwrap();
+            ipc::channel::<DeviceIndependentIntSize>(self.global().time_profiler_chan().clone())
+                .unwrap();
         self.window
             .compositor_api()
             .sender()
             .send(CrossProcessCompositorMessage::GetScreenSize(send))
             .unwrap();
-        let dpr = self.window.device_pixel_ratio();
-        let screen = recv.recv().unwrap_or(Size2D::zero());
-        (screen.to_f32() / dpr).to_u32()
+        let size = recv.recv().unwrap_or(Size2D::zero()).to_u32();
+        Size2D::new(size.width, size.height)
     }
 
     fn screen_avail_size(&self) -> Size2D<u32, CSSPixel> {
         let (send, recv) =
-            ipc::channel::<DeviceIntSize>(self.global().time_profiler_chan().clone()).unwrap();
+            ipc::channel::<DeviceIndependentIntSize>(self.global().time_profiler_chan().clone())
+                .unwrap();
         self.window
             .compositor_api()
             .sender()
             .send(CrossProcessCompositorMessage::GetAvailableScreenSize(send))
             .unwrap();
-        let dpr = self.window.device_pixel_ratio();
-        let screen = recv.recv().unwrap_or(Size2D::zero());
-        (screen.to_f32() / dpr).to_u32()
+        let size = recv.recv().unwrap_or(Size2D::zero()).to_u32();
+        Size2D::new(size.width, size.height)
     }
 }
 

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -63,7 +63,7 @@ use selectors::attr::CaseSensitivity;
 use servo_arc::Arc as ServoArc;
 use servo_atoms::Atom;
 use servo_config::pref;
-use servo_geometry::{f32_rect_to_au_rect, MaxRect};
+use servo_geometry::{f32_rect_to_au_rect, DeviceIndependentIntRect, MaxRect};
 use servo_url::{ImmutableOrigin, MutableOrigin, ServoUrl};
 use style::dom::OpaqueNode;
 use style::error_reporting::{ContextualParseError, ParseErrorReporter};
@@ -76,7 +76,7 @@ use style::str::HTML_SPACE_CHARACTERS;
 use style::stylesheets::{CssRuleType, Origin, UrlExtraData};
 use style_traits::{CSSPixel, DevicePixel, ParsingMode};
 use url::Position;
-use webrender_api::units::{DeviceIntRect, LayoutPixel};
+use webrender_api::units::LayoutPixel;
 use webrender_api::{DocumentId, ExternalScrollId};
 use webrender_traits::CrossProcessCompositorApi;
 
@@ -1779,16 +1779,16 @@ impl Window {
 
     fn client_window(&self) -> (Size2D<u32, CSSPixel>, Point2D<i32, CSSPixel>) {
         let timer_profile_chan = self.global().time_profiler_chan().clone();
-        let (send, recv) = ProfiledIpc::channel::<DeviceIntRect>(timer_profile_chan).unwrap();
+        let (send, recv) =
+            ProfiledIpc::channel::<DeviceIndependentIntRect>(timer_profile_chan).unwrap();
         let _ = self
             .compositor_api
             .sender()
             .send(webrender_traits::CrossProcessCompositorMessage::GetClientWindowRect(send));
-        let rect = recv.recv().unwrap_or_default();
-        let dpr = self.device_pixel_ratio();
+        let rect = recv.recv().unwrap_or_default().to_u32();
         (
-            (rect.size().to_f32() / dpr).to_u32(),
-            (rect.min.to_f32() / dpr).to_i32(),
+            Size2D::new(rect.size().width, rect.size().height),
+            Point2D::new(rect.min.x as i32, rect.min.y as i32),
         )
     }
 

--- a/components/shared/webrender/Cargo.toml
+++ b/components/shared/webrender/Cargo.toml
@@ -21,5 +21,6 @@ log = { workspace = true }
 libc = { workspace = true }
 webrender_api = { workspace = true }
 serde = { workspace = true }
+servo_geometry = { path = "../../geometry" }
 surfman = { workspace = true }
 

--- a/components/shared/webrender/lib.rs
+++ b/components/shared/webrender/lib.rs
@@ -14,12 +14,13 @@ use std::sync::{Arc, Mutex};
 use base::id::PipelineId;
 use display_list::{CompositorDisplayListInfo, ScrollTreeNodeId};
 use embedder_traits::Cursor;
-use euclid::default::Size2D;
+use euclid::default::Size2D as UntypedSize2D;
 use ipc_channel::ipc::{self, IpcSender, IpcSharedMemory};
 use libc::c_void;
 use log::warn;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use webrender_api::units::{DeviceIntRect, DeviceIntSize, DevicePoint, LayoutPoint, TexelRect};
+use servo_geometry::{DeviceIndependentIntRect, DeviceIndependentIntSize};
+use webrender_api::units::{DevicePoint, LayoutPoint, TexelRect};
 use webrender_api::{
     BuiltDisplayList, BuiltDisplayListDescriptor, ExternalImage, ExternalImageData,
     ExternalImageHandler, ExternalImageId, ExternalImageSource, ExternalScrollId,
@@ -77,12 +78,12 @@ pub enum CrossProcessCompositorMessage {
     RemoveFonts(Vec<FontKey>, Vec<FontInstanceKey>),
 
     /// Get the client window size and position.
-    GetClientWindowRect(IpcSender<DeviceIntRect>),
+    GetClientWindowRect(IpcSender<DeviceIndependentIntRect>),
     /// Get the size of the screen that the client window inhabits.
-    GetScreenSize(IpcSender<DeviceIntSize>),
+    GetScreenSize(IpcSender<DeviceIndependentIntSize>),
     /// Get the available screen size (without toolbars and docks) for the screen
     /// the client window inhabits.
-    GetAvailableScreenSize(IpcSender<DeviceIntSize>),
+    GetAvailableScreenSize(IpcSender<DeviceIndependentIntSize>),
 }
 
 impl fmt::Debug for CrossProcessCompositorMessage {
@@ -291,7 +292,7 @@ impl CrossProcessCompositorApi {
 /// This trait is used to notify lock/unlock messages and get the
 /// required info that WR needs.
 pub trait WebrenderExternalImageApi {
-    fn lock(&mut self, id: u64) -> (WebrenderImageSource, Size2D<i32>);
+    fn lock(&mut self, id: u64) -> (WebrenderImageSource, UntypedSize2D<i32>);
     fn unlock(&mut self, id: u64);
 }
 

--- a/etc/start_servo.py
+++ b/etc/start_servo.py
@@ -18,7 +18,7 @@ import subprocess
 def start_servo(port, resolution):
 
     # Use the below command if you are running this script on windows
-    # cmds = 'mach.bat run --webdriver ' + port + ' --resolution ' + resolution
-    cmds = './mach run --webdriver=' + port + ' --resolution ' + resolution
+    # cmds = 'mach.bat run --webdriver ' + port + ' --window-size ' + resolution
+    cmds = './mach run --webdriver=' + port + ' --window-size ' + resolution
     process = subprocess.Popen(cmds, shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     return process

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -38,12 +38,12 @@ use super::window_trait::{WindowPortsMethods, LINE_HEIGHT};
 pub struct Window {
     winit_window: winit::window::Window,
     rendering_context: RenderingContext,
-    screen_size: Size2D<u32, DevicePixel>,
-    inner_size: Cell<Size2D<u32, DevicePixel>>,
+    screen_size: Size2D<u32, DeviceIndependentPixel>,
+    inner_size: Cell<PhysicalSize<u32>>,
     toolbar_height: Cell<Length<f32, DeviceIndependentPixel>>,
     mouse_down_button: Cell<Option<winit::event::MouseButton>>,
     mouse_down_point: Cell<Point2D<i32, DevicePixel>>,
-    primary_monitor: winit::monitor::MonitorHandle,
+    monitor: winit::monitor::MonitorHandle,
     event_queue: RefCell<Vec<EmbedderEvent>>,
     mouse_pos: Cell<Point2D<i32, DevicePixel>>,
     last_pressed: Cell<Option<(KeyboardEvent, Option<LogicalKey>)>>,
@@ -59,7 +59,7 @@ pub struct Window {
 
 impl Window {
     pub fn new(
-        win_size: Size2D<u32, DeviceIndependentPixel>,
+        window_size: Size2D<u32, DeviceIndependentPixel>,
         event_loop: &winit::event_loop::EventLoop<WakerEvent>,
         no_native_titlebar: bool,
         device_pixel_ratio_override: Option<f32>,
@@ -76,7 +76,7 @@ impl Window {
             .with_title("Servo".to_string())
             .with_decorations(!no_native_titlebar)
             .with_transparent(no_native_titlebar)
-            .with_inner_size(LogicalSize::new(win_size.width, win_size.height))
+            .with_inner_size(LogicalSize::new(window_size.width, window_size.height))
             .with_visible(visible);
 
         #[allow(deprecated)]
@@ -90,13 +90,18 @@ impl Window {
             winit_window.set_window_icon(Some(load_icon(icon_bytes)));
         }
 
-        let primary_monitor = winit_window
-            .available_monitors()
-            .nth(0)
+        let monitor = winit_window
+            .current_monitor()
+            .or_else(|| winit_window.available_monitors().nth(0))
             .expect("No monitor detected");
 
-        let screen_size = winit_size_to_euclid_size(primary_monitor.size());
-        let inner_size = winit_size_to_euclid_size(winit_window.inner_size());
+        let (screen_size, screen_scale) = opts.screen_size_override.map_or_else(
+            || (monitor.size(), monitor.scale_factor()),
+            |size| (PhysicalSize::new(size.width, size.height), 1.0),
+        );
+        let screen_scale: Scale<f64, DevicePixel, DeviceIndependentPixel> =
+            Scale::new(screen_scale);
+        let screen_size = (winit_size_to_euclid_size(screen_size).to_f64() * screen_scale).to_u32();
 
         // Initialize surfman
         let display_handle = winit_window
@@ -110,12 +115,15 @@ impl Window {
         let window_handle = winit_window
             .window_handle()
             .expect("could not get window handle from window");
+
+        let inner_size = winit_window.inner_size();
         let native_widget = connection
             .create_native_widget_from_window_handle(
                 window_handle,
-                inner_size.to_i32().to_untyped(),
+                winit_size_to_euclid_size(inner_size).to_i32().to_untyped(),
             )
             .expect("Failed to create native widget");
+
         let surface_type = SurfaceType::Widget { native_widget };
         let rendering_context = RenderingContext::create(&connection, &adapter, surface_type)
             .expect("Failed to create WR surfman");
@@ -133,7 +141,7 @@ impl Window {
             animation_state: Cell::new(AnimationState::Idle),
             fullscreen: Cell::new(false),
             inner_size: Cell::new(inner_size),
-            primary_monitor,
+            monitor,
             screen_size,
             device_pixel_ratio_override,
             xr_window_poses: RefCell::new(vec![]),
@@ -321,7 +329,7 @@ impl WindowPortsMethods for Window {
         if self.fullscreen.get() != state {
             self.winit_window.set_fullscreen(if state {
                 Some(winit::window::Fullscreen::Borderless(Some(
-                    self.primary_monitor.clone(),
+                    self.monitor.clone(),
                 )))
             } else {
                 None
@@ -469,13 +477,10 @@ impl WindowPortsMethods for Window {
             winit::event::WindowEvent::CloseRequested => {
                 self.event_queue.borrow_mut().push(EmbedderEvent::Quit);
             },
-            winit::event::WindowEvent::Resized(physical_size) => {
-                let (width, height) = physical_size.into();
-                let new_size = Size2D::new(width, height);
+            winit::event::WindowEvent::Resized(new_size) => {
                 if self.inner_size.get() != new_size {
-                    let physical_size = Size2D::new(physical_size.width, physical_size.height);
                     self.rendering_context
-                        .resize(physical_size.to_i32())
+                        .resize(Size2D::new(new_size.width, new_size.height).to_i32())
                         .expect("Failed to resize");
                     self.inner_size.set(new_size);
                     self.event_queue
@@ -528,6 +533,11 @@ impl WindowMethods for Window {
         let window_size = winit_size_to_euclid_size(self.winit_window.outer_size()).to_i32();
         let window_origin = self.winit_window.outer_position().unwrap_or_default();
         let window_origin = winit_position_to_euclid_point(window_origin).to_i32();
+        let window_rect = DeviceIntRect::from_origin_and_size(window_origin, window_size);
+        let window_scale: Scale<f64, DevicePixel, DeviceIndependentPixel> =
+            Scale::new(self.winit_window.scale_factor());
+        let window_rect = (window_rect.to_f64() * window_scale).to_i32();
+
         let viewport_origin = DeviceIntPoint::zero(); // bottom left
         let viewport_size = winit_size_to_euclid_size(self.winit_window.inner_size()).to_f32();
         let viewport = DeviceIntRect::from_origin_and_size(viewport_origin, viewport_size.to_i32());
@@ -536,7 +546,7 @@ impl WindowMethods for Window {
         EmbedderCoordinates {
             viewport,
             framebuffer: viewport.size(),
-            window_rect: DeviceIntRect::from_origin_and_size(window_origin, window_size),
+            window_rect,
             screen_size,
             // FIXME: Winit doesn't have API for available size. Fallback to screen size
             available_screen_size: screen_size,

--- a/ports/servoshell/egl/servo_glue.rs
+++ b/ports/servoshell/egl/servo_glue.rs
@@ -18,7 +18,7 @@ use servo::embedder_traits::{
     ContextMenuResult, EmbedderMsg, EmbedderProxy, EventLoopWaker, MediaSessionEvent,
     PermissionPrompt, PermissionRequest, PromptDefinition, PromptOrigin, PromptResult,
 };
-use servo::euclid::{Point2D, Rect, Scale, Size2D, Vector2D};
+use servo::euclid::{Box2D, Point2D, Rect, Scale, Size2D, Vector2D};
 use servo::keyboard_types::{Key, KeyState, KeyboardEvent};
 use servo::script_traits::{
     MediaSessionActionType, MouseButton, TouchEventType, TouchId, TraversalDirection,
@@ -691,12 +691,13 @@ impl EmbedderMethods for ServoEmbedderCallbacks {
 impl WindowMethods for ServoWindowCallbacks {
     fn get_coordinates(&self) -> EmbedderCoordinates {
         let coords = self.coordinates.borrow();
+        let screen_size = (coords.viewport.size.to_f32() * Scale::new(self.density)).to_i32();
         EmbedderCoordinates {
             viewport: coords.viewport.to_box2d(),
             framebuffer: coords.framebuffer,
-            window_rect: DeviceIntRect::from_origin_and_size(Point2D::zero(), coords.viewport.size),
-            screen_size: coords.viewport.size,
-            available_screen_size: coords.viewport.size,
+            window_rect: Box2D::from_origin_and_size(Point2D::zero(), screen_size),
+            screen_size,
+            available_screen_size: screen_size,
             hidpi_factor: Scale::new(self.density),
         }
     }

--- a/tests/wpt/tests/tools/wptrunner/wptrunner/executors/executorservo.py
+++ b/tests/wpt/tests/tools/wptrunner/wptrunner/executors/executorservo.py
@@ -230,7 +230,7 @@ class ServoRefTestExecutor(ServoExecutor):
         with TempFilename(self.tempdir) as output_path:
             extra_args = ["--exit",
                           "--output=%s" % output_path,
-                          "--resolution", viewport_size or "800x600"]
+                          "--window-size", viewport_size or "800x600"]
             debug_opts = "disable-text-aa,load-webfonts-synchronously,replace-surrogates"
 
             if dpi:


### PR DESCRIPTION
There is a command-line argument to override the default window size,
but not one for overriding the default screen resolution. This is
important for testing pages that use screen size to have different
behavior.

In addition to adding the new option this change:

 - Renames the `--resolution` command-line argument to `--window-size`
   to remove ambiguity with the `--screen-size` argument.
 - Passes the screen size as device independent (device pixels scaled by
   HiDPI factor) to Servo internals. Not only it make it simpler to pass
   the `--window-size` override, it makes more sense. Different screens
   can have different HiDPI factors and these can be different from the
   scale of the window. This makes the screen HiDPI factor totally
   independent of the one that Servo uses for the window.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because this change adds an interactive configuration option to servoshell. We do not test this kind of behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
