### PR TITLE
Cleanup: Remove reference to closed issue 7193

### DIFF
--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -248,7 +248,7 @@ pub struct HTMLInputElement {
     size: Cell<u32>,
     maxlength: Cell<i32>,
     minlength: Cell<i32>,
-    #[ignore_malloc_size_of = "#7193"]
+    #[ignore_malloc_size_of = "TextInput contains an IPCSender which cannot be measured"]
     #[no_trace]
     textinput: DomRefCell<TextInput<ScriptToConstellationChan>>,
     // https://html.spec.whatwg.org/multipage/#concept-input-value-dirty-flag

--- a/components/script/dom/htmltextareaelement.rs
+++ b/components/script/dom/htmltextareaelement.rs
@@ -50,7 +50,7 @@ use crate::textinput::{
 #[dom_struct]
 pub struct HTMLTextAreaElement {
     htmlelement: HTMLElement,
-    #[ignore_malloc_size_of = "#7193"]
+    #[ignore_malloc_size_of = "TextInput contains an IPCSender which cannot be measured"]
     #[no_trace]
     textinput: DomRefCell<TextInput<ScriptToConstellationChan>>,
     placeholder: DomRefCell<DOMString>,


### PR DESCRIPTION
File Changes:
components/script/dom/htmltextareaelement.rs
components/script/dom/htmlinputelement.rs

This pull request removes the reference to the closed and half-relevant issue #7193 from the #[ignore_malloc_size_of] attribute in HTMLTextAreaElement and HTMLInputElement.

The changes include:
Replacing the reference to issue #7193 with an explanation: "TextInput contains an IPCSender which cannot be measured".
Implementing the MallocSizeOf trait for HTMLTextAreaElement and HTMLInputElement to properly handle memory size calculations.

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #25679 
- [X] These changes do not require tests  because they do not modify functionality
