### PR TITLE
mach try: Remove `wpt-2013` from `full` and `wpt`

### DIFF
--- a/python/servo/try_parser.py
+++ b/python/servo/try_parser.py
@@ -86,7 +86,7 @@ def handle_preset(s: str) -> Optional[JobConfig]:
     elif s in ["wpt-2013", "linux-wpt-2013"]:
         return JobConfig("Linux WPT", Workflow.LINUX, wpt_layout=Layout.layout2013)
     elif s in ["wpt-2020", "linux-wpt-2020", "wpt", "linux-wpt"]:
-        return JobConfig("Linux WPT", Workflow.LINUX, unit_tests=True, wpt_layout=Layout.all())
+        return JobConfig("Linux WPT", Workflow.LINUX, wpt_layout=Layout.layout2020)
     elif s in ["mac-wpt", "wpt-mac"]:
         return JobConfig("MacOS WPT", Workflow.MACOS, wpt_layout=Layout.all())
     elif s == "mac-wpt-2013":
@@ -187,9 +187,9 @@ class TestParser(unittest.TestCase):
                               {
                                   "name": "Linux WPT",
                                   "workflow": "linux",
-                                  "wpt_layout": "all",
+                                  "wpt_layout": "2020",
                                   "profile": "release",
-                                  "unit_tests": True,
+                                  "unit_tests": False,
                                   "wpt_args": ""
                               },
                               {
@@ -239,7 +239,7 @@ class TestParser(unittest.TestCase):
                               'matrix': [{
                                   'name': 'Linux WPT',
                                   'profile': 'release',
-                                  'unit_tests': True,
+                                  'unit_tests': False,
                                   'workflow': 'linux',
                                   'wpt_layout': 'all',
                                   'wpt_args': ''

--- a/python/servo/try_parser.py
+++ b/python/servo/try_parser.py
@@ -83,12 +83,10 @@ def handle_preset(s: str) -> Optional[JobConfig]:
         return JobConfig("MacOS", Workflow.MACOS, unit_tests=True)
     elif s in ["win", "windows"]:
         return JobConfig("Windows", Workflow.WINDOWS, unit_tests=True)
-    elif s in ["wpt", "linux-wpt"]:
-        return JobConfig("Linux WPT", Workflow.LINUX, unit_tests=True, wpt_layout=Layout.all())
     elif s in ["wpt-2013", "linux-wpt-2013"]:
         return JobConfig("Linux WPT", Workflow.LINUX, wpt_layout=Layout.layout2013)
-    elif s in ["wpt-2020", "linux-wpt-2020"]:
-        return JobConfig("Linux WPT", Workflow.LINUX, wpt_layout=Layout.layout2020)
+    elif s in ["wpt-2020", "linux-wpt-2020", "wpt", "linux-wpt"]:
+        return JobConfig("Linux WPT", Workflow.LINUX, unit_tests=True, wpt_layout=Layout.all())
     elif s in ["mac-wpt", "wpt-mac"]:
         return JobConfig("MacOS WPT", Workflow.MACOS, wpt_layout=Layout.all())
     elif s == "mac-wpt-2013":
@@ -241,7 +239,7 @@ class TestParser(unittest.TestCase):
                               'matrix': [{
                                   'name': 'Linux WPT',
                                   'profile': 'release',
-                                  'unit_tests': False,
+                                  'unit_tests': True,
                                   'workflow': 'linux',
                                   'wpt_layout': 'all',
                                   'wpt_args': ''


### PR DESCRIPTION
Makes `linux-wpt` and `wpt` an alias for `linux-wpt-2020` and makes `full` run all tests except layout 2013 WPT tests.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #34023 
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
