### PR TITLE
webgpu: Only send mapping back on unmap when MapMode = WRITE

### DIFF
--- a/components/webgpu/ipc_messages/recv.rs
+++ b/components/webgpu/ipc_messages/recv.rs
@@ -32,7 +32,7 @@ pub use {wgpu_core as wgc, wgpu_types as wgt};
 use crate::identity::*;
 use crate::render_commands::RenderCommand;
 use crate::swapchain::WebGPUContextId;
-use crate::{Error, ErrorFilter, WebGPUResponse, PRESENTATION_BUFFER_COUNT};
+use crate::{Error, ErrorFilter, Mapping, WebGPUResponse, PRESENTATION_BUFFER_COUNT};
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 pub struct ContextConfiguration {
@@ -276,10 +276,8 @@ pub enum WebGPURequest {
     },
     UnmapBuffer {
         buffer_id: id::BufferId,
-        array_buffer: IpcSharedMemory,
-        write_back: bool,
-        offset: u64,
-        size: u64,
+        /// Return back mapping for writeback
+        mapping: Option<Mapping>,
     },
     WriteBuffer {
         device_id: id::DeviceId,

--- a/components/webgpu/wgpu_thread.rs
+++ b/components/webgpu/wgpu_thread.rs
@@ -995,25 +995,21 @@ impl WGPU {
                         };
                         self.maybe_dispatch_error(device_id, result.err());
                     },
-                    WebGPURequest::UnmapBuffer {
-                        buffer_id,
-                        array_buffer,
-                        write_back,
-                        offset,
-                        size,
-                    } => {
+                    WebGPURequest::UnmapBuffer { buffer_id, mapping } => {
                         let global = &self.global;
-                        if write_back {
-                            if let Ok((slice_pointer, range_size)) =
-                                global.buffer_get_mapped_range(buffer_id, offset, Some(size))
-                            {
+                        if let Some(mapping) = mapping {
+                            if let Ok((slice_pointer, range_size)) = global.buffer_get_mapped_range(
+                                buffer_id,
+                                mapping.range.start,
+                                Some(mapping.range.end - mapping.range.start),
+                            ) {
                                 unsafe {
                                     slice::from_raw_parts_mut(
                                         slice_pointer.as_ptr(),
                                         range_size as usize,
                                     )
                                 }
-                                .copy_from_slice(&array_buffer);
+                                .copy_from_slice(&mapping.data);
                             }
                         }
                         // Ignore result because this operation always succeed from user perspective


### PR DESCRIPTION
I think this is more concise (and possibly even more performant).

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes in WebGPU CTS
<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
