### PR TITLE
Import `size_of_test` from servo/stylo repo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,7 +346,6 @@ dependencies = [
  "malloc_size_of_derive",
  "parking_lot",
  "serde",
- "size_of_test",
  "webrender_api",
 ]
 
@@ -377,7 +376,7 @@ dependencies = [
  "malloc_size_of_derive",
  "parking_lot",
  "serde",
- "size_of_test",
+ "static_assertions",
  "time 0.3.36",
  "webrender_api",
  "windows-sys 0.59.0",
@@ -3894,7 +3893,6 @@ dependencies = [
  "servo_config",
  "servo_geometry",
  "servo_url",
- "size_of_test",
  "smallvec",
  "style",
  "style_traits",
@@ -6778,14 +6776,6 @@ name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
-
-[[package]]
-name = "size_of_test"
-version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-10-04#789ab89c30d94e25f514c19c079a00a6ab583638"
-dependencies = [
- "static_assertions",
-]
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,10 +113,10 @@ servo-media-dummy = { git = "https://github.com/servo/media" }
 servo-media-gstreamer = { git = "https://github.com/servo/media" }
 servo_arc = { git = "https://github.com/servo/stylo", branch = "2024-10-04", features = ["servo"] }
 servo_atoms = { git = "https://github.com/servo/stylo", branch = "2024-10-04" }
-size_of_test = { git = "https://github.com/servo/stylo", branch = "2024-10-04" }
 smallbitvec = "2.5.3"
 smallvec = "1.13"
 sparkle = "0.1.26"
+static_assertions = "1.1"
 string_cache = "0.8"
 string_cache_codegen = "0.5"
 style = { git = "https://github.com/servo/stylo", branch = "2024-10-04", features = ["servo"] }
@@ -192,7 +192,6 @@ codegen-units = 1
 # selectors = { path = "../stylo/selectors" }
 # servo_arc = { path = "../stylo/servo_arc" }
 # servo_atoms = { path = "../stylo/atoms" }
-# size_of_test = { path = "../stylo/size_of_test" }
 # static_prefs = { path = "../stylo/style_static_prefs" }
 # style = { path = "../stylo/style" }
 # style_config = { path = "../stylo/style_config" }

--- a/components/layout/Cargo.toml
+++ b/components/layout/Cargo.toml
@@ -44,7 +44,6 @@ servo_atoms = { workspace = true }
 servo_config = { path = "../config" }
 servo_geometry = { path = "../geometry" }
 servo_url = { path = "../url" }
-size_of_test = { workspace = true }
 smallvec = { workspace = true, features = ["union"] }
 style = { workspace = true }
 style_traits = { workspace = true }

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -29,7 +29,6 @@ use script_layout_interface::wrapper_traits::{
 use script_layout_interface::{HTMLCanvasData, HTMLCanvasDataSource, HTMLMediaData, SVGSVGData};
 use serde::ser::{Serialize, SerializeStruct, Serializer};
 use servo_url::ServoUrl;
-use size_of_test::size_of_test;
 use style::computed_values::border_collapse::T as BorderCollapse;
 use style::computed_values::box_sizing::T as BoxSizing;
 use style::computed_values::clear::T as Clear;
@@ -167,11 +166,6 @@ pub struct Fragment {
     pub established_reference_frame: Option<ClipScrollNodeIndex>,
 }
 
-#[cfg(debug_assertions)]
-size_of_test!(Fragment, 176);
-#[cfg(not(debug_assertions))]
-size_of_test!(Fragment, 152);
-
 impl Serialize for Fragment {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let mut serializer = serializer.serialize_struct("fragment", 3)?;
@@ -225,8 +219,6 @@ pub enum SpecificFragmentInfo {
     /// Other fragments can only be totally truncated or not truncated at all.
     TruncatedFragment(Box<TruncatedFragmentInfo>),
 }
-
-size_of_test!(SpecificFragmentInfo, 24);
 
 impl SpecificFragmentInfo {
     fn restyle_damage(&self) -> RestyleDamage {

--- a/components/shared/background_hang_monitor/Cargo.toml
+++ b/components/shared/background_hang_monitor/Cargo.toml
@@ -20,5 +20,4 @@ malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
 parking_lot = { workspace = true }
 serde = { workspace = true }
-size_of_test = { workspace = true }
 webrender_api = { workspace = true }

--- a/components/shared/base/Cargo.toml
+++ b/components/shared/base/Cargo.toml
@@ -20,9 +20,9 @@ malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
 parking_lot = { workspace = true }
 serde = { workspace = true }
-size_of_test = { workspace = true }
 time_03 = { workspace = true }
 webrender_api = { workspace = true }
+static_assertions = { workspace = true }
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 mach2 = { workspace = true }

--- a/components/shared/base/id.rs
+++ b/components/shared/base/id.rs
@@ -16,8 +16,15 @@ use malloc_size_of::malloc_size_of_is_0;
 use malloc_size_of_derive::MallocSizeOf;
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
-use size_of_test::size_of_test;
 use webrender_api::{ExternalScrollId, PipelineId as WebRenderPipelineId};
+
+/// Asserts the size of a type at compile time.
+macro_rules! size_of_test {
+    ($t: ty, $expected_size: expr) => {
+        #[cfg(target_pointer_width = "64")]
+        ::static_assertions::const_assert_eq!(std::mem::size_of::<$t>(), $expected_size);
+    };
+}
 
 macro_rules! namespace_id_method {
     ($func_name:ident, $func_return_data_type:ident, $self:ident, $index_name:ident) => {


### PR DESCRIPTION
This is a small utility crate that was previous in the `servo/stylo` repo. But it is only used by crates in this repo. So moving it here. PR to remove it from `servo/stylo` is https://github.com/servo/stylo/pull/87

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because it's just moving code. So if it compiles it's very unlikely that test results would change.