### PR TITLE
layout: Add support for `mix-blend-mode: plus-lighter`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1638,7 +1638,7 @@ dependencies = [
 [[package]]
 name = "dom"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-10-04#789ab89c30d94e25f514c19c079a00a6ab583638"
+source = "git+https://github.com/servo/stylo?branch=2024-10-04#1c069c5e62fb70a64f3305fcafed2c12073608b8"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -4263,7 +4263,7 @@ dependencies = [
 [[package]]
 name = "malloc_size_of"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-10-04#789ab89c30d94e25f514c19c079a00a6ab583638"
+source = "git+https://github.com/servo/stylo?branch=2024-10-04#1c069c5e62fb70a64f3305fcafed2c12073608b8"
 dependencies = [
  "accountable-refcell",
  "app_units",
@@ -6263,7 +6263,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.25.0"
-source = "git+https://github.com/servo/stylo?branch=2024-10-04#789ab89c30d94e25f514c19c079a00a6ab583638"
+source = "git+https://github.com/servo/stylo?branch=2024-10-04#1c069c5e62fb70a64f3305fcafed2c12073608b8"
 dependencies = [
  "bitflags 2.6.0",
  "cssparser",
@@ -6551,7 +6551,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.0"
-source = "git+https://github.com/servo/stylo?branch=2024-10-04#789ab89c30d94e25f514c19c079a00a6ab583638"
+source = "git+https://github.com/servo/stylo?branch=2024-10-04#1c069c5e62fb70a64f3305fcafed2c12073608b8"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -6560,7 +6560,7 @@ dependencies = [
 [[package]]
 name = "servo_atoms"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-10-04#789ab89c30d94e25f514c19c079a00a6ab583638"
+source = "git+https://github.com/servo/stylo?branch=2024-10-04#1c069c5e62fb70a64f3305fcafed2c12073608b8"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -6913,7 +6913,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "static_prefs"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2024-10-04#789ab89c30d94e25f514c19c079a00a6ab583638"
+source = "git+https://github.com/servo/stylo?branch=2024-10-04#1c069c5e62fb70a64f3305fcafed2c12073608b8"
 
 [[package]]
 name = "strck"
@@ -6966,7 +6966,7 @@ dependencies = [
 [[package]]
 name = "style"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-10-04#789ab89c30d94e25f514c19c079a00a6ab583638"
+source = "git+https://github.com/servo/stylo?branch=2024-10-04#1c069c5e62fb70a64f3305fcafed2c12073608b8"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -7024,7 +7024,7 @@ dependencies = [
 [[package]]
 name = "style_config"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-10-04#789ab89c30d94e25f514c19c079a00a6ab583638"
+source = "git+https://github.com/servo/stylo?branch=2024-10-04#1c069c5e62fb70a64f3305fcafed2c12073608b8"
 dependencies = [
  "lazy_static",
 ]
@@ -7032,7 +7032,7 @@ dependencies = [
 [[package]]
 name = "style_derive"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-10-04#789ab89c30d94e25f514c19c079a00a6ab583638"
+source = "git+https://github.com/servo/stylo?branch=2024-10-04#1c069c5e62fb70a64f3305fcafed2c12073608b8"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -7062,7 +7062,7 @@ dependencies = [
 [[package]]
 name = "style_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-10-04#789ab89c30d94e25f514c19c079a00a6ab583638"
+source = "git+https://github.com/servo/stylo?branch=2024-10-04#1c069c5e62fb70a64f3305fcafed2c12073608b8"
 dependencies = [
  "app_units",
  "bitflags 2.6.0",
@@ -7431,7 +7431,7 @@ dependencies = [
 [[package]]
 name = "to_shmem"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2024-10-04#789ab89c30d94e25f514c19c079a00a6ab583638"
+source = "git+https://github.com/servo/stylo?branch=2024-10-04#1c069c5e62fb70a64f3305fcafed2c12073608b8"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -7444,7 +7444,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2024-10-04#789ab89c30d94e25f514c19c079a00a6ab583638"
+source = "git+https://github.com/servo/stylo?branch=2024-10-04#1c069c5e62fb70a64f3305fcafed2c12073608b8"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/components/layout/display_list/conversions.rs
+++ b/components/layout/display_list/conversions.rs
@@ -102,6 +102,7 @@ impl ToLayout for MixBlendMode {
             MixBlendMode::Saturation => wr::MixBlendMode::Saturation,
             MixBlendMode::Color => wr::MixBlendMode::Color,
             MixBlendMode::Luminosity => wr::MixBlendMode::Luminosity,
+            MixBlendMode::PlusLighter => wr::MixBlendMode::PlusLighter,
         }
     }
 }

--- a/components/layout_2020/display_list/conversions.rs
+++ b/components/layout_2020/display_list/conversions.rs
@@ -70,6 +70,7 @@ impl ToWebRender for ComputedMixBlendMode {
             ComputedMixBlendMode::Saturation => MixBlendMode::Saturation,
             ComputedMixBlendMode::Color => MixBlendMode::Color,
             ComputedMixBlendMode::Luminosity => MixBlendMode::Luminosity,
+            ComputedMixBlendMode::PlusLighter => MixBlendMode::PlusLighter,
         }
     }
 }

--- a/tests/wpt/meta/css/compositing/mix-blend-mode/mix-blend-mode-parsing.html.ini
+++ b/tests/wpt/meta/css/compositing/mix-blend-mode/mix-blend-mode-parsing.html.ini
@@ -1,3 +1,0 @@
-[mix-blend-mode-parsing.html]
-  [Mix-blend-mode plus-lighter]
-    expected: FAIL

--- a/tests/wpt/meta/css/compositing/mix-blend-mode/mix-blend-mode-plus-lighter-basic.html.ini
+++ b/tests/wpt/meta/css/compositing/mix-blend-mode/mix-blend-mode-plus-lighter-basic.html.ini
@@ -1,2 +1,0 @@
-[mix-blend-mode-plus-lighter-basic.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/compositing/mix-blend-mode/mix-blend-mode-plus-lighter.html.ini
+++ b/tests/wpt/meta/css/compositing/mix-blend-mode/mix-blend-mode-plus-lighter.html.ini
@@ -1,2 +1,0 @@
-[mix-blend-mode-plus-lighter.html]
-  expected: FAIL


### PR DESCRIPTION
This just requires translating the style value into a WebRender value.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes OR

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
