### PR TITLE
readme: Fix typos in Android build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ For more detailed build instructions, see the Servo book under [Setting up your 
   `$ANDROID_SDK_ROOT/cmdline-tools/latest`.
 - Run the following command to install the necessary components:
   ```shell
-  sudo $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager --install
-   "build-tools;34.0.00 \
+  sudo $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager --install \
+   "build-tools;34.0.0" \
    "emulator" \
    "ndk;26.2.11394342" \
    "platform-tools" \


### PR DESCRIPTION
Fix some typos in the Android build instructions that prevented them
from working properly.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they do not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
