### PR TITLE
andrdoid/ohos: Fix some compiler warnings

### DIFF
--- a/components/fonts/platform/freetype/android/font_list.rs
+++ b/components/fonts/platform/freetype/android/font_list.rs
@@ -2,15 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::fs::File;
-use std::io::Read;
 use std::path::Path;
 use std::sync::LazyLock;
 
 use base::text::{is_cjk, UnicodeBlock, UnicodeBlockMethod};
 use log::warn;
-use malloc_size_of_derive::MallocSizeOf;
-use serde::{Deserialize, Serialize};
 use style::values::computed::font::GenericFontFamily;
 use style::values::computed::{
     FontStretch as StyleFontStretch, FontStyle as StyleFontStyle, FontWeight as StyleFontWeight,

--- a/components/fonts/platform/freetype/font_list.rs
+++ b/components/fonts/platform/freetype/font_list.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::ffi::CString;
+use std::ffi::{CStr, CString};
 use std::ptr;
 
 use base::text::{UnicodeBlock, UnicodeBlockMethod};
@@ -26,7 +26,7 @@ use style::values::computed::{FontStretch, FontStyle, FontWeight};
 use style::Atom;
 use unicode_script::Script;
 
-use super::{c_str_to_string, LocalFontIdentifier};
+use super::LocalFontIdentifier;
 use crate::font::map_platform_values_to_style_values;
 use crate::font_template::{FontTemplate, FontTemplateDescriptor};
 use crate::platform::add_noto_fallback_families;
@@ -288,4 +288,12 @@ fn font_weight_from_fontconfig_pattern(pattern: *mut FcPattern) -> Option<FontWe
 
     let mapped_weight = map_platform_values_to_style_values(&mapping, weight as f64);
     Some(FontWeight::from_float(mapped_weight as f32))
+}
+
+/// Creates a String from the given null-terminated buffer.
+/// Panics if the buffer does not contain UTF-8.
+unsafe fn c_str_to_string(s: *const c_char) -> String {
+    std::str::from_utf8(CStr::from_ptr(s).to_bytes())
+        .unwrap()
+        .to_owned()
 }

--- a/components/fonts/platform/freetype/mod.rs
+++ b/components/fonts/platform/freetype/mod.rs
@@ -3,25 +3,15 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::convert::TryInto;
-use std::ffi::CStr;
 use std::fs::File;
 use std::path::{Path, PathBuf};
 use std::str;
 
-use libc::c_char;
 use malloc_size_of_derive::MallocSizeOf;
 use memmap2::Mmap;
 use serde::{Deserialize, Serialize};
 use style::Atom;
 use webrender_api::NativeFontHandle;
-
-/// Creates a String from the given null-terminated buffer.
-/// Panics if the buffer does not contain UTF-8.
-unsafe fn c_str_to_string(s: *const c_char) -> String {
-    str::from_utf8(CStr::from_ptr(s).to_bytes())
-        .unwrap()
-        .to_owned()
-}
 
 pub mod font;
 

--- a/components/fonts/platform/freetype/ohos/font_list.rs
+++ b/components/fonts/platform/freetype/ohos/font_list.rs
@@ -3,8 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 use std::collections::HashMap;
 use std::ffi::OsStr;
-use std::fs::File;
-use std::io::Read;
 use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
@@ -13,7 +11,6 @@ use std::{fs, io};
 use base::text::{UnicodeBlock, UnicodeBlockMethod};
 use log::{debug, error, warn};
 use malloc_size_of_derive::MallocSizeOf;
-use serde::{Deserialize, Serialize};
 use style::values::computed::font::GenericFontFamily;
 use style::values::computed::{
     FontStretch as StyleFontStretch, FontStyle as StyleFontStyle, FontWeight as StyleFontWeight,

--- a/ports/servoshell/crash_handler.rs
+++ b/ports/servoshell/crash_handler.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+#[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "android")))]
 pub fn install() {}
 
 #[cfg(any(target_os = "macos", target_os = "linux"))]
@@ -49,7 +49,7 @@ pub fn install() {
     signal!(libc::SIGBUS, handler); // handle invalid memory access
 }
 
-#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+#[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "android")))]
 pub(crate) fn raise_signal_or_exit_with_error(_signal: i32) {
     std::process::exit(1);
 }

--- a/ports/servoshell/egl/android.rs
+++ b/ports/servoshell/egl/android.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 
 use android_logger::{self, Config, FilterBuilder};
 use jni::objects::{GlobalRef, JClass, JObject, JString, JValue, JValueOwned};
-use jni::sys::{jboolean, jfloat, jint, jobject, jstring, JNI_TRUE};
+use jni::sys::{jboolean, jfloat, jint, jobject, JNI_TRUE};
 use jni::{JNIEnv, JavaVM};
 use log::{debug, error, info, warn};
 use simpleservo::{
@@ -59,7 +59,7 @@ where
 
 #[no_mangle]
 pub extern "C" fn Java_org_servo_servoview_JNIServo_version<'local>(
-    mut env: JNIEnv<'local>,
+    env: JNIEnv<'local>,
     _class: JClass<'local>,
 ) -> JString<'local> {
     let v = crate::servo_version();
@@ -708,16 +708,6 @@ fn throw(env: &mut JNIEnv, err: &str) {
             "Failed to throw Java exception: `{}`. Exception was: `{}`",
             e, err
         );
-    }
-}
-
-fn new_string(env: &mut JNIEnv, s: &str) -> Result<jstring, &'static str> {
-    match env.new_string(s) {
-        Ok(s) => Ok(s.into_raw()),
-        Err(_) => {
-            throw(env, "Couldn't create Java string");
-            Err("Couldn't create Java String")
-        },
     }
 }
 

--- a/ports/servoshell/egl/servo_glue.rs
+++ b/ports/servoshell/egl/servo_glue.rs
@@ -23,7 +23,6 @@ use servo::keyboard_types::{Key, KeyState, KeyboardEvent};
 use servo::script_traits::{
     MediaSessionActionType, MouseButton, TouchEventType, TouchId, TraversalDirection,
 };
-use servo::servo_url::ServoUrl;
 use servo::style_traits::DevicePixel;
 use servo::webrender_api::units::DeviceIntRect;
 use servo::webrender_api::ScrollLocation;


### PR DESCRIPTION
This removes unused code in order to reduce the number of compiler
warnings in the Android and OHOS builds. Some of this code might be used in the
future and it can be restored from git commit history.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they do not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
