### PR TITLE
webgpu: Use IpcSharedMemory for mapped buffers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3658,8 +3658,7 @@ dependencies = [
 [[package]]
 name = "ipc-channel"
 version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb8251fb7bcd9ccd3725ed8deae9fe7db8e586495c9eb5b0c52e6233e5e75ea"
+source = "git+https://github.com/sagudev/ipc-channel?branch=back-sharedmem#0b3bb83eeafcf68e159d5afa79514378a8acb42c"
 dependencies = [
  "bincode",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,6 +179,7 @@ lto = "thin"
 codegen-units = 1
 
 [patch.crates-io]
+ipc-channel = { git = "https://github.com/sagudev/ipc-channel", branch = "back-sharedmem" }
 # If you need to temporarily test Servo with a local fork of some upstream
 # crate, add that here. Use the form:
 #

--- a/components/script/dom/gpubuffer.rs
+++ b/components/script/dom/gpubuffer.rs
@@ -44,8 +44,13 @@ pub struct ActiveBufferMapping {
 }
 
 impl ActiveBufferMapping {
+    #[allow(unsafe_code)]
     /// <https://gpuweb.github.io/gpuweb/#abstract-opdef-initialize-an-active-buffer-mapping>
-    pub fn new(mode: GPUMapModeFlags, range: Range<u64>) -> Fallible<Self> {
+    pub fn new(
+        mode: GPUMapModeFlags,
+        range: Range<u64>,
+        data: Option<IpcSharedMemory>,
+    ) -> Fallible<Self> {
         // Step 1
         let size = range.end - range.start;
         // Step 2
@@ -55,11 +60,16 @@ impl ActiveBufferMapping {
         let size: usize = size
             .try_into()
             .map_err(|_| Error::Range("Over usize".to_string()))?;
-        Ok(Self {
-            data: DataBlock::new_zeroed(size),
-            mode,
-            range,
-        })
+        let data = if let Some(data) = data {
+            unsafe { DataBlock::from(data) }
+        } else {
+            DataBlock::new_zeroed(size)
+        };
+        Ok(Self { data, mode, range })
+    }
+
+    pub fn unmap(self) -> IpcSharedMemory {
+        self.data.consume()
     }
 }
 
@@ -160,6 +170,7 @@ impl GPUBuffer {
             Some(ActiveBufferMapping::new(
                 GPUMapModeConstants::WRITE,
                 0..descriptor.size,
+                None,
             )?)
         } else {
             None
@@ -193,8 +204,8 @@ impl GPUBufferMethods for GPUBuffer {
             promise.reject_error(Error::Abort);
         }
         // Step 2
-        let mut mapping = self.mapping.borrow_mut().take();
-        let mapping = if let Some(mapping) = mapping.as_mut() {
+        let mapping = self.mapping.borrow_mut().take();
+        let mut mapping = if let Some(mapping) = mapping {
             mapping
         } else {
             return;
@@ -207,8 +218,8 @@ impl GPUBufferMethods for GPUBuffer {
             buffer_id: self.id().0,
             mapping: if mapping.mode >= GPUMapModeConstants::WRITE {
                 Some(Mapping {
-                    data: IpcSharedMemory::from_bytes(mapping.data.data()),
                     range: mapping.range.clone(),
+                    data: mapping.unmap(),
                     mode: HostMap::Write,
                 })
             } else {
@@ -388,13 +399,14 @@ impl GPUBuffer {
         // Step 2
         assert!(p.is_pending());
 
-        // Step 4
+        // Step 4&5
         let mapping = ActiveBufferMapping::new(
             match wgpu_mapping.mode {
                 HostMap::Read => GPUMapModeConstants::READ,
                 HostMap::Write => GPUMapModeConstants::WRITE,
             },
             wgpu_mapping.range,
+            Some(wgpu_mapping.data),
         );
 
         match mapping {
@@ -402,9 +414,7 @@ impl GPUBuffer {
                 *pending_map = None;
                 p.reject_error(error.clone());
             },
-            Ok(mut mapping) => {
-                // Step 5
-                mapping.data.load(&wgpu_mapping.data);
+            Ok(mapping) => {
                 // Step 6
                 self.mapping.borrow_mut().replace(mapping);
                 // Step 7


### PR DESCRIPTION
with https://github.com/servo/ipc-channel/pull/356 this allows us to reuse allocation of IpcSharedMemory.

I made webgpu map_unmap bench: https://sagudev.github.io/briefcase/webgpu_map_speed.html?write=true. Still need to do exact measurements but results are good.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
