### PR TITLE
Fix timeout in position-absolute-replaced-minmax.html

### DIFF
--- a/tests/wpt/meta/css/css-position/position-absolute-replaced-minmax.html.ini
+++ b/tests/wpt/meta/css/css-position/position-absolute-replaced-minmax.html.ini
@@ -1,5 +1,4 @@
 [position-absolute-replaced-minmax.html]
-  expected: TIMEOUT
   [minmax replaced IFRAME 10]
     expected: FAIL
 
@@ -7,58 +6,58 @@
     expected: FAIL
 
   [minmax replaced IMG svg 23]
-    expected: NOTRUN
+    expected: FAIL
 
   [minmax replaced IMG svg 24]
-    expected: NOTRUN
+    expected: FAIL
 
   [minmax replaced IMG svg 25]
-    expected: NOTRUN
+    expected: FAIL
 
   [minmax replaced IMG svg 26]
-    expected: NOTRUN
+    expected: FAIL
 
   [minmax replaced IMG svg 27]
-    expected: NOTRUN
+    expected: FAIL
 
   [minmax replaced IMG svg 28]
-    expected: NOTRUN
+    expected: FAIL
 
   [minmax replaced IMG svg 29]
-    expected: NOTRUN
+    expected: FAIL
 
   [minmax replaced IMG svg 30]
-    expected: NOTRUN
+    expected: FAIL
 
   [minmax replaced IMG svg 31]
-    expected: NOTRUN
+    expected: FAIL
 
   [minmax replaced IMG svg 32]
-    expected: NOTRUN
+    expected: FAIL
 
   [minmax replaced IMG svg 33]
-    expected: NOTRUN
+    expected: FAIL
 
   [minmax replaced IMG 34]
-    expected: NOTRUN
+    expected: FAIL
 
   [minmax replaced IMG 35]
-    expected: NOTRUN
+    expected: FAIL
 
   [minmax replaced IMG 36]
-    expected: NOTRUN
+    expected: FAIL
 
   [minmax replaced IMG 37]
-    expected: NOTRUN
+    expected: FAIL
 
   [minmax replaced IMG 38]
-    expected: NOTRUN
+    expected: FAIL
 
   [minmax replaced IMG 39]
-    expected: NOTRUN
+    expected: FAIL
 
   [minmax replaced IMG 40]
-    expected: NOTRUN
+    expected: FAIL
 
   [minmax replaced IMG 41]
-    expected: NOTRUN
+    expected: FAIL

--- a/tests/wpt/tests/css/css-position/position-absolute-replaced-minmax.html
+++ b/tests/wpt/tests/css/css-position/position-absolute-replaced-minmax.html
@@ -336,6 +336,7 @@
 
   function testAfterImageLoads(img, test) {
     let asyncTest = async_test(getTestName(img));
+    img.addEventListener("error", asyncTest.unreached_func("Load shouldn't fail"));
     img.addEventListener("load", _ => {
       asyncTest.step(test);
       asyncTest.done();


### PR DESCRIPTION
Some images don't load because we don't support SVG.
In that case this makes the test fail rather than timing out.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because there is no behavior change

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
