### PR TITLE
Unify sizing logic for replaced elements

### DIFF
--- a/tests/wpt/meta/css/css-position/position-absolute-replaced-minmax.html.ini
+++ b/tests/wpt/meta/css/css-position/position-absolute-replaced-minmax.html.ini
@@ -1,10 +1,4 @@
 [position-absolute-replaced-minmax.html]
-  [minmax replaced IFRAME 10]
-    expected: FAIL
-
-  [minmax replaced IFRAME 11]
-    expected: FAIL
-
   [minmax replaced IMG svg 23]
     expected: FAIL
 

--- a/tests/wpt/tests/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/video-intrinsic-width-height.html
+++ b/tests/wpt/tests/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/video-intrinsic-width-height.html
@@ -25,7 +25,7 @@
         <!-- A width:height ratio other than 2:1 and overriding the specified style must be used to
              verify that width/height does not influence intrinsic ratio -->
         <video title="both width/height attributes and style"
-               data-expected-width="300" data-expected-height="300"
+               data-expected-width="300" data-expected-height="150"
                width="100" height="100" style="width: auto; height: auto"></video>
         <script>
             Array.prototype.forEach.call(document.querySelectorAll('video'), function(video)


### PR DESCRIPTION
The logic varied quite a bit depending on the case, now it's unified.

This also fixes the following case where the iframe was 150px tall instead of 50px:
```html
<iframe style="min-width: 400px; max-height: 50px"></iframe>
```

This also modifies video-intrinsic-width-height.html to expect the new behavior that we share with Blink and WebKit. In fact WebKit already modified this test but forgot to export the change upstream. Firefox is different but it was already failing anyways.
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
