### PR TITLE
Properly handle fallback aspect ratio for videos

### DIFF
--- a/tests/wpt/meta/css/css-sizing/intrinsic-size-fallback-video.html.ini
+++ b/tests/wpt/meta/css/css-sizing/intrinsic-size-fallback-video.html.ini
@@ -1,0 +1,9 @@
+[intrinsic-size-fallback-video.html]
+  [.wrapper 1]
+    expected: FAIL
+
+  [.wrapper 3]
+    expected: FAIL
+
+  [.wrapper 4]
+    expected: FAIL

--- a/tests/wpt/tests/css/css-sizing/intrinsic-size-fallback-video.html
+++ b/tests/wpt/tests/css/css-sizing/intrinsic-size-fallback-video.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<title>CSS Sizing Test: intrinsic contribution of videos with fallback size</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-3/#intrinsic-sizes">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-3/#intrinsic-contribution">
+<meta name="assert" content="
+    These <video>s have no natural size nor natural aspect ratio,
+    but fall back to default size of 300x150 and ratio of 300/150.
+    Their intrinsic contributions should take these fallbacks into account.">
+<style>
+.wrapper {
+  float: left;
+  clear: both;
+  border: solid;
+}
+video {
+  background: cyan;
+}
+</style>
+<div id="log"></div>
+<div class="wrapper" data-expected-client-width="300">
+  <video></video>
+</div>
+<div class="wrapper" data-expected-client-width="200">
+  <video style="height: 100px"></video>
+</div>
+<div class="wrapper" data-expected-client-width="100">
+  <video style="max-height: 50px"></video>
+</div>
+<div class="wrapper" data-expected-client-width="400">
+  <video style="min-height: 200px"></video>
+</div>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<script>
+checkLayout(".wrapper");
+</script>


### PR DESCRIPTION
A `<video>` element with no source won't have a natural aspect ratio, but `aspect-ratio: auto` should still fall back to a ratio of 300/150.

`used_size_as_if_inline_element_from_content_box_sizes()` was already handling this, but other consumers of `preferred_aspect_ratio()` were wrong. In particular, this resulted in a 0px wide inline-block:

```html
<div style="display: inline-block; border: solid">
  <video style="height: 100px; background: cyan"></video>
</div>
```

So this patch moves the fallback into `preferred_aspect_ratio()`.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes
    Only 1 out of the 4 subtests pass (after #34083), the others will be addressed in follow-ups.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
