### PR TITLE
Use default object size as fallback for intrinsic size of replaced element

### DIFF
--- a/tests/wpt/meta/css/css-sizing/intrinsic-size-fallback-video.html.ini
+++ b/tests/wpt/meta/css/css-sizing/intrinsic-size-fallback-video.html.ini
@@ -1,7 +1,4 @@
 [intrinsic-size-fallback-video.html]
-  [.wrapper 1]
-    expected: FAIL
-
   [.wrapper 3]
     expected: FAIL
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Instead of falling back to zero.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
