### PR TITLE
Use out parameter for generated methods returning JSVal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4516,7 +4516,7 @@ dependencies = [
 [[package]]
 name = "mozjs"
 version = "0.14.1"
-source = "git+https://github.com/servo/mozjs#118aae2bcdb39617473b2cfe9fc680274ebbb9fc"
+source = "git+https://github.com/servo/mozjs#8526195dce129d2ccd83e7e1e5d03a954c11fafe"
 dependencies = [
  "bindgen",
  "cc",
@@ -4528,8 +4528,8 @@ dependencies = [
 
 [[package]]
 name = "mozjs_sys"
-version = "0.128.3-1"
-source = "git+https://github.com/servo/mozjs#118aae2bcdb39617473b2cfe9fc680274ebbb9fc"
+version = "0.128.3-4"
+source = "git+https://github.com/servo/mozjs#8526195dce129d2ccd83e7e1e5d03a954c11fafe"
 dependencies = [
  "bindgen",
  "cc",

--- a/components/script/dom/bindings/utils.rs
+++ b/components/script/dom/bindings/utils.rs
@@ -117,13 +117,15 @@ impl Clone for DOMJSClass {
 unsafe impl Sync for DOMJSClass {}
 
 /// Returns a JSVal representing the frozen JavaScript array
-pub fn to_frozen_array<T: ToJSValConvertible>(convertibles: &[T], cx: SafeJSContext) -> JSVal {
-    rooted!(in(*cx) let mut ports = UndefinedValue());
-    unsafe { convertibles.to_jsval(*cx, ports.handle_mut()) };
+pub fn to_frozen_array<T: ToJSValConvertible>(
+    convertibles: &[T],
+    cx: SafeJSContext,
+    rval: MutableHandleValue,
+) {
+    unsafe { convertibles.to_jsval(*cx, rval) };
 
-    rooted!(in(*cx) let obj = ports.to_object());
+    rooted!(in(*cx) let obj = rval.to_object());
     unsafe { JS_FreezeObject(*cx, RawHandleObject::from(obj.handle())) };
-    *ports
 }
 
 /// Returns the ProtoOrIfaceArray for the given global object.

--- a/components/script/dom/csslayerstatementrule.rs
+++ b/components/script/dom/csslayerstatementrule.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use js::jsval::JSVal;
+use js::rust::MutableHandleValue;
 use servo_arc::Arc;
 use style::shared_lock::ToCssWithGuard;
 use style::stylesheets::{CssRuleType, LayerStatementRule};
@@ -67,13 +67,13 @@ impl SpecificCSSRule for CSSLayerStatementRule {
 
 impl CSSLayerStatementRuleMethods for CSSLayerStatementRule {
     /// <https://drafts.csswg.org/css-cascade-5/#dom-csslayerstatementrule-namelist>
-    fn NameList(&self, cx: SafeJSContext) -> JSVal {
+    fn NameList(&self, cx: SafeJSContext, retval: MutableHandleValue) {
         let names: Vec<DOMString> = self
             .layerstatementrule
             .names
             .iter()
             .map(|name| DOMString::from_string(name.to_css_string()))
             .collect();
-        to_frozen_array(names.as_slice(), cx)
+        to_frozen_array(names.as_slice(), cx, retval)
     }
 }

--- a/components/script/dom/customevent.rs
+++ b/components/script/dom/customevent.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::jsapi::Heap;
 use js::jsval::JSVal;
-use js::rust::{HandleObject, HandleValue};
+use js::rust::{HandleObject, HandleValue, MutableHandleValue};
 use servo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::CustomEventBinding;
@@ -105,8 +105,8 @@ impl CustomEventMethods for CustomEvent {
     }
 
     // https://dom.spec.whatwg.org/#dom-customevent-detail
-    fn Detail(&self, _cx: JSContext) -> JSVal {
-        self.detail.get()
+    fn Detail(&self, _cx: JSContext, mut retval: MutableHandleValue) {
+        retval.set(self.detail.get())
     }
 
     // https://dom.spec.whatwg.org/#dom-customevent-initcustomevent

--- a/components/script/dom/dissimilaroriginwindow.rs
+++ b/components/script/dom/dissimilaroriginwindow.rs
@@ -5,8 +5,8 @@
 use base::id::PipelineId;
 use dom_struct::dom_struct;
 use js::jsapi::{Heap, JSObject};
-use js::jsval::{JSVal, UndefinedValue};
-use js::rust::{CustomAutoRooter, CustomAutoRooterGuard, HandleValue};
+use js::jsval::UndefinedValue;
+use js::rust::{CustomAutoRooter, CustomAutoRooterGuard, HandleValue, MutableHandleValue};
 use script_traits::{ScriptMsg, StructuredSerializedData};
 use servo_url::ServoUrl;
 
@@ -167,9 +167,9 @@ impl DissimilarOriginWindowMethods for DissimilarOriginWindow {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-opener
-    fn Opener(&self, _: JSContext) -> JSVal {
+    fn Opener(&self, _: JSContext, mut retval: MutableHandleValue) {
         // TODO: Implement x-origin opener
-        UndefinedValue()
+        retval.set(UndefinedValue());
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-opener

--- a/components/script/dom/errorevent.rs
+++ b/components/script/dom/errorevent.rs
@@ -7,7 +7,7 @@ use std::cell::Cell;
 use dom_struct::dom_struct;
 use js::jsapi::Heap;
 use js::jsval::JSVal;
-use js::rust::{HandleObject, HandleValue};
+use js::rust::{HandleObject, HandleValue, MutableHandleValue};
 use servo_atoms::Atom;
 
 use crate::dom::bindings::cell::DomRefCell;
@@ -166,8 +166,8 @@ impl ErrorEventMethods for ErrorEvent {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-errorevent-error
-    fn Error(&self, _cx: JSContext) -> JSVal {
-        self.error.get()
+    fn Error(&self, _cx: JSContext, mut retval: MutableHandleValue) {
+        retval.set(self.error.get());
     }
 
     // https://dom.spec.whatwg.org/#dom-event-istrusted

--- a/components/script/dom/gamepadhapticactuator.rs
+++ b/components/script/dom/gamepadhapticactuator.rs
@@ -9,7 +9,7 @@ use dom_struct::dom_struct;
 use embedder_traits::{DualRumbleEffectParams, EmbedderMsg};
 use ipc_channel::ipc;
 use ipc_channel::router::ROUTER;
-use js::jsval::JSVal;
+use js::rust::MutableHandleValue;
 use script_traits::GamepadSupportedHapticEffects;
 
 use crate::dom::bindings::cell::DomRefCell;
@@ -134,8 +134,8 @@ impl GamepadHapticActuator {
 
 impl GamepadHapticActuatorMethods for GamepadHapticActuator {
     /// <https://www.w3.org/TR/gamepad/#dom-gamepadhapticactuator-effects>
-    fn Effects(&self, cx: JSContext) -> JSVal {
-        to_frozen_array(self.effects.as_slice(), cx)
+    fn Effects(&self, cx: JSContext, retval: MutableHandleValue) {
+        to_frozen_array(self.effects.as_slice(), cx, retval)
     }
 
     /// <https://www.w3.org/TR/gamepad/#dom-gamepadhapticactuator-playeffect>

--- a/components/script/dom/gpucompilationinfo.rs
+++ b/components/script/dom/gpucompilationinfo.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use js::jsval::JSVal;
+use js::rust::MutableHandleValue;
 use webgpu::ShaderCompilationInfo;
 
 use super::bindings::codegen::Bindings::WebGPUBinding::GPUCompilationInfoMethods;
@@ -58,7 +58,7 @@ impl GPUCompilationInfo {
 
 impl GPUCompilationInfoMethods for GPUCompilationInfo {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpucompilationinfo-messages>
-    fn Messages(&self, cx: JSContext) -> JSVal {
-        to_frozen_array(self.msg.as_slice(), cx)
+    fn Messages(&self, cx: JSContext, retval: MutableHandleValue) {
+        to_frozen_array(self.msg.as_slice(), cx, retval)
     }
 }

--- a/components/script/dom/history.rs
+++ b/components/script/dom/history.rs
@@ -9,7 +9,7 @@ use base::id::HistoryStateId;
 use dom_struct::dom_struct;
 use js::jsapi::Heap;
 use js::jsval::{JSVal, NullValue, UndefinedValue};
-use js::rust::HandleValue;
+use js::rust::{HandleValue, MutableHandleValue};
 use net_traits::{CoreResourceMsg, IpcSend};
 use profile_traits::ipc;
 use profile_traits::ipc::channel;
@@ -289,11 +289,12 @@ impl History {
 
 impl HistoryMethods for History {
     /// <https://html.spec.whatwg.org/multipage/#dom-history-state>
-    fn GetState(&self, _cx: JSContext) -> Fallible<JSVal> {
+    fn GetState(&self, _cx: JSContext, mut retval: MutableHandleValue) -> Fallible<()> {
         if !self.window.Document().is_fully_active() {
             return Err(Error::Security);
         }
-        Ok(self.state.get())
+        retval.set(self.state.get());
+        Ok(())
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-history-length>

--- a/components/script/dom/intersectionobserver.rs
+++ b/components/script/dom/intersectionobserver.rs
@@ -5,8 +5,7 @@
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
-use js::jsval::{JSVal, NullValue};
-use js::rust::HandleObject;
+use js::rust::{HandleObject, MutableHandleValue};
 
 use super::bindings::codegen::Bindings::IntersectionObserverBinding::{
     IntersectionObserverCallback, IntersectionObserverMethods,
@@ -93,9 +92,7 @@ impl IntersectionObserverMethods for IntersectionObserver {
     /// > constructor, or the sequence is empty, the value of this attribute will be [0].
     ///
     /// <https://w3c.github.io/IntersectionObserver/#dom-intersectionobserver-thresholds>
-    fn Thresholds(&self, _context: JSContext) -> JSVal {
-        NullValue()
-    }
+    fn Thresholds(&self, _context: JSContext, _retval: MutableHandleValue) {}
 
     /// > A number indicating the minimum delay in milliseconds between notifications from
     /// > this observer for a given target.

--- a/components/script/dom/macros.rs
+++ b/components/script/dom/macros.rs
@@ -666,14 +666,3 @@ macro_rules! impl_rare_data (
         }
     );
 );
-
-#[macro_export]
-macro_rules! optional_root_object_to_js_or_null {
-    ($cx: expr, $binding:expr) => {{
-        rooted!(in($cx) let mut rval = NullValue());
-        if let Some(object) = $binding {
-            object.to_jsval($cx, rval.handle_mut());
-        }
-        rval.get()
-    }};
-}

--- a/components/script/dom/messageevent.rs
+++ b/components/script/dom/messageevent.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::jsapi::Heap;
 use js::jsval::JSVal;
-use js::rust::{HandleObject, HandleValue};
+use js::rust::{HandleObject, HandleValue, MutableHandleValue};
 use servo_atoms::Atom;
 
 use crate::dom::bindings::cell::DomRefCell;
@@ -266,8 +266,8 @@ impl MessageEventMethods for MessageEvent {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-messageevent-data>
-    fn Data(&self, _cx: JSContext) -> JSVal {
-        self.data.get()
+    fn Data(&self, _cx: JSContext, mut retval: MutableHandleValue) {
+        retval.set(self.data.get())
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-messageevent-origin>
@@ -302,9 +302,10 @@ impl MessageEventMethods for MessageEvent {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-messageevent-ports>
-    fn Ports(&self, cx: JSContext) -> JSVal {
+    fn Ports(&self, cx: JSContext, mut retval: MutableHandleValue) {
         if let Some(ports) = &*self.frozen_ports.borrow() {
-            return ports.get();
+            retval.set(ports.get());
+            return;
         }
 
         let ports: Vec<DomRoot<MessagePort>> = self
@@ -313,7 +314,7 @@ impl MessageEventMethods for MessageEvent {
             .iter()
             .map(|port| DomRoot::from_ref(&**port))
             .collect();
-        let frozen_ports = to_frozen_array(ports.as_slice(), cx);
+        to_frozen_array(ports.as_slice(), cx, retval);
 
         // Safety: need to create the Heap value in its final memory location before setting it.
         *self.frozen_ports.borrow_mut() = Some(Heap::default());
@@ -321,9 +322,7 @@ impl MessageEventMethods for MessageEvent {
             .borrow()
             .as_ref()
             .unwrap()
-            .set(frozen_ports);
-
-        frozen_ports
+            .set(retval.get());
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-messageevent-initmessageevent>

--- a/components/script/dom/navigator.rs
+++ b/components/script/dom/navigator.rs
@@ -7,7 +7,7 @@ use std::convert::TryInto;
 use std::sync::LazyLock;
 
 use dom_struct::dom_struct;
-use js::jsval::JSVal;
+use js::rust::MutableHandleValue;
 
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::NavigatorBinding::NavigatorMethods;
@@ -199,8 +199,8 @@ impl NavigatorMethods for Navigator {
 
     // https://html.spec.whatwg.org/multipage/#dom-navigator-languages
     #[allow(unsafe_code)]
-    fn Languages(&self, cx: JSContext) -> JSVal {
-        to_frozen_array(&[self.Language()], cx)
+    fn Languages(&self, cx: JSContext, retval: MutableHandleValue) {
+        to_frozen_array(&[self.Language()], cx, retval)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-navigator-plugins

--- a/components/script/dom/performanceobserver.rs
+++ b/components/script/dom/performanceobserver.rs
@@ -6,8 +6,7 @@ use std::cell::Cell;
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
-use js::jsval::JSVal;
-use js::rust::HandleObject;
+use js::rust::{HandleObject, MutableHandleValue};
 
 use crate::dom::bindings::callback::ExceptionHandling;
 use crate::dom::bindings::cell::DomRefCell;
@@ -137,10 +136,10 @@ impl PerformanceObserverMethods for PerformanceObserver {
     }
 
     // https://w3c.github.io/performance-timeline/#supportedentrytypes-attribute
-    fn SupportedEntryTypes(cx: JSContext, global: &GlobalScope) -> JSVal {
+    fn SupportedEntryTypes(cx: JSContext, global: &GlobalScope, retval: MutableHandleValue) {
         // While this is exposed through a method of PerformanceObserver,
         // it is specified as associated with the global scope.
-        global.supported_performance_entry_types(cx)
+        global.supported_performance_entry_types(cx, retval)
     }
 
     // https://w3c.github.io/performance-timeline/#dom-performanceobserver-observe()

--- a/components/script/dom/popstateevent.rs
+++ b/components/script/dom/popstateevent.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::jsapi::Heap;
 use js::jsval::JSVal;
-use js::rust::{HandleObject, HandleValue};
+use js::rust::{HandleObject, HandleValue, MutableHandleValue};
 use servo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::EventMethods;
@@ -102,8 +102,8 @@ impl PopStateEventMethods for PopStateEvent {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-popstateevent-state
-    fn State(&self, _cx: JSContext) -> JSVal {
-        self.state.get()
+    fn State(&self, _cx: JSContext, mut retval: MutableHandleValue) {
+        retval.set(self.state.get())
     }
 
     // https://dom.spec.whatwg.org/#dom-event-istrusted

--- a/components/script/dom/promiserejectionevent.rs
+++ b/components/script/dom/promiserejectionevent.rs
@@ -8,7 +8,7 @@ use std::rc::Rc;
 use dom_struct::dom_struct;
 use js::jsapi::{Heap, JSObject};
 use js::jsval::JSVal;
-use js::rust::{HandleObject, HandleValue};
+use js::rust::{HandleObject, HandleValue, MutableHandleValue};
 use servo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::EventMethods;
@@ -127,8 +127,8 @@ impl PromiseRejectionEventMethods for PromiseRejectionEvent {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-promiserejectionevent-reason
-    fn Reason(&self, _cx: JSContext) -> JSVal {
-        self.reason.get()
+    fn Reason(&self, _cx: JSContext, mut retval: MutableHandleValue) {
+        retval.set(self.reason.get())
     }
 
     // https://dom.spec.whatwg.org/#dom-event-istrusted

--- a/components/script/dom/resizeobserverentry.rs
+++ b/components/script/dom/resizeobserverentry.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use js::jsval::JSVal;
+use js::rust::MutableHandleValue;
 
 use crate::dom::bindings::codegen::Bindings::ResizeObserverEntryBinding::ResizeObserverEntryMethods;
 use crate::dom::bindings::reflector::{reflect_dom_object_with_proto, Reflector};
@@ -90,32 +90,32 @@ impl ResizeObserverEntryMethods for ResizeObserverEntry {
     }
 
     /// <https://drafts.csswg.org/resize-observer/#dom-resizeobserverentry-borderboxsize>
-    fn BorderBoxSize(&self, cx: SafeJSContext) -> JSVal {
+    fn BorderBoxSize(&self, cx: SafeJSContext, retval: MutableHandleValue) {
         let sizes: Vec<DomRoot<ResizeObserverSize>> = self
             .border_box_size
             .iter()
             .map(|size| DomRoot::from_ref(&**size))
             .collect();
-        to_frozen_array(sizes.as_slice(), cx)
+        to_frozen_array(sizes.as_slice(), cx, retval)
     }
 
     /// <https://drafts.csswg.org/resize-observer/#dom-resizeobserverentry-contentboxsize>
-    fn ContentBoxSize(&self, cx: SafeJSContext) -> JSVal {
+    fn ContentBoxSize(&self, cx: SafeJSContext, retval: MutableHandleValue) {
         let sizes: Vec<DomRoot<ResizeObserverSize>> = self
             .content_box_size
             .iter()
             .map(|size| DomRoot::from_ref(&**size))
             .collect();
-        to_frozen_array(sizes.as_slice(), cx)
+        to_frozen_array(sizes.as_slice(), cx, retval);
     }
 
     /// <https://drafts.csswg.org/resize-observer/#dom-resizeobserverentry-devicepixelcontentboxsize>
-    fn DevicePixelContentBoxSize(&self, cx: SafeJSContext) -> JSVal {
+    fn DevicePixelContentBoxSize(&self, cx: SafeJSContext, retval: MutableHandleValue) {
         let sizes: Vec<DomRoot<ResizeObserverSize>> = self
             .device_pixel_content_box_size
             .iter()
             .map(|size| DomRoot::from_ref(&**size))
             .collect();
-        to_frozen_array(sizes.as_slice(), cx)
+        to_frozen_array(sizes.as_slice(), cx, retval);
     }
 }

--- a/components/script/dom/testbinding.rs
+++ b/components/script/dom/testbinding.rs
@@ -11,8 +11,8 @@ use std::time::Duration;
 
 use dom_struct::dom_struct;
 use js::jsapi::{Heap, JSObject, JS_NewPlainObject};
-use js::jsval::{JSVal, NullValue};
-use js::rust::{CustomAutoRooterGuard, HandleObject, HandleValue};
+use js::jsval::JSVal;
+use js::rust::{CustomAutoRooterGuard, HandleObject, HandleValue, MutableHandleValue};
 use js::typedarray::{self, Uint8ClampedArray};
 use script_traits::serializable::BlobImpl;
 use servo_config::prefs;
@@ -229,9 +229,7 @@ impl TestBindingMethods for TestBinding {
         create_buffer_source(cx, &data, array.handle_mut())
             .expect("Creating ClampedU8 array should never fail")
     }
-    fn AnyAttribute(&self, _: SafeJSContext) -> JSVal {
-        NullValue()
-    }
+    fn AnyAttribute(&self, _: SafeJSContext, _: MutableHandleValue) {}
     fn SetAnyAttribute(&self, _: SafeJSContext, _: HandleValue) {}
     #[allow(unsafe_code)]
     fn ObjectAttribute(&self, cx: SafeJSContext) -> NonNull<JSObject> {
@@ -426,9 +424,7 @@ impl TestBindingMethods for TestBinding {
             can_gc,
         )
     }
-    fn ReceiveAny(&self, _: SafeJSContext) -> JSVal {
-        NullValue()
-    }
+    fn ReceiveAny(&self, _: SafeJSContext, _: MutableHandleValue) {}
     fn ReceiveObject(&self, cx: SafeJSContext) -> NonNull<JSObject> {
         self.ObjectAttribute(cx)
     }

--- a/components/script/dom/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl2renderingcontext.rs
@@ -16,11 +16,8 @@ use dom_struct::dom_struct;
 use euclid::default::{Point2D, Rect, Size2D};
 use ipc_channel::ipc::{self, IpcSharedMemory};
 use js::jsapi::{JSObject, Type};
-use js::jsval::{
-    BooleanValue, DoubleValue, Int32Value, JSVal, NullValue, ObjectValue, UInt32Value,
-    UndefinedValue,
-};
-use js::rust::{CustomAutoRooterGuard, HandleObject};
+use js::jsval::{BooleanValue, DoubleValue, Int32Value, NullValue, ObjectValue, UInt32Value};
+use js::rust::{CustomAutoRooterGuard, HandleObject, MutableHandleValue};
 use js::typedarray::{ArrayBufferView, CreateWith, Float32, Int32Array, Uint32, Uint32Array};
 use script_layout_interface::HTMLCanvasDataSource;
 use servo_config::pref;
@@ -591,14 +588,19 @@ impl WebGL2RenderingContext {
     }
 
     #[allow(unsafe_code)]
-    fn get_default_fb_attachment_param(&self, attachment: u32, pname: u32) -> WebGLResult<JSVal> {
+    fn get_default_fb_attachment_param(
+        &self,
+        attachment: u32,
+        pname: u32,
+        mut retval: MutableHandleValue,
+    ) -> WebGLResult<()> {
         match attachment {
             constants::BACK | constants::DEPTH | constants::STENCIL => {},
             _ => return Err(InvalidEnum),
         }
 
         if pname == constants::FRAMEBUFFER_ATTACHMENT_OBJECT_NAME {
-            return Ok(NullValue());
+            return Ok(retval.set(NullValue()));
         }
 
         let attrs = self
@@ -646,7 +648,8 @@ impl WebGL2RenderingContext {
             },
             _ => return Err(InvalidEnum),
         };
-        Ok(Int32Value(intval))
+        retval.set(Int32Value(intval));
+        Ok(())
     }
 
     #[allow(unsafe_code)]
@@ -657,7 +660,8 @@ impl WebGL2RenderingContext {
         target: u32,
         attachment: u32,
         pname: u32,
-    ) -> WebGLResult<JSVal> {
+        mut rval: MutableHandleValue,
+    ) -> WebGLResult<()> {
         use crate::dom::webglframebuffer::WebGLFramebufferAttachmentRoot::{Renderbuffer, Texture};
 
         match attachment {
@@ -692,17 +696,16 @@ impl WebGL2RenderingContext {
         };
 
         if pname == constants::FRAMEBUFFER_ATTACHMENT_OBJECT_NAME {
-            rooted!(in(*cx) let mut rval = NullValue());
             match fb.attachment(attachment) {
                 Some(Renderbuffer(rb)) => unsafe {
-                    rb.to_jsval(*cx, rval.handle_mut());
+                    rb.to_jsval(*cx, rval);
                 },
                 Some(Texture(texture)) => unsafe {
-                    texture.to_jsval(*cx, rval.handle_mut());
+                    texture.to_jsval(*cx, rval);
                 },
-                _ => {},
+                _ => rval.set(NullValue()),
             }
-            return Ok(rval.get());
+            return Ok(());
         }
 
         match pname {
@@ -738,7 +741,8 @@ impl WebGL2RenderingContext {
             ));
 
         let retval = receiver.recv().unwrap();
-        Ok(Int32Value(retval))
+        rval.set(Int32Value(retval));
+        Ok(())
     }
 
     fn clearbuffer_array_size(&self, buffer: u32, draw_buffer: i32) -> WebGLResult<usize> {
@@ -931,101 +935,108 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5>
-    fn GetBufferParameter(&self, _cx: JSContext, target: u32, parameter: u32) -> JSVal {
-        let buffer =
-            handle_potential_webgl_error!(self.base, self.bound_buffer(target), return NullValue());
-        self.base.get_buffer_param(buffer, parameter)
+    fn GetBufferParameter(
+        &self,
+        _cx: JSContext,
+        target: u32,
+        parameter: u32,
+        mut retval: MutableHandleValue,
+    ) {
+        let buffer = handle_potential_webgl_error!(
+            self.base,
+            self.bound_buffer(target),
+            return retval.set(NullValue())
+        );
+        self.base.get_buffer_param(buffer, parameter, retval)
     }
 
     #[allow(unsafe_code)]
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3>
-    fn GetParameter(&self, cx: JSContext, parameter: u32) -> JSVal {
+    fn GetParameter(&self, cx: JSContext, parameter: u32, mut rval: MutableHandleValue) {
         match parameter {
             constants::VERSION => unsafe {
-                rooted!(in(*cx) let mut rval = UndefinedValue());
-                "WebGL 2.0".to_jsval(*cx, rval.handle_mut());
-                return rval.get();
+                "WebGL 2.0".to_jsval(*cx, rval);
+                return;
             },
             constants::SHADING_LANGUAGE_VERSION => unsafe {
-                rooted!(in(*cx) let mut rval = UndefinedValue());
-                "WebGL GLSL ES 3.00".to_jsval(*cx, rval.handle_mut());
-                return rval.get();
+                "WebGL GLSL ES 3.00".to_jsval(*cx, rval);
+                return;
             },
             constants::MAX_CLIENT_WAIT_TIMEOUT_WEBGL => {
-                return DoubleValue(
-                    self.base.limits().max_client_wait_timeout_webgl.as_nanos() as f64
-                );
+                rval.set(DoubleValue(
+                    self.base.limits().max_client_wait_timeout_webgl.as_nanos() as f64,
+                ));
+                return;
             },
             constants::MAX_SERVER_WAIT_TIMEOUT => {
-                return DoubleValue(self.base.limits().max_server_wait_timeout.as_nanos() as f64);
+                rval.set(DoubleValue(
+                    self.base.limits().max_server_wait_timeout.as_nanos() as f64,
+                ));
+                return;
             },
             constants::SAMPLER_BINDING => unsafe {
                 let idx = (self.base.textures().active_unit_enum() - constants::TEXTURE0) as usize;
                 assert!(idx < self.samplers.len());
                 let sampler = self.samplers[idx].get();
-                return optional_root_object_to_js_or_null!(*cx, sampler);
+                sampler.to_jsval(*cx, rval);
+                return;
             },
             constants::COPY_READ_BUFFER_BINDING => unsafe {
-                return optional_root_object_to_js_or_null!(
-                    *cx,
-                    &self.bound_copy_read_buffer.get()
-                );
+                self.bound_copy_read_buffer.get().to_jsval(*cx, rval);
+                return;
             },
             constants::COPY_WRITE_BUFFER_BINDING => unsafe {
-                return optional_root_object_to_js_or_null!(
-                    *cx,
-                    &self.bound_copy_write_buffer.get()
-                );
+                self.bound_copy_write_buffer.get().to_jsval(*cx, rval);
+                return;
             },
             constants::PIXEL_PACK_BUFFER_BINDING => unsafe {
-                return optional_root_object_to_js_or_null!(
-                    *cx,
-                    &self.bound_pixel_pack_buffer.get()
-                );
+                self.bound_pixel_pack_buffer.get().to_jsval(*cx, rval);
+                return;
             },
             constants::PIXEL_UNPACK_BUFFER_BINDING => unsafe {
-                return optional_root_object_to_js_or_null!(
-                    *cx,
-                    &self.bound_pixel_unpack_buffer.get()
-                );
+                self.bound_pixel_unpack_buffer.get().to_jsval(*cx, rval);
+                return;
             },
             constants::TRANSFORM_FEEDBACK_BUFFER_BINDING => unsafe {
-                return optional_root_object_to_js_or_null!(
-                    *cx,
-                    &self.bound_transform_feedback_buffer.get()
-                );
+                self.bound_transform_feedback_buffer
+                    .get()
+                    .to_jsval(*cx, rval);
+                return;
             },
             constants::UNIFORM_BUFFER_BINDING => unsafe {
-                return optional_root_object_to_js_or_null!(*cx, &self.bound_uniform_buffer.get());
+                self.bound_uniform_buffer.get().to_jsval(*cx, rval);
+                return;
             },
             constants::TRANSFORM_FEEDBACK_BINDING => unsafe {
-                return optional_root_object_to_js_or_null!(
-                    *cx,
-                    self.current_transform_feedback.get()
-                );
+                self.current_transform_feedback.get().to_jsval(*cx, rval);
+                return;
             },
             constants::ELEMENT_ARRAY_BUFFER_BINDING => unsafe {
                 let buffer = self.current_vao().element_array_buffer().get();
-                return optional_root_object_to_js_or_null!(*cx, buffer);
+                buffer.to_jsval(*cx, rval);
+                return;
             },
             constants::VERTEX_ARRAY_BINDING => unsafe {
                 let vao = self.current_vao();
                 let vao = vao.id().map(|_| &*vao);
-                return optional_root_object_to_js_or_null!(*cx, vao);
+                vao.to_jsval(*cx, rval);
+                return;
             },
             // NOTE: DRAW_FRAMEBUFFER_BINDING is the same as FRAMEBUFFER_BINDING, handled on the WebGL1 side
             constants::READ_FRAMEBUFFER_BINDING => unsafe {
-                return optional_root_object_to_js_or_null!(
-                    *cx,
-                    &self.base.get_read_framebuffer_slot().get()
-                );
+                self.base
+                    .get_read_framebuffer_slot()
+                    .get()
+                    .to_jsval(*cx, rval);
+                return;
             },
             constants::READ_BUFFER => {
                 let buffer = match self.base.get_read_framebuffer_slot().get() {
                     Some(fb) => fb.read_buffer(),
                     None => self.default_fb_readbuffer.get(),
                 };
-                return UInt32Value(buffer);
+                rval.set(UInt32Value(buffer));
+                return;
             },
             constants::DRAW_BUFFER0..=constants::DRAW_BUFFER15 => {
                 let buffer = match self.base.get_read_framebuffer_slot().get() {
@@ -1038,29 +1049,38 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
                     },
                     None => constants::NONE,
                 };
-                return UInt32Value(buffer);
+                rval.set(UInt32Value(buffer));
+                return;
             },
             constants::MAX_TEXTURE_LOD_BIAS => {
-                return DoubleValue(self.base.limits().max_texture_lod_bias as f64)
+                rval.set(DoubleValue(self.base.limits().max_texture_lod_bias as f64));
+                return;
             },
             constants::MAX_COMBINED_FRAGMENT_UNIFORM_COMPONENTS => {
-                return DoubleValue(
+                rval.set(DoubleValue(
                     self.base.limits().max_combined_fragment_uniform_components as f64,
-                )
+                ));
+                return;
             },
             constants::MAX_COMBINED_VERTEX_UNIFORM_COMPONENTS => {
-                return DoubleValue(
+                rval.set(DoubleValue(
                     self.base.limits().max_combined_vertex_uniform_components as f64,
-                )
+                ));
+                return;
             },
             constants::MAX_ELEMENT_INDEX => {
-                return DoubleValue(self.base.limits().max_element_index as f64)
+                rval.set(DoubleValue(self.base.limits().max_element_index as f64));
+                return;
             },
             constants::MAX_UNIFORM_BLOCK_SIZE => {
-                return DoubleValue(self.base.limits().max_uniform_block_size as f64)
+                rval.set(DoubleValue(
+                    self.base.limits().max_uniform_block_size as f64,
+                ));
+                return;
             },
             constants::MIN_PROGRAM_TEXEL_OFFSET => {
-                return Int32Value(self.base.limits().min_program_texel_offset)
+                rval.set(Int32Value(self.base.limits().min_program_texel_offset));
+                return;
             },
             _ => {},
         }
@@ -1109,15 +1129,16 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
             _ => None,
         };
         if let Some(limit) = limit {
-            return UInt32Value(limit);
+            rval.set(UInt32Value(limit));
+            return;
         }
 
-        self.base.GetParameter(cx, parameter)
+        self.base.GetParameter(cx, parameter, rval)
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8>
-    fn GetTexParameter(&self, cx: JSContext, target: u32, pname: u32) -> JSVal {
-        self.base.GetTexParameter(cx, target, pname)
+    fn GetTexParameter(&self, cx: JSContext, target: u32, pname: u32, retval: MutableHandleValue) {
+        self.base.GetTexParameter(cx, target, pname, retval)
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3>
@@ -1152,7 +1173,8 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         target: u32,
         attachment: u32,
         pname: u32,
-    ) -> JSVal {
+        mut rval: MutableHandleValue,
+    ) {
         let fb_slot = match target {
             constants::FRAMEBUFFER | constants::DRAW_FRAMEBUFFER => {
                 self.base.get_draw_framebuffer_slot()
@@ -1160,31 +1182,43 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
             constants::READ_FRAMEBUFFER => self.base.get_read_framebuffer_slot(),
             _ => {
                 self.base.webgl_error(InvalidEnum);
-                return NullValue();
+                rval.set(NullValue());
+                return;
             },
         };
 
         if let Some(fb) = fb_slot.get() {
             // A selected framebuffer is bound to the target
-            handle_potential_webgl_error!(self.base, fb.validate_transparent(), return NullValue());
             handle_potential_webgl_error!(
                 self.base,
-                self.get_specific_fb_attachment_param(cx, &fb, target, attachment, pname),
-                NullValue()
+                fb.validate_transparent(),
+                return rval.set(NullValue())
+            );
+            handle_potential_webgl_error!(
+                self.base,
+                self.get_specific_fb_attachment_param(cx, &fb, target, attachment, pname, rval),
+                rval.set(NullValue())
             )
         } else {
             // The default framebuffer is bound to the target
             handle_potential_webgl_error!(
                 self.base,
-                self.get_default_fb_attachment_param(attachment, pname),
-                NullValue()
+                self.get_default_fb_attachment_param(attachment, pname, rval),
+                rval.set(NullValue())
             )
         }
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.7>
-    fn GetRenderbufferParameter(&self, cx: JSContext, target: u32, pname: u32) -> JSVal {
-        self.base.GetRenderbufferParameter(cx, target, pname)
+    fn GetRenderbufferParameter(
+        &self,
+        cx: JSContext,
+        target: u32,
+        pname: u32,
+        retval: MutableHandleValue,
+    ) {
+        self.base
+            .GetRenderbufferParameter(cx, target, pname, retval)
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3>
@@ -1856,24 +1890,30 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9>
-    fn GetProgramParameter(&self, cx: JSContext, program: &WebGLProgram, param_id: u32) -> JSVal {
+    fn GetProgramParameter(
+        &self,
+        cx: JSContext,
+        program: &WebGLProgram,
+        param_id: u32,
+        mut retval: MutableHandleValue,
+    ) {
         handle_potential_webgl_error!(
             self.base,
             self.base.validate_ownership(program),
-            return NullValue()
+            return retval.set(NullValue())
         );
         if program.is_deleted() {
             self.base.webgl_error(InvalidOperation);
-            return NullValue();
+            return retval.set(NullValue());
         }
         match param_id {
             constants::TRANSFORM_FEEDBACK_VARYINGS => {
-                Int32Value(program.transform_feedback_varyings_length())
+                retval.set(Int32Value(program.transform_feedback_varyings_length()))
             },
             constants::TRANSFORM_FEEDBACK_BUFFER_MODE => {
-                Int32Value(program.transform_feedback_buffer_mode())
+                retval.set(Int32Value(program.transform_feedback_buffer_mode()))
             },
-            _ => self.base.GetProgramParameter(cx, program, param_id),
+            _ => self.base.GetProgramParameter(cx, program, param_id, retval),
         }
     }
 
@@ -1883,8 +1923,14 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9>
-    fn GetShaderParameter(&self, cx: JSContext, shader: &WebGLShader, param_id: u32) -> JSVal {
-        self.base.GetShaderParameter(cx, shader, param_id)
+    fn GetShaderParameter(
+        &self,
+        cx: JSContext,
+        shader: &WebGLShader,
+        param_id: u32,
+        retval: MutableHandleValue,
+    ) {
+        self.base.GetShaderParameter(cx, shader, param_id, retval)
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9>
@@ -1899,7 +1945,13 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.2>
     #[allow(unsafe_code)]
-    fn GetIndexedParameter(&self, cx: JSContext, target: u32, index: u32) -> JSVal {
+    fn GetIndexedParameter(
+        &self,
+        cx: JSContext,
+        target: u32,
+        index: u32,
+        mut retval: MutableHandleValue,
+    ) {
         let bindings = match target {
             constants::TRANSFORM_FEEDBACK_BUFFER_BINDING |
             constants::TRANSFORM_FEEDBACK_BUFFER_SIZE |
@@ -1911,7 +1963,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
             constants::UNIFORM_BUFFER_START => &self.indexed_uniform_buffer_bindings,
             _ => {
                 self.base.webgl_error(InvalidEnum);
-                return NullValue();
+                return retval.set(NullValue());
             },
         };
 
@@ -1919,19 +1971,19 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
             Some(binding) => binding,
             None => {
                 self.base.webgl_error(InvalidValue);
-                return NullValue();
+                return retval.set(NullValue());
             },
         };
 
         match target {
             constants::TRANSFORM_FEEDBACK_BUFFER_BINDING | constants::UNIFORM_BUFFER_BINDING => unsafe {
-                optional_root_object_to_js_or_null!(*cx, binding.buffer.get())
+                binding.buffer.get().to_jsval(*cx, retval)
             },
             constants::TRANSFORM_FEEDBACK_BUFFER_START | constants::UNIFORM_BUFFER_START => {
-                Int32Value(binding.start.get() as _)
+                retval.set(Int32Value(binding.start.get() as _))
             },
             constants::TRANSFORM_FEEDBACK_BUFFER_SIZE | constants::UNIFORM_BUFFER_SIZE => {
-                Int32Value(binding.size.get() as _)
+                retval.set(Int32Value(binding.size.get() as _))
             },
             _ => unreachable!(),
         }
@@ -1947,8 +1999,8 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9>
-    fn GetVertexAttrib(&self, cx: JSContext, index: u32, pname: u32) -> JSVal {
-        self.base.GetVertexAttrib(cx, index, pname)
+    fn GetVertexAttrib(&self, cx: JSContext, index: u32, pname: u32, retval: MutableHandleValue) {
+        self.base.GetVertexAttrib(cx, index, pname, retval)
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
@@ -2709,68 +2761,88 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         cx: JSContext,
         program: &WebGLProgram,
         location: &WebGLUniformLocation,
-    ) -> JSVal {
+        mut retval: MutableHandleValue,
+    ) {
         handle_potential_webgl_error!(
             self.base,
             self.base.uniform_check_program(program, location),
-            return NullValue()
+            return retval.set(NullValue())
         );
 
         let triple = (&*self.base, program.id(), location.id());
 
         match location.type_() {
-            constants::UNSIGNED_INT => {
-                UInt32Value(uniform_get(triple, WebGLCommand::GetUniformUint))
-            },
+            constants::UNSIGNED_INT => retval.set(UInt32Value(uniform_get(
+                triple,
+                WebGLCommand::GetUniformUint,
+            ))),
             constants::UNSIGNED_INT_VEC2 => unsafe {
-                uniform_typed::<Uint32>(*cx, &uniform_get(triple, WebGLCommand::GetUniformUint2))
+                uniform_typed::<Uint32>(
+                    *cx,
+                    &uniform_get(triple, WebGLCommand::GetUniformUint2),
+                    retval,
+                )
             },
             constants::UNSIGNED_INT_VEC3 => unsafe {
-                uniform_typed::<Uint32>(*cx, &uniform_get(triple, WebGLCommand::GetUniformUint3))
+                uniform_typed::<Uint32>(
+                    *cx,
+                    &uniform_get(triple, WebGLCommand::GetUniformUint3),
+                    retval,
+                )
             },
             constants::UNSIGNED_INT_VEC4 => unsafe {
-                uniform_typed::<Uint32>(*cx, &uniform_get(triple, WebGLCommand::GetUniformUint4))
+                uniform_typed::<Uint32>(
+                    *cx,
+                    &uniform_get(triple, WebGLCommand::GetUniformUint4),
+                    retval,
+                )
             },
             constants::FLOAT_MAT2x3 => unsafe {
                 uniform_typed::<Float32>(
                     *cx,
                     &uniform_get(triple, WebGLCommand::GetUniformFloat2x3),
+                    retval,
                 )
             },
             constants::FLOAT_MAT2x4 => unsafe {
                 uniform_typed::<Float32>(
                     *cx,
                     &uniform_get(triple, WebGLCommand::GetUniformFloat2x4),
+                    retval,
                 )
             },
             constants::FLOAT_MAT3x2 => unsafe {
                 uniform_typed::<Float32>(
                     *cx,
                     &uniform_get(triple, WebGLCommand::GetUniformFloat3x2),
+                    retval,
                 )
             },
             constants::FLOAT_MAT3x4 => unsafe {
                 uniform_typed::<Float32>(
                     *cx,
                     &uniform_get(triple, WebGLCommand::GetUniformFloat3x4),
+                    retval,
                 )
             },
             constants::FLOAT_MAT4x2 => unsafe {
                 uniform_typed::<Float32>(
                     *cx,
                     &uniform_get(triple, WebGLCommand::GetUniformFloat4x2),
+                    retval,
                 )
             },
             constants::FLOAT_MAT4x3 => unsafe {
                 uniform_typed::<Float32>(
                     *cx,
                     &uniform_get(triple, WebGLCommand::GetUniformFloat4x3),
+                    retval,
                 )
             },
             constants::SAMPLER_3D | constants::SAMPLER_2D_ARRAY => {
-                Int32Value(uniform_get(triple, WebGLCommand::GetUniformInt))
+                retval.set(Int32Value(uniform_get(triple, WebGLCommand::GetUniformInt)))
             },
-            _ => self.base.GetUniform(cx, program, location),
+            _ => self.base.GetUniform(cx, program, location, retval),
         }
     }
 
@@ -3530,21 +3602,21 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.12>
     #[rustfmt::skip]
-    fn GetQueryParameter(&self, _cx: JSContext, query: &WebGLQuery, pname: u32) -> JSVal {
+    fn GetQueryParameter(&self, _cx: JSContext, query: &WebGLQuery, pname: u32, mut retval: MutableHandleValue) {
         handle_potential_webgl_error!(
             self.base,
             self.base.validate_ownership(query),
-            return NullValue()
+            return retval.set(NullValue())
         );
         match query.get_parameter(&self.base, pname) {
             Ok(value) => match pname {
-                constants::QUERY_RESULT => UInt32Value(value),
-                constants::QUERY_RESULT_AVAILABLE => BooleanValue(value != 0),
+                constants::QUERY_RESULT => retval.set(UInt32Value(value)),
+                constants::QUERY_RESULT_AVAILABLE => retval.set(BooleanValue(value != 0)),
                 _ => unreachable!(),
             },
             Err(error) => {
                 self.base.webgl_error(error);
-                NullValue()
+                retval.set(NullValue())
             },
         }
     }
@@ -3631,30 +3703,36 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.14>
-    fn GetSyncParameter(&self, _cx: JSContext, sync: &WebGLSync, pname: u32) -> JSVal {
+    fn GetSyncParameter(
+        &self,
+        _cx: JSContext,
+        sync: &WebGLSync,
+        pname: u32,
+        mut retval: MutableHandleValue,
+    ) {
         if !sync.is_valid() {
             self.base.webgl_error(InvalidOperation);
-            return NullValue();
+            return retval.set(NullValue());
         }
         handle_potential_webgl_error!(
             self.base,
             self.base.validate_ownership(sync),
-            return NullValue()
+            return retval.set(NullValue())
         );
         match pname {
             constants::OBJECT_TYPE | constants::SYNC_CONDITION | constants::SYNC_FLAGS => {
                 let (sender, receiver) = webgl_channel().unwrap();
                 self.base
                     .send_command(WebGLCommand::GetSyncParameter(sync.id(), pname, sender));
-                UInt32Value(receiver.recv().unwrap())
+                retval.set(UInt32Value(receiver.recv().unwrap()))
             },
             constants::SYNC_STATUS => match sync.get_sync_status(pname, &self.base) {
-                Some(status) => UInt32Value(status),
-                None => UInt32Value(constants::UNSIGNALED),
+                Some(status) => retval.set(UInt32Value(status)),
+                None => retval.set(UInt32Value(constants::UNSIGNALED)),
             },
             _ => {
                 self.base.webgl_error(InvalidEnum);
-                NullValue()
+                retval.set(NullValue())
             },
         }
     }
@@ -3711,20 +3789,26 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.13>
-    fn GetSamplerParameter(&self, _cx: JSContext, sampler: &WebGLSampler, pname: u32) -> JSVal {
+    fn GetSamplerParameter(
+        &self,
+        _cx: JSContext,
+        sampler: &WebGLSampler,
+        pname: u32,
+        mut retval: MutableHandleValue,
+    ) {
         handle_potential_webgl_error!(
             self.base,
             self.base.validate_ownership(sampler),
-            return NullValue()
+            return retval.set(NullValue())
         );
         match sampler.get_parameter(&self.base, pname) {
             Ok(value) => match value {
-                WebGLSamplerValue::GLenum(value) => UInt32Value(value),
-                WebGLSamplerValue::Float(value) => DoubleValue(value as f64),
+                WebGLSamplerValue::GLenum(value) => retval.set(UInt32Value(value)),
+                WebGLSamplerValue::Float(value) => retval.set(DoubleValue(value as f64)),
             },
             Err(error) => {
                 self.base.webgl_error(error);
-                NullValue()
+                retval.set(NullValue())
             },
         }
     }
@@ -4085,19 +4169,19 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         program: &WebGLProgram,
         indices: Vec<u32>,
         pname: u32,
-    ) -> JSVal {
+        mut rval: MutableHandleValue,
+    ) {
         handle_potential_webgl_error!(
             self.base,
             self.base.validate_ownership(program),
-            return NullValue()
+            return rval.set(NullValue())
         );
         let values = handle_potential_webgl_error!(
             self.base,
             program.get_active_uniforms(indices, pname),
-            return NullValue()
+            return rval.set(NullValue())
         );
 
-        rooted!(in(*cx) let mut rval = UndefinedValue());
         match pname {
             constants::UNIFORM_SIZE |
             constants::UNIFORM_TYPE |
@@ -4105,15 +4189,14 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
             constants::UNIFORM_OFFSET |
             constants::UNIFORM_ARRAY_STRIDE |
             constants::UNIFORM_MATRIX_STRIDE => unsafe {
-                values.to_jsval(*cx, rval.handle_mut());
+                values.to_jsval(*cx, rval);
             },
             constants::UNIFORM_IS_ROW_MAJOR => unsafe {
                 let values = values.iter().map(|&v| v != 0).collect::<Vec<_>>();
-                values.to_jsval(*cx, rval.handle_mut());
+                values.to_jsval(*cx, rval);
             },
             _ => unreachable!(),
         }
-        rval.get()
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.16>
@@ -4138,34 +4221,35 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         program: &WebGLProgram,
         block_index: u32,
         pname: u32,
-    ) -> JSVal {
+        mut retval: MutableHandleValue,
+    ) {
         handle_potential_webgl_error!(
             self.base,
             self.base.validate_ownership(program),
-            return NullValue()
+            return retval.set(NullValue())
         );
         let values = handle_potential_webgl_error!(
             self.base,
             program.get_active_uniform_block_parameter(block_index, pname),
-            return NullValue()
+            return retval.set(NullValue())
         );
         match pname {
             constants::UNIFORM_BLOCK_BINDING |
             constants::UNIFORM_BLOCK_DATA_SIZE |
             constants::UNIFORM_BLOCK_ACTIVE_UNIFORMS => {
                 assert!(values.len() == 1);
-                UInt32Value(values[0] as u32)
+                retval.set(UInt32Value(values[0] as u32))
             },
             constants::UNIFORM_BLOCK_ACTIVE_UNIFORM_INDICES => unsafe {
                 let values = values.iter().map(|&v| v as u32).collect::<Vec<_>>();
                 rooted!(in(*cx) let mut result = ptr::null_mut::<JSObject>());
                 Uint32Array::create(*cx, CreateWith::Slice(&values), result.handle_mut()).unwrap();
-                ObjectValue(result.get())
+                retval.set(ObjectValue(result.get()))
             },
             constants::UNIFORM_BLOCK_REFERENCED_BY_VERTEX_SHADER |
             constants::UNIFORM_BLOCK_REFERENCED_BY_FRAGMENT_SHADER => {
                 assert!(values.len() == 1);
-                BooleanValue(values[0] != 0)
+                retval.set(BooleanValue(values[0] != 0))
             },
             _ => unreachable!(),
         }
@@ -4367,16 +4451,17 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         target: u32,
         internal_format: u32,
         pname: u32,
-    ) -> JSVal {
+        mut retval: MutableHandleValue,
+    ) {
         if target != constants::RENDERBUFFER {
             self.base.webgl_error(InvalidEnum);
-            return NullValue();
+            return retval.set(NullValue());
         }
 
         match handle_potential_webgl_error!(
             self.base,
             InternalFormatParameter::from_u32(pname),
-            return NullValue()
+            return retval.set(NullValue())
         ) {
             InternalFormatParameter::IntVec(param) => unsafe {
                 let (sender, receiver) = webgl_channel().unwrap();
@@ -4395,7 +4480,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
                     rval.handle_mut(),
                 )
                 .unwrap();
-                ObjectValue(rval.get())
+                retval.set(ObjectValue(rval.get()))
             },
         }
     }

--- a/components/script/dom/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl2renderingcontext.rs
@@ -600,7 +600,8 @@ impl WebGL2RenderingContext {
         }
 
         if pname == constants::FRAMEBUFFER_ATTACHMENT_OBJECT_NAME {
-            return Ok(retval.set(NullValue()));
+            retval.set(NullValue());
+            return Ok(());
         }
 
         let attrs = self

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -708,17 +708,22 @@ impl WindowMethods for Window {
         let current = match self.window_proxy.get() {
             Some(proxy) => proxy,
             // Step 2, If current is null, then return null.
-            None => return Ok(retval.set(NullValue())),
+            None => {
+                retval.set(NullValue());
+                return Ok(());
+            },
         };
         // Still step 2, since the window's BC is the associated doc's BC,
         // see https://html.spec.whatwg.org/multipage/#window-bc
         // and a doc's BC is null if it has been discarded.
         // see https://html.spec.whatwg.org/multipage/#concept-document-bc
         if current.is_browsing_context_discarded() {
-            return Ok(retval.set(NullValue()));
+            retval.set(NullValue());
+            return Ok(());
         }
         // Step 3 to 5.
-        Ok(current.opener(*cx, in_realm_proof, retval))
+        current.opener(*cx, in_realm_proof, retval);
+        Ok(())
     }
 
     #[allow(unsafe_code)]

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -33,10 +33,11 @@ use ipc_channel::ipc::{self, IpcSender};
 use ipc_channel::router::ROUTER;
 use js::conversions::ToJSValConvertible;
 use js::jsapi::{GCReason, Heap, JSAutoRealm, JSObject, StackFormat, JSPROP_ENUMERATE, JS_GC};
-use js::jsval::{JSVal, NullValue, UndefinedValue};
+use js::jsval::{NullValue, UndefinedValue};
 use js::rust::wrappers::JS_DefineProperty;
 use js::rust::{
     CustomAutoRooter, CustomAutoRooterGuard, HandleObject, HandleValue, MutableHandleObject,
+    MutableHandleValue,
 };
 use malloc_size_of::MallocSizeOf;
 use media::WindowGLContext;
@@ -697,22 +698,27 @@ impl WindowMethods for Window {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-opener
-    fn GetOpener(&self, cx: JSContext, in_realm_proof: InRealm) -> Fallible<JSVal> {
+    fn GetOpener(
+        &self,
+        cx: JSContext,
+        in_realm_proof: InRealm,
+        mut retval: MutableHandleValue,
+    ) -> Fallible<()> {
         // Step 1, Let current be this Window object's browsing context.
         let current = match self.window_proxy.get() {
             Some(proxy) => proxy,
             // Step 2, If current is null, then return null.
-            None => return Ok(NullValue()),
+            None => return Ok(retval.set(NullValue())),
         };
         // Still step 2, since the window's BC is the associated doc's BC,
         // see https://html.spec.whatwg.org/multipage/#window-bc
         // and a doc's BC is null if it has been discarded.
         // see https://html.spec.whatwg.org/multipage/#concept-document-bc
         if current.is_browsing_context_discarded() {
-            return Ok(NullValue());
+            return Ok(retval.set(NullValue()));
         }
         // Step 3 to 5.
-        Ok(current.opener(*cx, in_realm_proof))
+        Ok(current.opener(*cx, in_realm_proof, retval))
     }
 
     #[allow(unsafe_code)]
@@ -1388,17 +1394,12 @@ impl WindowMethods for Window {
 
     // https://dom.spec.whatwg.org/#dom-window-event
     #[allow(unsafe_code)]
-    fn Event(&self, cx: JSContext) -> JSVal {
-        rooted!(in(*cx) let mut rval = UndefinedValue());
+    fn Event(&self, cx: JSContext, rval: MutableHandleValue) {
         if let Some(ref event) = *self.current_event.borrow() {
             unsafe {
-                event
-                    .reflector()
-                    .get_jsobject()
-                    .to_jsval(*cx, rval.handle_mut());
+                event.reflector().get_jsobject().to_jsval(*cx, rval);
             }
         }
-        rval.get()
     }
 
     fn IsSecureContext(&self) -> bool {
@@ -1571,9 +1572,10 @@ impl WindowMethods for Window {
         cx: JSContext,
         value: HandleValue,
         options: RootedTraceableBox<StructuredSerializeOptions>,
-    ) -> Fallible<js::jsval::JSVal> {
+        retval: MutableHandleValue,
+    ) -> Fallible<()> {
         self.upcast::<GlobalScope>()
-            .structured_clone(cx, value, options)
+            .structured_clone(cx, value, options, retval)
     }
 }
 

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -16,7 +16,7 @@ use dom_struct::dom_struct;
 use ipc_channel::ipc::IpcSender;
 use js::jsval::UndefinedValue;
 use js::panic::maybe_resume_unwind;
-use js::rust::{HandleValue, ParentRuntime};
+use js::rust::{HandleValue, MutableHandleValue, ParentRuntime};
 use net_traits::request::{
     CredentialsMode, Destination, ParserMetadata, RequestBuilder as NetRequestInit,
 };
@@ -439,9 +439,10 @@ impl WorkerGlobalScopeMethods for WorkerGlobalScope {
         cx: JSContext,
         value: HandleValue,
         options: RootedTraceableBox<StructuredSerializeOptions>,
-    ) -> Fallible<js::jsval::JSVal> {
+        retval: MutableHandleValue,
+    ) -> Fallible<()> {
         self.upcast::<GlobalScope>()
-            .structured_clone(cx, value, options)
+            .structured_clone(cx, value, options, retval)
     }
 }
 

--- a/components/script/dom/workernavigator.rs
+++ b/components/script/dom/workernavigator.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use js::jsval::JSVal;
+use js::rust::MutableHandleValue;
 
 use crate::dom::bindings::codegen::Bindings::WorkerNavigatorBinding::WorkerNavigatorMethods;
 use crate::dom::bindings::reflector::{reflect_dom_object, DomObject, Reflector};
@@ -97,8 +97,8 @@ impl WorkerNavigatorMethods for WorkerNavigator {
 
     // https://html.spec.whatwg.org/multipage/#dom-navigator-languages
     #[allow(unsafe_code)]
-    fn Languages(&self, cx: JSContext) -> JSVal {
-        to_frozen_array(&[self.Language()], cx)
+    fn Languages(&self, cx: JSContext, retval: MutableHandleValue) {
+        to_frozen_array(&[self.Language()], cx, retval)
     }
 
     // https://w3c.github.io/permissions/#navigator-and-workernavigator-extension

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -20,9 +20,9 @@ use http::Method;
 use hyper_serde::Serde;
 use ipc_channel::ipc;
 use js::jsapi::{Heap, JS_ClearPendingException};
-use js::jsval::{JSVal, NullValue, UndefinedValue};
+use js::jsval::{JSVal, NullValue};
 use js::rust::wrappers::JS_ParseJSON;
-use js::rust::HandleObject;
+use js::rust::{HandleObject, MutableHandleValue};
 use js::typedarray::{ArrayBuffer, ArrayBufferU8};
 use mime::{self, Mime, Name};
 use net_traits::http_status::HttpStatus;
@@ -935,8 +935,7 @@ impl XMLHttpRequestMethods for XMLHttpRequest {
 
     #[allow(unsafe_code)]
     /// <https://xhr.spec.whatwg.org/#the-response-attribute>
-    fn Response(&self, cx: JSContext, can_gc: CanGc) -> JSVal {
-        rooted!(in(*cx) let mut rval = UndefinedValue());
+    fn Response(&self, cx: JSContext, can_gc: CanGc, mut rval: MutableHandleValue) {
         match self.response_type.get() {
             XMLHttpRequestResponseType::_empty | XMLHttpRequestResponseType::Text => unsafe {
                 let ready_state = self.ready_state.get();
@@ -944,33 +943,29 @@ impl XMLHttpRequestMethods for XMLHttpRequest {
                 if ready_state == XMLHttpRequestState::Done ||
                     ready_state == XMLHttpRequestState::Loading
                 {
-                    self.text_response().to_jsval(*cx, rval.handle_mut());
+                    self.text_response().to_jsval(*cx, rval);
                 } else {
                     // Step 1
-                    "".to_jsval(*cx, rval.handle_mut());
+                    "".to_jsval(*cx, rval);
                 }
             },
             // Step 1
             _ if self.ready_state.get() != XMLHttpRequestState::Done => {
-                return NullValue();
+                return rval.set(NullValue());
             },
             // Step 2
             XMLHttpRequestResponseType::Document => unsafe {
-                self.document_response(can_gc)
-                    .to_jsval(*cx, rval.handle_mut());
+                self.document_response(can_gc).to_jsval(*cx, rval);
             },
-            XMLHttpRequestResponseType::Json => unsafe {
-                self.json_response(cx).to_jsval(*cx, rval.handle_mut());
-            },
+            XMLHttpRequestResponseType::Json => self.json_response(cx, rval),
             XMLHttpRequestResponseType::Blob => unsafe {
-                self.blob_response(can_gc).to_jsval(*cx, rval.handle_mut());
+                self.blob_response(can_gc).to_jsval(*cx, rval);
             },
             XMLHttpRequestResponseType::Arraybuffer => match self.arraybuffer_response(cx) {
-                Some(array_buffer) => unsafe { array_buffer.to_jsval(*cx, rval.handle_mut()) },
-                None => return NullValue(),
+                Some(array_buffer) => unsafe { array_buffer.to_jsval(*cx, rval) },
+                None => return rval.set(NullValue()),
             },
         }
-        rval.get()
     }
 
     /// <https://xhr.spec.whatwg.org/#the-responsetext-attribute>
@@ -1447,17 +1442,17 @@ impl XMLHttpRequest {
 
     #[allow(unsafe_code)]
     /// <https://xhr.spec.whatwg.org/#json-response>
-    fn json_response(&self, cx: JSContext) -> JSVal {
+    fn json_response(&self, cx: JSContext, mut rval: MutableHandleValue) {
         // Step 1
         let response_json = self.response_json.get();
         if !response_json.is_null_or_undefined() {
-            return response_json;
+            return rval.set(response_json);
         }
         // Step 2
         let bytes = self.response.borrow();
         // Step 3
         if bytes.len() == 0 {
-            return NullValue();
+            return rval.set(NullValue());
         }
         // Step 4
         fn decode_to_utf16_with_bom_removal(bytes: &[u8], encoding: &'static Encoding) -> Vec<u16> {
@@ -1480,21 +1475,14 @@ impl XMLHttpRequest {
         // if present, but UTF-16BE/LE BOM must not be honored.
         let json_text = decode_to_utf16_with_bom_removal(&bytes, UTF_8);
         // Step 5
-        rooted!(in(*cx) let mut rval = UndefinedValue());
         unsafe {
-            if !JS_ParseJSON(
-                *cx,
-                json_text.as_ptr(),
-                json_text.len() as u32,
-                rval.handle_mut(),
-            ) {
+            if !JS_ParseJSON(*cx, json_text.as_ptr(), json_text.len() as u32, rval) {
                 JS_ClearPendingException(*cx);
-                return NullValue();
+                return rval.set(NullValue());
             }
         }
         // Step 6
         self.response_json.set(rval.get());
-        self.response_json.get()
     }
 
     fn document_text_html(&self, can_gc: CanGc) -> DomRoot<Document> {

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -951,7 +951,7 @@ impl XMLHttpRequestMethods for XMLHttpRequest {
             },
             // Step 1
             _ if self.ready_state.get() != XMLHttpRequestState::Done => {
-                return rval.set(NullValue());
+                rval.set(NullValue());
             },
             // Step 2
             XMLHttpRequestResponseType::Document => unsafe {
@@ -963,7 +963,7 @@ impl XMLHttpRequestMethods for XMLHttpRequest {
             },
             XMLHttpRequestResponseType::Arraybuffer => match self.arraybuffer_response(cx) {
                 Some(array_buffer) => unsafe { array_buffer.to_jsval(*cx, rval) },
-                None => return rval.set(NullValue()),
+                None => rval.set(NullValue()),
             },
         }
     }

--- a/components/script/dom/xrboundedreferencespace.rs
+++ b/components/script/dom/xrboundedreferencespace.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use js::jsval::JSVal;
+use js::rust::MutableHandleValue;
 
 use crate::dom::bindings::codegen::Bindings::XRBoundedReferenceSpaceBinding::XRBoundedReferenceSpaceMethods;
 use crate::dom::bindings::codegen::Bindings::XRReferenceSpaceBinding::XRReferenceSpaceType;
@@ -67,7 +67,7 @@ impl XRBoundedReferenceSpace {
 
 impl XRBoundedReferenceSpaceMethods for XRBoundedReferenceSpace {
     /// <https://www.w3.org/TR/webxr/#dom-xrboundedreferencespace-boundsgeometry>
-    fn BoundsGeometry(&self, cx: JSContext, can_gc: CanGc) -> JSVal {
+    fn BoundsGeometry(&self, cx: JSContext, can_gc: CanGc, retval: MutableHandleValue) {
         if let Some(bounds) = self.reference_space.get_bounds() {
             let points: Vec<DomRoot<DOMPointReadOnly>> = bounds
                 .into_iter()
@@ -83,9 +83,9 @@ impl XRBoundedReferenceSpaceMethods for XRBoundedReferenceSpace {
                 })
                 .collect();
 
-            to_frozen_array(&points, cx)
+            to_frozen_array(&points, cx, retval)
         } else {
-            to_frozen_array::<DomRoot<DOMPointReadOnly>>(&[], cx)
+            to_frozen_array::<DomRoot<DOMPointReadOnly>>(&[], cx, retval)
         }
     }
 }

--- a/components/script/dom/xrinputsource.rs
+++ b/components/script/dom/xrinputsource.rs
@@ -6,6 +6,7 @@ use dom_struct::dom_struct;
 use js::conversions::ToJSValConvertible;
 use js::jsapi::Heap;
 use js::jsval::{JSVal, UndefinedValue};
+use js::rust::MutableHandleValue;
 use script_traits::GamepadSupportedHapticEffects;
 use webxr_api::{Handedness, InputFrame, InputId, InputSource, TargetRayMode};
 
@@ -159,8 +160,8 @@ impl XRInputSourceMethods for XRInputSource {
         }
     }
     // https://immersive-web.github.io/webxr/#dom-xrinputsource-profiles
-    fn Profiles(&self, _cx: JSContext) -> JSVal {
-        self.profiles.get()
+    fn Profiles(&self, _cx: JSContext, mut retval: MutableHandleValue) {
+        retval.set(self.profiles.get())
     }
 
     /// <https://www.w3.org/TR/webxr/#dom-xrinputsource-skiprendering>

--- a/components/script/dom/xrinputsourceschangeevent.rs
+++ b/components/script/dom/xrinputsourceschangeevent.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::jsapi::Heap;
 use js::jsval::JSVal;
-use js::rust::HandleObject;
+use js::rust::{HandleObject, MutableHandleValue};
 use servo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::Event_Binding::EventMethods;
@@ -87,8 +87,11 @@ impl XRInputSourcesChangeEvent {
         }
         let _ac = enter_realm(global);
         let cx = GlobalScope::get_cx();
-        changeevent.added.set(to_frozen_array(added, cx));
-        changeevent.removed.set(to_frozen_array(removed, cx));
+        rooted!(in(*cx) let mut frozen_val: JSVal);
+        to_frozen_array(added, cx, frozen_val.handle_mut());
+        changeevent.added.set(*frozen_val);
+        to_frozen_array(removed, cx, frozen_val.handle_mut());
+        changeevent.removed.set(*frozen_val);
         changeevent
     }
 }
@@ -121,13 +124,13 @@ impl XRInputSourcesChangeEventMethods for XRInputSourcesChangeEvent {
     }
 
     // https://immersive-web.github.io/webxr/#dom-xrinputsourceschangeevent-added
-    fn Added(&self, _cx: JSContext) -> JSVal {
-        self.added.get()
+    fn Added(&self, _cx: JSContext, mut retval: MutableHandleValue) {
+        retval.set(self.added.get())
     }
 
     // https://immersive-web.github.io/webxr/#dom-xrinputsourceschangeevent-removed
-    fn Removed(&self, _cx: JSContext) -> JSVal {
-        self.removed.get()
+    fn Removed(&self, _cx: JSContext, mut retval: MutableHandleValue) {
+        retval.set(self.removed.get())
     }
 
     // https://dom.spec.whatwg.org/#dom-event-istrusted

--- a/components/script/dom/xrrenderstate.rs
+++ b/components/script/dom/xrrenderstate.rs
@@ -5,7 +5,7 @@
 use std::cell::Cell;
 
 use dom_struct::dom_struct;
-use js::jsval::JSVal;
+use js::rust::MutableHandleValue;
 use webxr_api::SubImages;
 
 use crate::dom::bindings::cell::DomRefCell;
@@ -146,10 +146,10 @@ impl XRRenderStateMethods for XRRenderState {
     }
 
     /// <https://immersive-web.github.io/layers/#dom-xrrenderstate-layers>
-    fn Layers(&self, cx: JSContext) -> JSVal {
+    fn Layers(&self, cx: JSContext, retval: MutableHandleValue) {
         // TODO: cache this array?
         let layers = self.layers.borrow();
         let layers: Vec<&XRLayer> = layers.iter().map(|x| &**x).collect();
-        to_frozen_array(&layers[..], cx)
+        to_frozen_array(&layers[..], cx, retval)
     }
 }

--- a/components/script/dom/xrsession.rs
+++ b/components/script/dom/xrsession.rs
@@ -14,7 +14,7 @@ use euclid::{RigidTransform3D, Transform3D, Vector3D};
 use ipc_channel::ipc::IpcReceiver;
 use ipc_channel::router::ROUTER;
 use js::jsapi::JSObject;
-use js::jsval::JSVal;
+use js::rust::MutableHandleValue;
 use js::typedarray::Float32Array;
 use profile_traits::ipc;
 use servo_atoms::Atom;
@@ -1011,10 +1011,10 @@ impl XRSessionMethods for XRSession {
     }
 
     /// <https://www.w3.org/TR/webxr/#dom-xrsession-enabledfeatures>
-    fn EnabledFeatures(&self, cx: JSContext) -> JSVal {
+    fn EnabledFeatures(&self, cx: JSContext, retval: MutableHandleValue) {
         let session = self.session.borrow();
         let features = session.granted_features();
-        to_frozen_array(features, cx)
+        to_frozen_array(features, cx, retval)
     }
 
     /// <https://www.w3.org/TR/webxr/#dom-xrsession-issystemkeyboardsupported>

--- a/components/script/dom/xrtest.rs
+++ b/components/script/dom/xrtest.rs
@@ -11,6 +11,7 @@ use std::rc::Rc;
 use dom_struct::dom_struct;
 use ipc_channel::ipc::IpcSender;
 use ipc_channel::router::ROUTER;
+use js::jsval::JSVal;
 use profile_traits::ipc;
 use webxr_api::{self, Error as XRError, MockDeviceInit, MockDeviceMsg};
 
@@ -184,7 +185,8 @@ impl XRTestMethods for XRTest {
     /// <https://github.com/immersive-web/webxr-test-api/blob/master/explainer.md>
     fn SimulateUserActivation(&self, f: Rc<Function>) {
         ScriptThread::set_user_interacting(true);
-        let _ = f.Call__(vec![], ExceptionHandling::Rethrow);
+        rooted!(in(*GlobalScope::get_cx()) let mut value: JSVal);
+        let _ = f.Call__(vec![], value.handle_mut(), ExceptionHandling::Rethrow);
         ScriptThread::set_user_interacting(false);
     }
 

--- a/components/script/dom/xrviewerpose.rs
+++ b/components/script/dom/xrviewerpose.rs
@@ -7,6 +7,7 @@ use euclid::RigidTransform3D;
 use js::conversions::ToJSValConvertible;
 use js::jsapi::Heap;
 use js::jsval::{JSVal, UndefinedValue};
+use js::rust::MutableHandleValue;
 use webxr_api::{Viewer, ViewerPose, Views};
 
 use crate::dom::bindings::codegen::Bindings::XRViewBinding::XREye;
@@ -189,7 +190,7 @@ impl XRViewerPose {
 
 impl XRViewerPoseMethods for XRViewerPose {
     /// <https://immersive-web.github.io/webxr/#dom-xrviewerpose-views>
-    fn Views(&self, _cx: JSContext) -> JSVal {
-        self.views.get()
+    fn Views(&self, _cx: JSContext, mut retval: MutableHandleValue) {
+        retval.set(self.views.get())
     }
 }

--- a/components/script/timers.rs
+++ b/components/script/timers.rs
@@ -563,7 +563,8 @@ impl JsTimerTask {
             },
             InternalTimerCallback::FunctionTimerCallback(ref function, ref arguments) => {
                 let arguments = self.collect_heap_args(arguments);
-                let _ = function.Call_(this, arguments, Report);
+                rooted!(in(*GlobalScope::get_cx()) let mut value: JSVal);
+                let _ = function.Call_(this, arguments, value.handle_mut(), Report);
             },
         };
         ScriptThread::set_user_interacting(was_user_interacting);


### PR DESCRIPTION
Returning raw JSVal values makes it easier to create GC hazards in code that calls these methods. Accepting a MutableHandle argument instead ensures that the values are rooted by the caller. As a side benefit, this also allows us to remove a bunch of awkward macro use in the WebGL code. Depends on https://github.com/servo/mozjs/pull/519.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #6307
- [x] There are tests for these changes