### PR TITLE
ReadableStream: Correct ReadableStream::error_native implementation and fix clippy warnings

### DIFF
--- a/components/script/dom/bindings/function.rs
+++ b/components/script/dom/bindings/function.rs
@@ -10,8 +10,8 @@
 #[macro_export]
 macro_rules! native_fn {
     ($call:expr, $name:expr, $nargs:expr, $flags:expr) => {{
-        let cx = crate::dom::types::GlobalScope::get_cx();
-        let fun_obj = crate::native_raw_obj_fn!(cx, $call, $name, $nargs, $flags);
+        let cx = $crate::dom::types::GlobalScope::get_cx();
+        let fun_obj = $crate::native_raw_obj_fn!(cx, $call, $name, $nargs, $flags);
         #[allow(unsafe_code)]
         unsafe {
             Function::new(cx, fun_obj)
@@ -28,13 +28,15 @@ macro_rules! native_fn {
 macro_rules! native_raw_obj_fn {
     ($cx:expr, $call:expr, $name:expr, $nargs:expr, $flags:expr) => {{
         #[allow(unsafe_code)]
+        #[allow(clippy::macro_metavars_in_unsafe)]
         unsafe extern "C" fn wrapper(cx: *mut JSContext, argc: u32, vp: *mut JSVal) -> bool {
             $call(cx, argc, vp)
         }
         #[allow(unsafe_code)]
+        #[allow(clippy::macro_metavars_in_unsafe)]
         unsafe {
             let name: &std::ffi::CStr = $name;
-            let raw_fun = crate::dom::bindings::import::module::jsapi::JS_NewFunction(
+            let raw_fun = $crate::dom::bindings::import::module::jsapi::JS_NewFunction(
                 *$cx,
                 Some(wrapper),
                 $nargs,
@@ -42,7 +44,7 @@ macro_rules! native_raw_obj_fn {
                 name.as_ptr() as *const std::ffi::c_char,
             );
             assert!(!raw_fun.is_null());
-            crate::dom::bindings::import::module::jsapi::JS_GetFunctionObject(raw_fun)
+            $crate::dom::bindings::import::module::jsapi::JS_GetFunctionObject(raw_fun)
         }
     }};
 }

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -3445,9 +3445,10 @@ impl GlobalScope {
     }
 
     pub(crate) fn set_byte_length_queuing_strategy_size(&self, function: Rc<Function>) {
-        if let Err(_) = self
+        if self
             .byte_length_queuing_strategy_size_function
             .set(function)
+            .is_err()
         {
             warn!("byte length queuing strategy size function is set twice.");
         };
@@ -3456,19 +3457,21 @@ impl GlobalScope {
     pub(crate) fn get_byte_length_queuing_strategy_size(&self) -> Option<Rc<Function>> {
         self.byte_length_queuing_strategy_size_function
             .get()
-            .map(|s| s.clone())
+            .cloned()
     }
 
     pub(crate) fn set_count_queuing_strategy_size(&self, function: Rc<Function>) {
-        if let Err(_) = self.count_queuing_strategy_size_function.set(function) {
+        if self
+            .count_queuing_strategy_size_function
+            .set(function)
+            .is_err()
+        {
             warn!("count queuing strategy size function is set twice.");
         };
     }
 
     pub(crate) fn get_count_queuing_strategy_size(&self) -> Option<Rc<Function>> {
-        self.count_queuing_strategy_size_function
-            .get()
-            .map(|s| s.clone())
+        self.count_queuing_strategy_size_function.get().cloned()
     }
 }
 

--- a/components/script/dom/readablestreambyobreader.rs
+++ b/components/script/dom/readablestreambyobreader.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#![allow(dead_code)]
+
 use std::rc::Rc;
 
 use dom_struct::dom_struct;

--- a/components/script/dom/readablestreamdefaultreader.rs
+++ b/components/script/dom/readablestreamdefaultreader.rs
@@ -133,9 +133,6 @@ impl ReadableStreamDefaultReader {
         stream: &ReadableStream,
         can_gc: CanGc,
     ) -> DomRoot<ReadableStreamDefaultReader> {
-        // step 1 & 2
-        let stream = stream;
-
         let promise;
         if stream.is_readable() {
             // step 3
@@ -226,7 +223,7 @@ impl ReadableStreamDefaultReader {
                 unsafe {
                     Error::Type("Cannot release lock due to stream state.".to_owned())
                         .clone()
-                        .to_jsval(*cx, &*self.global(), rval.handle_mut())
+                        .to_jsval(*cx, &self.global(), rval.handle_mut())
                 };
 
                 *self.closed_promise.borrow_mut() =
@@ -256,7 +253,7 @@ impl ReadableStreamDefaultReader {
         unsafe {
             Error::Type("Reader is released".to_owned())
                 .clone()
-                .to_jsval(*cx, &*self.global(), rval.handle_mut())
+                .to_jsval(*cx, &self.global(), rval.handle_mut())
         };
 
         // step 3
@@ -337,7 +334,7 @@ impl ReadableStreamDefaultReaderMethods for ReadableStreamDefaultReader {
             unsafe {
                 Error::Type("stream is undefined".to_owned())
                     .clone()
-                    .to_jsval(*cx, &*self.global(), rval.handle_mut())
+                    .to_jsval(*cx, &self.global(), rval.handle_mut())
             };
             return Promise::new_rejected(&self.global(), cx, rval.handle()).unwrap();
         }
@@ -357,13 +354,11 @@ impl ReadableStreamDefaultReaderMethods for ReadableStreamDefaultReader {
     /// <https://streams.spec.whatwg.org/#default-reader-release-lock>
     #[allow(unsafe_code)]
     fn ReleaseLock(&self) {
-        if self.stream.get().is_none() {
-            // step 1
-            return;
-        } else {
-            // step 2
+        if self.stream.get().is_some() {
+            // step 2 - Perform ! ReadableStreamDefaultReaderRelease(this).
             self.release();
         }
+        // step 1 - If this.[[stream]] is undefined, return.
     }
 
     /// <https://streams.spec.whatwg.org/#generic-reader-closed>

--- a/components/script/dom/underlyingsourcecontainer.rs
+++ b/components/script/dom/underlyingsourcecontainer.rs
@@ -38,12 +38,12 @@ pub enum UnderlyingSourceType {
 impl UnderlyingSourceType {
     /// Is the source backed by a Rust native source?
     pub fn is_native(&self) -> bool {
-        match self {
+        matches!(
+            self,
             UnderlyingSourceType::Memory(_) |
-            UnderlyingSourceType::Blob(_) |
-            UnderlyingSourceType::FetchResponse => true,
-            _ => false,
-        }
+                UnderlyingSourceType::Blob(_) |
+                UnderlyingSourceType::FetchResponse
+        )
     }
 
     /// Does the source have all data in memory?
@@ -65,7 +65,7 @@ impl UnderlyingSourceContainer {
     fn new_inherited(underlying_source_type: UnderlyingSourceType) -> UnderlyingSourceContainer {
         UnderlyingSourceContainer {
             reflector_: Reflector::new(),
-            underlying_source_type: underlying_source_type,
+            underlying_source_type,
         }
     }
 
@@ -143,8 +143,7 @@ impl UnderlyingSourceContainer {
                     let promise = Promise::new_with_js_promise(result_object.handle(), cx);
                     promise
                 } else {
-                    let global = self.global();
-                    let promise = Promise::new(&*global, can_gc);
+                    let promise = Promise::new(&self.global(), can_gc);
                     promise.resolve_native(&result);
                     promise
                 };


### PR DESCRIPTION
Part of https://github.com/servo/servo/issues/32898

I tried to finish remaining TODOs e.g `error_native` and fix clippy warnings

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
