### PR TITLE
Replace ComputedValues with WritingMode on IndefiniteContainingBlock

### DIFF
--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -1826,10 +1826,9 @@ impl FlexItem<'_> {
         } else {
             (
                 cross_size.auto_is(|| {
-                    let style = ifc.style().clone();
                     let containing_block_for_children =
-                        IndefiniteContainingBlock::new_for_style_and_block_size(
-                            &style,
+                        IndefiniteContainingBlock::new_for_writing_mode_and_block_size(
+                            item_writing_mode,
                             AuOrAuto::LengthPercentage(used_main_size),
                         );
                     let content_contributions = ifc
@@ -2439,9 +2438,12 @@ impl FlexItemBox {
         // > preferred aspect ratio, by any definite minimum and maximum cross sizes converted through the
         // > aspect ratio.
         let main_content_size = if cross_axis_is_item_block_axis {
-            let style = self.independent_formatting_context.style().clone();
+            let writing_mode = self.independent_formatting_context.style().writing_mode;
             let containing_block_for_children =
-                IndefiniteContainingBlock::new_for_style_and_block_size(&style, cross_size);
+                IndefiniteContainingBlock::new_for_writing_mode_and_block_size(
+                    writing_mode,
+                    cross_size,
+                );
             self.independent_formatting_context
                 .inline_content_sizes(
                     layout_context,
@@ -2596,7 +2598,7 @@ impl FlexItemBox {
                 let flex_basis = if cross_axis_is_item_block_axis {
                     // The main axis is the inline axis, so we can get the content size from the normal
                     // preferred widths calculation.
-                    let style = flex_item.style().clone();
+                    let writing_mode = flex_item.style().writing_mode;
                     let block_size = content_box_size.cross.map(|v| {
                         v.clamp_between_extremums(
                             content_min_box_size.cross,
@@ -2604,7 +2606,10 @@ impl FlexItemBox {
                         )
                     });
                     let containing_block_for_children =
-                        IndefiniteContainingBlock::new_for_style_and_block_size(&style, block_size);
+                        IndefiniteContainingBlock::new_for_writing_mode_and_block_size(
+                            writing_mode,
+                            block_size,
+                        );
                     let max_content = flex_item
                         .inline_content_sizes(
                             layout_context,
@@ -2690,9 +2695,10 @@ impl FlexItemBox {
                         if item_with_auto_cross_size_stretches_to_container_size {
                             containing_block_inline_size_minus_pbm
                         } else {
-                            let style = non_replaced.style.clone();
                             let containing_block_for_children =
-                                IndefiniteContainingBlock::new_for_style(&style);
+                                IndefiniteContainingBlock::new_for_writing_mode(
+                                    non_replaced.style.writing_mode,
+                                );
                             non_replaced
                                 .inline_content_sizes(
                                     flex_context.layout_context,

--- a/components/layout_2020/flow/inline/mod.rs
+++ b/components/layout_2020/flow/inline/mod.rs
@@ -2188,7 +2188,7 @@ fn inline_container_needs_strut(
 /// A struct which takes care of computing [`ContentSizes`] for an [`InlineFormattingContext`].
 struct ContentSizesComputation<'layout_data> {
     layout_context: &'layout_data LayoutContext<'layout_data>,
-    containing_block: &'layout_data IndefiniteContainingBlock<'layout_data>,
+    containing_block: &'layout_data IndefiniteContainingBlock,
     paragraph: ContentSizes,
     current_line: ContentSizes,
     /// Size for whitespace pending to be added to this line.
@@ -2236,14 +2236,14 @@ impl<'layout_data> ContentSizesComputation<'layout_data> {
                 let zero = Au::zero();
                 let padding = inline_box
                     .style
-                    .padding(self.containing_block.style.writing_mode)
+                    .padding(self.containing_block.writing_mode)
                     .percentages_relative_to(zero);
                 let border = inline_box
                     .style
-                    .border_width(self.containing_block.style.writing_mode);
+                    .border_width(self.containing_block.writing_mode);
                 let margin = inline_box
                     .style
-                    .margin(self.containing_block.style.writing_mode)
+                    .margin(self.containing_block.writing_mode)
                     .percentages_relative_to(zero)
                     .auto_is(Au::zero);
 

--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -235,7 +235,7 @@ impl OutsideMarker {
     ) -> Fragment {
         let content_sizes = self.block_container.inline_content_sizes(
             layout_context,
-            &IndefiniteContainingBlock::new_for_style(&self.marker_style),
+            &IndefiniteContainingBlock::new_for_writing_mode(self.marker_style.writing_mode),
         );
         let containing_block_for_children = ContainingBlock {
             inline_size: content_sizes.sizes.max_content,
@@ -2058,8 +2058,8 @@ impl IndependentFormattingContext {
 
                 let mut get_content_size = || {
                     let containing_block_for_children =
-                        IndefiniteContainingBlock::new_for_style_and_block_size(
-                            &style,
+                        IndefiniteContainingBlock::new_for_writing_mode_and_block_size(
+                            style.writing_mode,
                             tentative_block_size,
                         );
                     non_replaced

--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -547,7 +547,10 @@ impl HoistedAbsolutelyPositionedBox {
         // tentative block size.
         let mut inline_axis = inline_axis_solver.solve(Some(|| {
             let containing_block_for_children =
-                IndefiniteContainingBlock::new_for_style_and_block_size(&style, block_axis.size);
+                IndefiniteContainingBlock::new_for_writing_mode_and_block_size(
+                    style.writing_mode,
+                    block_axis.size,
+                );
             context
                 .inline_content_sizes(
                     layout_context,

--- a/components/layout_2020/replaced.rs
+++ b/components/layout_2020/replaced.rs
@@ -277,7 +277,7 @@ impl ReplacedContent {
                 depends_on_block_constraints: true,
             },
             _ => {
-                let writing_mode = containing_block_for_children.style.writing_mode;
+                let writing_mode = containing_block_for_children.writing_mode;
                 InlineContentSizesResult {
                     sizes: self
                         .flow_relative_natural_size(writing_mode)
@@ -423,8 +423,7 @@ impl ReplacedContent {
         style
             .preferred_aspect_ratio(
                 self.inline_size_over_block_size_intrinsic_ratio(style),
-                containing_block.try_into().ok().as_ref(),
-                containing_block.style.writing_mode,
+                containing_block,
             )
             .or_else(|| {
                 matches!(self.kind, ReplacedContentKind::Video(_)).then(|| {

--- a/components/layout_2020/sizing.rs
+++ b/components/layout_2020/sizing.rs
@@ -162,7 +162,10 @@ pub(crate) fn outer_inline(
         })
         .map_or(AuOrAuto::Auto, AuOrAuto::LengthPercentage);
         let containing_block_for_children =
-            IndefiniteContainingBlock::new_for_style_and_block_size(style, block_size);
+            IndefiniteContainingBlock::new_for_writing_mode_and_block_size(
+                style.writing_mode,
+                block_size,
+            );
         get_content_size(&containing_block_for_children)
     });
     let resolve_non_initial = |inline_size| {

--- a/components/layout_2020/table/layout.rs
+++ b/components/layout_2020/table/layout.rs
@@ -301,7 +301,9 @@ impl<'a> TableLayout<'a> {
                             .contents
                             .inline_content_sizes(
                                 layout_context,
-                                &IndefiniteContainingBlock::new_for_style(&cell.style),
+                                &IndefiniteContainingBlock::new_for_writing_mode(
+                                    cell.style.writing_mode,
+                                ),
                             )
                             .sizes
                     };
@@ -774,6 +776,8 @@ impl<'a> TableLayout<'a> {
 
     /// Compute CAPMIN: <https://drafts.csswg.org/css-tables/#capmin>
     fn compute_caption_minimum_inline_size(&mut self, layout_context: &LayoutContext) -> Au {
+        let containing_block =
+            IndefiniteContainingBlock::new_for_writing_mode(self.table.style.writing_mode);
         self.table
             .captions
             .iter()
@@ -782,7 +786,7 @@ impl<'a> TableLayout<'a> {
                 context
                     .outer_inline_content_sizes(
                         layout_context,
-                        &IndefiniteContainingBlock::new_for_style(&self.table.style),
+                        &containing_block,
                         &LogicalVec2::zero(),
                         false, /* auto_block_size_stretches_to_containing_block */
                     )
@@ -2628,7 +2632,7 @@ impl Table {
         layout_context: &LayoutContext,
         containing_block_for_children: &IndefiniteContainingBlock,
     ) -> InlineContentSizesResult {
-        let writing_mode = containing_block_for_children.style.writing_mode;
+        let writing_mode = containing_block_for_children.writing_mode;
         let mut layout = TableLayout::new(self);
         let mut table_content_sizes = layout.compute_grid_min_max(layout_context, writing_mode);
 


### PR DESCRIPTION
We only need the writing mode, not the entire computed style.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because there should be no behavior change

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
