### PR TITLE
Remove assert on controller having a stream within should call pull

### DIFF
--- a/components/script/dom/readablestreamdefaultcontroller.rs
+++ b/components/script/dom/readablestreamdefaultcontroller.rs
@@ -328,11 +328,14 @@ impl ReadableStreamDefaultController {
     }
 
     /// <https://streams.spec.whatwg.org/#readable-stream-default-controller-should-call-pull>
-    fn should_pull(&self) -> bool {
-        let stream = self
-            .stream
-            .get()
-            .expect("Controller must have a stream when the should pull algo is called into.");
+    fn should_call_pull(&self) -> bool {
+        // Let stream be controller.[[stream]].
+        // Note: the spec does not assert that stream is not undefined here,
+        // so we return false if it is.
+        let Some(stream) = self.stream.get() else {
+            debug!("`should_call_pull` called on a controller without a stream.");
+            return false;
+        };
 
         // If ! ReadableStreamDefaultControllerCanCloseOrEnqueue(controller) is false, return.
         if !self.can_close_or_enqueue() {
@@ -363,7 +366,7 @@ impl ReadableStreamDefaultController {
 
     /// <https://streams.spec.whatwg.org/#readable-stream-default-controller-call-pull-if-needed>
     fn call_pull_if_needed(&self, can_gc: CanGc) {
-        if !self.should_pull() {
+        if !self.should_call_pull() {
             return;
         }
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
The spec doesn't assert, so I think we were too eager to do so in that spot. 

Fixes a "Controller must have a stream when the should pull algo is called into." CRASH of tee.any.js.

The test still crashes elsewhere though with:
```called `Result::unwrap()` on an `Err` value: () (thread Script(1,1), at /Users/Gregory/Projects/servo/target/debug/build/script-5f068b888146758c/out/Bindings/UnderlyingSourceBinding.rs:168)```

To be investigated separately.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
