### PR TITLE
Fix call to to_jsobject in underlying source algos

### DIFF
--- a/components/script/dom/underlyingsourcecontainer.rs
+++ b/components/script/dom/underlyingsourcecontainer.rs
@@ -6,7 +6,7 @@ use std::ptr;
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
-use js::jsapi::{IsPromiseObject, JSObject};
+use js::jsapi::{IsPromiseObject, JSObject, JS_NewObject};
 use js::rust::IntoHandle;
 
 use crate::dom::bindings::callback::ExceptionHandling;
@@ -94,7 +94,11 @@ impl UnderlyingSourceContainer {
             if let Some(pull) = &source.pull {
                 let cx = GlobalScope::get_cx();
                 rooted!(in(*cx) let mut this_object = ptr::null_mut::<JSObject>());
+                // TODO: move this into `bindings`.
                 unsafe {
+                    let obj = JS_NewObject(*cx, ptr::null_mut());
+                    assert!(!obj.is_null());
+                    this_object.set(obj);
                     source.to_jsobject(*cx, this_object.handle_mut());
                 }
                 let this_handle = this_object.handle();
@@ -125,7 +129,11 @@ impl UnderlyingSourceContainer {
             if let Some(start) = &source.start {
                 let cx = GlobalScope::get_cx();
                 rooted!(in(*cx) let mut this_object = ptr::null_mut::<JSObject>());
+                // TODO: move this into `bindings`.
                 unsafe {
+                    let obj = JS_NewObject(*cx, ptr::null_mut());
+                    assert!(!obj.is_null());
+                    this_object.set(obj);
                     source.to_jsobject(*cx, this_object.handle_mut());
                 }
                 let this_handle = this_object.handle();


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This fixes quite a lot of different crashes like ```called `Result::unwrap()` on an `Err` value: () (thread Script(1,1), at /Users/Gregory/Projects/servo/target/debug/build/script-5f068b888146758c/out/Bindings/UnderlyingSourceBinding.rs:168)```

which relate to the `set_dictionary_property` call within `UnderlyingSource::to_jsobject`, which we call each time we want to call into an algo, for example [in the start algo](https://github.com/servo/servo/blob/b460d74a42333eb5b552e33a6958c3b0df1bb50d/components/script/dom/underlyingsourcecontainer.rs#L129)

The problem was a null object was passed to the call to `to_jsobject`, which is now replaced to one created using `JS_NewObject`.

Various test still fails, but later at [the actual JS call](https://github.com/servo/servo/blob/be4f79de49e3f7276137d958daf0bae474bc247e/components/script/dom/underlyingsourcecontainer.rs#L134) which returns `JS_Failed`. To be investigated separately. 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
