### PR TITLE
frozen array in XRInputSourcesChangeEvent, update `to_frozen_array` doc

### DIFF
--- a/components/script/dom/bindings/utils.rs
+++ b/components/script/dom/bindings/utils.rs
@@ -116,7 +116,7 @@ impl Clone for DOMJSClass {
 }
 unsafe impl Sync for DOMJSClass {}
 
-/// Returns a JSVal representing a frozen array of ports
+/// Returns a JSVal representing the frozen JavaScript array
 pub fn to_frozen_array<T: ToJSValConvertible>(convertibles: &[T], cx: SafeJSContext) -> JSVal {
     rooted!(in(*cx) let mut ports = UndefinedValue());
     unsafe { convertibles.to_jsval(*cx, ports.handle_mut()) };

--- a/components/script/dom/xrinputsourceschangeevent.rs
+++ b/components/script/dom/xrinputsourceschangeevent.rs
@@ -3,9 +3,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use js::conversions::ToJSValConvertible;
 use js::jsapi::Heap;
-use js::jsval::{JSVal, UndefinedValue};
+use js::jsval::JSVal;
 use js::rust::HandleObject;
 use servo_atoms::Atom;
 
@@ -17,6 +16,7 @@ use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::{reflect_dom_object_with_proto, DomObject};
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::DOMString;
+use crate::dom::bindings::utils::to_frozen_array;
 use crate::dom::event::Event;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::window::Window;
@@ -88,12 +88,12 @@ impl XRInputSourcesChangeEvent {
         let _ac = enter_realm(global);
         let cx = GlobalScope::get_cx();
         unsafe {
-            rooted!(in(*cx) let mut added_val = UndefinedValue());
-            added.to_jsval(*cx, added_val.handle_mut());
-            changeevent.added.set(added_val.get());
-            rooted!(in(*cx) let mut removed_val = UndefinedValue());
-            removed.to_jsval(*cx, removed_val.handle_mut());
-            changeevent.removed.set(removed_val.get());
+            changeevent
+                .added
+                .set(to_frozen_array(added, JSContext::from_ptr(*cx)));
+            changeevent
+                .removed
+                .set(to_frozen_array(removed, JSContext::from_ptr(*cx)));
         }
 
         changeevent

--- a/components/script/dom/xrinputsourceschangeevent.rs
+++ b/components/script/dom/xrinputsourceschangeevent.rs
@@ -87,15 +87,8 @@ impl XRInputSourcesChangeEvent {
         }
         let _ac = enter_realm(global);
         let cx = GlobalScope::get_cx();
-        unsafe {
-            changeevent
-                .added
-                .set(to_frozen_array(added, JSContext::from_ptr(*cx)));
-            changeevent
-                .removed
-                .set(to_frozen_array(removed, JSContext::from_ptr(*cx)));
-        }
-
+        changeevent.added.set(to_frozen_array(added, cx));
+        changeevent.removed.set(to_frozen_array(removed, cx));
         changeevent
     }
 }

--- a/tests/wpt/tests/webxr/events_input_sources_change.https.html
+++ b/tests/wpt/tests/webxr/events_input_sources_change.https.html
@@ -5,6 +5,7 @@
 <script src="resources/webxr_test_constants.js"></script>
 
 <script>
+"use strict"
 let testName = "Transient input sources fire events in the right order";
 
 let watcherDone = new Event("watcherdone");
@@ -24,6 +25,17 @@ let testFunction = function(session, fakeDeviceController, t) {
       inputChangeEvents++;
       assert_equals(event.session, session);
       validateSameObject(event);
+
+      assert_throws_js(
+          TypeError,
+          () => { event.added[0] = "test"; },
+          "added array must be frozen"
+      );
+      assert_throws_js(
+          TypeError,
+          () => { event.removed[0] = "test"; },
+          "removed array must be frozen"
+      );
 
       // The first change event should be adding our controller.
       if (inputChangeEvents === 1) {


### PR DESCRIPTION
PR Description
Issue:

1. `XRInputSourcesChangeEvent` was not using `to_frozen_array` for array conversion, leading to manual conversions inconsistent with WebXR spec requirements. 
2. `to_frozen_array` rustdoc comment needs to be updated.

Changes:
1. Replaced manual conversions with `to_frozen_array`
2. Used `JSContext::from_ptr(*cx)` for context creation
3. Changed `to_frozen_array` rustdoc comment to reflect broader usage
4. Add tests to ensure `XRInputSourcesChangeEvent` `.added` and `.removed` are frozen arrays, with assertions that modifications throw `TypeError`.

Test:
`tests/wpt/tests/webxr/events_input_sources_change.https.html`
---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #34050 

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
