### PR TITLE
Fix `already mutably borrowed` crash

### DIFF
--- a/components/script/dom/readablestreamdefaultcontroller.rs
+++ b/components/script/dom/readablestreamdefaultcontroller.rs
@@ -528,24 +528,26 @@ impl ReadableStreamDefaultController {
         };
         value_with_size.value.set(*object);
 
-        // Let enqueueResult be EnqueueValueWithSize(controller, chunk, chunkSize).
-        let mut queue = self.queue.borrow_mut();
-        if let Err(error) = queue.enqueue_value_with_size(EnqueuedValue::Js(value_with_size)) {
-            // If enqueueResult is an abrupt completion,
+        {
+            // Let enqueueResult be EnqueueValueWithSize(controller, chunk, chunkSize).
+            let mut queue = self.queue.borrow_mut();
+            if let Err(error) = queue.enqueue_value_with_size(EnqueuedValue::Js(value_with_size)) {
+                // If enqueueResult is an abrupt completion,
 
-            rooted!(in(*cx) let mut rval = UndefinedValue());
-            // TODO: check if this is the right globalscope.
-            unsafe {
-                error
-                    .clone()
-                    .to_jsval(*cx, &self.global(), rval.handle_mut())
-            };
+                rooted!(in(*cx) let mut rval = UndefinedValue());
+                // TODO: check if this is the right globalscope.
+                unsafe {
+                    error
+                        .clone()
+                        .to_jsval(*cx, &self.global(), rval.handle_mut())
+                };
 
-            // Perform ! ReadableStreamDefaultControllerError(controller, enqueueResult.[[Value]]).
-            self.error(rval.handle());
+                // Perform ! ReadableStreamDefaultControllerError(controller, enqueueResult.[[Value]]).
+                self.error(rval.handle());
 
-            // Return enqueueResult.
-            return Err(error);
+                // Return enqueueResult.
+                return Err(error);
+            }
         }
 
         // Perform ! ReadableStreamDefaultControllerCallPullIfNeeded(controller).


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Fix `already mutably borrowed` crash in #34064

```
  │ already mutably borrowed: BorrowError (thread Script(1,1), at components/script/dom/readablestreamdefaultcontroller.rs:633)
  │    0: servoshell::backtrace::print
  │    1: servoshell::panic_hook::panic_hook
  │    2: std::panicking::rust_panic_with_hook
  │    3: std::panicking::begin_panic_handler::{{closure}}
  │    4: std::sys_common::backtrace::__rust_end_short_backtrace
  │    5: rust_begin_unwind
  │    6: core::panicking::panic_fmt
  │    7: core::cell::panic_already_mutably_borrowed
  │    8: script::dom::readablestreamdefaultcontroller::ReadableStreamDefaultController::get_desired_size
  │    9: script::dom::readablestreamdefaultcontroller::ReadableStreamDefaultController::call_pull_if_needed
  │   10: script::dom::readablestreamdefaultcontroller::ReadableStreamDefaultController::enqueue
  ```

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
