### PR TITLE
ohos: Fix mach build on windows hosts

### DIFF
--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -138,11 +138,11 @@ class MachCommands(CommandBase):
                 if rv:
                     return rv
 
-            if sys.platform == "win32":
+            if "windows" in target_triple:
                 if not copy_windows_dlls_to_build_directory(built_binary, self.target):
                     status = 1
 
-            elif sys.platform == "darwin":
+            elif "darwin" in target_triple:
                 servo_bin_dir = os.path.dirname(built_binary)
                 assert os.path.exists(servo_bin_dir)
 


### PR DESCRIPTION
With the latest release (5.0) of the OpenHarmony SDK libclang.dll is now available and we can support
building for OpenHarmony from windows hosts.

Other changes required for building OH on windows:
- We can't use the `<target_triple>-clang` wrappers, since those are bash scripts, which fails on windows when cc-rs tries to directly call them. However, we already pass all the required flags the wrapper script would set, so this is not an issue.
- We need to use posix paths, otherwise the sysroot parameter will not be applied correctly (by bindgen). It seems to only cause issues with bindgen in practice, possibly because bindgen interprets the path with [`shlex::split`](https://github.com/rust-lang/rust-bindgen/blob/8a6d851318153b7304b651a7fd8f559938683de3/bindgen/lib.rs#L312C27-L312C40) which presumably causes the issues with windows paths. To be consistent I decided to use posix paths for all paths.
- Fix checks for copying dlls. We need to check the target OS, not the host OS when determining what libraries to copy.
- Note: This PR just focuses on `./mach build --ohos --no-package`. Improving the packaging workflow on windows 
  can be done in a follow-up PR.

We could test that this scenario works in CI, but then again CI already takes quite a long time, so I'm not sure if its worth it.

---

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix building servo for OpenHarmony on Windows machines.\
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

