### PR TITLE
Remove unnecessary clamping in `used_size_as_if_inline_element()`

### DIFF
--- a/components/layout_2020/replaced.rs
+++ b/components/layout_2020/replaced.rs
@@ -447,19 +447,13 @@ impl ReplacedContent {
         style: &ComputedValues,
         content_box_sizes_and_pbm: &ContentBoxSizesAndPBMDeprecated,
     ) -> LogicalVec2<Au> {
-        // We need to clamp to zero here to obtain the proper aspect ratio when box-sizing
-        // is border-box and the inner box size would otherwise be negative.
-        let content_box_size = content_box_sizes_and_pbm
-            .content_box_size
-            .map(|value| value.map(|value| value.max(Au::zero())));
-        let content_min_box_size = content_box_sizes_and_pbm
-            .content_min_box_size
-            .auto_is(Au::zero);
         self.used_size_as_if_inline_element_from_content_box_sizes(
             containing_block,
             style,
-            content_box_size,
-            content_min_box_size,
+            content_box_sizes_and_pbm.content_box_size,
+            content_box_sizes_and_pbm
+                .content_min_box_size
+                .auto_is(Au::zero),
             content_box_sizes_and_pbm.content_max_box_size,
         )
     }


### PR DESCRIPTION
We don't need to floor the preferred box sizes to be at least zero, since `used_size_as_if_inline_element_from_content_box_sizes()` will take care of applying min and max constraints, and the min has been floored to be at least zero.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because there is no behavior change

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
