### PR TITLE
Cleanup: malloc_size_of for NodeIterator and HTMLCollection

### DIFF
--- a/components/script/dom/htmlcollection.rs
+++ b/components/script/dom/htmlcollection.rs
@@ -56,7 +56,7 @@ impl OptionU32 {
 pub struct HTMLCollection {
     reflector_: Reflector,
     root: Dom<Node>,
-    #[ignore_malloc_size_of = "Contains a trait object; can't measure due to #6870"]
+    #[ignore_malloc_size_of = "Trait object (Box<dyn CollectionFilter>) cannot be sized"]
     filter: Box<dyn CollectionFilter + 'static>,
     // We cache the version of the root node and all its decendents,
     // the length of the collection, and a cursor into the collection.

--- a/components/script/dom/nodeiterator.rs
+++ b/components/script/dom/nodeiterator.rs
@@ -25,7 +25,7 @@ pub struct NodeIterator {
     reference_node: MutDom<Node>,
     pointer_before_reference_node: Cell<bool>,
     what_to_show: u32,
-    #[ignore_malloc_size_of = "Can't measure due to #6870"]
+    #[ignore_malloc_size_of = "Rc<NodeFilter> has shared ownership, so its size cannot be measured accurately"]
     filter: Filter,
     active: Cell<bool>,
 }


### PR DESCRIPTION
File Changes:
components/script/dom/nodeiterator.rs
components/script/dom/htmlcollection.rs

This pull request addresses cleanup related to the malloc_size_of macro for the NodeIterator and HTMLCollection components.
- Removed the ignore_malloc_size_of annotation from NodeIterator involving Rc<NodeFilterBinding::NodeFilter>. 
- Retained the ignore_malloc_size_of annotation for HTMLCollection, specifically for Box<dyn CollectionFilter>. Since trait objects in Rust can't have their size accurately measured due to dynamic dispatch, the ignore_malloc_size_of annotation remains necessary here.

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #25682 
- [X] These changes do not require tests because they do not modify functionality
