### PR TITLE
Fix GC borrow hazards triggered by LoadBlocker::terminate

### DIFF
--- a/components/script/document_loader.rs
+++ b/components/script/document_loader.rs
@@ -11,6 +11,7 @@ use net_traits::request::RequestBuilder;
 use net_traits::{fetch_async, BoxedFetchCallback, ResourceThreads};
 use servo_url::ServoUrl;
 
+use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::root::Dom;
 use crate::dom::document::Document;
 use crate::fetch::FetchCanceller;
@@ -49,11 +50,12 @@ impl LoadBlocker {
     }
 
     /// Remove this load from the associated document's list of blocking loads.
-    pub fn terminate(blocker: &mut Option<LoadBlocker>, can_gc: CanGc) {
-        if let Some(this) = blocker.as_mut() {
-            this.doc.finish_load(this.load.take().unwrap(), can_gc);
+    pub fn terminate(blocker: &DomRefCell<Option<LoadBlocker>>, can_gc: CanGc) {
+        if let Some(this) = blocker.borrow().as_ref() {
+            let load_data = this.load.clone().unwrap();
+            this.doc.finish_load(load_data, can_gc);
         }
-        *blocker = None;
+        *blocker.borrow_mut() = None;
     }
 }
 

--- a/components/script/document_loader.rs
+++ b/components/script/document_loader.rs
@@ -51,10 +51,10 @@ impl LoadBlocker {
 
     /// Remove this load from the associated document's list of blocking loads.
     pub fn terminate(blocker: &DomRefCell<Option<LoadBlocker>>, can_gc: CanGc) {
-        let Some(mut this) = blocker.borrow_mut().take() else {
-            return;
-        };
-        this.doc.finish_load(this.load.take().unwrap(), can_gc);
+        if let Some(this) = blocker.borrow().as_ref() {
+            let load_data = this.load.clone().unwrap();
+            this.doc.finish_load(load_data, can_gc);
+        }
         *blocker.borrow_mut() = None;
     }
 }

--- a/components/script/document_loader.rs
+++ b/components/script/document_loader.rs
@@ -51,10 +51,10 @@ impl LoadBlocker {
 
     /// Remove this load from the associated document's list of blocking loads.
     pub fn terminate(blocker: &DomRefCell<Option<LoadBlocker>>, can_gc: CanGc) {
-        if let Some(this) = blocker.borrow().as_ref() {
-            let load_data = this.load.clone().unwrap();
-            this.doc.finish_load(load_data, can_gc);
-        }
+        let Some(mut this) = blocker.borrow_mut().take() else {
+            return;
+        };
+        this.doc.finish_load(this.load.take().unwrap(), can_gc);
         *blocker.borrow_mut() = None;
     }
 }

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -146,10 +146,10 @@ impl HTMLIFrameElement {
         let document = document_from_node(self);
 
         {
-            let mut load_blocker = self.load_blocker.borrow_mut();
+            let load_blocker = &self.load_blocker;
             // Any oustanding load is finished from the point of view of the blocked
             // document; the new navigation will continue blocking it.
-            LoadBlocker::terminate(&mut load_blocker, can_gc);
+            LoadBlocker::terminate(&load_blocker, can_gc);
         }
 
         if load_data.url.scheme() == "javascript" {
@@ -422,8 +422,8 @@ impl HTMLIFrameElement {
         // Only terminate the load blocker if the pipeline id was updated due to a traversal.
         // The load blocker will be terminated for a navigation in iframe_load_event_steps.
         if reason == UpdatePipelineIdReason::Traversal {
-            let mut blocker = self.load_blocker.borrow_mut();
-            LoadBlocker::terminate(&mut blocker, can_gc);
+            let blocker = &self.load_blocker;
+            LoadBlocker::terminate(&blocker, can_gc);
         }
 
         self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
@@ -507,8 +507,8 @@ impl HTMLIFrameElement {
         self.upcast::<EventTarget>()
             .fire_event(atom!("load"), can_gc);
 
-        let mut blocker = self.load_blocker.borrow_mut();
-        LoadBlocker::terminate(&mut blocker, can_gc);
+        let blocker = &self.load_blocker;
+        LoadBlocker::terminate(&blocker, can_gc);
 
         // TODO Step 5 - unset child document `mut iframe load` flag
     }
@@ -740,8 +740,8 @@ impl VirtualMethods for HTMLIFrameElement {
     fn unbind_from_tree(&self, context: &UnbindContext) {
         self.super_type().unwrap().unbind_from_tree(context);
 
-        let mut blocker = self.load_blocker.borrow_mut();
-        LoadBlocker::terminate(&mut blocker, CanGc::note());
+        let blocker = &self.load_blocker;
+        LoadBlocker::terminate(&blocker, CanGc::note());
 
         // https://html.spec.whatwg.org/multipage/#a-browsing-context-is-discarded
         let window = window_from_node(self);

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -149,7 +149,7 @@ impl HTMLIFrameElement {
             let load_blocker = &self.load_blocker;
             // Any oustanding load is finished from the point of view of the blocked
             // document; the new navigation will continue blocking it.
-            LoadBlocker::terminate(&load_blocker, can_gc);
+            LoadBlocker::terminate(load_blocker, can_gc);
         }
 
         if load_data.url.scheme() == "javascript" {
@@ -423,7 +423,7 @@ impl HTMLIFrameElement {
         // The load blocker will be terminated for a navigation in iframe_load_event_steps.
         if reason == UpdatePipelineIdReason::Traversal {
             let blocker = &self.load_blocker;
-            LoadBlocker::terminate(&blocker, can_gc);
+            LoadBlocker::terminate(blocker, can_gc);
         }
 
         self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
@@ -508,7 +508,7 @@ impl HTMLIFrameElement {
             .fire_event(atom!("load"), can_gc);
 
         let blocker = &self.load_blocker;
-        LoadBlocker::terminate(&blocker, can_gc);
+        LoadBlocker::terminate(blocker, can_gc);
 
         // TODO Step 5 - unset child document `mut iframe load` flag
     }
@@ -741,7 +741,7 @@ impl VirtualMethods for HTMLIFrameElement {
         self.super_type().unwrap().unbind_from_tree(context);
 
         let blocker = &self.load_blocker;
-        LoadBlocker::terminate(&blocker, CanGc::note());
+        LoadBlocker::terminate(blocker, CanGc::note());
 
         // https://html.spec.whatwg.org/multipage/#a-browsing-context-is-discarded
         let window = window_from_node(self);

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -154,7 +154,7 @@ struct ImageRequest {
     #[no_trace]
     parsed_url: Option<ServoUrl>,
     source_url: Option<USVString>,
-    blocker: Option<LoadBlocker>,
+    blocker: DomRefCell<Option<LoadBlocker>>,
     #[ignore_malloc_size_of = "Arc"]
     #[no_trace]
     image: Option<Arc<Image>>,
@@ -431,7 +431,7 @@ impl HTMLImageElement {
         self.current_request.borrow_mut().final_url = Some(url);
         self.current_request.borrow_mut().image = Some(image);
         self.current_request.borrow_mut().state = State::CompletelyAvailable;
-        LoadBlocker::terminate(&mut self.current_request.borrow_mut().blocker, can_gc);
+        LoadBlocker::terminate(&self.current_request.borrow().blocker, can_gc);
         // Mark the node dirty
         self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
         self.resolve_image_decode_promises();
@@ -537,7 +537,7 @@ impl HTMLImageElement {
             ImageRequestPhase::Current => self.current_request.borrow_mut(),
             ImageRequestPhase::Pending => self.pending_request.borrow_mut(),
         };
-        LoadBlocker::terminate(&mut request.blocker, can_gc);
+        LoadBlocker::terminate(&request.blocker, can_gc);
         request.state = state;
         request.image = None;
         request.metadata = None;
@@ -821,8 +821,11 @@ impl HTMLImageElement {
         request.image = None;
         request.metadata = None;
         let document = document_from_node(self);
-        LoadBlocker::terminate(&mut request.blocker, can_gc);
-        request.blocker = Some(LoadBlocker::new(&document, LoadType::Image(url.clone())));
+        LoadBlocker::terminate(&request.blocker, can_gc);
+        request.blocker = DomRefCell::new(Some(LoadBlocker::new(
+            &document,
+            LoadType::Image(url.clone()),
+        )));
     }
 
     /// Step 13-17 of html.spec.whatwg.org/multipage/#update-the-image-data
@@ -853,7 +856,7 @@ impl HTMLImageElement {
                             // Step 15 abort pending request
                             pending_request.image = None;
                             pending_request.parsed_url = None;
-                            LoadBlocker::terminate(&mut pending_request.blocker, can_gc);
+                            LoadBlocker::terminate(&pending_request.blocker, can_gc);
                             // TODO: queue a task to restart animation, if restart-animation is set
                             return;
                         }
@@ -1311,7 +1314,7 @@ impl HTMLImageElement {
                 source_url: None,
                 image: None,
                 metadata: None,
-                blocker: None,
+                blocker: DomRefCell::new(None),
                 final_url: None,
                 current_pixel_density: None,
             }),
@@ -1321,7 +1324,7 @@ impl HTMLImageElement {
                 source_url: None,
                 image: None,
                 metadata: None,
-                blocker: None,
+                blocker: DomRefCell::new(None),
                 final_url: None,
                 current_pixel_density: None,
             }),

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -822,10 +822,8 @@ impl HTMLImageElement {
         request.metadata = None;
         let document = document_from_node(self);
         LoadBlocker::terminate(&request.blocker, can_gc);
-        request.blocker = DomRefCell::new(Some(LoadBlocker::new(
-            &document,
-            LoadType::Image(url.clone()),
-        )));
+        *request.blocker.borrow_mut() =
+            Some(LoadBlocker::new(&document, LoadType::Image(url.clone())));
     }
 
     /// Step 13-17 of html.spec.whatwg.org/multipage/#update-the-image-data

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -516,7 +516,7 @@ impl HTMLMediaElement {
             *blocker.borrow_mut() =
                 Some(LoadBlocker::new(&document_from_node(self), LoadType::Media));
         } else if !delay && blocker.borrow().is_some() {
-            LoadBlocker::terminate(&blocker, can_gc);
+            LoadBlocker::terminate(blocker, can_gc);
         }
     }
 

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -511,11 +511,12 @@ impl HTMLMediaElement {
     ///
     /// <https://html.spec.whatwg.org/multipage/#delaying-the-load-event-flag>
     pub fn delay_load_event(&self, delay: bool, can_gc: CanGc) {
-        let mut blocker = self.delaying_the_load_event_flag.borrow_mut();
-        if delay && blocker.is_none() {
-            *blocker = Some(LoadBlocker::new(&document_from_node(self), LoadType::Media));
-        } else if !delay && blocker.is_some() {
-            LoadBlocker::terminate(&mut blocker, can_gc);
+        let blocker = &self.delaying_the_load_event_flag;
+        if delay && blocker.borrow().is_none() {
+            *blocker.borrow_mut() =
+                Some(LoadBlocker::new(&document_from_node(self), LoadType::Media));
+        } else if !delay && blocker.borrow().is_some() {
+            LoadBlocker::terminate(&blocker, can_gc);
         }
     }
 

--- a/components/script/dom/htmlvideoelement.rs
+++ b/components/script/dom/htmlvideoelement.rs
@@ -226,7 +226,7 @@ impl HTMLVideoElement {
         // (which triggers no media load algorithm unless a explicit call to .load() is done)
         // will block the document's load event forever.
         let blocker = &self.load_blocker;
-        LoadBlocker::terminate(&blocker, can_gc);
+        LoadBlocker::terminate(blocker, can_gc);
         *blocker.borrow_mut() = Some(LoadBlocker::new(
             &document_from_node(self),
             LoadType::Image(poster_url.clone()),

--- a/components/script/dom/htmlvideoelement.rs
+++ b/components/script/dom/htmlvideoelement.rs
@@ -225,9 +225,9 @@ impl HTMLVideoElement {
         // <video poster="poster.png"></video>
         // (which triggers no media load algorithm unless a explicit call to .load() is done)
         // will block the document's load event forever.
-        let mut blocker = self.load_blocker.borrow_mut();
-        LoadBlocker::terminate(&mut blocker, can_gc);
-        *blocker = Some(LoadBlocker::new(
+        let blocker = &self.load_blocker;
+        LoadBlocker::terminate(&blocker, can_gc);
+        *blocker.borrow_mut() = Some(LoadBlocker::new(
             &document_from_node(self),
             LoadType::Image(poster_url.clone()),
         ));
@@ -309,13 +309,13 @@ impl ImageCacheListener for HTMLVideoElement {
             ImageResponse::Loaded(image, url) => {
                 debug!("Loaded poster image for video element: {:?}", url);
                 self.htmlmediaelement.process_poster_image_loaded(image);
-                LoadBlocker::terminate(&mut self.load_blocker.borrow_mut(), can_gc);
+                LoadBlocker::terminate(&self.load_blocker, can_gc);
             },
             ImageResponse::MetadataLoaded(..) => {},
             // The image cache may have loaded a placeholder for an invalid poster url
             ImageResponse::PlaceholderLoaded(..) | ImageResponse::None => {
                 // A failed load should unblock the document load.
-                LoadBlocker::terminate(&mut self.load_blocker.borrow_mut(), can_gc);
+                LoadBlocker::terminate(&self.load_blocker, can_gc);
             },
         }
     }

--- a/tests/wpt/meta/dom/ranges/Range-cloneContents.html.ini
+++ b/tests/wpt/meta/dom/ranges/Range-cloneContents.html.ini
@@ -1,2 +1,0 @@
-[Range-cloneContents.html]
-  expected: ERROR

--- a/tests/wpt/meta/dom/ranges/Range-deleteContents.html.ini
+++ b/tests/wpt/meta/dom/ranges/Range-deleteContents.html.ini
@@ -1,2 +1,0 @@
-[Range-deleteContents.html]
-  expected: ERROR

--- a/tests/wpt/meta/dom/ranges/Range-extractContents.html.ini
+++ b/tests/wpt/meta/dom/ranges/Range-extractContents.html.ini
@@ -1,2 +1,0 @@
-[Range-extractContents.html]
-  expected: ERROR

--- a/tests/wpt/meta/dom/ranges/Range-insertNode.html.ini
+++ b/tests/wpt/meta/dom/ranges/Range-insertNode.html.ini
@@ -1,2 +1,0 @@
-[Range-insertNode.html]
-  expected: ERROR

--- a/tests/wpt/meta/dom/ranges/Range-surroundContents.html.ini
+++ b/tests/wpt/meta/dom/ranges/Range-surroundContents.html.ini
@@ -1,2 +1,0 @@
-[Range-surroundContents.html]
-  expected: ERROR


### PR DESCRIPTION
Fixes GC borrow hazards triggered by LoadBlocker::terminate


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #34108 
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
