### PR TITLE
Implement `ImageBitmap.close`

### DIFF
--- a/components/script/dom/webidls/ImageBitmap.webidl
+++ b/components/script/dom/webidls/ImageBitmap.webidl
@@ -14,7 +14,7 @@
 interface ImageBitmap {
   readonly attribute unsigned long width;
   readonly attribute unsigned long height;
-  //void close();
+  undefined close();
 };
 
 typedef (CanvasImageSource or

--- a/tests/wpt/meta/html/dom/idlharness.https.html.ini
+++ b/tests/wpt/meta/html/dom/idlharness.https.html.ini
@@ -662,9 +662,6 @@
   [CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "filter" with the proper type]
     expected: FAIL
 
-  [ImageBitmap interface: operation close()]
-    expected: FAIL
-
   [DataTransfer interface: attribute files]
     expected: FAIL
 

--- a/tests/wpt/meta/html/dom/idlharness.worker.js.ini
+++ b/tests/wpt/meta/html/dom/idlharness.worker.js.ini
@@ -170,9 +170,6 @@
   [WorkerGlobalScope interface: attribute ononline]
     expected: FAIL
 
-  [ImageBitmap interface: operation close()]
-    expected: FAIL
-
   [OffscreenCanvasRenderingContext2D interface: operation setLineDash(sequence<unrestricted double>)]
     expected: FAIL
 


### PR DESCRIPTION
Implements https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#dom-imagebitmap-close.

This doesn't pass any tests in [`html/canvas/element/manual/imagebitmap`](https://github.com/servo/servo/tree/main/tests/wpt/meta/html/canvas/element/manual/imagebitmap) because (among other things)  those use `window.createImageBitmap` with a `ImageData` argument. We don't support this, but I have a patch ready, if this gets merged.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are a part of https://github.com/servo/servo/issues/34112
- [X] There are tests for these changes 

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
