### PR TITLE
CI: Higher timeout for mac unit tests

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -107,7 +107,7 @@ jobs:
         if: ${{ inputs.unit-tests }}
         uses: nick-fields/retry@v3
         with:
-          timeout_minutes: 20 # https://github.com/servo/servo/issues/30275
+          timeout_minutes: 40 # https://github.com/servo/servo/issues/30275
           max_attempts: 3 # https://github.com/servo/servo/issues/30683
           command: python3 ./mach test-unit --${{ inputs.profile }}
       - name: Build mach package


### PR DESCRIPTION
I noticed that in practice it takes about ~30min to run unit tests.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because only CI timeout change

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
