### PR TITLE
Optimize Document::Fonts() creation to reduce GC and remove CanGc from Window::reflow()

### DIFF
--- a/components/script/canvas_state.rs
+++ b/components/script/canvas_state.rs
@@ -737,13 +737,8 @@ impl CanvasState {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-shadowcolor
-    pub fn set_shadow_color(
-        &self,
-        canvas: Option<&HTMLCanvasElement>,
-        value: DOMString,
-        can_gc: CanGc,
-    ) {
-        if let Ok(rgba) = parse_color(canvas, &value, can_gc) {
+    pub fn set_shadow_color(&self, canvas: Option<&HTMLCanvasElement>, value: DOMString) {
+        if let Ok(rgba) = parse_color(canvas, &value) {
             self.state.borrow_mut().shadow_color = rgba;
             self.send_canvas_2d_msg(Canvas2dMsg::SetShadowColor(rgba))
         }
@@ -771,11 +766,10 @@ impl CanvasState {
         &self,
         canvas: Option<&HTMLCanvasElement>,
         value: StringOrCanvasGradientOrCanvasPattern,
-        can_gc: CanGc,
     ) {
         match value {
             StringOrCanvasGradientOrCanvasPattern::String(string) => {
-                if let Ok(rgba) = parse_color(canvas, &string, can_gc) {
+                if let Ok(rgba) = parse_color(canvas, &string) {
                     self.state.borrow_mut().stroke_style = CanvasFillOrStrokeStyle::Color(rgba);
                 }
             },
@@ -815,11 +809,10 @@ impl CanvasState {
         &self,
         canvas: Option<&HTMLCanvasElement>,
         value: StringOrCanvasGradientOrCanvasPattern,
-        can_gc: CanGc,
     ) {
         match value {
             StringOrCanvasGradientOrCanvasPattern::String(string) => {
-                if let Ok(rgba) = parse_color(canvas, &string, can_gc) {
+                if let Ok(rgba) = parse_color(canvas, &string) {
                     self.state.borrow_mut().fill_style = CanvasFillOrStrokeStyle::Color(rgba);
                 }
             },
@@ -1009,7 +1002,6 @@ impl CanvasState {
         x: f64,
         y: f64,
         max_width: Option<f64>,
-        can_gc: CanGc,
     ) {
         if !x.is_finite() || !y.is_finite() {
             return;
@@ -1018,11 +1010,7 @@ impl CanvasState {
             return;
         }
         if self.state.borrow().font_style.is_none() {
-            self.set_font(
-                canvas,
-                CanvasContextState::DEFAULT_FONT_STYLE.into(),
-                can_gc,
-            )
+            self.set_font(canvas, CanvasContextState::DEFAULT_FONT_STYLE.into())
         }
 
         let is_rtl = match self.state.borrow().direction {
@@ -1048,14 +1036,9 @@ impl CanvasState {
         global: &GlobalScope,
         canvas: Option<&HTMLCanvasElement>,
         text: DOMString,
-        can_gc: CanGc,
     ) -> DomRoot<TextMetrics> {
         if self.state.borrow().font_style.is_none() {
-            self.set_font(
-                canvas,
-                CanvasContextState::DEFAULT_FONT_STYLE.into(),
-                can_gc,
-            );
+            self.set_font(canvas, CanvasContextState::DEFAULT_FONT_STYLE.into());
         }
 
         let (sender, receiver) = ipc::channel::<CanvasTextMetrics>().unwrap();
@@ -1080,18 +1063,17 @@ impl CanvasState {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-font
-    pub fn set_font(&self, canvas: Option<&HTMLCanvasElement>, value: DOMString, can_gc: CanGc) {
+    pub fn set_font(&self, canvas: Option<&HTMLCanvasElement>, value: DOMString) {
         let canvas = match canvas {
             Some(element) => element,
             None => return, // offscreen canvas doesn't have a placeholder canvas
         };
         let node = canvas.upcast::<Node>();
         let window = window_from_node(canvas);
-        let resolved_font_style =
-            match window.resolved_font_style_query(node, value.to_string(), can_gc) {
-                Some(value) => value,
-                None => return, // syntax error
-            };
+        let resolved_font_style = match window.resolved_font_style_query(node, value.to_string()) {
+            Some(value) => value,
+            None => return, // syntax error
+        };
         self.state.borrow_mut().font_style = Some((*resolved_font_style).clone());
         self.send_canvas_2d_msg(Canvas2dMsg::SetFont((*resolved_font_style).clone()));
     }
@@ -1735,11 +1717,7 @@ impl CanvasState {
     }
 }
 
-pub fn parse_color(
-    canvas: Option<&HTMLCanvasElement>,
-    string: &str,
-    can_gc: CanGc,
-) -> Result<AbsoluteColor, ()> {
+pub fn parse_color(canvas: Option<&HTMLCanvasElement>, string: &str) -> Result<AbsoluteColor, ()> {
     let mut input = ParserInput::new(string);
     let mut parser = Parser::new(&mut input);
     let url = Url::parse("about:blank").unwrap().into();
@@ -1767,8 +1745,8 @@ pub fn parse_color(
                 None => AbsoluteColor::BLACK,
                 Some(canvas) => {
                     let canvas_element = canvas.upcast::<Element>();
-                    match canvas_element.style(can_gc) {
-                        Some(ref s) if canvas_element.has_css_layout_box(can_gc) => {
+                    match canvas_element.style() {
+                        Some(ref s) if canvas_element.has_css_layout_box() => {
                             s.get_inherited_text().color
                         },
                         _ => AbsoluteColor::BLACK,

--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -190,7 +190,6 @@ pub fn handle_get_attribute_style(
     pipeline: PipelineId,
     node_id: String,
     reply: IpcSender<Option<Vec<NodeStyle>>>,
-    can_gc: CanGc,
 ) {
     let node = match find_node_by_unique_id(documents, pipeline, &node_id) {
         None => return reply.send(None).unwrap(),
@@ -207,7 +206,7 @@ pub fn handle_get_attribute_style(
             let name = style.Item(i);
             NodeStyle {
                 name: name.to_string(),
-                value: style.GetPropertyValue(name.clone(), can_gc).to_string(),
+                value: style.GetPropertyValue(name.clone()).to_string(),
                 priority: style.GetPropertyPriority(name).to_string(),
             }
         })
@@ -224,7 +223,6 @@ pub fn handle_get_stylesheet_style(
     selector: String,
     stylesheet: usize,
     reply: IpcSender<Option<Vec<NodeStyle>>>,
-    can_gc: CanGc,
 ) {
     let msg = (|| {
         let node = find_node_by_unique_id(documents, pipeline, &node_id)?;
@@ -250,7 +248,7 @@ pub fn handle_get_stylesheet_style(
                     let name = style.Item(i);
                     NodeStyle {
                         name: name.to_string(),
-                        value: style.GetPropertyValue(name.clone(), can_gc).to_string(),
+                        value: style.GetPropertyValue(name.clone()).to_string(),
                         priority: style.GetPropertyPriority(name).to_string(),
                     }
                 })
@@ -305,7 +303,6 @@ pub fn handle_get_computed_style(
     pipeline: PipelineId,
     node_id: String,
     reply: IpcSender<Option<Vec<NodeStyle>>>,
-    can_gc: CanGc,
 ) {
     let node = match find_node_by_unique_id(documents, pipeline, &node_id) {
         None => return reply.send(None).unwrap(),
@@ -323,9 +320,7 @@ pub fn handle_get_computed_style(
             let name = computed_style.Item(i);
             NodeStyle {
                 name: name.to_string(),
-                value: computed_style
-                    .GetPropertyValue(name.clone(), can_gc)
-                    .to_string(),
+                value: computed_style.GetPropertyValue(name.clone()).to_string(),
                 priority: computed_style.GetPropertyPriority(name).to_string(),
             }
         })
@@ -365,7 +360,7 @@ pub fn handle_get_layout(
             position: String::from(computed_style.Position()),
             z_index: String::from(computed_style.ZIndex()),
             box_sizing: String::from(computed_style.BoxSizing()),
-            auto_margins: determine_auto_margins(&node, can_gc),
+            auto_margins: determine_auto_margins(&node),
             margin_top: String::from(computed_style.MarginTop()),
             margin_right: String::from(computed_style.MarginRight()),
             margin_bottom: String::from(computed_style.MarginBottom()),
@@ -384,8 +379,8 @@ pub fn handle_get_layout(
         .unwrap();
 }
 
-fn determine_auto_margins(node: &Node, can_gc: CanGc) -> AutoMargins {
-    let style = node.style(can_gc).unwrap();
+fn determine_auto_margins(node: &Node) -> AutoMargins {
+    let style = node.style().unwrap();
     let margin = style.get_margin();
     AutoMargins {
         top: margin.margin_top.is_auto(),

--- a/components/script/dom/activation.rs
+++ b/components/script/dom/activation.rs
@@ -37,21 +37,13 @@ pub trait Activatable {
         self.as_element().set_active_state(true);
 
         let win = window_from_node(self.as_element());
-        win.reflow(
-            ReflowGoal::Full,
-            ReflowReason::ElementStateChanged,
-            CanGc::note(),
-        );
+        win.reflow(ReflowGoal::Full, ReflowReason::ElementStateChanged);
     }
 
     fn exit_formal_activation_state(&self) {
         self.as_element().set_active_state(false);
 
         let win = window_from_node(self.as_element());
-        win.reflow(
-            ReflowGoal::Full,
-            ReflowReason::ElementStateChanged,
-            CanGc::note(),
-        );
+        win.reflow(ReflowGoal::Full, ReflowReason::ElementStateChanged);
     }
 }

--- a/components/script/dom/bindings/codegen/Bindings.conf
+++ b/components/script/dom/bindings/codegen/Bindings.conf
@@ -63,7 +63,7 @@ DOMInterfaces = {
 },
 
 'CanvasRenderingContext2D': {
-    'canGc': ['GetTransform','GetImageData', 'CreateImageData', 'CreateImageData_', 'SetFont', 'FillText', 'MeasureText', 'SetStrokeStyle', 'SetFillStyle', 'SetShadowColor'],
+    'canGc': ['GetTransform','GetImageData', 'CreateImageData', 'CreateImageData_'],
 },
 
 'CharacterData': {
@@ -71,11 +71,7 @@ DOMInterfaces = {
 },
 
 'CSSStyleDeclaration': {
-    'canGc': ['RemoveProperty', 'SetCssText', 'GetPropertyValue', 'SetProperty', 'CssFloat', 'SetCssFloat']
-},
-
-'CanvasGradient': {
-    'canGc': ['AddColorStop'],
+    'canGc': ['RemoveProperty', 'SetCssText', 'SetProperty', 'SetCssFloat']
 },
 
 'CustomElementRegistry': {
@@ -112,7 +108,7 @@ DOMInterfaces = {
 },
 
 'Document': {
-    'canGc': ['Close', 'CreateElement', 'CreateElementNS', 'ImportNode', 'SetTitle', 'Write', 'Writeln', 'CreateEvent', 'CreateRange', 'Open', 'Open_', 'CreateComment', 'CreateAttribute', 'CreateAttributeNS', 'CreateDocumentFragment', 'CreateTextNode', 'CreateCDATASection', 'CreateProcessingInstruction', 'Prepend', 'Append', 'ReplaceChildren', 'SetBgColor', 'SetFgColor', 'Fonts', 'ElementFromPoint', 'ElementsFromPoint', 'ExitFullscreen'],
+    'canGc': ['Close', 'CreateElement', 'CreateElementNS', 'ImportNode', 'SetTitle', 'Write', 'Writeln', 'CreateEvent', 'CreateRange', 'Open', 'Open_', 'CreateComment', 'CreateAttribute', 'CreateAttributeNS', 'CreateDocumentFragment', 'CreateTextNode', 'CreateCDATASection', 'CreateProcessingInstruction', 'Prepend', 'Append', 'ReplaceChildren', 'SetBgColor', 'SetFgColor', 'ExitFullscreen'],
 },
 
 'DynamicModuleOwner': {
@@ -136,7 +132,7 @@ DOMInterfaces = {
 },
 
 'Element': {
-    'canGc': ['SetInnerHTML', 'SetOuterHTML', 'InsertAdjacentHTML', 'GetClientRects', 'GetBoundingClientRect', 'InsertAdjacentText', 'ToggleAttribute', 'SetAttribute', 'SetAttributeNS', 'SetId','SetClassName','Prepend','Append','ReplaceChildren','Before','After','ReplaceWith', 'SetRole', 'SetAriaAtomic', 'SetAriaAutoComplete', 'SetAriaBrailleLabel', 'SetAriaBrailleRoleDescription', 'SetAriaBusy', 'SetAriaChecked', 'SetAriaColCount', 'SetAriaColIndex', 'SetAriaColIndexText', 'SetAriaColSpan', 'SetAriaCurrent', 'SetAriaDescription', 'SetAriaDisabled', 'SetAriaExpanded', 'SetAriaHasPopup', 'SetAriaHidden', 'SetAriaInvalid', 'SetAriaKeyShortcuts', 'SetAriaLabel', 'SetAriaLevel', 'SetAriaLive', 'SetAriaModal', 'SetAriaMultiLine', 'SetAriaMultiSelectable', 'SetAriaOrientation', 'SetAriaPlaceholder', 'SetAriaPosInSet', 'SetAriaPressed','SetAriaReadOnly', 'SetAriaRelevant', 'SetAriaRequired', 'SetAriaRoleDescription', 'SetAriaRowCount', 'SetAriaRowIndex', 'SetAriaRowIndexText', 'SetAriaRowSpan', 'SetAriaSelected', 'SetAriaSetSize','SetAriaSort', 'SetAriaValueMax', 'SetAriaValueMin', 'SetAriaValueNow', 'SetAriaValueText', 'SetScrollTop', 'SetScrollLeft', 'Scroll', 'Scroll_', 'ScrollBy', 'ScrollBy_', 'ScrollWidth', 'ScrollHeight', 'ScrollTop', 'ScrollLeft', 'ClientTop', 'ClientLeft', 'ClientWidth', 'ClientHeight', 'RequestFullscreen'],
+    'canGc': ['SetInnerHTML', 'SetOuterHTML', 'InsertAdjacentHTML', 'GetClientRects', 'GetBoundingClientRect', 'InsertAdjacentText', 'ToggleAttribute', 'SetAttribute', 'SetAttributeNS', 'SetId','SetClassName','Prepend','Append','ReplaceChildren','Before','After','ReplaceWith', 'SetRole', 'SetAriaAtomic', 'SetAriaAutoComplete', 'SetAriaBrailleLabel', 'SetAriaBrailleRoleDescription', 'SetAriaBusy', 'SetAriaChecked', 'SetAriaColCount', 'SetAriaColIndex', 'SetAriaColIndexText', 'SetAriaColSpan', 'SetAriaCurrent', 'SetAriaDescription', 'SetAriaDisabled', 'SetAriaExpanded', 'SetAriaHasPopup', 'SetAriaHidden', 'SetAriaInvalid', 'SetAriaKeyShortcuts', 'SetAriaLabel', 'SetAriaLevel', 'SetAriaLive', 'SetAriaModal', 'SetAriaMultiLine', 'SetAriaMultiSelectable', 'SetAriaOrientation', 'SetAriaPlaceholder', 'SetAriaPosInSet', 'SetAriaPressed','SetAriaReadOnly', 'SetAriaRelevant', 'SetAriaRequired', 'SetAriaRoleDescription', 'SetAriaRowCount', 'SetAriaRowIndex', 'SetAriaRowIndexText', 'SetAriaRowSpan', 'SetAriaSelected', 'SetAriaSetSize','SetAriaSort', 'SetAriaValueMax', 'SetAriaValueMin', 'SetAriaValueNow', 'SetAriaValueText', 'RequestFullscreen'],
 },
 
 'ElementInternals': {
@@ -212,7 +208,7 @@ DOMInterfaces = {
 },
 
 'HTMLElement': {
-    'canGc': ['Focus', 'Blur', 'Click', 'SetInnerText', 'SetOuterText', "SetTranslate", 'SetAutofocus', 'GetOffsetParent', 'OffsetTop', 'OffsetLeft', 'OffsetWidth', 'OffsetHeight', 'InnerText', 'GetOuterText', 'GetOnerror', 'GetOnload', 'GetOnblur', 'GetOnfocus', 'GetOnresize', 'GetOnscroll'],
+    'canGc': ['Focus', 'Blur', 'Click', 'SetInnerText', 'SetOuterText', "SetTranslate", 'SetAutofocus', 'GetOnerror', 'GetOnload', 'GetOnblur', 'GetOnfocus', 'GetOnresize', 'GetOnscroll'],
 },
 
 'HTMLFieldSetElement': {
@@ -228,7 +224,7 @@ DOMInterfaces = {
 },
 
 'HTMLImageElement': {
-    'canGc': ['RequestSubmit', 'ReportValidity', 'Reset','SetRel', 'Width', 'Height', 'Decode', 'SetCrossOrigin', 'SetWidth', 'SetHeight', 'SetReferrerPolicy'],
+    'canGc': ['RequestSubmit', 'ReportValidity', 'Reset','SetRel', 'Decode', 'SetCrossOrigin', 'SetWidth', 'SetHeight', 'SetReferrerPolicy'],
 },
 
 'HTMLFontElement': {
@@ -337,10 +333,6 @@ DOMInterfaces = {
     'canGc': ['GetMetadata'],
 },
 
-'MouseEvent': {
-    'canGc': ['OffsetX', 'OffsetY'],
-},
-
 'MediaQueryList': {
     'weakReferenceable': True,
 },
@@ -369,11 +361,11 @@ DOMInterfaces = {
 },
 
 'OffscreenCanvasRenderingContext2D': {
-    'canGc': ['CreateImageData', 'CreateImageData_', 'GetImageData', 'GetTransform', 'SetFont', 'FillText', 'MeasureText', 'SetStrokeStyle', 'SetFillStyle', 'SetShadowColor'],
+    'canGc': ['CreateImageData', 'CreateImageData_', 'GetImageData', 'GetTransform'],
 },
 
 'PaintRenderingContext2D': {
-    'canGc': ['GetTransform', 'SetStrokeStyle', 'SetFillStyle', 'SetShadowColor'],
+    'canGc': ['GetTransform'],
 },
 
 'Performance': {
@@ -424,10 +416,6 @@ DOMInterfaces = {
     'canGc': ['Register'],
 },
 
-'ShadowRoot': {
-    'canGc': ['ElementFromPoint', 'ElementsFromPoint'],
-},
-
 'StaticRange': {
     'weakReferenceable': True,
 },
@@ -470,7 +458,7 @@ DOMInterfaces = {
 },
 
 'Window': {
-    'canGc': ['Stop', 'Fetch', 'Scroll', 'Scroll_','ScrollBy', 'ScrollBy_', 'Stop', 'Fetch', 'Open', 'CreateImageBitmap'],
+    'canGc': ['Stop', 'Fetch', 'Stop', 'Fetch', 'Open', 'CreateImageBitmap'],
     'inRealms': ['Fetch', 'GetOpener'],
 },
 

--- a/components/script/dom/canvasgradient.rs
+++ b/components/script/dom/canvasgradient.rs
@@ -16,7 +16,6 @@ use crate::dom::bindings::reflector::{reflect_dom_object, Reflector};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
-use crate::script_runtime::CanGc;
 
 // https://html.spec.whatwg.org/multipage/#canvasgradient
 #[dom_struct]
@@ -49,12 +48,12 @@ impl CanvasGradient {
 
 impl CanvasGradientMethods for CanvasGradient {
     // https://html.spec.whatwg.org/multipage/#dom-canvasgradient-addcolorstop
-    fn AddColorStop(&self, offset: Finite<f64>, color: DOMString, can_gc: CanGc) -> ErrorResult {
+    fn AddColorStop(&self, offset: Finite<f64>, color: DOMString) -> ErrorResult {
         if *offset < 0f64 || *offset > 1f64 {
             return Err(Error::IndexSize);
         }
 
-        let color = match parse_color(None, &color, can_gc) {
+        let color = match parse_color(None, &color) {
             Ok(color) => color,
             Err(_) => return Err(Error::Syntax),
         };

--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -285,16 +285,16 @@ impl CanvasRenderingContext2DMethods for CanvasRenderingContext2D {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-filltext
-    fn FillText(&self, text: DOMString, x: f64, y: f64, max_width: Option<f64>, can_gc: CanGc) {
+    fn FillText(&self, text: DOMString, x: f64, y: f64, max_width: Option<f64>) {
         self.canvas_state
-            .fill_text(self.canvas.as_deref(), text, x, y, max_width, can_gc);
+            .fill_text(self.canvas.as_deref(), text, x, y, max_width);
         self.mark_as_dirty();
     }
 
     // https://html.spec.whatwg.org/multipage/#textmetrics
-    fn MeasureText(&self, text: DOMString, can_gc: CanGc) -> DomRoot<TextMetrics> {
+    fn MeasureText(&self, text: DOMString) -> DomRoot<TextMetrics> {
         self.canvas_state
-            .measure_text(&self.global(), self.canvas.as_deref(), text, can_gc)
+            .measure_text(&self.global(), self.canvas.as_deref(), text)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-font
@@ -303,9 +303,8 @@ impl CanvasRenderingContext2DMethods for CanvasRenderingContext2D {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-font
-    fn SetFont(&self, value: DOMString, can_gc: CanGc) {
-        self.canvas_state
-            .set_font(self.canvas.as_deref(), value, can_gc)
+    fn SetFont(&self, value: DOMString) {
+        self.canvas_state.set_font(self.canvas.as_deref(), value)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-textalign
@@ -452,9 +451,9 @@ impl CanvasRenderingContext2DMethods for CanvasRenderingContext2D {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-strokestyle
-    fn SetStrokeStyle(&self, value: StringOrCanvasGradientOrCanvasPattern, can_gc: CanGc) {
+    fn SetStrokeStyle(&self, value: StringOrCanvasGradientOrCanvasPattern) {
         self.canvas_state
-            .set_stroke_style(self.canvas.as_deref(), value, can_gc)
+            .set_stroke_style(self.canvas.as_deref(), value)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-strokestyle
@@ -463,9 +462,9 @@ impl CanvasRenderingContext2DMethods for CanvasRenderingContext2D {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-strokestyle
-    fn SetFillStyle(&self, value: StringOrCanvasGradientOrCanvasPattern, can_gc: CanGc) {
+    fn SetFillStyle(&self, value: StringOrCanvasGradientOrCanvasPattern) {
         self.canvas_state
-            .set_fill_style(self.canvas.as_deref(), value, can_gc)
+            .set_fill_style(self.canvas.as_deref(), value)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-createimagedata
@@ -657,9 +656,9 @@ impl CanvasRenderingContext2DMethods for CanvasRenderingContext2D {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-shadowcolor
-    fn SetShadowColor(&self, value: DOMString, can_gc: CanGc) {
+    fn SetShadowColor(&self, value: DOMString) {
         self.canvas_state
-            .set_shadow_color(self.canvas.as_deref(), value, can_gc)
+            .set_shadow_color(self.canvas.as_deref(), value)
     }
 }
 

--- a/components/script/dom/cssstyledeclaration.rs
+++ b/components/script/dom/cssstyledeclaration.rs
@@ -192,7 +192,7 @@ macro_rules! css_properties(
                     $id.enabled_for_all_content(),
                     "Someone forgot a #[Pref] annotation"
                 );
-                self.get_property_value($id, CanGc::note())
+                self.get_property_value($id)
             }
             fn $setter(&self, value: DOMString) -> ErrorResult {
                 debug_assert!(
@@ -247,7 +247,7 @@ impl CSSStyleDeclaration {
         )
     }
 
-    fn get_computed_style(&self, property: PropertyId, can_gc: CanGc) -> DOMString {
+    fn get_computed_style(&self, property: PropertyId) -> DOMString {
         match self.owner {
             CSSStyleOwner::CSSRule(..) => {
                 panic!("get_computed_style called on CSSStyleDeclaration with a CSSRule owner")
@@ -258,15 +258,15 @@ impl CSSStyleDeclaration {
                     return DOMString::new();
                 }
                 let addr = node.to_trusted_node_address();
-                window_from_node(node).resolved_style_query(addr, self.pseudo, property, can_gc)
+                window_from_node(node).resolved_style_query(addr, self.pseudo, property)
             },
         }
     }
 
-    fn get_property_value(&self, id: PropertyId, can_gc: CanGc) -> DOMString {
+    fn get_property_value(&self, id: PropertyId) -> DOMString {
         if self.readonly {
             // Readonly style declarations are used for getComputedStyle.
-            return self.get_computed_style(id, can_gc);
+            return self.get_computed_style(id);
         }
 
         let mut string = String::new();
@@ -400,12 +400,12 @@ impl CSSStyleDeclarationMethods for CSSStyleDeclaration {
     }
 
     // https://dev.w3.org/csswg/cssom/#dom-cssstyledeclaration-getpropertyvalue
-    fn GetPropertyValue(&self, property: DOMString, can_gc: CanGc) -> DOMString {
+    fn GetPropertyValue(&self, property: DOMString) -> DOMString {
         let id = match PropertyId::parse_enabled_for_all_content(&property) {
             Ok(id) => id,
             Err(..) => return DOMString::new(),
         };
-        self.get_property_value(id, can_gc)
+        self.get_property_value(id)
     }
 
     // https://dev.w3.org/csswg/cssom/#dom-cssstyledeclaration-getpropertypriority
@@ -471,8 +471,8 @@ impl CSSStyleDeclarationMethods for CSSStyleDeclaration {
     }
 
     // https://dev.w3.org/csswg/cssom/#dom-cssstyledeclaration-cssfloat
-    fn CssFloat(&self, can_gc: CanGc) -> DOMString {
-        self.get_property_value(PropertyId::NonCustom(LonghandId::Float.into()), can_gc)
+    fn CssFloat(&self) -> DOMString {
+        self.get_property_value(PropertyId::NonCustom(LonghandId::Float.into()))
     }
 
     // https://dev.w3.org/csswg/cssom/#dom-cssstyledeclaration-cssfloat

--- a/components/script/dom/documentorshadowroot.rs
+++ b/components/script/dom/documentorshadowroot.rs
@@ -25,7 +25,6 @@ use crate::dom::element::Element;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::node::{self, Node, VecPreOrderInsertionHelper};
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 use crate::stylesheet_set::StylesheetSetRef;
 
 #[derive(Clone, JSTraceable, MallocSizeOf)]
@@ -91,12 +90,8 @@ impl DocumentOrShadowRoot {
         &self,
         client_point: &Point2D<f32>,
         query_type: NodesFromPointQueryType,
-        can_gc: CanGc,
     ) -> Vec<UntrustedNodeAddress> {
-        if !self
-            .window
-            .layout_reflow(QueryMsg::NodesFromPointQuery, can_gc)
-        {
+        if !self.window.layout_reflow(QueryMsg::NodesFromPointQuery) {
             return vec![];
         };
 
@@ -113,7 +108,6 @@ impl DocumentOrShadowRoot {
         y: Finite<f64>,
         document_element: Option<DomRoot<Element>>,
         has_browsing_context: bool,
-        can_gc: CanGc,
     ) -> Option<DomRoot<Element>> {
         let x = *x as f32;
         let y = *y as f32;
@@ -129,7 +123,7 @@ impl DocumentOrShadowRoot {
         }
 
         match self
-            .nodes_from_point(point, NodesFromPointQueryType::Topmost, can_gc)
+            .nodes_from_point(point, NodesFromPointQueryType::Topmost)
             .first()
         {
             Some(address) => {
@@ -153,7 +147,6 @@ impl DocumentOrShadowRoot {
         y: Finite<f64>,
         document_element: Option<DomRoot<Element>>,
         has_browsing_context: bool,
-        can_gc: CanGc,
     ) -> Vec<DomRoot<Element>> {
         let x = *x as f32;
         let y = *y as f32;
@@ -170,7 +163,7 @@ impl DocumentOrShadowRoot {
         }
 
         // Step 1 and Step 3
-        let nodes = self.nodes_from_point(point, NodesFromPointQueryType::All, can_gc);
+        let nodes = self.nodes_from_point(point, NodesFromPointQueryType::All);
         let mut elements: Vec<DomRoot<Element>> = nodes
             .iter()
             .flat_map(|&untrusted_node_address| {

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -429,18 +429,18 @@ impl Element {
 
     /// style will be `None` for elements in a `display: none` subtree. otherwise, the element has a
     /// layout box iff it doesn't have `display: none`.
-    pub fn style(&self, can_gc: CanGc) -> Option<Arc<ComputedValues>> {
-        self.upcast::<Node>().style(can_gc)
+    pub fn style(&self) -> Option<Arc<ComputedValues>> {
+        self.upcast::<Node>().style()
     }
 
     // https://drafts.csswg.org/cssom-view/#css-layout-box
-    pub fn has_css_layout_box(&self, can_gc: CanGc) -> bool {
-        self.style(can_gc)
+    pub fn has_css_layout_box(&self) -> bool {
+        self.style()
             .is_some_and(|s| !s.get_box().clone_display().is_none())
     }
 
     // https://drafts.csswg.org/cssom-view/#potentially-scrollable
-    fn is_potentially_scrollable_body(&self, can_gc: CanGc) -> bool {
+    fn is_potentially_scrollable_body(&self) -> bool {
         let node = self.upcast::<Node>();
         debug_assert!(
             node.owner_doc().GetBody().as_deref() == self.downcast::<HTMLElement>(),
@@ -450,14 +450,14 @@ impl Element {
         // "An element body (which will be the body element) is potentially
         // scrollable if all of the following conditions are true:
         //  - body has an associated box."
-        if !self.has_css_layout_box(can_gc) {
+        if !self.has_css_layout_box() {
             return false;
         }
 
         // " - body’s parent element’s computed value of the overflow-x or
         //     overflow-y properties is neither visible nor clip."
         if let Some(parent) = node.GetParentElement() {
-            if let Some(style) = parent.style(can_gc) {
+            if let Some(style) = parent.style() {
                 if !style.get_box().clone_overflow_x().is_scrollable() &&
                     !style.get_box().clone_overflow_y().is_scrollable()
                 {
@@ -468,7 +468,7 @@ impl Element {
 
         // " - body’s computed value of the overflow-x or overflow-y properties
         //     is neither visible nor clip."
-        if let Some(style) = self.style(can_gc) {
+        if let Some(style) = self.style() {
             if !style.get_box().clone_overflow_x().is_scrollable() &&
                 !style.get_box().clone_overflow_y().is_scrollable()
             {
@@ -480,18 +480,17 @@ impl Element {
     }
 
     // https://drafts.csswg.org/cssom-view/#scrolling-box
-    fn has_scrolling_box(&self, can_gc: CanGc) -> bool {
+    fn has_scrolling_box(&self) -> bool {
         // TODO: scrolling mechanism, such as scrollbar (We don't have scrollbar yet)
         //       self.has_scrolling_mechanism()
-        self.style(can_gc).is_some_and(|style| {
+        self.style().is_some_and(|style| {
             style.get_box().clone_overflow_x().is_scrollable() ||
                 style.get_box().clone_overflow_y().is_scrollable()
         })
     }
 
-    fn has_overflow(&self, can_gc: CanGc) -> bool {
-        self.ScrollHeight(can_gc) > self.ClientHeight(can_gc) ||
-            self.ScrollWidth(can_gc) > self.ClientWidth(can_gc)
+    fn has_overflow(&self) -> bool {
+        self.ScrollHeight() > self.ClientHeight() || self.ScrollWidth() > self.ClientWidth()
     }
 
     fn shadow_root(&self) -> Option<DomRoot<ShadowRoot>> {
@@ -1904,7 +1903,7 @@ impl Element {
     }
 
     // https://drafts.csswg.org/cssom-view/#dom-element-scroll
-    pub fn scroll(&self, x_: f64, y_: f64, behavior: ScrollBehavior, can_gc: CanGc) {
+    pub fn scroll(&self, x_: f64, y_: f64, behavior: ScrollBehavior) {
         // Step 1.2 or 2.3
         let x = if x_.is_finite() { x_ } else { 0.0f64 };
         let y = if y_.is_finite() { y_ } else { 0.0f64 };
@@ -1928,7 +1927,7 @@ impl Element {
         // Step 7
         if *self.root_element() == *self {
             if doc.quirks_mode() != QuirksMode::Quirks {
-                win.scroll(x, y, behavior, can_gc);
+                win.scroll(x, y, behavior);
             }
 
             return;
@@ -1937,22 +1936,19 @@ impl Element {
         // Step 9
         if doc.GetBody().as_deref() == self.downcast::<HTMLElement>() &&
             doc.quirks_mode() == QuirksMode::Quirks &&
-            !self.is_potentially_scrollable_body(can_gc)
+            !self.is_potentially_scrollable_body()
         {
-            win.scroll(x, y, behavior, can_gc);
+            win.scroll(x, y, behavior);
             return;
         }
 
         // Step 10
-        if !self.has_css_layout_box(can_gc) ||
-            !self.has_scrolling_box(can_gc) ||
-            !self.has_overflow(can_gc)
-        {
+        if !self.has_css_layout_box() || !self.has_scrolling_box() || !self.has_overflow() {
             return;
         }
 
         // Step 11
-        win.scroll_node(node, x, y, behavior, can_gc);
+        win.scroll_node(node, x, y, behavior);
     }
 
     // https://w3c.github.io/DOM-Parsing/#parsing
@@ -2434,7 +2430,7 @@ impl ElementMethods for Element {
     // https://drafts.csswg.org/cssom-view/#dom-element-getclientrects
     fn GetClientRects(&self, can_gc: CanGc) -> DomRoot<DOMRectList> {
         let win = window_from_node(self);
-        let raw_rects = self.upcast::<Node>().content_boxes(can_gc);
+        let raw_rects = self.upcast::<Node>().content_boxes();
         let rects: Vec<DomRoot<DOMRect>> = raw_rects
             .iter()
             .map(|rect| {
@@ -2454,7 +2450,7 @@ impl ElementMethods for Element {
     // https://drafts.csswg.org/cssom-view/#dom-element-getboundingclientrect
     fn GetBoundingClientRect(&self, can_gc: CanGc) -> DomRoot<DOMRect> {
         let win = window_from_node(self);
-        let rect = self.upcast::<Node>().bounding_content_box_or_zero(can_gc);
+        let rect = self.upcast::<Node>().bounding_content_box_or_zero();
         DOMRect::new(
             win.upcast(),
             rect.origin.x.to_f64_px(),
@@ -2466,52 +2462,47 @@ impl ElementMethods for Element {
     }
 
     // https://drafts.csswg.org/cssom-view/#dom-element-scroll
-    fn Scroll(&self, options: &ScrollToOptions, can_gc: CanGc) {
+    fn Scroll(&self, options: &ScrollToOptions) {
         // Step 1
-        let left = options.left.unwrap_or(self.ScrollLeft(can_gc));
-        let top = options.top.unwrap_or(self.ScrollTop(can_gc));
-        self.scroll(left, top, options.parent.behavior, can_gc);
+        let left = options.left.unwrap_or(self.ScrollLeft());
+        let top = options.top.unwrap_or(self.ScrollTop());
+        self.scroll(left, top, options.parent.behavior);
     }
 
     // https://drafts.csswg.org/cssom-view/#dom-element-scroll
-    fn Scroll_(&self, x: f64, y: f64, can_gc: CanGc) {
-        self.scroll(x, y, ScrollBehavior::Auto, can_gc);
+    fn Scroll_(&self, x: f64, y: f64) {
+        self.scroll(x, y, ScrollBehavior::Auto);
     }
 
     // https://drafts.csswg.org/cssom-view/#dom-element-scrollto
     fn ScrollTo(&self, options: &ScrollToOptions) {
-        self.Scroll(options, CanGc::note());
+        self.Scroll(options);
     }
 
     // https://drafts.csswg.org/cssom-view/#dom-element-scrollto
     fn ScrollTo_(&self, x: f64, y: f64) {
-        self.Scroll_(x, y, CanGc::note());
+        self.Scroll_(x, y);
     }
 
     // https://drafts.csswg.org/cssom-view/#dom-element-scrollby
-    fn ScrollBy(&self, options: &ScrollToOptions, can_gc: CanGc) {
+    fn ScrollBy(&self, options: &ScrollToOptions) {
         // Step 2
         let delta_left = options.left.unwrap_or(0.0f64);
         let delta_top = options.top.unwrap_or(0.0f64);
-        let left = self.ScrollLeft(can_gc);
-        let top = self.ScrollTop(can_gc);
-        self.scroll(
-            left + delta_left,
-            top + delta_top,
-            options.parent.behavior,
-            can_gc,
-        );
+        let left = self.ScrollLeft();
+        let top = self.ScrollTop();
+        self.scroll(left + delta_left, top + delta_top, options.parent.behavior);
     }
 
     // https://drafts.csswg.org/cssom-view/#dom-element-scrollby
-    fn ScrollBy_(&self, x: f64, y: f64, can_gc: CanGc) {
-        let left = self.ScrollLeft(can_gc);
-        let top = self.ScrollTop(can_gc);
-        self.scroll(left + x, top + y, ScrollBehavior::Auto, can_gc);
+    fn ScrollBy_(&self, x: f64, y: f64) {
+        let left = self.ScrollLeft();
+        let top = self.ScrollTop();
+        self.scroll(left + x, top + y, ScrollBehavior::Auto);
     }
 
     // https://drafts.csswg.org/cssom-view/#dom-element-scrolltop
-    fn ScrollTop(&self, can_gc: CanGc) -> f64 {
+    fn ScrollTop(&self) -> f64 {
         let node = self.upcast::<Node>();
 
         // Step 1
@@ -2541,13 +2532,13 @@ impl ElementMethods for Element {
         // Step 7
         if doc.GetBody().as_deref() == self.downcast::<HTMLElement>() &&
             doc.quirks_mode() == QuirksMode::Quirks &&
-            !self.is_potentially_scrollable_body(can_gc)
+            !self.is_potentially_scrollable_body()
         {
             return win.ScrollY() as f64;
         }
 
         // Step 8
-        if !self.has_css_layout_box(can_gc) {
+        if !self.has_css_layout_box() {
             return 0.0;
         }
 
@@ -2557,7 +2548,7 @@ impl ElementMethods for Element {
     }
 
     // https://drafts.csswg.org/cssom-view/#dom-element-scrolltop
-    fn SetScrollTop(&self, y_: f64, can_gc: CanGc) {
+    fn SetScrollTop(&self, y_: f64) {
         let behavior = ScrollBehavior::Auto;
 
         // Step 1, 2
@@ -2582,7 +2573,7 @@ impl ElementMethods for Element {
         // Step 7
         if *self.root_element() == *self {
             if doc.quirks_mode() != QuirksMode::Quirks {
-                win.scroll(win.ScrollX() as f64, y, behavior, can_gc);
+                win.scroll(win.ScrollX() as f64, y, behavior);
             }
 
             return;
@@ -2591,26 +2582,23 @@ impl ElementMethods for Element {
         // Step 9
         if doc.GetBody().as_deref() == self.downcast::<HTMLElement>() &&
             doc.quirks_mode() == QuirksMode::Quirks &&
-            !self.is_potentially_scrollable_body(can_gc)
+            !self.is_potentially_scrollable_body()
         {
-            win.scroll(win.ScrollX() as f64, y, behavior, can_gc);
+            win.scroll(win.ScrollX() as f64, y, behavior);
             return;
         }
 
         // Step 10
-        if !self.has_css_layout_box(can_gc) ||
-            !self.has_scrolling_box(can_gc) ||
-            !self.has_overflow(can_gc)
-        {
+        if !self.has_css_layout_box() || !self.has_scrolling_box() || !self.has_overflow() {
             return;
         }
 
         // Step 11
-        win.scroll_node(node, self.ScrollLeft(can_gc), y, behavior, can_gc);
+        win.scroll_node(node, self.ScrollLeft(), y, behavior);
     }
 
     // https://drafts.csswg.org/cssom-view/#dom-element-scrolltop
-    fn ScrollLeft(&self, can_gc: CanGc) -> f64 {
+    fn ScrollLeft(&self) -> f64 {
         let node = self.upcast::<Node>();
 
         // Step 1
@@ -2640,13 +2628,13 @@ impl ElementMethods for Element {
         // Step 7
         if doc.GetBody().as_deref() == self.downcast::<HTMLElement>() &&
             doc.quirks_mode() == QuirksMode::Quirks &&
-            !self.is_potentially_scrollable_body(can_gc)
+            !self.is_potentially_scrollable_body()
         {
             return win.ScrollX() as f64;
         }
 
         // Step 8
-        if !self.has_css_layout_box(can_gc) {
+        if !self.has_css_layout_box() {
             return 0.0;
         }
 
@@ -2656,7 +2644,7 @@ impl ElementMethods for Element {
     }
 
     // https://drafts.csswg.org/cssom-view/#dom-element-scrollleft
-    fn SetScrollLeft(&self, x_: f64, can_gc: CanGc) {
+    fn SetScrollLeft(&self, x_: f64) {
         let behavior = ScrollBehavior::Auto;
 
         // Step 1, 2
@@ -2684,59 +2672,56 @@ impl ElementMethods for Element {
                 return;
             }
 
-            win.scroll(x, win.ScrollY() as f64, behavior, can_gc);
+            win.scroll(x, win.ScrollY() as f64, behavior);
             return;
         }
 
         // Step 9
         if doc.GetBody().as_deref() == self.downcast::<HTMLElement>() &&
             doc.quirks_mode() == QuirksMode::Quirks &&
-            !self.is_potentially_scrollable_body(can_gc)
+            !self.is_potentially_scrollable_body()
         {
-            win.scroll(x, win.ScrollY() as f64, behavior, can_gc);
+            win.scroll(x, win.ScrollY() as f64, behavior);
             return;
         }
 
         // Step 10
-        if !self.has_css_layout_box(can_gc) ||
-            !self.has_scrolling_box(can_gc) ||
-            !self.has_overflow(can_gc)
-        {
+        if !self.has_css_layout_box() || !self.has_scrolling_box() || !self.has_overflow() {
             return;
         }
 
         // Step 11
-        win.scroll_node(node, x, self.ScrollTop(can_gc), behavior, can_gc);
+        win.scroll_node(node, x, self.ScrollTop(), behavior);
     }
 
     // https://drafts.csswg.org/cssom-view/#dom-element-scrollwidth
-    fn ScrollWidth(&self, can_gc: CanGc) -> i32 {
-        self.upcast::<Node>().scroll_area(can_gc).size.width
+    fn ScrollWidth(&self) -> i32 {
+        self.upcast::<Node>().scroll_area().size.width
     }
 
     // https://drafts.csswg.org/cssom-view/#dom-element-scrollheight
-    fn ScrollHeight(&self, can_gc: CanGc) -> i32 {
-        self.upcast::<Node>().scroll_area(can_gc).size.height
+    fn ScrollHeight(&self) -> i32 {
+        self.upcast::<Node>().scroll_area().size.height
     }
 
     // https://drafts.csswg.org/cssom-view/#dom-element-clienttop
-    fn ClientTop(&self, can_gc: CanGc) -> i32 {
-        self.client_rect(can_gc).origin.y
+    fn ClientTop(&self) -> i32 {
+        self.client_rect().origin.y
     }
 
     // https://drafts.csswg.org/cssom-view/#dom-element-clientleft
-    fn ClientLeft(&self, can_gc: CanGc) -> i32 {
-        self.client_rect(can_gc).origin.x
+    fn ClientLeft(&self) -> i32 {
+        self.client_rect().origin.x
     }
 
     // https://drafts.csswg.org/cssom-view/#dom-element-clientwidth
-    fn ClientWidth(&self, can_gc: CanGc) -> i32 {
-        self.client_rect(can_gc).size.width
+    fn ClientWidth(&self) -> i32 {
+        self.client_rect().size.width
     }
 
     // https://drafts.csswg.org/cssom-view/#dom-element-clientheight
-    fn ClientHeight(&self, can_gc: CanGc) -> i32 {
-        self.client_rect(can_gc).size.height
+    fn ClientHeight(&self) -> i32 {
+        self.client_rect().size.height
     }
 
     /// <https://w3c.github.io/DOM-Parsing/#widl-Element-innerHTML>
@@ -3960,7 +3945,7 @@ impl SelectorsElement for DomRoot<Element> {
 }
 
 impl Element {
-    fn client_rect(&self, can_gc: CanGc) -> Rect<i32> {
+    fn client_rect(&self) -> Rect<i32> {
         let doc = self.node.owner_doc();
 
         if let Some(rect) = self
@@ -3977,7 +3962,7 @@ impl Element {
             }
         }
 
-        let mut rect = self.upcast::<Node>().client_rect(can_gc);
+        let mut rect = self.upcast::<Node>().client_rect();
         let in_quirks_mode = doc.quirks_mode() == QuirksMode::Quirks;
 
         if (in_quirks_mode && doc.GetBody().as_deref() == self.downcast::<HTMLElement>()) ||
@@ -4439,11 +4424,9 @@ impl TaskOnce for ElementPerformFullscreenEnter {
         // Step 7.5
         element.set_fullscreen_state(true);
         document.set_fullscreen_element(Some(&element));
-        document.window().reflow(
-            ReflowGoal::Full,
-            ReflowReason::ElementStateChanged,
-            CanGc::note(),
-        );
+        document
+            .window()
+            .reflow(ReflowGoal::Full, ReflowReason::ElementStateChanged);
 
         // Step 7.6
         document
@@ -4478,11 +4461,9 @@ impl TaskOnce for ElementPerformFullscreenExit {
         // Step 9.6
         element.set_fullscreen_state(false);
 
-        document.window().reflow(
-            ReflowGoal::Full,
-            ReflowReason::ElementStateChanged,
-            CanGc::note(),
-        );
+        document
+            .window()
+            .reflow(ReflowGoal::Full, ReflowReason::ElementStateChanged);
 
         document.set_fullscreen_element(None);
 

--- a/components/script/dom/fontfaceset.rs
+++ b/components/script/dom/fontfaceset.rs
@@ -24,19 +24,24 @@ pub struct FontFaceSet {
 }
 
 impl FontFaceSet {
-    pub fn new_inherited(global: &GlobalScope, can_gc: CanGc) -> Self {
-        FontFaceSet {
+    pub fn new_inherited(global: &GlobalScope, is_ready: bool) -> Self {
+        let promise = Promise::new(global, CanGc::note());
+        if is_ready {
+            promise.resolve_native(&promise);
+        }
+
+        Self {
             target: EventTarget::new_inherited(),
-            promise: Promise::new(global, can_gc),
+            promise,
         }
     }
 
-    pub fn new(global: &GlobalScope, proto: Option<HandleObject>, can_gc: CanGc) -> DomRoot<Self> {
+    pub fn new(global: &GlobalScope, proto: Option<HandleObject>, is_ready: bool) -> DomRoot<Self> {
         reflect_dom_object_with_proto(
-            Box::new(FontFaceSet::new_inherited(global, can_gc)),
+            Box::new(Self::new_inherited(global, is_ready)),
             global,
             proto,
-            can_gc,
+            CanGc::note(),
         )
     }
 

--- a/components/script/dom/history.rs
+++ b/components/script/dom/history.rs
@@ -94,7 +94,7 @@ impl History {
 
         // Step 8
         if let Some(fragment) = url.fragment() {
-            document.check_and_scroll_fragment(fragment, can_gc);
+            document.check_and_scroll_fragment(fragment);
         }
 
         // Step 11

--- a/components/script/dom/htmlanchorelement.rs
+++ b/components/script/dom/htmlanchorelement.rs
@@ -609,7 +609,7 @@ impl Activatable for HTMLAnchorElement {
         if let Some(element) = target.downcast::<Element>() {
             if target.is::<HTMLImageElement>() && element.has_attribute(&local_name!("ismap")) {
                 let target_node = element.upcast::<Node>();
-                let rect = target_node.bounding_content_box_or_zero(CanGc::note());
+                let rect = target_node.bounding_content_box_or_zero();
                 ismap_suffix = Some(format!(
                     "?{},{}",
                     mouse_event.ClientX().to_f32().unwrap() - rect.origin.x.to_f32_px(),

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -115,18 +115,18 @@ impl HTMLElement {
     /// `.outerText` in JavaScript.`
     ///
     /// <https://html.spec.whatwg.org/multipage/#get-the-text-steps>
-    fn get_inner_outer_text(&self, can_gc: CanGc) -> DOMString {
+    fn get_inner_outer_text(&self) -> DOMString {
         let node = self.upcast::<Node>();
         let window = window_from_node(node);
         let element = self.as_element();
 
         // Step 1.
-        let element_not_rendered = !node.is_connected() || !element.has_css_layout_box(can_gc);
+        let element_not_rendered = !node.is_connected() || !element.has_css_layout_box();
         if element_not_rendered {
             return node.GetTextContent().unwrap();
         }
 
-        window.layout_reflow(QueryMsg::ElementInnerOuterTextQuery, can_gc);
+        window.layout_reflow(QueryMsg::ElementInnerOuterTextQuery);
         let text = window
             .layout()
             .query_element_inner_outer_text(node.to_trusted_node_address());
@@ -421,65 +421,65 @@ impl HTMLElementMethods for HTMLElement {
     }
 
     // https://drafts.csswg.org/cssom-view/#dom-htmlelement-offsetparent
-    fn GetOffsetParent(&self, can_gc: CanGc) -> Option<DomRoot<Element>> {
+    fn GetOffsetParent(&self) -> Option<DomRoot<Element>> {
         if self.is::<HTMLBodyElement>() || self.is::<HTMLHtmlElement>() {
             return None;
         }
 
         let node = self.upcast::<Node>();
         let window = window_from_node(self);
-        let (element, _) = window.offset_parent_query(node, can_gc);
+        let (element, _) = window.offset_parent_query(node);
 
         element
     }
 
     // https://drafts.csswg.org/cssom-view/#dom-htmlelement-offsettop
-    fn OffsetTop(&self, can_gc: CanGc) -> i32 {
+    fn OffsetTop(&self) -> i32 {
         if self.is::<HTMLBodyElement>() {
             return 0;
         }
 
         let node = self.upcast::<Node>();
         let window = window_from_node(self);
-        let (_, rect) = window.offset_parent_query(node, can_gc);
+        let (_, rect) = window.offset_parent_query(node);
 
         rect.origin.y.to_nearest_px()
     }
 
     // https://drafts.csswg.org/cssom-view/#dom-htmlelement-offsetleft
-    fn OffsetLeft(&self, can_gc: CanGc) -> i32 {
+    fn OffsetLeft(&self) -> i32 {
         if self.is::<HTMLBodyElement>() {
             return 0;
         }
 
         let node = self.upcast::<Node>();
         let window = window_from_node(self);
-        let (_, rect) = window.offset_parent_query(node, can_gc);
+        let (_, rect) = window.offset_parent_query(node);
 
         rect.origin.x.to_nearest_px()
     }
 
     // https://drafts.csswg.org/cssom-view/#dom-htmlelement-offsetwidth
-    fn OffsetWidth(&self, can_gc: CanGc) -> i32 {
+    fn OffsetWidth(&self) -> i32 {
         let node = self.upcast::<Node>();
         let window = window_from_node(self);
-        let (_, rect) = window.offset_parent_query(node, can_gc);
+        let (_, rect) = window.offset_parent_query(node);
 
         rect.size.width.to_nearest_px()
     }
 
     // https://drafts.csswg.org/cssom-view/#dom-htmlelement-offsetheight
-    fn OffsetHeight(&self, can_gc: CanGc) -> i32 {
+    fn OffsetHeight(&self) -> i32 {
         let node = self.upcast::<Node>();
         let window = window_from_node(self);
-        let (_, rect) = window.offset_parent_query(node, can_gc);
+        let (_, rect) = window.offset_parent_query(node);
 
         rect.size.height.to_nearest_px()
     }
 
     /// <https://html.spec.whatwg.org/multipage/#the-innertext-idl-attribute>
-    fn InnerText(&self, can_gc: CanGc) -> DOMString {
-        self.get_inner_outer_text(can_gc)
+    fn InnerText(&self) -> DOMString {
+        self.get_inner_outer_text()
     }
 
     /// <https://html.spec.whatwg.org/multipage/#set-the-inner-text-steps>
@@ -493,8 +493,8 @@ impl HTMLElementMethods for HTMLElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-outertext>
-    fn GetOuterText(&self, can_gc: CanGc) -> Fallible<DOMString> {
-        Ok(self.get_inner_outer_text(can_gc))
+    fn GetOuterText(&self) -> Fallible<DOMString> {
+        Ok(self.get_inner_outer_text())
     }
 
     /// <https://html.spec.whatwg.org/multipage/#the-innertext-idl-attribute:dom-outertext-2>

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -193,7 +193,7 @@ impl HTMLIFrameElement {
 
         let window_size = WindowSizeData {
             initial_viewport: window
-                .inner_window_dimensions_query(browsing_context_id, can_gc)
+                .inner_window_dimensions_query(browsing_context_id)
                 .unwrap_or_default(),
             device_pixel_ratio: window.device_pixel_ratio(),
         };

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -1602,9 +1602,9 @@ impl HTMLImageElementMethods for HTMLImageElement {
     make_bool_setter!(SetIsMap, "ismap");
 
     // https://html.spec.whatwg.org/multipage/#dom-img-width
-    fn Width(&self, can_gc: CanGc) -> u32 {
+    fn Width(&self) -> u32 {
         let node = self.upcast::<Node>();
-        match node.bounding_content_box(can_gc) {
+        match node.bounding_content_box() {
             Some(rect) => rect.size.width.to_px() as u32,
             None => self.NaturalWidth(),
         }
@@ -1616,9 +1616,9 @@ impl HTMLImageElementMethods for HTMLImageElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-img-height
-    fn Height(&self, can_gc: CanGc) -> u32 {
+    fn Height(&self) -> u32 {
         let node = self.upcast::<Node>();
-        match node.bounding_content_box(can_gc) {
+        match node.bounding_content_box() {
             Some(rect) => rect.size.height.to_px() as u32,
             None => self.NaturalHeight(),
         }

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -2525,11 +2525,7 @@ impl VirtualMethods for HTMLInputElement {
                     // now.
                     if let Some(point_in_target) = mouse_event.point_in_target() {
                         let window = window_from_node(self);
-                        let index = window.text_index_query(
-                            self.upcast::<Node>(),
-                            point_in_target,
-                            CanGc::note(),
-                        );
+                        let index = window.text_index_query(self.upcast::<Node>(), point_in_target);
                         if let Some(i) = index {
                             self.textinput.borrow_mut().set_edit_point_index(i);
                             // trigger redraw

--- a/components/script/dom/mouseevent.rs
+++ b/components/script/dom/mouseevent.rs
@@ -276,13 +276,13 @@ impl MouseEventMethods for MouseEvent {
     }
 
     // https://drafts.csswg.org/cssom-view/#dom-mouseevent-offsetx
-    fn OffsetX(&self, can_gc: CanGc) -> i32 {
+    fn OffsetX(&self) -> i32 {
         let event = self.upcast::<Event>();
         if event.dispatching() {
             match event.GetTarget() {
                 Some(target) => {
                     if let Some(node) = target.downcast::<Node>() {
-                        let rect = node.client_rect(can_gc);
+                        let rect = node.client_rect();
                         self.client_x.get() - rect.origin.x
                     } else {
                         self.offset_x.get()
@@ -296,13 +296,13 @@ impl MouseEventMethods for MouseEvent {
     }
 
     // https://drafts.csswg.org/cssom-view/#dom-mouseevent-offsety
-    fn OffsetY(&self, can_gc: CanGc) -> i32 {
+    fn OffsetY(&self) -> i32 {
         let event = self.upcast::<Event>();
         if event.dispatching() {
             match event.GetTarget() {
                 Some(target) => {
                     if let Some(node) = target.downcast::<Node>() {
-                        let rect = node.client_rect(can_gc);
+                        let rect = node.client_rect();
                         self.client_y.get() - rect.origin.y
                     } else {
                         self.offset_y.get()

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -793,25 +793,25 @@ impl Node {
 
     /// Returns the rendered bounding content box if the element is rendered,
     /// and none otherwise.
-    pub fn bounding_content_box(&self, can_gc: CanGc) -> Option<Rect<Au>> {
-        window_from_node(self).content_box_query(self, can_gc)
+    pub fn bounding_content_box(&self) -> Option<Rect<Au>> {
+        window_from_node(self).content_box_query(self)
     }
 
-    pub fn bounding_content_box_or_zero(&self, can_gc: CanGc) -> Rect<Au> {
-        self.bounding_content_box(can_gc).unwrap_or_else(Rect::zero)
+    pub fn bounding_content_box_or_zero(&self) -> Rect<Au> {
+        self.bounding_content_box().unwrap_or_else(Rect::zero)
     }
 
-    pub fn content_boxes(&self, can_gc: CanGc) -> Vec<Rect<Au>> {
-        window_from_node(self).content_boxes_query(self, can_gc)
+    pub fn content_boxes(&self) -> Vec<Rect<Au>> {
+        window_from_node(self).content_boxes_query(self)
     }
 
-    pub fn client_rect(&self, can_gc: CanGc) -> Rect<i32> {
-        window_from_node(self).client_rect_query(self, can_gc)
+    pub fn client_rect(&self) -> Rect<i32> {
+        window_from_node(self).client_rect_query(self)
     }
 
     /// <https://drafts.csswg.org/cssom-view/#dom-element-scrollwidth>
     /// <https://drafts.csswg.org/cssom-view/#dom-element-scrollheight>
-    pub fn scroll_area(&self, can_gc: CanGc) -> Rect<i32> {
+    pub fn scroll_area(&self) -> Rect<i32> {
         // "1. Let document be the element’s node document.""
         let document = self.owner_doc();
 
@@ -837,7 +837,7 @@ impl Node {
         // element is not potentially scrollable, return max(viewport scrolling area
         // width, viewport width)."
         if (is_root && !in_quirks_mode) || (is_body_element && in_quirks_mode) {
-            let viewport_scrolling_area = window.scrolling_area_query(None, can_gc);
+            let viewport_scrolling_area = window.scrolling_area_query(None);
             return Rect::new(
                 viewport_scrolling_area.origin,
                 viewport_scrolling_area.size.max(viewport),
@@ -847,7 +847,7 @@ impl Node {
         // "6. If the element does not have any associated box return zero and terminate
         // these steps."
         // "7. Return the width of the element’s scrolling area."
-        window.scrolling_area_query(Some(self), can_gc)
+        window.scrolling_area_query(Some(self))
     }
 
     pub fn scroll_offset(&self) -> Vector2D<f32> {
@@ -1276,8 +1276,8 @@ impl Node {
         })
     }
 
-    pub fn style(&self, can_gc: CanGc) -> Option<Arc<ComputedValues>> {
-        if !window_from_node(self).layout_reflow(QueryMsg::StyleQuery, can_gc) {
+    pub fn style(&self) -> Option<Arc<ComputedValues>> {
+        if !window_from_node(self).layout_reflow(QueryMsg::StyleQuery) {
             return None;
         }
         self.style_data

--- a/components/script/dom/offscreencanvasrenderingcontext2d.rs
+++ b/components/script/dom/offscreencanvasrenderingcontext2d.rs
@@ -140,9 +140,9 @@ impl OffscreenCanvasRenderingContext2DMethods for OffscreenCanvasRenderingContex
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-shadowcolor
-    fn SetShadowColor(&self, value: DOMString, can_gc: CanGc) {
+    fn SetShadowColor(&self, value: DOMString) {
         self.canvas_state
-            .set_shadow_color(self.htmlcanvas.as_deref(), value, can_gc)
+            .set_shadow_color(self.htmlcanvas.as_deref(), value)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-strokestyle
@@ -151,9 +151,9 @@ impl OffscreenCanvasRenderingContext2DMethods for OffscreenCanvasRenderingContex
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-strokestyle
-    fn SetStrokeStyle(&self, value: StringOrCanvasGradientOrCanvasPattern, can_gc: CanGc) {
+    fn SetStrokeStyle(&self, value: StringOrCanvasGradientOrCanvasPattern) {
         self.canvas_state
-            .set_stroke_style(self.htmlcanvas.as_deref(), value, can_gc)
+            .set_stroke_style(self.htmlcanvas.as_deref(), value)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-strokestyle
@@ -162,9 +162,9 @@ impl OffscreenCanvasRenderingContext2DMethods for OffscreenCanvasRenderingContex
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-strokestyle
-    fn SetFillStyle(&self, value: StringOrCanvasGradientOrCanvasPattern, can_gc: CanGc) {
+    fn SetFillStyle(&self, value: StringOrCanvasGradientOrCanvasPattern) {
         self.canvas_state
-            .set_fill_style(self.htmlcanvas.as_deref(), value, can_gc)
+            .set_fill_style(self.htmlcanvas.as_deref(), value)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-createlineargradient
@@ -250,15 +250,15 @@ impl OffscreenCanvasRenderingContext2DMethods for OffscreenCanvasRenderingContex
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-filltext
-    fn FillText(&self, text: DOMString, x: f64, y: f64, max_width: Option<f64>, can_gc: CanGc) {
+    fn FillText(&self, text: DOMString, x: f64, y: f64, max_width: Option<f64>) {
         self.canvas_state
-            .fill_text(self.htmlcanvas.as_deref(), text, x, y, max_width, can_gc)
+            .fill_text(self.htmlcanvas.as_deref(), text, x, y, max_width)
     }
 
     // https://html.spec.whatwg.org/multipage/#textmetrics
-    fn MeasureText(&self, text: DOMString, can_gc: CanGc) -> DomRoot<TextMetrics> {
+    fn MeasureText(&self, text: DOMString) -> DomRoot<TextMetrics> {
         self.canvas_state
-            .measure_text(&self.global(), self.htmlcanvas.as_deref(), text, can_gc)
+            .measure_text(&self.global(), self.htmlcanvas.as_deref(), text)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-font
@@ -267,9 +267,9 @@ impl OffscreenCanvasRenderingContext2DMethods for OffscreenCanvasRenderingContex
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-font
-    fn SetFont(&self, value: DOMString, can_gc: CanGc) {
+    fn SetFont(&self, value: DOMString) {
         self.canvas_state
-            .set_font(self.htmlcanvas.as_deref(), value, can_gc)
+            .set_font(self.htmlcanvas.as_deref(), value)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-textalign

--- a/components/script/dom/paintrenderingcontext2d.rs
+++ b/components/script/dom/paintrenderingcontext2d.rs
@@ -304,8 +304,8 @@ impl PaintRenderingContext2DMethods for PaintRenderingContext2D {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-strokestyle
-    fn SetStrokeStyle(&self, value: StringOrCanvasGradientOrCanvasPattern, can_gc: CanGc) {
-        self.context.SetStrokeStyle(value, can_gc)
+    fn SetStrokeStyle(&self, value: StringOrCanvasGradientOrCanvasPattern) {
+        self.context.SetStrokeStyle(value)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-strokestyle
@@ -314,8 +314,8 @@ impl PaintRenderingContext2DMethods for PaintRenderingContext2D {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-strokestyle
-    fn SetFillStyle(&self, value: StringOrCanvasGradientOrCanvasPattern, can_gc: CanGc) {
-        self.context.SetFillStyle(value, can_gc)
+    fn SetFillStyle(&self, value: StringOrCanvasGradientOrCanvasPattern) {
+        self.context.SetFillStyle(value)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-createlineargradient
@@ -427,7 +427,7 @@ impl PaintRenderingContext2DMethods for PaintRenderingContext2D {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-shadowcolor
-    fn SetShadowColor(&self, value: DOMString, can_gc: CanGc) {
-        self.context.SetShadowColor(value, can_gc)
+    fn SetShadowColor(&self, value: DOMString) {
+        self.context.SetShadowColor(value)
     }
 }

--- a/components/script/dom/resizeobserver.rs
+++ b/components/script/dom/resizeobserver.rs
@@ -75,11 +75,10 @@ impl ResizeObserver {
         &self,
         depth: &ResizeObservationDepth,
         has_active: &mut bool,
-        can_gc: CanGc,
     ) {
         for (observation, target) in self.observation_targets.borrow_mut().iter_mut() {
             observation.state = Default::default();
-            if let Some(size) = observation.is_active(target, can_gc) {
+            if let Some(size) = observation.is_active(target) {
                 let target_depth = calculate_depth_for_node(target);
                 if target_depth > *depth {
                     observation.state = ObservationState::Active(size).into();
@@ -252,9 +251,9 @@ impl ResizeObservation {
     /// <https://drafts.csswg.org/resize-observer/#dom-resizeobservation-isactive>
     /// Returning an optional calculated size, instead of a boolean,
     /// to avoid recalculating the size in the subsequent broadcast.
-    fn is_active(&self, target: &Element, can_gc: CanGc) -> Option<Rect<Au>> {
+    fn is_active(&self, target: &Element) -> Option<Rect<Au>> {
         let last_reported_size = self.last_reported_sizes.borrow()[0];
-        let box_size = calculate_box_size(target, &self.observed_box.borrow(), can_gc);
+        let box_size = calculate_box_size(target, &self.observed_box.borrow());
         let is_active = box_size.width().to_f64_px() != last_reported_size.inline_size() ||
             box_size.height().to_f64_px() != last_reported_size.block_size();
         if is_active {
@@ -273,18 +272,14 @@ fn calculate_depth_for_node(target: &Element) -> ResizeObservationDepth {
 }
 
 /// <https://drafts.csswg.org/resize-observer/#calculate-box-size>
-fn calculate_box_size(
-    target: &Element,
-    observed_box: &ResizeObserverBoxOptions,
-    can_gc: CanGc,
-) -> Rect<Au> {
+fn calculate_box_size(target: &Element, observed_box: &ResizeObserverBoxOptions) -> Rect<Au> {
     match observed_box {
         ResizeObserverBoxOptions::Content_box => {
             // Note: only taking first fragment,
             // but the spec will expand to cover all fragments.
             target
                 .upcast::<Node>()
-                .content_boxes(can_gc)
+                .content_boxes()
                 .pop()
                 .unwrap_or_else(Rect::zero)
         },

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -589,7 +589,7 @@ impl ServoParser {
             assert!(!self.suspended.get());
             assert!(!self.aborted.get());
 
-            self.document.reflow_if_reflow_timer_expired(can_gc);
+            self.document.reflow_if_reflow_timer_expired();
             let script = match feed(&self.tokenizer) {
                 TokenizerResult::Done => return,
                 TokenizerResult::Script(script) => script,

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -26,7 +26,6 @@ use crate::dom::element::Element;
 use crate::dom::node::{Node, NodeDamage, NodeFlags, ShadowIncluding, UnbindContext};
 use crate::dom::stylesheetlist::{StyleSheetList, StyleSheetListOwner};
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 use crate::stylesheet_set::StylesheetSetRef;
 
 /// Whether a shadow root hosts an User Agent widget.
@@ -178,12 +177,7 @@ impl ShadowRootMethods for ShadowRoot {
     }
 
     // https://drafts.csswg.org/cssom-view/#dom-document-elementfrompoint
-    fn ElementFromPoint(
-        &self,
-        x: Finite<f64>,
-        y: Finite<f64>,
-        can_gc: CanGc,
-    ) -> Option<DomRoot<Element>> {
+    fn ElementFromPoint(&self, x: Finite<f64>, y: Finite<f64>) -> Option<DomRoot<Element>> {
         // Return the result of running the retargeting algorithm with context object
         // and the original result as input.
         match self.document_or_shadow_root.element_from_point(
@@ -191,7 +185,6 @@ impl ShadowRootMethods for ShadowRoot {
             y,
             None,
             self.document.has_browsing_context(),
-            can_gc,
         ) {
             Some(e) => {
                 let retargeted_node = self.upcast::<Node>().retarget(e.upcast::<Node>());
@@ -202,18 +195,13 @@ impl ShadowRootMethods for ShadowRoot {
     }
 
     // https://drafts.csswg.org/cssom-view/#dom-document-elementsfrompoint
-    fn ElementsFromPoint(
-        &self,
-        x: Finite<f64>,
-        y: Finite<f64>,
-        can_gc: CanGc,
-    ) -> Vec<DomRoot<Element>> {
+    fn ElementsFromPoint(&self, x: Finite<f64>, y: Finite<f64>) -> Vec<DomRoot<Element>> {
         // Return the result of running the retargeting algorithm with context object
         // and the original result as input
         let mut elements = Vec::new();
         for e in self
             .document_or_shadow_root
-            .elements_from_point(x, y, None, self.document.has_browsing_context(), can_gc)
+            .elements_from_point(x, y, None, self.document.has_browsing_context())
             .iter()
         {
             let retargeted_node = self.upcast::<Node>().retarget(e.upcast::<Node>());

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1661,12 +1661,12 @@ impl ScriptThread {
             // https://html.spec.whatwg.org/multipage/#context-lost-steps.
 
             // Run the animation frame callbacks.
-            document.tick_all_animations(should_run_rafs, can_gc);
+            document.tick_all_animations(should_run_rafs);
 
             // Run the resize observer steps.
             let _realm = enter_realm(&*document);
             let mut depth = Default::default();
-            while document.gather_active_resize_observations_at_depth(&depth, can_gc) {
+            while document.gather_active_resize_observations_at_depth(&depth) {
                 // Note: this will reflow the doc.
                 depth = document.broadcast_active_resize_observations(can_gc);
             }
@@ -1820,7 +1820,7 @@ impl ScriptThread {
                 },
                 FromConstellation(ConstellationControlMsg::Viewport(id, rect)) => self
                     .profile_event(ScriptThreadEventCategory::SetViewport, Some(id), || {
-                        self.handle_viewport(id, rect, can_gc);
+                        self.handle_viewport(id, rect);
                     }),
                 FromConstellation(ConstellationControlMsg::TickAllAnimations(
                     pipeline_id,
@@ -1998,17 +1998,13 @@ impl ScriptThread {
 
             let pending_reflows = window.get_pending_reflow_count();
             if pending_reflows > 0 {
-                window.reflow(ReflowGoal::Full, ReflowReason::PendingReflow, can_gc);
+                window.reflow(ReflowGoal::Full, ReflowReason::PendingReflow);
             } else {
                 // Reflow currently happens when explicitly invoked by code that
                 // knows the document could have been modified. This should really
                 // be driven by the compositor on an as-needed basis instead, to
                 // minimize unnecessary work.
-                window.reflow(
-                    ReflowGoal::Full,
-                    ReflowReason::MissingExplicitReflow,
-                    can_gc,
-                );
+                window.reflow(ReflowGoal::Full, ReflowReason::MissingExplicitReflow);
             }
         }
 
@@ -2489,7 +2485,7 @@ impl ScriptThread {
                 self.collect_reports(chan)
             },
             MainThreadScriptMsg::WorkletLoaded(pipeline_id) => {
-                self.handle_worklet_loaded(pipeline_id, CanGc::note())
+                self.handle_worklet_loaded(pipeline_id)
             },
             MainThreadScriptMsg::RegisterPaintWorklet {
                 pipeline_id,
@@ -2523,7 +2519,7 @@ impl ScriptThread {
                 devtools::handle_get_children(&documents, id, node_id, reply)
             },
             DevtoolScriptControlMsg::GetAttributeStyle(id, node_id, reply) => {
-                devtools::handle_get_attribute_style(&documents, id, node_id, reply, can_gc)
+                devtools::handle_get_attribute_style(&documents, id, node_id, reply)
             },
             DevtoolScriptControlMsg::GetStylesheetStyle(
                 id,
@@ -2532,13 +2528,13 @@ impl ScriptThread {
                 stylesheet,
                 reply,
             ) => devtools::handle_get_stylesheet_style(
-                &documents, id, node_id, selector, stylesheet, reply, can_gc,
+                &documents, id, node_id, selector, stylesheet, reply,
             ),
             DevtoolScriptControlMsg::GetSelectors(id, node_id, reply) => {
                 devtools::handle_get_selectors(&documents, id, node_id, reply)
             },
             DevtoolScriptControlMsg::GetComputedStyle(id, node_id, reply) => {
-                devtools::handle_get_computed_style(&documents, id, node_id, reply, can_gc)
+                devtools::handle_get_computed_style(&documents, id, node_id, reply)
             },
             DevtoolScriptControlMsg::GetLayout(id, node_id, reply) => {
                 devtools::handle_get_layout(&documents, id, node_id, reply, can_gc)
@@ -2774,17 +2770,10 @@ impl ScriptThread {
                 )
             },
             WebDriverScriptCommand::GetElementCSS(node_id, name, reply) => {
-                webdriver_handlers::handle_get_css(
-                    &documents,
-                    pipeline_id,
-                    node_id,
-                    name,
-                    reply,
-                    can_gc,
-                )
+                webdriver_handlers::handle_get_css(&documents, pipeline_id, node_id, name, reply)
             },
             WebDriverScriptCommand::GetElementRect(node_id, reply) => {
-                webdriver_handlers::handle_get_rect(&documents, pipeline_id, node_id, reply, can_gc)
+                webdriver_handlers::handle_get_rect(&documents, pipeline_id, node_id, reply)
             },
             WebDriverScriptCommand::GetBoundingClientRect(node_id, reply) => {
                 webdriver_handlers::handle_get_bounding_client_rect(
@@ -2862,11 +2851,11 @@ impl ScriptThread {
         }
     }
 
-    fn handle_viewport(&self, id: PipelineId, rect: Rect<f32>, can_gc: CanGc) {
+    fn handle_viewport(&self, id: PipelineId, rect: Rect<f32>) {
         let document = self.documents.borrow().find_document(id);
         if let Some(document) = document {
             if document.window().set_page_clip_rect_with_new_viewport(rect) {
-                self.rebuild_and_force_reflow(&document, ReflowReason::Viewport, can_gc);
+                self.rebuild_and_force_reflow(&document, ReflowReason::Viewport);
             }
             return;
         }
@@ -2972,7 +2961,7 @@ impl ScriptThread {
         );
         let document = self.documents.borrow().find_document(id);
         if let Some(document) = document {
-            document.set_activity(activity, CanGc::note());
+            document.set_activity(activity);
             return;
         }
         let mut loads = self.incomplete_loads.borrow_mut();
@@ -3386,10 +3375,10 @@ impl ScriptThread {
     }
 
     /// Handles a worklet being loaded. Does nothing if the page no longer exists.
-    fn handle_worklet_loaded(&self, pipeline_id: PipelineId, can_gc: CanGc) {
+    fn handle_worklet_loaded(&self, pipeline_id: PipelineId) {
         let document = self.documents.borrow().find_document(pipeline_id);
         if let Some(document) = document {
-            self.rebuild_and_force_reflow(&document, ReflowReason::WorkletLoaded, can_gc);
+            self.rebuild_and_force_reflow(&document, ReflowReason::WorkletLoaded);
         }
     }
 
@@ -3850,10 +3839,10 @@ impl ScriptThread {
     }
 
     /// Reflows non-incrementally, rebuilding the entire layout tree in the process.
-    fn rebuild_and_force_reflow(&self, document: &Document, reason: ReflowReason, can_gc: CanGc) {
+    fn rebuild_and_force_reflow(&self, document: &Document, reason: ReflowReason) {
         let window = window_from_node(document);
         document.dirty_all_nodes();
-        window.reflow(ReflowGoal::Full, reason, can_gc);
+        window.reflow(ReflowGoal::Full, reason);
     }
 
     /// Queue compositor events for later dispatching as part of a

--- a/components/script/timers.rs
+++ b/components/script/timers.rs
@@ -95,7 +95,7 @@ impl OneshotTimerCallback {
             OneshotTimerCallback::EventSourceTimeout(callback) => callback.invoke(),
             OneshotTimerCallback::JsTimer(task) => task.invoke(this, js_timers, can_gc),
             OneshotTimerCallback::TestBindingCallback(callback) => callback.invoke(),
-            OneshotTimerCallback::FakeRequestAnimationFrame(callback) => callback.invoke(can_gc),
+            OneshotTimerCallback::FakeRequestAnimationFrame(callback) => callback.invoke(),
             OneshotTimerCallback::RefreshRedirectDue(callback) => callback.invoke(can_gc),
         }
     }

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -392,8 +392,8 @@ fn get_element_in_view_center_point(element: &Element, can_gc: CanGc) -> Option<
                 let width = rectangle.Width().round() as i64;
                 let height = rectangle.Height().round() as i64;
 
-                let client_width = body.ClientWidth(can_gc) as i64;
-                let client_height = body.ClientHeight(can_gc) as i64;
+                let client_width = body.ClientWidth() as i64;
+                let client_height = body.ClientHeight() as i64;
 
                 // Steps 2 - 5
                 let left = cmp::max(0, cmp::min(x, x + width));
@@ -885,7 +885,6 @@ pub fn handle_get_rect(
     pipeline: PipelineId,
     element_id: String,
     reply: IpcSender<Result<Rect<f64>, ErrorStatus>>,
-    can_gc: CanGc,
 ) {
     reply
         .send(
@@ -897,15 +896,15 @@ pub fn handle_get_rect(
                         let mut x = 0;
                         let mut y = 0;
 
-                        let mut offset_parent = html_element.GetOffsetParent(can_gc);
+                        let mut offset_parent = html_element.GetOffsetParent();
 
                         // Step 2
                         while let Some(element) = offset_parent {
                             offset_parent = match element.downcast::<HTMLElement>() {
                                 Some(elem) => {
-                                    x += elem.OffsetLeft(can_gc);
-                                    y += elem.OffsetTop(can_gc);
-                                    elem.GetOffsetParent(can_gc)
+                                    x += elem.OffsetLeft();
+                                    y += elem.OffsetTop();
+                                    elem.GetOffsetParent()
                                 },
                                 None => None,
                             };
@@ -914,8 +913,8 @@ pub fn handle_get_rect(
                         Ok(Rect::new(
                             Point2D::new(x as f64, y as f64),
                             Size2D::new(
-                                html_element.OffsetWidth(can_gc) as f64,
-                                html_element.OffsetHeight(can_gc) as f64,
+                                html_element.OffsetWidth() as f64,
+                                html_element.OffsetHeight() as f64,
                             ),
                         ))
                     },
@@ -1044,7 +1043,6 @@ pub fn handle_get_css(
     node_id: String,
     name: String,
     reply: IpcSender<Result<String, ErrorStatus>>,
-    can_gc: CanGc,
 ) {
     reply
         .send(
@@ -1054,7 +1052,7 @@ pub fn handle_get_css(
                 String::from(
                     window
                         .GetComputedStyle(element, None)
-                        .GetPropertyValue(DOMString::from(name), can_gc),
+                        .GetPropertyValue(DOMString::from(name)),
                 )
             }),
         )


### PR DESCRIPTION
**PR Description**

**Issue**:
Creating a font object was triggering avoidable garbage collection (GC).

**Changes Made:**

1. Added a status to track if the font object is created.
2. Updated `Fonts()` to only create the font object when needed.
3. Removed CanGc from `Window::reflow()` as it's no longer necessary.
4. Followed through and removed other unneeded CanGc.

**Impact:**
Reduces unnecessary GC, improving performance and making the code easier to maintain.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #34037 

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
