### PR TITLE
layout: Remove an obselete comment from flexbox

### DIFF
--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -39,11 +39,6 @@ use crate::style_ext::{
 };
 use crate::{ContainingBlock, IndefiniteContainingBlock};
 
-// FIMXE: “Flex items […] `z-index` values other than `auto` create a stacking context
-// even if `position` is `static` (behaving exactly as if `position` were `relative`).”
-// https://drafts.csswg.org/css-flexbox/#painting
-// (likely in `display_list/stacking_context.rs`)
-
 /// Layout parameters and intermediate results about a flex container,
 /// grouped to avoid passing around many parameters
 struct FlexContext<'a> {


### PR DESCRIPTION
This behavior is handled properly in `style_ext.rs`.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they just remove a comment.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
