### PR TITLE
Rename ImageOrientation default to "from-image"

### DIFF
--- a/components/script/dom/webidls/ImageBitmap.webidl
+++ b/components/script/dom/webidls/ImageBitmap.webidl
@@ -21,13 +21,13 @@ typedef (CanvasImageSource or
          Blob or
          ImageData) ImageBitmapSource;
 
-enum ImageOrientation { "none", "flipY" };
+enum ImageOrientation { "from-image", "flipY" };
 enum PremultiplyAlpha { "none", "premultiply", "default" };
 enum ColorSpaceConversion { "none", "default" };
 enum ResizeQuality { "pixelated", "low", "medium", "high" };
 
 dictionary ImageBitmapOptions {
-  ImageOrientation imageOrientation = "none";
+  ImageOrientation imageOrientation = "from-image";
   PremultiplyAlpha premultiplyAlpha = "default";
   ColorSpaceConversion colorSpaceConversion = "default";
   [EnforceRange] unsigned long resizeWidth;


### PR DESCRIPTION
The spec has changed since our implementation was written.

Doesn't fix any tests, presumably because [servo's implementation](https://github.com/servo/servo/blob/25a0764a37a585d032ca352923b24995f8cbf1a0/components/script/dom/globalscope.rs#L2816) of `window.createImageBitmap` ignores the orientation argument. 

[try run](https://github.com/simonwuelker/servo/actions/runs/11680999203)

Spec: https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#imageorientation

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are a part of #34112
- [X] These changes do not require tests because it's just renaming the default value.


