### PR TITLE
layout: Properly calculate free space in flexbox flexible length resolution

### DIFF
--- a/tests/wpt/meta/css/css-flexbox/flex-flow-013.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-flow-013.html.ini
@@ -5,18 +5,6 @@
   [.flexbox 11]
     expected: FAIL
 
-  [.flexbox 4]
-    expected: FAIL
-
-  [.flexbox 2]
-    expected: FAIL
-
-  [.flexbox 1]
-    expected: FAIL
-
-  [.flexbox 3]
-    expected: FAIL
-
   [.flexbox 9]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-flexbox/flexbox-basic-canvas-horiz-001.xhtml.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-basic-canvas-horiz-001.xhtml.ini
@@ -1,2 +1,0 @@
-[flexbox-basic-canvas-horiz-001.xhtml]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox-basic-canvas-horiz-001v.xhtml.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-basic-canvas-horiz-001v.xhtml.ini
@@ -1,2 +1,0 @@
-[flexbox-basic-canvas-horiz-001v.xhtml]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox-basic-canvas-vert-001.xhtml.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-basic-canvas-vert-001.xhtml.ini
@@ -1,2 +1,0 @@
-[flexbox-basic-canvas-vert-001.xhtml]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox-basic-canvas-vert-001v.xhtml.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-basic-canvas-vert-001v.xhtml.ini
@@ -1,2 +1,0 @@
-[flexbox-basic-canvas-vert-001v.xhtml]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox-basic-fieldset-horiz-001.xhtml.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-basic-fieldset-horiz-001.xhtml.ini
@@ -1,2 +1,0 @@
-[flexbox-basic-fieldset-horiz-001.xhtml]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox-basic-fieldset-vert-001.xhtml.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-basic-fieldset-vert-001.xhtml.ini
@@ -1,2 +1,0 @@
-[flexbox-basic-fieldset-vert-001.xhtml]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox-basic-iframe-horiz-001.xhtml.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-basic-iframe-horiz-001.xhtml.ini
@@ -1,2 +1,0 @@
-[flexbox-basic-iframe-horiz-001.xhtml]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox-basic-iframe-vert-001.xhtml.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-basic-iframe-vert-001.xhtml.ini
@@ -1,2 +1,0 @@
-[flexbox-basic-iframe-vert-001.xhtml]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox-basic-img-horiz-001.xhtml.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-basic-img-horiz-001.xhtml.ini
@@ -1,2 +1,0 @@
-[flexbox-basic-img-horiz-001.xhtml]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox-basic-img-vert-001.xhtml.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-basic-img-vert-001.xhtml.ini
@@ -1,2 +1,0 @@
-[flexbox-basic-img-vert-001.xhtml]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox-basic-textarea-horiz-001.xhtml.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-basic-textarea-horiz-001.xhtml.ini
@@ -1,2 +1,0 @@
-[flexbox-basic-textarea-horiz-001.xhtml]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox-basic-textarea-vert-001.xhtml.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-basic-textarea-vert-001.xhtml.ini
@@ -1,2 +1,0 @@
-[flexbox-basic-textarea-vert-001.xhtml]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox-basic-video-horiz-001.xhtml.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-basic-video-horiz-001.xhtml.ini
@@ -1,2 +1,0 @@
-[flexbox-basic-video-horiz-001.xhtml]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox-basic-video-vert-001.xhtml.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-basic-video-vert-001.xhtml.ini
@@ -1,2 +1,0 @@
-[flexbox-basic-video-vert-001.xhtml]
-  expected: FAIL


### PR DESCRIPTION
Previously, when there were no more violations, the returned value for
line free space was incorrect for flexible length resolution. It was
returning the container main space minus the inner size of each item.
Free space is determined by removing the outer sizes though. Fix this
by reusing the `free_space()` function, but with an argument indicating
that all items are now frozen.

Fixes #34079.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
