### PR TITLE
Fix inline content sizes of intrinsic element with indefinite block size

### DIFF
--- a/tests/wpt/meta/css/css-sizing/box-sizing-replaced-001.xht.ini
+++ b/tests/wpt/meta/css/css-sizing/box-sizing-replaced-001.xht.ini
@@ -1,2 +1,0 @@
-[box-sizing-replaced-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/box-sizing-replaced-002.xht.ini
+++ b/tests/wpt/meta/css/css-sizing/box-sizing-replaced-002.xht.ini
@@ -1,2 +1,0 @@
-[box-sizing-replaced-002.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/box-sizing-replaced-003.xht.ini
+++ b/tests/wpt/meta/css/css-sizing/box-sizing-replaced-003.xht.ini
@@ -1,2 +1,0 @@
-[box-sizing-replaced-003.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/intrinsic-percent-replaced-017.html.ini
+++ b/tests/wpt/meta/css/css-sizing/intrinsic-percent-replaced-017.html.ini
@@ -1,2 +1,0 @@
-[intrinsic-percent-replaced-017.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/intrinsic-size-fallback-video.html.ini
+++ b/tests/wpt/meta/css/css-sizing/intrinsic-size-fallback-video.html.ini
@@ -1,6 +1,0 @@
-[intrinsic-size-fallback-video.html]
-  [.wrapper 3]
-    expected: FAIL
-
-  [.wrapper 4]
-    expected: FAIL


### PR DESCRIPTION
To compute the min-content and max-content inline sizes of a replaced element, we were only using the aspect ratio to transfer definite block sizes resulting from clamping the preferred block size between the min and max block sizes.

However, if the preferred block size is indefinite, then we weren't transfering the min and max through the aspect ratio.

This patch adds a `SizeConstraint` enum that can represent these cases, and a `ConstraintSpace` struct analogous to `IndefiniteContainingBlock` but with no inline size, and a `SizeConstraint` block size.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
