### PR TITLE
ohos: Bump ohos-vsync and ohos-sys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5147,15 +5147,18 @@ dependencies = [
 
 [[package]]
 name = "ohos-sys"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "491c77f0fe6b4336266f9da68b8dffb15d3bbe19c32ac0145b861851af3c8e41"
+checksum = "8a786868a20866e5682c6666ebd84435563d7ff2d6088576d958c1bb7475e460"
+dependencies = [
+ "xcomponent-sys",
+]
 
 [[package]]
 name = "ohos-vsync"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5871e38034a33e8d43c711a40d39e24fd3500f43b61b9269b8586f608a70aec3"
+checksum = "f861dc51ec885943dc9fcb757c26b1e934cc307daf79e025a0bf68a4875fc4a8"
 dependencies = [
  "ohos-sys",
 ]
@@ -8917,6 +8920,12 @@ dependencies = [
  "linux-raw-sys",
  "rustix",
 ]
+
+[[package]]
+name = "xcomponent-sys"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "663e26cce4f574daf506a01f4e5cfedd5355c60afebc30daeeeea95f38f6b600"
 
 [[package]]
 name = "xcursor"

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -88,8 +88,8 @@ ipc-channel = { workspace = true, features = ["force-inprocess"] }
 hilog = "0.1.1"
 napi-derive-ohos = "1.0.1"
 napi-ohos = "0.1"
-ohos-sys = { version = "0.3.1", features = ["xcomponent"] }
-ohos-vsync = "0.1"
+ohos-sys = { version = "0.4.0", features = ["xcomponent"] }
+ohos-vsync = "0.1.2"
 
 [target.'cfg(any(target_os = "android", target_env = "ohos"))'.dependencies]
 nix = { workspace = true, features = ["fs"] }


### PR DESCRIPTION
Manual PR for https://github.com/servo/servo/pull/34140 and https://github.com/servo/servo/pull/34074


---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

