### PR TITLE
layout: Fix caching of streching flex items in row flex

### DIFF
--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -1815,8 +1815,11 @@ impl FlexItem<'_> {
             }),
         };
 
-        let ifc = &mut self.box_.independent_formatting_context;
-        let item_writing_mode = ifc.style().writing_mode;
+        let item_writing_mode = self
+            .box_
+            .independent_formatting_context
+            .style()
+            .writing_mode;
         let item_is_horizontal = item_writing_mode.is_horizontal();
         let flex_axis = flex_context.config.flex_axis;
         let cross_axis_is_item_block_axis = cross_axis_is_item_block_axis(
@@ -1835,7 +1838,9 @@ impl FlexItem<'_> {
                             item_writing_mode,
                             AuOrAuto::LengthPercentage(used_main_size),
                         );
-                    let content_contributions = ifc
+                    let content_contributions = self
+                        .box_
+                        .independent_formatting_context
                         .inline_content_sizes(
                             flex_context.layout_context,
                             &containing_block_for_children,
@@ -1865,7 +1870,7 @@ impl FlexItem<'_> {
         };
 
         let container_writing_mode = containing_block.style.writing_mode;
-        match ifc {
+        match &self.box_.independent_formatting_context {
             IndependentFormattingContext::Replaced(replaced) => {
                 let size = replaced
                     .contents
@@ -1967,6 +1972,8 @@ impl FlexItem<'_> {
                     &item_as_containing_block,
                     containing_block,
                 );
+                let depends_on_block_constraints = depends_on_block_constraints ||
+                    (flex_axis == FlexAxis::Row && self.stretches());
 
                 let has_child_which_depends_on_block_constraints = fragments.iter().any(|fragment| {
                         fragment.base().map_or(false,|base|
@@ -1977,7 +1984,7 @@ impl FlexItem<'_> {
                 let item_writing_mode_is_orthogonal_to_container_writing_mode =
                     flex_context.config.writing_mode.is_horizontal() !=
                         non_replaced.style.writing_mode.is_horizontal();
-                let has_compatible_baseline = match flex_context.config.flex_axis {
+                let has_compatible_baseline = match flex_axis {
                     FlexAxis::Row => !item_writing_mode_is_orthogonal_to_container_writing_mode,
                     FlexAxis::Column => item_writing_mode_is_orthogonal_to_container_writing_mode,
                 };

--- a/tests/wpt/tests/css/css-flexbox/stretched-child-in-nested-flexbox.html
+++ b/tests/wpt/tests/css/css-flexbox/stretched-child-in-nested-flexbox.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<link rel="help" href="https://drafts.csswg.org/css-flexbox/#propdef-align-content" />
+<title>css-flexbox: Tests nested flex item with `align-items: stretch`</title>
+<link rel="author" title="Martin Robinson" href="mailto:mrobinson@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox/#align-items-property">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="This checks that a stretched flex item in a nested flexbox streches to the size of the parent flex container's line.">
+<body>
+    <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+    <div style="display: flex;">
+        <div style="width: 50px; height: 100px; background: green;"></div>
+        <div style="display: flex;">
+            <div style="background: green; width: 50px;"></div>
+      </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
When a flex item stretches in the cross axis in a row flex, we need to
mark it as depending on block constraints. This fixes an issue where the
cached layout was used in this case when stretching should trigger a new
layout.

Fixes #34154.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>
Co-authored-by: Oriol Brufau <obrufau@igalia.com>
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #34154.
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
