### PR TITLE
Support associated types in must_root lint

### DIFF
--- a/components/script/dom/bindings/inheritance.rs
+++ b/components/script/dom/bindings/inheritance.rs
@@ -55,6 +55,7 @@ pub trait Castable: IDLInterface + DomObject + Sized {
 
 #[allow(missing_docs)]
 pub trait HasParent {
+    #[crown::unrooted_must_root_lint::must_root]
     type Parent;
     fn as_parent(&self) -> &Self::Parent;
 }

--- a/components/script/dom/permissions.rs
+++ b/components/script/dom/permissions.rs
@@ -29,6 +29,7 @@ use crate::script_runtime::{CanGc, JSContext};
 
 pub trait PermissionAlgorithm {
     type Descriptor;
+    #[crown::unrooted_must_root_lint::must_root]
     type Status;
     fn create_descriptor(
         cx: JSContext,

--- a/components/script/dom/webgl_extensions/extension.rs
+++ b/components/script/dom/webgl_extensions/extension.rs
@@ -15,6 +15,7 @@ pub trait WebGLExtension: Sized
 where
     Self::Extension: DomObject + JSTraceable,
 {
+    #[crown::unrooted_must_root_lint::must_root]
     type Extension;
 
     /// Creates the DOM object of the WebGL extension.

--- a/support/crown/src/unrooted_must_root.rs
+++ b/support/crown/src/unrooted_must_root.rs
@@ -52,19 +52,6 @@ impl UnrootedPass {
     }
 }
 
-fn has_lint_attr(sym: &Symbols, attrs: &[Attribute], name: Symbol) -> bool {
-    attrs.iter().any(|attr| {
-        matches!(
-            &attr.kind,
-            AttrKind::Normal(normal)
-            if normal.item.path.segments.len() == 3 &&
-            normal.item.path.segments[0].ident.name == sym.crown &&
-            normal.item.path.segments[1].ident.name == sym.unrooted_must_root_lint &&
-            normal.item.path.segments[2].ident.name == name
-        )
-    })
-}
-
 /// Checks if a type is unrooted or contains any owned unrooted types
 fn is_unrooted_ty<'tcx>(
     sym: &'_ Symbols,
@@ -82,7 +69,8 @@ fn is_unrooted_ty<'tcx>(
                 continue;
             },
         };
-        let has_attr = |did, name| has_lint_attr(sym, cx.tcx.get_attrs_unchecked(did), name);
+        let has_attr =
+                    |did, name| cx.tcx.has_attrs_with_path(did, &[sym.crown, sym.unrooted_must_root_lint, name]);
         let recur_into_subtree = match t.kind() {
             ty::Adt(did, substs) => {
                 if has_attr(did.did(), sym.must_root) {

--- a/support/crown/src/unrooted_must_root.rs
+++ b/support/crown/src/unrooted_must_root.rs
@@ -268,7 +268,7 @@ impl<'tcx> LateLintPass<'tcx> for UnrootedPass {
                         lint.primary_message(
                             "Type trait declaration must be marked with \
                         #[crown::unrooted_must_root_lint::must_root] \
-                        to allow binding must_root types in associate types",
+                        to allow binding must_root types in associated types",
                         );
                         lint.span(trait_item.span);
                     })

--- a/support/crown/src/unrooted_must_root.rs
+++ b/support/crown/src/unrooted_must_root.rs
@@ -68,8 +68,10 @@ fn is_unrooted_ty<'tcx>(
                 continue;
             },
         };
-        let has_attr =
-                    |did, name| cx.tcx.has_attrs_with_path(did, &[sym.crown, sym.unrooted_must_root_lint, name]);
+        let has_attr = |did, name| {
+            cx.tcx
+                .has_attrs_with_path(did, &[sym.crown, sym.unrooted_must_root_lint, name])
+        };
         let recur_into_subtree = match t.kind() {
             ty::Adt(did, substs) => {
                 if has_attr(did.did(), sym.must_root) {
@@ -145,7 +147,10 @@ fn is_unrooted_ty<'tcx>(
             ty::Ref(..) => false,    // don't recurse down &ptrs
             ty::RawPtr(..) => false, // don't recurse down *ptrs
             ty::FnDef(..) | ty::FnPtr(_) => false,
-            ty::Alias(_, ty) => {
+            ty::Alias(
+                ty::AliasTyKind::Projection | ty::AliasTyKind::Inherent | ty::AliasTyKind::Weak,
+                ty,
+            ) => {
                 if has_attr(ty.def_id, sym.must_root) {
                     ret = true;
                     false
@@ -173,7 +178,10 @@ impl<'tcx> LateLintPass<'tcx> for UnrootedPass {
     /// must be #[crown::unrooted_must_root_lint::must_root] themselves
     fn check_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx hir::Item) {
         let sym = &self.symbols;
-        if cx.tcx.has_attrs_with_path(item.hir_id().expect_owner(), &[sym.crown, sym.unrooted_must_root_lint, sym.must_root]) {
+        if cx.tcx.has_attrs_with_path(
+            item.hir_id().expect_owner(),
+            &[sym.crown, sym.unrooted_must_root_lint, sym.must_root],
+        ) {
             return;
         }
         if let hir::ItemKind::Struct(def, ..) = &item.kind {
@@ -198,7 +206,10 @@ impl<'tcx> LateLintPass<'tcx> for UnrootedPass {
         let map = &cx.tcx.hir();
         let parent_item = map.expect_item(map.get_parent_item(var.hir_id).def_id);
         let sym = &self.symbols;
-        if !cx.tcx.has_attrs_with_path(parent_item.hir_id().expect_owner(), &[sym.crown, sym.unrooted_must_root_lint, sym.must_root]) {
+        if !cx.tcx.has_attrs_with_path(
+            parent_item.hir_id().expect_owner(),
+            &[sym.crown, sym.unrooted_must_root_lint, sym.must_root],
+        ) {
             match var.data {
                 hir::VariantData::Tuple(fields, ..) => {
                     for field in fields {
@@ -231,7 +242,10 @@ impl<'tcx> LateLintPass<'tcx> for UnrootedPass {
         };
 
         let sym = &self.symbols;
-        if cx.tcx.has_attrs_with_path(trait_item.hir_id().expect_owner(), &[sym.crown, sym.unrooted_must_root_lint, sym.must_root]) {
+        if cx.tcx.has_attrs_with_path(
+            trait_item.hir_id().expect_owner(),
+            &[sym.crown, sym.unrooted_must_root_lint, sym.must_root],
+        ) {
             return;
         }
 

--- a/support/crown/tests/compile-fail/trait_type_impl_must_root.rs
+++ b/support/crown/tests/compile-fail/trait_type_impl_must_root.rs
@@ -1,0 +1,16 @@
+#[crown::unrooted_must_root_lint::must_root]
+struct Foo;
+
+trait Trait {
+    type F;
+    //~^ ERROR: Type trait declaration must be marked with #[crown::unrooted_must_root_lint::must_root] to allow binding must_root types in associate types
+}
+
+struct TypeHolder;
+
+impl Trait for TypeHolder {
+    // type F in trait must be also marked as must_root if we want to do this
+    type F = Foo;
+}
+
+fn main() {}

--- a/support/crown/tests/compile-fail/trait_type_impl_must_root.rs
+++ b/support/crown/tests/compile-fail/trait_type_impl_must_root.rs
@@ -3,7 +3,7 @@ struct Foo;
 
 trait Trait {
     type F;
-    //~^ ERROR: Type trait declaration must be marked with #[crown::unrooted_must_root_lint::must_root] to allow binding must_root types in associate types
+    //~^ ERROR: Type trait declaration must be marked with #[crown::unrooted_must_root_lint::must_root] to allow binding must_root types in associated types
 }
 
 struct TypeHolder;

--- a/support/crown/tests/compile-fail/trait_type_impl_must_root.rs
+++ b/support/crown/tests/compile-fail/trait_type_impl_must_root.rs
@@ -1,3 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+//@rustc-env:RUSTC_BOOTSTRAP=1
+
 #[crown::unrooted_must_root_lint::must_root]
 struct Foo;
 

--- a/support/crown/tests/compile-fail/type_holder_user_must_root.rs
+++ b/support/crown/tests/compile-fail/type_holder_user_must_root.rs
@@ -1,0 +1,17 @@
+struct Foo(i32);
+
+struct Bar<TH: TypeHolderTrait>(TH::F);
+//~^ ERROR: Type must be rooted, use #[crown::unrooted_must_root_lint::must_root] on the struct definition to propagate
+
+trait TypeHolderTrait {
+    #[crown::unrooted_must_root_lint::must_root]
+    type F;
+}
+
+struct TypeHolder;
+
+impl TypeHolderTrait for TypeHolder {
+    type F = Foo;
+}
+
+fn main() {}

--- a/support/crown/tests/compile-fail/type_holder_user_must_root.rs
+++ b/support/crown/tests/compile-fail/type_holder_user_must_root.rs
@@ -1,3 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+//@rustc-env:RUSTC_BOOTSTRAP=1
+
 struct Foo(i32);
 
 struct Bar<TH: TypeHolderTrait>(TH::F);

--- a/support/crown/tests/run-pass/type_holder_must_root.rs
+++ b/support/crown/tests/run-pass/type_holder_must_root.rs
@@ -1,0 +1,21 @@
+#[crown::unrooted_must_root_lint::must_root]
+struct Foo(i32);
+#[crown::unrooted_must_root_lint::must_root]
+struct Bar<TH: TypeHolderTrait>(TH::F, TH::B);
+
+struct Baz(i32);
+
+trait TypeHolderTrait {
+    #[crown::unrooted_must_root_lint::must_root]
+    type F;
+    type B;
+}
+
+struct TypeHolder;
+
+impl TypeHolderTrait for TypeHolder {
+    type F = Foo;
+    type B = Baz;
+}
+
+fn main() {}

--- a/support/crown/tests/run-pass/type_holder_must_root.rs
+++ b/support/crown/tests/run-pass/type_holder_must_root.rs
@@ -1,3 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+//@rustc-env:RUSTC_BOOTSTRAP=1
+
 #[crown::unrooted_must_root_lint::must_root]
 struct Foo(i32);
 #[crown::unrooted_must_root_lint::must_root]


### PR DESCRIPTION
This will be needed for https://github.com/servo/servo/pull/33416

Because we cannot do MIR level lints, we force that any associated type on trait is also marked with must_root if any must_root type is binded to it. Also we start checking associated type in is_rooted_ty. See tests for examples.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
