### PR TITLE
ohos: Remove unneeded dirs dependency in servo_config

### DIFF
--- a/components/config/Cargo.toml
+++ b/components/config/Cargo.toml
@@ -25,5 +25,5 @@ servo_url = { path = "../url" }
 style_config = { workspace = true }
 url = { workspace = true }
 
-[target.'cfg(not(target_os = "android"))'.dependencies]
+[target.'cfg(not(any(target_os = "android", target_env = "ohos")))'.dependencies]
 dirs = "5.0"

--- a/components/config/basedir.rs
+++ b/components/config/basedir.rs
@@ -12,7 +12,8 @@ use std::path::PathBuf;
     unix,
     not(target_os = "macos"),
     not(target_os = "ios"),
-    not(target_os = "android")
+    not(target_os = "android"),
+    not(target_env = "ohos")
 ))]
 pub fn default_config_dir() -> Option<PathBuf> {
     let mut config_dir = ::dirs::config_dir().unwrap();
@@ -21,7 +22,7 @@ pub fn default_config_dir() -> Option<PathBuf> {
     Some(config_dir)
 }
 
-#[cfg(target_os = "android")]
+#[cfg(any(target_os = "android", target_env = "ohos"))]
 pub fn default_config_dir() -> Option<PathBuf> {
     None
 }


### PR DESCRIPTION
`dirs` does not support OpenHarmony, and it also seems that there currently is no native API that `dirs` could use on OpenHarmony and the directory needs to be read from ArkTS.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

