### PR TITLE
Consistently use `Dom` in native promise handlers

### DIFF
--- a/components/script/body.rs
+++ b/components/script/body.rs
@@ -274,6 +274,7 @@ impl TransmitBodyConnectHandler {
 /// The handler of read promises of body streams used in
 /// <https://fetch.spec.whatwg.org/#concept-request-transmit-body>.
 #[derive(Clone, JSTraceable, MallocSizeOf)]
+#[crown::unrooted_must_root_lint::must_root]
 struct TransmitBodyPromiseHandler {
     #[ignore_malloc_size_of = "Channels are hard"]
     #[no_trace]
@@ -610,6 +611,7 @@ impl Callback for ConsumeBodyPromiseRejectionHandler {
 }
 
 #[derive(Clone, JSTraceable, MallocSizeOf)]
+#[crown::unrooted_must_root_lint::must_root]
 /// The promise handler used to consume the body,
 /// <https://fetch.spec.whatwg.org/#concept-body-consume-body>
 struct ConsumeBodyPromiseHandler {
@@ -649,6 +651,7 @@ impl ConsumeBodyPromiseHandler {
 impl Callback for ConsumeBodyPromiseHandler {
     /// Continuing Step 4 of <https://fetch.spec.whatwg.org/#concept-body-consume-body>
     /// Step 3 of <https://fetch.spec.whatwg.org/#concept-read-all-bytes-from-readablestream>.
+    #[allow(crown::unrooted_must_root)]
     fn callback(&self, cx: JSContext, v: HandleValue, _realm: InRealm, can_gc: CanGc) {
         let stream = self
             .stream

--- a/components/script/body.rs
+++ b/components/script/body.rs
@@ -27,7 +27,7 @@ use crate::dom::bindings::codegen::Bindings::XMLHttpRequestBinding::BodyInit;
 use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::DomObject;
-use crate::dom::bindings::root::DomRoot;
+use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::bindings::trace::RootedTraceableBox;
 use crate::dom::blob::{normalize_type_string, Blob};
@@ -249,7 +249,7 @@ impl TransmitBodyConnectHandler {
                 // and the corresponding IPC route in `component::net::http_loader`.
                 let promise_handler = Box::new(TransmitBodyPromiseHandler {
                     bytes_sender: bytes_sender.clone(),
-                    stream: rooted_stream.clone(),
+                    stream: Dom::from_ref(&rooted_stream.clone()),
                     control_sender: control_sender.clone(),
                 });
 
@@ -278,7 +278,7 @@ struct TransmitBodyPromiseHandler {
     #[ignore_malloc_size_of = "Channels are hard"]
     #[no_trace]
     bytes_sender: IpcSender<BodyChunkResponse>,
-    stream: DomRoot<ReadableStream>,
+    stream: Dom<ReadableStream>,
     #[ignore_malloc_size_of = "Channels are hard"]
     #[no_trace]
     control_sender: IpcSender<BodyChunkRequest>,
@@ -615,7 +615,7 @@ impl Callback for ConsumeBodyPromiseRejectionHandler {
 struct ConsumeBodyPromiseHandler {
     #[ignore_malloc_size_of = "Rc are hard"]
     result_promise: Rc<Promise>,
-    stream: Option<DomRoot<ReadableStream>>,
+    stream: Option<Dom<ReadableStream>>,
     body_type: DomRefCell<Option<BodyType>>,
     mime_type: DomRefCell<Option<Vec<u8>>>,
     bytes: DomRefCell<Option<Vec<u8>>>,
@@ -775,7 +775,7 @@ fn consume_body_with_promise<T: BodyMixin + DomObject>(
 
     let promise_handler = Box::new(ConsumeBodyPromiseHandler {
         result_promise: promise.clone(),
-        stream: Some(stream),
+        stream: Some(Dom::from_ref(&stream)),
         body_type: DomRefCell::new(Some(body_type)),
         mime_type: DomRefCell::new(Some(object.get_mime_type(can_gc))),
         // Step 2.

--- a/components/script/dom/promisenativehandler.rs
+++ b/components/script/dom/promisenativehandler.rs
@@ -14,6 +14,10 @@ use crate::dom::globalscope::GlobalScope;
 use crate::realms::InRealm;
 use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
 
+/// Types that implement the `Callback` trait follow the same rooting requirements
+/// as types that use the `#[dom_struct]` attribute.
+/// Prefer storing `Dom<T>` members inside them instead of `DomRoot<T>`
+/// to minimize redundant work by the garbage collector.
 pub trait Callback: JSTraceable + MallocSizeOf {
     fn callback(&self, cx: SafeJSContext, v: HandleValue, realm: InRealm, can_gc: CanGc);
 }


### PR DESCRIPTION
Use a `Dom` instead of a `DomRoot` in [`TransmitBodyPromiseHandler`](https://github.com/servo/servo/blob/05ecb8eddb3989ffcee51df5c2c86887fee8b7e8/components/script/body.rs#L281) and [`ConsumeBodyPromiseHandler`](https://github.com/servo/servo/blob/05ecb8eddb3989ffcee51df5c2c86887fee8b7e8/components/script/body.rs#L619) and document it at the definition of [`Callback`](https://github.com/servo/servo/blob/05ecb8eddb3989ffcee51df5c2c86887fee8b7e8/components/script/dom/promisenativehandler.rs#L17)


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #33604 
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
