### PR TITLE
ohos/android: Fix some compiler warnings

### DIFF
--- a/components/fonts/platform/freetype/ohos/font_list.rs
+++ b/components/fonts/platform/freetype/ohos/font_list.rs
@@ -10,7 +10,6 @@ use std::{fs, io};
 
 use base::text::{UnicodeBlock, UnicodeBlockMethod};
 use log::{debug, error, warn};
-use malloc_size_of_derive::MallocSizeOf;
 use style::values::computed::font::GenericFontFamily;
 use style::values::computed::{
     FontStretch as StyleFontStretch, FontStyle as StyleFontStyle, FontWeight as StyleFontWeight,

--- a/components/fonts/platform/mod.rs
+++ b/components/fonts/platform/mod.rs
@@ -2,9 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(all(
+    any(target_os = "linux", target_os = "macos"),
+    not(target_os = "android"),
+    not(target_env = "ohos")
+))]
 use base::text::{UnicodeBlock, UnicodeBlockMethod};
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(all(
+    any(target_os = "linux", target_os = "macos"),
+    not(target_os = "android"),
+    not(target_env = "ohos")
+))]
 use unicode_script::Script;
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -15,7 +23,11 @@ pub use crate::platform::macos::{
 };
 #[cfg(target_os = "windows")]
 pub use crate::platform::windows::{font, font_list, font_list::LocalFontIdentifier};
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(all(
+    any(target_os = "linux", target_os = "macos"),
+    not(target_os = "android"),
+    not(target_env = "ohos")
+))]
 use crate::FallbackFontSelectionOptions;
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -34,7 +46,11 @@ mod windows {
     pub mod font_list;
 }
 
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(all(
+    any(target_os = "linux", target_os = "macos"),
+    not(target_os = "android"),
+    not(target_env = "ohos")
+))]
 pub(crate) fn add_noto_fallback_families(
     options: FallbackFontSelectionOptions,
     families: &mut Vec<&'static str>,

--- a/ports/servoshell/egl/ohos.rs
+++ b/ports/servoshell/egl/ohos.rs
@@ -34,12 +34,8 @@ use super::servo_glue::ServoGlue;
 mod resources;
 mod simpleservo;
 
-// Todo: in the future these libraries should be added by Rust sys-crates
+// Can be removed once <https://github.com/ohos-rs/ohos-rs/pull/105> is merged / released.
 #[link(name = "ace_napi.z")]
-#[link(name = "ace_ndk.z")]
-#[link(name = "hilog_ndk.z")]
-#[link(name = "native_window")]
-#[link(name = "clang_rt.builtins", kind = "static")]
 extern "C" {}
 
 #[napi(object)]

--- a/ports/servoshell/parser.rs
+++ b/ports/servoshell/parser.rs
@@ -10,6 +10,7 @@ use servo::servo_config::pref;
 use servo::servo_url::ServoUrl;
 use url::{self, Url};
 
+#[cfg(not(any(target_os = "android", target_env = "ohos")))]
 pub fn parse_url_or_filename(cwd: &Path, input: &str) -> Result<ServoUrl, ()> {
     match ServoUrl::parse(input) {
         Ok(url) => Ok(url),
@@ -20,6 +21,7 @@ pub fn parse_url_or_filename(cwd: &Path, input: &str) -> Result<ServoUrl, ()> {
     }
 }
 
+#[cfg(not(any(target_os = "android", target_env = "ohos")))]
 pub fn get_default_url(
     url_opt: Option<&str>,
     cwd: impl AsRef<Path>,


### PR DESCRIPTION
Reduce the amount of warnings when compiling for ohos / android by:

- Make some dead code conditional on the target platform
- Remove some unnecessary duplicate links to system libraries on ohos


---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

