### PR TITLE
Add some more CanGc arguments for compiling/evaluating module scripts.

### DIFF
--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -1053,7 +1053,7 @@ impl HTMLScriptElement {
             if let Some(record) = record {
                 rooted!(in(*GlobalScope::get_cx()) let mut rval = UndefinedValue());
                 let evaluated =
-                    module_tree.execute_module(global, record, rval.handle_mut().into());
+                    module_tree.execute_module(global, record, rval.handle_mut().into(), can_gc);
 
                 if let Err(exception) = evaluated {
                     module_tree.set_rethrow_error(exception);


### PR DESCRIPTION
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because there is no runtime behaviour change.