### PR TITLE
subtlecrypto: Replace `NormalizedAlgorithm` with specialized variants

### DIFF
--- a/components/script/dom/subtlecrypto.rs
+++ b/components/script/dom/subtlecrypto.rs
@@ -1012,7 +1012,7 @@ fn normalize_algorithm_for_generate_key(
 
     let name = algorithm.name.str();
     let normalized_algorithm =
-        if name.eq_ignore_ascii_case(ALG_AES_CBC) | name.eq_ignore_ascii_case(ALG_AES_CTR) {
+        if name.eq_ignore_ascii_case(ALG_AES_CBC) || name.eq_ignore_ascii_case(ALG_AES_CTR) {
             let params = value_from_js_object!(AesKeyGenParams, cx, value);
             KeyGenerationAlgorithm::Aes(params.into())
         } else {

--- a/components/script/dom/subtlecrypto.rs
+++ b/components/script/dom/subtlecrypto.rs
@@ -852,14 +852,13 @@ macro_rules! value_from_js_object {
 }
 
 /// <https://w3c.github.io/webcrypto/#algorithm-normalization-normalize-an-algorithm> with operation `"get key length"`
-#[allow(unsafe_code)]
 fn normalize_algorithm_for_get_key_length(
     cx: JSContext,
     algorithm: &AlgorithmIdentifier,
 ) -> Result<GetKeyLengthAlgorithm, Error> {
     match algorithm {
         AlgorithmIdentifier::Object(obj) => {
-            rooted!(in(*cx) let value = ObjectValue(unsafe { *obj.get_unsafe() }));
+            rooted!(in(*cx) let value = ObjectValue(obj.get()));
             let Ok(ConversionResult::Success(algorithm)) = Algorithm::new(cx, value.handle())
             else {
                 return Err(Error::Syntax);
@@ -885,14 +884,13 @@ fn normalize_algorithm_for_get_key_length(
 }
 
 /// <https://w3c.github.io/webcrypto/#algorithm-normalization-normalize-an-algorithm> with operation `"digest"`
-#[allow(unsafe_code)]
 fn normalize_algorithm_for_digest(
     cx: JSContext,
     algorithm: &AlgorithmIdentifier,
 ) -> Result<DigestAlgorithm, Error> {
     let name = match algorithm {
         AlgorithmIdentifier::Object(obj) => {
-            rooted!(in(*cx) let value = ObjectValue(unsafe { *obj.get_unsafe() }));
+            rooted!(in(*cx) let value = ObjectValue(obj.get()));
             let Ok(ConversionResult::Success(algorithm)) = Algorithm::new(cx, value.handle())
             else {
                 return Err(Error::Syntax);
@@ -915,14 +913,13 @@ fn normalize_algorithm_for_digest(
 }
 
 /// <https://w3c.github.io/webcrypto/#algorithm-normalization-normalize-an-algorithm> with operation `"importKey"`
-#[allow(unsafe_code)]
 fn normalize_algorithm_for_import_key(
     cx: JSContext,
     algorithm: &AlgorithmIdentifier,
 ) -> Result<ImportKeyAlgorithm, Error> {
     let name = match algorithm {
         AlgorithmIdentifier::Object(obj) => {
-            rooted!(in(*cx) let value = ObjectValue(unsafe { *obj.get_unsafe() }));
+            rooted!(in(*cx) let value = ObjectValue(obj.get()));
             let Ok(ConversionResult::Success(algorithm)) = Algorithm::new(cx, value.handle())
             else {
                 return Err(Error::Syntax);
@@ -944,7 +941,6 @@ fn normalize_algorithm_for_import_key(
 }
 
 /// <https://w3c.github.io/webcrypto/#algorithm-normalization-normalize-an-algorithm> with operation `"deriveBits"`
-#[allow(unsafe_code)]
 fn normalize_algorithm_for_derive_bits(
     cx: JSContext,
     algorithm: &AlgorithmIdentifier,
@@ -954,7 +950,7 @@ fn normalize_algorithm_for_derive_bits(
         return Err(Error::NotSupported);
     };
 
-    rooted!(in(*cx) let value = ObjectValue(unsafe { *obj.get_unsafe() }));
+    rooted!(in(*cx) let value = ObjectValue(obj.get()));
     let Ok(ConversionResult::Success(algorithm)) = Algorithm::new(cx, value.handle()) else {
         return Err(Error::Syntax);
     };
@@ -971,7 +967,6 @@ fn normalize_algorithm_for_derive_bits(
 }
 
 /// <https://w3c.github.io/webcrypto/#algorithm-normalization-normalize-an-algorithm> with operation `"deriveBits"`
-#[allow(unsafe_code)]
 fn normalize_algorithm_for_encrypt_or_decrypt(
     cx: JSContext,
     algorithm: &AlgorithmIdentifier,
@@ -981,7 +976,7 @@ fn normalize_algorithm_for_encrypt_or_decrypt(
         return Err(Error::NotSupported);
     };
 
-    rooted!(in(*cx) let value = ObjectValue(unsafe { *obj.get_unsafe() }));
+    rooted!(in(*cx) let value = ObjectValue(obj.get()));
     let Ok(ConversionResult::Success(algorithm)) = Algorithm::new(cx, value.handle()) else {
         return Err(Error::Syntax);
     };
@@ -1001,7 +996,6 @@ fn normalize_algorithm_for_encrypt_or_decrypt(
 }
 
 /// <https://w3c.github.io/webcrypto/#algorithm-normalization-normalize-an-algorithm> with operation `"generateKey"`
-#[allow(unsafe_code)]
 fn normalize_algorithm_for_generate_key(
     cx: JSContext,
     algorithm: &AlgorithmIdentifier,
@@ -1011,7 +1005,7 @@ fn normalize_algorithm_for_generate_key(
         return Err(Error::NotSupported);
     };
 
-    rooted!(in(*cx) let value = ObjectValue(unsafe { *obj.get_unsafe() }));
+    rooted!(in(*cx) let value = ObjectValue(obj.get()));
     let Ok(ConversionResult::Success(algorithm)) = Algorithm::new(cx, value.handle()) else {
         return Err(Error::Syntax);
     };

--- a/tests/wpt/meta/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.js.ini
+++ b/tests/wpt/meta/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.js.ini
@@ -29,55 +29,19 @@
   [long password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -176,24 +140,6 @@
   [long password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using long password, short salt, SHA-384, with 0 iterations]
     expected: FAIL
 
@@ -224,55 +170,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-384, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -371,55 +281,19 @@
   [long password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -518,55 +392,19 @@
   [long password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -665,24 +503,6 @@
   [long password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using long password, short salt, SHA-512, with 0 iterations]
     expected: FAIL
 
@@ -713,55 +533,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-512, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -860,55 +644,19 @@
   [long password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -1007,55 +755,19 @@
   [long password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -1154,24 +866,6 @@
   [long password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using long password, short salt, SHA-1, with 0 iterations]
     expected: FAIL
 
@@ -1202,55 +896,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-1, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -1349,55 +1007,19 @@
   [long password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -1496,55 +1118,19 @@
   [long password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -1643,24 +1229,6 @@
   [long password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using long password, short salt, SHA-256, with 0 iterations]
     expected: FAIL
 
@@ -1691,55 +1259,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-256, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -1838,55 +1370,19 @@
   [long password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -1985,55 +1481,19 @@
   [long password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
 
@@ -2134,24 +1594,6 @@
   [long password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using long password, long salt, SHA-384, with 0 iterations]
     expected: FAIL
 
@@ -2182,55 +1624,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-384, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -2329,55 +1735,19 @@
   [long password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -2476,55 +1846,19 @@
   [long password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -2623,24 +1957,6 @@
   [long password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using long password, long salt, SHA-512, with 0 iterations]
     expected: FAIL
 
@@ -2671,55 +1987,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-512, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -2818,55 +2098,19 @@
   [long password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -2965,55 +2209,19 @@
   [long password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -3112,24 +2320,6 @@
   [long password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using long password, long salt, SHA-1, with 0 iterations]
     expected: FAIL
 
@@ -3160,55 +2350,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-1, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -3307,55 +2461,19 @@
   [long password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -3454,55 +2572,19 @@
   [long password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -3601,24 +2683,6 @@
   [long password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using long password, long salt, SHA-256, with 0 iterations]
     expected: FAIL
 
@@ -3649,55 +2713,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-256, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -3796,55 +2824,19 @@
   [long password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -3943,55 +2935,19 @@
   [long password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -4089,16 +3045,7 @@
 
 
 [pbkdf2.https.any.html?6001-7000]
-  [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -4197,55 +3144,19 @@
   [empty password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -4344,55 +3255,19 @@
   [empty password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -4491,24 +3366,6 @@
   [empty password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using empty password, short salt, SHA-512, with 0 iterations]
     expected: FAIL
 
@@ -4539,55 +3396,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-512, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -4686,55 +3507,19 @@
   [empty password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -4833,55 +3618,19 @@
   [empty password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -4980,24 +3729,6 @@
   [empty password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using empty password, short salt, SHA-1, with 0 iterations]
     expected: FAIL
 
@@ -5028,55 +3759,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-1, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -5175,55 +3870,19 @@
   [empty password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -5322,55 +3981,19 @@
   [empty password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -5469,24 +4092,6 @@
   [empty password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using empty password, short salt, SHA-256, with 0 iterations]
     expected: FAIL
 
@@ -5517,55 +4122,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-256, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -5664,55 +4233,19 @@
   [empty password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -5811,55 +4344,19 @@
   [empty password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -5958,24 +4455,6 @@
   [empty password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using empty password, long salt, SHA-384, with 0 iterations]
     expected: FAIL
 
@@ -6006,55 +4485,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-384, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -6143,28 +4586,10 @@
   [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -6263,55 +4688,19 @@
   [short password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -6410,24 +4799,6 @@
   [short password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using short password, empty salt, SHA-384, with 0 iterations]
     expected: FAIL
 
@@ -6458,55 +4829,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-384, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -6605,55 +4940,19 @@
   [short password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -6752,55 +5051,19 @@
   [short password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -6899,24 +5162,6 @@
   [short password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using short password, empty salt, SHA-512, with 0 iterations]
     expected: FAIL
 
@@ -6947,55 +5192,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-512, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -7094,55 +5303,19 @@
   [short password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -7241,55 +5414,19 @@
   [short password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -7388,24 +5525,6 @@
   [short password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using short password, empty salt, SHA-1, with 0 iterations]
     expected: FAIL
 
@@ -7436,55 +5555,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-1, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -7583,55 +5666,19 @@
   [short password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -7730,55 +5777,19 @@
   [short password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -7877,24 +5888,6 @@
   [short password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using short password, empty salt, SHA-256, with 0 iterations]
     expected: FAIL
 
@@ -7925,55 +5918,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-256, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -8072,55 +6029,19 @@
   [long password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -8272,55 +6193,19 @@
   [empty password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -8419,24 +6304,6 @@
   [empty password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using empty password, empty salt, SHA-512, with 0 iterations]
     expected: FAIL
 
@@ -8467,55 +6334,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-512, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -8614,55 +6445,19 @@
   [empty password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -8761,55 +6556,19 @@
   [empty password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -8908,24 +6667,6 @@
   [empty password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using empty password, empty salt, SHA-1, with 0 iterations]
     expected: FAIL
 
@@ -8956,55 +6697,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-1, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -9103,55 +6808,19 @@
   [empty password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -9250,55 +6919,19 @@
   [empty password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -9395,24 +7028,6 @@
     expected: FAIL
 
   [empty password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-256, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty password, empty salt, SHA-256, with 0 iterations]
@@ -9543,24 +7158,6 @@
   [long password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using long password, long salt, SHA-384, with 0 iterations]
     expected: FAIL
 
@@ -9591,55 +7188,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-384, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -9738,55 +7299,19 @@
   [long password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -9885,55 +7410,19 @@
   [long password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -10032,24 +7521,6 @@
   [long password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using long password, long salt, SHA-512, with 0 iterations]
     expected: FAIL
 
@@ -10080,55 +7551,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-512, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -10227,55 +7662,19 @@
   [long password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -10374,55 +7773,19 @@
   [long password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -10521,24 +7884,6 @@
   [long password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using long password, long salt, SHA-1, with 0 iterations]
     expected: FAIL
 
@@ -10569,55 +7914,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-1, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -10716,55 +8025,19 @@
   [long password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -10863,55 +8136,19 @@
   [long password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -11010,24 +8247,6 @@
   [long password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using long password, long salt, SHA-256, with 0 iterations]
     expected: FAIL
 
@@ -11058,55 +8277,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-256, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -11205,55 +8388,19 @@
   [long password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -11352,55 +8499,19 @@
   [long password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -11498,16 +8609,7 @@
 
 
 [pbkdf2.https.any.worker.html?6001-7000]
-  [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -11606,55 +8708,19 @@
   [empty password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -11753,55 +8819,19 @@
   [empty password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -11900,24 +8930,6 @@
   [empty password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using empty password, short salt, SHA-512, with 0 iterations]
     expected: FAIL
 
@@ -11948,55 +8960,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-512, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -12095,55 +9071,19 @@
   [empty password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -12242,55 +9182,19 @@
   [empty password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -12389,24 +9293,6 @@
   [empty password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using empty password, short salt, SHA-1, with 0 iterations]
     expected: FAIL
 
@@ -12437,55 +9323,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-1, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -12584,55 +9434,19 @@
   [empty password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -12731,55 +9545,19 @@
   [empty password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -12878,24 +9656,6 @@
   [empty password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using empty password, short salt, SHA-256, with 0 iterations]
     expected: FAIL
 
@@ -12926,55 +9686,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-256, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -13073,55 +9797,19 @@
   [empty password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -13220,55 +9908,19 @@
   [empty password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -13367,24 +10019,6 @@
   [empty password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using empty password, long salt, SHA-384, with 0 iterations]
     expected: FAIL
 
@@ -13415,55 +10049,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-384, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -13606,55 +10204,19 @@
   [short password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -13753,55 +10315,19 @@
   [short password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -13900,24 +10426,6 @@
   [short password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using short password, long salt, SHA-384, with 0 iterations]
     expected: FAIL
 
@@ -13948,55 +10456,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-384, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -14095,55 +10567,19 @@
   [short password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -14242,55 +10678,19 @@
   [short password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -14389,24 +10789,6 @@
   [short password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using short password, long salt, SHA-512, with 0 iterations]
     expected: FAIL
 
@@ -14437,55 +10819,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-512, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -14584,55 +10930,19 @@
   [short password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -14731,55 +11041,19 @@
   [short password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -14878,24 +11152,6 @@
   [short password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using short password, long salt, SHA-1, with 0 iterations]
     expected: FAIL
 
@@ -14926,55 +11182,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-1, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -15073,55 +11293,19 @@
   [short password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -15220,55 +11404,19 @@
   [short password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -15367,24 +11515,6 @@
   [short password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using short password, long salt, SHA-256, with 0 iterations]
     expected: FAIL
 
@@ -15415,55 +11545,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-256, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -15562,28 +11656,10 @@
   [short password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
 
@@ -15645,55 +11721,19 @@
   [short password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -15792,55 +11832,19 @@
   [short password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -15939,24 +11943,6 @@
   [short password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using short password, long salt, SHA-384, with 0 iterations]
     expected: FAIL
 
@@ -15987,55 +11973,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-384, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -16134,55 +12084,19 @@
   [short password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -16281,55 +12195,19 @@
   [short password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -16428,24 +12306,6 @@
   [short password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using short password, long salt, SHA-512, with 0 iterations]
     expected: FAIL
 
@@ -16476,55 +12336,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-512, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -16623,55 +12447,19 @@
   [short password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -16770,55 +12558,19 @@
   [short password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -16917,24 +12669,6 @@
   [short password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using short password, long salt, SHA-1, with 0 iterations]
     expected: FAIL
 
@@ -16965,55 +12699,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-1, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -17112,55 +12810,19 @@
   [short password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -17259,55 +12921,19 @@
   [short password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -17406,24 +13032,6 @@
   [short password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using short password, long salt, SHA-256, with 0 iterations]
     expected: FAIL
 
@@ -17454,55 +13062,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-256, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -17601,51 +13173,15 @@
   [short password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
 
 [pbkdf2.https.any.worker.html?5001-6000]
   [long password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-384, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long password, empty salt, SHA-384, with 0 iterations]
@@ -17678,55 +13214,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-384, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -17825,55 +13325,19 @@
   [long password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -17972,55 +13436,19 @@
   [long password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -18119,24 +13547,6 @@
   [long password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using long password, empty salt, SHA-512, with 0 iterations]
     expected: FAIL
 
@@ -18167,55 +13577,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-512, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -18314,55 +13688,19 @@
   [long password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -18461,55 +13799,19 @@
   [long password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -18608,24 +13910,6 @@
   [long password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using long password, empty salt, SHA-1, with 0 iterations]
     expected: FAIL
 
@@ -18656,55 +13940,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-1, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -18803,55 +14051,19 @@
   [long password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -18950,55 +14162,19 @@
   [long password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -19097,24 +14273,6 @@
   [long password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using long password, empty salt, SHA-256, with 0 iterations]
     expected: FAIL
 
@@ -19145,55 +14303,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-256, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -19292,55 +14414,19 @@
   [empty password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -19439,55 +14525,19 @@
   [empty password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -19586,24 +14636,6 @@
   [empty password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using empty password, short salt, SHA-384, with 0 iterations]
     expected: FAIL
 
@@ -19634,96 +14666,33 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-384, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
 
 [pbkdf2.https.any.html?1-1000]
-  [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -19822,55 +14791,19 @@
   [short password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -19969,55 +14902,19 @@
   [short password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -20116,24 +15013,6 @@
   [short password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using short password, short salt, SHA-384, with 0 iterations]
     expected: FAIL
 
@@ -20164,55 +15043,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-384, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -20311,55 +15154,19 @@
   [short password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -20458,55 +15265,19 @@
   [short password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -20605,24 +15376,6 @@
   [short password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using short password, short salt, SHA-512, with 0 iterations]
     expected: FAIL
 
@@ -20653,55 +15406,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-512, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -20800,55 +15517,19 @@
   [short password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -20947,55 +15628,19 @@
   [short password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -21094,24 +15739,6 @@
   [short password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using short password, short salt, SHA-1, with 0 iterations]
     expected: FAIL
 
@@ -21142,55 +15769,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-1, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -21289,55 +15880,19 @@
   [short password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -21436,55 +15991,19 @@
   [short password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -21583,24 +16102,6 @@
   [short password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using short password, short salt, SHA-256, with 0 iterations]
     expected: FAIL
 
@@ -21631,55 +16132,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-256, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -21738,55 +16203,19 @@
   [empty password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -21885,55 +16314,19 @@
   [empty password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -22032,24 +16425,6 @@
   [empty password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using empty password, long salt, SHA-512, with 0 iterations]
     expected: FAIL
 
@@ -22080,55 +16455,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-512, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -22227,55 +16566,19 @@
   [empty password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -22374,55 +16677,19 @@
   [empty password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -22521,24 +16788,6 @@
   [empty password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using empty password, long salt, SHA-1, with 0 iterations]
     expected: FAIL
 
@@ -22569,55 +16818,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-1, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -22716,55 +16929,19 @@
   [empty password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -22863,55 +17040,19 @@
   [empty password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -23010,24 +17151,6 @@
   [empty password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using empty password, long salt, SHA-256, with 0 iterations]
     expected: FAIL
 
@@ -23058,55 +17181,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-256, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -23205,55 +17292,19 @@
   [empty password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -23352,55 +17403,19 @@
   [empty password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -23499,24 +17514,6 @@
   [empty password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using empty password, empty salt, SHA-384, with 0 iterations]
     expected: FAIL
 
@@ -23547,55 +17544,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-384, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -23694,55 +17655,19 @@
   [empty password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -23777,55 +17702,19 @@
   [empty password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -23924,55 +17813,19 @@
   [empty password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -24071,24 +17924,6 @@
   [empty password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using empty password, long salt, SHA-512, with 0 iterations]
     expected: FAIL
 
@@ -24119,55 +17954,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-512, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -24266,55 +18065,19 @@
   [empty password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -24413,55 +18176,19 @@
   [empty password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -24560,24 +18287,6 @@
   [empty password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using empty password, long salt, SHA-1, with 0 iterations]
     expected: FAIL
 
@@ -24608,55 +18317,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-1, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -24755,55 +18428,19 @@
   [empty password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -24902,55 +18539,19 @@
   [empty password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -25049,24 +18650,6 @@
   [empty password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using empty password, long salt, SHA-256, with 0 iterations]
     expected: FAIL
 
@@ -25097,55 +18680,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-256, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -25244,55 +18791,19 @@
   [empty password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -25391,55 +18902,19 @@
   [empty password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -25538,24 +19013,6 @@
   [empty password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using empty password, empty salt, SHA-384, with 0 iterations]
     expected: FAIL
 
@@ -25586,55 +19043,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-384, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -25733,55 +19154,19 @@
   [empty password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -25831,55 +19216,19 @@
   [long password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -25978,24 +19327,6 @@
   [long password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using long password, short salt, SHA-384, with 0 iterations]
     expected: FAIL
 
@@ -26026,55 +19357,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-384, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -26173,55 +19468,19 @@
   [long password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -26320,55 +19579,19 @@
   [long password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -26467,24 +19690,6 @@
   [long password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using long password, short salt, SHA-512, with 0 iterations]
     expected: FAIL
 
@@ -26515,55 +19720,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-512, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -26662,55 +19831,19 @@
   [long password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -26809,55 +19942,19 @@
   [long password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -26956,24 +20053,6 @@
   [long password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using long password, short salt, SHA-1, with 0 iterations]
     expected: FAIL
 
@@ -27004,55 +20083,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-1, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -27151,55 +20194,19 @@
   [long password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -27298,55 +20305,19 @@
   [long password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -27445,24 +20416,6 @@
   [long password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using long password, short salt, SHA-256, with 0 iterations]
     expected: FAIL
 
@@ -27493,55 +20446,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-256, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -27640,55 +20557,19 @@
   [long password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -27787,55 +20668,19 @@
   [long password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
 
@@ -27843,28 +20688,10 @@
   [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -27963,55 +20790,19 @@
   [short password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -28110,24 +20901,6 @@
   [short password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using short password, empty salt, SHA-384, with 0 iterations]
     expected: FAIL
 
@@ -28158,55 +20931,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-384, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -28305,55 +21042,19 @@
   [short password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -28452,55 +21153,19 @@
   [short password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -28599,24 +21264,6 @@
   [short password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using short password, empty salt, SHA-512, with 0 iterations]
     expected: FAIL
 
@@ -28647,55 +21294,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-512, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -28794,55 +21405,19 @@
   [short password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -28941,55 +21516,19 @@
   [short password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -29088,24 +21627,6 @@
   [short password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using short password, empty salt, SHA-1, with 0 iterations]
     expected: FAIL
 
@@ -29136,55 +21657,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-1, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -29283,55 +21768,19 @@
   [short password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -29430,55 +21879,19 @@
   [short password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -29577,24 +21990,6 @@
   [short password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using short password, empty salt, SHA-256, with 0 iterations]
     expected: FAIL
 
@@ -29625,55 +22020,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-256, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -29772,55 +22131,19 @@
   [long password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -29972,55 +22295,19 @@
   [empty password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -30119,24 +22406,6 @@
   [empty password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using empty password, empty salt, SHA-512, with 0 iterations]
     expected: FAIL
 
@@ -30167,55 +22436,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-512, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -30314,55 +22547,19 @@
   [empty password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -30461,55 +22658,19 @@
   [empty password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -30608,24 +22769,6 @@
   [empty password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using empty password, empty salt, SHA-1, with 0 iterations]
     expected: FAIL
 
@@ -30656,55 +22799,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-1, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -30803,55 +22910,19 @@
   [empty password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -30950,55 +23021,19 @@
   [empty password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -31097,24 +23132,6 @@
   [empty password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using empty password, empty salt, SHA-256, with 0 iterations]
     expected: FAIL
 
@@ -31150,24 +23167,6 @@
   [long password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using long password, empty salt, SHA-384, with 0 iterations]
     expected: FAIL
 
@@ -31198,55 +23197,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-384, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -31345,55 +23308,19 @@
   [long password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -31492,55 +23419,19 @@
   [long password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -31639,24 +23530,6 @@
   [long password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using long password, empty salt, SHA-512, with 0 iterations]
     expected: FAIL
 
@@ -31687,55 +23560,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-512, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -31834,55 +23671,19 @@
   [long password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -31981,55 +23782,19 @@
   [long password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -32128,24 +23893,6 @@
   [long password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using long password, empty salt, SHA-1, with 0 iterations]
     expected: FAIL
 
@@ -32176,55 +23923,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-1, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -32323,55 +24034,19 @@
   [long password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -32470,55 +24145,19 @@
   [long password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -32617,24 +24256,6 @@
   [long password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using long password, empty salt, SHA-256, with 0 iterations]
     expected: FAIL
 
@@ -32665,55 +24286,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-256, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -32812,55 +24397,19 @@
   [empty password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -32959,55 +24508,19 @@
   [empty password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -33106,24 +24619,6 @@
   [empty password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using empty password, short salt, SHA-384, with 0 iterations]
     expected: FAIL
 
@@ -33154,96 +24649,33 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-384, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using empty password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using empty password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using empty password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
 
 [pbkdf2.https.any.worker.html?1-1000]
-  [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -33342,55 +24774,19 @@
   [short password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -33489,55 +24885,19 @@
   [short password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -33636,24 +24996,6 @@
   [short password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using short password, short salt, SHA-384, with 0 iterations]
     expected: FAIL
 
@@ -33684,55 +25026,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-384, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -33831,55 +25137,19 @@
   [short password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -33978,55 +25248,19 @@
   [short password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -34125,24 +25359,6 @@
   [short password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using short password, short salt, SHA-512, with 0 iterations]
     expected: FAIL
 
@@ -34173,55 +25389,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-512, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -34320,55 +25500,19 @@
   [short password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -34467,55 +25611,19 @@
   [short password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -34614,24 +25722,6 @@
   [short password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using short password, short salt, SHA-1, with 0 iterations]
     expected: FAIL
 
@@ -34662,55 +25752,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-1, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -34809,55 +25863,19 @@
   [short password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -34956,55 +25974,19 @@
   [short password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -35103,24 +26085,6 @@
   [short password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using short password, short salt, SHA-256, with 0 iterations]
     expected: FAIL
 
@@ -35151,55 +26115,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-256, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 192  using short password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 256  using short password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 128  using short password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]

--- a/tests/wpt/meta/fetch/content-encoding/br/big-br-body.https.any.js.ini
+++ b/tests/wpt/meta/fetch/content-encoding/br/big-br-body.https.any.js.ini
@@ -2,17 +2,11 @@
   expected: ERROR
 
 [big-br-body.https.any.html]
-  [large br data should be decompressed successfully]
-    expected: FAIL
-
   [large br data should be decompressed successfully with byte stream]
     expected: FAIL
 
 
 [big-br-body.https.any.worker.html]
-  [large br data should be decompressed successfully]
-    expected: FAIL
-
   [large br data should be decompressed successfully with byte stream]
     expected: FAIL
 

--- a/tests/wpt/meta/fetch/content-encoding/gzip/big-gzip-body.https.any.js.ini
+++ b/tests/wpt/meta/fetch/content-encoding/gzip/big-gzip-body.https.any.js.ini
@@ -2,17 +2,11 @@
   expected: ERROR
 
 [big-gzip-body.https.any.worker.html]
-  [large gzip data should be decompressed successfully]
-    expected: FAIL
-
   [large gzip data should be decompressed successfully with byte stream]
     expected: FAIL
 
 
 [big-gzip-body.https.any.html]
-  [large gzip data should be decompressed successfully]
-    expected: FAIL
-
   [large gzip data should be decompressed successfully with byte stream]
     expected: FAIL
 


### PR DESCRIPTION
This is a refactoring that requires some understanding of the [WebCryptoAPI spec](https://w3c.github.io/webcrypto), so I'll write slightly more than usual.

## Context
All functions in [`subtlecrypto`](https://w3c.github.io/webcrypto/#subtlecrypto-interface) receive either an object or a string to identify an algorithm. They then call [`normalize_algorithm`](https://w3c.github.io/webcrypto/#algorithm-normalization-normalize-an-algorithm) and provide a operation (`"digest"`, `"encrypt"` etc) to turn it into a `NormalizedAlgorithm`. This could for example be `Sha1` for hashing, or [`RsaHashedKeyGenParams`](https://w3c.github.io/webcrypto/#RsaHashedKeyGenParams-dictionary) for generating RSA keys. There are a lot of different `NormalizedAlgorithm` variants. [`RSASSA-PKCS1-v1_5`](https://w3c.github.io/webcrypto/#rsassa-pkcs1) alone defines four different ones.

Due to this, we currently have an ever-growing [`NormalizedAlgorithm`](https://github.com/servo/servo/blob/main/components/script/dom/subtlecrypto.rs#L722) enum that contains every algorithm in existence.

This is, of course, overly complex. When the spec creates a algorithm with operation `"generateKey"` then this algorithm will only ever generate keys, never encrypt values, and it's never going to be a value that identifies a hash.

## Proposed Changes
Instead of implementing one `normalize_algorithm(algorithm, operation)` function that returns a `NormalizedAlgorithm`, we should implement dedicated functions for each operation that return dedicated data structures.

For example, there is now `normalize_algorithm_for_digest(algorithm)`, which returns `DigestAlgorithm`. `DigestAlgorithm` is less clunky to use than the old `NormalizedAlgorithm`, because you don't have to deal with the (impossible) case of it containing AES encryption parameters for example.

The obvious downside is that this implementation deviates from the spec. However, the deviation is self-contained (everything outside of `normalize_algorithm` remains the same) and our current implementation of `normalize_algorithm` already doesn't really follow the spec.

Some tests are fixed because apparently `"get key length"` was broken before.

cc @msub2 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes
