### PR TITLE
Ensure ConsumeBodyPromiseHandler values are always rooted

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -30,7 +30,7 @@ linker = "lld-link.exe"
 
 [env]
 MACOSX_DEPLOYMENT_TARGET = "13.0"
-RUSTC_BOOTSTRAP = "crown,script,style_tests,mozjs"
+RUSTC_BOOTSTRAP = "crown,script,style_tests,mozjs,mozjs_sys"
 
 [build]
 rustdocflags = ["--document-private-items"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4447,7 +4447,7 @@ dependencies = [
 [[package]]
 name = "mozjs"
 version = "0.14.1"
-source = "git+https://github.com/servo/mozjs#ce24cb7ef19f0d649ecaa90b6e006c7c213ef991"
+source = "git+https://github.com/servo/mozjs#1765a7c7eaf1e4a02fdfff6866c8f427c659dc91"
 dependencies = [
  "bindgen",
  "cc",
@@ -4459,8 +4459,8 @@ dependencies = [
 
 [[package]]
 name = "mozjs_sys"
-version = "0.128.6-0"
-source = "git+https://github.com/servo/mozjs#ce24cb7ef19f0d649ecaa90b6e006c7c213ef991"
+version = "0.128.6-1"
+source = "git+https://github.com/servo/mozjs#1765a7c7eaf1e4a02fdfff6866c8f427c659dc91"
 dependencies = [
  "bindgen",
  "cc",


### PR DESCRIPTION
The code that sets up the ConsumeBodyPromiseHandler does not look like it contains a GC hazard right now (ie. no potential GC operation could run before the handler is attached to the native promise handler, thereby becoming reachable in the GC graph). However, there's always a risk that the code could be rewritten in a way that would make it unsafe in the future, so these changes make it possible to follow the familiar rooting patterns that we use elsewhere and remove the rooting warning suppression.

Depends on https://github.com/servo/mozjs/pull/535.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #34176
- [x] There are tests for these changes