### PR TITLE
Add HLS plugin to gstreamer packaging.

### DIFF
--- a/python/servo/gstreamer.py
+++ b/python/servo/gstreamer.py
@@ -85,6 +85,7 @@ GSTREAMER_PLUGIN_LIBS = [
     # gst-plugins-bad
     "gstaudiobuffersplit",
     "gstdtls",
+    "gsthls",
     "gstid3tag",
     "gstproxy",
     "gstvideoparsersbad",


### PR DESCRIPTION
This change allows reproducing the error in #34174 on all platforms.