### PR TITLE
Implement HKDF support for `subtlecrypto.deriveBits`

### DIFF
--- a/components/script/dom/cryptokey.rs
+++ b/components/script/dom/cryptokey.rs
@@ -27,6 +27,7 @@ pub enum Handle {
     Aes192(Vec<u8>),
     Aes256(Vec<u8>),
     Pbkdf2(Vec<u8>),
+    Hkdf(Vec<u8>),
 }
 
 /// <https://w3c.github.io/webcrypto/#cryptokey-interface>
@@ -148,6 +149,7 @@ impl Handle {
             Self::Aes192(bytes) => bytes,
             Self::Aes256(bytes) => bytes,
             Self::Pbkdf2(bytes) => bytes,
+            Self::Hkdf(bytes) => bytes,
         }
     }
 }

--- a/components/script/dom/webidls/SubtleCrypto.webidl
+++ b/components/script/dom/webidls/SubtleCrypto.webidl
@@ -92,6 +92,13 @@ dictionary AesCtrParams : Algorithm {
   required [EnforceRange] octet length;
 };
 
+// https://w3c.github.io/webcrypto/#hkdf-params
+dictionary HkdfParams : Algorithm {
+  required HashAlgorithmIdentifier hash;
+  required BufferSource salt;
+  required BufferSource info;
+};
+
 // https://w3c.github.io/webcrypto/#pbkdf2-params
 dictionary Pbkdf2Params : Algorithm {
   required BufferSource salt;

--- a/tests/wpt/meta/WebCryptoAPI/algorithm-discards-context.https.window.js.ini
+++ b/tests/wpt/meta/WebCryptoAPI/algorithm-discards-context.https.window.js.ini
@@ -12,15 +12,6 @@
   [Context is discarded in verify]
     expected: TIMEOUT
 
-  [Context is discarded in deriveBits]
-    expected: TIMEOUT
-
-  [Context is discarded in deriveKey]
-    expected: TIMEOUT
-
-  [Context is discarded in deriveKey (2)]
-    expected: TIMEOUT
-
   [Context is discarded in wrapKey]
     expected: TIMEOUT
 

--- a/tests/wpt/meta/WebCryptoAPI/derive_bits_keys/derived_bits_length.https.any.js.ini
+++ b/tests/wpt/meta/WebCryptoAPI/derive_bits_keys/derived_bits_length.https.any.js.ini
@@ -1,19 +1,4 @@
 [derived_bits_length.https.any.html]
-  [HKDF derivation with 256 as 'length' parameter]
-    expected: FAIL
-
-  [HKDF derivation with 0 as 'length' parameter]
-    expected: FAIL
-
-  [HKDF derivation with null as 'length' parameter]
-    expected: FAIL
-
-  [HKDF derivation with undefined as 'length' parameter]
-    expected: FAIL
-
-  [HKDF derivation with omitted as 'length' parameter]
-    expected: FAIL
-
   [ECDH derivation with 256 as 'length' parameter]
     expected: FAIL
 
@@ -45,9 +30,6 @@
     expected: FAIL
 
   [HKDF derivation with 384 as 'length' parameter]
-    expected: FAIL
-
-  [HKDF derivation with 230 as 'length' parameter]
     expected: FAIL
 
   [ECDH derivation with 384 as 'length' parameter]
@@ -64,21 +46,6 @@
 
 
 [derived_bits_length.https.any.worker.html]
-  [HKDF derivation with 256 as 'length' parameter]
-    expected: FAIL
-
-  [HKDF derivation with 0 as 'length' parameter]
-    expected: FAIL
-
-  [HKDF derivation with null as 'length' parameter]
-    expected: FAIL
-
-  [HKDF derivation with undefined as 'length' parameter]
-    expected: FAIL
-
-  [HKDF derivation with omitted as 'length' parameter]
-    expected: FAIL
-
   [ECDH derivation with 256 as 'length' parameter]
     expected: FAIL
 
@@ -110,9 +77,6 @@
     expected: FAIL
 
   [HKDF derivation with 384 as 'length' parameter]
-    expected: FAIL
-
-  [HKDF derivation with 230 as 'length' parameter]
     expected: FAIL
 
   [ECDH derivation with 384 as 'length' parameter]

--- a/tests/wpt/meta/WebCryptoAPI/derive_bits_keys/hkdf.https.any.js.ini
+++ b/tests/wpt/meta/WebCryptoAPI/derive_bits_keys/hkdf.https.any.js.ini
@@ -8,9 +8,6 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -20,142 +17,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [empty derivedKey, normal salt, SHA-256, with empty info with non-multiple of 8 length]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-256, with empty info with missing deriveBits usage]
-    expected: FAIL
-
   [empty derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, PBKDF2, with normal info with non-digest algorithm PBKDF2]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using empty derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 192  using empty derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using empty derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, PBKDF2, with empty info with non-digest algorithm PBKDF2]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using empty derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 192  using empty derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using empty derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, PBKDF2, with empty info]
     expected: FAIL
 
   [empty derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [empty derivedKey, empty salt, SHA-384, with normal info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -164,22 +38,10 @@
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -188,22 +50,10 @@
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -212,19 +62,10 @@
   [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using empty derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
@@ -236,9 +77,6 @@
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using empty derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -246,9 +84,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
@@ -260,9 +95,6 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -270,9 +102,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
@@ -284,9 +113,6 @@
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -294,9 +120,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
@@ -308,9 +131,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -318,9 +138,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
@@ -332,22 +149,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-384, with normal info with non-multiple of 8 length]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-384, with normal info with missing deriveBits usage]
     expected: FAIL
 
   [empty derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -356,16 +161,7 @@
   [empty derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [empty derivedKey, empty salt, SHA-384, with empty info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -374,22 +170,10 @@
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -398,22 +182,10 @@
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -422,19 +194,10 @@
   [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using empty derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
@@ -446,9 +209,6 @@
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using empty derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -456,9 +216,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
@@ -470,9 +227,6 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -480,9 +234,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
@@ -494,9 +245,6 @@
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -504,9 +252,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
@@ -518,9 +263,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -528,9 +270,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
@@ -542,22 +281,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-384, with empty info with non-multiple of 8 length]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-384, with empty info with missing deriveBits usage]
     expected: FAIL
 
   [empty derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -566,16 +293,7 @@
   [empty derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [empty derivedKey, empty salt, SHA-512, with normal info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -584,22 +302,10 @@
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -608,22 +314,10 @@
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -632,19 +326,10 @@
   [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using empty derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
@@ -656,9 +341,6 @@
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using empty derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -666,9 +348,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
@@ -680,9 +359,6 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -690,9 +366,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
@@ -704,9 +377,6 @@
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -714,9 +384,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
@@ -728,9 +395,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -738,9 +402,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
@@ -752,22 +413,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-512, with normal info with non-multiple of 8 length]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-512, with normal info with missing deriveBits usage]
     expected: FAIL
 
   [empty derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -776,16 +425,7 @@
   [empty derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [empty derivedKey, empty salt, SHA-512, with empty info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -794,22 +434,10 @@
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -818,22 +446,10 @@
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -842,19 +458,10 @@
   [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using empty derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
@@ -866,9 +473,6 @@
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using empty derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -876,9 +480,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
@@ -890,9 +491,6 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -900,9 +498,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
@@ -914,9 +509,6 @@
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -924,9 +516,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
@@ -938,9 +527,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -948,9 +534,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
@@ -962,22 +545,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-512, with empty info with non-multiple of 8 length]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-512, with empty info with missing deriveBits usage]
     expected: FAIL
 
   [empty derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -986,16 +557,7 @@
   [empty derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [empty derivedKey, empty salt, SHA-1, with normal info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -1004,22 +566,10 @@
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -1028,22 +578,10 @@
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -1052,19 +590,10 @@
   [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using empty derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
@@ -1076,9 +605,6 @@
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using empty derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -1086,9 +612,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
@@ -1100,9 +623,6 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -1110,9 +630,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
@@ -1124,9 +641,6 @@
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -1134,9 +648,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
@@ -1148,9 +659,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -1158,9 +666,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
@@ -1172,22 +677,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-1, with normal info with non-multiple of 8 length]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-1, with normal info with missing deriveBits usage]
     expected: FAIL
 
   [empty derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -1196,16 +689,7 @@
   [empty derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [empty derivedKey, empty salt, SHA-1, with empty info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -1214,22 +698,10 @@
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -1238,22 +710,10 @@
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -1262,19 +722,10 @@
   [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using empty derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
@@ -1286,9 +737,6 @@
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using empty derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -1296,9 +744,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
@@ -1310,9 +755,6 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -1320,9 +762,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
@@ -1334,9 +773,6 @@
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -1344,9 +780,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
@@ -1358,9 +791,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -1368,9 +798,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
@@ -1382,40 +809,16 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [empty derivedKey, empty salt, SHA-1, with empty info with non-multiple of 8 length]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-1, with empty info with missing deriveBits usage]
-    expected: FAIL
-
   [empty derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [empty derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-256, with normal info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -1424,22 +827,7 @@
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -1448,43 +836,19 @@
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using empty derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
@@ -1496,9 +860,6 @@
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using empty derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -1506,9 +867,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
@@ -1520,9 +878,6 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -1530,9 +885,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
@@ -1544,9 +896,6 @@
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -1554,9 +903,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
@@ -1568,9 +914,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -1578,9 +921,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
@@ -1592,40 +932,16 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
-  [empty derivedKey, empty salt, SHA-256, with normal info with non-multiple of 8 length]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-256, with normal info with missing deriveBits usage]
-    expected: FAIL
-
   [empty derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
-  [empty derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-256, with empty info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -1634,22 +950,7 @@
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -1658,43 +959,19 @@
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using empty derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
@@ -1706,9 +983,6 @@
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using empty derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -1716,9 +990,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
@@ -1730,9 +1001,6 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -1740,9 +1008,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
@@ -1754,9 +1019,6 @@
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -1764,9 +1026,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
@@ -1778,9 +1037,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -1788,9 +1044,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
@@ -1802,127 +1055,13 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [empty derivedKey, empty salt, SHA-256, with empty info with non-multiple of 8 length]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-256, with empty info with missing deriveBits usage]
-    expected: FAIL
-
   [empty derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, PBKDF2, with normal info with non-digest algorithm PBKDF2]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using empty derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 192  using empty derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using empty derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, PBKDF2, with empty info with non-digest algorithm PBKDF2]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using empty derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 192  using empty derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using empty derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, PBKDF2, with empty info]
     expected: FAIL
 
 
@@ -1930,16 +1069,7 @@
   [short derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [short derivedKey, normal salt, SHA-384, with normal info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -1948,22 +1078,10 @@
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -1972,22 +1090,10 @@
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -1996,19 +1102,10 @@
   [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using short derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
@@ -2020,9 +1117,6 @@
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using short derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -2030,9 +1124,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using short derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
@@ -2044,9 +1135,6 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -2054,9 +1142,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
@@ -2068,9 +1153,6 @@
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -2078,9 +1160,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
@@ -2092,9 +1171,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -2102,9 +1178,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
@@ -2116,22 +1189,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-384, with normal info with non-multiple of 8 length]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-384, with normal info with missing deriveBits usage]
     expected: FAIL
 
   [short derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -2140,16 +1201,7 @@
   [short derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [short derivedKey, normal salt, SHA-384, with empty info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -2158,22 +1210,10 @@
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -2182,22 +1222,10 @@
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -2206,19 +1234,10 @@
   [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using short derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
@@ -2230,9 +1249,6 @@
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using short derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -2240,9 +1256,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using short derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
@@ -2254,9 +1267,6 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -2264,9 +1274,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
@@ -2278,9 +1285,6 @@
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -2288,9 +1292,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
@@ -2302,9 +1303,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -2312,9 +1310,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
@@ -2326,22 +1321,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-384, with empty info with non-multiple of 8 length]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-384, with empty info with missing deriveBits usage]
     expected: FAIL
 
   [short derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -2350,16 +1333,7 @@
   [short derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [short derivedKey, normal salt, SHA-512, with normal info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -2368,22 +1342,10 @@
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -2392,22 +1354,10 @@
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -2416,19 +1366,10 @@
   [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using short derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
@@ -2440,9 +1381,6 @@
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using short derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -2450,9 +1388,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using short derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
@@ -2464,9 +1399,6 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -2474,9 +1406,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
@@ -2488,9 +1417,6 @@
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -2498,9 +1424,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
@@ -2512,9 +1435,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -2522,9 +1442,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
@@ -2536,22 +1453,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-512, with normal info with non-multiple of 8 length]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-512, with normal info with missing deriveBits usage]
     expected: FAIL
 
   [short derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -2560,16 +1465,7 @@
   [short derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [short derivedKey, normal salt, SHA-512, with empty info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -2578,22 +1474,10 @@
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -2602,22 +1486,10 @@
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -2626,19 +1498,10 @@
   [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using short derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
@@ -2650,9 +1513,6 @@
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using short derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -2660,9 +1520,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using short derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
@@ -2674,9 +1531,6 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -2684,9 +1538,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
@@ -2698,9 +1549,6 @@
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -2708,9 +1556,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
@@ -2722,9 +1567,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -2732,9 +1574,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
@@ -2746,22 +1585,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-512, with empty info with non-multiple of 8 length]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-512, with empty info with missing deriveBits usage]
     expected: FAIL
 
   [short derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -2770,16 +1597,7 @@
   [short derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [short derivedKey, normal salt, SHA-1, with normal info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -2788,22 +1606,10 @@
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -2812,22 +1618,10 @@
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -2836,19 +1630,10 @@
   [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using short derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
@@ -2860,9 +1645,6 @@
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using short derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -2870,9 +1652,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using short derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
@@ -2884,9 +1663,6 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -2894,9 +1670,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
@@ -2908,9 +1681,6 @@
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -2918,9 +1688,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
@@ -2932,9 +1699,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -2942,9 +1706,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
@@ -2956,22 +1717,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-1, with normal info with non-multiple of 8 length]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-1, with normal info with missing deriveBits usage]
     expected: FAIL
 
   [short derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -2980,16 +1729,7 @@
   [short derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [short derivedKey, normal salt, SHA-1, with empty info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -2998,22 +1738,10 @@
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -3022,22 +1750,10 @@
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -3046,19 +1762,10 @@
   [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using short derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
@@ -3070,9 +1777,6 @@
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using short derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -3080,9 +1784,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using short derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
@@ -3094,9 +1795,6 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -3104,9 +1802,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
@@ -3118,9 +1813,6 @@
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -3128,9 +1820,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
@@ -3142,9 +1831,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -3152,9 +1838,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
@@ -3166,40 +1849,16 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [short derivedKey, normal salt, SHA-1, with empty info with non-multiple of 8 length]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-1, with empty info with missing deriveBits usage]
-    expected: FAIL
-
   [short derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [short derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-256, with normal info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -3208,22 +1867,7 @@
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -3232,43 +1876,19 @@
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using short derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
@@ -3280,9 +1900,6 @@
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using short derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -3290,9 +1907,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using short derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
@@ -3304,9 +1918,6 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -3314,9 +1925,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
@@ -3328,9 +1936,6 @@
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -3338,9 +1943,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
@@ -3352,9 +1954,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -3362,9 +1961,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
@@ -3376,40 +1972,16 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
-  [short derivedKey, normal salt, SHA-256, with normal info with non-multiple of 8 length]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-256, with normal info with missing deriveBits usage]
-    expected: FAIL
-
   [short derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
-  [short derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-256, with empty info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -3418,22 +1990,7 @@
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -3442,43 +1999,19 @@
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using short derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
@@ -3490,9 +2023,6 @@
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using short derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -3500,9 +2030,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using short derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
@@ -3514,9 +2041,6 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -3524,9 +2048,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
@@ -3538,9 +2059,6 @@
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -3548,9 +2066,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
@@ -3562,9 +2077,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -3572,9 +2084,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
@@ -3586,142 +2095,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [short derivedKey, normal salt, SHA-256, with empty info with non-multiple of 8 length]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-256, with empty info with missing deriveBits usage]
-    expected: FAIL
-
   [short derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [short derivedKey, normal salt, PBKDF2, with normal info with non-digest algorithm PBKDF2]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using short derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 192  using short derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using short derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [short derivedKey, normal salt, PBKDF2, with empty info with non-digest algorithm PBKDF2]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using short derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 192  using short derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using short derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, PBKDF2, with empty info]
     expected: FAIL
 
   [short derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [short derivedKey, empty salt, SHA-384, with normal info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -3730,22 +2116,10 @@
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -3754,22 +2128,10 @@
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -3778,19 +2140,10 @@
   [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using short derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
@@ -3802,9 +2155,6 @@
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using short derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -3812,9 +2162,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using short derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
@@ -3826,9 +2173,6 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -3836,9 +2180,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
@@ -3850,9 +2191,6 @@
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -3860,9 +2198,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
@@ -3874,9 +2209,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -3884,9 +2216,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
@@ -3898,22 +2227,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-384, with normal info with non-multiple of 8 length]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-384, with normal info with missing deriveBits usage]
     expected: FAIL
 
   [short derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -3922,16 +2239,7 @@
   [short derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [short derivedKey, empty salt, SHA-384, with empty info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -3940,22 +2248,10 @@
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -3964,22 +2260,10 @@
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -3988,19 +2272,10 @@
   [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using short derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
@@ -4012,9 +2287,6 @@
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using short derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -4022,9 +2294,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using short derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
@@ -4036,9 +2305,6 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -4046,9 +2312,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
@@ -4060,9 +2323,6 @@
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -4070,9 +2330,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
@@ -4084,9 +2341,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -4094,9 +2348,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
@@ -4108,22 +2359,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-384, with empty info with non-multiple of 8 length]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-384, with empty info with missing deriveBits usage]
     expected: FAIL
 
   [short derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -4132,16 +2371,7 @@
   [short derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [short derivedKey, empty salt, SHA-512, with normal info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -4150,22 +2380,10 @@
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -4174,22 +2392,10 @@
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -4198,19 +2404,10 @@
   [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using short derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
@@ -4222,9 +2419,6 @@
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using short derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -4232,9 +2426,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using short derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
@@ -4246,9 +2437,6 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -4256,9 +2444,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
@@ -4270,9 +2455,6 @@
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -4280,9 +2462,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
@@ -4294,9 +2473,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -4304,9 +2480,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
@@ -4318,22 +2491,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-512, with normal info with non-multiple of 8 length]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-512, with normal info with missing deriveBits usage]
     expected: FAIL
 
   [short derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -4342,16 +2503,7 @@
   [short derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [short derivedKey, empty salt, SHA-512, with empty info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -4360,22 +2512,10 @@
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -4384,22 +2524,10 @@
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -4408,19 +2536,10 @@
   [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using short derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
@@ -4432,9 +2551,6 @@
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using short derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -4442,9 +2558,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using short derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
@@ -4456,9 +2569,6 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -4466,9 +2576,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
@@ -4480,9 +2587,6 @@
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -4490,9 +2594,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
@@ -4504,9 +2605,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -4514,9 +2612,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
@@ -4528,22 +2623,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-512, with empty info with non-multiple of 8 length]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-512, with empty info with missing deriveBits usage]
     expected: FAIL
 
   [short derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -4552,16 +2635,7 @@
   [short derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [short derivedKey, empty salt, SHA-1, with normal info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -4570,22 +2644,10 @@
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -4594,22 +2656,10 @@
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -4618,19 +2668,10 @@
   [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using short derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
@@ -4642,9 +2683,6 @@
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using short derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -4652,9 +2690,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using short derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
@@ -4666,9 +2701,6 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -4676,9 +2708,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
@@ -4690,9 +2719,6 @@
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -4700,9 +2726,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
@@ -4714,9 +2737,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -4724,9 +2744,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
@@ -4738,22 +2755,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-1, with normal info with non-multiple of 8 length]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-1, with normal info with missing deriveBits usage]
     expected: FAIL
 
   [short derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -4762,16 +2767,7 @@
   [short derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [short derivedKey, empty salt, SHA-1, with empty info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -4780,22 +2776,10 @@
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -4804,22 +2788,10 @@
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -4828,19 +2800,10 @@
   [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using short derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
@@ -4860,9 +2823,6 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -4872,142 +2832,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [empty derivedKey, normal salt, SHA-256, with empty info with non-multiple of 8 length]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-256, with empty info with missing deriveBits usage]
-    expected: FAIL
-
   [empty derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, PBKDF2, with normal info with non-digest algorithm PBKDF2]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using empty derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 192  using empty derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using empty derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, PBKDF2, with empty info with non-digest algorithm PBKDF2]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using empty derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 192  using empty derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using empty derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, PBKDF2, with empty info]
     expected: FAIL
 
   [empty derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [empty derivedKey, empty salt, SHA-384, with normal info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -5016,22 +2853,10 @@
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -5040,22 +2865,10 @@
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -5064,19 +2877,10 @@
   [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using empty derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
@@ -5088,9 +2892,6 @@
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using empty derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -5098,9 +2899,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
@@ -5112,9 +2910,6 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -5122,9 +2917,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
@@ -5136,9 +2928,6 @@
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -5146,9 +2935,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
@@ -5160,9 +2946,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -5170,9 +2953,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
@@ -5184,22 +2964,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-384, with normal info with non-multiple of 8 length]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-384, with normal info with missing deriveBits usage]
     expected: FAIL
 
   [empty derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -5208,16 +2976,7 @@
   [empty derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [empty derivedKey, empty salt, SHA-384, with empty info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -5226,22 +2985,10 @@
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -5250,22 +2997,10 @@
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -5274,19 +3009,10 @@
   [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using empty derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
@@ -5298,9 +3024,6 @@
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using empty derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -5308,9 +3031,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
@@ -5322,9 +3042,6 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -5332,9 +3049,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
@@ -5346,9 +3060,6 @@
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -5356,9 +3067,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
@@ -5370,9 +3078,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -5380,9 +3085,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
@@ -5394,22 +3096,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-384, with empty info with non-multiple of 8 length]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-384, with empty info with missing deriveBits usage]
     expected: FAIL
 
   [empty derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -5418,16 +3108,7 @@
   [empty derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [empty derivedKey, empty salt, SHA-512, with normal info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -5436,22 +3117,10 @@
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -5460,22 +3129,10 @@
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -5484,19 +3141,10 @@
   [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using empty derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
@@ -5508,9 +3156,6 @@
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using empty derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -5518,9 +3163,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
@@ -5532,9 +3174,6 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -5542,9 +3181,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
@@ -5556,9 +3192,6 @@
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -5566,9 +3199,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
@@ -5580,9 +3210,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -5590,9 +3217,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
@@ -5604,22 +3228,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-512, with normal info with non-multiple of 8 length]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-512, with normal info with missing deriveBits usage]
     expected: FAIL
 
   [empty derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -5628,16 +3240,7 @@
   [empty derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [empty derivedKey, empty salt, SHA-512, with empty info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -5646,22 +3249,10 @@
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -5670,22 +3261,10 @@
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -5694,19 +3273,10 @@
   [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using empty derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
@@ -5718,9 +3288,6 @@
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using empty derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -5728,9 +3295,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
@@ -5742,9 +3306,6 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -5752,9 +3313,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
@@ -5766,9 +3324,6 @@
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -5776,9 +3331,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
@@ -5790,9 +3342,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -5800,9 +3349,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
@@ -5814,22 +3360,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-512, with empty info with non-multiple of 8 length]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-512, with empty info with missing deriveBits usage]
     expected: FAIL
 
   [empty derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -5838,16 +3372,7 @@
   [empty derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [empty derivedKey, empty salt, SHA-1, with normal info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -5856,22 +3381,10 @@
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -5880,22 +3393,10 @@
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -5904,19 +3405,10 @@
   [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using empty derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
@@ -5928,9 +3420,6 @@
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using empty derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -5938,9 +3427,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
@@ -5952,9 +3438,6 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -5962,9 +3445,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
@@ -5976,9 +3456,6 @@
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -5986,9 +3463,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
@@ -6000,9 +3474,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -6010,9 +3481,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
@@ -6024,22 +3492,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-1, with normal info with non-multiple of 8 length]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-1, with normal info with missing deriveBits usage]
     expected: FAIL
 
   [empty derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -6048,16 +3504,7 @@
   [empty derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [empty derivedKey, empty salt, SHA-1, with empty info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -6066,22 +3513,10 @@
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -6090,22 +3525,10 @@
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -6114,19 +3537,10 @@
   [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using empty derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
@@ -6138,9 +3552,6 @@
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using empty derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -6148,9 +3559,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
@@ -6162,9 +3570,6 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -6172,9 +3577,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
@@ -6186,9 +3588,6 @@
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -6196,9 +3595,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
@@ -6210,9 +3606,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -6220,9 +3613,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
@@ -6234,40 +3624,16 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [empty derivedKey, empty salt, SHA-1, with empty info with non-multiple of 8 length]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-1, with empty info with missing deriveBits usage]
-    expected: FAIL
-
   [empty derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [empty derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-256, with normal info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -6276,22 +3642,7 @@
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -6300,43 +3651,19 @@
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using empty derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
@@ -6348,9 +3675,6 @@
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using empty derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -6358,9 +3682,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
@@ -6372,9 +3693,6 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -6382,9 +3700,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
@@ -6396,9 +3711,6 @@
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -6406,9 +3718,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
@@ -6420,9 +3729,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -6430,9 +3736,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
@@ -6444,40 +3747,16 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
-  [empty derivedKey, empty salt, SHA-256, with normal info with non-multiple of 8 length]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-256, with normal info with missing deriveBits usage]
-    expected: FAIL
-
   [empty derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
-  [empty derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-256, with empty info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -6486,22 +3765,7 @@
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -6510,43 +3774,19 @@
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using empty derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
@@ -6558,9 +3798,6 @@
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using empty derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -6568,9 +3805,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
@@ -6582,9 +3816,6 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -6592,9 +3823,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
@@ -6606,9 +3834,6 @@
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -6616,9 +3841,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
@@ -6630,9 +3852,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -6640,9 +3859,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
@@ -6654,135 +3870,18 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [empty derivedKey, empty salt, SHA-256, with empty info with non-multiple of 8 length]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-256, with empty info with missing deriveBits usage]
-    expected: FAIL
-
   [empty derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, PBKDF2, with normal info with non-digest algorithm PBKDF2]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using empty derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 192  using empty derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using empty derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, PBKDF2, with empty info with non-digest algorithm PBKDF2]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using empty derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 192  using empty derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using empty derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, PBKDF2, with empty info]
     expected: FAIL
 
 
 [hkdf.https.any.worker.html?1001-2000]
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 192  using short derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
@@ -6794,9 +3893,6 @@
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 256  using short derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -6804,9 +3900,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
@@ -6818,9 +3911,6 @@
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -6828,9 +3918,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
@@ -6842,9 +3929,6 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -6852,9 +3936,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
@@ -6866,9 +3947,6 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -6878,40 +3956,16 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [short derivedKey, empty salt, SHA-1, with empty info with non-multiple of 8 length]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-1, with empty info with missing deriveBits usage]
-    expected: FAIL
-
   [short derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [short derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-256, with normal info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -6920,22 +3974,7 @@
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -6944,43 +3983,19 @@
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using short derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
@@ -6992,9 +4007,6 @@
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using short derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -7002,9 +4014,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using short derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
@@ -7016,9 +4025,6 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -7026,9 +4032,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
@@ -7040,9 +4043,6 @@
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -7050,9 +4050,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
@@ -7064,9 +4061,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -7074,9 +4068,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
@@ -7088,40 +4079,16 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
-  [short derivedKey, empty salt, SHA-256, with normal info with non-multiple of 8 length]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-256, with normal info with missing deriveBits usage]
-    expected: FAIL
-
   [short derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
-  [short derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-256, with empty info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -7130,22 +4097,7 @@
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -7154,43 +4106,19 @@
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using short derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
@@ -7202,9 +4130,6 @@
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using short derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -7212,9 +4137,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using short derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
@@ -7226,9 +4148,6 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -7236,9 +4155,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
@@ -7250,9 +4166,6 @@
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -7260,9 +4173,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
@@ -7274,9 +4184,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -7284,9 +4191,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
@@ -7298,142 +4202,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [short derivedKey, empty salt, SHA-256, with empty info with non-multiple of 8 length]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-256, with empty info with missing deriveBits usage]
-    expected: FAIL
-
   [short derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [short derivedKey, empty salt, PBKDF2, with normal info with non-digest algorithm PBKDF2]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using short derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 192  using short derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using short derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [short derivedKey, empty salt, PBKDF2, with empty info with non-digest algorithm PBKDF2]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using short derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 192  using short derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using short derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, PBKDF2, with empty info]
     expected: FAIL
 
   [long derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [long derivedKey, normal salt, SHA-384, with normal info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -7442,22 +4223,10 @@
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -7466,22 +4235,10 @@
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -7490,19 +4247,10 @@
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using long derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
@@ -7514,9 +4262,6 @@
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using long derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -7524,9 +4269,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using long derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
@@ -7538,9 +4280,6 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -7548,9 +4287,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
@@ -7562,9 +4298,6 @@
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -7572,9 +4305,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
@@ -7586,9 +4316,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -7596,9 +4323,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
@@ -7610,22 +4334,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-384, with normal info with non-multiple of 8 length]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-384, with normal info with missing deriveBits usage]
     expected: FAIL
 
   [long derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -7634,16 +4346,7 @@
   [long derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [long derivedKey, normal salt, SHA-384, with empty info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -7652,22 +4355,10 @@
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -7676,22 +4367,10 @@
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -7700,19 +4379,10 @@
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using long derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
@@ -7724,9 +4394,6 @@
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using long derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -7734,9 +4401,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using long derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
@@ -7748,9 +4412,6 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -7758,9 +4419,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
@@ -7772,9 +4430,6 @@
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -7782,9 +4437,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
@@ -7796,9 +4448,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -7806,9 +4455,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
@@ -7820,22 +4466,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-384, with empty info with non-multiple of 8 length]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-384, with empty info with missing deriveBits usage]
     expected: FAIL
 
   [long derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -7844,16 +4478,7 @@
   [long derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [long derivedKey, normal salt, SHA-512, with normal info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -7862,22 +4487,10 @@
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -7886,22 +4499,10 @@
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -7910,19 +4511,10 @@
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using long derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
@@ -7934,9 +4526,6 @@
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using long derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -7944,9 +4533,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using long derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
@@ -7958,9 +4544,6 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -7968,9 +4551,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
@@ -7982,9 +4562,6 @@
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -7992,9 +4569,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
@@ -8006,9 +4580,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -8016,9 +4587,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
@@ -8030,22 +4598,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-512, with normal info with non-multiple of 8 length]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-512, with normal info with missing deriveBits usage]
     expected: FAIL
 
   [long derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -8054,16 +4610,7 @@
   [long derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [long derivedKey, normal salt, SHA-512, with empty info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -8072,22 +4619,10 @@
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -8096,22 +4631,10 @@
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -8120,19 +4643,10 @@
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using long derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
@@ -8144,9 +4658,6 @@
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using long derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -8154,9 +4665,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using long derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
@@ -8168,9 +4676,6 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -8178,9 +4683,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
@@ -8192,9 +4694,6 @@
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -8202,9 +4701,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
@@ -8216,9 +4712,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -8226,9 +4719,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
@@ -8240,22 +4730,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-512, with empty info with non-multiple of 8 length]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-512, with empty info with missing deriveBits usage]
     expected: FAIL
 
   [long derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -8264,16 +4742,7 @@
   [long derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [long derivedKey, normal salt, SHA-1, with normal info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -8282,22 +4751,10 @@
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -8306,22 +4763,10 @@
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -8330,19 +4775,10 @@
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using long derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
@@ -8354,9 +4790,6 @@
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using long derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -8364,9 +4797,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using long derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
@@ -8378,9 +4808,6 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -8388,9 +4815,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
@@ -8402,9 +4826,6 @@
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -8412,9 +4833,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
@@ -8426,9 +4844,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -8436,9 +4851,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
@@ -8450,22 +4862,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-1, with normal info with non-multiple of 8 length]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-1, with normal info with missing deriveBits usage]
     expected: FAIL
 
   [long derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -8474,16 +4874,7 @@
   [long derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [long derivedKey, normal salt, SHA-1, with empty info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -8492,22 +4883,10 @@
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -8516,22 +4895,10 @@
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -8540,19 +4907,10 @@
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using long derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
@@ -8564,9 +4922,6 @@
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using long derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -8574,9 +4929,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using long derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
@@ -8588,9 +4940,6 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -8598,9 +4947,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
@@ -8612,9 +4958,6 @@
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -8622,9 +4965,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
@@ -8636,9 +4976,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -8646,9 +4983,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
@@ -8660,40 +4994,16 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [long derivedKey, normal salt, SHA-1, with empty info with non-multiple of 8 length]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-1, with empty info with missing deriveBits usage]
-    expected: FAIL
-
   [long derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [long derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-256, with normal info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -8702,22 +5012,7 @@
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -8726,43 +5021,19 @@
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using long derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
@@ -8774,9 +5045,6 @@
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using long derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -8784,9 +5052,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using long derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
@@ -8798,9 +5063,6 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -8808,9 +5070,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
@@ -8822,9 +5081,6 @@
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -8832,9 +5088,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
@@ -8846,9 +5099,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -8856,9 +5106,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
@@ -8870,40 +5117,16 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
-  [long derivedKey, normal salt, SHA-256, with normal info with non-multiple of 8 length]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-256, with normal info with missing deriveBits usage]
-    expected: FAIL
-
   [long derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
-  [long derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-256, with empty info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -8912,22 +5135,7 @@
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -8936,43 +5144,19 @@
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using long derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
@@ -8984,9 +5168,6 @@
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using long derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -8994,9 +5175,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using long derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
@@ -9008,9 +5186,6 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -9018,9 +5193,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
@@ -9032,9 +5204,6 @@
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -9042,9 +5211,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
@@ -9056,9 +5222,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -9066,9 +5229,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
@@ -9080,142 +5240,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [long derivedKey, normal salt, SHA-256, with empty info with non-multiple of 8 length]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-256, with empty info with missing deriveBits usage]
-    expected: FAIL
-
   [long derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [long derivedKey, normal salt, PBKDF2, with normal info with non-digest algorithm PBKDF2]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using long derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 192  using long derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using long derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [long derivedKey, normal salt, PBKDF2, with empty info with non-digest algorithm PBKDF2]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using long derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 192  using long derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using long derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, PBKDF2, with empty info]
     expected: FAIL
 
   [long derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [long derivedKey, empty salt, SHA-384, with normal info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -9224,22 +5261,10 @@
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -9248,22 +5273,10 @@
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -9272,19 +5285,10 @@
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using long derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
@@ -9296,9 +5300,6 @@
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using long derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -9306,9 +5307,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using long derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
@@ -9320,9 +5318,6 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -9330,9 +5325,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
@@ -9344,9 +5336,6 @@
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -9354,9 +5343,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
@@ -9368,9 +5354,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -9378,9 +5361,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
@@ -9392,22 +5372,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-384, with normal info with non-multiple of 8 length]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-384, with normal info with missing deriveBits usage]
     expected: FAIL
 
   [long derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -9416,16 +5384,7 @@
   [long derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [long derivedKey, empty salt, SHA-384, with empty info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -9434,22 +5393,10 @@
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -9458,22 +5405,10 @@
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -9482,19 +5417,10 @@
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using long derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
@@ -9506,9 +5432,6 @@
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using long derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -9516,9 +5439,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using long derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
@@ -9530,9 +5450,6 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -9540,9 +5457,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
@@ -9554,9 +5468,6 @@
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -9564,9 +5475,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
@@ -9578,9 +5486,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -9588,9 +5493,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
@@ -9602,22 +5504,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-384, with empty info with non-multiple of 8 length]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-384, with empty info with missing deriveBits usage]
     expected: FAIL
 
   [long derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -9626,16 +5516,7 @@
   [long derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [long derivedKey, empty salt, SHA-512, with normal info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -9644,22 +5525,10 @@
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -9668,34 +5537,16 @@
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -9706,16 +5557,7 @@
   [short derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [short derivedKey, normal salt, SHA-384, with normal info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -9724,22 +5566,10 @@
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -9748,22 +5578,10 @@
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -9772,19 +5590,10 @@
   [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using short derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
@@ -9796,9 +5605,6 @@
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using short derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -9806,9 +5612,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using short derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
@@ -9820,9 +5623,6 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -9830,9 +5630,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
@@ -9844,9 +5641,6 @@
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -9854,9 +5648,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
@@ -9868,9 +5659,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -9878,9 +5666,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
@@ -9892,22 +5677,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-384, with normal info with non-multiple of 8 length]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-384, with normal info with missing deriveBits usage]
     expected: FAIL
 
   [short derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -9916,16 +5689,7 @@
   [short derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [short derivedKey, normal salt, SHA-384, with empty info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -9934,22 +5698,10 @@
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -9958,22 +5710,10 @@
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -9982,19 +5722,10 @@
   [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using short derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
@@ -10006,9 +5737,6 @@
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using short derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -10016,9 +5744,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using short derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
@@ -10030,9 +5755,6 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -10040,9 +5762,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
@@ -10054,9 +5773,6 @@
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -10064,9 +5780,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
@@ -10078,9 +5791,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -10088,9 +5798,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
@@ -10102,22 +5809,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-384, with empty info with non-multiple of 8 length]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-384, with empty info with missing deriveBits usage]
     expected: FAIL
 
   [short derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -10126,16 +5821,7 @@
   [short derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [short derivedKey, normal salt, SHA-512, with normal info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -10144,22 +5830,10 @@
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -10168,22 +5842,10 @@
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -10192,19 +5854,10 @@
   [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using short derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
@@ -10216,9 +5869,6 @@
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using short derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -10226,9 +5876,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using short derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
@@ -10240,9 +5887,6 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -10250,9 +5894,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
@@ -10264,9 +5905,6 @@
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -10274,9 +5912,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
@@ -10288,9 +5923,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -10298,9 +5930,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
@@ -10312,22 +5941,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-512, with normal info with non-multiple of 8 length]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-512, with normal info with missing deriveBits usage]
     expected: FAIL
 
   [short derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -10336,16 +5953,7 @@
   [short derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [short derivedKey, normal salt, SHA-512, with empty info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -10354,22 +5962,10 @@
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -10378,22 +5974,10 @@
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -10402,19 +5986,10 @@
   [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using short derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
@@ -10426,9 +6001,6 @@
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using short derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -10436,9 +6008,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using short derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
@@ -10450,9 +6019,6 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -10460,9 +6026,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
@@ -10474,9 +6037,6 @@
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -10484,9 +6044,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
@@ -10498,9 +6055,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -10508,9 +6062,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
@@ -10522,22 +6073,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-512, with empty info with non-multiple of 8 length]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-512, with empty info with missing deriveBits usage]
     expected: FAIL
 
   [short derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -10546,16 +6085,7 @@
   [short derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [short derivedKey, normal salt, SHA-1, with normal info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -10564,22 +6094,10 @@
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -10588,22 +6106,10 @@
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -10612,19 +6118,10 @@
   [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using short derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
@@ -10636,9 +6133,6 @@
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using short derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -10646,9 +6140,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using short derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
@@ -10660,9 +6151,6 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -10670,9 +6158,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
@@ -10684,9 +6169,6 @@
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -10694,9 +6176,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
@@ -10708,9 +6187,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -10718,9 +6194,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
@@ -10732,22 +6205,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-1, with normal info with non-multiple of 8 length]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-1, with normal info with missing deriveBits usage]
     expected: FAIL
 
   [short derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -10756,16 +6217,7 @@
   [short derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [short derivedKey, normal salt, SHA-1, with empty info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -10774,22 +6226,10 @@
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -10798,22 +6238,10 @@
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -10822,19 +6250,10 @@
   [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using short derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
@@ -10846,9 +6265,6 @@
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using short derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -10856,9 +6272,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using short derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
@@ -10870,9 +6283,6 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -10880,9 +6290,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
@@ -10894,9 +6301,6 @@
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -10904,9 +6308,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
@@ -10918,9 +6319,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -10928,9 +6326,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
@@ -10942,40 +6337,16 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [short derivedKey, normal salt, SHA-1, with empty info with non-multiple of 8 length]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-1, with empty info with missing deriveBits usage]
-    expected: FAIL
-
   [short derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [short derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-256, with normal info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -10984,22 +6355,7 @@
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -11008,43 +6364,19 @@
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using short derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
@@ -11056,9 +6388,6 @@
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using short derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -11066,9 +6395,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using short derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
@@ -11080,9 +6406,6 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -11090,9 +6413,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
@@ -11104,9 +6424,6 @@
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -11114,9 +6431,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
@@ -11128,9 +6442,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -11138,9 +6449,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
@@ -11152,40 +6460,16 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
-  [short derivedKey, normal salt, SHA-256, with normal info with non-multiple of 8 length]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-256, with normal info with missing deriveBits usage]
-    expected: FAIL
-
   [short derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
-  [short derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-256, with empty info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -11194,22 +6478,7 @@
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -11218,43 +6487,19 @@
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using short derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
@@ -11266,9 +6511,6 @@
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using short derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -11276,9 +6518,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using short derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
@@ -11290,9 +6529,6 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -11300,9 +6536,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
@@ -11314,9 +6547,6 @@
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -11324,9 +6554,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
@@ -11338,9 +6565,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -11348,9 +6572,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
@@ -11362,142 +6583,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [short derivedKey, normal salt, SHA-256, with empty info with non-multiple of 8 length]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-256, with empty info with missing deriveBits usage]
-    expected: FAIL
-
   [short derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [short derivedKey, normal salt, PBKDF2, with normal info with non-digest algorithm PBKDF2]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using short derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 192  using short derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using short derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [short derivedKey, normal salt, PBKDF2, with empty info with non-digest algorithm PBKDF2]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using short derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 192  using short derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using short derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, PBKDF2, with empty info]
     expected: FAIL
 
   [short derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [short derivedKey, empty salt, SHA-384, with normal info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -11506,22 +6604,10 @@
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -11530,22 +6616,10 @@
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -11554,19 +6628,10 @@
   [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using short derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
@@ -11578,9 +6643,6 @@
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using short derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -11588,9 +6650,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using short derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
@@ -11602,9 +6661,6 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -11612,9 +6668,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
@@ -11626,9 +6679,6 @@
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -11636,9 +6686,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
@@ -11650,9 +6697,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -11660,9 +6704,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
@@ -11674,22 +6715,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-384, with normal info with non-multiple of 8 length]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-384, with normal info with missing deriveBits usage]
     expected: FAIL
 
   [short derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -11698,16 +6727,7 @@
   [short derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [short derivedKey, empty salt, SHA-384, with empty info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -11716,22 +6736,10 @@
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -11740,22 +6748,10 @@
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -11764,19 +6760,10 @@
   [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using short derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
@@ -11788,9 +6775,6 @@
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using short derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -11798,9 +6782,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using short derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
@@ -11812,9 +6793,6 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -11822,9 +6800,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
@@ -11836,9 +6811,6 @@
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -11846,9 +6818,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
@@ -11860,9 +6829,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -11870,9 +6836,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
@@ -11884,22 +6847,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-384, with empty info with non-multiple of 8 length]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-384, with empty info with missing deriveBits usage]
     expected: FAIL
 
   [short derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -11908,16 +6859,7 @@
   [short derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [short derivedKey, empty salt, SHA-512, with normal info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -11926,22 +6868,10 @@
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -11950,22 +6880,10 @@
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -11974,19 +6892,10 @@
   [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using short derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
@@ -11998,9 +6907,6 @@
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using short derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -12008,9 +6914,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using short derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
@@ -12022,9 +6925,6 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -12032,9 +6932,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
@@ -12046,9 +6943,6 @@
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -12056,9 +6950,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
@@ -12070,9 +6961,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -12080,9 +6968,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
@@ -12094,22 +6979,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-512, with normal info with non-multiple of 8 length]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-512, with normal info with missing deriveBits usage]
     expected: FAIL
 
   [short derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -12118,16 +6991,7 @@
   [short derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [short derivedKey, empty salt, SHA-512, with empty info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -12136,22 +7000,10 @@
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -12160,22 +7012,10 @@
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -12184,19 +7024,10 @@
   [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using short derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
@@ -12208,9 +7039,6 @@
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using short derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -12218,9 +7046,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using short derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
@@ -12232,9 +7057,6 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -12242,9 +7064,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
@@ -12256,9 +7075,6 @@
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -12266,9 +7082,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
@@ -12280,9 +7093,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -12290,9 +7100,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
@@ -12304,22 +7111,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-512, with empty info with non-multiple of 8 length]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-512, with empty info with missing deriveBits usage]
     expected: FAIL
 
   [short derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -12328,16 +7123,7 @@
   [short derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [short derivedKey, empty salt, SHA-1, with normal info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -12346,22 +7132,10 @@
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -12370,22 +7144,10 @@
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -12394,19 +7156,10 @@
   [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using short derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
@@ -12418,9 +7171,6 @@
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using short derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -12428,9 +7178,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using short derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
@@ -12442,9 +7189,6 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -12452,9 +7196,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
@@ -12466,9 +7207,6 @@
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -12476,9 +7214,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
@@ -12490,9 +7225,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -12500,9 +7232,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
@@ -12514,22 +7243,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-1, with normal info with non-multiple of 8 length]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-1, with normal info with missing deriveBits usage]
     expected: FAIL
 
   [short derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -12538,16 +7255,7 @@
   [short derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [short derivedKey, empty salt, SHA-1, with empty info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -12556,22 +7264,10 @@
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -12580,22 +7276,10 @@
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -12604,19 +7288,10 @@
   [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using short derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
@@ -12630,9 +7305,6 @@
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using short derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -12640,9 +7312,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using short derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
@@ -12654,9 +7323,6 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -12664,9 +7330,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
@@ -12678,9 +7341,6 @@
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -12688,9 +7348,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
@@ -12702,9 +7359,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -12712,9 +7366,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
@@ -12726,40 +7377,16 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [short derivedKey, empty salt, SHA-1, with empty info with non-multiple of 8 length]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-1, with empty info with missing deriveBits usage]
-    expected: FAIL
-
   [short derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [short derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-256, with normal info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -12768,22 +7395,7 @@
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -12792,43 +7404,19 @@
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using short derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
@@ -12840,9 +7428,6 @@
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using short derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -12850,9 +7435,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using short derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
@@ -12864,9 +7446,6 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -12874,9 +7453,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
@@ -12888,9 +7464,6 @@
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -12898,9 +7471,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
@@ -12912,9 +7482,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -12922,9 +7489,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
@@ -12936,40 +7500,16 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
-  [short derivedKey, empty salt, SHA-256, with normal info with non-multiple of 8 length]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-256, with normal info with missing deriveBits usage]
-    expected: FAIL
-
   [short derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
-  [short derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-256, with empty info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -12978,22 +7518,7 @@
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -13002,43 +7527,19 @@
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using short derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
@@ -13050,9 +7551,6 @@
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using short derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -13060,9 +7558,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using short derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
@@ -13074,9 +7569,6 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -13084,9 +7576,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
@@ -13098,9 +7587,6 @@
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -13108,9 +7594,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
@@ -13122,9 +7605,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -13132,9 +7612,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
@@ -13146,142 +7623,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [short derivedKey, empty salt, SHA-256, with empty info with non-multiple of 8 length]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-256, with empty info with missing deriveBits usage]
-    expected: FAIL
-
   [short derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [short derivedKey, empty salt, PBKDF2, with normal info with non-digest algorithm PBKDF2]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using short derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 192  using short derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using short derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [short derivedKey, empty salt, PBKDF2, with empty info with non-digest algorithm PBKDF2]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using short derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using short derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using short derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using short derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using short derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using short derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using short derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 192  using short derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using short derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, PBKDF2, with empty info]
     expected: FAIL
 
   [long derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [long derivedKey, normal salt, SHA-384, with normal info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -13290,22 +7644,10 @@
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -13314,22 +7656,10 @@
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -13338,19 +7668,10 @@
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using long derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
@@ -13362,9 +7683,6 @@
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using long derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -13372,9 +7690,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using long derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
@@ -13386,9 +7701,6 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -13396,9 +7708,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
@@ -13410,9 +7719,6 @@
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -13420,9 +7726,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
@@ -13434,9 +7737,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -13444,9 +7744,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
@@ -13458,22 +7755,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-384, with normal info with non-multiple of 8 length]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-384, with normal info with missing deriveBits usage]
     expected: FAIL
 
   [long derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -13482,16 +7767,7 @@
   [long derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [long derivedKey, normal salt, SHA-384, with empty info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -13500,22 +7776,10 @@
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -13524,22 +7788,10 @@
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -13548,19 +7800,10 @@
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using long derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
@@ -13572,9 +7815,6 @@
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using long derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -13582,9 +7822,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using long derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
@@ -13596,9 +7833,6 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -13606,9 +7840,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
@@ -13620,9 +7851,6 @@
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -13630,9 +7858,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
@@ -13644,9 +7869,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -13654,9 +7876,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
@@ -13668,22 +7887,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-384, with empty info with non-multiple of 8 length]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-384, with empty info with missing deriveBits usage]
     expected: FAIL
 
   [long derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -13692,16 +7899,7 @@
   [long derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [long derivedKey, normal salt, SHA-512, with normal info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -13710,22 +7908,10 @@
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -13734,22 +7920,10 @@
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -13758,19 +7932,10 @@
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using long derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
@@ -13782,9 +7947,6 @@
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using long derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -13792,9 +7954,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using long derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
@@ -13806,9 +7965,6 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -13816,9 +7972,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
@@ -13830,9 +7983,6 @@
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -13840,9 +7990,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
@@ -13854,9 +8001,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -13864,9 +8008,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
@@ -13878,22 +8019,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-512, with normal info with non-multiple of 8 length]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-512, with normal info with missing deriveBits usage]
     expected: FAIL
 
   [long derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -13902,16 +8031,7 @@
   [long derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [long derivedKey, normal salt, SHA-512, with empty info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -13920,22 +8040,10 @@
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -13944,22 +8052,10 @@
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -13968,19 +8064,10 @@
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using long derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
@@ -13992,9 +8079,6 @@
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using long derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -14002,9 +8086,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using long derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
@@ -14016,9 +8097,6 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -14026,9 +8104,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
@@ -14040,9 +8115,6 @@
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -14050,9 +8122,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
@@ -14064,9 +8133,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -14074,9 +8140,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
@@ -14088,22 +8151,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-512, with empty info with non-multiple of 8 length]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-512, with empty info with missing deriveBits usage]
     expected: FAIL
 
   [long derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -14112,16 +8163,7 @@
   [long derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [long derivedKey, normal salt, SHA-1, with normal info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -14130,22 +8172,10 @@
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -14154,22 +8184,10 @@
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -14178,19 +8196,10 @@
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using long derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
@@ -14202,9 +8211,6 @@
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using long derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -14212,9 +8218,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using long derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
@@ -14226,9 +8229,6 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -14236,9 +8236,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
@@ -14250,9 +8247,6 @@
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -14260,9 +8254,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
@@ -14274,9 +8265,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -14284,9 +8272,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
@@ -14298,22 +8283,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-1, with normal info with non-multiple of 8 length]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-1, with normal info with missing deriveBits usage]
     expected: FAIL
 
   [long derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -14322,16 +8295,7 @@
   [long derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [long derivedKey, normal salt, SHA-1, with empty info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -14340,22 +8304,10 @@
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -14364,22 +8316,10 @@
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -14388,19 +8328,10 @@
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using long derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
@@ -14412,9 +8343,6 @@
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using long derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -14422,9 +8350,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using long derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
@@ -14436,9 +8361,6 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -14446,9 +8368,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
@@ -14460,9 +8379,6 @@
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -14470,9 +8386,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
@@ -14484,9 +8397,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -14494,9 +8404,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
@@ -14508,40 +8415,16 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [long derivedKey, normal salt, SHA-1, with empty info with non-multiple of 8 length]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-1, with empty info with missing deriveBits usage]
-    expected: FAIL
-
   [long derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [long derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-256, with normal info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -14550,22 +8433,7 @@
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -14574,43 +8442,19 @@
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using long derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
@@ -14622,9 +8466,6 @@
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using long derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -14632,9 +8473,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using long derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
@@ -14646,9 +8484,6 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -14656,9 +8491,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
@@ -14670,9 +8502,6 @@
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -14680,9 +8509,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
@@ -14694,9 +8520,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -14704,9 +8527,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
@@ -14718,40 +8538,16 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
-  [long derivedKey, normal salt, SHA-256, with normal info with non-multiple of 8 length]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-256, with normal info with missing deriveBits usage]
-    expected: FAIL
-
   [long derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
-  [long derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-256, with empty info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -14760,22 +8556,7 @@
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -14784,43 +8565,19 @@
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using long derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
@@ -14832,9 +8589,6 @@
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using long derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -14842,9 +8596,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using long derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
@@ -14856,9 +8607,6 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -14866,9 +8614,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
@@ -14880,9 +8625,6 @@
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -14890,9 +8632,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
@@ -14904,9 +8643,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -14914,9 +8650,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
@@ -14928,142 +8661,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [long derivedKey, normal salt, SHA-256, with empty info with non-multiple of 8 length]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-256, with empty info with missing deriveBits usage]
-    expected: FAIL
-
   [long derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [long derivedKey, normal salt, PBKDF2, with normal info with non-digest algorithm PBKDF2]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using long derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 192  using long derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using long derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [long derivedKey, normal salt, PBKDF2, with empty info with non-digest algorithm PBKDF2]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using long derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 192  using long derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using long derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, PBKDF2, with empty info]
     expected: FAIL
 
   [long derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [long derivedKey, empty salt, SHA-384, with normal info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -15072,22 +8682,10 @@
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -15096,22 +8694,10 @@
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -15120,19 +8706,10 @@
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using long derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
@@ -15144,9 +8721,6 @@
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using long derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -15154,9 +8728,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using long derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
@@ -15168,9 +8739,6 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -15178,9 +8746,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
@@ -15192,9 +8757,6 @@
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -15202,9 +8764,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
@@ -15216,9 +8775,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -15226,9 +8782,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
@@ -15240,22 +8793,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-384, with normal info with non-multiple of 8 length]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-384, with normal info with missing deriveBits usage]
     expected: FAIL
 
   [long derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -15264,16 +8805,7 @@
   [long derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [long derivedKey, empty salt, SHA-384, with empty info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -15282,22 +8814,10 @@
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -15306,22 +8826,10 @@
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -15330,19 +8838,10 @@
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using long derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
@@ -15354,9 +8853,6 @@
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using long derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -15364,9 +8860,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using long derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
@@ -15378,9 +8871,6 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -15388,9 +8878,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
@@ -15402,9 +8889,6 @@
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -15412,9 +8896,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
@@ -15426,9 +8907,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -15436,9 +8914,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
@@ -15450,22 +8925,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-384, with empty info with non-multiple of 8 length]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-384, with empty info with missing deriveBits usage]
     expected: FAIL
 
   [long derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -15474,16 +8937,7 @@
   [long derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [long derivedKey, empty salt, SHA-512, with normal info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -15492,22 +8946,10 @@
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -15516,34 +8958,16 @@
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -15554,9 +8978,6 @@
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 128  using long derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -15564,9 +8985,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 192  using long derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
@@ -15578,9 +8996,6 @@
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 256  using long derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -15588,9 +9003,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
@@ -15602,9 +9014,6 @@
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -15612,9 +9021,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
@@ -15626,9 +9032,6 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -15636,9 +9039,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
@@ -15650,9 +9050,6 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -15662,22 +9059,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-512, with normal info with non-multiple of 8 length]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-512, with normal info with missing deriveBits usage]
     expected: FAIL
 
   [long derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -15686,16 +9071,7 @@
   [long derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [long derivedKey, empty salt, SHA-512, with empty info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -15704,22 +9080,10 @@
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -15728,22 +9092,10 @@
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -15752,19 +9104,10 @@
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using long derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
@@ -15776,9 +9119,6 @@
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using long derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -15786,9 +9126,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using long derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
@@ -15800,9 +9137,6 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -15810,9 +9144,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
@@ -15824,9 +9155,6 @@
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -15834,9 +9162,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
@@ -15848,9 +9173,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -15858,9 +9180,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
@@ -15872,22 +9191,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-512, with empty info with non-multiple of 8 length]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-512, with empty info with missing deriveBits usage]
     expected: FAIL
 
   [long derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -15896,16 +9203,7 @@
   [long derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [long derivedKey, empty salt, SHA-1, with normal info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -15914,22 +9212,10 @@
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -15938,22 +9224,10 @@
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -15962,19 +9236,10 @@
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using long derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
@@ -15986,9 +9251,6 @@
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using long derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -15996,9 +9258,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using long derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
@@ -16010,9 +9269,6 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -16020,9 +9276,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
@@ -16034,9 +9287,6 @@
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -16044,9 +9294,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
@@ -16058,9 +9305,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -16068,9 +9312,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
@@ -16082,22 +9323,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-1, with normal info with non-multiple of 8 length]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-1, with normal info with missing deriveBits usage]
     expected: FAIL
 
   [long derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -16106,16 +9335,7 @@
   [long derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [long derivedKey, empty salt, SHA-1, with empty info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -16124,22 +9344,10 @@
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -16148,22 +9356,10 @@
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -16172,19 +9368,10 @@
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using long derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
@@ -16196,9 +9383,6 @@
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using long derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -16206,9 +9390,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using long derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
@@ -16220,9 +9401,6 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -16230,9 +9408,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
@@ -16244,9 +9419,6 @@
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -16254,9 +9426,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
@@ -16268,9 +9437,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -16278,9 +9444,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
@@ -16292,40 +9455,16 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [long derivedKey, empty salt, SHA-1, with empty info with non-multiple of 8 length]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-1, with empty info with missing deriveBits usage]
-    expected: FAIL
-
   [long derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [long derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-256, with normal info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -16334,22 +9473,7 @@
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -16358,43 +9482,19 @@
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using long derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
@@ -16406,9 +9506,6 @@
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using long derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -16416,9 +9513,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using long derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
@@ -16430,9 +9524,6 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -16440,9 +9531,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
@@ -16454,9 +9542,6 @@
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -16464,9 +9549,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
@@ -16478,9 +9560,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -16488,9 +9567,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
@@ -16502,40 +9578,16 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
-  [long derivedKey, empty salt, SHA-256, with normal info with non-multiple of 8 length]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-256, with normal info with missing deriveBits usage]
-    expected: FAIL
-
   [long derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
-  [long derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-256, with empty info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -16544,22 +9596,7 @@
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -16568,43 +9605,19 @@
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using long derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
@@ -16616,9 +9629,6 @@
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using long derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -16626,9 +9636,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using long derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
@@ -16640,9 +9647,6 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -16650,9 +9654,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
@@ -16664,9 +9665,6 @@
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -16674,9 +9672,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
@@ -16688,9 +9683,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -16698,9 +9690,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
@@ -16712,142 +9701,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [long derivedKey, empty salt, SHA-256, with empty info with non-multiple of 8 length]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-256, with empty info with missing deriveBits usage]
-    expected: FAIL
-
   [long derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [long derivedKey, empty salt, PBKDF2, with normal info with non-digest algorithm PBKDF2]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using long derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 192  using long derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using long derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [long derivedKey, empty salt, PBKDF2, with empty info with non-digest algorithm PBKDF2]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using long derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 192  using long derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using long derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, PBKDF2, with empty info]
     expected: FAIL
 
   [empty derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [empty derivedKey, normal salt, SHA-384, with normal info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -16856,22 +9722,10 @@
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -16880,22 +9734,10 @@
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -16904,19 +9746,10 @@
   [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using empty derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
@@ -16928,9 +9761,6 @@
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using empty derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -16938,9 +9768,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
@@ -16952,9 +9779,6 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -16962,9 +9786,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
@@ -16976,9 +9797,6 @@
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -16986,9 +9804,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
@@ -17000,9 +9815,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -17010,9 +9822,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
@@ -17024,22 +9833,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-384, with normal info with non-multiple of 8 length]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-384, with normal info with missing deriveBits usage]
     expected: FAIL
 
   [empty derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -17048,16 +9845,7 @@
   [empty derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [empty derivedKey, normal salt, SHA-384, with empty info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -17066,22 +9854,10 @@
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -17090,22 +9866,10 @@
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -17114,19 +9878,10 @@
   [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using empty derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
@@ -17138,9 +9893,6 @@
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using empty derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -17148,9 +9900,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
@@ -17162,9 +9911,6 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -17172,9 +9918,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
@@ -17186,9 +9929,6 @@
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -17196,9 +9936,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
@@ -17210,9 +9947,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -17220,9 +9954,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
@@ -17234,22 +9965,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-384, with empty info with non-multiple of 8 length]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-384, with empty info with missing deriveBits usage]
     expected: FAIL
 
   [empty derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -17258,16 +9977,7 @@
   [empty derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [empty derivedKey, normal salt, SHA-512, with normal info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -17276,22 +9986,10 @@
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -17300,22 +9998,10 @@
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -17324,19 +10010,10 @@
   [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using empty derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
@@ -17348,9 +10025,6 @@
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using empty derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -17358,9 +10032,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
@@ -17372,9 +10043,6 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -17382,9 +10050,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
@@ -17396,9 +10061,6 @@
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -17406,9 +10068,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
@@ -17420,9 +10079,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -17430,9 +10086,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
@@ -17444,22 +10097,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-512, with normal info with non-multiple of 8 length]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-512, with normal info with missing deriveBits usage]
     expected: FAIL
 
   [empty derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -17468,16 +10109,7 @@
   [empty derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [empty derivedKey, normal salt, SHA-512, with empty info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -17486,22 +10118,10 @@
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -17510,22 +10130,10 @@
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -17534,19 +10142,10 @@
   [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using empty derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
@@ -17558,9 +10157,6 @@
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using empty derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -17568,9 +10164,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
@@ -17582,9 +10175,6 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -17592,9 +10182,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
@@ -17606,9 +10193,6 @@
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -17616,9 +10200,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
@@ -17630,9 +10211,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -17640,9 +10218,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
@@ -17654,22 +10229,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-512, with empty info with non-multiple of 8 length]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-512, with empty info with missing deriveBits usage]
     expected: FAIL
 
   [empty derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -17678,16 +10241,7 @@
   [empty derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [empty derivedKey, normal salt, SHA-1, with normal info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -17696,22 +10250,10 @@
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -17720,22 +10262,10 @@
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -17744,19 +10274,10 @@
   [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using empty derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
@@ -17768,9 +10289,6 @@
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using empty derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -17778,9 +10296,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
@@ -17792,9 +10307,6 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -17802,9 +10314,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
@@ -17816,9 +10325,6 @@
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -17826,9 +10332,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
@@ -17840,9 +10343,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -17850,9 +10350,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
@@ -17864,22 +10361,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-1, with normal info with non-multiple of 8 length]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-1, with normal info with missing deriveBits usage]
     expected: FAIL
 
   [empty derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -17888,16 +10373,7 @@
   [empty derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [empty derivedKey, normal salt, SHA-1, with empty info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -17906,22 +10382,10 @@
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -17930,22 +10394,10 @@
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -17954,19 +10406,10 @@
   [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using empty derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
@@ -17978,9 +10421,6 @@
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using empty derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -17988,9 +10428,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
@@ -18002,9 +10439,6 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -18012,9 +10446,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
@@ -18026,9 +10457,6 @@
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -18036,9 +10464,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
@@ -18050,9 +10475,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -18060,9 +10482,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
@@ -18074,40 +10493,16 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [empty derivedKey, normal salt, SHA-1, with empty info with non-multiple of 8 length]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-1, with empty info with missing deriveBits usage]
-    expected: FAIL
-
   [empty derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [empty derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-256, with normal info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -18116,22 +10511,7 @@
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -18140,43 +10520,19 @@
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using empty derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
@@ -18188,9 +10544,6 @@
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using empty derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -18198,9 +10551,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
@@ -18212,9 +10562,6 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -18222,9 +10569,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
@@ -18236,9 +10580,6 @@
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -18246,9 +10587,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
@@ -18260,9 +10598,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -18270,9 +10605,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
@@ -18284,40 +10616,16 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
-  [empty derivedKey, normal salt, SHA-256, with normal info with non-multiple of 8 length]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-256, with normal info with missing deriveBits usage]
-    expected: FAIL
-
   [empty derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
-  [empty derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-256, with empty info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -18326,22 +10634,7 @@
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -18350,43 +10643,19 @@
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using empty derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
@@ -18398,9 +10667,6 @@
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using empty derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -18408,9 +10674,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
@@ -18422,9 +10685,6 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -18432,9 +10692,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
@@ -18446,9 +10703,6 @@
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -18458,9 +10712,6 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -18468,9 +10719,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL
 
 
@@ -18478,9 +10726,6 @@
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 128  using long derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -18488,9 +10733,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 192  using long derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
@@ -18502,9 +10744,6 @@
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 256  using long derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -18512,9 +10751,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
@@ -18526,9 +10762,6 @@
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -18536,9 +10769,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
@@ -18550,9 +10780,6 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -18560,9 +10787,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
@@ -18574,9 +10798,6 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -18586,22 +10807,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-512, with normal info with non-multiple of 8 length]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-512, with normal info with missing deriveBits usage]
     expected: FAIL
 
   [long derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -18610,16 +10819,7 @@
   [long derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [long derivedKey, empty salt, SHA-512, with empty info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -18628,22 +10828,10 @@
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -18652,22 +10840,10 @@
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -18676,19 +10852,10 @@
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using long derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
@@ -18700,9 +10867,6 @@
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using long derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -18710,9 +10874,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using long derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
@@ -18724,9 +10885,6 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -18734,9 +10892,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
@@ -18748,9 +10903,6 @@
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -18758,9 +10910,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
@@ -18772,9 +10921,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -18782,9 +10928,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
@@ -18796,22 +10939,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-512, with empty info with non-multiple of 8 length]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-512, with empty info with missing deriveBits usage]
     expected: FAIL
 
   [long derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -18820,16 +10951,7 @@
   [long derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [long derivedKey, empty salt, SHA-1, with normal info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -18838,22 +10960,10 @@
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -18862,22 +10972,10 @@
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -18886,19 +10984,10 @@
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using long derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
@@ -18910,9 +10999,6 @@
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using long derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -18920,9 +11006,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using long derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
@@ -18934,9 +11017,6 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -18944,9 +11024,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
@@ -18958,9 +11035,6 @@
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -18968,9 +11042,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
@@ -18982,9 +11053,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -18992,9 +11060,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
@@ -19006,22 +11071,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-1, with normal info with non-multiple of 8 length]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-1, with normal info with missing deriveBits usage]
     expected: FAIL
 
   [long derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -19030,16 +11083,7 @@
   [long derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [long derivedKey, empty salt, SHA-1, with empty info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -19048,22 +11092,10 @@
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -19072,22 +11104,10 @@
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -19096,19 +11116,10 @@
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using long derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
@@ -19120,9 +11131,6 @@
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using long derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -19130,9 +11138,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using long derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
@@ -19144,9 +11149,6 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -19154,9 +11156,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
@@ -19168,9 +11167,6 @@
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -19178,9 +11174,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
@@ -19192,9 +11185,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -19202,9 +11192,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
@@ -19216,40 +11203,16 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [long derivedKey, empty salt, SHA-1, with empty info with non-multiple of 8 length]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-1, with empty info with missing deriveBits usage]
-    expected: FAIL
-
   [long derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [long derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-256, with normal info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -19258,22 +11221,7 @@
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -19282,43 +11230,19 @@
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using long derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
@@ -19330,9 +11254,6 @@
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using long derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -19340,9 +11261,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using long derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
@@ -19354,9 +11272,6 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -19364,9 +11279,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
@@ -19378,9 +11290,6 @@
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -19388,9 +11297,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
@@ -19402,9 +11308,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -19412,9 +11315,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
@@ -19426,40 +11326,16 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
-  [long derivedKey, empty salt, SHA-256, with normal info with non-multiple of 8 length]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-256, with normal info with missing deriveBits usage]
-    expected: FAIL
-
   [long derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
-  [long derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-256, with empty info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -19468,22 +11344,7 @@
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -19492,43 +11353,19 @@
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using long derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
@@ -19540,9 +11377,6 @@
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using long derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using long derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -19550,9 +11384,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using long derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using long derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
@@ -19564,9 +11395,6 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -19574,9 +11402,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
@@ -19588,9 +11413,6 @@
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -19598,9 +11420,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
@@ -19612,9 +11431,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -19622,9 +11438,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
@@ -19636,142 +11449,19 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [long derivedKey, empty salt, SHA-256, with empty info with non-multiple of 8 length]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-256, with empty info with missing deriveBits usage]
-    expected: FAIL
-
   [long derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [long derivedKey, empty salt, PBKDF2, with normal info with non-digest algorithm PBKDF2]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using long derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 192  using long derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using long derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, PBKDF2, with normal info]
-    expected: FAIL
-
-  [long derivedKey, empty salt, PBKDF2, with empty info with non-digest algorithm PBKDF2]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using long derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using long derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using long derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using long derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using long derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using long derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 192  using long derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using long derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, PBKDF2, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, PBKDF2, with empty info]
     expected: FAIL
 
   [empty derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [empty derivedKey, normal salt, SHA-384, with normal info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -19780,22 +11470,10 @@
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -19804,22 +11482,10 @@
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -19828,19 +11494,10 @@
   [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using empty derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
@@ -19852,9 +11509,6 @@
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using empty derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -19862,9 +11516,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
@@ -19876,9 +11527,6 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -19886,9 +11534,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
@@ -19900,9 +11545,6 @@
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -19910,9 +11552,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
@@ -19924,9 +11563,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -19934,9 +11570,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
@@ -19948,22 +11581,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-384, with normal info with non-multiple of 8 length]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-384, with normal info with bad hash name SHA384]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-384, with normal info with missing deriveBits usage]
     expected: FAIL
 
   [empty derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -19972,16 +11593,7 @@
   [empty derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [empty derivedKey, normal salt, SHA-384, with empty info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -19990,22 +11602,10 @@
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -20014,22 +11614,10 @@
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -20038,19 +11626,10 @@
   [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using empty derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
@@ -20062,9 +11641,6 @@
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using empty derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -20072,9 +11648,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
@@ -20086,9 +11659,6 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -20096,9 +11666,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
@@ -20110,9 +11677,6 @@
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -20120,9 +11684,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
@@ -20134,9 +11695,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -20144,9 +11702,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
@@ -20158,22 +11713,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-384, with empty info with non-multiple of 8 length]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-384, with empty info with bad hash name SHA384]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-384, with empty info with missing deriveBits usage]
     expected: FAIL
 
   [empty derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -20182,16 +11725,7 @@
   [empty derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [empty derivedKey, normal salt, SHA-512, with normal info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -20200,22 +11734,10 @@
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -20224,22 +11746,10 @@
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -20248,19 +11758,10 @@
   [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using empty derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
@@ -20272,9 +11773,6 @@
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using empty derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -20282,9 +11780,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
@@ -20296,9 +11791,6 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -20306,9 +11798,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
@@ -20320,9 +11809,6 @@
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -20330,9 +11816,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
@@ -20344,9 +11827,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -20354,9 +11834,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
@@ -20368,22 +11845,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-512, with normal info with non-multiple of 8 length]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-512, with normal info with bad hash name SHA512]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-512, with normal info with missing deriveBits usage]
     expected: FAIL
 
   [empty derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -20392,16 +11857,7 @@
   [empty derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [empty derivedKey, normal salt, SHA-512, with empty info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -20410,22 +11866,10 @@
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -20434,22 +11878,10 @@
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -20458,19 +11890,10 @@
   [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using empty derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
@@ -20482,9 +11905,6 @@
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using empty derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -20492,9 +11912,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
@@ -20506,9 +11923,6 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -20516,9 +11930,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
@@ -20530,9 +11941,6 @@
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -20540,9 +11948,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
@@ -20554,9 +11959,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -20564,9 +11966,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
@@ -20578,22 +11977,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-512, with empty info with non-multiple of 8 length]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-512, with empty info with bad hash name SHA512]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-512, with empty info with missing deriveBits usage]
     expected: FAIL
 
   [empty derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -20602,16 +11989,7 @@
   [empty derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [empty derivedKey, normal salt, SHA-1, with normal info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -20620,22 +11998,10 @@
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -20644,22 +12010,10 @@
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -20668,19 +12022,10 @@
   [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using empty derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
@@ -20692,9 +12037,6 @@
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using empty derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -20702,9 +12044,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
@@ -20716,9 +12055,6 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -20726,9 +12062,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
@@ -20740,9 +12073,6 @@
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -20750,9 +12080,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
@@ -20764,9 +12091,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -20774,9 +12098,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
@@ -20788,22 +12109,10 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-1, with normal info with non-multiple of 8 length]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-1, with normal info with bad hash name SHA1]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-1, with normal info with missing deriveBits usage]
     expected: FAIL
 
   [empty derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -20812,16 +12121,7 @@
   [empty derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [empty derivedKey, normal salt, SHA-1, with empty info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -20830,22 +12130,10 @@
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -20854,22 +12142,10 @@
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -20878,19 +12154,10 @@
   [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using empty derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
@@ -20902,9 +12169,6 @@
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using empty derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -20912,9 +12176,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
@@ -20926,9 +12187,6 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -20936,9 +12194,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
@@ -20950,9 +12205,6 @@
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -20960,9 +12212,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
@@ -20974,9 +12223,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -20984,9 +12230,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
@@ -20998,40 +12241,16 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [empty derivedKey, normal salt, SHA-1, with empty info with non-multiple of 8 length]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-1, with empty info with bad hash name SHA1]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-1, with empty info with missing deriveBits usage]
-    expected: FAIL
-
   [empty derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [empty derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-256, with normal info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -21040,22 +12259,7 @@
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -21064,43 +12268,19 @@
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using empty derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
@@ -21112,9 +12292,6 @@
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using empty derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -21122,9 +12299,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
@@ -21136,9 +12310,6 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -21146,9 +12317,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
@@ -21160,9 +12328,6 @@
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -21170,9 +12335,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
@@ -21184,9 +12346,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
@@ -21194,9 +12353,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
@@ -21208,40 +12364,16 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
-  [empty derivedKey, normal salt, SHA-256, with normal info with non-multiple of 8 length]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-256, with normal info with bad hash name SHA256]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-256, with normal info with missing deriveBits usage]
-    expected: FAIL
-
   [empty derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
-  [empty derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-256, with empty info with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -21250,22 +12382,7 @@
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 192  using empty derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -21274,43 +12391,19 @@
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 128  using empty derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-CTR length: 192  using empty derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
-  [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 128  using empty derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
@@ -21322,9 +12415,6 @@
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-GCM length: 192  using empty derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 192  using empty derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -21332,9 +12422,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-GCM length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
@@ -21346,9 +12433,6 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -21356,9 +12440,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
@@ -21370,9 +12451,6 @@
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -21382,9 +12460,6 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
@@ -21392,7 +12467,4 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with bad hash name SHA256]
     expected: FAIL

--- a/tests/wpt/meta/WebCryptoAPI/import_export/symmetric_importKey.https.any.js.ini
+++ b/tests/wpt/meta/WebCryptoAPI/import_export/symmetric_importKey.https.any.js.ini
@@ -431,33 +431,6 @@
   [Good parameters: 256 bits (jwk, {alg: HS512, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {hash: SHA-512, name: HMAC}, false, [verify\])]
     expected: FAIL
 
-  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: HKDF}, false, [deriveBits\])]
-    expected: FAIL
-
-  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: HKDF}, false, [deriveKey, deriveBits\])]
-    expected: FAIL
-
-  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: HKDF}, false, [deriveKey\])]
-    expected: FAIL
-
-  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: HKDF}, false, [deriveBits\])]
-    expected: FAIL
-
-  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: HKDF}, false, [deriveKey, deriveBits\])]
-    expected: FAIL
-
-  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: HKDF}, false, [deriveKey\])]
-    expected: FAIL
-
-  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: HKDF}, false, [deriveBits\])]
-    expected: FAIL
-
-  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: HKDF}, false, [deriveKey, deriveBits\])]
-    expected: FAIL
-
-  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: HKDF}, false, [deriveKey\])]
-    expected: FAIL
-
   [Empty Usages: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-GCM}, true, [\])]
     expected: FAIL
 
@@ -762,15 +735,6 @@
     expected: FAIL
 
   [Good parameters: 256 bits (jwk, {alg: HS512, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {hash: SHA-512, name: HMAC}, false, [sign, verify, sign, verify\])]
-    expected: FAIL
-
-  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: HKDF}, false, [deriveBits, deriveKey, deriveBits, deriveKey\])]
-    expected: FAIL
-
-  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: HKDF}, false, [deriveBits, deriveKey, deriveBits, deriveKey\])]
-    expected: FAIL
-
-  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: HKDF}, false, [deriveBits, deriveKey, deriveBits, deriveKey\])]
     expected: FAIL
 
 
@@ -1207,33 +1171,6 @@
   [Good parameters: 256 bits (jwk, {alg: HS512, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {hash: SHA-512, name: HMAC}, false, [verify\])]
     expected: FAIL
 
-  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: HKDF}, false, [deriveBits\])]
-    expected: FAIL
-
-  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: HKDF}, false, [deriveKey, deriveBits\])]
-    expected: FAIL
-
-  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: HKDF}, false, [deriveKey\])]
-    expected: FAIL
-
-  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: HKDF}, false, [deriveBits\])]
-    expected: FAIL
-
-  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: HKDF}, false, [deriveKey, deriveBits\])]
-    expected: FAIL
-
-  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: HKDF}, false, [deriveKey\])]
-    expected: FAIL
-
-  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: HKDF}, false, [deriveBits\])]
-    expected: FAIL
-
-  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: HKDF}, false, [deriveKey, deriveBits\])]
-    expected: FAIL
-
-  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: HKDF}, false, [deriveKey\])]
-    expected: FAIL
-
   [Empty Usages: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-GCM}, true, [\])]
     expected: FAIL
 
@@ -1538,13 +1475,4 @@
     expected: FAIL
 
   [Good parameters: 256 bits (jwk, {alg: HS512, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {hash: SHA-512, name: HMAC}, false, [sign, verify, sign, verify\])]
-    expected: FAIL
-
-  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: HKDF}, false, [deriveBits, deriveKey, deriveBits, deriveKey\])]
-    expected: FAIL
-
-  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: HKDF}, false, [deriveBits, deriveKey, deriveBits, deriveKey\])]
-    expected: FAIL
-
-  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: HKDF}, false, [deriveBits, deriveKey, deriveBits, deriveKey\])]
     expected: FAIL


### PR DESCRIPTION
Implements [HKDF](https://w3c.github.io/webcrypto/#hkdf) support for `subtlecrypto.deriveBits`.

[try run](https://github.com/simonwuelker/servo/actions/runs/11758845904)

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes 
