### PR TITLE
Unminify module scripts.

### DIFF
--- a/components/script/dom/dissimilaroriginwindow.rs
+++ b/components/script/dom/dissimilaroriginwindow.rs
@@ -66,6 +66,7 @@ impl DissimilarOriginWindow {
                 global_to_clone_from.get_user_agent(),
                 global_to_clone_from.wgpu_id_hub(),
                 Some(global_to_clone_from.is_secure_context()),
+                false,
             ),
             window_proxy: Dom::from_ref(window_proxy),
             location: Default::default(),

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -143,6 +143,7 @@ use crate::task_source::{TaskSource, TaskSourceName};
 use crate::timers::{
     IsInterval, OneshotTimerCallback, OneshotTimerHandle, OneshotTimers, TimerCallback,
 };
+use crate::unminify::unminified_path;
 
 #[derive(JSTraceable)]
 pub struct AutoCloseWorker {
@@ -356,6 +357,10 @@ pub struct GlobalScope {
 
     /// Is considered in a secure context
     inherited_secure_context: Option<bool>,
+
+    /// Directory to store unminified scripts for this window if unminify-js
+    /// opt is enabled.
+    unminified_js_dir: Option<String>,
 }
 
 /// A wrapper for glue-code between the ipc router and the event-loop.
@@ -764,6 +769,7 @@ impl GlobalScope {
         user_agent: Cow<'static, str>,
         gpu_id_hub: Arc<IdentityHub>,
         inherited_secure_context: Option<bool>,
+        unminify_js: bool,
     ) -> Self {
         Self {
             message_port_state: DomRefCell::new(MessagePortState::UnManaged),
@@ -805,6 +811,7 @@ impl GlobalScope {
             console_count_map: Default::default(),
             dynamic_modules: DomRefCell::new(DynamicModuleList::new()),
             inherited_secure_context,
+            unminified_js_dir: unminify_js.then(|| unminified_path("unminified-js")),
         }
     }
 
@@ -3423,6 +3430,10 @@ impl GlobalScope {
             cancellation_receiver,
             network_listener.into_callback(),
         );
+    }
+
+    pub fn unminified_js_dir(&self) -> Option<String> {
+        self.unminified_js_dir.clone()
     }
 }
 

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -166,6 +166,7 @@ impl WorkerGlobalScope {
                 init.user_agent,
                 gpu_id_hub,
                 init.inherited_secure_context,
+                false,
             ),
             worker_id: init.worker_id,
             worker_name,

--- a/components/script/dom/workletglobalscope.rs
+++ b/components/script/dom/workletglobalscope.rs
@@ -101,6 +101,7 @@ impl WorkletGlobalScope {
                 init.user_agent.clone(),
                 init.gpu_id_hub.clone(),
                 init.inherited_secure_context,
+                false,
             ),
             base_url,
             to_script_thread_sender: init.to_script_thread_sender.clone(),

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -418,6 +418,35 @@ pub enum ModuleStatus {
     Finished,
 }
 
+struct ModuleSource {
+    source: Rc<DOMString>,
+    unminified_dir: Option<String>,
+    external: bool,
+    url: ServoUrl,
+}
+
+impl crate::unminify::ScriptSource for ModuleSource {
+    fn unminified_dir(&self) -> Option<String> {
+        self.unminified_dir.clone()
+    }
+
+    fn extract_bytes(&self) -> &[u8] {
+        self.source.as_bytes()
+    }
+
+    fn rewrite_source(&mut self, source: Rc<DOMString>) {
+        self.source = source;
+    }
+
+    fn url(&self) -> ServoUrl {
+        self.url.clone()
+    }
+
+    fn is_external(&self) -> bool {
+        self.external
+    }
+}
+
 impl ModuleTree {
     #[allow(unsafe_code)]
     /// <https://html.spec.whatwg.org/multipage/#creating-a-module-script>
@@ -430,17 +459,25 @@ impl ModuleTree {
         url: &ServoUrl,
         options: ScriptFetchOptions,
         mut module_script: RustMutableHandleObject,
+        inline: bool,
     ) -> Result<(), RethrowError> {
         let cx = GlobalScope::get_cx();
         let _ac = JSAutoRealm::new(*cx, *global.reflector().get_jsobject());
 
         let compile_options = unsafe { CompileOptionsWrapper::new(*cx, url.as_str(), 1) };
+        let mut module_source = ModuleSource {
+            source: module_script_text,
+            unminified_dir: global.unminified_js_dir(),
+            external: !inline,
+            url: url.clone(),
+        };
+        crate::unminify::unminify_js(&mut module_source);
 
         unsafe {
             module_script.set(CompileModule1(
                 *cx,
                 compile_options.ptr,
-                &mut transform_str_to_source_text(&module_script_text),
+                &mut transform_str_to_source_text(&module_source.source),
             ));
 
             if module_script.is_null() {
@@ -931,12 +968,14 @@ impl ModuleOwner {
                                 script_src.clone(),
                                 fetch_options,
                                 ScriptType::Module,
+                                global.unminified_js_dir(),
                             )),
                             ModuleIdentity::ScriptId(_) => Ok(ScriptOrigin::internal(
                                 Rc::clone(&module_tree.get_text().borrow()),
                                 document.base_url().clone(),
                                 fetch_options,
                                 ScriptType::Module,
+                                global.unminified_js_dir(),
                             )),
                         },
                     }
@@ -1149,6 +1188,7 @@ impl FetchResponseListener for ModuleContext {
                 meta.final_url,
                 self.options.clone(),
                 ScriptType::Module,
+                global.unminified_js_dir(),
             ))
         });
 
@@ -1178,6 +1218,7 @@ impl FetchResponseListener for ModuleContext {
                     &self.url,
                     self.options.clone(),
                     compiled_module.handle_mut(),
+                    false,
                 );
 
                 match compiled_module_result {
@@ -1748,6 +1789,7 @@ pub(crate) fn fetch_inline_module_script(
         &url,
         options.clone(),
         compiled_module.handle_mut(),
+        true,
     );
 
     match compiled_module_result {

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -448,7 +448,7 @@ impl crate::unminify::ScriptSource for ModuleSource {
 }
 
 impl ModuleTree {
-    #[allow(unsafe_code)]
+    #[allow(unsafe_code, clippy::too_many_arguments)]
     /// <https://html.spec.whatwg.org/multipage/#creating-a-module-script>
     /// Step 7-11.
     fn compile_module_script(

--- a/components/script/stylesheet_loader.rs
+++ b/components/script/stylesheet_loader.rs
@@ -94,9 +94,9 @@ pub struct StylesheetContext {
 
 impl StylesheetContext {
     fn unminify_css(&self, data: Vec<u8>, file_url: ServoUrl) -> Vec<u8> {
-        if self.document.root().window().unminified_css_dir().is_none() {
+        let Some(unminified_dir) = self.document.root().window().unminified_css_dir() else {
             return data;
-        }
+        };
 
         let mut style_content = data;
 
@@ -110,11 +110,7 @@ impl StylesheetContext {
                 output.read_to_end(&mut style_content).unwrap();
             }
         }
-        match create_output_file(
-            self.document.root().window().unminified_css_dir(),
-            &file_url,
-            None,
-        ) {
+        match create_output_file(unminified_dir, &file_url, None) {
             Ok(mut file) => {
                 file.write_all(&style_content).unwrap();
             },

--- a/components/script/unminify.rs
+++ b/components/script/unminify.rs
@@ -131,5 +131,5 @@ pub(crate) fn unminify_js(script: &mut dyn ScriptSource) {
 pub(crate) fn unminified_path(dir: &str) -> String {
     let mut path = env::current_dir().unwrap();
     path.push(dir);
-    return path.into_os_string().into_string().unwrap();
+    path.into_os_string().into_string().unwrap()
 }


### PR DESCRIPTION
These changes allow module scripts to be unminified like classic scripts, and add a layer of abstraction to reduce code duplication between the two kinds of scripts.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #34198
- [x] These changes do not require tests because we don't support testing unminification.