### PR TITLE
Fix `assert!(self.is_readable())` crash

### DIFF
--- a/components/script/dom/readablestream.rs
+++ b/components/script/dom/readablestream.rs
@@ -20,6 +20,8 @@ use crate::dom::bindings::codegen::Bindings::ReadableStreamBinding::{
     ReadableStreamGetReaderOptions, ReadableStreamMethods, ReadableStreamReaderMode,
 };
 use crate::dom::bindings::codegen::Bindings::ReadableStreamDefaultReaderBinding::ReadableStreamDefaultReaderMethods;
+use crate::dom::bindings::codegen::Bindings::ReadableStreamDefaultControllerBinding::ReadableStreamDefaultController_Binding::ReadableStreamDefaultControllerMethods;
+use crate::dom::bindings::codegen::Bindings::ReadableByteStreamControllerBinding::ReadableByteStreamController_Binding::ReadableByteStreamControllerMethods;
 use crate::dom::bindings::codegen::Bindings::UnderlyingSourceBinding::UnderlyingSource as JsUnderlyingSource;
 use crate::dom::bindings::conversions::{ConversionBehavior, ConversionResult};
 use crate::dom::bindings::error::Error;
@@ -280,6 +282,18 @@ impl ReadableStream {
                 .to_jsval(*cx, &self.global(), rval.handle_mut())
         };
         self.error(rval.handle());
+    }
+
+    /// Call into the controller's `Close` method.
+    pub fn close_native(&self) {
+        match self.controller {
+            ControllerType::Default(ref controller) => {
+                let _ = controller.Close();
+            },
+            ControllerType::Byte(ref controller) => {
+                let _ = controller.Close();
+            },
+        }
     }
 
     /// Returns a boolean reflecting whether the stream has all data in memory.

--- a/components/script/dom/response.rs
+++ b/components/script/dom/response.rs
@@ -458,7 +458,7 @@ impl Response {
     #[allow(crown::unrooted_must_root)]
     pub fn finish(&self) {
         if let Some(body) = self.body_stream.get() {
-            body.close();
+            body.close_native();
         }
         let stream_consumer = self.stream_consumer.borrow_mut().take();
         if let Some(stream_consumer) = stream_consumer {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Something is either wrong with implementation to the spec:

from the spec I see, close:
```
https://streams.spec.whatwg.org/#readable-stream-close

1. Assert: stream.state is "readable".

2. Set stream.state to "closed".
```

error:

```
https://streams.spec.whatwg.org/#readable-stream-error

1. Assert: stream.state is "readable".

2. Set stream.state to "errored".
```

both are asserting that stream's state is readable then changing the state, but in some test like `/fetch/api/basic/scheme-about.any.html` , `close` is called after `error` but Assert fails since it is not `readable` anymore.

by removing Assert test is passing!

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
