### PR TITLE
Filter Perfetto traces to `servo_profiling` spans and events only

### DIFF
--- a/ports/servoshell/lib.rs
+++ b/ports/servoshell/lib.rs
@@ -52,7 +52,8 @@ pub fn init_tracing() {
             // Set up a PerfettoLayer for performance tracing.
             // The servo.pftrace file can be uploaded to https://ui.perfetto.dev for analysis.
             let file = std::fs::File::create("servo.pftrace").unwrap();
-            let perfetto_layer = tracing_perfetto::PerfettoLayer::new(std::sync::Mutex::new(file));
+            let perfetto_layer = tracing_perfetto::PerfettoLayer::new(std::sync::Mutex::new(file))
+                .with_filter_by_marker(|field_name| field_name == "servo_profiling");
             subscriber.with(perfetto_layer)
         };
 


### PR DESCRIPTION
This patch filters our Perfetto output (--features tracing-perfetto) to only spans and events with the `servo_profiling` field, like we do for our hitrace output.

As a result, this cuts an eight-minute trace from 13 GB (1.8 GiB on disk) to 9 GB (1.1 GiB on disk).

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes partially address #34172