### PR TITLE
Allow tidy to pass without support/crown/target

### DIFF
--- a/python/tidy/tidy.py
+++ b/python/tidy/tidy.py
@@ -949,7 +949,7 @@ def check_config_file(config_file, print_text=True):
 
     # Check for invalid listed ignored directories
     exclude_dirs = [d for p in exclude.get("directories", []) for d in (glob.glob(p) or [p])]
-    skip_dirs = ["./target", "./tests"]
+    skip_dirs = ["./target", "./tests", "./support/crown/target"]
     invalid_dirs = [d for d in exclude_dirs if not os.path.isdir(d) and not any(s in d for s in skip_dirs)]
 
     # Check for invalid listed ignored files


### PR DESCRIPTION
It is possible that developers do not have support/crown/target, so tidy check should still pass. We use similar logic for ./target.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #34210
- [x] These changes do not require tests because it's just tidy check

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
