### PR TITLE
Fix writing of apis.html

### DIFF
--- a/components/script/dom/bindings/codegen/run.py
+++ b/components/script/dom/bindings/codegen/run.py
@@ -16,7 +16,10 @@ def main():
     sys.path.insert(0, os.path.join(SERVO_ROOT, "third_party", "ply"))
 
     css_properties_json, out_dir = sys.argv[1:]
-    doc_servo = os.path.join(SERVO_ROOT, "target", "doc", "servo")
+    # Four dotdots: /path/to/target(4)/debug(3)/build(2)/style-*(1)/out
+    # Do not ascend above the target dir, because it may not be called target
+    # or even have a parent (see CARGO_TARGET_DIR).
+    doc_servo = os.path.join(out_dir, "..", "..", "..", "..", "doc")
     webidls_dir = os.path.join(SCRIPT_PATH, "..", "..", "webidls")
     config_file = "Bindings.conf"
 


### PR DESCRIPTION
As described in https://github.com/servo/servo/issues/28537#issuecomment-2468820031 the problem is that cargo doc overwrites folders when generating docs for crate, so instead of puting apis.html in target/doc/script we put it in target/doc. Also fixed handling of outputs (before it was assumed that target folder lied in servo folder, which is not always true), based on code from stylo: https://github.com/servo/stylo/blob/1c069c5e62fb70a64f3305fcafed2c12073608b8/style/properties/build.py#L74


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #34213
- [x] These changes do not require tests because it's just docs generating

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
