### PR TITLE
Enable caching & beautifying of HTML page sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ Sessionx.vim
 
 /unminified-js
 /unminified-css
+/unminified-html
 
 # Layout debugger trace files
 layout_trace*

--- a/components/config/opts.rs
+++ b/components/config/opts.rs
@@ -133,6 +133,9 @@ pub struct Opts {
     /// Unminify Css.
     pub unminify_css: bool,
 
+    ///Unminify Html.
+    pub unminify_html: bool,
+
     /// Print Progressive Web Metrics to console.
     pub print_pwm: bool,
 }
@@ -430,6 +433,7 @@ pub fn default_opts() -> Opts {
         unminify_js: false,
         local_script_source: None,
         unminify_css: false,
+        unminify_html: false,
         print_pwm: false,
     }
 }
@@ -581,6 +585,7 @@ pub fn from_cmdline_args(mut opts: Options, args: &[String]) -> ArgumentParsingR
         "",
     );
     opts.optflag("", "unminify-css", "Unminify Css");
+    opts.optflag("", "unminify-html", "Unminify Html");
 
     let opt_match = match opts.parse(args) {
         Ok(m) => m,
@@ -796,6 +801,7 @@ pub fn from_cmdline_args(mut opts: Options, args: &[String]) -> ArgumentParsingR
         unminify_js: opt_match.opt_present("unminify-js"),
         local_script_source: opt_match.opt_str("local-script-source"),
         unminify_css: opt_match.opt_present("unminify-css"),
+        unminify_html: opt_match.opt_present("unminify-html"),
         print_pwm: opt_match.opt_present("print-pwm"),
     };
 

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -299,6 +299,10 @@ pub struct Window {
     /// opt is enabled.
     unminified_css_dir: DomRefCell<Option<String>>,
 
+    /// Directory to store unminified html for this window if unminify-html
+    /// opt is enabled.
+    unminified_html_dir: DomRefCell<Option<String>>,
+
     /// Directory with stored unminified scripts
     local_script_source: Option<String>,
 
@@ -331,6 +335,9 @@ pub struct Window {
 
     /// Unminify Css.
     unminify_css: bool,
+
+    /// Unminify Html.
+    unminify_html: bool,
 
     /// Where to load userscripts from, if any. An empty string will load from
     /// the resources/user-agent-js directory, and if the option isn't passed userscripts
@@ -2522,6 +2529,10 @@ impl Window {
         self.unminified_css_dir.borrow().clone()
     }
 
+    pub fn unminified_html_dir(&self) -> Option<String> {
+        self.unminified_html_dir.borrow().clone()
+    }
+
     pub fn local_script_source(&self) -> &Option<String> {
         &self.local_script_source
     }
@@ -2587,6 +2598,7 @@ impl Window {
         prepare_for_screenshot: bool,
         unminify_js: bool,
         unminify_css: bool,
+        unminify_html: bool,
         local_script_source: Option<String>,
         userscripts_path: Option<String>,
         is_headless: bool,
@@ -2664,6 +2676,7 @@ impl Window {
             webxr_registry,
             pending_layout_images: Default::default(),
             unminified_css_dir: Default::default(),
+            unminified_html_dir: Default::default(),
             local_script_source,
             test_worklet: Default::default(),
             paint_worklet: Default::default(),
@@ -2674,6 +2687,7 @@ impl Window {
             relayout_event,
             prepare_for_screenshot,
             unminify_css,
+            unminify_html,
             userscripts_path,
             replace_surrogates,
             player_context,

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -711,6 +711,9 @@ pub struct ScriptThread {
     /// Unminify Css.
     unminify_css: bool,
 
+    /// Unminify Html.
+    unminify_html: bool,
+
     /// Where to load userscripts from, if any. An empty string will load from
     /// the resources/user-agent-js directory, and if the option isn't passed userscripts
     /// won't be loaded
@@ -1348,6 +1351,7 @@ impl ScriptThread {
             unminify_js: opts.unminify_js,
             local_script_source: opts.local_script_source.clone(),
             unminify_css: opts.unminify_css,
+            unminify_html: opts.unminify_html,
 
             userscripts_path: opts.userscripts.clone(),
             headless: opts.headless,
@@ -3756,6 +3760,7 @@ impl ScriptThread {
             self.prepare_for_screenshot,
             self.unminify_js,
             self.unminify_css,
+            self.unminify_html,
             self.local_script_source.clone(),
             self.userscripts_path.clone(),
             self.headless,

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -4134,7 +4134,7 @@ impl ScriptThread {
             .origin(incomplete.origin.immutable().clone())
             .crash(load_data.crash);
 
-        let context = ParserContext::new(id, load_data.url);
+        let context = ParserContext::new(id, load_data.url, "unminified-html".to_string());
         self.incomplete_parser_contexts
             .0
             .borrow_mut()
@@ -4215,7 +4215,7 @@ impl ScriptThread {
         self.incomplete_loads.borrow_mut().push(incomplete);
 
         let url = ServoUrl::parse("about:blank").unwrap();
-        let mut context = ParserContext::new(id, url.clone());
+        let mut context = ParserContext::new(id, url.clone(), "unminified-html".to_string());
 
         let mut meta = Metadata::default(url);
         meta.set_content_type(Some(&mime::TEXT_HTML));
@@ -4247,7 +4247,7 @@ impl ScriptThread {
         self.incomplete_loads.borrow_mut().push(incomplete);
 
         let url = ServoUrl::parse("about:srcdoc").unwrap();
-        let mut context = ParserContext::new(id, url.clone());
+        let mut context = ParserContext::new(id, url.clone(), "unminified-html".to_string());
 
         let mut meta = Metadata::default(url);
         meta.set_content_type(Some(&mime::TEXT_HTML));

--- a/components/script/unminify.rs
+++ b/components/script/unminify.rs
@@ -42,6 +42,7 @@ pub fn create_temp_files() -> Option<(NamedTempFile, File)> {
 pub enum BeautifyFileType {
     Css,
     Js,
+    Html,
 }
 
 pub fn execute_js_beautify(input: &Path, output: File, file_type: BeautifyFileType) -> bool {
@@ -50,6 +51,9 @@ pub fn execute_js_beautify(input: &Path, output: File, file_type: BeautifyFileTy
         BeautifyFileType::Js => (),
         BeautifyFileType::Css => {
             cmd.arg("--type").arg("css");
+        },
+        BeautifyFileType::Html => {
+            cmd.arg("--type").arg("html").arg("--file").arg(input);
         },
     }
     match cmd.arg(input).stdout(output).status() {


### PR DESCRIPTION
Supports local tweaking of page source by enabling caching & beautifying of HTML page sources


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #33663 
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
