### PR TITLE
build(deps): bump napi-ohos related crates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,10 @@ updates:
          - "egui_glow"
          - "emath"
          - "epaint"
+    napi-ohos-related:
+      patterns:
+        - "napi-ohos*"
+        - "napi-*-ohos*"
   ignore:
   # Ignore all stylo crates as their upgrades are coordinated via companion PRs.
   - dependency-name: servo_atoms

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4497,23 +4497,23 @@ dependencies = [
 
 [[package]]
 name = "napi-derive-backend-ohos"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "913b83a4b0a51a41a03af86960598d87d26acf7ddef8a14baaad5d66f1eacce6"
+checksum = "ee89f0553eb651d27e7402df9e6564e2ca327a261d0fab7fec7feb64d319f531"
 dependencies = [
  "convert_case",
  "once_cell",
  "proc-macro2",
  "quote",
- "regex",
+ "semver",
  "syn",
 ]
 
 [[package]]
 name = "napi-derive-ohos"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80cc82f130a44465f1c9b30344387f5b5bec2a579f78baf982b86ef92c22d26f"
+checksum = "ba695c18e242caab837f7b5113fe271d516a24afdc82b24fe3ee5d92b4f2ec48"
 dependencies = [
  "convert_case",
  "napi-derive-backend-ohos",
@@ -4524,9 +4524,9 @@ dependencies = [
 
 [[package]]
 name = "napi-ohos"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f51da5368ed904ee9274332875955442a7dda4f0352d3eb7a29d238650fc96"
+checksum = "2595591bd7525f697450c326b0b786babd5b568d61a582e96e48e4ede82f5ac4"
 dependencies = [
  "bitflags 2.6.0",
  "ctor",
@@ -4535,9 +4535,9 @@ dependencies = [
 
 [[package]]
 name = "napi-sys-ohos"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7fcdef583bb4e03060b852a65d2d9ca3a781c43b97cf7e546d3937ea2b0612"
+checksum = "271aa4dcc256a7e30d9f6564f8540e0f9fd323c838c63c259ff1a2fd2c7ba16b"
 dependencies = [
  "libloading",
 ]


### PR DESCRIPTION
Bumping the crates individually [seems to fail](https://github.com/servo/servo/pull/34218#issuecomment-2469465367)


---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

