### PR TITLE
Implement `"get key length"` operation for HMAC algorithm

### DIFF
--- a/tests/wpt/meta/WebCryptoAPI/derive_bits_keys/hkdf.https.any.js.ini
+++ b/tests/wpt/meta/WebCryptoAPI/derive_bits_keys/hkdf.https.any.js.ini
@@ -1,23 +1,14 @@
 [hkdf.https.any.worker.html?3001-last]
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -122,16 +113,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -140,16 +125,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -254,16 +233,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -272,16 +245,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -386,16 +353,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -404,16 +365,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -518,16 +473,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -536,16 +485,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -650,16 +593,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -668,16 +605,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -782,16 +713,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -800,16 +725,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -905,16 +824,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -923,16 +836,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -1028,16 +935,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -1046,16 +947,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -1162,16 +1057,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -1180,16 +1069,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -1294,16 +1177,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -1312,16 +1189,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -1426,16 +1297,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -1444,16 +1309,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -1558,16 +1417,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -1576,16 +1429,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -1690,16 +1537,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -1708,16 +1549,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -1822,16 +1657,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -1840,16 +1669,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -1945,16 +1768,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -1963,16 +1780,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -2068,16 +1879,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -2086,16 +1891,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -2200,16 +1999,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -2218,16 +2011,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -2332,16 +2119,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -2350,16 +2131,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -2464,16 +2239,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -2482,16 +2251,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -2596,16 +2359,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -2614,16 +2371,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -2728,16 +2479,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -2746,16 +2491,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -2814,25 +2553,16 @@
 
 
 [hkdf.https.any.html?3001-last]
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -2937,16 +2667,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -2955,16 +2679,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -3069,16 +2787,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -3087,16 +2799,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -3201,16 +2907,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -3219,16 +2919,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -3333,16 +3027,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -3351,16 +3039,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -3465,16 +3147,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -3483,16 +3159,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -3597,16 +3267,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -3615,16 +3279,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -3720,16 +3378,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -3738,16 +3390,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -3843,16 +3489,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -3861,16 +3501,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -3929,16 +3563,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -3947,16 +3575,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -4052,16 +3674,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -4070,16 +3686,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -4175,16 +3785,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -4193,16 +3797,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -4307,16 +3905,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -4325,16 +3917,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -4439,16 +4025,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -4457,16 +4037,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -4571,16 +4145,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -4589,16 +4157,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -4703,16 +4265,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -4721,16 +4277,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -4835,16 +4385,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -4853,16 +4397,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -4967,16 +4505,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -4985,16 +4517,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -5090,16 +4616,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -5108,16 +4628,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -5213,16 +4727,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -5231,16 +4739,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -5345,16 +4847,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -5363,16 +4859,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -5477,16 +4967,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -5495,16 +4979,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -5650,16 +5128,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -5668,16 +5140,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -5782,16 +5248,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -5800,16 +5260,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -5914,16 +5368,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -5932,16 +5380,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -6046,16 +5488,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -6064,16 +5500,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -6178,16 +5608,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -6196,16 +5620,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -6310,16 +5728,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -6328,16 +5740,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -6433,16 +5839,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -6451,16 +5851,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -6556,16 +5950,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -6574,16 +5962,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -6688,16 +6070,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -6706,16 +6082,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -6820,16 +6190,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -6838,16 +6202,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -6952,16 +6310,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -6970,16 +6322,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -7084,16 +6430,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -7102,16 +6442,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -7216,16 +6550,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -7234,16 +6562,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -7350,16 +6672,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -7368,16 +6684,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -7473,16 +6783,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -7491,16 +6795,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -7596,16 +6894,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -7614,16 +6906,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -7728,16 +7014,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -7746,16 +7026,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -7860,16 +7134,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -7878,16 +7146,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -7992,16 +7254,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -8010,16 +7266,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -8124,16 +7374,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -8142,16 +7386,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -8256,16 +7494,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -8274,16 +7506,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -8388,16 +7614,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -8406,16 +7626,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -8511,16 +7725,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -8529,16 +7737,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -8634,16 +7836,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -8652,16 +7848,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -8766,16 +7956,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -8784,16 +7968,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -8898,16 +8076,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -8916,16 +8088,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -9032,16 +8198,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -9050,16 +8210,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -9164,16 +8318,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -9182,16 +8330,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -9296,16 +8438,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -9314,16 +8450,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -9428,16 +8558,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -9446,16 +8570,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -9551,16 +8669,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -9569,16 +8681,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -9674,16 +8780,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -9692,16 +8792,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -9806,16 +8900,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -9824,16 +8912,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -9938,16 +9020,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -9956,16 +9032,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -10070,16 +9140,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -10088,16 +9152,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -10202,16 +9260,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -10220,16 +9272,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -10334,16 +9380,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -10352,16 +9392,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -10466,16 +9500,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -10484,16 +9512,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -10589,16 +9611,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -10607,16 +9623,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -10710,9 +9720,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -10780,16 +9787,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -10798,16 +9799,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -10912,16 +9907,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -10930,16 +9919,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -11044,16 +10027,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -11062,16 +10039,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -11176,16 +10147,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -11194,16 +10159,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -11299,16 +10258,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -11317,16 +10270,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -11422,16 +10369,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -11440,16 +10381,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -11554,16 +10489,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -11572,16 +10501,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -11686,16 +10609,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -11704,16 +10621,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -11818,16 +10729,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -11836,16 +10741,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -11950,16 +10849,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -11968,16 +10861,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -12082,16 +10969,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -12100,16 +10981,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -12214,16 +11089,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -12232,16 +11101,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -12337,16 +11200,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -12355,16 +11212,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -12458,9 +11309,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]

--- a/tests/wpt/meta/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.js.ini
+++ b/tests/wpt/meta/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.js.ini
@@ -2,25 +2,16 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -104,16 +95,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -122,16 +107,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -156,18 +135,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-384, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -245,16 +212,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-512, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -263,16 +224,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-512, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -356,16 +311,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -374,16 +323,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -467,16 +410,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -485,16 +422,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -519,18 +450,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-512, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -608,16 +527,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-1, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -626,16 +539,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-1, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -719,16 +626,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -737,16 +638,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -830,16 +725,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -848,16 +737,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -882,18 +765,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-1, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -971,16 +842,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-256, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -989,16 +854,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-256, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -1082,16 +941,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -1100,16 +953,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -1193,16 +1040,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -1211,16 +1052,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -1245,18 +1080,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-256, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -1334,16 +1157,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-384, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -1352,16 +1169,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-384, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -1445,16 +1256,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -1463,16 +1268,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -1558,16 +1357,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -1576,16 +1369,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -1610,18 +1397,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-384, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -1699,16 +1474,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-512, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -1717,16 +1486,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-512, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -1810,16 +1573,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -1828,16 +1585,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -1921,16 +1672,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -1939,16 +1684,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -1973,18 +1712,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-512, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -2062,16 +1789,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-1, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -2080,16 +1801,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-1, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -2173,16 +1888,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -2191,16 +1900,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -2284,16 +1987,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -2302,16 +1999,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -2336,18 +2027,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-1, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -2425,16 +2104,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-256, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -2443,16 +2116,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-256, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -2536,16 +2203,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -2554,16 +2215,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -2647,16 +2302,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -2665,16 +2314,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -2699,18 +2342,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-256, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -2788,16 +2419,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-384, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -2806,16 +2431,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-384, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -2899,16 +2518,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -2917,16 +2530,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -3010,16 +2617,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -3028,16 +2629,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -3108,16 +2703,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-512, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -3126,16 +2715,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-512, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -3219,16 +2802,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -3237,16 +2814,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -3330,16 +2901,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -3348,16 +2913,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -3382,18 +2941,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-512, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -3471,16 +3018,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-1, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -3489,16 +3030,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-1, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -3582,16 +3117,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -3600,16 +3129,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -3693,16 +3216,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -3711,16 +3228,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -3745,18 +3256,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-1, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -3834,16 +3333,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-256, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -3852,16 +3345,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-256, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -3945,16 +3432,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -3963,16 +3444,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -4056,16 +3531,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -4074,16 +3543,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -4108,18 +3571,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-256, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -4197,16 +3648,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-384, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -4215,16 +3660,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-384, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -4308,16 +3747,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -4326,16 +3759,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -4419,16 +3846,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -4437,16 +3858,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -4471,18 +3886,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-384, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -4560,25 +3963,16 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-512, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-512, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
 
@@ -4652,16 +4046,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -4670,16 +4058,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -4763,16 +4145,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -4781,16 +4157,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -4815,18 +4185,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-384, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -4904,16 +4262,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-512, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -4922,16 +4274,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-512, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -5015,16 +4361,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -5033,16 +4373,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -5126,16 +4460,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -5144,16 +4472,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -5178,18 +4500,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-512, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -5267,16 +4577,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-1, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -5285,16 +4589,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-1, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -5378,16 +4676,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -5396,16 +4688,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -5489,16 +4775,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -5507,16 +4787,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -5541,18 +4815,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-1, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -5630,16 +4892,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-256, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -5648,16 +4904,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-256, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -5741,16 +4991,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -5759,16 +5003,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -5852,16 +5090,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -5870,16 +5102,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -5904,18 +5130,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-256, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -5993,16 +5207,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-384, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -6011,16 +5219,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-384, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -6104,9 +5306,6 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
@@ -6157,16 +5356,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -6175,16 +5368,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -6268,16 +5455,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -6286,16 +5467,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -6320,18 +5495,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-512, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -6409,16 +5572,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-1, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -6427,16 +5584,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-1, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -6520,16 +5671,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -6538,16 +5683,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -6631,16 +5770,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -6649,16 +5782,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -6683,18 +5810,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-1, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -6772,16 +5887,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-256, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -6790,16 +5899,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-256, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -6883,16 +5986,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -6901,16 +5998,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -6994,16 +6085,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -7012,16 +6097,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -7046,18 +6125,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-256, with 0 iterations]
     expected: FAIL
 
 
@@ -7122,16 +6189,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -7140,16 +6201,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -7174,18 +6229,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-384, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -7263,16 +6306,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-512, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -7281,16 +6318,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-512, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -7374,16 +6405,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -7392,16 +6417,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -7485,16 +6504,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -7503,16 +6516,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -7537,18 +6544,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-512, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -7626,16 +6621,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-1, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -7644,16 +6633,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-1, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -7737,16 +6720,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -7755,16 +6732,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -7848,16 +6819,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -7866,16 +6831,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -7900,18 +6859,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-1, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -7989,16 +6936,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-256, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -8007,16 +6948,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-256, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -8100,16 +7035,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -8118,16 +7047,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -8211,16 +7134,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -8229,16 +7146,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -8263,18 +7174,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-256, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -8352,16 +7251,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-384, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -8370,16 +7263,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-384, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -8463,16 +7350,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -8481,16 +7362,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -8574,16 +7449,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -8592,16 +7461,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -8672,16 +7535,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-512, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -8690,16 +7547,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-512, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -8783,16 +7634,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -8801,16 +7646,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -8894,16 +7733,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -8912,16 +7745,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -8946,18 +7773,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-512, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -9035,16 +7850,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-1, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -9053,16 +7862,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-1, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -9146,16 +7949,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -9164,16 +7961,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -9257,16 +8048,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -9275,16 +8060,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -9309,18 +8088,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-1, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -9398,16 +8165,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-256, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -9416,16 +8177,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-256, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -9509,16 +8264,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -9527,16 +8276,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -9620,16 +8363,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -9638,16 +8375,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -9672,18 +8403,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-256, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -9761,16 +8480,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-384, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -9779,16 +8492,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-384, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -9872,16 +8579,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -9890,16 +8591,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -9983,16 +8678,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -10001,16 +8690,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -10035,18 +8718,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-384, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -10124,25 +8795,16 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-512, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-512, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
 
@@ -10168,16 +8830,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-384, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -10186,16 +8842,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-384, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -10279,16 +8929,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -10297,16 +8941,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -10390,16 +9028,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -10408,16 +9040,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -10442,18 +9068,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-384, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -10531,16 +9145,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-512, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -10549,16 +9157,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-512, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -10642,16 +9244,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -10660,16 +9256,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -10753,16 +9343,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -10771,16 +9355,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -10805,18 +9383,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-512, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -10894,16 +9460,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-1, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -10912,16 +9472,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-1, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -11005,16 +9559,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -11023,16 +9571,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -11116,16 +9658,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -11134,16 +9670,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -11168,18 +9698,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-1, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -11257,16 +9775,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-256, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -11275,16 +9787,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-256, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -11368,16 +9874,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -11386,16 +9886,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -11479,16 +9973,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -11497,16 +9985,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -11531,18 +10013,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-256, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -11620,16 +10090,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-384, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -11638,16 +10102,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-384, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -11685,16 +10143,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-384, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -11703,16 +10155,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-384, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -11796,16 +10242,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -11814,16 +10254,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -11907,16 +10341,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -11925,16 +10353,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -11959,18 +10381,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-384, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -12048,16 +10458,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-512, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -12066,16 +10470,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-512, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -12159,16 +10557,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -12177,16 +10569,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -12270,16 +10656,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -12288,16 +10668,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -12322,18 +10696,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-512, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -12411,16 +10773,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-1, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -12429,16 +10785,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-1, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -12522,16 +10872,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -12540,16 +10884,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -12633,16 +10971,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -12651,16 +10983,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -12685,18 +11011,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-1, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -12774,16 +11088,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-256, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -12792,16 +11100,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-256, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -12885,16 +11187,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -12903,16 +11199,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -12996,16 +11286,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -13014,16 +11298,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -13048,18 +11326,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-256, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -13137,16 +11403,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-384, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -13155,16 +11415,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-384, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -13200,18 +11454,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-384, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -13289,16 +11531,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-512, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -13307,16 +11543,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-512, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -13400,16 +11630,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -13418,16 +11642,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -13511,16 +11729,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -13529,16 +11741,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -13563,18 +11769,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-512, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -13652,16 +11846,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-1, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -13670,16 +11858,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-1, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -13763,16 +11945,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -13781,16 +11957,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -13874,16 +12044,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -13892,16 +12056,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -13926,18 +12084,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-1, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -14015,16 +12161,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-256, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -14033,16 +12173,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-256, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -14126,16 +12260,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -14144,16 +12272,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -14237,16 +12359,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -14255,16 +12371,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -14289,18 +12399,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-256, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -14378,16 +12476,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-384, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -14396,16 +12488,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-384, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -14489,16 +12575,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -14507,16 +12587,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -14600,16 +12674,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -14618,16 +12686,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -14652,18 +12714,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-384, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -14755,16 +12805,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-384, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -14773,16 +12817,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-384, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -14866,16 +12904,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -14884,16 +12916,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -14977,16 +13003,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -14995,16 +13015,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -15029,18 +13043,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-384, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -15118,16 +13120,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-512, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -15136,16 +13132,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-512, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -15229,16 +13219,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -15247,16 +13231,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -15340,16 +13318,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -15358,16 +13330,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -15392,18 +13358,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-512, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -15481,16 +13435,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-1, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -15499,16 +13447,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-1, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -15592,16 +13534,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -15610,16 +13546,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -15703,16 +13633,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -15721,16 +13645,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -15755,18 +13673,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-1, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -15844,16 +13750,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-256, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -15862,16 +13762,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-256, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -15955,16 +13849,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -15973,16 +13861,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -16066,16 +13948,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -16084,16 +13960,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -16118,18 +13988,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-256, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -16194,9 +14052,6 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-512, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
@@ -16278,16 +14133,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -16296,16 +14145,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -16389,16 +14232,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -16407,16 +14244,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -16441,18 +14272,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-512, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -16530,16 +14349,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-1, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -16548,16 +14361,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-1, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -16641,16 +14448,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -16659,16 +14460,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -16752,16 +14547,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -16770,16 +14559,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -16804,18 +14587,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-1, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -16893,16 +14664,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-256, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -16911,16 +14676,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-256, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -17004,16 +14763,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -17022,16 +14775,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -17115,16 +14862,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -17133,16 +14874,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -17167,18 +14902,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-256, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -17256,16 +14979,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-384, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -17274,16 +14991,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-384, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -17367,16 +15078,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -17385,16 +15090,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -17478,16 +15177,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -17496,16 +15189,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -17530,18 +15217,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-384, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -17619,16 +15294,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-512, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -17637,16 +15306,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-512, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -17693,9 +15356,6 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-512, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
@@ -17777,16 +15437,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -17795,16 +15449,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -17888,16 +15536,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -17906,16 +15548,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -17940,18 +15576,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-512, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -18029,16 +15653,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-1, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -18047,16 +15665,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-1, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -18140,16 +15752,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -18158,16 +15764,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -18251,16 +15851,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -18269,16 +15863,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -18303,18 +15891,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-1, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -18392,16 +15968,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-256, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -18410,16 +15980,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-256, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -18503,16 +16067,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -18521,16 +16079,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -18614,16 +16166,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -18632,16 +16178,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -18666,18 +16206,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-256, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -18755,16 +16283,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-384, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -18773,16 +16295,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-384, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -18866,16 +16382,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -18884,16 +16394,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -18977,16 +16481,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -18995,16 +16493,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -19029,18 +16521,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-384, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -19118,16 +16598,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-512, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -19136,16 +16610,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-512, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -19189,25 +16657,16 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -19291,16 +16750,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -19309,16 +16762,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -19343,18 +16790,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-384, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -19432,16 +16867,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-512, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -19450,16 +16879,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-512, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -19543,16 +16966,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -19561,16 +16978,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -19654,16 +17065,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -19672,16 +17077,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -19706,18 +17105,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-512, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -19795,16 +17182,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-1, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -19813,16 +17194,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-1, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -19906,16 +17281,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -19924,16 +17293,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -20017,16 +17380,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -20035,16 +17392,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -20069,18 +17420,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-1, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -20158,16 +17497,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-256, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -20176,16 +17509,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-256, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -20269,16 +17596,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -20287,16 +17608,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -20380,16 +17695,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -20398,16 +17707,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -20432,18 +17735,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-256, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -20521,16 +17812,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-384, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -20539,16 +17824,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-384, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -20632,16 +17911,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -20650,16 +17923,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -20754,16 +18021,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -20772,16 +18033,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -20865,16 +18120,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -20883,16 +18132,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -20917,18 +18160,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-384, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -21006,16 +18237,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-512, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -21024,16 +18249,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-512, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -21117,16 +18336,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -21135,16 +18348,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -21228,16 +18435,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -21246,16 +18447,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -21280,18 +18475,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-512, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -21369,16 +18552,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-1, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -21387,16 +18564,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-1, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -21480,16 +18651,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -21498,16 +18663,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -21591,16 +18750,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -21609,16 +18762,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -21643,18 +18790,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-1, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -21732,16 +18867,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-256, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -21750,16 +18879,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-256, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -21843,16 +18966,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -21861,16 +18978,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -21954,16 +19065,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -21972,16 +19077,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -22006,18 +19105,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-256, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -22095,16 +19182,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-384, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -22113,16 +19194,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-384, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -22206,9 +19281,6 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
@@ -22259,16 +19331,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -22277,16 +19343,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -22370,16 +19430,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -22388,16 +19442,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -22422,18 +19470,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-512, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -22511,16 +19547,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-1, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -22529,16 +19559,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-1, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -22622,16 +19646,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -22640,16 +19658,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -22733,16 +19745,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -22751,16 +19757,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -22785,18 +19785,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-1, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -22874,16 +19862,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-256, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -22892,16 +19874,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-256, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -22985,16 +19961,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -23003,16 +19973,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -23096,16 +20060,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -23114,16 +20072,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -23150,18 +20102,6 @@
   [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-256, with 0 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
 
 [pbkdf2.https.any.html?5001-6000]
   [long password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -23183,18 +20123,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-384, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -23272,16 +20200,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-512, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -23290,16 +20212,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-512, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -23383,16 +20299,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -23401,16 +20311,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -23494,16 +20398,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -23512,16 +20410,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -23546,18 +20438,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-512, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -23635,16 +20515,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-1, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -23653,16 +20527,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-1, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -23746,16 +20614,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -23764,16 +20626,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -23857,16 +20713,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -23875,16 +20725,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -23909,18 +20753,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-1, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -23998,16 +20830,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-256, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -24016,16 +20842,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-256, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -24109,16 +20929,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -24127,16 +20941,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -24220,16 +21028,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -24238,16 +21040,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -24272,18 +21068,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-256, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -24361,16 +21145,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-384, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -24379,16 +21157,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-384, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -24472,16 +21244,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -24490,16 +21256,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -24583,16 +21343,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -24601,16 +21355,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -24635,18 +21383,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-384, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -24738,16 +21474,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-384, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -24756,16 +21486,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-384, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -24849,16 +21573,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -24867,16 +21585,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -24960,16 +21672,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -24978,16 +21684,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -25012,18 +21712,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-384, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -25101,16 +21789,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-512, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -25119,16 +21801,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-512, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -25212,16 +21888,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -25230,16 +21900,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -25323,16 +21987,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -25341,16 +21999,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -25375,18 +22027,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-512, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -25464,16 +22104,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-1, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -25482,16 +22116,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-1, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -25575,16 +22203,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -25593,16 +22215,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -25686,16 +22302,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -25704,16 +22314,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -25738,18 +22342,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-1, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -25827,16 +22419,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-256, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -25845,16 +22431,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-256, with 1 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -25938,16 +22518,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -25956,16 +22530,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -26049,16 +22617,10 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -26067,16 +22629,10 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -26101,18 +22657,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-256, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]


### PR DESCRIPTION
This allows us to derive HMAC keys with `subtle.crypto.deriveKey`.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
