### PR TITLE
Add `js.disable_jit` pref

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -435,6 +435,8 @@ mod gen {
                 baseline_interpreter: {
                     enabled: bool,
                 },
+                /// Whether to disable the jit within SpiderMonkey
+                disable_jit: bool,
                 baseline_jit: {
                     enabled: bool,
                     unsafe_eager_compilation: {

--- a/components/script/init.rs
+++ b/components/script/init.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use js::jsapi::JSObject;
+use servo_config::pref;
 
 use crate::dom::bindings::codegen::RegisterBindings;
 use crate::dom::bindings::conversions::is_dom_proxy;
@@ -61,6 +62,9 @@ unsafe extern "C" fn is_dom_object(obj: *mut JSObject) -> bool {
 #[allow(unsafe_code)]
 pub fn init() -> JSEngineSetup {
     unsafe {
+        if pref!(js.disable_jit) {
+            js::jsapi::DisableJitBackend();
+        }
         proxyhandler::init();
 
         // Create the global vtables used by the (generated) DOM

--- a/resources/prefs.json
+++ b/resources/prefs.json
@@ -61,6 +61,7 @@
   "js.baseline_interpreter.enabled": true,
   "js.baseline_jit.enabled": true,
   "js.baseline_jit.unsafe_eager_compilation.enabled": false,
+  "js.disable_jit": false,
   "js.discard_system_source.enabled": false,
   "js.dump_stack_on_debuggee_would_run.enabled": false,
   "js.ion.enabled": true,


### PR DESCRIPTION
In Firefox this is [javascript.options.main_process_disable_jit](https://searchfox.org/mozilla-central/source/modules/libpref/init/StaticPrefList.yaml#8689) and it is important on IOS to disable JIT.

Based on my comment: https://github.com/servo/mozjs/pull/523#issuecomment-2470273961

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because it's new pref

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
