### PR TITLE
Use a RwLock to cache inline_content_sizes()

### DIFF
--- a/components/layout_2020/flexbox/construct.rs
+++ b/components/layout_2020/flexbox/construct.rs
@@ -171,7 +171,7 @@ where
                     let non_replaced = NonReplacedFormattingContext {
                         base_fragment_info: info.into(),
                         style: info.style.clone(),
-                        content_sizes_result: None,
+                        content_sizes_result: Default::default(),
                         contents: NonReplacedFormattingContextContents::Flow(
                             block_formatting_context,
                         ),

--- a/components/layout_2020/flow/float.rs
+++ b/components/layout_2020/flow/float.rs
@@ -891,7 +891,7 @@ impl FloatBox {
     /// the float containing block formatting context. A later step adjusts the position
     /// to be relative to the containing block.
     pub fn layout(
-        &mut self,
+        &self,
         layout_context: &LayoutContext,
         positioning_context: &mut PositioningContext,
         containing_block: &ContainingBlock,

--- a/components/layout_2020/flow/inline/mod.rs
+++ b/components/layout_2020/flow/inline/mod.rs
@@ -1656,7 +1656,7 @@ impl InlineFormattingContext {
         }
 
         for item in self.inline_items.iter() {
-            let item = &mut *item.borrow_mut();
+            let item = &*item.borrow();
 
             // Any new box should flush a pending hard line break.
             if !matches!(item, InlineItem::EndInlineBox) {
@@ -1684,7 +1684,7 @@ impl InlineFormattingContext {
                         },
                     ));
                 },
-                InlineItem::OutOfFlowFloatBox(ref mut float_box) => {
+                InlineItem::OutOfFlowFloatBox(ref float_box) => {
                     float_box.layout_into_line_items(&mut layout);
                 },
             }
@@ -1915,7 +1915,7 @@ impl InlineContainerState {
 
 impl IndependentFormattingContext {
     fn layout_into_line_items(
-        &mut self,
+        &self,
         layout: &mut InlineFormattingContextLayout,
         offset_in_text: usize,
         bidi_level: Level,
@@ -2071,7 +2071,7 @@ impl IndependentFormattingContext {
 }
 
 impl FloatBox {
-    fn layout_into_line_items(&mut self, layout: &mut InlineFormattingContextLayout) {
+    fn layout_into_line_items(&self, layout: &mut InlineFormattingContextLayout) {
         let fragment = self.layout(
             layout.layout_context,
             layout.positioning_context,
@@ -2211,7 +2211,7 @@ impl<'layout_data> ContentSizesComputation<'layout_data> {
         inline_formatting_context: &InlineFormattingContext,
     ) -> InlineContentSizesResult {
         for inline_item in inline_formatting_context.inline_items.iter() {
-            self.process_item(&mut inline_item.borrow_mut(), inline_formatting_context);
+            self.process_item(&inline_item.borrow(), inline_formatting_context);
         }
 
         self.forced_line_break();
@@ -2223,7 +2223,7 @@ impl<'layout_data> ContentSizesComputation<'layout_data> {
 
     fn process_item(
         &mut self,
-        inline_item: &mut InlineItem,
+        inline_item: &InlineItem,
         inline_formatting_context: &InlineFormattingContext,
     ) {
         match inline_item {

--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -370,10 +370,10 @@ fn calculate_inline_content_size_for_block_level_boxes(
     containing_block: &IndefiniteContainingBlock,
 ) -> InlineContentSizesResult {
     let get_box_info = |box_: &ArcRefCell<BlockLevelBox>| {
-        match &mut *box_.borrow_mut() {
+        match &*box_.borrow() {
             BlockLevelBox::OutOfFlowAbsolutelyPositionedBox(_) |
             BlockLevelBox::OutsideMarker { .. } => None,
-            BlockLevelBox::OutOfFlowFloatBox(ref mut float_box) => {
+            BlockLevelBox::OutOfFlowFloatBox(ref float_box) => {
                 let inline_content_sizes_result = float_box.contents.outer_inline_content_sizes(
                     layout_context,
                     containing_block,
@@ -404,7 +404,7 @@ fn calculate_inline_content_size_for_block_level_boxes(
                 // Instead, we treat it like an independent block with 'clear: both'.
                 Some((inline_content_sizes_result, Float::None, Clear::Both))
             },
-            BlockLevelBox::Independent(ref mut independent) => {
+            BlockLevelBox::Independent(ref independent) => {
                 let inline_content_sizes_result = independent.outer_inline_content_sizes(
                     layout_context,
                     containing_block,
@@ -606,7 +606,7 @@ fn layout_block_level_children_in_parallel(
         .map(|child_box| {
             let mut child_positioning_context =
                 PositioningContext::new_for_subtree(collects_for_nearest_positioned_ancestor);
-            let fragment = child_box.borrow_mut().layout(
+            let fragment = child_box.borrow().layout(
                 layout_context,
                 &mut child_positioning_context,
                 containing_block,
@@ -646,7 +646,7 @@ fn layout_block_level_children_sequentially(
         .iter()
         .map(|child_box| {
             let positioning_context_length_before_layout = positioning_context.len();
-            let mut fragment = child_box.borrow_mut().layout(
+            let mut fragment = child_box.borrow().layout(
                 layout_context,
                 positioning_context,
                 containing_block,
@@ -670,7 +670,7 @@ fn layout_block_level_children_sequentially(
 
 impl BlockLevelBox {
     fn layout(
-        &mut self,
+        &self,
         layout_context: &LayoutContext,
         positioning_context: &mut PositioningContext,
         containing_block: &ContainingBlock,
@@ -1997,7 +1997,7 @@ fn block_size_is_zero_or_intrinsic(size: &StyleSize, containing_block: &Containi
 
 impl IndependentFormattingContext {
     pub(crate) fn layout_float_or_atomic_inline(
-        &mut self,
+        &self,
         layout_context: &LayoutContext,
         child_positioning_context: &mut PositioningContext,
         containing_block: &ContainingBlock,

--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -449,8 +449,8 @@ impl HoistedAbsolutelyPositionedBox {
         let cbis = containing_block.size.inline;
         let cbbs = containing_block.size.block;
         let containing_block_writing_mode = containing_block.style.writing_mode;
-        let mut absolutely_positioned_box = self.absolutely_positioned_box.borrow_mut();
-        let context = &mut absolutely_positioned_box.context;
+        let absolutely_positioned_box = self.absolutely_positioned_box.borrow();
+        let context = &absolutely_positioned_box.context;
         let style = context.style().clone();
         let containing_block = &containing_block.into();
         let pbm = style.padding_border_margin(containing_block);

--- a/components/layout_2020/table/construct.rs
+++ b/components/layout_2020/table/construct.rs
@@ -137,7 +137,7 @@ impl Table {
         IndependentFormattingContext::NonReplaced(NonReplacedFormattingContext {
             base_fragment_info: (&anonymous_info).into(),
             style: grid_and_wrapper_style,
-            content_sizes_result: None,
+            content_sizes_result: Default::default(),
             contents: NonReplacedFormattingContextContents::Table(table),
         })
     }
@@ -858,7 +858,7 @@ where
                         context: ArcRefCell::new(NonReplacedFormattingContext {
                             style: info.style.clone(),
                             base_fragment_info: info.into(),
-                            content_sizes_result: None,
+                            content_sizes_result: Default::default(),
                             contents,
                         }),
                     };

--- a/components/layout_2020/table/layout.rs
+++ b/components/layout_2020/table/layout.rs
@@ -772,7 +772,7 @@ impl<'a> TableLayout<'a> {
     }
 
     /// Compute CAPMIN: <https://drafts.csswg.org/css-tables/#capmin>
-    fn compute_caption_minimum_inline_size(&mut self, layout_context: &LayoutContext) -> Au {
+    fn compute_caption_minimum_inline_size(&self, layout_context: &LayoutContext) -> Au {
         let containing_block = IndefiniteContainingBlock {
             size: LogicalVec2 {
                 inline: AuOrAuto::Auto,
@@ -784,7 +784,7 @@ impl<'a> TableLayout<'a> {
             .captions
             .iter()
             .map(|caption| {
-                let mut context = caption.context.borrow_mut();
+                let context = caption.context.borrow();
                 context
                     .outer_inline_content_sizes(
                         layout_context,
@@ -1605,7 +1605,7 @@ impl<'a> TableLayout<'a> {
     }
 
     fn layout_caption(
-        &mut self,
+        &self,
         caption: &TableCaption,
         table_pbm: &PaddingBorderMargin,
         layout_context: &LayoutContext,
@@ -2186,7 +2186,7 @@ impl<'a> TableLayout<'a> {
     }
 
     fn make_fragments_for_columns_and_column_groups(
-        &mut self,
+        &self,
         dimensions: &TableAndTrackDimensions,
         fragments: &mut Vec<Fragment>,
     ) {
@@ -2630,7 +2630,7 @@ impl Table {
         )
     )]
     pub(crate) fn inline_content_sizes(
-        &mut self,
+        &self,
         layout_context: &LayoutContext,
         constraint_space: &ConstraintSpace,
     ) -> InlineContentSizesResult {


### PR DESCRIPTION
In order to support size keywords in block layout, we may need to call `inline_content_sizes()` in order to compute the min/max-content sizes. But this required a mutable reference in order the update the cache, and in various places we already had mutable references.

So this switches the cache into a RwLock to avoid needing mutable refs.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because there should be no behavior change

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
