### PR TITLE
Add `BoxFragment::is_inline_box()`

### DIFF
--- a/components/layout_2020/fragment_tree/box_fragment.rs
+++ b/components/layout_2020/fragment_tree/box_fragment.rs
@@ -15,6 +15,7 @@ use style::Zero;
 use super::{BaseFragment, BaseFragmentInfo, CollapsedBlockMargins, Fragment};
 use crate::cell::ArcRefCell;
 use crate::formatting_contexts::Baselines;
+use crate::fragment_tree::FragmentFlags;
 use crate::geom::{
     AuOrAuto, LengthPercentageOrAuto, PhysicalPoint, PhysicalRect, PhysicalSides, ToLogical,
 };
@@ -324,5 +325,12 @@ impl BoxFragment {
         };
 
         convert_to_au_or_auto(PhysicalSides::new(top, right, bottom, left))
+    }
+
+    /// Whether this is a non-replaced inline-level box whose inner display type is `flow`.
+    /// <https://drafts.csswg.org/css-display-3/#inline-box>
+    pub(crate) fn is_inline_box(&self) -> bool {
+        self.style.get_box().display.is_inline_flow() &&
+            !self.base.flags.contains(FragmentFlags::IS_REPLACED)
     }
 }

--- a/components/layout_2020/fragment_tree/fragment_tree.rs
+++ b/components/layout_2020/fragment_tree/fragment_tree.rs
@@ -16,7 +16,6 @@ use super::{ContainingBlockManager, Fragment, Tag};
 use crate::cell::ArcRefCell;
 use crate::display_list::StackingContext;
 use crate::flow::CanvasBackground;
-use crate::fragment_tree::FragmentFlags;
 use crate::geom::PhysicalRect;
 
 #[derive(Serialize)]
@@ -141,9 +140,7 @@ impl FragmentTree {
                     //   CSS layout box is inline, return zero." For this check we
                     // also explicitly ignore the list item portion of the display
                     // style.
-                    if fragment.style.get_box().display.is_inline_flow() &&
-                        !fragment.base.flags.contains(FragmentFlags::IS_REPLACED)
-                    {
+                    if fragment.is_inline_box() {
                         return Some(Rect::zero());
                     }
 

--- a/components/layout_2020/query.rs
+++ b/components/layout_2020/query.rs
@@ -248,12 +248,7 @@ fn resolved_size_should_be_used_value(fragment: &Fragment) -> bool {
     // https://drafts.csswg.org/css-sizing-3/#preferred-size-properties
     // > Applies to: all elements except non-replaced inlines
     match fragment {
-        Fragment::Box(box_fragment) => {
-            !box_fragment.style.get_box().display.is_inline_flow() ||
-                fragment
-                    .base()
-                    .is_some_and(|base| base.flags.contains(FragmentFlags::IS_REPLACED))
-        },
+        Fragment::Box(box_fragment) => !box_fragment.is_inline_box(),
         Fragment::Float(_) |
         Fragment::Positioning(_) |
         Fragment::AbsoluteOrFixedPositioned(_) |


### PR DESCRIPTION
A helper function to check for inline boxes.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because there is no change in behavior

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
