### PR TITLE
Allow filtering of tracing events via SERVO_TRACING

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4261,6 +4261,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5803,7 +5812,16 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata 0.4.8",
- "regex-syntax",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -5823,8 +5841,14 @@ checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -7533,10 +7557,14 @@ version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -67,7 +67,7 @@ url = { workspace = true }
 servo-media = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true, optional = true }
-tracing-subscriber = { workspace = true, optional = true }
+tracing-subscriber = { workspace = true, optional = true, features = ["env-filter"] }
 tracing-perfetto = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "android")'.dependencies]

--- a/ports/servoshell/lib.rs
+++ b/ports/servoshell/lib.rs
@@ -65,7 +65,10 @@ pub fn init_tracing() {
 
         // Filter events and spans by the directives in SERVO_TRACING, using EnvFilter as a global filter.
         // <https://docs.rs/tracing-subscriber/0.3.18/tracing_subscriber/layer/index.html#global-filtering>
-        let filter = tracing_subscriber::EnvFilter::from_env("SERVO_TRACING");
+        let filter = tracing_subscriber::EnvFilter::builder()
+            .with_default_directive(tracing::level_filters::LevelFilter::OFF.into())
+            .with_env_var("SERVO_TRACING")
+            .from_env_lossy();
         let subscriber = subscriber.with(filter);
 
         // Same as SubscriberInitExt::init, but avoids initialising the tracing-log compat layer,

--- a/servo-tidy.toml
+++ b/servo-tidy.toml
@@ -76,6 +76,11 @@ packages = [
     # tracing-subscriber -> matchers -> regex-automata 0.1.0
     "regex-automata",
 
+    # tracing-subscriber (tokio-rs/tracing#3033) uses old version
+    # regex [-> regex-automata 0.4.7] -> regex-syntax 0.8.4
+    # tracing-subscriber -> matchers -> regex-automata 0.1.0 -> regex-syntax 0.6.29
+    "regex-syntax",
+
     # gilrs is on 0.10.0, but Servo is still on 0.9.4
     "core-foundation",
 


### PR DESCRIPTION
This patch allows tracing events to be filtered, beyond the implied check for a `servo_profiling` field, by setting SERVO_TRACING to [EnvFilter](https://docs.rs/tracing-subscriber/0.3.18/tracing_subscriber/filter/struct.EnvFilter.html) [directives](https://docs.rs/tracing-subscriber/0.3.18/tracing_subscriber/filter/struct.EnvFilter.html#directives). For example:

- `SERVO_TRACING=off` disables all tracing (this is the default)
- `SERVO_TRACING=trace` enables all tracing (yields massive traces due to `compositing`)
- `SERVO_TRACING=[{servo_profiling}]` does the same, since we implicitly filter on `servo_profiling`
- `SERVO_TRACING=info` would enable only the `info` level and above, but we don’t yet use levels
- `SERVO_TRACING=layout_2020` enables tracing in the `layout_2020` crate only
- `SERVO_TRACING=trace,compositing=off` enables all tracing except in the `compositing` crate
- `SERVO_TRACING=[handle_reflow]` enables tracing in spans named “handle_reflow” *or their descendants*

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #34172