### PR TITLE
ohos: avoid passing some cli arguments to servo

### DIFF
--- a/support/openharmony/entry/src/main/ets/entryability/EntryAbility.ets
+++ b/support/openharmony/entry/src/main/ets/entryability/EntryAbility.ets
@@ -15,8 +15,10 @@ export default class EntryAbility extends UIAbility {
         // Skip some default parameters, since servo is not interested in those
         if (key.startsWith("ohos.")
           || key.startsWith("component.")
+          || key.startsWith("send_to_erms_")
           || key === "isCallBySCB"
           || key === "moduleName"
+          || key === "debugApp"
         ) {
           return
         }


### PR DESCRIPTION
The following four OHOS specific arguments are being passed by the
OHOS runtime to the EntryAbility, which then passess them on to Servo's
argument parsing logic:

* `--debugApp=false`
* `--send_to_erms_targetAppDistType=os_integration`
* `--send_to_erms_targetAppProvisionType=release`
* `--send_to_erms_targetBundleType=0`

When Servo's argument parsing logic encounters an unrecognized argument,
it terminates the process after logging an error to stderr (which is not
visible in hilog).

This patch simply filters out these arguments so the parsing logic
doesn't fail.

Signed-off-by: Mukilan Thiyagarajan <mukilan@igalia.com>

---

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not have tests. We are working on adding OHOS specific santity checks to the CI that works by launching servo on an RockChip board, to catch similar issues in the future. This PR is required to unblock the CI changes needed.

