### PR TITLE
subtlecrypto: Don't throw exceptions twice when converting to Algorithm object

### DIFF
--- a/components/script/dom/subtlecrypto.rs
+++ b/components/script/dom/subtlecrypto.rs
@@ -1126,10 +1126,7 @@ fn normalize_algorithm_for_get_key_length(
     match algorithm {
         AlgorithmIdentifier::Object(obj) => {
             rooted!(in(*cx) let value = ObjectValue(obj.get()));
-            let Ok(ConversionResult::Success(algorithm)) = Algorithm::new(cx, value.handle())
-            else {
-                return Err(Error::Syntax);
-            };
+            let algorithm = value_from_js_object!(Algorithm, cx, value);
 
             let name = algorithm.name.str();
             let normalized_algorithm = if name.eq_ignore_ascii_case(ALG_AES_CBC) ||
@@ -1162,10 +1159,7 @@ fn normalize_algorithm_for_digest(
     let name = match algorithm {
         AlgorithmIdentifier::Object(obj) => {
             rooted!(in(*cx) let value = ObjectValue(obj.get()));
-            let Ok(ConversionResult::Success(algorithm)) = Algorithm::new(cx, value.handle())
-            else {
-                return Err(Error::Syntax);
-            };
+            let algorithm = value_from_js_object!(Algorithm, cx, value);
 
             algorithm.name.str().to_uppercase()
         },
@@ -1191,10 +1185,7 @@ fn normalize_algorithm_for_import_key(
     let name = match algorithm {
         AlgorithmIdentifier::Object(obj) => {
             rooted!(in(*cx) let value = ObjectValue(obj.get()));
-            let Ok(ConversionResult::Success(algorithm)) = Algorithm::new(cx, value.handle())
-            else {
-                return Err(Error::Syntax);
-            };
+            let algorithm = value_from_js_object!(Algorithm, cx, value);
 
             let name = algorithm.name.str().to_uppercase();
             if name == ALG_HMAC {
@@ -1230,9 +1221,7 @@ fn normalize_algorithm_for_derive_bits(
     };
 
     rooted!(in(*cx) let value = ObjectValue(obj.get()));
-    let Ok(ConversionResult::Success(algorithm)) = Algorithm::new(cx, value.handle()) else {
-        return Err(Error::Syntax);
-    };
+    let algorithm = value_from_js_object!(Algorithm, cx, value);
 
     let normalized_algorithm = if algorithm.name.str().eq_ignore_ascii_case(ALG_PBKDF2) {
         let params = value_from_js_object!(Pbkdf2Params, cx, value);
@@ -1260,9 +1249,7 @@ fn normalize_algorithm_for_encrypt_or_decrypt(
     };
 
     rooted!(in(*cx) let value = ObjectValue(obj.get()));
-    let Ok(ConversionResult::Success(algorithm)) = Algorithm::new(cx, value.handle()) else {
-        return Err(Error::Syntax);
-    };
+    let algorithm = value_from_js_object!(Algorithm, cx, value);
 
     let name = algorithm.name.str();
     let normalized_algorithm = if name.eq_ignore_ascii_case(ALG_AES_CBC) {
@@ -1287,10 +1274,7 @@ fn normalize_algorithm_for_sign_or_verify(
     let name = match algorithm {
         AlgorithmIdentifier::Object(obj) => {
             rooted!(in(*cx) let value = ObjectValue(obj.get()));
-            let Ok(ConversionResult::Success(algorithm)) = Algorithm::new(cx, value.handle())
-            else {
-                return Err(Error::Syntax);
-            };
+            let algorithm = value_from_js_object!(Algorithm, cx, value);
 
             algorithm.name.str().to_uppercase()
         },
@@ -1316,9 +1300,7 @@ fn normalize_algorithm_for_generate_key(
     };
 
     rooted!(in(*cx) let value = ObjectValue(obj.get()));
-    let Ok(ConversionResult::Success(algorithm)) = Algorithm::new(cx, value.handle()) else {
-        return Err(Error::Syntax);
-    };
+    let algorithm = value_from_js_object!(Algorithm, cx, value);
 
     let name = algorithm.name.str();
     let normalized_algorithm =

--- a/tests/wpt/tests/WebCryptoAPI/digest/digest.https.any.js
+++ b/tests/wpt/tests/WebCryptoAPI/digest/digest.https.any.js
@@ -118,6 +118,20 @@
         });
     });
 
+    // Call digest() with empty algorithm object
+    Object.keys(sourceData).forEach(function(size) {
+        promise_test(function(test) {
+            var promise = subtle.digest({}, sourceData[size])
+            .then(function(result) {
+                assert_unreached("digest() with missing algorithm name should have thrown a TypeError");
+            }, function(err) {
+                assert_equals(err.name, "TypeError", "Missing algorithm name should cause TypeError")
+            });
+
+            return promise;
+        }, "empty algorithm object with " + size);
+    });
+
 
     done();
 

--- a/tests/wpt/tests/WebCryptoAPI/generateKey/failures.js
+++ b/tests/wpt/tests/WebCryptoAPI/generateKey/failures.js
@@ -166,6 +166,14 @@ function run_test(algorithmNames) {
         });
     });
 
+    // Empty algorithm should fail with TypeError
+    allValidUsages(["decrypt", "sign", "deriveBits"], true, []) // Small search space, shouldn't matter because should fail before used
+        .forEach(function(usages) {
+            [false, true, "RED", 7].forEach(function(extractable){
+                testError({}, extractable, usages, "TypeError", "Empty algorithm");
+            });
+        });
+
 
     // Algorithms normalize okay, but usages bad (though not empty).
     // It shouldn't matter what other extractable is. Should fail

--- a/tests/wpt/tests/WebCryptoAPI/import_export/importKey_failures.js
+++ b/tests/wpt/tests/WebCryptoAPI/import_export/importKey_failures.js
@@ -192,4 +192,19 @@ function run_test(algorithmNames) {
             });
         });
     });
+
+    // Missing mandatory "name" field on algorithm
+    testVectors.forEach(function(vector) {
+        var name = vector.name;
+        // We just need *some* valid keydata, so pick the first available algorithm.
+        var algorithm = allAlgorithmSpecifiersFor(name)[0];
+        getValidKeyData(algorithm).forEach(function(test) {
+            validUsages(vector, test.format, test.data).forEach(function(usages) {
+                [true, false].forEach(function(extractable) {
+                    testError(test.format, {}, test.data, name, usages, extractable, "TypeError", "Missing algorithm name");
+                });
+            });
+        });
+    });
+
 }


### PR DESCRIPTION
Removes match statements like
```rust
let Ok(ConversionResult::Success(algorithm)) = Algorithm::new(cx, value.handle())
else {
    return Err(Error::Syntax);
};
```
These don't cause issues if `Algorithm::new` returns `Ok(ConversionResult::Failure`, but in the case of `Err(())` the implementation already called `throw_type_error` and we must not throw an additional Syntax error, otherwise we'll crash.

Luckily, this case is already handled elsewhere by the `value_from_js_object` macro.



---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
