### PR TITLE
servoshell: Fix --no-default-features and make webxr optional on ohos/android

### DIFF
--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -39,7 +39,7 @@ ProductName = "Servo"
 
 [features]
 debugmozjs = ["libservo/debugmozjs"]
-default = ["layout_2013", "max_log_level", "webdriver", "libservo/webxr"]
+default = ["layout_2013", "max_log_level", "webdriver", "webxr"]
 jitspew = ["libservo/jitspew"]
 js_backtrace = ["libservo/js_backtrace"]
 layout_2013 = ["libservo/layout_2013"]
@@ -54,6 +54,7 @@ tracing-hitrace = ["tracing", "dep:hitrace"]
 tracing-perfetto = ["tracing", "dep:tracing-perfetto"]
 webdriver = ["libservo/webdriver"]
 webgl_backtrace = ["libservo/webgl_backtrace"]
+webxr = ["libservo/webxr"]
 
 [dependencies]
 libc = { workspace = true }

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -54,7 +54,7 @@ tracing-hitrace = ["tracing", "dep:hitrace"]
 tracing-perfetto = ["tracing", "dep:tracing-perfetto"]
 webdriver = ["libservo/webdriver"]
 webgl_backtrace = ["libservo/webgl_backtrace"]
-webxr = ["libservo/webxr"]
+webxr = ["dep:webxr", "libservo/webxr"]
 
 [dependencies]
 libc = { workspace = true }
@@ -96,7 +96,7 @@ ohos-vsync = "0.1.2"
 nix = { workspace = true, features = ["fs"] }
 surfman = { workspace = true, features = ["sm-angle-default"] }
 serde_json = { workspace = true }
-webxr = { workspace = true }
+webxr = { workspace = true, optional = true }
 
 
 [target.'cfg(not(any(target_os = "android", target_env = "ohos")))'.dependencies]

--- a/ports/servoshell/desktop/embedder.rs
+++ b/ports/servoshell/desktop/embedder.rs
@@ -42,6 +42,7 @@ impl EmbedderMethods for EmbedderCallbacks {
         self.event_loop_waker.clone()
     }
 
+    #[cfg(feature = "webxr")]
     fn register_webxr(
         &mut self,
         xr: &mut webxr::MainThreadRegistry,

--- a/ports/servoshell/egl/android/simpleservo.rs
+++ b/ports/servoshell/egl/android/simpleservo.rs
@@ -40,6 +40,7 @@ pub struct InitOptions {
     pub url: Option<String>,
     pub coordinates: Coordinates,
     pub density: f32,
+    #[cfg(feature = "webxr")]
     pub xr_discovery: Option<webxr::Discovery>,
     pub surfman_integration: SurfmanIntegration,
     pub prefs: Option<HashMap<String, PrefValue>>,
@@ -109,6 +110,7 @@ pub fn init(
 
     let embedder_callbacks = Box::new(ServoEmbedderCallbacks::new(
         waker,
+        #[cfg(feature = "webxr")]
         init_opts.xr_discovery,
         gl.clone(),
     ));

--- a/ports/servoshell/egl/ohos/simpleservo.rs
+++ b/ports/servoshell/egl/ohos/simpleservo.rs
@@ -141,7 +141,12 @@ pub fn init(
         rendering_context.clone(),
     ));
 
-    let embedder_callbacks = Box::new(ServoEmbedderCallbacks::new(waker, None, gl.clone()));
+    let embedder_callbacks = Box::new(ServoEmbedderCallbacks::new(
+        waker,
+        #[cfg(feature = "webxr")]
+        None,
+        gl.clone(),
+    ));
 
     let servo = Servo::new(
         embedder_callbacks,

--- a/ports/servoshell/egl/servo_glue.rs
+++ b/ports/servoshell/egl/servo_glue.rs
@@ -676,6 +676,7 @@ impl EmbedderMethods for ServoEmbedderCallbacks {
         self.waker.clone()
     }
 
+    #[cfg(feature = "webxr")]
     fn register_webxr(
         &mut self,
         registry: &mut webxr::MainThreadRegistry,

--- a/ports/servoshell/egl/servo_glue.rs
+++ b/ports/servoshell/egl/servo_glue.rs
@@ -651,6 +651,7 @@ impl ServoGlue {
 
 pub(super) struct ServoEmbedderCallbacks {
     waker: Box<dyn EventLoopWaker>,
+    #[cfg(feature = "webxr")]
     xr_discovery: Option<webxr::Discovery>,
     #[allow(unused)]
     gl: Rc<dyn gl::Gl>,
@@ -659,11 +660,12 @@ pub(super) struct ServoEmbedderCallbacks {
 impl ServoEmbedderCallbacks {
     pub(super) fn new(
         waker: Box<dyn EventLoopWaker>,
-        xr_discovery: Option<webxr::Discovery>,
+        #[cfg(feature = "webxr")] xr_discovery: Option<webxr::Discovery>,
         gl: Rc<dyn gl::Gl>,
     ) -> Self {
         Self {
             waker,
+            #[cfg(feature = "webxr")]
             xr_discovery,
             gl,
         }


### PR DESCRIPTION
The first commit fixes `./mach build --no-default-features` (The Embeddertraits only contain `register_webxr` if the
webxr feature is enabled, hence we also need to guard the trait implementation).

The second commit makes `webxr` an optional dependency in servoshell on ohos/android.


---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix  `./mach build --no-default-features` 

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

