### PR TITLE
do not assume presence of a stream when performing pull steps

### DIFF
--- a/components/script/dom/readablestream.rs
+++ b/components/script/dom/readablestream.rs
@@ -205,10 +205,16 @@ impl ReadableStream {
     /// <https://streams.spec.whatwg.org/#readable-stream-add-read-request>
     pub fn add_read_request(&self, read_request: ReadRequest) {
         match self.reader {
+            // Assert: stream.[[reader]] implements ReadableStreamDefaultReader.
             ReaderType::Default(ref reader) => {
                 let Some(reader) = reader.get() else {
                     panic!("Attempt to add a read request without having first acquired a reader.");
                 };
+
+                // Assert: stream.[[state]] is "readable".
+                assert!(self.is_readable());
+
+                // Append readRequest to stream.[[reader]].[[readRequests]].
                 reader.add_read_request(read_request);
             },
             _ => unreachable!("Adding a read request can only be done on a default reader."),

--- a/components/script/dom/readablestreamdefaultcontroller.rs
+++ b/components/script/dom/readablestreamdefaultcontroller.rs
@@ -435,7 +435,7 @@ impl ReadableStreamDefaultController {
                 // Perform ! ReadableStreamClose(stream).
                 stream.close();
             }
-
+/// Otherwise, perform ! ReadableStreamDefaultControllerCallPullIfNeeded(this).
             self.call_pull_if_needed(CanGc::note());
 
             let cx = GlobalScope::get_cx();

--- a/components/script/dom/readablestreamdefaultcontroller.rs
+++ b/components/script/dom/readablestreamdefaultcontroller.rs
@@ -417,6 +417,12 @@ impl ReadableStreamDefaultController {
     /// <https://streams.spec.whatwg.org/#rs-default-controller-private-pull>
     #[allow(unsafe_code)]
     pub fn perform_pull_steps(&self, read_request: ReadRequest) {
+        // Let stream be this.[[stream]].
+        // Note: the spec does not assert that there is a stream.
+        let Some(stream) = self.stream.get() else {
+            return;
+        };
+
         // if queue contains bytes, perform chunk steps.
         if !self.queue.borrow().is_empty() {
             let chunk = self.dequeue_value();
@@ -427,10 +433,7 @@ impl ReadableStreamDefaultController {
                 self.clear_algorithms();
 
                 // Perform ! ReadableStreamClose(stream).
-                self.stream
-                    .get()
-                    .expect("Controller must have a stream when pull steps are called into.")
-                    .close();
+                stream.close();
             }
 
             self.call_pull_if_needed(CanGc::note());
@@ -450,12 +453,10 @@ impl ReadableStreamDefaultController {
             read_request.chunk_steps(result);
         }
 
-        // else, append read request to reader.
-        self.stream
-            .get()
-            .expect("Controller must have a stream when pull steps are called into.")
-            .add_read_request(read_request);
+        // Perform ! ReadableStreamAddReadRequest(stream, readRequest).
+        stream.add_read_request(read_request);
 
+        // Perform ! ReadableStreamDefaultControllerCallPullIfNeeded(this).
         self.call_pull_if_needed(CanGc::note());
     }
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

`perform_pull_steps` is currently crashing where there is no stream attached to the controller, but a review of the spec reveals a lack of such assertion. It could still be a bug on our side, but for now it seems to make sense to remove this assertion. I have also added some doc comments. 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
