### PR TITLE
Ensure result of calling start algo is an object

### DIFF
--- a/components/script/dom/underlyingsourcecontainer.rs
+++ b/components/script/dom/underlyingsourcecontainer.rs
@@ -142,8 +142,12 @@ impl UnderlyingSourceContainer {
                     .Call_(&this_handle, controller, ExceptionHandling::Report)
                     .expect("Start algorithm call failed");
                 let is_promise = unsafe {
-                    result_object.set(result.to_object());
-                    IsPromiseObject(result_object.handle().into_handle())
+                    if result.is_object() {
+                        result_object.set(result.to_object());
+                        IsPromiseObject(result_object.handle().into_handle())
+                    } else {
+                        false
+                    }
                 };
                 // Let startPromise be a promise resolved with startResult.
                 // from #set-up-readable-stream-default-controller.


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

We need to make sure the `JSVal` result is an object, before trying to call `to_object` on it. This fixes a crash. 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
