### PR TITLE
Fix stream constructor handling of underlyingsource error

### DIFF
--- a/components/script/dom/readablestream.rs
+++ b/components/script/dom/readablestream.rs
@@ -531,9 +531,7 @@ impl ReadableStreamMethods for ReadableStream {
                 Ok(ConversionResult::Success(val)) => val,
                 Ok(ConversionResult::Failure(error)) => return Err(Error::Type(error.to_string())),
                 _ => {
-                    return Err(Error::Type(
-                        "Unknown format for underlying source.".to_string(),
-                    ))
+                    return Err(Error::JSFailed);
                 },
             }
         } else {

--- a/components/script/dom/readablestreamdefaultcontroller.rs
+++ b/components/script/dom/readablestreamdefaultcontroller.rs
@@ -435,7 +435,7 @@ impl ReadableStreamDefaultController {
                 // Perform ! ReadableStreamClose(stream).
                 stream.close();
             }
-/// Otherwise, perform ! ReadableStreamDefaultControllerCallPullIfNeeded(this).
+            // Otherwise, perform ! ReadableStreamDefaultControllerCallPullIfNeeded(this).
             self.call_pull_if_needed(CanGc::note());
 
             let cx = GlobalScope::get_cx();


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Since `JsUnderlyingSource::new` throws before returning an `Err(())`, we must clear exceptions before returning an error from the constructor, to prevent a panic when the error is thrown [here](https://github.com/servo/servo/blob/3fd1a229df65406699c5795cf504948cdb314320/components/script/dom/bindings/error.rs#L147).

This may have to be dealt with in the codegen later. 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
