### PR TITLE
Fix release reader lock and misc

### DIFF
--- a/components/script/dom/readablebytestreamcontroller.rs
+++ b/components/script/dom/readablebytestreamcontroller.rs
@@ -8,13 +8,21 @@ use js::rust::HandleValue as SafeHandleValue;
 use crate::dom::bindings::codegen::Bindings::ReadableByteStreamControllerBinding::ReadableByteStreamControllerMethods;
 use crate::dom::bindings::import::module::{Error, Fallible};
 use crate::dom::bindings::reflector::Reflector;
-use crate::dom::bindings::root::DomRoot;
+use crate::dom::bindings::root::{DomRoot, MutNullableDom};
+use crate::dom::readablestream::ReadableStream;
 use crate::script_runtime::JSContext as SafeJSContext;
 
 /// <https://streams.spec.whatwg.org/#readablebytestreamcontroller>
 #[dom_struct]
 pub struct ReadableByteStreamController {
     reflector_: Reflector,
+    stream: MutNullableDom<ReadableStream>,
+}
+
+impl ReadableByteStreamController {
+    pub fn set_stream(&self, stream: &ReadableStream) {
+        self.stream.set(Some(stream))
+    }
 }
 
 impl ReadableByteStreamControllerMethods for ReadableByteStreamController {

--- a/components/script/dom/readablestreamdefaultcontroller.rs
+++ b/components/script/dom/readablestreamdefaultcontroller.rs
@@ -320,6 +320,8 @@ impl ReadableStreamDefaultController {
     }
 
     pub fn set_stream(&self, stream: &ReadableStream) {
+        // Stream is set in its default readable state.
+        assert!(stream.is_readable());
         self.stream.set(Some(stream))
     }
 
@@ -653,7 +655,7 @@ impl ReadableStreamDefaultController {
     }
 
     /// <https://streams.spec.whatwg.org/#readable-stream-default-controller-error>
-    pub fn error(&self, e: SafeHandleValue) {
+    fn error(&self, e: SafeHandleValue) {
         let Some(stream) = self.stream.get() else {
             return;
         };


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This started by fixing a timeout in a test on releasing the lock, due to the stream not being set on the controller, and lead to a few other fixes:

- fix release reader lock
- fix setting stream on controller in new
- fix match arms fall through.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
