### PR TITLE
Set all tracing spans to trace level for now

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -665,7 +665,7 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
     /// instance in the parent process.
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_cross_process_message(&mut self, msg: CrossProcessCompositorMessage) {
         match msg {
@@ -2027,7 +2027,7 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
     /// GPU and returned as Ok(Some(png::Image)), otherwise we return Ok(None).
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn composite_specific_target(
         &mut self,
@@ -2271,7 +2271,7 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     pub fn present(&mut self) {
         #[cfg(feature = "tracing")]
@@ -2340,7 +2340,7 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     pub fn receive_messages(&mut self) -> bool {
         // Check for new messages coming from the other threads in the system.
@@ -2370,7 +2370,7 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     pub fn perform_updates(&mut self) -> bool {
         if self.shutdown_state == ShutdownState::FinishedShuttingDown {

--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -753,13 +753,11 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
                 );
 
                 #[cfg(feature = "tracing")]
-                let span = tracing::span!(
-                    tracing::Level::TRACE,
+                let _span = tracing::trace_span!(
                     "ScriptToCompositorMsg::BuiltDisplayList",
-                    servo_profiling = true
-                );
-                #[cfg(feature = "tracing")]
-                let _enter = span.enter();
+                    servo_profiling = true,
+                )
+                .entered();
                 let pipeline_id = display_list_info.pipeline_id;
                 let details = self.pipeline_details(pipeline_id.into());
                 details.most_recent_display_list_epoch = Some(display_list_info.epoch);
@@ -2244,13 +2242,9 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
         };
 
         #[cfg(feature = "tracing")]
-        let span = tracing::span!(
-            tracing::Level::TRACE,
-            "ConstellationMsg::ReadyToPresent",
-            servo_profiling = true
-        );
-        #[cfg(feature = "tracing")]
-        let _enter = span.enter();
+        let _span =
+            tracing::trace_span!("ConstellationMsg::ReadyToPresent", servo_profiling = true)
+                .entered();
         // Notify embedder that servo is ready to present.
         // Embedder should call `present` to tell compositor to continue rendering.
         self.waiting_on_present = true;
@@ -2281,13 +2275,8 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
     )]
     pub fn present(&mut self) {
         #[cfg(feature = "tracing")]
-        let span = tracing::span!(
-            tracing::Level::TRACE,
-            "Compositor Present Surface",
-            servo_profiling = true
-        );
-        #[cfg(feature = "tracing")]
-        let _enter = span.enter();
+        let _span =
+            tracing::trace_span!("Compositor Present Surface", servo_profiling = true).entered();
         if let Err(err) = self.rendering_context.present() {
             warn!("Failed to present surface: {:?}", err);
         }

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -612,7 +612,11 @@ where
     #[allow(clippy::too_many_arguments)]
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip(state, layout_factory), fields(servo_profiling = true))
+        tracing::instrument(
+            skip(state, layout_factory),
+            fields(servo_profiling = true),
+            level = "trace",
+        )
     )]
     pub fn start(
         state: InitialConstellationState,
@@ -1159,7 +1163,7 @@ where
     /// Handles loading pages, navigation, and granting access to the compositor
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_request(&mut self) {
         #[derive(Debug)]
@@ -1259,7 +1263,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_request_for_pipeline_namespace(&mut self, request: PipelineNamespaceRequest) {
         let PipelineNamespaceRequest(sender) = request;
@@ -1268,7 +1272,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_request_from_background_hang_monitor(&self, message: HangMonitorAlert) {
         match message {
@@ -1285,7 +1289,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_request_from_network_listener(&mut self, message: (PipelineId, FetchResponseMsg)) {
         let (id, message_) = message;
@@ -1314,7 +1318,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_request_from_compositor(&mut self, message: FromCompositorMsg) {
         trace_msg_from_compositor!(message, "{message:?}");
@@ -1548,7 +1552,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_request_from_script(&mut self, message: (PipelineId, FromScriptMsg)) {
         let (source_pipeline_id, content) = message;
@@ -1869,7 +1873,7 @@ where
     /// Broadcast a message via routers in various event-loops.
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_schedule_broadcast(
         &self,
@@ -1916,7 +1920,7 @@ where
     /// Remove a channel-name for a given broadcast router.
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_remove_broadcast_channel_name_in_router(
         &mut self,
@@ -1955,7 +1959,7 @@ where
     /// Note a new channel-name relevant to a given broadcast router.
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_new_broadcast_channel_name_in_router(
         &mut self,
@@ -1980,7 +1984,7 @@ where
     /// Remove a broadcast router.
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_remove_broadcast_channel_router(
         &mut self,
@@ -2002,7 +2006,7 @@ where
     /// Add a new broadcast router.
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_new_broadcast_channel_router(
         &mut self,
@@ -2028,7 +2032,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_wgpu_request(
         &mut self,
@@ -2109,7 +2113,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_request_from_layout(&mut self, message: FromLayoutMsg) {
         trace_layout_msg!(message, "{message:?}");
@@ -2127,7 +2131,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_message_port_transfer_completed(
         &mut self,
@@ -2269,7 +2273,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_complete_message_port_transfer(
         &mut self,
@@ -2353,7 +2357,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_reroute_messageport(&mut self, port_id: MessagePortId, task: PortMessageTask) {
         let info = match self.message_ports.get_mut(&port_id) {
@@ -2388,7 +2392,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_messageport_shipped(&mut self, port_id: MessagePortId) {
         if let Some(info) = self.message_ports.get_mut(&port_id) {
@@ -2446,7 +2450,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_remove_messageport(&mut self, port_id: MessagePortId) {
         let entangled = match self.message_ports.remove(&port_id) {
@@ -2497,7 +2501,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_entangle_messageports(&mut self, port1: MessagePortId, port2: MessagePortId) {
         if let Some(info) = self.message_ports.get_mut(&port1) {
@@ -2526,7 +2530,7 @@ where
     /// which are scoped per origin.
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_schedule_serviceworker_job(&mut self, pipeline_id: PipelineId, job: Job) {
         let origin = job.scope_url.origin();
@@ -2569,7 +2573,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_broadcast_storage_event(
         &self,
@@ -2603,7 +2607,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_exit(&mut self) {
         debug!("Handling exit.");
@@ -2687,7 +2691,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_shutdown(&mut self) {
         debug!("Handling shutdown.");
@@ -2815,7 +2819,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_send_error(&mut self, pipeline_id: PipelineId, err: IpcError) {
         // Treat send error the same as receiving a panic message
@@ -2830,7 +2834,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_panic(
         &mut self,
@@ -2931,7 +2935,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_log_entry(
         &mut self,
@@ -3014,7 +3018,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_new_top_level_browsing_context(
         &mut self,
@@ -3084,7 +3088,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_close_top_level_browsing_context(
         &mut self,
@@ -3134,7 +3138,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_iframe_size_msg(&mut self, iframe_sizes: Vec<IFrameSizeMsg>) {
         for IFrameSizeMsg {
@@ -3154,7 +3158,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_subframe_loaded(&mut self, pipeline_id: PipelineId) {
         let browsing_context_id = match self.pipelines.get(&pipeline_id) {
@@ -3198,7 +3202,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_navigate_request(
         &self,
@@ -3222,7 +3226,7 @@ where
     // the result of a page navigation.
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_script_loaded_url_in_iframe_msg(&mut self, load_info: IFrameLoadInfoWithData) {
         let IFrameLoadInfo {
@@ -3332,7 +3336,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_script_new_iframe(&mut self, load_info: IFrameLoadInfoWithData) {
         let IFrameLoadInfo {
@@ -3396,7 +3400,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_script_new_auxiliary(&mut self, load_info: AuxiliaryBrowsingContextLoadInfo) {
         let AuxiliaryBrowsingContextLoadInfo {
@@ -3485,7 +3489,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_pending_paint_metric(&self, pipeline_id: PipelineId, epoch: Epoch) {
         self.compositor_proxy
@@ -3494,7 +3498,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_set_cursor_msg(&mut self, cursor: Cursor) {
         self.embedder_proxy
@@ -3503,7 +3507,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_change_running_animations_state(
         &mut self,
@@ -3524,7 +3528,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_tick_animation(&mut self, pipeline_id: PipelineId, tick_type: AnimationTickType) {
         let pipeline = match self.pipelines.get(&pipeline_id) {
@@ -3543,7 +3547,7 @@ where
     /// 2: Store the details of the navigation, pending approval from the embedder.
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn schedule_navigation(
         &mut self,
@@ -3573,7 +3577,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn load_url(
         &mut self,
@@ -3705,7 +3709,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_abort_load_url_msg(&mut self, new_pipeline_id: PipelineId) {
         let pending_index = self
@@ -3726,7 +3730,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_load_complete_msg(
         &mut self,
@@ -3778,7 +3782,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_navigated_to_fragment(
         &mut self,
@@ -3813,7 +3817,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_traverse_history_msg(
         &mut self,
@@ -3958,7 +3962,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn update_browsing_context(
         &mut self,
@@ -4086,7 +4090,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn update_pipeline(
         &mut self,
@@ -4116,7 +4120,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_joint_session_history_length(
         &self,
@@ -4133,7 +4137,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_push_history_state_msg(
         &mut self,
@@ -4176,7 +4180,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_replace_history_state_msg(
         &mut self,
@@ -4204,7 +4208,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_ime_dismissed(&mut self) {
         // Send to the focused browsing contexts' current pipeline.
@@ -4238,7 +4242,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_ime_msg(&mut self, event: CompositionEvent) {
         // Send to the focused browsing contexts' current pipeline.
@@ -4316,7 +4320,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_reload_msg(&mut self, top_level_browsing_context_id: TopLevelBrowsingContextId) {
         let browsing_context_id = BrowsingContextId::from(top_level_browsing_context_id);
@@ -4338,7 +4342,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_post_message_msg(
         &mut self,
@@ -4380,7 +4384,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_get_pipeline(
         &mut self,
@@ -4405,7 +4409,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_get_browsing_context(
         &mut self,
@@ -4423,7 +4427,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_focus_msg(&mut self, pipeline_id: PipelineId) {
         let (browsing_context_id, top_level_browsing_context_id) =
@@ -4461,7 +4465,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn focus_parent_pipeline(&mut self, browsing_context_id: BrowsingContextId) {
         let parent_pipeline_id = match self.browsing_contexts.get(&browsing_context_id) {
@@ -4495,7 +4499,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_remove_iframe_msg(
         &mut self,
@@ -4511,7 +4515,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_set_throttled_complete(&mut self, pipeline_id: PipelineId, throttled: bool) {
         let browsing_context_id = match self.pipelines.get(&pipeline_id) {
@@ -4549,7 +4553,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_create_canvas_paint_thread_msg(
         &mut self,
@@ -4576,7 +4580,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_webdriver_msg(&mut self, msg: WebDriverCommandMsg) {
         // Find the script channel for the given parent pipeline,
@@ -4710,7 +4714,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn set_webview_throttled(&mut self, webview_id: WebViewId, throttled: bool) {
         let browsing_context_id = BrowsingContextId::from(webview_id);
@@ -4728,7 +4732,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn notify_history_changed(&self, top_level_browsing_context_id: TopLevelBrowsingContextId) {
         // Send a flat projection of the history to embedder.
@@ -4845,7 +4849,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn load_url_for_webdriver(
         &mut self,
@@ -4876,7 +4880,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn change_session_history(&mut self, change: SessionHistoryChange) {
         debug!(
@@ -5034,7 +5038,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn focused_browsing_context_is_descendant_of(
         &self,
@@ -5053,7 +5057,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn trim_history(&mut self, top_level_browsing_context_id: TopLevelBrowsingContextId) {
         let pipelines_to_evict = {
@@ -5116,7 +5120,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_activate_document_msg(&mut self, pipeline_id: PipelineId) {
         debug!("{}: Document ready to activate", pipeline_id);
@@ -5165,7 +5169,7 @@ where
     /// Called when the window is resized.
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_window_size_msg(
         &mut self,
@@ -5191,7 +5195,7 @@ where
     /// Called when the window exits from fullscreen mode
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_exit_fullscreen_msg(
         &mut self,
@@ -5208,7 +5212,7 @@ where
     /// Since this function is only used in reftests, we do not harden it against panic.
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_is_ready_to_save_image(
         &mut self,
@@ -5295,7 +5299,7 @@ where
     /// Get the current activity of a pipeline.
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn get_activity(&self, pipeline_id: PipelineId) -> DocumentActivity {
         let mut ancestor_id = pipeline_id;
@@ -5325,7 +5329,7 @@ where
     /// Set the current activity of a pipeline.
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn set_activity(&self, pipeline_id: PipelineId, activity: DocumentActivity) {
         debug!("{}: Setting activity to {:?}", pipeline_id, activity);
@@ -5347,7 +5351,7 @@ where
     /// Update the current activity of a pipeline.
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn update_activity(&self, pipeline_id: PipelineId) {
         self.set_activity(pipeline_id, self.get_activity(pipeline_id));
@@ -5357,7 +5361,7 @@ where
     /// This notifies every pipeline in the context of the new size.
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn resize_browsing_context(
         &mut self,
@@ -5417,7 +5421,7 @@ where
     // Handle switching from fullscreen mode
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn switch_fullscreen_mode(&mut self, browsing_context_id: BrowsingContextId) {
         if let Some(browsing_context) = self.browsing_contexts.get(&browsing_context_id) {
@@ -5440,7 +5444,7 @@ where
     // Close and return the browsing context with the given id (and its children), if it exists.
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn close_browsing_context(
         &mut self,
@@ -5483,7 +5487,7 @@ where
     // Close the children of a browsing context
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn close_browsing_context_children(
         &mut self,
@@ -5517,7 +5521,7 @@ where
     // Discard the pipeline for a given document, udpdate the joint session history.
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_discard_document(
         &mut self,
@@ -5552,7 +5556,7 @@ where
     // Send a message to script requesting the document associated with this pipeline runs the 'unload' algorithm.
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn unload_document(&self, pipeline_id: PipelineId) {
         if let Some(pipeline) = self.pipelines.get(&pipeline_id) {
@@ -5564,7 +5568,7 @@ where
     // Close all pipelines at and beneath a given browsing context
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn close_pipeline(
         &mut self,
@@ -5631,7 +5635,7 @@ where
     // Randomly close a pipeline -if --random-pipeline-closure-probability is set
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn maybe_close_random_pipeline(&mut self) {
         match self.random_pipeline_closure {
@@ -5672,7 +5676,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn get_joint_session_history(
         &mut self,
@@ -5687,7 +5691,7 @@ where
     // Convert a browsing context to a sendable form to pass to the compositor
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn browsing_context_to_sendable(
         &self,
@@ -5720,7 +5724,7 @@ where
     /// Send the frame tree for the given webview to the compositor.
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn update_webview_in_compositor(&mut self, webview_id: WebViewId) {
         // Note that this function can panic, due to ipc-channel creation failure.
@@ -5736,7 +5740,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_media_session_action_msg(&mut self, action: MediaSessionActionType) {
         if let Some(media_session_pipeline_id) = self.active_media_session {
@@ -5766,7 +5770,7 @@ where
     /// Handle GamepadEvents from the embedder and forward them to the script thread
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_gamepad_msg(&mut self, event: GamepadEvent) {
         // Send to the focused browsing contexts' current pipeline.

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -1532,13 +1532,11 @@ where
             },
             FromCompositorMsg::ReadyToPresent(webview_ids) => {
                 #[cfg(feature = "tracing")]
-                let span = tracing::span!(
-                    tracing::Level::TRACE,
+                let _span = tracing::trace_span!(
                     "FromCompositorMsg::ReadyToPresent",
-                    servo_profiling = true
-                );
-                #[cfg(feature = "tracing")]
-                let _enter = span.enter();
+                    servo_profiling = true,
+                )
+                .entered();
                 self.embedder_proxy
                     .send((None, EmbedderMsg::ReadyToPresent(webview_ids)));
             },

--- a/components/fonts/font_context.rs
+++ b/components/fonts/font_context.rs
@@ -280,7 +280,7 @@ impl FontContext {
     /// cache thread and a `FontDescriptor` which contains the styling parameters.
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn create_font(
         &self,

--- a/components/fonts/system_font_service.rs
+++ b/components/fonts/system_font_service.rs
@@ -154,13 +154,8 @@ impl SystemFontService {
             let msg = self.port.recv().unwrap();
 
             #[cfg(feature = "tracing")]
-            let span = tracing::span!(
-                tracing::Level::TRACE,
-                "SystemFontServiceMessage",
-                servo_profiling = true
-            );
-            #[cfg(feature = "tracing")]
-            let _enter = span.enter();
+            let _span =
+                tracing::trace_span!("SystemFontServiceMessage", servo_profiling = true).entered();
             match msg {
                 SystemFontServiceMessage::GetFontTemplates(
                     font_descriptor,

--- a/components/fonts/system_font_service.rs
+++ b/components/fonts/system_font_service.rs
@@ -147,7 +147,7 @@ impl SystemFontService {
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn run(&mut self) {
         loop {
@@ -187,7 +187,7 @@ impl SystemFontService {
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn fetch_new_keys(&mut self) {
         if !self.free_font_keys.is_empty() && !self.free_font_instance_keys.is_empty() {
@@ -207,7 +207,7 @@ impl SystemFontService {
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn get_font_templates(
         &mut self,
@@ -223,7 +223,7 @@ impl SystemFontService {
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn refresh_local_families(&mut self) {
         self.local_families.clear();
@@ -237,7 +237,7 @@ impl SystemFontService {
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn find_font_templates(
         &mut self,
@@ -264,7 +264,7 @@ impl SystemFontService {
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn get_font_instance(
         &mut self,

--- a/components/layout_2020/display_list/clip_path.rs
+++ b/components/layout_2020/display_list/clip_path.rs
@@ -70,7 +70,8 @@ pub(super) fn build_clip_path_clip_chain_if_necessary(
     tracing::instrument(
         name = "display_list::build_simple_shape",
         skip_all,
-        fields(servo_profiling = true)
+        fields(servo_profiling = true),
+        level = "trace",
     )
 )]
 fn build_simple_shape(

--- a/components/layout_2020/display_list/mod.rs
+++ b/components/layout_2020/display_list/mod.rs
@@ -182,9 +182,7 @@ impl DisplayList {
         root_stacking_context: &StackingContext,
     ) -> (FnvHashMap<BrowsingContextId, Size2D<f32, CSSPixel>>, bool) {
         #[cfg(feature = "tracing")]
-        let span = tracing::span!(tracing::Level::TRACE, "display_list::build");
-        #[cfg(feature = "tracing")]
-        let _enter = span.enter();
+        let _span = tracing::trace_span!("display_list::build", servo_profiling = true).entered();
         let mut builder = DisplayListBuilder {
             current_scroll_node_id: self.compositor_info.root_reference_frame_id,
             current_reference_frame_scroll_node_id: self.compositor_info.root_reference_frame_id,

--- a/components/layout_2020/display_list/stacking_context.rs
+++ b/components/layout_2020/display_list/stacking_context.rs
@@ -106,7 +106,8 @@ impl DisplayList {
         tracing::instrument(
             name = "display_list::build_stacking_context_tree",
             skip_all,
-            fields(servo_profiling = true)
+            fields(servo_profiling = true),
+            level = "trace",
         )
     )]
     pub fn build_stacking_context_tree(

--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -395,7 +395,8 @@ impl FlexContainer {
         tracing::instrument(
             name = "FlexContainer::inline_content_sizes",
             skip_all,
-            fields(servo_profiling = true)
+            fields(servo_profiling = true),
+            level = "trace",
         )
     )]
     pub fn inline_content_sizes(
@@ -607,7 +608,8 @@ impl FlexContainer {
         tracing::instrument(
             name = "FlexContainer::layout",
             skip_all,
-            fields(servo_profiling = true)
+            fields(servo_profiling = true),
+            level = "trace",
         )
     )]
     pub(crate) fn layout(
@@ -2689,7 +2691,8 @@ impl FlexItemBox {
         tracing::instrument(
             name = "FlexContainer::layout_for_block_content_size",
             skip_all,
-            fields(servo_profiling = true)
+            fields(servo_profiling = true),
+            level = "trace",
         )
     )]
     fn layout_for_block_content_size(

--- a/components/layout_2020/table/layout.rs
+++ b/components/layout_2020/table/layout.rs
@@ -1641,7 +1641,12 @@ impl<'a> TableLayout<'a> {
     /// only be be called after calling [`TableLayout.compute_measures`].
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(name = "Table::layout", skip_all, fields(servo_profiling = true))
+        tracing::instrument(
+            name = "Table::layout",
+            skip_all,
+            fields(servo_profiling = true),
+            level = "trace",
+        )
     )]
     fn layout(
         mut self,
@@ -2626,7 +2631,8 @@ impl Table {
         tracing::instrument(
             name = "Table::inline_content_sizes",
             skip_all,
-            fields(servo_profiling = true)
+            fields(servo_profiling = true),
+            level = "trace",
         )
     )]
     pub(crate) fn inline_content_sizes(

--- a/components/layout_thread_2020/lib.rs
+++ b/components/layout_thread_2020/lib.rs
@@ -822,13 +822,8 @@ impl LayoutThread {
 
         if token.should_traverse() {
             #[cfg(feature = "tracing")]
-            let span = tracing::span!(
-                tracing::Level::TRACE,
-                "driver::traverse_dom",
-                servo_profiling = true
-            );
-            #[cfg(feature = "tracing")]
-            let _enter = span.enter();
+            let _span =
+                tracing::trace_span!("driver::traverse_dom", servo_profiling = true).entered();
             let dirty_root: ServoLayoutNode =
                 driver::traverse_dom(&traversal, token, rayon_pool).as_node();
 

--- a/components/layout_thread_2020/lib.rs
+++ b/components/layout_thread_2020/lib.rs
@@ -255,7 +255,7 @@ impl Layout for LayoutThread {
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn add_stylesheet(
         &mut self,
@@ -278,7 +278,7 @@ impl Layout for LayoutThread {
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn remove_stylesheet(&mut self, stylesheet: ServoArc<Stylesheet>) {
         let guard = stylesheet.shared_lock.read();
@@ -290,7 +290,7 @@ impl Layout for LayoutThread {
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn query_content_box(&self, node: OpaqueNode) -> Option<UntypedRect<Au>> {
         process_content_box_request(node, self.fragment_tree.borrow().clone())
@@ -298,7 +298,7 @@ impl Layout for LayoutThread {
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn query_content_boxes(&self, node: OpaqueNode) -> Vec<UntypedRect<Au>> {
         process_content_boxes_request(node, self.fragment_tree.borrow().clone())
@@ -306,7 +306,7 @@ impl Layout for LayoutThread {
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn query_client_rect(&self, node: OpaqueNode) -> UntypedRect<i32> {
         process_node_geometry_request(node, self.fragment_tree.borrow().clone())
@@ -314,7 +314,7 @@ impl Layout for LayoutThread {
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn query_element_inner_outer_text(
         &self,
@@ -335,7 +335,7 @@ impl Layout for LayoutThread {
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn query_nodes_from_point(
         &self,
@@ -361,7 +361,7 @@ impl Layout for LayoutThread {
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn query_offset_parent(&self, node: OpaqueNode) -> OffsetParentResponse {
         process_offset_parent_query(node, self.fragment_tree.borrow().clone())
@@ -369,7 +369,7 @@ impl Layout for LayoutThread {
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn query_resolved_style(
         &self,
@@ -408,7 +408,7 @@ impl Layout for LayoutThread {
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn query_resolved_font_style(
         &self,
@@ -444,7 +444,7 @@ impl Layout for LayoutThread {
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn query_scrolling_area(&self, node: Option<OpaqueNode>) -> UntypedRect<i32> {
         process_node_scroll_area_request(node, self.fragment_tree.borrow().clone())
@@ -452,7 +452,7 @@ impl Layout for LayoutThread {
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn query_text_indext(
         &self,
@@ -700,7 +700,7 @@ impl LayoutThread {
     /// The high-level routine that performs layout.
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true))
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_reflow(&mut self, data: &mut ScriptReflowResult) {
         let document = unsafe { ServoLayoutNode::new(&data.document) };

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -226,7 +226,11 @@ where
 {
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip(embedder, window), fields(servo_profiling = true))
+        tracing::instrument(
+            skip(embedder, window),
+            fields(servo_profiling = true),
+            level = "trace",
+        )
     )]
     #[allow(clippy::new_ret_no_self)]
     pub fn new(


### PR DESCRIPTION
This patch sets all tracing spans to trace level for now, rather than some being trace level (`span!()`) and some being info level (`#[instrument]`). From here, we can upgrade spans to debug or info as needed, as we build confidence in their usefulness and our understanding of what they measure.

This is especially important due to the way the filtering in #34236 works — if you set `SERVO_TRACING='[span name]'`, you get that span and all of its descendants, and the only way to exclude descendants seems to be by setting a maximum level like `SERVO_TRACING='[span name]=info'`.

This patch also includes some changes to clean up our tracing instrumentation:
- we now use the [`trace_span!()`](https://docs.rs/tracing/0.1.40/tracing/macro.trace_span.html) shorthand, rather than `span!(TRACE, …)`
- we now use the [`Span::entered`](https://docs.rs/tracing/0.1.40/tracing/span/struct.Span.html#method.entered) shorthand, rather than binding the Span and calling `Span::enter`
- we now set `servo_profiling = true` on the `display_list::build` span added in #34128

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] ~~These changes fix #___ (GitHub issue number if applicable)~~