### PR TITLE
CI: Fix lint job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -44,6 +44,8 @@ jobs:
         with:
           crate: cargo-deny
           locked: true
+          # 0.16.2 requires Rust 1.81 or newer.
+          version: '0.16.1'
       - name: Bootstrap Python
         run: python3 -m pip install --upgrade pip
       - name: Bootstrap dependencies


### PR DESCRIPTION
cargo-deny 0.16.2 requires Rust 1.81, so we install the previous version

Fixes the Lint job failing with the following error:
```
  error: failed to compile `cargo-deny v0.16.2`, intermediate artifacts can be found at `/tmp/cargo-installdlCaeR`.
  To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.
  
  Caused by:
    rustc 1.80.1 is not supported by the following package:
      twox-hash@2.0.1 requires rustc 1.81
  Error: The process '/home/runner/.cargo/bin/cargo' failed with exit code 101
```

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix a CI failure
