### PR TITLE
mach bootstrap: Lock cargo-deny to 0.16.1

### DIFF
--- a/python/servo/platform/base.py
+++ b/python/servo/platform/base.py
@@ -83,7 +83,8 @@ class Base:
             return False
 
         print(" * Installing cargo-deny...")
-        if subprocess.call(["cargo", "install", "cargo-deny", "--locked"]) != 0:
+        # cargo-deny 0.16.2 requires Rust 1.81.
+        if subprocess.call(["cargo", "install", "cargo-deny", "--locked", "--version", "0.16.1"]) != 0:
             raise EnvironmentError("Installation of cargo-deny failed.")
 
         return True


### PR DESCRIPTION
As mentioned in https://github.com/servo/servo/pull/34257 we should also lock the cargo-deny version in mach bootstrap until we bump our own MSRV to 1.81 or newer.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors


