### PR TITLE
layout: Use `Size::FitContent` when the alignment isn't `normal` or `stretch` for absolutely positioned elements

### DIFF
--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -846,7 +846,7 @@ impl<'a> AbsoluteAxisSolver<'a> {
                 let stretch_size = free_space -
                     self.computed_margin_start.auto_is(Au::zero) -
                     self.computed_margin_end.auto_is(Au::zero);
-                let used_size = match self.alignment.flags() {
+                let used_size = match self.alignment.value() {
                     AlignFlags::STRETCH | AlignFlags::NORMAL => {
                         solve_size(Size::Stretch, stretch_size)
                     },

--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -853,7 +853,7 @@ impl<'a> AbsoluteAxisSolver<'a> {
                     _ => solve_size(Size::FitContent, stretch_size),
                 }
                 .to_definite()
-                .unwrap();
+                .unwrap_or_default();
                 free_space -= used_size;
                 let (margin_start, margin_end) =
                     match (self.computed_margin_start, self.computed_margin_end) {

--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -846,15 +846,16 @@ impl<'a> AbsoluteAxisSolver<'a> {
                 let stretch_size = free_space -
                     self.computed_margin_start.auto_is(Au::zero) -
                     self.computed_margin_end.auto_is(Au::zero);
-                let used_size = match self.alignment.value() {
-                    AlignFlags::STRETCH | AlignFlags::NORMAL => {
-                        solve_size(Size::Stretch, stretch_size)
-                    },
-                    _ => solve_size(Size::FitContent, stretch_size),
+                let initial_behavior = match self.alignment.value() {
+                    AlignFlags::STRETCH | AlignFlags::NORMAL => Size::Stretch,
+                    _ => Size::FitContent,
+                };
+                let size = solve_size(initial_behavior, stretch_size);
+                if let Some(used_size) = size.to_definite() {
+                    free_space -= used_size;
+                } else {
+                    free_space = Au::zero();
                 }
-                .to_definite()
-                .unwrap_or_default();
-                free_space -= used_size;
                 let (margin_start, margin_end) =
                     match (self.computed_margin_start, self.computed_margin_end) {
                         (AuOrAuto::Auto, AuOrAuto::Auto) => {
@@ -877,7 +878,7 @@ impl<'a> AbsoluteAxisSolver<'a> {
                     };
                 AxisResult {
                     anchor: Anchor::Start(start),
-                    size: SizeConstraint::Definite(used_size),
+                    size,
                     margin_start,
                     margin_end,
                 }

--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -846,9 +846,14 @@ impl<'a> AbsoluteAxisSolver<'a> {
                 let stretch_size = free_space -
                     self.computed_margin_start.auto_is(Au::zero) -
                     self.computed_margin_end.auto_is(Au::zero);
-                let used_size = solve_size(Size::Stretch, stretch_size)
-                    .to_definite()
-                    .unwrap();
+                let used_size = match self.alignment.flags() {
+                    AlignFlags::STRETCH | AlignFlags::NORMAL => {
+                        solve_size(Size::Stretch, stretch_size)
+                    },
+                    _ => solve_size(Size::FitContent, stretch_size),
+                }
+                .to_definite()
+                .unwrap();
                 free_space -= used_size;
                 let (margin_start, margin_end) =
                     match (self.computed_margin_start, self.computed_margin_end) {

--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -847,7 +847,7 @@ impl<'a> AbsoluteAxisSolver<'a> {
                     self.computed_margin_start.auto_is(Au::zero) -
                     self.computed_margin_end.auto_is(Au::zero);
                 let initial_behavior = match self.alignment.value() {
-                    AlignFlags::STRETCH | AlignFlags::NORMAL => Size::Stretch,
+                    AlignFlags::STRETCH | AlignFlags::NORMAL | AlignFlags::AUTO => Size::Stretch,
                     _ => Size::FitContent,
                 };
                 let size = solve_size(initial_behavior, stretch_size);

--- a/tests/wpt/meta/css/css-align/abspos/align-self-default-overflow-htb-ltr-htb.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/align-self-default-overflow-htb-ltr-htb.html.ini
@@ -1,26 +1,8 @@
 [align-self-default-overflow-htb-ltr-htb.html]
-  [.item 1]
-    expected: FAIL
-
-  [.item 2]
-    expected: FAIL
-
   [.item 3]
     expected: FAIL
 
   [.item 4]
-    expected: FAIL
-
-  [.item 5]
-    expected: FAIL
-
-  [.item 6]
-    expected: FAIL
-
-  [.item 8]
-    expected: FAIL
-
-  [.item 9]
     expected: FAIL
 
   [.item 10]
@@ -29,8 +11,8 @@
   [.item 11]
     expected: FAIL
 
-  [.item 12]
+  [.item 7]
     expected: FAIL
 
-  [.item 13]
+  [.item 14]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/align-self-default-overflow-htb-ltr-vrl.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/align-self-default-overflow-htb-ltr-vrl.html.ini
@@ -1,26 +1,8 @@
 [align-self-default-overflow-htb-ltr-vrl.html]
-  [.item 1]
-    expected: FAIL
-
-  [.item 2]
-    expected: FAIL
-
   [.item 3]
     expected: FAIL
 
   [.item 4]
-    expected: FAIL
-
-  [.item 5]
-    expected: FAIL
-
-  [.item 6]
-    expected: FAIL
-
-  [.item 8]
-    expected: FAIL
-
-  [.item 9]
     expected: FAIL
 
   [.item 10]
@@ -29,8 +11,8 @@
   [.item 11]
     expected: FAIL
 
-  [.item 12]
+  [.item 7]
     expected: FAIL
 
-  [.item 13]
+  [.item 14]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/align-self-default-overflow-htb-rtl-htb.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/align-self-default-overflow-htb-rtl-htb.html.ini
@@ -1,26 +1,8 @@
 [align-self-default-overflow-htb-rtl-htb.html]
-  [.item 1]
-    expected: FAIL
-
-  [.item 2]
-    expected: FAIL
-
   [.item 3]
     expected: FAIL
 
   [.item 4]
-    expected: FAIL
-
-  [.item 5]
-    expected: FAIL
-
-  [.item 6]
-    expected: FAIL
-
-  [.item 8]
-    expected: FAIL
-
-  [.item 9]
     expected: FAIL
 
   [.item 10]
@@ -29,8 +11,8 @@
   [.item 11]
     expected: FAIL
 
-  [.item 12]
+  [.item 7]
     expected: FAIL
 
-  [.item 13]
+  [.item 14]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/align-self-default-overflow-htb-rtl-vrl.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/align-self-default-overflow-htb-rtl-vrl.html.ini
@@ -1,26 +1,8 @@
 [align-self-default-overflow-htb-rtl-vrl.html]
-  [.item 1]
-    expected: FAIL
-
-  [.item 2]
-    expected: FAIL
-
   [.item 3]
     expected: FAIL
 
   [.item 4]
-    expected: FAIL
-
-  [.item 5]
-    expected: FAIL
-
-  [.item 6]
-    expected: FAIL
-
-  [.item 8]
-    expected: FAIL
-
-  [.item 9]
     expected: FAIL
 
   [.item 10]
@@ -29,8 +11,8 @@
   [.item 11]
     expected: FAIL
 
-  [.item 12]
+  [.item 7]
     expected: FAIL
 
-  [.item 13]
+  [.item 14]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/align-self-htb-ltr-htb.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/align-self-htb-ltr-htb.html.ini
@@ -1,41 +1,11 @@
 [align-self-htb-ltr-htb.html]
-  [.item 1]
-    expected: FAIL
-
-  [.item 2]
-    expected: FAIL
-
-  [.item 3]
-    expected: FAIL
-
-  [.item 4]
-    expected: FAIL
-
   [.item 5]
-    expected: FAIL
-
-  [.item 6]
     expected: FAIL
 
   [.item 7]
     expected: FAIL
 
-  [.item 9]
-    expected: FAIL
-
-  [.item 10]
-    expected: FAIL
-
-  [.item 11]
-    expected: FAIL
-
-  [.item 12]
-    expected: FAIL
-
   [.item 13]
-    expected: FAIL
-
-  [.item 14]
     expected: FAIL
 
   [.item 15]

--- a/tests/wpt/meta/css/css-align/abspos/align-self-htb-ltr-vlr.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/align-self-htb-ltr-vlr.html.ini
@@ -1,42 +1,12 @@
 [align-self-htb-ltr-vlr.html]
-  [.item 1]
-    expected: FAIL
-
-  [.item 2]
-    expected: FAIL
-
-  [.item 3]
-    expected: FAIL
-
-  [.item 4]
-    expected: FAIL
-
   [.item 5]
     expected: FAIL
 
-  [.item 6]
-    expected: FAIL
-
   [.item 7]
-    expected: FAIL
-
-  [.item 9]
-    expected: FAIL
-
-  [.item 10]
-    expected: FAIL
-
-  [.item 11]
-    expected: FAIL
-
-  [.item 12]
     expected: FAIL
 
   [.item 13]
     expected: FAIL
 
   [.item 14]
-    expected: FAIL
-
-  [.item 15]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/align-self-htb-ltr-vrl.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/align-self-htb-ltr-vrl.html.ini
@@ -1,42 +1,12 @@
 [align-self-htb-ltr-vrl.html]
-  [.item 1]
-    expected: FAIL
-
-  [.item 2]
-    expected: FAIL
-
-  [.item 3]
-    expected: FAIL
-
-  [.item 4]
-    expected: FAIL
-
   [.item 5]
     expected: FAIL
 
-  [.item 6]
-    expected: FAIL
-
   [.item 7]
-    expected: FAIL
-
-  [.item 9]
-    expected: FAIL
-
-  [.item 10]
-    expected: FAIL
-
-  [.item 11]
-    expected: FAIL
-
-  [.item 12]
     expected: FAIL
 
   [.item 13]
     expected: FAIL
 
   [.item 14]
-    expected: FAIL
-
-  [.item 15]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/align-self-htb-rtl-htb.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/align-self-htb-rtl-htb.html.ini
@@ -1,41 +1,11 @@
 [align-self-htb-rtl-htb.html]
-  [.item 1]
-    expected: FAIL
-
-  [.item 2]
-    expected: FAIL
-
-  [.item 3]
-    expected: FAIL
-
-  [.item 4]
-    expected: FAIL
-
   [.item 5]
-    expected: FAIL
-
-  [.item 6]
     expected: FAIL
 
   [.item 7]
     expected: FAIL
 
-  [.item 9]
-    expected: FAIL
-
-  [.item 10]
-    expected: FAIL
-
-  [.item 11]
-    expected: FAIL
-
-  [.item 12]
-    expected: FAIL
-
   [.item 13]
-    expected: FAIL
-
-  [.item 14]
     expected: FAIL
 
   [.item 15]

--- a/tests/wpt/meta/css/css-align/abspos/align-self-htb-rtl-vlr.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/align-self-htb-rtl-vlr.html.ini
@@ -1,42 +1,12 @@
 [align-self-htb-rtl-vlr.html]
-  [.item 1]
-    expected: FAIL
-
-  [.item 2]
-    expected: FAIL
-
-  [.item 3]
-    expected: FAIL
-
-  [.item 4]
-    expected: FAIL
-
   [.item 5]
     expected: FAIL
 
-  [.item 6]
-    expected: FAIL
-
   [.item 7]
-    expected: FAIL
-
-  [.item 9]
-    expected: FAIL
-
-  [.item 10]
-    expected: FAIL
-
-  [.item 11]
-    expected: FAIL
-
-  [.item 12]
     expected: FAIL
 
   [.item 13]
     expected: FAIL
 
   [.item 14]
-    expected: FAIL
-
-  [.item 15]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/align-self-htb-rtl-vrl.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/align-self-htb-rtl-vrl.html.ini
@@ -1,42 +1,12 @@
 [align-self-htb-rtl-vrl.html]
-  [.item 1]
-    expected: FAIL
-
-  [.item 2]
-    expected: FAIL
-
-  [.item 3]
-    expected: FAIL
-
-  [.item 4]
-    expected: FAIL
-
   [.item 5]
     expected: FAIL
 
-  [.item 6]
-    expected: FAIL
-
   [.item 7]
-    expected: FAIL
-
-  [.item 9]
-    expected: FAIL
-
-  [.item 10]
-    expected: FAIL
-
-  [.item 11]
-    expected: FAIL
-
-  [.item 12]
     expected: FAIL
 
   [.item 13]
     expected: FAIL
 
   [.item 14]
-    expected: FAIL
-
-  [.item 15]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/justify-self-default-overflow-htb-ltr-htb.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/justify-self-default-overflow-htb-ltr-htb.html.ini
@@ -1,26 +1,8 @@
 [justify-self-default-overflow-htb-ltr-htb.html]
-  [.item 1]
-    expected: FAIL
-
-  [.item 2]
-    expected: FAIL
-
   [.item 3]
     expected: FAIL
 
   [.item 4]
-    expected: FAIL
-
-  [.item 5]
-    expected: FAIL
-
-  [.item 6]
-    expected: FAIL
-
-  [.item 8]
-    expected: FAIL
-
-  [.item 9]
     expected: FAIL
 
   [.item 10]
@@ -29,8 +11,8 @@
   [.item 11]
     expected: FAIL
 
-  [.item 12]
+  [.item 7]
     expected: FAIL
 
-  [.item 13]
+  [.item 14]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/justify-self-default-overflow-htb-ltr-vrl.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/justify-self-default-overflow-htb-ltr-vrl.html.ini
@@ -1,26 +1,8 @@
 [justify-self-default-overflow-htb-ltr-vrl.html]
-  [.item 1]
-    expected: FAIL
-
-  [.item 2]
-    expected: FAIL
-
   [.item 3]
     expected: FAIL
 
   [.item 4]
-    expected: FAIL
-
-  [.item 5]
-    expected: FAIL
-
-  [.item 6]
-    expected: FAIL
-
-  [.item 8]
-    expected: FAIL
-
-  [.item 9]
     expected: FAIL
 
   [.item 10]
@@ -29,8 +11,8 @@
   [.item 11]
     expected: FAIL
 
-  [.item 12]
+  [.item 7]
     expected: FAIL
 
-  [.item 13]
+  [.item 14]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/justify-self-default-overflow-htb-rtl-htb.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/justify-self-default-overflow-htb-rtl-htb.html.ini
@@ -1,41 +1,17 @@
 [justify-self-default-overflow-htb-rtl-htb.html]
-  [.item 1]
-    expected: FAIL
-
-  [.item 2]
-    expected: FAIL
-
   [.item 3]
     expected: FAIL
 
   [.item 4]
     expected: FAIL
 
-  [.item 5]
-    expected: FAIL
-
-  [.item 6]
-    expected: FAIL
-
   [.item 7]
-    expected: FAIL
-
-  [.item 8]
-    expected: FAIL
-
-  [.item 9]
     expected: FAIL
 
   [.item 10]
     expected: FAIL
 
   [.item 11]
-    expected: FAIL
-
-  [.item 12]
-    expected: FAIL
-
-  [.item 13]
     expected: FAIL
 
   [.item 14]

--- a/tests/wpt/meta/css/css-align/abspos/justify-self-default-overflow-htb-rtl-vrl.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/justify-self-default-overflow-htb-rtl-vrl.html.ini
@@ -1,41 +1,17 @@
 [justify-self-default-overflow-htb-rtl-vrl.html]
-  [.item 1]
-    expected: FAIL
-
-  [.item 2]
-    expected: FAIL
-
   [.item 3]
     expected: FAIL
 
   [.item 4]
     expected: FAIL
 
-  [.item 5]
-    expected: FAIL
-
-  [.item 6]
-    expected: FAIL
-
   [.item 7]
-    expected: FAIL
-
-  [.item 8]
-    expected: FAIL
-
-  [.item 9]
     expected: FAIL
 
   [.item 10]
     expected: FAIL
 
   [.item 11]
-    expected: FAIL
-
-  [.item 12]
-    expected: FAIL
-
-  [.item 13]
     expected: FAIL
 
   [.item 14]

--- a/tests/wpt/meta/css/css-align/abspos/justify-self-htb-ltr-htb.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/justify-self-htb-ltr-htb.html.ini
@@ -1,53 +1,17 @@
 [justify-self-htb-ltr-htb.html]
-  [.item 1]
-    expected: FAIL
-
-  [.item 2]
-    expected: FAIL
-
-  [.item 3]
-    expected: FAIL
-
-  [.item 4]
-    expected: FAIL
-
   [.item 5]
-    expected: FAIL
-
-  [.item 6]
     expected: FAIL
 
   [.item 7]
     expected: FAIL
 
-  [.item 8]
-    expected: FAIL
-
   [.item 9]
-    expected: FAIL
-
-  [.item 11]
-    expected: FAIL
-
-  [.item 12]
-    expected: FAIL
-
-  [.item 13]
-    expected: FAIL
-
-  [.item 14]
     expected: FAIL
 
   [.item 15]
     expected: FAIL
 
   [.item 16]
-    expected: FAIL
-
-  [.item 17]
-    expected: FAIL
-
-  [.item 18]
     expected: FAIL
 
   [.item 19]

--- a/tests/wpt/meta/css/css-align/abspos/justify-self-htb-ltr-vlr.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/justify-self-htb-ltr-vlr.html.ini
@@ -1,53 +1,17 @@
 [justify-self-htb-ltr-vlr.html]
-  [.item 1]
-    expected: FAIL
-
-  [.item 2]
-    expected: FAIL
-
-  [.item 3]
-    expected: FAIL
-
-  [.item 4]
-    expected: FAIL
-
   [.item 5]
-    expected: FAIL
-
-  [.item 6]
     expected: FAIL
 
   [.item 7]
     expected: FAIL
 
-  [.item 8]
-    expected: FAIL
-
   [.item 9]
-    expected: FAIL
-
-  [.item 11]
-    expected: FAIL
-
-  [.item 12]
-    expected: FAIL
-
-  [.item 13]
-    expected: FAIL
-
-  [.item 14]
     expected: FAIL
 
   [.item 15]
     expected: FAIL
 
-  [.item 16]
-    expected: FAIL
-
   [.item 17]
-    expected: FAIL
-
-  [.item 18]
     expected: FAIL
 
   [.item 19]

--- a/tests/wpt/meta/css/css-align/abspos/justify-self-htb-ltr-vrl.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/justify-self-htb-ltr-vrl.html.ini
@@ -1,53 +1,17 @@
 [justify-self-htb-ltr-vrl.html]
-  [.item 1]
-    expected: FAIL
-
-  [.item 2]
-    expected: FAIL
-
-  [.item 3]
-    expected: FAIL
-
-  [.item 4]
-    expected: FAIL
-
   [.item 5]
     expected: FAIL
 
   [.item 6]
     expected: FAIL
 
-  [.item 7]
-    expected: FAIL
-
-  [.item 8]
-    expected: FAIL
-
   [.item 9]
-    expected: FAIL
-
-  [.item 11]
-    expected: FAIL
-
-  [.item 12]
-    expected: FAIL
-
-  [.item 13]
-    expected: FAIL
-
-  [.item 14]
     expected: FAIL
 
   [.item 15]
     expected: FAIL
 
   [.item 16]
-    expected: FAIL
-
-  [.item 17]
-    expected: FAIL
-
-  [.item 18]
     expected: FAIL
 
   [.item 19]

--- a/tests/wpt/meta/css/css-align/abspos/justify-self-htb-rtl-htb.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/justify-self-htb-rtl-htb.html.ini
@@ -1,54 +1,18 @@
 [justify-self-htb-rtl-htb.html]
-  [.item 1]
-    expected: FAIL
-
-  [.item 2]
-    expected: FAIL
-
-  [.item 3]
-    expected: FAIL
-
-  [.item 4]
-    expected: FAIL
-
   [.item 5]
     expected: FAIL
 
   [.item 6]
     expected: FAIL
 
-  [.item 7]
-    expected: FAIL
-
   [.item 8]
     expected: FAIL
 
-  [.item 9]
-    expected: FAIL
-
-  [.item 11]
-    expected: FAIL
-
-  [.item 12]
-    expected: FAIL
-
-  [.item 13]
-    expected: FAIL
-
-  [.item 14]
-    expected: FAIL
-
   [.item 15]
-    expected: FAIL
-
-  [.item 16]
     expected: FAIL
 
   [.item 17]
     expected: FAIL
 
   [.item 18]
-    expected: FAIL
-
-  [.item 19]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/justify-self-htb-rtl-vlr.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/justify-self-htb-rtl-vlr.html.ini
@@ -1,41 +1,11 @@
 [justify-self-htb-rtl-vlr.html]
-  [.item 1]
-    expected: FAIL
-
-  [.item 2]
-    expected: FAIL
-
-  [.item 3]
-    expected: FAIL
-
-  [.item 4]
-    expected: FAIL
-
   [.item 5]
     expected: FAIL
 
   [.item 6]
     expected: FAIL
 
-  [.item 7]
-    expected: FAIL
-
   [.item 8]
-    expected: FAIL
-
-  [.item 9]
-    expected: FAIL
-
-  [.item 11]
-    expected: FAIL
-
-  [.item 12]
-    expected: FAIL
-
-  [.item 13]
-    expected: FAIL
-
-  [.item 14]
     expected: FAIL
 
   [.item 15]
@@ -44,11 +14,5 @@
   [.item 16]
     expected: FAIL
 
-  [.item 17]
-    expected: FAIL
-
   [.item 18]
-    expected: FAIL
-
-  [.item 19]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/justify-self-htb-rtl-vrl.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/justify-self-htb-rtl-vrl.html.ini
@@ -1,20 +1,5 @@
 [justify-self-htb-rtl-vrl.html]
-  [.item 1]
-    expected: FAIL
-
-  [.item 2]
-    expected: FAIL
-
-  [.item 3]
-    expected: FAIL
-
-  [.item 4]
-    expected: FAIL
-
   [.item 5]
-    expected: FAIL
-
-  [.item 6]
     expected: FAIL
 
   [.item 7]
@@ -23,32 +8,11 @@
   [.item 8]
     expected: FAIL
 
-  [.item 9]
-    expected: FAIL
-
-  [.item 11]
-    expected: FAIL
-
-  [.item 12]
-    expected: FAIL
-
-  [.item 13]
-    expected: FAIL
-
-  [.item 14]
-    expected: FAIL
-
   [.item 15]
-    expected: FAIL
-
-  [.item 16]
     expected: FAIL
 
   [.item 17]
     expected: FAIL
 
   [.item 18]
-    expected: FAIL
-
-  [.item 19]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/stretch-intrinsic-size-htb-htb.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/stretch-intrinsic-size-htb-htb.html.ini
@@ -1,14 +1,8 @@
 [stretch-intrinsic-size-htb-htb.html]
-  [.item 1]
-    expected: FAIL
-
   [.item 2]
     expected: FAIL
 
   [.item 3]
-    expected: FAIL
-
-  [.item 5]
     expected: FAIL
 
   [.item 6]

--- a/tests/wpt/meta/css/css-align/abspos/stretch-intrinsic-size-htb-vrl.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/stretch-intrinsic-size-htb-vrl.html.ini
@@ -1,14 +1,8 @@
 [stretch-intrinsic-size-htb-vrl.html]
-  [.item 1]
-    expected: FAIL
-
   [.item 2]
     expected: FAIL
 
   [.item 3]
-    expected: FAIL
-
-  [.item 5]
     expected: FAIL
 
   [.item 6]

--- a/tests/wpt/meta/css/css-align/abspos/stretch-intrinsic-size-vrl-htb.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/stretch-intrinsic-size-vrl-htb.html.ini
@@ -1,14 +1,8 @@
 [stretch-intrinsic-size-vrl-htb.html]
-  [.item 1]
-    expected: FAIL
-
   [.item 2]
     expected: FAIL
 
   [.item 3]
-    expected: FAIL
-
-  [.item 5]
     expected: FAIL
 
   [.item 6]

--- a/tests/wpt/meta/css/css-align/abspos/stretch-intrinsic-size-vrl-vrl.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/stretch-intrinsic-size-vrl-vrl.html.ini
@@ -1,14 +1,8 @@
 [stretch-intrinsic-size-vrl-vrl.html]
-  [.item 1]
-    expected: FAIL
-
   [.item 2]
     expected: FAIL
 
   [.item 3]
-    expected: FAIL
-
-  [.item 5]
     expected: FAIL
 
   [.item 6]


### PR DESCRIPTION
Uses `Size::FitContent` when the `AlignFlags` isn't `normal` or `stretch` (Non-replaced case of #34248)


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #34248 
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
