### PR TITLE
mach: Fix notifications on windows 11

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -28,7 +28,7 @@ PyGithub == 1.58.1
 six == 1.16
 
 # For sending build notifications.
-notify-py == 0.3.42
+notify-py == 0.3.43
 
 # For wpt scripts and their tests.
 flask


### PR DESCRIPTION
Bumps notify-py to the latest version v0.3.43.
Release notes: https://github.com/ms7m/notify-py/releases/tag/v0.3.43 
This fixes notifications on windows 11.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix notifications on windows 11