### PR TITLE
Changes alignment check from explicit SAFE to !UNSAFE in positioned.rs

### DIFF
--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -919,7 +919,7 @@ impl<'a> AbsoluteAxisSolver<'a> {
         };
 
         let mut value_after_safety = self.alignment.value();
-        if self.alignment.flags() == AlignFlags::SAFE &&
+        if self.alignment.flags() != AlignFlags::UNSAFE &&
             margin_box_axis.length > alignment_container.length
         {
             value_after_safety = AlignFlags::START;


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
**File:** `servo/components/layout_2020/positioned.rs: `

**PR Description**
Makes absolutely positioned elements default to safe alignment unless explicitly marked unsafe.

**Changes:**
- Modified alignment check from `flags() == AlignFlags::SAFE` to `flags() != AlignFlags::UNSAFE`

**Future work:**
Could implement proper logic that evaluates and adjusts the alignment based on overflow conditions (unsafe/safe/unspecified) as described in [here](https://drafts.csswg.org/css-align/#auto-safety-position)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #34240 

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
