### PR TITLE
build: upgrade rustc to 1.81.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -44,8 +44,6 @@ jobs:
         with:
           crate: cargo-deny
           locked: true
-          # 0.16.2 requires Rust 1.81 or newer.
-          version: '0.16.1'
       - name: Bootstrap Python
         run: python3 -m pip install --upgrade pip
       - name: Bootstrap dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ authors = ["The Servo Project Developers"]
 license = "MPL-2.0"
 edition = "2021"
 publish = false
-rust-version = "1.80.1"
+rust-version = "1.81.0"
 
 [workspace.dependencies]
 accountable-refcell = "0.2.0"

--- a/components/layout_2020/dom_traversal.rs
+++ b/components/layout_2020/dom_traversal.rs
@@ -448,9 +448,8 @@ where
 {
     let mut next = parent.first_child();
     std::iter::from_fn(move || {
-        next.map(|child| {
+        next.inspect(|child| {
             next = child.next_sibling();
-            child
         })
     })
 }

--- a/components/layout_2020/flow/inline/construct.rs
+++ b/components/layout_2020/flow/inline/construct.rs
@@ -232,13 +232,12 @@ impl InlineFormattingContextBuilder {
 
         let white_space_collapse = info.style.clone_white_space_collapse();
         let new_text: String = char_iterator
-            .map(|character| {
+            .inspect(|&character| {
                 self.has_uncollapsible_text_content |= matches!(
                     white_space_collapse,
                     WhiteSpaceCollapse::Preserve | WhiteSpaceCollapse::BreakSpaces
                 ) || !character.is_ascii_whitespace() ||
                     (character == '\n' && white_space_collapse != WhiteSpaceCollapse::Collapse);
-                character
             })
             .collect();
 

--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -125,7 +125,7 @@ impl AllPendingLoads {
     }
 
     fn remove(&mut self, key: &LoadKey) -> Option<PendingLoad> {
-        self.loads.remove(key).map(|pending_load| {
+        self.loads.remove(key).inspect(|pending_load| {
             self.url_to_load_key
                 .remove(&(
                     pending_load.url.clone(),
@@ -133,7 +133,6 @@ impl AllPendingLoads {
                     pending_load.cors_setting,
                 ))
                 .unwrap();
-            pending_load
         })
     }
 

--- a/components/net/storage_thread.rs
+++ b/components/net/storage_thread.rs
@@ -244,9 +244,8 @@ impl StorageManager {
         let old_value = data
             .get_mut(&origin)
             .and_then(|&mut (ref mut total, ref mut entry)| {
-                entry.remove(&name).map(|old| {
+                entry.remove(&name).inspect(|old| {
                     *total -= name.as_bytes().len() + old.as_bytes().len();
-                    old
                 })
             });
         sender.send(old_value).unwrap();

--- a/components/script/body.rs
+++ b/components/script/body.rs
@@ -873,11 +873,7 @@ fn run_form_data_algorithm(
     mime: &[u8],
     can_gc: CanGc,
 ) -> Fallible<FetchedData> {
-    let mime_str = if let Ok(s) = str::from_utf8(mime) {
-        s
-    } else {
-        ""
-    };
+    let mime_str = str::from_utf8(mime).unwrap_or_default();
     let mime: Mime = mime_str
         .parse()
         .map_err(|_| Error::Type("Inappropriate MIME-type for Body".to_string()))?;

--- a/components/script/textinput.rs
+++ b/components/script/textinput.rs
@@ -1037,7 +1037,7 @@ impl<T: ClipboardProvider> TextInput<T> {
             // https://html.spec.whatwg.org/multipage/#textarea-line-break-normalisation-transformation
             content
                 .replace("\r\n", "\n")
-                .split(|c| c == '\n' || c == '\r')
+                .split(['\n', '\r'])
                 .map(DOMString::from)
                 .collect()
         } else {

--- a/ports/servoshell/parser.rs
+++ b/ports/servoshell/parser.rs
@@ -31,9 +31,8 @@ pub fn get_default_url(
     let mut new_url = None;
     let cmdline_url = url_opt.map(|s| s.to_string()).and_then(|url_string| {
         parse_url_or_filename(cwd.as_ref(), &url_string)
-            .map_err(|error| {
+            .inspect_err(|&error| {
                 log::warn!("URL parsing failed ({:?}).", error);
-                error
             })
             .ok()
     });

--- a/python/servo/platform/base.py
+++ b/python/servo/platform/base.py
@@ -83,8 +83,7 @@ class Base:
             return False
 
         print(" * Installing cargo-deny...")
-        # cargo-deny 0.16.2 requires Rust 1.81.
-        if subprocess.call(["cargo", "install", "cargo-deny", "--locked", "--version", "0.16.1"]) != 0:
+        if subprocess.call(["cargo", "install", "cargo-deny", "--locked"]) != 0:
             raise EnvironmentError("Installation of cargo-deny failed.")
 
         return True

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 # Be sure to update shell.nix and support/crown/rust-toolchain.toml when bumping this!
-channel = "1.80.1"
+channel = "1.81.0"
 
 components = [
     "clippy",

--- a/shell.nix
+++ b/shell.nix
@@ -10,7 +10,7 @@ with import (builtins.fetchTarball {
   overlays = [
     (import (builtins.fetchTarball {
       # Bumped the channel in rust-toolchain.toml? Bump this commit too!
-      url = "https://github.com/oxalica/rust-overlay/archive/65e3dc0fe079fe8df087cd38f1fe6836a0373aad.tar.gz";
+      url = "https://github.com/oxalica/rust-overlay/archive/0be641045af6d8666c11c2c40e45ffc9667839b5.tar.gz";
     }))
   ];
   config = {

--- a/support/crown/Cargo.lock
+++ b/support/crown/Cargo.lock
@@ -25,9 +25,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "compiletest_rs"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fcc3c0c91b59c137b3cf8073cbc2f72a49b3d5505660ec88f94da3ed4bb1de"
+checksum = "f150fe9105fcd2a57cad53f0c079a24de65195903ef670990f5909f695eac04c"
 dependencies = [
  "diff",
  "filetime",

--- a/support/crown/rust-toolchain.toml
+++ b/support/crown/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.80.1"
+channel = "1.81.0"
 
 components = [
     "clippy",

--- a/support/crown/tests/compile_test.rs
+++ b/support/crown/tests/compile_test.rs
@@ -35,6 +35,8 @@ fn run_mode(mode: &'static str, bless: bool) {
     // Does not work reliably: https://github.com/servo/servo/pull/30508#issuecomment-1834542203
     //config.link_deps();
     config.strict_headers = true;
+    // See https://github.com/Manishearth/compiletest-rs/issues/295
+    config.compile_test_exit_code = Some(101);
 
     compiletest::run_tests(&config);
 }


### PR DESCRIPTION
I [tried to upgrade to 1.82.0][1], but there were a handful of new clippy
warnings that can't be fixed using `cargo clippy --fix`. The try run also
showed unit test failures related to crown lints.

Hence, this PR only gets us to 1.81.0 for now.

[1]: https://github.com/mukilan/servo/actions/runs/11886069630

Signed-off-by: Mukilan Thiyagarajan <mukilan@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
