### PR TITLE
Make ScriptParseHTML and ScriptParseXML only count actual parsing time

### DIFF
--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -27,7 +27,7 @@ use net_traits::{
     ResourceTimingType,
 };
 use profile_traits::time::{
-    ProfilerCategory, TimerMetadata, TimerMetadataFrameType, TimerMetadataReflowType,
+    ProfilerCategory, ProfilerChan, TimerMetadata, TimerMetadataFrameType, TimerMetadataReflowType,
 };
 use profile_traits::time_profile;
 use script_traits::DocumentActivity;
@@ -363,7 +363,28 @@ impl ServoParser {
             input.push_back(String::from(chunk).into());
         }
 
-        self.tokenize(|tokenizer| tokenizer.feed(&input, can_gc), can_gc);
+        let profiler_chan = self
+            .document
+            .window()
+            .upcast::<GlobalScope>()
+            .time_profiler_chan()
+            .clone();
+        let profiler_metadata = TimerMetadata {
+            url: self.document.url().as_str().into(),
+            iframe: TimerMetadataFrameType::RootWindow,
+            incremental: TimerMetadataReflowType::FirstReflow,
+        };
+        self.tokenize(
+            |tokenizer| {
+                tokenizer.feed(
+                    &input,
+                    can_gc,
+                    profiler_chan.clone(),
+                    profiler_metadata.clone(),
+                )
+            },
+            can_gc,
+        );
 
         if self.suspended.get() {
             // Parser got suspended, insert remaining input at end of
@@ -517,36 +538,10 @@ impl ServoParser {
     }
 
     fn parse_sync(&self, can_gc: CanGc) {
-        let metadata = TimerMetadata {
-            url: self.document.url().as_str().into(),
-            iframe: TimerMetadataFrameType::RootWindow,
-            incremental: TimerMetadataReflowType::FirstReflow,
-        };
-        let profiler_chan = self
-            .document
-            .window()
-            .upcast::<GlobalScope>()
-            .time_profiler_chan()
-            .clone();
         match self.tokenizer {
-            Tokenizer::Html(_) => time_profile!(
-                ProfilerCategory::ScriptParseHTML,
-                Some(metadata),
-                profiler_chan,
-                || self.do_parse_sync(can_gc),
-            ),
-            Tokenizer::AsyncHtml(_) => time_profile!(
-                ProfilerCategory::ScriptParseHTML,
-                Some(metadata),
-                profiler_chan,
-                || self.do_parse_sync(can_gc),
-            ),
-            Tokenizer::Xml(_) => time_profile!(
-                ProfilerCategory::ScriptParseXML,
-                Some(metadata),
-                profiler_chan,
-                || self.do_parse_sync(can_gc),
-            ),
+            Tokenizer::Html(_) => self.do_parse_sync(can_gc),
+            Tokenizer::AsyncHtml(_) => self.do_parse_sync(can_gc),
+            Tokenizer::Xml(_) => self.do_parse_sync(can_gc),
         }
     }
 
@@ -564,8 +559,27 @@ impl ServoParser {
                 }
             }
         }
+
+        let profiler_chan = self
+            .document
+            .window()
+            .upcast::<GlobalScope>()
+            .time_profiler_chan()
+            .clone();
+        let profiler_metadata = TimerMetadata {
+            url: self.document.url().as_str().into(),
+            iframe: TimerMetadataFrameType::RootWindow,
+            incremental: TimerMetadataReflowType::FirstReflow,
+        };
         self.tokenize(
-            |tokenizer| tokenizer.feed(&self.network_input, can_gc),
+            |tokenizer| {
+                tokenizer.feed(
+                    &self.network_input,
+                    can_gc,
+                    profiler_chan.clone(),
+                    profiler_metadata.clone(),
+                )
+            },
             can_gc,
         );
 
@@ -705,11 +719,28 @@ impl Tokenizer {
         &self,
         input: &BufferQueue,
         can_gc: CanGc,
+        profiler_chan: ProfilerChan,
+        profiler_metadata: TimerMetadata,
     ) -> TokenizerResult<DomRoot<HTMLScriptElement>> {
         match *self {
-            Tokenizer::Html(ref tokenizer) => tokenizer.feed(input),
-            Tokenizer::AsyncHtml(ref tokenizer) => tokenizer.feed(input, can_gc),
-            Tokenizer::Xml(ref tokenizer) => tokenizer.feed(input),
+            Tokenizer::Html(ref tokenizer) => time_profile!(
+                ProfilerCategory::ScriptParseHTML,
+                Some(profiler_metadata),
+                profiler_chan,
+                || tokenizer.feed(input),
+            ),
+            Tokenizer::AsyncHtml(ref tokenizer) => time_profile!(
+                ProfilerCategory::ScriptParseHTML,
+                Some(profiler_metadata),
+                profiler_chan,
+                || tokenizer.feed(input, can_gc),
+            ),
+            Tokenizer::Xml(ref tokenizer) => time_profile!(
+                ProfilerCategory::ScriptParseXML,
+                Some(profiler_metadata),
+                profiler_chan,
+                || tokenizer.feed(input),
+            ),
         }
     }
 

--- a/components/shared/profile/time.rs
+++ b/components/shared/profile/time.rs
@@ -91,7 +91,10 @@ pub enum ProfilerCategory {
     ScriptImageCacheMsg = 0x68,
     ScriptInputEvent = 0x69,
     ScriptNetworkEvent = 0x6a,
+
+    /// The script thread is parsing HTML, rather than doing other work like evaluating scripts or doing layout.
     ScriptParseHTML = 0x6b,
+
     ScriptPlannedNavigation = 0x6c,
     ScriptResize = 0x6d,
     ScriptSetScrollState = 0x6e,
@@ -102,7 +105,10 @@ pub enum ProfilerCategory {
     ScriptWebSocketEvent = 0x73,
     ScriptWorkerEvent = 0x74,
     ScriptServiceWorkerEvent = 0x75,
+
+    /// The script thread is parsing XML, rather than doing other work like evaluating scripts or doing layout.
     ScriptParseXML = 0x76,
+
     ScriptEnterFullscreen = 0x77,
     ScriptExitFullscreen = 0x78,
     ScriptWebVREvent = 0x79,


### PR DESCRIPTION
This patch redefines ScriptParseHTML and ScriptParseXML as time spent in Tokenizer::feed (components/script/dom/servoparser/mod.rs line 718), excluding time spent doing reflow (line 622) and running scripts (line 634).

As a result, we also count time parsing for document.write() now, which we weren’t doing previously.

Perfetto output for test case in #34253:

![image](https://github.com/user-attachments/assets/be2244d4-d9e4-4c3d-85c4-dcc826f69b73)

![image](https://github.com/user-attachments/assets/4e101abb-63ad-4541-b947-89f10372af76)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #34253