### PR TITLE
Fix various clippy warnings on OpenHarmony

### DIFF
--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -128,7 +128,7 @@ winit = "0.30.5"
 [target.'cfg(any(all(target_os = "linux", not(target_env = "ohos")), target_os = "windows"))'.dependencies]
 image = { workspace = true }
 
-[target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
+[target.'cfg(any(all(target_os = "linux", not(target_env = "ohos")), target_os = "macos"))'.dependencies]
 sig = "1.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/ports/servoshell/crash_handler.rs
+++ b/ports/servoshell/crash_handler.rs
@@ -11,6 +11,8 @@ pub fn install() {
     use std::sync::atomic;
     use std::thread;
 
+    use sig::signal;
+
     use crate::backtrace;
 
     extern "C" fn handler(sig: i32) {

--- a/ports/servoshell/egl/ohos/simpleservo.rs
+++ b/ports/servoshell/egl/ohos/simpleservo.rs
@@ -82,18 +82,12 @@ pub fn init(
         "--prefs-file /path/to/prefs.json",
     );
 
-    let opts_matches;
-    let content_process_token;
-    match opts::from_cmdline_args(opts, &args) {
-        ArgumentParsingResult::ContentProcess(matches, token) => {
+    let opts_matches = match opts::from_cmdline_args(opts, &args) {
+        ArgumentParsingResult::ContentProcess(matches, _token) => {
             error!("Content Process mode not supported / tested yet on OpenHarmony!");
-            opts_matches = matches;
-            content_process_token = Some(token);
+            matches
         },
-        ArgumentParsingResult::ChromeProcess(matches) => {
-            opts_matches = matches;
-            content_process_token = None;
-        },
+        ArgumentParsingResult::ChromeProcess(matches) => matches,
     };
 
     crate::prefs::register_user_prefs(&opts_matches);

--- a/ports/servoshell/egl/servo_glue.rs
+++ b/ports/servoshell/egl/servo_glue.rs
@@ -26,7 +26,6 @@ use servo::script_traits::{
 };
 use servo::servo_geometry::DeviceIndependentPixel;
 use servo::style_traits::DevicePixel;
-use servo::webrender_api::units::DeviceIntRect;
 use servo::webrender_api::ScrollLocation;
 use servo::webrender_traits::RenderingContext;
 use servo::{gl, Servo, TopLevelBrowsingContextId};
@@ -501,7 +500,8 @@ impl ServoGlue {
                     let trusted = origin == PromptOrigin::Trusted;
                     let res = match definition {
                         PromptDefinition::Alert(message, sender) => {
-                            sender.send(cb.prompt_alert(message, trusted))
+                            cb.prompt_alert(message, trusted);
+                            sender.send(())
                         },
                         PromptDefinition::OkCancel(message, sender) => {
                             sender.send(cb.prompt_ok_cancel(message, trusted))

--- a/ports/servoshell/lib.rs
+++ b/ports/servoshell/lib.rs
@@ -13,12 +13,13 @@ mod test;
 
 #[cfg(not(target_os = "android"))]
 mod backtrace;
+#[cfg(not(target_env = "ohos"))]
 mod crash_handler;
 #[cfg(not(any(target_os = "android", target_env = "ohos")))]
 pub(crate) mod desktop;
 #[cfg(any(target_os = "android", target_env = "ohos"))]
 mod egl;
-#[cfg(not(target_os = "android"))]
+#[cfg(not(any(target_os = "android", target_env = "ohos")))]
 mod panic_hook;
 mod parser;
 mod prefs;

--- a/ports/servoshell/lib.rs
+++ b/ports/servoshell/lib.rs
@@ -4,10 +4,6 @@
 
 use cfg_if::cfg_if;
 
-#[cfg(any(target_os = "macos", target_os = "linux"))]
-#[macro_use]
-extern crate sig;
-
 #[cfg(test)]
 mod test;
 

--- a/ports/servoshell/parser.rs
+++ b/ports/servoshell/parser.rs
@@ -2,20 +2,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#[cfg(not(any(target_os = "android", target_env = "ohos")))]
 use std::path::{Path, PathBuf};
 
-use log::warn;
 use servo::net_traits::pub_domains::is_reg_domain;
 use servo::servo_config::pref;
 use servo::servo_url::ServoUrl;
-use url::{self, Url};
 
 #[cfg(not(any(target_os = "android", target_env = "ohos")))]
 pub fn parse_url_or_filename(cwd: &Path, input: &str) -> Result<ServoUrl, ()> {
     match ServoUrl::parse(input) {
         Ok(url) => Ok(url),
         Err(url::ParseError::RelativeUrlWithoutBase) => {
-            Url::from_file_path(&*cwd.join(input)).map(ServoUrl::from_url)
+            url::Url::from_file_path(&*cwd.join(input)).map(ServoUrl::from_url)
         },
         Err(_) => Err(()),
     }
@@ -33,7 +32,7 @@ pub fn get_default_url(
     let cmdline_url = url_opt.map(|s| s.to_string()).and_then(|url_string| {
         parse_url_or_filename(cwd.as_ref(), &url_string)
             .map_err(|error| {
-                warn!("URL parsing failed ({:?}).", error);
+                log::warn!("URL parsing failed ({:?}).", error);
                 error
             })
             .ok()


### PR DESCRIPTION
Fix various clippy warnings on OpenHarmony


---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix various clippy warnings on OpenHarmony


