### PR TITLE
Make ScriptEvaluate count script execution in DOM events and timers

### DIFF
--- a/components/script/dom/bindings/settings_stack.rs
+++ b/components/script/dom/bindings/settings_stack.rs
@@ -42,6 +42,8 @@ pub fn is_execution_stack_empty() -> bool {
 /// RAII struct that pushes and pops entries from the script settings stack.
 pub struct AutoEntryScript {
     global: DomRoot<GlobalScope>,
+    #[cfg(feature = "tracing")]
+    span: tracing::span::EnteredSpan,
 }
 
 impl AutoEntryScript {
@@ -56,6 +58,8 @@ impl AutoEntryScript {
             });
             AutoEntryScript {
                 global: DomRoot::from_ref(global),
+                #[cfg(feature = "tracing")]
+                span: tracing::info_span!("ScriptEvaluate", servo_profiling = true).entered(),
             }
         })
     }

--- a/components/shared/profile/time.rs
+++ b/components/shared/profile/time.rs
@@ -78,7 +78,11 @@ pub enum ProfilerCategory {
     ScriptDevtoolsMsg = 0x62,
     ScriptDocumentEvent = 0x63,
     ScriptDomEvent = 0x64,
+
+    /// Rust tracing only: the script thread is executing a script.
+    /// This may include time doing layout or parse work initiated by the script.
     ScriptEvaluate = 0x65,
+
     ScriptEvent = 0x66,
     ScriptFileRead = 0x67,
     ScriptImageCacheMsg = 0x68,


### PR DESCRIPTION
This patch redefines ScriptEvaluate as time spent with an AutoEntryScript in scope. As a result, we count time executing scripts in many situations we weren’t before, such as:

- setTimeout(function), via JsTimerTask::invoke → Function::Call_ → CallSetup::new → AutoEntryScript::new
- DOM event listeners, via EventTarget::fire_event_with_params → … → invoke → inner_invoke → … → EventHandlerBinding::Call_ → CallSetup::new → AutoEntryScript::new
- [run a module script](https://html.spec.whatwg.org/multipage/#run-a-module-script), via HTMLScriptElement::run_a_module_script → AutoEntryScript::new
- worker script execution, via WorkerGlobalScope::execute_script → AutoEntryScript::new

Previously we only counted time in callers of GlobalScope::evaluate_script_on_global_with_result:

- HTMLScriptElement::run_a_classic_script (htmlscriptelement.rs:1000)
- load_script (userscripts.rs:51)
- handle_evaluate_js (devtools.rs:59)
- evaluate_js_on_global_with_result (globalscope.rs:2656)
  - eval_js_url (script_thread.rs:4045)
  - JsTimerTask::invoke (timers.rs:556) —  setTimeout(string)
  - handle_execute_script (webdriver_handlers.rs:300)
  - handle_execute_async_script (webdriver_handlers.rs:332)
  - WorkletGlobalScope::evaluate_js (workletglobalscope.rs:121)

Perfetto output for test cases in #34254:

![image](https://github.com/user-attachments/assets/a68ee477-e8a0-4003-9133-4e1359c6715e)

![image](https://github.com/user-attachments/assets/b105ba81-56e0-404e-aa0a-b5daf35bc9f3)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #34254

<!-- Either: -->
- [x] There are tests for these changes, but they are manual tests
- [ ] These changes do not require tests because ___