### PR TITLE
script: Remove a warning about a common situation involving OOP iframes

### DIFF
--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1620,8 +1620,11 @@ impl ScriptThread {
         // Note: the spec reads: "for doc in docs" at each step
         // whereas this runs all steps per doc in docs.
         for pipeline_id in pipelines_to_update {
+            // This document is not managed by this script thread. This can happen is the pipeline is
+            // unexpectedly closed or simply that it is managed by a different script thread.
+            // TODO: It would be better if iframes knew whether or not their Document was managed
+            // by the same script thread.
             let Some(document) = self.documents.borrow().find_document(pipeline_id) else {
-                warn!("Updating the rendering for closed pipeline {pipeline_id}.");
                 continue;
             };
             // TODO(#32004): The rendering should be updated according parent and shadow root order


### PR DESCRIPTION
When an iframe is out of process or running in a different
`ScriptThread`, it is expected that their `Document`s cannot be found in
the current `ScriptThread` during the *update-the-rendering* step.
Remove the warning in that situation and add a comment instead.

Co-authored-by: Mukilan Thiyagarajan <mukilan@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because it does not have any functional change.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
