### PR TITLE
Disable layout-2013 cargo feature by default

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -152,7 +152,7 @@ jobs:
 
       - name: Build (${{ inputs.profile }})
         run: |
-          python3 ./mach build --use-crown --locked --${{ inputs.profile }}
+          python3 ./mach build --use-crown --locked --${{ inputs.profile }} --features "layout_2013"
           cp -r target/cargo-timings target/cargo-timings-linux
       - name: Smoketest
         run: xvfb-run python3 ./mach smoketest --${{ inputs.profile  }}

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -1033,8 +1033,8 @@ fn get_layout_factory(legacy_layout: bool) -> Arc<dyn LayoutFactory> {
             }
         } else {
             if legacy_layout {
-                warn!("Runtime option `legacy_layout` was enabled, but the `layout_2013` \
-                feature was not enabled at compile time. Falling back to layout 2020! ");
+                panic!("Runtime option `legacy_layout` was enabled, but the `layout_2013` \
+                feature was not enabled at compile time! ");
            }
         }
     }

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -39,7 +39,7 @@ ProductName = "Servo"
 
 [features]
 debugmozjs = ["libservo/debugmozjs"]
-default = ["layout_2013", "max_log_level", "webdriver", "webxr"]
+default = ["max_log_level", "webdriver", "webxr"]
 jitspew = ["libservo/jitspew"]
 js_backtrace = ["libservo/js_backtrace"]
 layout_2013 = ["libservo/layout_2013"]


### PR DESCRIPTION
Most of the time layout-2013 is not needed and just wastes build time. Disable the optional feature by default and require users to specify the feature at compile time if they wish to use the legacy layout.
Servo will panic if `--legacy-layout` is specified at runtime, but servo was compiled without layout 2013.

In CI we enable the feature by default for Linux, since that we need it for wpt tests with the legacy layout and CI should ensure that the legacy code continues to compile.
Maybe we should also enable the now non-default feature in CI for the other platforms - I don't have a strong opinion here.


---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors


