### PR TITLE
Replace `sparkle` with `glow` in `components/shared/canvas`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -677,7 +677,7 @@ dependencies = [
  "fnv",
  "font-kit",
  "fonts",
- "glow 0.15.0",
+ "glow 0.16.0",
  "half",
  "ipc-channel",
  "log",
@@ -709,6 +709,7 @@ dependencies = [
  "base",
  "crossbeam-channel",
  "euclid",
+ "glow 0.16.0",
  "ipc-channel",
  "malloc_size_of",
  "malloc_size_of_derive",
@@ -716,7 +717,6 @@ dependencies = [
  "serde",
  "serde_bytes",
  "servo_config",
- "sparkle",
  "style",
  "webrender_api",
  "webxr-api",
@@ -2451,9 +2451,9 @@ dependencies = [
 
 [[package]]
 name = "glow"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33cd8ff5e02c1a5463ec10a846c8f3166a3ae0382ec33de6a327ea6dd61c41d"
+checksum = "c5e5ea60d70410161c8bf5da3fdfeaa1c72ed2c15f8bbb9d19fe3a4fad085f08"
 dependencies = [
  "js-sys",
  "slotmap",
@@ -4038,7 +4038,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -6048,7 +6048,7 @@ dependencies = [
  "fonts",
  "fonts_traits",
  "fxhash",
- "glow 0.15.0",
+ "glow 0.16.0",
  "headers",
  "html5ever",
  "http",
@@ -7049,7 +7049,7 @@ dependencies = [
 [[package]]
 name = "surfman"
 version = "0.9.8"
-source = "git+https://github.com/servo/surfman?rev=e0c34af64f2860bc56bc8a56e1c169a915b16aa3#e0c34af64f2860bc56bc8a56e1c169a915b16aa3"
+source = "git+https://github.com/servo/surfman?rev=c8d6b4b65aeab739ee7651602e29c8d58ceee123#c8d6b4b65aeab739ee7651602e29c8d58ceee123"
 dependencies = [
  "bitflags 2.6.0",
  "cfg_aliases 0.2.1",
@@ -7060,7 +7060,7 @@ dependencies = [
  "euclid",
  "fnv",
  "gl_generator",
- "glow 0.15.0",
+ "glow 0.16.0",
  "io-surface",
  "libc",
  "log",
@@ -8255,11 +8255,11 @@ dependencies = [
 [[package]]
 name = "webxr"
 version = "0.0.1"
-source = "git+https://github.com/servo/webxr#042a7af3271d93d68e357b0b19c9aaa2cb30d322"
+source = "git+https://github.com/servo/webxr#84c3022dc6e980119e2a04e1e248e74f825694b7"
 dependencies = [
  "crossbeam-channel",
  "euclid",
- "glow 0.15.0",
+ "glow 0.16.0",
  "log",
  "openxr",
  "serde",
@@ -8272,7 +8272,7 @@ dependencies = [
 [[package]]
 name = "webxr-api"
 version = "0.0.1"
-source = "git+https://github.com/servo/webxr#042a7af3271d93d68e357b0b19c9aaa2cb30d322"
+source = "git+https://github.com/servo/webxr#84c3022dc6e980119e2a04e1e248e74f825694b7"
 dependencies = [
  "euclid",
  "ipc-channel",
@@ -8402,7 +8402,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ fxhash = "0.2"
 getopts = "0.2.11"
 gleam = "0.15"
 glib = "0.19"
-glow = "0.15"
+glow = "0.16"
 gstreamer = { version = "0.22", features = ["v1_18"] }
 gstreamer-base = "0.22"
 gstreamer-gl = "0.22"
@@ -124,7 +124,7 @@ style = { git = "https://github.com/servo/stylo", branch = "2024-10-04", feature
 style_config = { git = "https://github.com/servo/stylo", branch = "2024-10-04" }
 style_dom = { git = "https://github.com/servo/stylo", package = "dom", branch = "2024-10-04" }
 style_traits = { git = "https://github.com/servo/stylo", branch = "2024-10-04", features = ["servo"] }
-surfman = { git = "https://github.com/servo/surfman", rev = "e0c34af64f2860bc56bc8a56e1c169a915b16aa3", features = ["chains"] }
+surfman = { git = "https://github.com/servo/surfman", rev = "c8d6b4b65aeab739ee7651602e29c8d58ceee123", features = ["chains"] }
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"
 thin-vec = "0.2.13"

--- a/components/shared/canvas/Cargo.toml
+++ b/components/shared/canvas/Cargo.toml
@@ -25,7 +25,7 @@ pixels = { path = "../../pixels" }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
 servo_config = { path = "../../config" }
-sparkle = { workspace = true }
+glow = { workspace = true }
 style = { workspace = true }
 webrender_api = { workspace = true }
 webxr-api = { workspace = true, features = ["ipc"] }


### PR DESCRIPTION
Also updates glow to 0.16

Split from #33918.

Part of https://github.com/servo/servo/issues/33539


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes in WPT

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
