### PR TITLE
Preference-gate `crypto.subtle`

### DIFF
--- a/components/script/dom/crypto.rs
+++ b/components/script/dom/crypto.rs
@@ -14,7 +14,7 @@ use crate::dom::bindings::codegen::Bindings::CryptoBinding::CryptoMethods;
 use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::reflector::{reflect_dom_object, DomObject, Reflector};
 use crate::dom::bindings::root::{DomRoot, MutNullableDom};
-use crate::dom::bindings::str::USVString;
+use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::SubtleCrypto;
 use crate::script_runtime::JSContext;
@@ -72,7 +72,7 @@ impl CryptoMethods for Crypto {
     }
 
     // https://w3c.github.io/webcrypto/#Crypto-method-randomUUID
-    fn RandomUUID(&self) -> USVString {
+    fn RandomUUID(&self) -> DOMString {
         let uuid = Uuid::new_v4();
         uuid.hyphenated()
             .encode_lower(&mut Uuid::encode_buffer())

--- a/components/script/dom/webidls/Crypto.webidl
+++ b/components/script/dom/webidls/Crypto.webidl
@@ -3,25 +3,17 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 /*
  * The origin of this IDL file is
- * https://dvcs.w3.org/hg/webcrypto-api/raw-file/tip/spec/Overview.html#crypto-interface
+ * https://w3c.github.io/webcrypto/#crypto-interface
  *
  */
 
-[Exposed=(Window,Worker)]
-interface mixin GlobalCrypto {
-  readonly attribute Crypto crypto;
+partial interface mixin WindowOrWorkerGlobalScope {
+  [SameObject] readonly attribute Crypto crypto;
 };
-
-Window includes GlobalCrypto;
-WorkerGlobalScope includes GlobalCrypto;
 
 [Exposed=(Window,Worker)]
 interface Crypto {
   [SecureContext] readonly attribute SubtleCrypto subtle;
-  [Throws]
-  ArrayBufferView getRandomValues(ArrayBufferView array);
-
-  [SecureContext]
-  // UTF8String is not observably different from USVString
-  USVString randomUUID();
+  [Throws] ArrayBufferView getRandomValues(ArrayBufferView array);
+  [SecureContext] DOMString randomUUID();
 };

--- a/components/script/dom/webidls/Crypto.webidl
+++ b/components/script/dom/webidls/Crypto.webidl
@@ -13,7 +13,7 @@ partial interface mixin WindowOrWorkerGlobalScope {
 
 [Exposed=(Window,Worker)]
 interface Crypto {
-  [SecureContext] readonly attribute SubtleCrypto subtle;
+  [SecureContext, Pref="dom.crypto.subtle.enabled"] readonly attribute SubtleCrypto subtle;
   [Throws] ArrayBufferView getRandomValues(ArrayBufferView array);
   [SecureContext] DOMString randomUUID();
 };


### PR DESCRIPTION
Updates `Crypto.idl` to match the spec and puts `crypto.subtle` behind `Pref="dom.crypto.subtle.enabled"`.

* https://w3c.github.io/webcrypto/#crypto-interface

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because the idl update does not change behaviour, and the rest is just pref-gating stuff