### PR TITLE
Include non-shadowdom children of shadow hosts in style calculation

### DIFF
--- a/components/script/layout_dom/element.rs
+++ b/components/script/layout_dom/element.rs
@@ -140,20 +140,41 @@ impl<'dom> ServoLayoutElement<'dom> {
     }
 }
 
+pub struct DomChildrenIncludingShadowDom<N> {
+    children: DomChildren<N>,
+    children_in_shadow_root: Option<DomChildren<N>>,
+}
+
+impl<N> Iterator for DomChildrenIncludingShadowDom<N>
+where
+    N: TNode,
+{
+    type Item = N;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.children
+            .next()
+            .or_else(|| self.children_in_shadow_root.as_mut()?.next())
+    }
+}
+
 impl<'dom> style::dom::TElement for ServoLayoutElement<'dom> {
     type ConcreteNode = ServoLayoutNode<'dom>;
-    type TraversalChildrenIterator = DomChildren<Self::ConcreteNode>;
+    type TraversalChildrenIterator = DomChildrenIncludingShadowDom<Self::ConcreteNode>;
 
     fn as_node(&self) -> ServoLayoutNode<'dom> {
         ServoLayoutNode::from_layout_js(self.element.upcast())
     }
 
     fn traversal_children(&self) -> LayoutIterator<Self::TraversalChildrenIterator> {
-        LayoutIterator(if let Some(shadow) = self.shadow_root() {
-            shadow.as_node().dom_children()
-        } else {
-            self.as_node().dom_children()
-        })
+        let children = DomChildrenIncludingShadowDom {
+            children: self.as_node().dom_children(),
+            children_in_shadow_root: self
+                .shadow_root()
+                .map(|shadow| shadow.as_node().dom_children()),
+        };
+
+        LayoutIterator(children)
     }
 
     fn is_html_element(&self) -> bool {

--- a/tests/wpt/meta/css/css-animations/cancel-animation-shadow-slot-invalidation.html.ini
+++ b/tests/wpt/meta/css/css-animations/cancel-animation-shadow-slot-invalidation.html.ini
@@ -1,2 +1,2 @@
 [cancel-animation-shadow-slot-invalidation.html]
-  expected: CRASH
+  expected: TIMEOUT

--- a/tests/wpt/meta/css/css-cascade/layer-slotted-rule.html.ini
+++ b/tests/wpt/meta/css/css-cascade/layer-slotted-rule.html.ini
@@ -1,2 +1,2 @@
 [layer-slotted-rule.html]
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/meta/css/css-cascade/revert-layer-014.html.ini
+++ b/tests/wpt/meta/css/css-cascade/revert-layer-014.html.ini
@@ -1,2 +1,2 @@
 [revert-layer-014.html]
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/meta/css/css-content/quotes-slot-scoping.html.ini
+++ b/tests/wpt/meta/css/css-content/quotes-slot-scoping.html.ini
@@ -1,2 +1,2 @@
 [quotes-slot-scoping.html]
-  expected: CRASH
+  expected: PASS

--- a/tests/wpt/meta/css/css-display/display-contents-shadow-dom-1.html.ini
+++ b/tests/wpt/meta/css/css-display/display-contents-shadow-dom-1.html.ini
@@ -1,2 +1,2 @@
 [display-contents-shadow-dom-1.html]
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/meta/css/css-lists/counter-list-item-slot-order.html.ini
+++ b/tests/wpt/meta/css/css-lists/counter-list-item-slot-order.html.ini
@@ -1,2 +1,2 @@
 [counter-list-item-slot-order.html]
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/meta/css/css-lists/counter-slot-order-scoping.html.ini
+++ b/tests/wpt/meta/css/css-lists/counter-slot-order-scoping.html.ini
@@ -1,2 +1,2 @@
 [counter-slot-order-scoping.html]
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/meta/css/css-lists/counter-slot-order.html.ini
+++ b/tests/wpt/meta/css/css-lists/counter-slot-order.html.ini
@@ -1,2 +1,2 @@
 [counter-slot-order.html]
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text-decor/text-decoration-propagation-shadow.html.ini
+++ b/tests/wpt/meta/css/css-text-decor/text-decoration-propagation-shadow.html.ini
@@ -1,2 +1,0 @@
-[text-decoration-propagation-shadow.html]
-  expected: CRASH

--- a/tests/wpt/meta/css/css-text/white-space/remove-slotted-with-whitespace-sibling.html.ini
+++ b/tests/wpt/meta/css/css-text/white-space/remove-slotted-with-whitespace-sibling.html.ini
@@ -1,2 +1,2 @@
 [remove-slotted-with-whitespace-sibling.html]
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/meta/css/cssom-view/checkVisibility.html.ini
+++ b/tests/wpt/meta/css/cssom-view/checkVisibility.html.ini
@@ -1,5 +1,4 @@
 [checkVisibility.html]
-  expected: CRASH
   [checkVisibility on visibility:hidden element.]
     expected: FAIL
 
@@ -28,4 +27,19 @@
     expected: FAIL
 
   [checkVisibility on content-visibility:hidden element after forced layout update.]
+    expected: FAIL
+
+  [checkVisibility on element slotted in content-visibility: hidden shadow host.]
+    expected: FAIL
+
+  [checkVisibility on element slotted in display:none shadow host.]
+    expected: FAIL
+
+  [checkVisibility on display:contents element.]
+    expected: FAIL
+
+  [checkVisibility on element slotted in opacity: 0; shadow host.]
+    expected: FAIL
+
+  [checkVisibility on root element with content-visibility: hidden returns true.]
     expected: FAIL

--- a/tests/wpt/meta/css/cssom/insert-dir-rule-crash.html.ini
+++ b/tests/wpt/meta/css/cssom/insert-dir-rule-crash.html.ini
@@ -1,2 +1,0 @@
-[insert-dir-rule-crash.html]
-  expected: CRASH

--- a/tests/wpt/meta/css/cssom/insert-dir-rule-in-iframe-crash.html.ini
+++ b/tests/wpt/meta/css/cssom/insert-dir-rule-in-iframe-crash.html.ini
@@ -1,2 +1,0 @@
-[insert-dir-rule-in-iframe-crash.html]
-  expected: CRASH

--- a/tests/wpt/meta/css/selectors/focus-within-shadow-001.html.ini
+++ b/tests/wpt/meta/css/selectors/focus-within-shadow-001.html.ini
@@ -1,2 +1,2 @@
 [focus-within-shadow-001.html]
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/meta/css/selectors/focus-within-shadow-002.html.ini
+++ b/tests/wpt/meta/css/selectors/focus-within-shadow-002.html.ini
@@ -1,2 +1,2 @@
 [focus-within-shadow-002.html]
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/meta/css/selectors/focus-within-shadow-003.html.ini
+++ b/tests/wpt/meta/css/selectors/focus-within-shadow-003.html.ini
@@ -1,2 +1,2 @@
 [focus-within-shadow-003.html]
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/meta/css/selectors/focus-within-shadow-004.html.ini
+++ b/tests/wpt/meta/css/selectors/focus-within-shadow-004.html.ini
@@ -1,2 +1,2 @@
 [focus-within-shadow-004.html]
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/meta/css/selectors/focus-within-shadow-005.html.ini
+++ b/tests/wpt/meta/css/selectors/focus-within-shadow-005.html.ini
@@ -1,2 +1,2 @@
 [focus-within-shadow-005.html]
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/meta/css/selectors/focus-within-shadow-006.html.ini
+++ b/tests/wpt/meta/css/selectors/focus-within-shadow-006.html.ini
@@ -1,2 +1,2 @@
 [focus-within-shadow-006.html]
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/meta/css/selectors/i18n/lang-pseudo-class-across-shadow-boundaries.html.ini
+++ b/tests/wpt/meta/css/selectors/i18n/lang-pseudo-class-across-shadow-boundaries.html.ini
@@ -1,2 +1,2 @@
 [lang-pseudo-class-across-shadow-boundaries.html]
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/meta/css/selectors/is-where-shadow.html.ini
+++ b/tests/wpt/meta/css/selectors/is-where-shadow.html.ini
@@ -1,2 +1,9 @@
 [is-where-shadow.html]
-  expected: CRASH
+  [:is() inside :host()]
+    expected: FAIL
+
+  [:is() inside :host-context()]
+    expected: FAIL
+
+  [:is() inside ::slotted()]
+    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/2d.text-outside-of-the-flat-tree.html.ini
+++ b/tests/wpt/meta/html/canvas/element/2d.text-outside-of-the-flat-tree.html.ini
@@ -1,2 +1,2 @@
 [2d.text-outside-of-the-flat-tree.html]
-  expected: CRASH
+  expected: PASS

--- a/tests/wpt/meta/html/dom/elements/global-attributes/dir-auto-dynamic-changes.window.js.ini
+++ b/tests/wpt/meta/html/dom/elements/global-attributes/dir-auto-dynamic-changes.window.js.ini
@@ -1,5 +1,5 @@
 [dir-auto-dynamic-changes.window.html]
-  expected: CRASH
+  expected: OK
   [dynamic insertion of RTL text in a child element]
     expected: FAIL
 

--- a/tests/wpt/meta/html/dom/elements/global-attributes/dir-shadow-01.html.ini
+++ b/tests/wpt/meta/html/dom/elements/global-attributes/dir-shadow-01.html.ini
@@ -1,2 +1,2 @@
 [dir-shadow-01.html]
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/meta/html/dom/elements/global-attributes/dir-shadow-02.html.ini
+++ b/tests/wpt/meta/html/dom/elements/global-attributes/dir-shadow-02.html.ini
@@ -1,2 +1,2 @@
 [dir-shadow-02.html]
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/meta/html/dom/elements/global-attributes/dir-shadow-03.html.ini
+++ b/tests/wpt/meta/html/dom/elements/global-attributes/dir-shadow-03.html.ini
@@ -1,2 +1,2 @@
 [dir-shadow-03.html]
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/meta/html/dom/elements/global-attributes/dir-shadow-04.html.ini
+++ b/tests/wpt/meta/html/dom/elements/global-attributes/dir-shadow-04.html.ini
@@ -1,2 +1,2 @@
 [dir-shadow-04.html]
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/meta/html/dom/elements/global-attributes/dir-shadow-05.html.ini
+++ b/tests/wpt/meta/html/dom/elements/global-attributes/dir-shadow-05.html.ini
@@ -1,2 +1,2 @@
 [dir-shadow-05.html]
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/meta/html/dom/elements/global-attributes/dir-shadow-06.html.ini
+++ b/tests/wpt/meta/html/dom/elements/global-attributes/dir-shadow-06.html.ini
@@ -1,2 +1,2 @@
 [dir-shadow-06.html]
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/meta/html/dom/elements/global-attributes/dir-shadow-07.html.ini
+++ b/tests/wpt/meta/html/dom/elements/global-attributes/dir-shadow-07.html.ini
@@ -1,2 +1,2 @@
 [dir-shadow-07.html]
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/meta/html/dom/elements/global-attributes/dir-shadow-08.html.ini
+++ b/tests/wpt/meta/html/dom/elements/global-attributes/dir-shadow-08.html.ini
@@ -1,2 +1,2 @@
 [dir-shadow-08.html]
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/meta/html/dom/elements/global-attributes/dir-shadow-09.html.ini
+++ b/tests/wpt/meta/html/dom/elements/global-attributes/dir-shadow-09.html.ini
@@ -1,2 +1,2 @@
 [dir-shadow-09.html]
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/meta/html/dom/elements/global-attributes/dir-shadow-10.html.ini
+++ b/tests/wpt/meta/html/dom/elements/global-attributes/dir-shadow-10.html.ini
@@ -1,2 +1,2 @@
 [dir-shadow-10.html]
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/meta/html/dom/elements/global-attributes/dir-shadow-11.html.ini
+++ b/tests/wpt/meta/html/dom/elements/global-attributes/dir-shadow-11.html.ini
@@ -1,2 +1,2 @@
 [dir-shadow-11.html]
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/meta/html/dom/elements/global-attributes/dir-shadow-12.html.ini
+++ b/tests/wpt/meta/html/dom/elements/global-attributes/dir-shadow-12.html.ini
@@ -1,2 +1,2 @@
 [dir-shadow-12.html]
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/meta/html/dom/elements/global-attributes/dir-shadow-31.html.ini
+++ b/tests/wpt/meta/html/dom/elements/global-attributes/dir-shadow-31.html.ini
@@ -1,2 +1,2 @@
 [dir-shadow-31.html]
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/meta/html/dom/elements/global-attributes/dir-shadow-35.html.ini
+++ b/tests/wpt/meta/html/dom/elements/global-attributes/dir-shadow-35.html.ini
@@ -1,2 +1,2 @@
 [dir-shadow-35.html]
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/meta/html/dom/elements/global-attributes/dir-shadow-41.html.ini
+++ b/tests/wpt/meta/html/dom/elements/global-attributes/dir-shadow-41.html.ini
@@ -1,2 +1,2 @@
 [dir-shadow-41.html]
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/meta/html/dom/elements/global-attributes/dir-shadow-42.html.ini
+++ b/tests/wpt/meta/html/dom/elements/global-attributes/dir-shadow-42.html.ini
@@ -1,2 +1,2 @@
 [dir-shadow-42.html]
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/meta/html/dom/elements/global-attributes/dir-slots-directionality.html.ini
+++ b/tests/wpt/meta/html/dom/elements/global-attributes/dir-slots-directionality.html.ini
@@ -1,5 +1,5 @@
 [dir-slots-directionality.html]
-  expected: CRASH
+  expected: OK
   [Slots: Directionality: dir=rtl on slot]
     expected: FAIL
 

--- a/tests/wpt/meta/html/editing/editing-0/contenteditable/contentEditable-slotted-inherit.html.ini
+++ b/tests/wpt/meta/html/editing/editing-0/contenteditable/contentEditable-slotted-inherit.html.ini
@@ -1,5 +1,5 @@
 [contentEditable-slotted-inherit.html]
-  expected: CRASH
+  expected: OK
   [Slotted child of contenteditable host should be editable - slot direct child of shadow root]
     expected: FAIL
 

--- a/tests/wpt/meta/html/rendering/non-replaced-elements/the-fieldset-and-legend-elements/legend-in-slot.html.ini
+++ b/tests/wpt/meta/html/rendering/non-replaced-elements/the-fieldset-and-legend-elements/legend-in-slot.html.ini
@@ -1,2 +1,2 @@
 [legend-in-slot.html]
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/meta/html/rendering/non-replaced-elements/the-fieldset-and-legend-elements/sticky-content-crash.html.ini
+++ b/tests/wpt/meta/html/rendering/non-replaced-elements/the-fieldset-and-legend-elements/sticky-content-crash.html.ini
@@ -1,2 +1,2 @@
 [sticky-content-crash.html]
-  expected: CRASH
+  expected: PASS

--- a/tests/wpt/meta/html/semantics/interactive-elements/the-dialog-element/showmodal-in-shadow-crash.html.ini
+++ b/tests/wpt/meta/html/semantics/interactive-elements/the-dialog-element/showmodal-in-shadow-crash.html.ini
@@ -1,2 +1,0 @@
-[showmodal-in-shadow-crash.html]
-  expected: CRASH

--- a/tests/wpt/meta/selection/shadow-dom/tentative/Selection-getComposedRanges-dom-mutations-removal.html.ini
+++ b/tests/wpt/meta/selection/shadow-dom/tentative/Selection-getComposedRanges-dom-mutations-removal.html.ini
@@ -1,5 +1,5 @@
 [Selection-getComposedRanges-dom-mutations-removal.html?mode=open]
-  expected: CRASH
+  expected: OK
   [Range is fully in shadow tree. Removing shadow host collapses composed StaticRange. Note it does not update previously returned composed StaticRange.]
     expected: FAIL
 
@@ -17,7 +17,7 @@
 
 
 [Selection-getComposedRanges-dom-mutations-removal.html?mode=closed]
-  expected: CRASH
+  expected: OK
   [Range is fully in shadow tree. Removing shadow host collapses composed StaticRange. Note it does not update previously returned composed StaticRange.]
     expected: FAIL
 

--- a/tests/wpt/meta/selection/shadow-dom/tentative/Selection-later-become-slotted-content.html.ini
+++ b/tests/wpt/meta/selection/shadow-dom/tentative/Selection-later-become-slotted-content.html.ini
@@ -1,4 +1,4 @@
 [Selection-later-become-slotted-content.html]
-  expected: CRASH
+  expected: OK
   [test to select a light DOM element and it becomes a slotted content after the selection]
     expected: FAIL

--- a/tests/wpt/meta/shadow-dom/declarative/declarative-after-attachshadow.html.ini
+++ b/tests/wpt/meta/shadow-dom/declarative/declarative-after-attachshadow.html.ini
@@ -1,2 +1,3 @@
 [declarative-after-attachshadow.html]
-  expected: CRASH
+  [Declarative Shadow DOM: declarative shadow should fail if attachShadow() already called]
+    expected: FAIL

--- a/tests/wpt/meta/shadow-dom/declarative/declarative-shadow-dom-repeats.html.ini
+++ b/tests/wpt/meta/shadow-dom/declarative/declarative-shadow-dom-repeats.html.ini
@@ -1,2 +1,9 @@
 [declarative-shadow-dom-repeats.html]
-  expected: CRASH
+  [Repeated declarative shadow roots keep only the first]
+    expected: FAIL
+
+  [Calling attachShadow() on declarative shadow root must match mode]
+    expected: FAIL
+
+  [Calling attachShadow() on declarative shadow root must match all parameters]
+    expected: FAIL

--- a/tests/wpt/meta/shadow-dom/declarative/innerhtml-on-ordinary-template.html.ini
+++ b/tests/wpt/meta/shadow-dom/declarative/innerhtml-on-ordinary-template.html.ini
@@ -1,2 +1,3 @@
 [innerhtml-on-ordinary-template.html]
-  expected: CRASH
+  [Declarative Shadow DOM: innerHTML should work on <template shadowroot> that is left over]
+    expected: FAIL

--- a/tests/wpt/meta/shadow-dom/directionality-001.tentative.html.ini
+++ b/tests/wpt/meta/shadow-dom/directionality-001.tentative.html.ini
@@ -1,2 +1,2 @@
 [directionality-001.tentative.html]
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/meta/shadow-dom/directionality-002.tentative.html.ini
+++ b/tests/wpt/meta/shadow-dom/directionality-002.tentative.html.ini
@@ -1,2 +1,2 @@
 [directionality-002.tentative.html]
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/meta/shadow-dom/event-inside-slotted-node.html.ini
+++ b/tests/wpt/meta/shadow-dom/event-inside-slotted-node.html.ini
@@ -1,2 +1,60 @@
 [event-inside-slotted-node.html]
-  expected: CRASH
+  [Firing an event inside a grand child of a detached open mode shadow host]
+    expected: FAIL
+
+  [Firing an event inside a grand child of a detached closed mode shadow host]
+    expected: FAIL
+
+  [Firing an event inside a grand child of an in-document open mode shadow host]
+    expected: FAIL
+
+  [Firing an event inside a grand child of an in-document closed mode shadow host]
+    expected: FAIL
+
+  [Firing an event on a node with two ancestors with a detached open and open shadow trees with an inner open shadow tree]
+    expected: FAIL
+
+  [Firing an event on a node with two ancestors with a detached open and open shadow trees with an inner closed shadow tree]
+    expected: FAIL
+
+  [Firing an event on a node with two ancestors with a detached open and closed shadow trees with an inner open shadow tree]
+    expected: FAIL
+
+  [Firing an event on a node with two ancestors with a detached open and closed shadow trees with an inner closed shadow tree]
+    expected: FAIL
+
+  [Firing an event on a node with two ancestors with a detached closed and open shadow trees with an inner open shadow tree]
+    expected: FAIL
+
+  [Firing an event on a node with two ancestors with a detached closed and open shadow trees with an inner closed shadow tree]
+    expected: FAIL
+
+  [Firing an event on a node with two ancestors with a detached closed and closed shadow trees with an inner open shadow tree]
+    expected: FAIL
+
+  [Firing an event on a node with two ancestors with a detached closed and closed shadow trees with an inner closed shadow tree]
+    expected: FAIL
+
+  [Firing an event on a node within a open shadow tree that is itself a open shadow tree (the latter being the descendent of a host for a separate open shadow tree)]
+    expected: FAIL
+
+  [Firing an event on a node within a closed shadow tree that is itself a open shadow tree (the latter being the descendent of a host for a separate open shadow tree)]
+    expected: FAIL
+
+  [Firing an event on a node within a open shadow tree that is itself a closed shadow tree (the latter being the descendent of a host for a separate open shadow tree)]
+    expected: FAIL
+
+  [Firing an event on a node within a closed shadow tree that is itself a closed shadow tree (the latter being the descendent of a host for a separate open shadow tree)]
+    expected: FAIL
+
+  [Firing an event on a node within a open shadow tree that is itself a open shadow tree (the latter being the descendent of a host for a separate closed shadow tree)]
+    expected: FAIL
+
+  [Firing an event on a node within a closed shadow tree that is itself a open shadow tree (the latter being the descendent of a host for a separate closed shadow tree)]
+    expected: FAIL
+
+  [Firing an event on a node within a open shadow tree that is itself a closed shadow tree (the latter being the descendent of a host for a separate closed shadow tree)]
+    expected: FAIL
+
+  [Firing an event on a node within a closed shadow tree that is itself a closed shadow tree (the latter being the descendent of a host for a separate closed shadow tree)]
+    expected: FAIL

--- a/tests/wpt/meta/shadow-dom/focus/focus-pseudo-on-shadow-host-2.html.ini
+++ b/tests/wpt/meta/shadow-dom/focus/focus-pseudo-on-shadow-host-2.html.ini
@@ -1,2 +1,2 @@
 [focus-pseudo-on-shadow-host-2.html]
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/meta/shadow-dom/focus/focus-pseudo-on-shadow-host-3.html.ini
+++ b/tests/wpt/meta/shadow-dom/focus/focus-pseudo-on-shadow-host-3.html.ini
@@ -1,2 +1,0 @@
-[focus-pseudo-on-shadow-host-3.html]
-  expected: CRASH

--- a/tests/wpt/meta/shadow-dom/imperative-slot-api-crash.html.ini
+++ b/tests/wpt/meta/shadow-dom/imperative-slot-api-crash.html.ini
@@ -1,2 +1,0 @@
-[imperative-slot-api-crash.html]
-  expected: CRASH

--- a/tests/wpt/meta/shadow-dom/imperative-slot-fallback-clear.html.ini
+++ b/tests/wpt/meta/shadow-dom/imperative-slot-fallback-clear.html.ini
@@ -1,2 +1,6 @@
 [imperative-slot-fallback-clear.html]
-  expected: CRASH
+  [Text node fallback should be cleared in a subsequently layout]
+    expected: FAIL
+
+  [Element fallback should be cleared in a subsequent layout]
+    expected: FAIL

--- a/tests/wpt/meta/shadow-dom/imperative-slot-layout-invalidation-001.html.ini
+++ b/tests/wpt/meta/shadow-dom/imperative-slot-layout-invalidation-001.html.ini
@@ -1,2 +1,2 @@
 [imperative-slot-layout-invalidation-001.html]
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/meta/shadow-dom/layout-slot-no-longer-assigned.html.ini
+++ b/tests/wpt/meta/shadow-dom/layout-slot-no-longer-assigned.html.ini
@@ -1,2 +1,0 @@
-[layout-slot-no-longer-assigned.html]
-  expected: CRASH

--- a/tests/wpt/meta/shadow-dom/layout-slot-no-longer-fallback.html.ini
+++ b/tests/wpt/meta/shadow-dom/layout-slot-no-longer-fallback.html.ini
@@ -1,2 +1,0 @@
-[layout-slot-no-longer-fallback.html]
-  expected: CRASH

--- a/tests/wpt/meta/shadow-dom/slot-fallback-content-001.html.ini
+++ b/tests/wpt/meta/shadow-dom/slot-fallback-content-001.html.ini
@@ -1,2 +1,0 @@
-[slot-fallback-content-001.html]
-  expected: CRASH

--- a/tests/wpt/meta/shadow-dom/slot-fallback-content-002.html.ini
+++ b/tests/wpt/meta/shadow-dom/slot-fallback-content-002.html.ini
@@ -1,2 +1,0 @@
-[slot-fallback-content-002.html]
-  expected: CRASH

--- a/tests/wpt/meta/shadow-dom/slot-fallback-content-004.html.ini
+++ b/tests/wpt/meta/shadow-dom/slot-fallback-content-004.html.ini
@@ -1,2 +1,2 @@
 [slot-fallback-content-004.html]
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/meta/shadow-dom/slot-fallback-content-005.html.ini
+++ b/tests/wpt/meta/shadow-dom/slot-fallback-content-005.html.ini
@@ -1,2 +1,2 @@
 [slot-fallback-content-005.html]
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/meta/shadow-dom/slot-fallback-content-006.html.ini
+++ b/tests/wpt/meta/shadow-dom/slot-fallback-content-006.html.ini
@@ -1,2 +1,2 @@
 [slot-fallback-content-006.html]
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/meta/shadow-dom/slot-fallback-content-007.html.ini
+++ b/tests/wpt/meta/shadow-dom/slot-fallback-content-007.html.ini
@@ -1,2 +1,2 @@
 [slot-fallback-content-007.html]
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/meta/shadow-dom/slot-fallback-content-008.html.ini
+++ b/tests/wpt/meta/shadow-dom/slot-fallback-content-008.html.ini
@@ -1,2 +1,2 @@
 [slot-fallback-content-008.html]
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/meta/shadow-dom/slotchange-event.html.ini
+++ b/tests/wpt/meta/shadow-dom/slotchange-event.html.ini
@@ -1,2 +1,96 @@
 [slotchange-event.html]
-  expected: CRASH
+  [slotchange event must fire on a default slot element inside an open shadow root  in a document]
+    expected: FAIL
+
+  [slotchange event must fire on a default slot element inside a closed shadow root  in a document]
+    expected: FAIL
+
+  [slotchange event must fire on a default slot element inside an open shadow root  not in a document]
+    expected: FAIL
+
+  [slotchange event must fire on a default slot element inside a closed shadow root  not in a document]
+    expected: FAIL
+
+  [slotchange event must fire on a named slot element insidean open shadow root  in a document]
+    expected: FAIL
+
+  [slotchange event must fire on a named slot element insidea closed shadow root  in a document]
+    expected: FAIL
+
+  [slotchange event must fire on a named slot element insidean open shadow root  not in a document]
+    expected: FAIL
+
+  [slotchange event must fire on a named slot element insidea closed shadow root  not in a document]
+    expected: FAIL
+
+  [slotchange event must not fire on a slot element inside an open shadow root  in a document when another slot's assigned nodes change]
+    expected: FAIL
+
+  [slotchange event must not fire on a slot element inside a closed shadow root  in a document when another slot's assigned nodes change]
+    expected: FAIL
+
+  [slotchange event must not fire on a slot element inside an open shadow root  not in a document when another slot's assigned nodes change]
+    expected: FAIL
+
+  [slotchange event must not fire on a slot element inside a closed shadow root  not in a document when another slot's assigned nodes change]
+    expected: FAIL
+
+  [slotchange event must fire on a slot element when a shadow host has a slottable and the slot was inserted and must not fire when the shadow host was mutated after the slot was removed inside an open shadow root  in a document]
+    expected: FAIL
+
+  [slotchange event must fire on a slot element when a shadow host has a slottable and the slot was inserted and must not fire when the shadow host was mutated after the slot was removed inside a closed shadow root  in a document]
+    expected: FAIL
+
+  [slotchange event must fire on a slot element when a shadow host has a slottable and the slot was inserted and must not fire when the shadow host was mutated after the slot was removed inside an open shadow root  not in a document]
+    expected: FAIL
+
+  [slotchange event must fire on a slot element when a shadow host has a slottable and the slot was inserted and must not fire when the shadow host was mutated after the slot was removed inside a closed shadow root  not in a document]
+    expected: FAIL
+
+  [slotchange event must fire on a slot element inside an open shadow root  in a document even if the slot was removed immediately after the assigned nodes were mutated]
+    expected: FAIL
+
+  [slotchange event must fire on a slot element inside a closed shadow root  in a document even if the slot was removed immediately after the assigned nodes were mutated]
+    expected: FAIL
+
+  [slotchange event must fire on a slot element inside an open shadow root  not in a document even if the slot was removed immediately after the assigned nodes were mutated]
+    expected: FAIL
+
+  [slotchange event must fire on a slot element inside a closed shadow root  not in a document even if the slot was removed immediately after the assigned nodes were mutated]
+    expected: FAIL
+
+  [slotchange event must fire on a slot element inside an open shadow root  in a document when innerHTML modifies the children of the shadow host]
+    expected: FAIL
+
+  [slotchange event must fire on a slot element inside a closed shadow root  in a document when innerHTML modifies the children of the shadow host]
+    expected: FAIL
+
+  [slotchange event must fire on a slot element inside an open shadow root  not in a document when innerHTML modifies the children of the shadow host]
+    expected: FAIL
+
+  [slotchange event must fire on a slot element inside a closed shadow root  not in a document when innerHTML modifies the children of the shadow host]
+    expected: FAIL
+
+  [slotchange event must fire on a slot element inside an open shadow root  in a document when nested slots's contents change]
+    expected: FAIL
+
+  [slotchange event must fire on a slot element inside a closed shadow root  in a document when nested slots's contents change]
+    expected: FAIL
+
+  [slotchange event must fire on a slot element inside an open shadow root  not in a document when nested slots's contents change]
+    expected: FAIL
+
+  [slotchange event must fire on a slot element inside a closed shadow root  not in a document when nested slots's contents change]
+    expected: FAIL
+
+  [slotchange event must fire at the end of current microtask after mutation observers are invoked inside an open shadow root  in a document when slots's contents change]
+    expected: FAIL
+
+  [slotchange event must fire at the end of current microtask after mutation observers are invoked inside a closed shadow root  in a document when slots's contents change]
+    expected: FAIL
+
+  [slotchange event must fire at the end of current microtask after mutation observers are invoked inside an open shadow root  not in a document when slots's contents change]
+    expected: FAIL
+
+  [slotchange event must fire at the end of current microtask after mutation observers are invoked inside a closed shadow root  not in a document when slots's contents change]
+    expected: FAIL

--- a/tests/wpt/meta/shadow-dom/slots-outside-shadow-dom.html.ini
+++ b/tests/wpt/meta/shadow-dom/slots-outside-shadow-dom.html.ini
@@ -1,2 +1,3 @@
 [slots-outside-shadow-dom.html]
-  expected: CRASH
+  [Light DOM slot element should be in flattened assignedNodes]
+    expected: FAIL

--- a/tests/wpt/meta/shadow-dom/untriaged/elements-and-dom-objects/extensions-to-element-interface/methods/test-002.html.ini
+++ b/tests/wpt/meta/shadow-dom/untriaged/elements-and-dom-objects/extensions-to-element-interface/methods/test-002.html.ini
@@ -1,2 +1,3 @@
 [test-002.html]
-  expected: CRASH
+  [A_10_02_02_02_T01]
+    expected: FAIL

--- a/tests/wpt/meta/shadow-dom/untriaged/events/event-retargeting/test-003.html.ini
+++ b/tests/wpt/meta/shadow-dom/untriaged/events/event-retargeting/test-003.html.ini
@@ -1,2 +1,0 @@
-[test-003.html]
-  expected: CRASH

--- a/tests/wpt/meta/shadow-dom/untriaged/events/retargeting-focus-events/test-001.html.ini
+++ b/tests/wpt/meta/shadow-dom/untriaged/events/retargeting-focus-events/test-001.html.ini
@@ -1,2 +1,0 @@
-[test-001.html]
-  expected: CRASH

--- a/tests/wpt/meta/shadow-dom/untriaged/shadow-trees/reprojection/reprojection-001.html.ini
+++ b/tests/wpt/meta/shadow-dom/untriaged/shadow-trees/reprojection/reprojection-001.html.ini
@@ -1,2 +1,2 @@
 [reprojection-001.html]
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/meta/shadow-dom/untriaged/shadow-trees/shadow-root-002.html.ini
+++ b/tests/wpt/meta/shadow-dom/untriaged/shadow-trees/shadow-root-002.html.ini
@@ -1,2 +1,2 @@
 [shadow-root-002.html]
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/meta/shadow-dom/untriaged/styles/test-008.html.ini
+++ b/tests/wpt/meta/shadow-dom/untriaged/styles/test-008.html.ini
@@ -1,2 +1,3 @@
 [test-008.html]
-  expected: CRASH
+  [A_06_00_09_T01]
+    expected: FAIL

--- a/tests/wpt/meta/shadow-dom/untriaged/user-interaction/ranges-and-selections/test-001.html.ini
+++ b/tests/wpt/meta/shadow-dom/untriaged/user-interaction/ranges-and-selections/test-001.html.ini
@@ -1,2 +1,0 @@
-[test-001.html]
-  expected: CRASH

--- a/tests/wpt/meta/shadow-dom/untriaged/user-interaction/ranges-and-selections/test-002.html.ini
+++ b/tests/wpt/meta/shadow-dom/untriaged/user-interaction/ranges-and-selections/test-002.html.ini
@@ -1,2 +1,6 @@
 [test-002.html]
-  expected: CRASH
+  [A_07_01_02_T01]
+    expected: FAIL
+
+  [A_07_07_02_T02]
+    expected: FAIL


### PR DESCRIPTION
Currently `ServoLayoutElement::traversal_children` fails to account for children outside the shadow DOM if the element is a shadow host:
https://github.com/servo/servo/blob/c73e4baca206c172802be145c1fb8d110c1be863/components/script/layout_dom/element.rs#L151-L157

Stylo doesn't know about those children, so they are never assigned a style. Trying to access the style data causes crashes as seen in #33495.

There are no tests for these changes, because we don't run `shadow-dom` web platform tests. Perhaps we should consider changing that?

[try run](https://github.com/simonwuelker/servo/actions/runs/11925266716)

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #33495


