### PR TITLE
Add @jschwe to `CODEOWNERS` for OpenHarmony-related code

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,3 +2,9 @@
 
 
 /components/script/  @gterzian
+
+# Reviewers for OpenHarmony related code
+/support/openharmony/                       @jschwe
+/ports/servoshell/egl/                      @jschwe
+/components/fonts/platform/freetype/ohos/   @jschwe
+/.github/workflows/ohos.yml                 @jschwe


### PR DESCRIPTION
Add myself as a reviewer for OpenHarmony related code


---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

