### PR TITLE
Implement `element.shadowRoot` attribute

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -509,8 +509,6 @@ impl Element {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-element-attachshadow>
-    /// XXX This is not exposed to web content yet. It is meant to be used
-    ///     for UA widgets only.
     pub fn attach_shadow(
         &self,
         is_ua_widget: IsUserAgentWidget,
@@ -3056,8 +3054,6 @@ impl ElementMethods for Element {
         doc.enter_fullscreen(self, can_gc)
     }
 
-    // XXX Hidden under dom.shadowdom.enabled pref. Only exposed to be able
-    //     to test partial Shadow DOM support for UA widgets.
     // https://dom.spec.whatwg.org/#dom-element-attachshadow
     fn AttachShadow(&self, init: &ShadowRootInit) -> Fallible<DomRoot<ShadowRoot>> {
         // Step 1. Run attach a shadow root with this, init["mode"], init["clonable"], init["serializable"],

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -54,6 +54,7 @@ use crate::dom::bindings::codegen::Bindings::MediaErrorBinding::MediaErrorConsta
 use crate::dom::bindings::codegen::Bindings::MediaErrorBinding::MediaErrorMethods;
 use crate::dom::bindings::codegen::Bindings::NavigatorBinding::Navigator_Binding::NavigatorMethods;
 use crate::dom::bindings::codegen::Bindings::NodeBinding::Node_Binding::NodeMethods;
+use crate::dom::bindings::codegen::Bindings::ShadowRootBinding::ShadowRootMode;
 use crate::dom::bindings::codegen::Bindings::TextTrackBinding::{TextTrackKind, TextTrackMode};
 use crate::dom::bindings::codegen::Bindings::URLBinding::URLMethods;
 use crate::dom::bindings::codegen::Bindings::WindowBinding::Window_Binding::WindowMethods;
@@ -1908,7 +1909,9 @@ impl HTMLMediaElement {
             // if we are already showing the controls.
             return;
         }
-        let shadow_root = element.attach_shadow(IsUserAgentWidget::Yes).unwrap();
+        let shadow_root = element
+            .attach_shadow(IsUserAgentWidget::Yes, ShadowRootMode::Closed)
+            .unwrap();
         let document = document_from_node(self);
         let script = HTMLScriptElement::new(
             local_name!("script"),

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -36,7 +36,7 @@ pub enum IsUserAgentWidget {
     Yes,
 }
 
-// https://dom.spec.whatwg.org/#interface-shadowroot
+/// <https://dom.spec.whatwg.org/#interface-shadowroot>
 #[dom_struct]
 pub struct ShadowRoot {
     document_fragment: DocumentFragment,
@@ -48,11 +48,14 @@ pub struct ShadowRoot {
     author_styles: DomRefCell<AuthorStyles<StyleSheetInDocument>>,
     stylesheet_list: MutNullableDom<StyleSheetList>,
     window: Dom<Window>,
+
+    /// <https://dom.spec.whatwg.org/#dom-shadowroot-mode>
+    mode: ShadowRootMode,
 }
 
 impl ShadowRoot {
     #[allow(crown::unrooted_must_root)]
-    fn new_inherited(host: &Element, document: &Document) -> ShadowRoot {
+    fn new_inherited(host: &Element, document: &Document, mode: ShadowRootMode) -> ShadowRoot {
         let document_fragment = DocumentFragment::new_inherited(document);
         let node = document_fragment.upcast::<Node>();
         node.set_flag(NodeFlags::IS_IN_SHADOW_TREE, true);
@@ -60,6 +63,7 @@ impl ShadowRoot {
             NodeFlags::IS_CONNECTED,
             host.upcast::<Node>().is_connected(),
         );
+
         ShadowRoot {
             document_fragment,
             document_or_shadow_root: DocumentOrShadowRoot::new(document.window()),
@@ -68,12 +72,13 @@ impl ShadowRoot {
             author_styles: DomRefCell::new(AuthorStyles::new()),
             stylesheet_list: MutNullableDom::new(None),
             window: Dom::from_ref(document.window()),
+            mode,
         }
     }
 
-    pub fn new(host: &Element, document: &Document) -> DomRoot<ShadowRoot> {
+    pub fn new(host: &Element, document: &Document, mode: ShadowRootMode) -> DomRoot<ShadowRoot> {
         reflect_dom_object(
-            Box::new(ShadowRoot::new_inherited(host, document)),
+            Box::new(ShadowRoot::new_inherited(host, document, mode)),
             document.window(),
         )
     }
@@ -226,7 +231,7 @@ impl ShadowRootMethods for ShadowRoot {
 
     /// <https://dom.spec.whatwg.org/#dom-shadowroot-mode>
     fn Mode(&self) -> ShadowRootMode {
-        ShadowRootMode::Closed
+        self.mode
     }
 
     /// <https://dom.spec.whatwg.org/#dom-shadowroot-host>

--- a/components/script/dom/webidls/Element.webidl
+++ b/components/script/dom/webidls/Element.webidl
@@ -83,7 +83,16 @@ interface Element : Node {
   [CEReactions, Throws]
   undefined insertAdjacentHTML(DOMString position, DOMString html);
 
-  [Throws, Pref="dom.shadowdom.enabled"] ShadowRoot attachShadow();
+  [Throws, Pref="dom.shadowdom.enabled"] ShadowRoot attachShadow(ShadowRootInit init);
+  readonly attribute ShadowRoot? shadowRoot;
+};
+
+dictionary ShadowRootInit {
+  required ShadowRootMode mode;
+  // boolean delegatesFocus = false;
+  // SlotAssignmentMode slotAssignment = "named";
+  // boolean clonable = false;
+  // boolean serializable = false;
 };
 
 // http://dev.w3.org/csswg/cssom-view/#extensions-to-the-element-interface

--- a/components/script/dom/webidls/ShadowRoot.webidl
+++ b/components/script/dom/webidls/ShadowRoot.webidl
@@ -13,5 +13,6 @@ interface ShadowRoot : DocumentFragment {
 };
 
 enum ShadowRootMode { "open", "closed"};
+// enum SlotAssignmentMode { "manual", "named" };
 
 ShadowRoot includes DocumentOrShadowRoot;

--- a/tests/wpt/meta/css/css-transforms/transform-origin-in-shadow.html.ini
+++ b/tests/wpt/meta/css/css-transforms/transform-origin-in-shadow.html.ini
@@ -1,2 +1,3 @@
 [transform-origin-in-shadow.html]
-  expected: ERROR
+  ['transform-origin' on <svg> being direct descendant of shadow root]
+    expected: FAIL

--- a/tests/wpt/meta/dom/idlharness.window.js.ini
+++ b/tests/wpt/meta/dom/idlharness.window.js.ini
@@ -64,9 +64,6 @@
   [XPathResult interface: constant STRING_TYPE on interface prototype object]
     expected: FAIL
 
-  [Element interface: attribute shadowRoot]
-    expected: FAIL
-
   [XPathResult interface: document.evaluate("//*", document.body) must inherit property "ORDERED_NODE_ITERATOR_TYPE" with the proper type]
     expected: FAIL
 
@@ -89,9 +86,6 @@
     expected: FAIL
 
   [EventTarget interface: new AbortController().signal must inherit property "removeEventListener(DOMString, EventListener?, optional (EventListenerOptions or boolean))" with the proper type]
-    expected: FAIL
-
-  [Element interface: operation attachShadow(ShadowRootInit)]
     expected: FAIL
 
   [Document interface: xmlDoc must inherit property "createNSResolver(Node)" with the proper type]
@@ -122,9 +116,6 @@
     expected: FAIL
 
   [XPathResult interface: constant UNORDERED_NODE_SNAPSHOT_TYPE on interface prototype object]
-    expected: FAIL
-
-  [Element interface: calling attachShadow(ShadowRootInit) on element with too few arguments must throw TypeError]
     expected: FAIL
 
   [XPathResult interface: constant ORDERED_NODE_SNAPSHOT_TYPE on interface object]
@@ -509,9 +500,6 @@
     expected: FAIL
 
   [Element interface: operation append((Node or DOMString)...)]
-    expected: FAIL
-
-  [Element interface: element must inherit property "shadowRoot" with the proper type]
     expected: FAIL
 
   [XPathEvaluator interface: existence and properties of interface prototype object]

--- a/tests/wpt/meta/html/semantics/interactive-elements/the-dialog-element/dialog-focus-shadow-double-nested.html.ini
+++ b/tests/wpt/meta/html/semantics/interactive-elements/the-dialog-element/dialog-focus-shadow-double-nested.html.ini
@@ -1,2 +1,2 @@
 [dialog-focus-shadow-double-nested.html]
-  expected: ERROR
+  expected: CRASH

--- a/tests/wpt/meta/html/semantics/interactive-elements/the-dialog-element/dialog-focus-shadow.html.ini
+++ b/tests/wpt/meta/html/semantics/interactive-elements/the-dialog-element/dialog-focus-shadow.html.ini
@@ -1,2 +1,150 @@
 [dialog-focus-shadow.html]
-  expected: ERROR
+  [show: No autofocus, no delegatesFocus, no siblings]
+    expected: FAIL
+
+  [showModal: No autofocus, no delegatesFocus, no siblings]
+    expected: FAIL
+
+  [show: No autofocus, no delegatesFocus, sibling before]
+    expected: FAIL
+
+  [showModal: No autofocus, no delegatesFocus, sibling before]
+    expected: FAIL
+
+  [show: No autofocus, no delegatesFocus, sibling after]
+    expected: FAIL
+
+  [showModal: No autofocus, no delegatesFocus, sibling after]
+    expected: FAIL
+
+  [show: No autofocus, yes delegatesFocus, no siblings]
+    expected: FAIL
+
+  [showModal: No autofocus, yes delegatesFocus, no siblings]
+    expected: FAIL
+
+  [show: No autofocus, yes delegatesFocus, sibling before]
+    expected: FAIL
+
+  [showModal: No autofocus, yes delegatesFocus, sibling before]
+    expected: FAIL
+
+  [show: No autofocus, yes delegatesFocus, sibling after]
+    expected: FAIL
+
+  [showModal: No autofocus, yes delegatesFocus, sibling after]
+    expected: FAIL
+
+  [show: Autofocus before, no delegatesFocus]
+    expected: FAIL
+
+  [showModal: Autofocus before, no delegatesFocus]
+    expected: FAIL
+
+  [show: Autofocus before, yes delegatesFocus]
+    expected: FAIL
+
+  [showModal: Autofocus before, yes delegatesFocus]
+    expected: FAIL
+
+  [show: Autofocus after, no delegatesFocus]
+    expected: FAIL
+
+  [showModal: Autofocus after, no delegatesFocus]
+    expected: FAIL
+
+  [show: Autofocus after, yes delegatesFocus]
+    expected: FAIL
+
+  [showModal: Autofocus after, yes delegatesFocus]
+    expected: FAIL
+
+  [show: Autofocus on shadow host, yes delegatesFocus, no siblings]
+    expected: FAIL
+
+  [showModal: Autofocus on shadow host, yes delegatesFocus, no siblings]
+    expected: FAIL
+
+  [show: Autofocus on shadow host, yes delegatesFocus, sibling before]
+    expected: FAIL
+
+  [showModal: Autofocus on shadow host, yes delegatesFocus, sibling before]
+    expected: FAIL
+
+  [show: Autofocus on shadow host, yes delegatesFocus, sibling after]
+    expected: FAIL
+
+  [showModal: Autofocus on shadow host, yes delegatesFocus, sibling after]
+    expected: FAIL
+
+  [show: Autofocus on shadow host, no delegatesFocus, no siblings]
+    expected: FAIL
+
+  [showModal: Autofocus on shadow host, no delegatesFocus, no siblings]
+    expected: FAIL
+
+  [show: Autofocus on shadow host, no delegatesFocus, sibling before]
+    expected: FAIL
+
+  [showModal: Autofocus on shadow host, no delegatesFocus, sibling before]
+    expected: FAIL
+
+  [show: Autofocus on shadow host, no delegatesFocus, sibling after]
+    expected: FAIL
+
+  [showModal: Autofocus on shadow host, no delegatesFocus, sibling after]
+    expected: FAIL
+
+  [show: Autofocus inside shadow tree, yes delegatesFocus, no siblings]
+    expected: FAIL
+
+  [showModal: Autofocus inside shadow tree, yes delegatesFocus, no siblings]
+    expected: FAIL
+
+  [show: Autofocus inside shadow tree, yes delegatesFocus, sibling before]
+    expected: FAIL
+
+  [showModal: Autofocus inside shadow tree, yes delegatesFocus, sibling before]
+    expected: FAIL
+
+  [show: Autofocus inside shadow tree, yes delegatesFocus, sibling after]
+    expected: FAIL
+
+  [showModal: Autofocus inside shadow tree, yes delegatesFocus, sibling after]
+    expected: FAIL
+
+  [show: Autofocus inside shadow tree, no delegatesFocus, no siblings]
+    expected: FAIL
+
+  [showModal: Autofocus inside shadow tree, no delegatesFocus, no siblings]
+    expected: FAIL
+
+  [show: Autofocus inside shadow tree, no delegatesFocus, sibling before]
+    expected: FAIL
+
+  [showModal: Autofocus inside shadow tree, no delegatesFocus, sibling before]
+    expected: FAIL
+
+  [show: Autofocus inside shadow tree, no delegatesFocus, sibling after]
+    expected: FAIL
+
+  [showModal: Autofocus inside shadow tree, no delegatesFocus, sibling after]
+    expected: FAIL
+
+  [show: Two shadow trees, both delegatesFocus, first tree doesn't have autofocus element, second does]
+    expected: FAIL
+
+  [showModal: Two shadow trees, both delegatesFocus, first tree doesn't have autofocus element, second does]
+    expected: FAIL
+
+  [show: No autofocus, no delegatesFocus, slotted target]
+    expected: FAIL
+
+  [showModal: No autofocus, no delegatesFocus, slotted target]
+    expected: FAIL
+
+  [show: Shadowroot on child, no autofocus, no delegatesFocus]
+    expected: FAIL
+
+  [showModal: Shadowroot on child, no autofocus, no delegatesFocus]
+    expected: FAIL

--- a/tests/wpt/meta/shadow-dom/Element-interface-attachShadow.html.ini
+++ b/tests/wpt/meta/shadow-dom/Element-interface-attachShadow.html.ini
@@ -1,6 +1,3 @@
 [Element-interface-attachShadow.html]
-  [Element.attachShadow must throw a TypeError if mode is not "open" or "closed"]
-    expected: FAIL
-
   [Element.attachShadow must throw a NotSupportedError if the context object already hosts a shadow tree]
     expected: FAIL

--- a/tests/wpt/meta/shadow-dom/Element-interface-shadowRoot-attribute.html.ini
+++ b/tests/wpt/meta/shadow-dom/Element-interface-shadowRoot-attribute.html.ini
@@ -1,9 +1,0 @@
-[Element-interface-shadowRoot-attribute.html]
-  [shadowRoot must be defined on Element prototype]
-    expected: FAIL
-
-  [shadowRoot attribute must return the open shadow root associated with the element]
-    expected: FAIL
-
-  [shadowRoot attribute must return null if the shadow root attached to the element is closed]
-    expected: FAIL

--- a/tests/wpt/meta/shadow-dom/Node-prototype-cloneNode.html.ini
+++ b/tests/wpt/meta/shadow-dom/Node-prototype-cloneNode.html.ini
@@ -4,6 +4,3 @@
 
   [cloneNode on a shadow root in closed mode must throw a NotSupportedError]
     expected: FAIL
-
-  [cloneNode on an element with an open shadow root should not clone its shadow root]
-    expected: FAIL

--- a/tests/wpt/meta/shadow-dom/declarative/declarative-shadow-dom-basic.html.ini
+++ b/tests/wpt/meta/shadow-dom/declarative/declarative-shadow-dom-basic.html.ini
@@ -56,8 +56,5 @@
   [Declarative Shadow DOM: template containing declarative shadow root and UA shadow root]
     expected: FAIL
 
-  [Declarative Shadow DOM: declarative shadow roots are not supported by the template element]
-    expected: FAIL
-
   [Declarative Shadow DOM: explicit test that exceptions are not thrown]
     expected: FAIL

--- a/tests/wpt/meta/shadow-dom/focus/focus-selector-delegatesFocus.html.ini
+++ b/tests/wpt/meta/shadow-dom/focus/focus-selector-delegatesFocus.html.ini
@@ -8,13 +8,7 @@
   [:focus applies to host with delegatesFocus=true when an element in a nested shadow tree with delegatesFocus=true is focused]
     expected: FAIL
 
-  [:focus should be removed from hosts with delegatesFocus=true when none of the elements in a nested shadow tree with delegatesFocus=true is focused]
-    expected: FAIL
-
   [:focus applies to host with delegatesFocus=true when an element in a nested shadow tree with delegatesFocus=false is focused]
-    expected: FAIL
-
-  [:focus should be removed from hosts with delegatesFocus=true when none of the elements in a nested shadow tree with delegatesFocus=false is focused]
     expected: FAIL
 
   [:focus applies to host with delegatesFocus=false when the shadow root's descendant has focus]
@@ -26,11 +20,5 @@
   [:focus applies to host with delegatesFocus=false when an element in a nested shadow tree with delegatesFocus=true is focused]
     expected: FAIL
 
-  [:focus should be removed from hosts with delegatesFocus=false when none of the elements in a nested shadow tree with delegatesFocus=true is focused]
-    expected: FAIL
-
   [:focus applies to host with delegatesFocus=false when an element in a nested shadow tree with delegatesFocus=false is focused]
-    expected: FAIL
-
-  [:focus should be removed from hosts with delegatesFocus=false when none of the elements in a nested shadow tree with delegatesFocus=false is focused]
     expected: FAIL

--- a/tests/wpt/meta/shadow-dom/untriaged/elements-and-dom-objects/extensions-to-element-interface/attributes/test-006.html.ini
+++ b/tests/wpt/meta/shadow-dom/untriaged/elements-and-dom-objects/extensions-to-element-interface/attributes/test-006.html.ini
@@ -1,3 +1,0 @@
-[test-006.html]
-  [A_10_02_01_06_T01]
-    expected: FAIL


### PR DESCRIPTION
Implements https://dom.spec.whatwg.org/#dom-element-shadowroot and, as a consequence, adds support for `ShadowRootMode::Closed`.

If a shadow root is `"closed"` then it is effectively "hidden", meaning `element.shadowRoot` returns `null`.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
