### PR TITLE
layout: Ensure alignment affects size of absolutely positioned elements

### DIFF
--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -1941,6 +1941,10 @@ impl FlexItem<'_> {
                             .vec2_to_flow_relative(self.content_max_size)
                             .map(|size| size.map_or(Size::Initial, Size::Numeric)),
                         flex_axis.vec2_to_flow_relative(self.pbm_auto_is_zero),
+                        LogicalVec2 {
+                            inline: AlignFlags::START,
+                            block: AlignFlags::START,
+                        },
                     );
                 let hypothetical_cross_size = flex_axis.vec2_to_flex_relative(size).cross;
 
@@ -2735,6 +2739,10 @@ impl FlexItemBox {
                         max_size.map(|size| size.map_or(Size::Initial, Size::Numeric)),
                         padding_border_margin.padding_border_sums +
                             padding_border_margin.margin.auto_is(Au::zero).sum(),
+                        LogicalVec2 {
+                            inline: AlignFlags::START,
+                            block: AlignFlags::START,
+                        },
                     )
                     .block
             },

--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -1942,8 +1942,8 @@ impl FlexItem<'_> {
                             .map(|size| size.map_or(Size::Initial, Size::Numeric)),
                         flex_axis.vec2_to_flow_relative(self.pbm_auto_is_zero),
                         LogicalVec2 {
-                            inline: AlignFlags::START,
-                            block: AlignFlags::START,
+                            inline: Size::FitContent,
+                            block: Size::FitContent,
                         },
                     );
                 let hypothetical_cross_size = flex_axis.vec2_to_flex_relative(size).cross;
@@ -2740,8 +2740,8 @@ impl FlexItemBox {
                         padding_border_margin.padding_border_sums +
                             padding_border_margin.margin.auto_is(Au::zero).sum(),
                         LogicalVec2 {
-                            inline: AlignFlags::START,
-                            block: AlignFlags::START,
+                            inline: Size::FitContent,
+                            block: Size::FitContent,
                         },
                     )
                     .block

--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -1941,10 +1941,7 @@ impl FlexItem<'_> {
                             .vec2_to_flow_relative(self.content_max_size)
                             .map(|size| size.map_or(Size::Initial, Size::Numeric)),
                         flex_axis.vec2_to_flow_relative(self.pbm_auto_is_zero),
-                        LogicalVec2 {
-                            inline: Size::FitContent,
-                            block: Size::FitContent,
-                        },
+                        Size::FitContent.into(),
                     );
                 let hypothetical_cross_size = flex_axis.vec2_to_flex_relative(size).cross;
 
@@ -2739,10 +2736,7 @@ impl FlexItemBox {
                         max_size.map(|size| size.map_or(Size::Initial, Size::Numeric)),
                         padding_border_margin.padding_border_sums +
                             padding_border_margin.margin.auto_is(Au::zero).sum(),
-                        LogicalVec2 {
-                            inline: Size::FitContent,
-                            block: Size::FitContent,
-                        },
+                        Size::FitContent.into(),
                     )
                     .block
             },

--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -2042,16 +2042,16 @@ impl IndependentFormattingContext {
                 let preferred_block_size = content_box_sizes_and_pbm
                     .content_box_size
                     .block
-                    .maybe_resolve_extrinsic(available_block_size, false);
+                    .maybe_resolve_extrinsic(Size::FitContent, available_block_size);
                 let min_block_size = content_box_sizes_and_pbm
                     .content_min_box_size
                     .block
-                    .maybe_resolve_extrinsic(available_block_size, false)
+                    .maybe_resolve_extrinsic(Size::FitContent, available_block_size)
                     .unwrap_or_default();
                 let max_block_size = content_box_sizes_and_pbm
                     .content_max_box_size
                     .block
-                    .maybe_resolve_extrinsic(available_block_size, false);
+                    .maybe_resolve_extrinsic(Size::FitContent, available_block_size);
                 let tentative_block_size =
                     SizeConstraint::new(preferred_block_size, min_block_size, max_block_size);
 

--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -1368,10 +1368,7 @@ fn layout_in_flow_replaced_block_level(
         containing_block,
         style,
         &content_box_sizes_and_pbm,
-        LogicalVec2 {
-            inline: Size::FitContent,
-            block: Size::FitContent,
-        },
+        Size::FitContent.into(),
     );
 
     let margin_inline_start;
@@ -2024,10 +2021,7 @@ impl IndependentFormattingContext {
                         containing_block,
                         &replaced.style,
                         &content_box_sizes_and_pbm,
-                        LogicalVec2 {
-                            inline: Size::FitContent,
-                            block: Size::FitContent,
-                        },
+                        Size::FitContent.into(),
                     )
                     .to_physical_size(container_writing_mode);
                 let fragments = replaced.contents.make_fragments(

--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -1369,8 +1369,8 @@ fn layout_in_flow_replaced_block_level(
         style,
         &content_box_sizes_and_pbm,
         LogicalVec2 {
-            inline: AlignFlags::START,
-            block: AlignFlags::START,
+            inline: Size::FitContent,
+            block: Size::FitContent,
         },
     );
 
@@ -2025,8 +2025,8 @@ impl IndependentFormattingContext {
                         &replaced.style,
                         &content_box_sizes_and_pbm,
                         LogicalVec2 {
-                            inline: AlignFlags::START,
-                            block: AlignFlags::START,
+                            inline: Size::FitContent,
+                            block: Size::FitContent,
                         },
                     )
                     .to_physical_size(container_writing_mode);

--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -2042,16 +2042,16 @@ impl IndependentFormattingContext {
                 let preferred_block_size = content_box_sizes_and_pbm
                     .content_box_size
                     .block
-                    .maybe_resolve_extrinsic(available_block_size);
+                    .maybe_resolve_extrinsic(available_block_size, false);
                 let min_block_size = content_box_sizes_and_pbm
                     .content_min_box_size
                     .block
-                    .maybe_resolve_extrinsic(available_block_size)
+                    .maybe_resolve_extrinsic(available_block_size, false)
                     .unwrap_or_default();
                 let max_block_size = content_box_sizes_and_pbm
                     .content_max_box_size
                     .block
-                    .maybe_resolve_extrinsic(available_block_size);
+                    .maybe_resolve_extrinsic(available_block_size, false);
                 let tentative_block_size =
                     SizeConstraint::new(preferred_block_size, min_block_size, max_block_size);
 

--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -1368,6 +1368,10 @@ fn layout_in_flow_replaced_block_level(
         containing_block,
         style,
         &content_box_sizes_and_pbm,
+        LogicalVec2 {
+            inline: AlignFlags::START,
+            block: AlignFlags::START,
+        },
     );
 
     let margin_inline_start;
@@ -2020,6 +2024,10 @@ impl IndependentFormattingContext {
                         containing_block,
                         &replaced.style,
                         &content_box_sizes_and_pbm,
+                        LogicalVec2 {
+                            inline: AlignFlags::START,
+                            block: AlignFlags::START,
+                        },
                     )
                     .to_physical_size(container_writing_mode);
                 let fragments = replaced.contents.make_fragments(

--- a/components/layout_2020/geom.rs
+++ b/components/layout_2020/geom.rs
@@ -535,6 +535,15 @@ impl LogicalRect<Au> {
     }
 }
 
+impl<T: Copy> From<T> for LogicalVec2<T> {
+    fn from(value: T) -> Self {
+        Self {
+            inline: value,
+            block: value,
+        }
+    }
+}
+
 impl From<LogicalVec2<CSSPixelLength>> for LogicalVec2<Au> {
     fn from(value: LogicalVec2<CSSPixelLength>) -> Self {
         LogicalVec2 {

--- a/components/layout_2020/geom.rs
+++ b/components/layout_2020/geom.rs
@@ -838,24 +838,20 @@ impl Size<Au> {
     ///
     /// Returns `None` if either:
     /// - The size is intrinsic.
-    /// - The size is the initial one.
-    ///   TODO: should we allow it to behave as `stretch` instead of assuming it's intrinsic?
     /// - The provided `stretch_size` is `None` but we need its value.
     #[inline]
     pub(crate) fn maybe_resolve_extrinsic(
         &self,
+        initial_behavior: Self,
         stretch_size: Option<Au>,
-        allow_stretch: bool,
     ) -> Option<Au> {
         match self {
-            Self::Initial | Self::MinContent | Self::MaxContent | Self::FitContent => None,
-            Self::Stretch => {
-                if allow_stretch {
-                    stretch_size.or(Some(Au::zero()))
-                } else {
-                    None
-                }
+            Self::Initial => {
+                assert!(!initial_behavior.is_initial());
+                initial_behavior.maybe_resolve_extrinsic(*self, stretch_size)
             },
+            Self::MinContent | Self::MaxContent | Self::FitContent => None,
+            Self::Stretch => stretch_size,
             Self::Numeric(numeric) => Some(*numeric),
         }
     }

--- a/components/layout_2020/geom.rs
+++ b/components/layout_2020/geom.rs
@@ -842,10 +842,20 @@ impl Size<Au> {
     ///   TODO: should we allow it to behave as `stretch` instead of assuming it's intrinsic?
     /// - The provided `stretch_size` is `None` but we need its value.
     #[inline]
-    pub(crate) fn maybe_resolve_extrinsic(&self, stretch_size: Option<Au>) -> Option<Au> {
+    pub(crate) fn maybe_resolve_extrinsic(
+        &self,
+        stretch_size: Option<Au>,
+        allow_stretch: bool,
+    ) -> Option<Au> {
         match self {
             Self::Initial | Self::MinContent | Self::MaxContent | Self::FitContent => None,
-            Self::Stretch => stretch_size,
+            Self::Stretch => {
+                if allow_stretch {
+                    stretch_size.or(Some(Au::zero()))
+                } else {
+                    None
+                }
+            },
             Self::Numeric(numeric) => Some(*numeric),
         }
     }

--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -800,15 +800,15 @@ impl<'a> AbsoluteAxisSolver<'a> {
             } else {
                 let preferred_size = self
                     .computed_size
-                    .maybe_resolve_extrinsic(Some(stretch_size), false)
+                    .maybe_resolve_extrinsic(Size::FitContent, Some(stretch_size))
                     .or(initial_is_stretch.then_some(stretch_size));
                 let min_size = self
                     .computed_min_size
-                    .maybe_resolve_extrinsic(Some(stretch_size), false)
+                    .maybe_resolve_extrinsic(Size::FitContent, Some(stretch_size))
                     .unwrap_or_default();
                 let max_size = self
                     .computed_max_size
-                    .maybe_resolve_extrinsic(Some(stretch_size), false);
+                    .maybe_resolve_extrinsic(Size::FitContent, Some(stretch_size));
                 SizeConstraint::new(preferred_size, min_size, max_size)
             }
         };

--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -800,15 +800,15 @@ impl<'a> AbsoluteAxisSolver<'a> {
             } else {
                 let preferred_size = self
                     .computed_size
-                    .maybe_resolve_extrinsic(Some(stretch_size))
+                    .maybe_resolve_extrinsic(Some(stretch_size), false)
                     .or(initial_is_stretch.then_some(stretch_size));
                 let min_size = self
                     .computed_min_size
-                    .maybe_resolve_extrinsic(Some(stretch_size))
+                    .maybe_resolve_extrinsic(Some(stretch_size), false)
                     .unwrap_or_default();
                 let max_size = self
                     .computed_max_size
-                    .maybe_resolve_extrinsic(Some(stretch_size));
+                    .maybe_resolve_extrinsic(Some(stretch_size), false);
                 SizeConstraint::new(preferred_size, min_size, max_size)
             }
         };

--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -476,6 +476,10 @@ impl HoistedAbsolutelyPositionedBox {
             true => style.clone_justify_self().0 .0,
             false => shared_fragment.resolved_alignment.inline,
         };
+        let inline_behaviour = match inline_alignment.value() {
+            AlignFlags::STRETCH => Size::Stretch,
+            _ => Size::FitContent,
+        };
 
         // When the "static-position rect" doesn't come into play, we re-resolve "align-self"
         // against this containing block.
@@ -486,6 +490,10 @@ impl HoistedAbsolutelyPositionedBox {
         let block_alignment = match block_box_offsets.either_specified() {
             true => style.clone_align_self().0 .0,
             false => shared_fragment.resolved_alignment.block,
+        };
+        let block_behaviour = match block_alignment.value() {
+            AlignFlags::STRETCH => Size::Stretch,
+            _ => Size::FitContent,
         };
 
         let (computed_size, computed_min_size, computed_max_size) = match context {
@@ -501,8 +509,8 @@ impl HoistedAbsolutelyPositionedBox {
                         &style,
                         &content_box_sizes_and_pbm,
                         LogicalVec2 {
-                            inline: inline_alignment,
-                            block: block_alignment,
+                            inline: inline_behaviour,
+                            block: block_behaviour,
                         },
                     )
                     .map(|size| Size::Numeric(*size));

--- a/components/layout_2020/replaced.rs
+++ b/components/layout_2020/replaced.rs
@@ -456,6 +456,7 @@ impl ReplacedContent {
         containing_block: &ContainingBlock,
         style: &ComputedValues,
         content_box_sizes_and_pbm: &ContentBoxSizesAndPBM,
+        alignment: LogicalVec2<AlignFlags>,
     ) -> LogicalVec2<Au> {
         let pbm = &content_box_sizes_and_pbm.pbm;
         self.used_size_as_if_inline_element_from_content_box_sizes(
@@ -465,10 +466,7 @@ impl ReplacedContent {
             content_box_sizes_and_pbm.content_min_box_size,
             content_box_sizes_and_pbm.content_max_box_size,
             pbm.padding_border_sums + pbm.margin.auto_is(Au::zero).sum(),
-            LogicalVec2 {
-                inline: AlignFlags::STRETCH,
-                block: AlignFlags::STRETCH,
-            },
+            alignment,
         )
     }
 
@@ -554,14 +552,14 @@ impl ReplacedContent {
                 SizeConstraint::new(
                     box_size
                         .block
-                        .maybe_resolve_extrinsic(Size::Stretch, Some(block_stretch_size)),
+                        .maybe_resolve_extrinsic(Size::FitContent, Some(block_stretch_size)),
                     min_box_size
                         .block
-                        .maybe_resolve_extrinsic(Size::Stretch, Some(block_stretch_size))
+                        .maybe_resolve_extrinsic(Size::FitContent, Some(block_stretch_size))
                         .unwrap_or_default(),
                     max_box_size
                         .block
-                        .maybe_resolve_extrinsic(Size::Stretch, Some(block_stretch_size)),
+                        .maybe_resolve_extrinsic(Size::FitContent, Some(block_stretch_size)),
                 )
             };
             self.content_size(
@@ -572,7 +570,7 @@ impl ReplacedContent {
             )
             .into()
         });
-        let inline_behaviour = match alignment.inline {
+        let inline_behaviour = match alignment.inline.value() {
             AlignFlags::STRETCH => Size::Stretch,
             _ => Size::FitContent,
         };
@@ -610,7 +608,7 @@ impl ReplacedContent {
         });
         let block_stretch_size =
             block_stretch_size.unwrap_or_else(|| block_content_size.max_content);
-        let block_behaviour = match alignment.block {
+        let block_behaviour = match alignment.block.value() {
             AlignFlags::STRETCH => Size::Stretch,
             _ => Size::FitContent,
         };

--- a/components/layout_2020/replaced.rs
+++ b/components/layout_2020/replaced.rs
@@ -507,6 +507,7 @@ impl ReplacedContent {
     ///
     /// <https://drafts.csswg.org/css-sizing-4/#aspect-ratio-size-transfers>
     /// <https://github.com/w3c/csswg-drafts/issues/6071#issuecomment-2243986313>
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn used_size_as_if_inline_element_from_content_box_sizes(
         &self,
         containing_block: &ContainingBlock,

--- a/components/layout_2020/replaced.rs
+++ b/components/layout_2020/replaced.rs
@@ -554,14 +554,14 @@ impl ReplacedContent {
                 SizeConstraint::new(
                     box_size
                         .block
-                        .maybe_resolve_extrinsic(Some(block_stretch_size), true),
+                        .maybe_resolve_extrinsic(Size::Stretch, Some(block_stretch_size)),
                     min_box_size
                         .block
-                        .maybe_resolve_extrinsic(Some(block_stretch_size), false)
+                        .maybe_resolve_extrinsic(Size::Stretch, Some(block_stretch_size))
                         .unwrap_or_default(),
                     max_box_size
                         .block
-                        .maybe_resolve_extrinsic(Some(block_stretch_size), false),
+                        .maybe_resolve_extrinsic(Size::Stretch, Some(block_stretch_size)),
                 )
             };
             self.content_size(

--- a/components/layout_2020/sizing.rs
+++ b/components/layout_2020/sizing.rs
@@ -141,15 +141,15 @@ pub(crate) fn outer_inline(
         } else {
             content_box_size
                 .block
-                .maybe_resolve_extrinsic(available_block_size, false)
+                .maybe_resolve_extrinsic(Size::FitContent, available_block_size)
         };
         let min_block_size = content_min_box_size
             .block
-            .maybe_resolve_extrinsic(available_block_size, false)
+            .maybe_resolve_extrinsic(Size::FitContent, available_block_size)
             .unwrap_or(auto_minimum.block);
         let max_block_size = content_max_box_size
             .block
-            .maybe_resolve_extrinsic(available_block_size, false);
+            .maybe_resolve_extrinsic(Size::FitContent, available_block_size);
         get_content_size(&ConstraintSpace::new(
             SizeConstraint::new(preferred_block_size, min_block_size, max_block_size),
             style.writing_mode,

--- a/components/layout_2020/sizing.rs
+++ b/components/layout_2020/sizing.rs
@@ -141,15 +141,15 @@ pub(crate) fn outer_inline(
         } else {
             content_box_size
                 .block
-                .maybe_resolve_extrinsic(available_block_size)
+                .maybe_resolve_extrinsic(available_block_size, false)
         };
         let min_block_size = content_min_box_size
             .block
-            .maybe_resolve_extrinsic(available_block_size)
+            .maybe_resolve_extrinsic(available_block_size, false)
             .unwrap_or(auto_minimum.block);
         let max_block_size = content_max_box_size
             .block
-            .maybe_resolve_extrinsic(available_block_size);
+            .maybe_resolve_extrinsic(available_block_size, false);
         get_content_size(&ConstraintSpace::new(
             SizeConstraint::new(preferred_block_size, min_block_size, max_block_size),
             style.writing_mode,

--- a/components/layout_2020/taffy/layout.rs
+++ b/components/layout_2020/taffy/layout.rs
@@ -169,10 +169,7 @@ impl taffy::LayoutPartialTree for TaffyContainerContext<'_> {
                                     block: Size::Initial,
                                 },
                                 pbm.padding_border_sums,
-                                LogicalVec2 {
-                                    inline: Size::FitContent,
-                                    block: Size::FitContent,
-                                },
+                                Size::FitContent.into(),
                             )
                             .to_physical_size(self.style.writing_mode);
 

--- a/components/layout_2020/taffy/layout.rs
+++ b/components/layout_2020/taffy/layout.rs
@@ -169,6 +169,10 @@ impl taffy::LayoutPartialTree for TaffyContainerContext<'_> {
                                     block: Size::Initial,
                                 },
                                 pbm.padding_border_sums,
+                                LogicalVec2 {
+                                    inline: AlignFlags::START,
+                                    block: AlignFlags::START,
+                                },
                             )
                             .to_physical_size(self.style.writing_mode);
 

--- a/components/layout_2020/taffy/layout.rs
+++ b/components/layout_2020/taffy/layout.rs
@@ -170,8 +170,8 @@ impl taffy::LayoutPartialTree for TaffyContainerContext<'_> {
                                 },
                                 pbm.padding_border_sums,
                                 LogicalVec2 {
-                                    inline: AlignFlags::START,
-                                    block: AlignFlags::START,
+                                    inline: Size::FitContent,
+                                    block: Size::FitContent,
                                 },
                             )
                             .to_physical_size(self.style.writing_mode);


### PR DESCRIPTION
Refactors `used_size_as_if_inline_element_from_content_box_sizes` to use alignment flags for controlling stretch behavior


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #34248 
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
