### PR TITLE
Stream: Fix reader closed promise init

### DIFF
--- a/components/script/dom/readablestreamdefaultreader.rs
+++ b/components/script/dom/readablestreamdefaultreader.rs
@@ -135,23 +135,26 @@ impl ReadableStreamDefaultReader {
     ) -> DomRoot<ReadableStreamDefaultReader> {
         let promise;
         if stream.is_readable() {
-            // step 3
+            // If stream.[[state]] is "readable
+            // Set reader.[[closedPromise]] to a new promise.
             promise = Promise::new(global, can_gc);
         } else if stream.is_closed() {
-            // step 4
+            // Otherwise, if stream.[[state]] is "closed",
+            // Set reader.[[closedPromise]] to a promise resolved with undefined.
             let cx = GlobalScope::get_cx();
             rooted!(in(*cx) let mut rval = UndefinedValue());
-            promise = Promise::new_rejected(global, cx, rval.handle()).unwrap();
+            promise = Promise::new_resolved(global, cx, rval.handle()).unwrap();
         } else {
-            // step 5.1
+            // Assert: stream.[[state]] is "errored"
             assert!(stream.is_errored());
-            // step 5.2
+
+            // Set reader.[[closedPromise]] to a promise rejected with stream.[[storedError]].
             let cx = GlobalScope::get_cx();
             rooted!(in(*cx) let mut rval = UndefinedValue());
             stream.get_stored_error(rval.handle_mut());
             promise = Promise::new_rejected(global, cx, rval.handle()).unwrap();
 
-            // step 5.3
+            // Set reader.[[closedPromise]].[[PromiseIsHandled]] to true
             promise.set_promise_is_handled();
         }
         reflect_dom_object(


### PR DESCRIPTION
When initializing the reader, the closed promise of the reader should be set to one resolved with undefined(not rejected as now) if the stream is already closed. 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
