### PR TITLE
fonts: fix broken caching of font template matches

### DIFF
--- a/components/fonts/system_font_service.rs
+++ b/components/fonts/system_font_service.rs
@@ -533,11 +533,15 @@ impl SystemFontServiceProxy {
             );
             panic!("SystemFontService has already exited.");
         };
-        templates
+
+        let templates: Vec<_> = templates
             .into_iter()
             .map(AtomicRefCell::new)
             .map(Arc::new)
-            .collect()
+            .collect();
+        self.templates.write().insert(cache_key, templates.clone());
+
+        templates
     }
 
     pub(crate) fn generate_font_key(&self) -> FontKey {

--- a/components/fonts/tests/font_context.rs
+++ b/components/fonts/tests/font_context.rs
@@ -370,6 +370,19 @@ mod font_context {
             .matching_templates(&font_descriptor, &family_descriptor)[0]
             .clone();
 
+        let _ = context
+            .context
+            .matching_templates(&font_descriptor, &family_descriptor);
+
+        assert_eq!(
+            context
+                .system_font_service
+                .find_font_count
+                .fetch_add(0, Ordering::Relaxed),
+            1,
+            "we should only have requested matching templates from the font service once"
+        );
+
         let font1 = context
             .context
             .font(font_template.clone(), &font_descriptor)


### PR DESCRIPTION
After a cache miss, `find_matching_font_template` never updates the
cache entry with the response from the `SystemFontService` leading to
several unnecessary IPC calls during layout.

Co-authored-by: Martin Robinson <mrobinson@igalia.com>
Signed-off-by: Mukilan Thiyagarajan <mukilan@igalia.com>

---

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

