### PR TITLE
Remove etc/shell.nix in favour of shell.nix

### DIFF
--- a/etc/shell.nix
+++ b/etc/shell.nix
@@ -1,1 +1,0 @@
-../shell.nix

--- a/mach
+++ b/mach
@@ -37,10 +37,10 @@ if __name__ == '__main__':
         from shlex import quote
         mach_dir = os.path.abspath(os.path.dirname(__file__))
         build_android_args = ['--arg', 'buildAndroid', 'true'] if 'SERVO_ANDROID_BUILD' in os.environ else []
-        print('NOTE: Entering nix-shell etc/shell.nix')
+        print(f'NOTE: Entering nix-shell {mach_dir}/shell.nix')
         try:
             # sys argv already contains the ./mach part, so we just need to pass it as-is
-            result = subprocess.run(['nix-shell', mach_dir + '/etc/shell.nix'] + build_android_args + ['--run', ' '.join(map(quote, sys.argv))])
+            result = subprocess.run(['nix-shell', f'{mach_dir}/shell.nix'] + build_android_args + ['--run', ' '.join(map(quote, sys.argv))])
             sys.exit(result.returncode)
         except KeyboardInterrupt:
             sys.exit(0)

--- a/python/servo/platform/linux.py
+++ b/python/servo/platform/linux.py
@@ -126,7 +126,7 @@ class Linux(Base):
             print('You will need to run a nix-shell if you are trying '
                   'to run any of the built binaries')
             print('To enter the nix-shell manually use:')
-            print('  $ nix-shell etc/shell.nix')
+            print('  $ nix-shell')
             return False
 
         if self.distro.lower() == 'ubuntu' and self.version > '22.04':

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-# Be sure to update etc/shell.nix and support/crown/rust-toolchain.toml when bumping this!
+# Be sure to update shell.nix and support/crown/rust-toolchain.toml when bumping this!
 channel = "1.80.1"
 
 components = [

--- a/support/crown/Cargo.toml
+++ b/support/crown/Cargo.toml
@@ -7,8 +7,7 @@ license = "MPL-2.0"
 publish = false
 
 # Do not use workspace dependencies in this package!
-# In etc/shell.nix, we filter Cargo.lock and build this package in isolation,
-# so it needs to make sense without the workspace manifest.
+# crown is not part of the Cargo workspace.
 [dev-dependencies]
 compiletest_rs = { version = "0.11", features = ["tmp"] }
 


### PR DESCRIPTION
This patch removes etc/shell.nix, which is now just a symlink to shell.nix, and updates references to it accordingly.

See also: servo/book#37

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] ~~These changes fix #___ (GitHub issue number if applicable)~~