### PR TITLE
Plumb URL into interval profiler tracing events

### DIFF
--- a/components/script/dom/bindings/settings_stack.rs
+++ b/components/script/dom/bindings/settings_stack.rs
@@ -59,7 +59,12 @@ impl AutoEntryScript {
             AutoEntryScript {
                 global: DomRoot::from_ref(global),
                 #[cfg(feature = "tracing")]
-                span: tracing::info_span!("ScriptEvaluate", servo_profiling = true).entered(),
+                span: tracing::info_span!(
+                    "ScriptEvaluate",
+                    servo_profiling = true,
+                    url = global.get_url().to_string(),
+                )
+                .entered(),
             }
         })
     }

--- a/components/shared/profile/lib.rs
+++ b/components/shared/profile/lib.rs
@@ -18,10 +18,15 @@ pub mod time;
 #[macro_export]
 macro_rules! time_profile {
     ($category:expr, $meta:expr, $profiler_chan:expr, $($callback:tt)+) => {{
+        let meta: Option<$crate::time::TimerMetadata> = $meta;
         #[cfg(feature = "tracing")]
-        let span = tracing::info_span!($category.variant_name(), servo_profiling = true);
+        let span = tracing::info_span!(
+            $category.variant_name(),
+            servo_profiling = true,
+            url = meta.as_ref().map(|m| m.url.clone()),
+        );
         #[cfg(not(feature = "tracing"))]
         let span = ();
-        $crate::time::profile($category, $meta, $profiler_chan, span, $($callback)+)
+        $crate::time::profile($category, meta, $profiler_chan, span, $($callback)+)
     }};
 }

--- a/components/shared/profile/time.rs
+++ b/components/shared/profile/time.rs
@@ -55,10 +55,16 @@ pub enum ProfilerMsg {
     Exit(IpcSender<()>),
 }
 
+/// Usage sites of variants marked “Rust tracing only” are not visible to rust-analyzer.
 #[repr(u32)]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum ProfilerCategory {
+    /// The compositor is rasterising or presenting.
+    ///
+    /// Not associated with a specific URL.
     Compositing = 0x00,
+
+    /// The script thread is doing layout work.
     LayoutPerform = 0x10,
 
     /// Events currently only used by Layout 2013.

--- a/ports/servoshell/lib.rs
+++ b/ports/servoshell/lib.rs
@@ -50,7 +50,8 @@ pub fn init_tracing() {
             // The servo.pftrace file can be uploaded to https://ui.perfetto.dev for analysis.
             let file = std::fs::File::create("servo.pftrace").unwrap();
             let perfetto_layer = tracing_perfetto::PerfettoLayer::new(std::sync::Mutex::new(file))
-                .with_filter_by_marker(|field_name| field_name == "servo_profiling");
+                .with_filter_by_marker(|field_name| field_name == "servo_profiling")
+                .with_debug_annotations(true);
             subscriber.with(perfetto_layer)
         };
 


### PR DESCRIPTION
This patch plumbs the TimerMetadata.url of interval profiler events (where available) into tracing. We need this in [perf-analysis-tools](https://github.com/servo/perf-analysis-tools) to filter profiling data to a specific page load, or at the very least ignore other (i)frames.

We may want to find a more efficient way to identify a specific page load at some point.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] ~~These changes fix #___ (GitHub issue number if applicable)~~