### PR TITLE
Stream: Fix reborrow in controller enqueue, and fix error and exception handling.

### DIFF
--- a/components/script/dom/readablestream.rs
+++ b/components/script/dom/readablestream.rs
@@ -102,7 +102,6 @@ pub struct ReadableStream {
     controller: ControllerType,
 
     /// <https://streams.spec.whatwg.org/#readablestream-storederror>
-    /// TODO: check correctness of this.
     #[ignore_malloc_size_of = "mozjs"]
     stored_error: Heap<JSVal>,
 

--- a/components/script/dom/readablestream.rs
+++ b/components/script/dom/readablestream.rs
@@ -9,7 +9,7 @@ use std::rc::Rc;
 use dom_struct::dom_struct;
 use js::conversions::ToJSValConvertible;
 use js::jsapi::{Heap, JSObject};
-use js::jsval::{ObjectValue, UndefinedValue};
+use js::jsval::{ObjectValue, UndefinedValue, JSVal};
 use js::rust::{
     HandleObject as SafeHandleObject, HandleValue as SafeHandleValue,
     MutableHandleValue as SafeMutableHandleValue,
@@ -104,7 +104,7 @@ pub struct ReadableStream {
     /// <https://streams.spec.whatwg.org/#readablestream-storederror>
     /// TODO: check correctness of this.
     #[ignore_malloc_size_of = "mozjs"]
-    stored_error: Heap<*mut JSObject>,
+    stored_error: Heap<JSVal>,
 
     /// <https://streams.spec.whatwg.org/#readablestream-disturbed>
     disturbed: Cell<bool>,
@@ -282,11 +282,7 @@ impl ReadableStream {
         // step 2
         self.state.set(ReadableStreamState::Errored);
         // step 3
-        {
-            let cx = GlobalScope::get_cx();
-            rooted!(in(*cx) let object = e.to_object());
-            self.stored_error.set(*object);
-        }
+        self.stored_error.set(e.get());
 
         // step 4
         match self.reader {

--- a/components/script/dom/readablestreamdefaultcontroller.rs
+++ b/components/script/dom/readablestreamdefaultcontroller.rs
@@ -550,13 +550,19 @@ impl ReadableStreamDefaultController {
                 Err(error) => {
                     // If result is an abrupt completion,
                     rooted!(in(*cx) let mut rval = UndefinedValue());
-
-                    // TODO: check if this is the right globalscope.
-                    unsafe {
-                        error
-                            .clone()
-                            .to_jsval(*cx, &self.global(), rval.handle_mut())
-                    };
+   
+                    match error {
+                        // Note: `to_jsval` on JSFailed panics.
+                        Error::JSFailed => (),
+                        _ => {
+                            // TODO: check if `self.global()` is the right globalscope.
+                            unsafe {
+                                error
+                                    .clone()
+                                    .to_jsval(*cx, &self.global(), rval.handle_mut())
+                            };
+                        },
+                    }
 
                     // Perform ! ReadableStreamDefaultControllerError(controller, result.[[Value]]).
                     self.error(rval.handle());

--- a/components/script/dom/readablestreamdefaultcontroller.rs
+++ b/components/script/dom/readablestreamdefaultcontroller.rs
@@ -538,7 +538,11 @@ impl ReadableStreamDefaultController {
         // Let result be the result of performing controller.[[strategySizeAlgorithm]],
         // passing in chunk, and interpreting the result as a completion record.
         // Note: the clone is necessary to prevent potential re-borrow panics.
-        let size = if let Some(strategy_size) = self.strategy_size.borrow().clone() {
+        let strategy_size = {
+            let reference = self.strategy_size.borrow();
+            reference.clone()
+        };
+        let size = if let Some(strategy_size) = strategy_size {
             let result = strategy_size.Call__(chunk, ExceptionHandling::Report);
             match result {
                 // Let chunkSize be result.[[Value]].


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

- Fix reborrow in controller enqueue
- Fix JS error and exeception handle in the call to strategy size in enqueue.
- Use JSVal for the stream error.

All to make `/streams/readable-streams/reentrant-strategies.any.html` pass. 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
