### PR TITLE
Optimize `production-stripped`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,6 +182,8 @@ codegen-units = 1
 [profile.production-stripped]
 inherits = "production"
 strip = true
+opt-level = "s"
+lto = true
 
 [profile.profiling]
 inherits = "release"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -176,14 +176,13 @@ debug = "line-tables-only"
 [profile.production]
 inherits = "release"
 debug-assertions = false
-lto = "thin"
+lto = true
 codegen-units = 1
+opt-level = "s"
 
 [profile.production-stripped]
 inherits = "production"
 strip = true
-opt-level = "s"
-lto = true
 
 [profile.profiling]
 inherits = "release"


### PR DESCRIPTION
Table shows the performance results for different optimizations. I have used [perf-analysis-tools](https://github.com/servo/perf-analysis-tools/tree/01d5b4152dae05b0d0d27d299d372ec630d118eb) to measure the numbers. See [here](https://github.com/servo/servo/wiki/Servo-Benchmarking-Report-(November-2024)) for more details about the tool and definition.


System: MacOS M2 Max, GPU: 12

Summary(descending order of preference based on the numbers below)
- `lto = true & opt-level = "s"` looks best as per above numbers. Improvement in Renderer (65.69ms vs. 74.07ms), Layout (42.7ms vs. 49.98ms), and FP/FPS (197.7ms vs. 206.7ms).
- `opt-level = "s"` Faster Renderer (60.59ms vs. 74.07ms) and Layout (39.31ms vs. 49.98ms)
- `lto = true` :  Major wins in Renderer (61.87ms vs. 74.07ms) and Layout (39.32ms vs. 49.98ms).
- `lto = true & opt-level = "z"` Smallest binary size but sacrifices runtime performance in critical areas like Renderer (81.46ms vs. 74.07ms) and Parse (8.942ms vs. 5.736ms)
- `opt-level = "z"` significant slowdowns in Renderer (101.4ms vs. 74.07ms), Layout (72.51ms vs. 49.98ms)

| Category | Main branch(82MB) | lto = true (77MB) | opt-level = "z" (65MB) | opt-level = "s" (75MB) | lto = true & opt-level = "z" (56MB) | lto = true & opt-level = "s" (65MB)
| -------- | -------- | -------- |-------- | -------- | -------- | -------- |
| FP (synthetic)     | 206.7ms     | 202.0ms       | 206.0ms      | 206.9ms      | 211.4ms      | 197.7ms  |
| FPS (synthetic)     | 206.7ms      | 202.0ms    | 206.0ms     | 206.9ms       | 211.4ms      | 197.7ms |
| Renderer (synthetic)     | 74.07ms      | 61.87ms      | 101.4ms   | 60.59ms      | 81.46ms     | 65.69ms |
| Parse (synthetic)     | 5.736ms      | 5.732ms     | 8.797ms     | 5.926ms     | 8.942ms     | 5.628ms  |
| Layout (synthetic)     | 49.98ms     | 39.32ms     | 72.51ms     | 39.31ms      | 56.46ms      | 42.70ms |
| Script (Synthetic)     | 7.314ms     | 7.055ms     | 7.987ms     | 6.982ms    | 8.357ms       | 7.302ms |
| Rasterise (synthetic)     | 13.99ms     | 13.48ms    | 12.66ms    | 12.94ms     | 13.18ms     | 14.00ms |
| Compositing (Real)     | 13.99ms       | 13.48ms     | 12.66ms      | 12.94ms     | 13.18ms      | 14.00ms  |
| LayoutPerform (Real)     | 49.98ms       | 39.32ms      | 72.51ms      | 39.31ms     | 56.46ms      | 42.70ms |
| ScriptParseHTML (Real)     | 5.736ms     | 5.732ms     | 8.797ms     | 5.926ms    | 8.942ms       | 5.628ms |
| ScriptEvaluate (Real)     | 7.326ms     | 7.069ms     | 8.002ms     | 6.997ms    | 8.368ms       | 7.311ms |



---
TODO
- [x] Add numbers for `Script` and `ScriptEvaluate`

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
