### PR TITLE
Update mozjs_sys to 128.3-5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4443,7 +4443,7 @@ dependencies = [
 [[package]]
 name = "mozjs"
 version = "0.14.1"
-source = "git+https://github.com/servo/mozjs#8526195dce129d2ccd83e7e1e5d03a954c11fafe"
+source = "git+https://github.com/servo/mozjs#18ab014e77eee726545ed544ea83d555bdfa46a3"
 dependencies = [
  "bindgen",
  "cc",
@@ -4455,8 +4455,8 @@ dependencies = [
 
 [[package]]
 name = "mozjs_sys"
-version = "0.128.3-4"
-source = "git+https://github.com/servo/mozjs#8526195dce129d2ccd83e7e1e5d03a954c11fafe"
+version = "0.128.3-5"
+source = "git+https://github.com/servo/mozjs#18ab014e77eee726545ed544ea83d555bdfa46a3"
 dependencies = [
  "bindgen",
  "cc",


### PR DESCRIPTION
Companion PR to https://github.com/servo/mozjs/pull/524 
This should reduce rebuilds when not using the prebuilt artifact (e.g. when `debug-mozjs` is true)

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix unnecessary rebuilds of mozjs_sys and everything that depends on it.

