### PR TITLE
Improve performance of column flexboxes

### DIFF
--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -1901,8 +1901,16 @@ impl FlexItem<'_> {
                                 self.content_max_size.cross,
                             )
                         });
-                    content_contributions
-                        .shrink_to_fit(containing_block.inline_size - self.pbm_auto_is_zero.cross)
+                    let stretch_size = containing_block.inline_size - self.pbm_auto_is_zero.cross;
+                    let style = self.box_.style();
+                    if flex_context
+                        .config
+                        .item_with_auto_cross_size_stretches_to_container_size(style, &self.margin)
+                    {
+                        stretch_size
+                    } else {
+                        content_contributions.shrink_to_fit(stretch_size)
+                    }
                 }),
                 // The main size of a flex item is considered to be definite if its flex basis is definite
                 // or the flex container has a definite main size.


### PR DESCRIPTION
If a flex item in a single-line column flex container stretches, then we can know its final size. So instead of first laying it out using its intrinsic inline size, and then stretching it later, we can use the correct size from the very beginning.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because this should have no behavior impact, just better performance

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
