### PR TITLE
mach: Report an error when running `try` with staged changes

### DIFF
--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -842,6 +842,11 @@ tests/wpt/mozilla/tests for Servo-only tests""" % reference_path)
     @CommandArgument('try_strings', default=["full"], nargs='...',
                      help="A list of try strings specifying what kind of job to run.")
     def try_command(self, remote: str, try_strings: list[str]):
+        if subprocess.check_output(["git", "diff", "--cached", "--name-only"]).strip():
+            print("Cannot run `try` with staged and uncommited changes. ")
+            print("Please either commit or stash them before running `try`.")
+            return 1
+
         remote_url = subprocess.check_output(["git", "config", "--get", f"remote.{remote}.url"]).decode().strip()
         if "github.com" not in remote_url:
             print(f"The remote provided ({remote_url}) isn't a GitHub remote.")


### PR DESCRIPTION

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #34293 
- [x] These changes do not require tests because they add a simple check in the `mach` tooling.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
