### PR TITLE
Remove unnecessary clone in layout

### DIFF
--- a/components/layout_2020/formatting_contexts.rs
+++ b/components/layout_2020/formatting_contexts.rs
@@ -327,7 +327,7 @@ impl NonReplacedFormattingContext {
         auto_block_size_stretches_to_containing_block: bool,
     ) -> InlineContentSizesResult {
         sizing::outer_inline(
-            &self.style.clone(),
+            &self.style,
             containing_block,
             auto_minimum,
             auto_block_size_stretches_to_containing_block,


### PR DESCRIPTION
Removes an unnecessary Arc clone. Feel a bit silly making a PR just for this, but at least it should be easy to review!

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors