### PR TITLE
Add nicoburns to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,8 +11,8 @@
 /components/compositing @mrobinson
 
 # Reviewers for layout-related code
-/components/layout_2020 @mrobinson @Loirooriol
-/components/layout @mrobinson @Loirooriol
+/components/layout_2020 @mrobinson @Loirooriol @nicoburns
+/components/layout @mrobinson @Loirooriol @nicoburns
 
 # Reviewers for Minibrowser related code
 /ports/servoshell/desktop @atbrakhi


### PR DESCRIPTION
I've added myself as a code owner for layout related code. I'm assuming that the main consequence of this is that I will automatically be notified to review PRs that touch this code.