### PR TITLE
Avoid laying out grid items and generating fragments if only inline size is requested

### DIFF
--- a/components/layout_2020/taffy/layout.rs
+++ b/components/layout_2020/taffy/layout.rs
@@ -172,11 +172,15 @@ impl taffy::LayoutPartialTree for TaffyContainerContext<'_> {
                             )
                             .to_physical_size(self.style.writing_mode);
 
-                        child.child_fragments = replaced.contents.make_fragments(
-                            &replaced.style,
-                            containing_block,
-                            content_box_size,
-                        );
+                        // Create fragments if the RunMode if PerformLayout
+                        // If the RunMode is ComputeSize then only the returned size will be used
+                        if inputs.run_mode == RunMode::PerformLayout {
+                            child.child_fragments = replaced.contents.make_fragments(
+                                &replaced.style,
+                                containing_block,
+                                content_box_size,
+                            );
+                        }
 
                         let computed_size = taffy::Size {
                             width: inputs.known_dimensions.width.unwrap_or_else(|| {

--- a/components/layout_2020/taffy/layout.rs
+++ b/components/layout_2020/taffy/layout.rs
@@ -10,7 +10,7 @@ use style::values::specified::align::AlignFlags;
 use style::values::specified::box_::DisplayInside;
 use style::Zero;
 use taffy::style_helpers::{TaffyMaxContent, TaffyMinContent};
-use taffy::{AvailableSpace, MaybeMath};
+use taffy::{AvailableSpace, MaybeMath, RequestedAxis, RunMode};
 
 use super::{TaffyContainer, TaffyItemBox, TaffyItemBoxInner, TaffyStyloStyle};
 use crate::cell::ArcRefCell;
@@ -235,6 +235,17 @@ impl taffy::LayoutPartialTree for TaffyContainerContext<'_> {
 
                             resolve_content_size(adjusted_available_space, result.sizes)
                         });
+
+                        // Return early if only inline content sizes are requested
+                        if inputs.run_mode == RunMode::ComputeSize &&
+                            inputs.axis == RequestedAxis::Horizontal
+                        {
+                            return taffy::LayoutOutput::from_outer_size(taffy::Size {
+                                width: inline_size + pbm.padding_border_sums.inline.to_f32_px(),
+                                // If RequestedAxis is Horizontal then height will be ignored.
+                                height: 0.0,
+                            });
+                        }
 
                         let maybe_block_size =
                             option_f32_to_lpa(content_box_known_dimensions.height);


### PR DESCRIPTION
This is a simple optimisation that integrates Taffy's `RunMode` with Servo's `compute_inline_sizes`. And should mean that calls to `compute_inline_sizes` on a Grid container in `layout_2020` are optimised similar to other layout modes (do not perform a full layout, and are cached for subsequent calls)

Taffy's `RunMode` is defined as:

```rust
enum RunMode {
     ComputeSize,
     PerformLayout,
}
```

Where:

- `ComputeSize` indicates a request for a size only (can be either an `inline` or `block` size - `axis` indicates which).
- `PerformLayout` indicates a request for a full recursive layout (generating sizes, positions and baselines for all descendents).

Taffy's API probably ought to change to split this out into separate methods at some point. But for the time being this gets us the performance optimisation without having to change Taffy's API.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes (existing WPT tests covering CSS Grid - there should be no test result changes here because it's purely an optimisation)