### PR TITLE
Don't register unconnected shadow roots with their owner document

### DIFF
--- a/components/script/dom/documentfragment.rs
+++ b/components/script/dom/documentfragment.rs
@@ -20,6 +20,7 @@ use crate::dom::element::Element;
 use crate::dom::htmlcollection::HTMLCollection;
 use crate::dom::node::{window_from_node, Node};
 use crate::dom::nodelist::NodeList;
+use crate::dom::virtualmethods::VirtualMethods;
 use crate::dom::window::Window;
 use crate::script_runtime::CanGc;
 
@@ -130,5 +131,11 @@ impl DocumentFragmentMethods for DocumentFragment {
     // https://dom.spec.whatwg.org/#dom-parentnode-queryselectorall
     fn QuerySelectorAll(&self, selectors: DOMString) -> Fallible<DomRoot<NodeList>> {
         self.upcast::<Node>().query_selector_all(selectors)
+    }
+}
+
+impl VirtualMethods for DocumentFragment {
+    fn super_type(&self) -> Option<&dyn VirtualMethods> {
+        Some(self.upcast::<Node>() as &dyn VirtualMethods)
     }
 }

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -11,7 +11,6 @@ use style::shared_lock::SharedRwLockReadGuard;
 use style::stylesheets::Stylesheet;
 use style::stylist::{CascadeData, Stylist};
 
-use crate::dom::virtualmethods::VirtualMethods;
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::ShadowRootBinding::ShadowRootMode;
 use crate::dom::bindings::codegen::Bindings::ShadowRootBinding::ShadowRoot_Binding::ShadowRootMethods;
@@ -25,8 +24,11 @@ use crate::dom::document::Document;
 use crate::dom::documentfragment::DocumentFragment;
 use crate::dom::documentorshadowroot::{DocumentOrShadowRoot, StyleSheetInDocument};
 use crate::dom::element::Element;
-use crate::dom::node::{Node, NodeDamage, NodeFlags, ShadowIncluding, BindContext, UnbindContext, document_from_node};
+use crate::dom::node::{
+    document_from_node, BindContext, Node, NodeDamage, NodeFlags, ShadowIncluding, UnbindContext,
+};
 use crate::dom::stylesheetlist::{StyleSheetList, StyleSheetListOwner};
+use crate::dom::virtualmethods::VirtualMethods;
 use crate::dom::window::Window;
 use crate::script_runtime::CanGc;
 use crate::stylesheet_set::StylesheetSetRef;
@@ -175,34 +177,6 @@ impl ShadowRoot {
             root,
         );
     }
-
-    pub fn bind_to_tree(&self, context: &BindContext) {
-        if context.tree_connected {
-            let document = document_from_node(self);
-            document.register_shadow_root(self);
-        }
-
-        let shadow_root = self.upcast::<Node>();
-        shadow_root.set_flag(NodeFlags::IS_CONNECTED, context.tree_connected);
-        for node in shadow_root.children() {
-            node.set_flag(NodeFlags::IS_CONNECTED, context.tree_connected);
-            node.bind_to_tree(context);
-        }
-    }
-
-    pub fn unbind_from_tree(&self, context: &UnbindContext) {
-        if context.tree_connected {
-            let document = document_from_node(self);
-            document.unregister_shadow_root(self);
-        }
-
-        let shadow_root = self.upcast::<Node>();
-        shadow_root.set_flag(NodeFlags::IS_CONNECTED, false);
-        for node in shadow_root.children() {
-            node.set_flag(NodeFlags::IS_CONNECTED, false);
-            node.unbind_from_tree(context);
-        }
-    }
 }
 
 impl ShadowRootMethods for ShadowRoot {
@@ -306,6 +280,48 @@ impl ShadowRootMethods for ShadowRoot {
 
         // Step 4. Replace all with fragment within this.
         Node::replace_all(Some(frag.upcast()), self.upcast());
+    }
+}
+
+impl VirtualMethods for ShadowRoot {
+    fn super_type(&self) -> Option<&dyn VirtualMethods> {
+        Some(self.upcast::<DocumentFragment>() as &dyn VirtualMethods)
+    }
+
+    fn bind_to_tree(&self, context: &BindContext) {
+        if let Some(s) = self.super_type() {
+            s.bind_to_tree(context);
+        }
+
+        if context.tree_connected {
+            let document = document_from_node(self);
+            document.register_shadow_root(self);
+        }
+
+        let shadow_root = self.upcast::<Node>();
+        shadow_root.set_flag(NodeFlags::IS_CONNECTED, context.tree_connected);
+        for node in shadow_root.children() {
+            node.set_flag(NodeFlags::IS_CONNECTED, context.tree_connected);
+            node.bind_to_tree(context);
+        }
+    }
+
+    fn unbind_from_tree(&self, context: &UnbindContext) {
+        if let Some(s) = self.super_type() {
+            s.unbind_from_tree(context);
+        }
+
+        if context.tree_connected {
+            let document = document_from_node(self);
+            document.unregister_shadow_root(self);
+        }
+
+        let shadow_root = self.upcast::<Node>();
+        shadow_root.set_flag(NodeFlags::IS_CONNECTED, false);
+        for node in shadow_root.children() {
+            node.set_flag(NodeFlags::IS_CONNECTED, false);
+            node.unbind_from_tree(context);
+        }
     }
 }
 

--- a/components/script/dom/virtualmethods.rs
+++ b/components/script/dom/virtualmethods.rs
@@ -5,14 +5,14 @@
 use html5ever::LocalName;
 use style::attr::AttrValue;
 
-use super::htmltablecolelement::HTMLTableColElement;
 use crate::dom::attr::Attr;
 use crate::dom::bindings::inheritance::{
-    Castable, ElementTypeId, HTMLElementTypeId, HTMLMediaElementTypeId, NodeTypeId,
-    SVGElementTypeId, SVGGraphicsElementTypeId,
+    Castable, DocumentFragmentTypeId, ElementTypeId, HTMLElementTypeId, HTMLMediaElementTypeId,
+    NodeTypeId, SVGElementTypeId, SVGGraphicsElementTypeId,
 };
 use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
+use crate::dom::documentfragment::DocumentFragment;
 use crate::dom::element::{AttributeMutation, Element};
 use crate::dom::event::Event;
 use crate::dom::htmlanchorelement::HTMLAnchorElement;
@@ -46,6 +46,7 @@ use crate::dom::htmlselectelement::HTMLSelectElement;
 use crate::dom::htmlsourceelement::HTMLSourceElement;
 use crate::dom::htmlstyleelement::HTMLStyleElement;
 use crate::dom::htmltablecellelement::HTMLTableCellElement;
+use crate::dom::htmltablecolelement::HTMLTableColElement;
 use crate::dom::htmltableelement::HTMLTableElement;
 use crate::dom::htmltablerowelement::HTMLTableRowElement;
 use crate::dom::htmltablesectionelement::HTMLTableSectionElement;
@@ -54,6 +55,7 @@ use crate::dom::htmltextareaelement::HTMLTextAreaElement;
 use crate::dom::htmltitleelement::HTMLTitleElement;
 use crate::dom::htmlvideoelement::HTMLVideoElement;
 use crate::dom::node::{BindContext, ChildrenMutation, CloneChildrenFlag, Node, UnbindContext};
+use crate::dom::shadowroot::ShadowRoot;
 use crate::dom::svgelement::SVGElement;
 use crate::dom::svgsvgelement::SVGSVGElement;
 
@@ -283,6 +285,12 @@ pub fn vtable_for(node: &Node) -> &dyn VirtualMethods {
             node.downcast::<Element>().unwrap() as &dyn VirtualMethods
         },
         NodeTypeId::Element(_) => node.downcast::<HTMLElement>().unwrap() as &dyn VirtualMethods,
+        NodeTypeId::DocumentFragment(DocumentFragmentTypeId::ShadowRoot) => {
+            node.downcast::<ShadowRoot>().unwrap() as &dyn VirtualMethods
+        },
+        NodeTypeId::DocumentFragment(_) => {
+            node.downcast::<DocumentFragment>().unwrap() as &dyn VirtualMethods
+        },
         _ => node as &dyn VirtualMethods,
     }
 }

--- a/tests/wpt/meta/custom-elements/CustomElementRegistry.html.ini
+++ b/tests/wpt/meta/custom-elements/CustomElementRegistry.html.ini
@@ -1,5 +1,4 @@
 [CustomElementRegistry.html]
-  expected: CRASH
   [customElements.define must upgrade elements in the shadow-including tree order]
     expected: FAIL
 

--- a/tests/wpt/meta/custom-elements/custom-element-registry/upgrade.html.ini
+++ b/tests/wpt/meta/custom-elements/custom-element-registry/upgrade.html.ini
@@ -1,4 +1,3 @@
 [upgrade.html]
-  expected: CRASH
   [Two elements as shadow-including descendants (and not descendants) of the upgraded node]
     expected: FAIL

--- a/tests/wpt/meta/html/semantics/forms/the-input-element/radio-disconnected-group-owner.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-input-element/radio-disconnected-group-owner.html.ini
@@ -1,5 +1,4 @@
 [radio-disconnected-group-owner.html]
-  expected: CRASH
   [Removed elements are moved into separate radio groups.]
     expected: FAIL
 

--- a/tests/wpt/meta/html/semantics/interactive-elements/the-dialog-element/dialog-focus-shadow-double-nested.html.ini
+++ b/tests/wpt/meta/html/semantics/interactive-elements/the-dialog-element/dialog-focus-shadow-double-nested.html.ini
@@ -1,2 +1,6 @@
 [dialog-focus-shadow-double-nested.html]
-  expected: CRASH
+  [show()]
+    expected: FAIL
+
+  [showModal()]
+    expected: FAIL

--- a/tests/wpt/meta/shadow-dom/Extensions-to-Event-Interface.html.ini
+++ b/tests/wpt/meta/shadow-dom/Extensions-to-Event-Interface.html.ini
@@ -1,2 +1,33 @@
 [Extensions-to-Event-Interface.html]
-  expected: CRASH
+  [composedPath() must return an empty array when the event is no longer dispatched]
+    expected: FAIL
+
+  [composed on EventInit must default to false]
+    expected: FAIL
+
+  [composed on EventInit must set the composed flag]
+    expected: FAIL
+
+  [The event must propagate out of open mode shadow boundaries when the composed flag is set]
+    expected: FAIL
+
+  [The event must propagate out of closed mode shadow boundaries when the composed flag is set]
+    expected: FAIL
+
+  [The event must not propagate out of open mode shadow tree of the target but must propagate out of inner shadow trees when the scoped flag is set]
+    expected: FAIL
+
+  [The event must not propagate out of closed mode shadow tree of the target but must propagate out of inner shadow trees when the scoped flag is set]
+    expected: FAIL
+
+  [The event must propagate out of open mode shadow tree in which the relative target and the relative related target are the same]
+    expected: FAIL
+
+  [The event must propagate out of closed mode shadow tree in which the relative target and the relative related target are the same]
+    expected: FAIL
+
+  [composedPath() must contain and only contain the unclosed nodes of target in open mode shadow trees]
+    expected: FAIL
+
+  [composedPath() must contain and only contain the unclosed nodes of target in closed mode shadow trees]
+    expected: FAIL

--- a/tests/wpt/meta/shadow-dom/event-with-related-target.html.ini
+++ b/tests/wpt/meta/shadow-dom/event-with-related-target.html.ini
@@ -1,2 +1,54 @@
 [event-with-related-target.html]
-  expected: CRASH
+  [Firing an event at B1a with relatedNode at B1 with open mode shadow trees]
+    expected: FAIL
+
+  [Firing an event at B1a with relatedNode at B1 with closed mode shadow trees]
+    expected: FAIL
+
+  [Firing an event at B1a with relatedNode at B1b1 with open mode shadow trees]
+    expected: FAIL
+
+  [Firing an event at B1a with relatedNode at B1b1 with closed mode shadow trees]
+    expected: FAIL
+
+  [Firing an event at B1b1 with relatedNode at B1a with open mode shadow trees]
+    expected: FAIL
+
+  [Firing an event at B1b1 with relatedNode at B1a with closed mode shadow trees]
+    expected: FAIL
+
+  [Firing an event at B1a with relatedNode at D1 with open mode shadow trees]
+    expected: FAIL
+
+  [Firing an event at B1a with relatedNode at D1 with closed mode shadow trees]
+    expected: FAIL
+
+  [Firing an event at D1 with relatedNode at B1a with open mode shadow trees]
+    expected: FAIL
+
+  [Firing an event at D1 with relatedNode at B1a with closed mode shadow trees]
+    expected: FAIL
+
+  [Firing an event at B1a with relatedNode at A1a with open mode shadow trees]
+    expected: FAIL
+
+  [Firing an event at B1a with relatedNode at A1a with closed mode shadow trees]
+    expected: FAIL
+
+  [Firing an event at A1a with relatedNode at B1a with open mode shadow trees]
+    expected: FAIL
+
+  [Firing an event at A1a with relatedNode at B1a with closed mode shadow trees]
+    expected: FAIL
+
+  [Firing an event at B1a with relatedNode at A1a (detached) with open mode shadow trees]
+    expected: FAIL
+
+  [Firing an event at B1a with relatedNode at A1a (detached) with closed mode shadow trees]
+    expected: FAIL
+
+  [Firing an event at A1a with relatedNode at B1a (detached) with open mode shadow trees]
+    expected: FAIL
+
+  [Firing an event at A1a with relatedNode at B1a (detached) with closed mode shadow trees]
+    expected: FAIL


### PR DESCRIPTION
`Element::bind_to_tree` currently registers a potential shadow root with the element's owner document, regardless of whether that element is connected with the document or not. This causing crashes as seen in https://github.com/servo/servo/issues/34358, because only shadow roots whose shadow-including root is a document should be registered with that document.

This case is now correctly handled in `ShadowRoot::bind_to_tree`. Note that `ShadowRoot` doesn't implement `VirtualMethods` - I wonder if it should?

[try run](https://github.com/simonwuelker/servo/actions/runs/11992130753)


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix https://github.com/servo/servo/issues/34358
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
