### PR TITLE
layout: Add missing support for some alignment keywords on absolutely positioned elements

### DIFF
--- a/tests/wpt/meta/css/css-align/abspos/align-self-htb-ltr-htb.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/align-self-htb-ltr-htb.html.ini
@@ -2,11 +2,5 @@
   [.item 5]
     expected: FAIL
 
-  [.item 7]
-    expected: FAIL
-
   [.item 13]
-    expected: FAIL
-
-  [.item 15]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/align-self-htb-ltr-vlr.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/align-self-htb-ltr-vlr.html.ini
@@ -2,11 +2,11 @@
   [.item 5]
     expected: FAIL
 
-  [.item 7]
-    expected: FAIL
-
   [.item 13]
     expected: FAIL
 
   [.item 14]
+    expected: FAIL
+
+  [.item 15]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/align-self-htb-ltr-vrl.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/align-self-htb-ltr-vrl.html.ini
@@ -2,11 +2,11 @@
   [.item 5]
     expected: FAIL
 
-  [.item 7]
-    expected: FAIL
-
   [.item 13]
     expected: FAIL
 
   [.item 14]
+    expected: FAIL
+
+  [.item 15]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/align-self-htb-rtl-htb.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/align-self-htb-rtl-htb.html.ini
@@ -2,11 +2,5 @@
   [.item 5]
     expected: FAIL
 
-  [.item 7]
-    expected: FAIL
-
   [.item 13]
-    expected: FAIL
-
-  [.item 15]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/align-self-htb-rtl-vlr.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/align-self-htb-rtl-vlr.html.ini
@@ -2,11 +2,11 @@
   [.item 5]
     expected: FAIL
 
-  [.item 7]
-    expected: FAIL
-
   [.item 13]
     expected: FAIL
 
   [.item 14]
+    expected: FAIL
+
+  [.item 15]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/align-self-htb-rtl-vrl.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/align-self-htb-rtl-vrl.html.ini
@@ -2,11 +2,11 @@
   [.item 5]
     expected: FAIL
 
-  [.item 7]
-    expected: FAIL
-
   [.item 13]
     expected: FAIL
 
   [.item 14]
+    expected: FAIL
+
+  [.item 15]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/justify-self-htb-ltr-htb.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/justify-self-htb-ltr-htb.html.ini
@@ -2,17 +2,5 @@
   [.item 5]
     expected: FAIL
 
-  [.item 7]
-    expected: FAIL
-
-  [.item 9]
-    expected: FAIL
-
   [.item 15]
-    expected: FAIL
-
-  [.item 16]
-    expected: FAIL
-
-  [.item 19]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/justify-self-htb-ltr-vlr.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/justify-self-htb-ltr-vlr.html.ini
@@ -2,17 +2,11 @@
   [.item 5]
     expected: FAIL
 
-  [.item 7]
-    expected: FAIL
-
-  [.item 9]
-    expected: FAIL
-
   [.item 15]
     expected: FAIL
 
   [.item 17]
     expected: FAIL
 
-  [.item 19]
+  [.item 16]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/justify-self-htb-ltr-vrl.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/justify-self-htb-ltr-vrl.html.ini
@@ -5,14 +5,8 @@
   [.item 6]
     expected: FAIL
 
-  [.item 9]
-    expected: FAIL
-
   [.item 15]
     expected: FAIL
 
-  [.item 16]
-    expected: FAIL
-
-  [.item 19]
+  [.item 7]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/justify-self-htb-rtl-htb.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/justify-self-htb-rtl-htb.html.ini
@@ -2,17 +2,5 @@
   [.item 5]
     expected: FAIL
 
-  [.item 6]
-    expected: FAIL
-
-  [.item 8]
-    expected: FAIL
-
   [.item 15]
-    expected: FAIL
-
-  [.item 17]
-    expected: FAIL
-
-  [.item 18]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/justify-self-htb-rtl-vlr.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/justify-self-htb-rtl-vlr.html.ini
@@ -2,17 +2,11 @@
   [.item 5]
     expected: FAIL
 
-  [.item 6]
-    expected: FAIL
-
-  [.item 8]
-    expected: FAIL
-
   [.item 15]
     expected: FAIL
 
   [.item 16]
     expected: FAIL
 
-  [.item 18]
+  [.item 17]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/justify-self-htb-rtl-vrl.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/justify-self-htb-rtl-vrl.html.ini
@@ -5,14 +5,8 @@
   [.item 7]
     expected: FAIL
 
-  [.item 8]
-    expected: FAIL
-
   [.item 15]
     expected: FAIL
 
-  [.item 17]
-    expected: FAIL
-
-  [.item 18]
+  [.item 6]
     expected: FAIL


### PR DESCRIPTION
Adds support for the `self-start`, `self-end`, `left`, and `right` alignment keywords for absolutely positioned elements.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #34282 
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
