### PR TITLE
Bump tracing-perfetto to 0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -921,15 +921,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cmake"
-version = "0.1.51"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb1e43aa7fd152b1f968787f7dbcdeb306d1867ff373c69955211876c053f91a"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "cocoa"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1979,12 +1970,6 @@ name = "fixedbitset"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
-
-[[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
@@ -4548,12 +4533,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "956787520e75e9bd233246045d19f42fb73242759cc57fba9611d940ae96d4b0"
 
 [[package]]
-name = "multimap"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
-
-[[package]]
 name = "naga"
 version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5357,18 +5336,8 @@ version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c3659d1ee90221741f65dd128d9998311b0e40c5d3c23a62445938214abce4f"
 dependencies = [
- "fixedbitset 0.1.9",
+ "fixedbitset",
  "ordermap",
-]
-
-[[package]]
-name = "petgraph"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
-dependencies = [
- "fixedbitset 0.4.2",
- "indexmap",
 ]
 
 [[package]]
@@ -5602,16 +5571,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
-name = "prettyplease"
-version = "0.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
 name = "proc-macro-crate"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5689,27 +5648,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost-build"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
-dependencies = [
- "bytes",
- "heck",
- "itertools 0.10.5",
- "log",
- "multimap",
- "once_cell",
- "petgraph 0.6.5",
- "prettyplease",
- "prost",
- "prost-types",
- "regex",
- "syn",
- "tempfile",
-]
-
-[[package]]
 name = "prost-derive"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5720,24 +5658,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
-dependencies = [
- "prost",
-]
-
-[[package]]
-name = "protobuf-src"
-version = "2.1.0+27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7edafa3bcc668fa93efafcbdf58d7821bbda0f4b458ac7fae3d57ec0fec8167"
-dependencies = [
- "cmake",
 ]
 
 [[package]]
@@ -6437,7 +6357,7 @@ dependencies = [
  "log",
  "num-complex",
  "num-traits",
- "petgraph 0.4.13",
+ "petgraph",
  "serde",
  "serde_derive",
  "servo-media-derive",
@@ -7694,16 +7614,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-perfetto"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c70bb5e88ac1d7f90334d3d84989b9862dfc2c907f339a1d494ee643246029c"
+checksum = "e2be16ec38f047b3a21652de3f393f9d39858e86ee7def469820828489f53c00"
 dependencies = [
  "anyhow",
  "bytes",
  "chrono",
  "prost",
- "prost-build",
- "protobuf-src",
  "rand",
  "thread-id",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,7 +137,7 @@ to_shmem = { git = "https://github.com/servo/stylo", branch = "2024-11-01" }
 tokio = "1"
 tokio-rustls = "0.24"
 tracing = "0.1.40"
-tracing-perfetto = "0.1.2"
+tracing-perfetto = "0.1.3"
 tracing-subscriber = "0.3.18"
 tungstenite = "0.20"
 uluru = "3.0"

--- a/servo-tidy.toml
+++ b/servo-tidy.toml
@@ -63,12 +63,6 @@ packages = [
     "phf_generator",
     "phf_shared",
 
-    # petgraph uses old version
-    "fixedbitset",
-
-    # servo-media-audio uses old version
-    "petgraph",
-
     # icu (from mozjs) uses old version
     # tracing-subscriber (tokio-rs/tracing#3033) uses old version
     # regex -> regex-automata 0.4.7


### PR DESCRIPTION
This patch bumps tracing-perfetto to 0.1.3, fixing a bug that prevented our Perfetto traces from being converted to the old Chrome JSON trace format (csmoe/tracing-perfetto#2, google/perfetto#940). Example trace:

```
$ ./mach build -r --features tracing-perfetto
$ export SERVO_TRACING='[ScriptParseHTML]=info,[ScriptEvaluate]=info,[LayoutPerform]=info,[Compositing]=info'
$ ./mach run -r --profiler-trace-path=trace.html
```

- [servo.pftrace.zip](https://github.com/user-attachments/files/17898408/servo.pftrace.zip) (Perfetto trace)
- [servo.json.zip](https://github.com/user-attachments/files/17898446/servo.json.zip) (converted to Chrome JSON)
- [trace.html.zip](https://github.com/user-attachments/files/17898409/trace.html.zip) (HTML trace, for comparison)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] ~~These changes fix #___ (GitHub issue number if applicable)~~