### PR TITLE
[NFC] Remove unused metrics code

### DIFF
--- a/components/metrics/lib.rs
+++ b/components/metrics/lib.rs
@@ -56,10 +56,9 @@ fn set_metric<U: ProgressiveWebMetric>(
     metric_type: ProgressiveWebMetricType,
     category: ProfilerCategory,
     attr: &Cell<Option<CrossProcessInstant>>,
-    metric_time: Option<CrossProcessInstant>,
+    metric_time: CrossProcessInstant,
     url: &ServoUrl,
 ) {
-    let metric_time = metric_time.unwrap_or_else(CrossProcessInstant::now);
     attr.set(Some(metric_time));
 
     // Queue performance observer notification.
@@ -211,7 +210,7 @@ impl InteractiveMetrics {
             ProgressiveWebMetricType::TimeToInteractive,
             ProfilerCategory::TimeToInteractive,
             &self.time_to_interactive,
-            Some(metric_time),
+            metric_time,
             &self.url,
         );
     }
@@ -285,25 +284,6 @@ impl PaintTimeMetrics {
         }
     }
 
-    pub fn maybe_set_first_paint<T>(&self, profiler_metadata_factory: &T)
-    where
-        T: ProfilerMetadataFactory,
-    {
-        if self.first_paint.get().is_some() {
-            return;
-        }
-
-        set_metric(
-            self,
-            profiler_metadata_factory.new_metadata(),
-            ProgressiveWebMetricType::FirstPaint,
-            ProfilerCategory::TimeToFirstPaint,
-            &self.first_paint,
-            None,
-            &self.url,
-        );
-    }
-
     pub fn maybe_observe_paint_time<T>(
         &self,
         profiler_metadata_factory: &T,
@@ -348,7 +328,7 @@ impl PaintTimeMetrics {
                 ProgressiveWebMetricType::FirstPaint,
                 ProfilerCategory::TimeToFirstPaint,
                 &self.first_paint,
-                Some(paint_time),
+                paint_time,
                 &self.url,
             );
 
@@ -359,7 +339,7 @@ impl PaintTimeMetrics {
                     ProgressiveWebMetricType::FirstContentfulPaint,
                     ProfilerCategory::TimeToFirstContentfulPaint,
                     &self.first_contentful_paint,
-                    Some(paint_time),
+                    paint_time,
                     &self.url,
                 );
             }


### PR DESCRIPTION
This patch removes some now-unused metrics code, simplifying the signature of set_metric().

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] ~~These changes fix #___ (GitHub issue number if applicable)~~

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because there are no functional changes