### PR TITLE
Refine logic for laying out flex item in column layout after #34346

### DIFF
--- a/components/layout_2020/sizing.rs
+++ b/components/layout_2020/sizing.rs
@@ -40,13 +40,6 @@ pub(crate) struct ContentSizes {
 
 /// <https://drafts.csswg.org/css-sizing/#intrinsic-sizes>
 impl ContentSizes {
-    pub fn map(&self, f: impl Fn(Au) -> Au) -> Self {
-        Self {
-            min_content: f(self.min_content),
-            max_content: f(self.max_content),
-        }
-    }
-
     pub fn max(&self, other: Self) -> Self {
         Self {
             min_content: self.min_content.max(other.min_content),


### PR DESCRIPTION
- Clamp the stretch size to not be negative when the sum of padding, borders and margins exceed the available space. This avoids a 2nd layout.
- Avoid computing the inline content sizes if the result isn't needed.
- Instead of clamping both the min-content and max-content sizes to be between the min and max constraints, just compute the fit-content size first, and then clamp. Then `ContentSizes::map()` can be removed.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because there shouldn't be any behavior change, just better perf

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
