### PR TITLE
Implement MallocSizeOf for markup5ever rather than xml5ever.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6553,6 +6553,7 @@ dependencies = [
  "indexmap",
  "keyboard-types",
  "malloc_size_of",
+ "markup5ever",
  "serde",
  "serde_bytes",
  "servo_allocator",
@@ -6566,7 +6567,6 @@ dependencies = [
  "uuid",
  "webrender_api",
  "wr_malloc_size_of",
- "xml5ever",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ log = "0.4"
 mach2 = "0.4"
 malloc_size_of = { package = "servo_malloc_size_of", path = "components/malloc_size_of" }
 malloc_size_of_derive = "0.1"
+markup5ever = "0.14"
 memmap2 = "0.9.5"
 mime = "0.3.13"
 mime_guess = "2.0.5"

--- a/components/malloc_size_of/Cargo.toml
+++ b/components/malloc_size_of/Cargo.toml
@@ -19,6 +19,7 @@ euclid = { workspace = true }
 http = { workspace = true }
 indexmap = { workspace = true }
 keyboard-types = { workspace = true }
+markup5ever = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
 servo_allocator = { path = "../allocator" }
@@ -34,4 +35,3 @@ url = { workspace = true }
 uuid = { workspace = true }
 webrender_api = { workspace = true }
 wr_malloc_size_of = { workspace = true }
-xml5ever = { workspace = true }

--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -146,7 +146,7 @@ impl MallocSizeOf for keyboard_types::Key {
     }
 }
 
-impl MallocSizeOf for xml5ever::QualName {
+impl MallocSizeOf for markup5ever::QualName {
     fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
         self.prefix.size_of(ops) + self.ns.size_of(ops) + self.local.size_of(ops)
     }


### PR DESCRIPTION
The QualName type which MallocSizeOf is implemented for is a markup5ever type which is re-exported in both html5ever and xml5ever.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix servo/servo#34404
- [x] These changes do not require tests because they are a type-level change. If they build then we can be confident that they are correct
