### PR TITLE
Stream: fix error handling in underlying source algorithms

### DIFF
--- a/components/script/dom/readablestream.rs
+++ b/components/script/dom/readablestream.rs
@@ -223,7 +223,9 @@ impl ReadableStream {
             extract_size_algorithm(&QueuingStrategy::empty()),
             can_gc,
         );
-        controller.setup(stream.clone(), can_gc);
+        controller
+            .setup(stream.clone(), can_gc)
+            .expect("Setup of controller with external underlying source cannot fail");
         stream
     }
 
@@ -669,7 +671,7 @@ impl ReadableStreamMethods for ReadableStream {
             controller.set_underlying_source_this_object(obj.handle());
 
             // Perform ? SetUpReadableStreamDefaultControllerFromUnderlyingSource
-            controller.setup(stream.clone(), can_gc);
+            controller.setup(stream.clone(), can_gc)?;
         };
 
         Ok(stream)

--- a/components/script/dom/underlyingsourcecontainer.rs
+++ b/components/script/dom/underlyingsourcecontainer.rs
@@ -123,18 +123,20 @@ impl UnderlyingSourceContainer {
 
     /// <https://streams.spec.whatwg.org/#dom-underlyingsource-pull>
     #[allow(unsafe_code)]
-    pub fn call_pull_algorithm(&self, controller: Controller) -> Option<Rc<Promise>> {
+    pub fn call_pull_algorithm(
+        &self,
+        controller: Controller,
+    ) -> Option<Result<Rc<Promise>, Error>> {
         if let UnderlyingSourceType::Js(source, this_obj) = &self.underlying_source_type {
-            if let Some(pull) = &source.pull {
-                unsafe {
-                    return pull
-                        .Call_(
-                            &SafeHandle::from_raw(this_obj.handle()),
-                            controller,
-                            ExceptionHandling::Report,
-                        )
-                        .ok();
-                }
+            if let Some(algo) = &source.pull {
+                let result = unsafe {
+                    algo.Call_(
+                        &SafeHandle::from_raw(this_obj.handle()),
+                        controller,
+                        ExceptionHandling::Rethrow,
+                    )
+                };
+                return Some(result);
             }
         }
         // Note: other source type have no pull steps for now.


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This fixes the error handling in the `cancel`, `pull`, and `start` algorithms of the underlying source. 

This PR consolidates https://github.com/servo/servo/pull/34387 and https://github.com/servo/servo/pull/34386.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
