### PR TITLE
ohos: fonts: Fix HalfwidthandFullwidthForms font fallback

### DIFF
--- a/components/fonts/platform/freetype/ohos/font_list.rs
+++ b/components/fonts/platform/freetype/ohos/font_list.rs
@@ -539,12 +539,20 @@ pub fn fallback_font_families(options: FallbackFontSelectionOptions) -> Vec<&'st
             UnicodeBlock::HangulJamoExtendedA |
             UnicodeBlock::HangulJamoExtendedB |
             UnicodeBlock::HangulSyllables => {
+                families.push("Noto Sans CJK");
+                families.push("Noto Serif CJK");
                 families.push("Noto Sans KR");
             },
             UnicodeBlock::Hiragana |
             UnicodeBlock::Katakana |
             UnicodeBlock::KatakanaPhoneticExtensions => {
+                families.push("Noto Sans CJK");
+                families.push("Noto Serif CJK");
                 families.push("Noto Sans JP");
+            },
+            UnicodeBlock::HalfwidthandFullwidthForms => {
+                families.push("HarmonyOS Sans SC");
+                families.push("Noto Sans CJK");
             },
             _ => {},
         }


### PR DESCRIPTION
This codeblock contains chinese, japanese and korean characters, so we add the simplified chinese and the CJK fallback fonts.

Additionally, we add the CJK fallback font for the koren and japanese unicode blocks, since the KR and JP fallback fonts don't seem to be present on the latest OH versions anymore.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix font fallback for characters in the HalfwidthandFullwidthForms unicode codeblock on OpenHarmony

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___


Tested manually with the following example page:

```html
<!DOCTYPE html>
<html lang="en">
<head>
    <meta charset="UTF-8">
    <meta name="viewport" content="width=device-width, initial-scale=1.0">
    <title>Document</title>
</head>
<body>
￥没有钱
｠ 	｡ 	｢ 	｣ 	､ 	･ 	ｦ 	ｧ 	ｨ 	ｩ 	ｪ 	ｫ 	ｬ 	ｭ 	ｮ 	ｯ
ｰ 	ｱ 	ｲ 	ｳ 	ｴ 	ｵ 	ｶ 	ｷ 	ｸ 	ｹ 	ｺ 	ｻ 	ｼ 	ｽ 	ｾ 	ｿ
ﾀ 	ﾁ 	ﾂ 	ﾃ 	ﾄ 	ﾅ 	ﾆ 	ﾇ 	ﾈ 	ﾉ 	ﾊ 	ﾋ 	ﾌ 	ﾍ 	ﾎ 	ﾏ
ﾐ 	ﾑ 	ﾒ 	ﾓ 	ﾔ 	ﾕ 	ﾖ 	ﾗ 	ﾘ 	ﾙ 	ﾚ 	ﾛ 	ﾜ 	ﾝ 	ﾞ 	ﾟ
ﾡ 	ﾢ 	ﾣ 	ﾤ 	ﾥ 	ﾦ 	ﾧ 	ﾨ 	ﾩ 	ﾪ 	ﾫ 	ﾬ 	ﾭ 	ﾮ 	ﾯ
ﾰ 	ﾱ 	ﾲ 	ﾳ 	ﾴ 	ﾵ 	ﾶ 	ﾷ 	ﾸ 	ﾹ 	ﾺ 	ﾻ 	ﾼ 	ﾽ 	ﾾ
ￂ 	ￃ 	ￄ 	ￅ 	ￆ 	ￇ 			ￊ 	ￋ 	ￌ 	ￍ 	ￎ 	ￏ
ￒ 	ￓ 	ￔ 	ￕ 	ￖ 	ￗ 			ￚ 	ￛ 	ￜ
￠ 	￡ 	￢ 	￣ 	￤ 	￥ 	￦ 		￨ 	￩ 	￪ 	￫ 	￬ 	￭ 	￮
</body>
</html>
```

