### PR TITLE
Differentiate between missing/invalid value in `make_enumerated_getter!`

### DIFF
--- a/components/script/dom/htmlbuttonelement.rs
+++ b/components/script/dom/htmlbuttonelement.rs
@@ -118,11 +118,11 @@ impl HTMLButtonElementMethods<crate::DomTypeHolder> for HTMLButtonElement {
     make_setter!(SetFormAction, "formaction");
 
     // https://html.spec.whatwg.org/multipage/#dom-fs-formenctype
-    make_enumerated_getter!(
+    make_enumerated_getter_new!(
         FormEnctype,
         "formenctype",
-        "application/x-www-form-urlencoded",
-        "text/plain" | "multipart/form-data"
+        "application/x-www-form-urlencoded" | "multipart/form-data" | "text/plain",
+        invalid => "application/x-www-form-urlencoded"
     );
 
     // https://html.spec.whatwg.org/multipage/#dom-fs-formenctype

--- a/components/script/dom/htmlbuttonelement.rs
+++ b/components/script/dom/htmlbuttonelement.rs
@@ -106,7 +106,7 @@ impl HTMLButtonElementMethods<crate::DomTypeHolder> for HTMLButtonElement {
     }
 
     // <https://html.spec.whatwg.org/multipage/#dom-button-type>
-    make_enumerated_getter_new!(
+    make_enumerated_getter!(
         Type,
         "type",
         "submit" | "reset" | "button",
@@ -124,7 +124,7 @@ impl HTMLButtonElementMethods<crate::DomTypeHolder> for HTMLButtonElement {
     make_setter!(SetFormAction, "formaction");
 
     // https://html.spec.whatwg.org/multipage/#dom-fs-formenctype
-    make_enumerated_getter_new!(
+    make_enumerated_getter!(
         FormEnctype,
         "formenctype",
         "application/x-www-form-urlencoded" | "multipart/form-data" | "text/plain",
@@ -135,7 +135,7 @@ impl HTMLButtonElementMethods<crate::DomTypeHolder> for HTMLButtonElement {
     make_setter!(SetFormEnctype, "formenctype");
 
     // https://html.spec.whatwg.org/multipage/#dom-fs-formmethod
-    make_enumerated_getter_new!(
+    make_enumerated_getter!(
         FormMethod,
         "formmethod",
         "get" | "post" | "dialog",

--- a/components/script/dom/htmlbuttonelement.rs
+++ b/components/script/dom/htmlbuttonelement.rs
@@ -105,8 +105,14 @@ impl HTMLButtonElementMethods<crate::DomTypeHolder> for HTMLButtonElement {
         self.form_owner()
     }
 
-    // https://html.spec.whatwg.org/multipage/#dom-button-type
-    make_enumerated_getter!(Type, "type", "submit", "reset" | "button");
+    // <https://html.spec.whatwg.org/multipage/#dom-button-type>
+    make_enumerated_getter_new!(
+        Type,
+        "type",
+        "submit" | "reset" | "button",
+        missing => "submit",
+        invalid => "submit"
+    );
 
     // https://html.spec.whatwg.org/multipage/#dom-button-type
     make_setter!(SetType, "type");
@@ -129,7 +135,13 @@ impl HTMLButtonElementMethods<crate::DomTypeHolder> for HTMLButtonElement {
     make_setter!(SetFormEnctype, "formenctype");
 
     // https://html.spec.whatwg.org/multipage/#dom-fs-formmethod
-    make_enumerated_getter!(FormMethod, "formmethod", "get", "post" | "dialog");
+    make_enumerated_getter_new!(
+        FormMethod,
+        "formmethod",
+        "get" | "post" | "dialog",
+        missing => "get",
+        invalid => "get"
+    );
 
     // https://html.spec.whatwg.org/multipage/#dom-fs-formmethod
     make_setter!(SetFormMethod, "formmethod");

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -160,7 +160,14 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
     make_setter!(SetLang, "lang");
 
     // https://html.spec.whatwg.org/multipage/#the-dir-attribute
-    make_enumerated_getter!(Dir, "dir", "", "ltr" | "rtl" | "auto");
+    make_enumerated_getter_new!(
+        Dir,
+        "dir",
+        "ltr" | "rtl" | "auto",
+        missing => "",
+        invalid => ""
+    );
+
     // https://html.spec.whatwg.org/multipage/#the-dir-attribute
     make_setter!(SetDir, "dir");
 

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -160,7 +160,7 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
     make_setter!(SetLang, "lang");
 
     // https://html.spec.whatwg.org/multipage/#the-dir-attribute
-    make_enumerated_getter_new!(
+    make_enumerated_getter!(
         Dir,
         "dir",
         "ltr" | "rtl" | "auto",

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -217,7 +217,7 @@ impl HTMLFormElementMethods<crate::DomTypeHolder> for HTMLFormElement {
     make_setter!(SetAction, "action");
 
     // https://html.spec.whatwg.org/multipage/#dom-form-autocomplete
-    make_enumerated_getter_new!(
+    make_enumerated_getter!(
         Autocomplete,
         "autocomplete",
         "on" | "off",
@@ -229,7 +229,7 @@ impl HTMLFormElementMethods<crate::DomTypeHolder> for HTMLFormElement {
     make_setter!(SetAutocomplete, "autocomplete");
 
     // https://html.spec.whatwg.org/multipage/#dom-fs-enctype
-    make_enumerated_getter_new!(
+    make_enumerated_getter!(
         Enctype,
         "enctype",
         "application/x-www-form-urlencoded" | "text/plain" | "multipart/form-data",
@@ -251,7 +251,7 @@ impl HTMLFormElementMethods<crate::DomTypeHolder> for HTMLFormElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-fs-method
-    make_enumerated_getter_new!(
+    make_enumerated_getter!(
         Method,
         "method",
         "get" | "post" | "dialog",

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -217,17 +217,24 @@ impl HTMLFormElementMethods<crate::DomTypeHolder> for HTMLFormElement {
     make_setter!(SetAction, "action");
 
     // https://html.spec.whatwg.org/multipage/#dom-form-autocomplete
-    make_enumerated_getter!(Autocomplete, "autocomplete", "on", "off");
+    make_enumerated_getter_new!(
+        Autocomplete,
+        "autocomplete",
+        "on" | "off",
+        missing => "on",
+        invalid => "on"
+    );
 
     // https://html.spec.whatwg.org/multipage/#dom-form-autocomplete
     make_setter!(SetAutocomplete, "autocomplete");
 
     // https://html.spec.whatwg.org/multipage/#dom-fs-enctype
-    make_enumerated_getter!(
+    make_enumerated_getter_new!(
         Enctype,
         "enctype",
-        "application/x-www-form-urlencoded",
-        "text/plain" | "multipart/form-data"
+        "application/x-www-form-urlencoded" | "text/plain" | "multipart/form-data",
+        missing => "application/x-www-form-urlencoded",
+        invalid => "application/x-www-form-urlencoded"
     );
 
     // https://html.spec.whatwg.org/multipage/#dom-fs-enctype
@@ -244,7 +251,13 @@ impl HTMLFormElementMethods<crate::DomTypeHolder> for HTMLFormElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-fs-method
-    make_enumerated_getter!(Method, "method", "get", "post" | "dialog");
+    make_enumerated_getter_new!(
+        Method,
+        "method",
+        "get" | "post" | "dialog",
+        missing => "get",
+        invalid => "get"
+    );
 
     // https://html.spec.whatwg.org/multipage/#dom-fs-method
     make_setter!(SetMethod, "method");

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -1400,7 +1400,7 @@ impl HTMLInputElementMethods<crate::DomTypeHolder> for HTMLInputElement {
     make_setter!(SetFormAction, "formaction");
 
     // https://html.spec.whatwg.org/multipage/#dom-fs-formenctype
-    make_enumerated_getter_new!(
+    make_enumerated_getter!(
         FormEnctype,
         "formenctype",
         "application/x-www-form-urlencoded" | "text/plain" | "multipart/form-data",
@@ -1412,7 +1412,7 @@ impl HTMLInputElementMethods<crate::DomTypeHolder> for HTMLInputElement {
     make_setter!(SetFormEnctype, "formenctype");
 
     // https://html.spec.whatwg.org/multipage/#dom-fs-formmethod
-    make_enumerated_getter_new!(
+    make_enumerated_getter!(
         FormMethod,
         "formmethod",
         "get" | "post" | "dialog",

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -1399,21 +1399,28 @@ impl HTMLInputElementMethods<crate::DomTypeHolder> for HTMLInputElement {
     // https://html.spec.whatwg.org/multipage/#dom-input-formaction
     make_setter!(SetFormAction, "formaction");
 
-    // https://html.spec.whatwg.org/multipage/#dom-input-formenctype
-    make_enumerated_getter!(
+    // https://html.spec.whatwg.org/multipage/#dom-fs-formenctype
+    make_enumerated_getter_new!(
         FormEnctype,
         "formenctype",
-        "application/x-www-form-urlencoded",
-        "text/plain" | "multipart/form-data"
+        "application/x-www-form-urlencoded" | "text/plain" | "multipart/form-data",
+        missing => "",
+        invalid => "application/x-www-form-urlencoded"
     );
 
     // https://html.spec.whatwg.org/multipage/#dom-input-formenctype
     make_setter!(SetFormEnctype, "formenctype");
 
-    // https://html.spec.whatwg.org/multipage/#dom-input-formmethod
-    make_enumerated_getter!(FormMethod, "formmethod", "get", "post" | "dialog");
+    // https://html.spec.whatwg.org/multipage/#dom-fs-formmethod
+    make_enumerated_getter_new!(
+        FormMethod,
+        "formmethod",
+        "get" | "post" | "dialog",
+        missing => "get",
+        invalid => "get"
+    );
 
-    // https://html.spec.whatwg.org/multipage/#dom-input-formmethod
+    // https://html.spec.whatwg.org/multipage/#dom-fs-formmethod
     make_setter!(SetFormMethod, "formmethod");
 
     // https://html.spec.whatwg.org/multipage/#dom-input-formtarget

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -2159,8 +2159,15 @@ impl HTMLMediaElementMethods<crate::DomTypeHolder> for HTMLMediaElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#attr-media-preload
-    // Missing value default is user-agent defined.
-    make_enumerated_getter!(Preload, "preload", "", "none" | "metadata" | "auto");
+    // Missing/Invalid values are user-agent defined.
+    make_enumerated_getter_new!(
+        Preload,
+        "preload",
+        "none" | "metadata" | "auto",
+        missing => "auto",
+        invalid => "auto"
+    );
+
     // https://html.spec.whatwg.org/multipage/#attr-media-preload
     make_setter!(SetPreload, "preload");
 

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -2160,7 +2160,7 @@ impl HTMLMediaElementMethods<crate::DomTypeHolder> for HTMLMediaElement {
 
     // https://html.spec.whatwg.org/multipage/#attr-media-preload
     // Missing/Invalid values are user-agent defined.
-    make_enumerated_getter_new!(
+    make_enumerated_getter!(
         Preload,
         "preload",
         "none" | "metadata" | "auto",

--- a/components/script/dom/macros.rs
+++ b/components/script/dom/macros.rs
@@ -160,8 +160,7 @@ macro_rules! make_labels_getter(
 
 /// Implements the `To determine the state of an attribute` steps from
 /// <https://html.spec.whatwg.org/multipage/#keywords-and-enumerated-attributes>
-#[macro_export]
-macro_rules! make_enumerated_getter_new(
+macro_rules! make_enumerated_getter(
     ($attr:ident,
         $htmlname:tt,
         $($choices:literal)|+,
@@ -205,7 +204,7 @@ macro_rules! make_enumerated_getter_new(
         $htmlname:tt,
         $($choices:literal)|+,
     ) => (
-        make_enumerated_getter_new!(
+        make_enumerated_getter!(
             $attr,
             $htmlname,
             $($choices)|+,
@@ -218,7 +217,7 @@ macro_rules! make_enumerated_getter_new(
         $($choices:literal)|+,
         invalid => $invalid:literal
     ) => (
-        make_enumerated_getter_new!(
+        make_enumerated_getter!(
             $attr,
             $htmlname,
             $($choices)|+,
@@ -231,31 +230,13 @@ macro_rules! make_enumerated_getter_new(
         $($choices:literal)|+,
         missing => $missing:literal,
     ) => (
-        make_enumerated_getter_new!(
+        make_enumerated_getter!(
             $attr,
             $htmlname,
             $($choices)|+,
             missing => $missing,
             invalid => ""
         );
-    );
-);
-
-#[macro_export]
-macro_rules! make_enumerated_getter(
-    ( $attr:ident, $htmlname:tt, $default:expr, $($choices:pat_param)|+) => (
-        fn $attr(&self) -> DOMString {
-            use $crate::dom::bindings::inheritance::Castable;
-            use $crate::dom::element::Element;
-            let element = self.upcast::<Element>();
-            let mut val = element.get_string_attribute(&html5ever::local_name!($htmlname));
-            val.make_ascii_lowercase();
-            // https://html.spec.whatwg.org/multipage/#attr-fs-method
-            match &*val {
-                $($choices)|+ => val,
-                _ => DOMString::from($default)
-            }
-        }
     );
 );
 

--- a/components/script/dom/macros.rs
+++ b/components/script/dom/macros.rs
@@ -185,9 +185,9 @@ macro_rules! make_enumerated_getter(
                 Some(attr) => {
                     // Step 2. If the attribute's value is an ASCII case-insensitive match for one of the keywords
                     // defined for the attribute, then return the state represented by that keyword.
-                    let value: DOMString = attr.Value();
+                    let value: DOMString = attr.Value().to_ascii_lowercase().into();
                     $(
-                        if $choices.eq_ignore_ascii_case(&value) {
+                        if value.str() == $choices {
                             return value;
                         }
                     )+

--- a/tests/wpt/meta/html/dom/reflection-forms-weekmonth.html.ini
+++ b/tests/wpt/meta/html/dom/reflection-forms-weekmonth.html.ini
@@ -248,9 +248,6 @@
   [input.autocomplete: IDL set to object "test-valueOf"]
     expected: FAIL
 
-  [input.formEnctype: IDL get with DOM attribute unset]
-    expected: FAIL
-
   [input.formMethod: IDL get with DOM attribute unset]
     expected: FAIL
 

--- a/tests/wpt/meta/html/dom/reflection-forms.html.ini
+++ b/tests/wpt/meta/html/dom/reflection-forms.html.ini
@@ -1130,9 +1130,6 @@
   [input.autocomplete: IDL set to object "test-valueOf"]
     expected: FAIL
 
-  [input.formEnctype: IDL get with DOM attribute unset]
-    expected: FAIL
-
   [input.formMethod: IDL get with DOM attribute unset]
     expected: FAIL
 
@@ -1602,9 +1599,6 @@
     expected: FAIL
 
   [button.tabIndex: IDL set to -2147483648]
-    expected: FAIL
-
-  [button.formEnctype: IDL get with DOM attribute unset]
     expected: FAIL
 
   [button.formMethod: IDL get with DOM attribute unset]


### PR DESCRIPTION
The current implementation of `make_enumerated_getter` does not follow the algorithm described in https://html.spec.whatwg.org/multipage/#keywords-and-enumerated-attributes. 

Specifically, it only considers a "default" state that is returned if the actual attribute state is either missing or not valid, while the spec allows different values to be returned in these cases. 

[try run](https://github.com/simonwuelker/servo/actions/runs/12059632145)


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes (covered by WPT)

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
