### PR TITLE
Use natural ratio for `object-fit`

### DIFF
--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -1986,7 +1986,6 @@ impl FlexItem<'_> {
 
                 let fragments = replaced.contents.make_fragments(
                     &replaced.style,
-                    containing_block,
                     size.to_physical_size(container_writing_mode),
                 );
 

--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -1377,7 +1377,7 @@ fn layout_in_flow_replaced_block_level(
 
     let containing_block_writing_mode = containing_block.style.writing_mode;
     let physical_content_size = content_size.to_physical_size(containing_block_writing_mode);
-    let fragments = replaced.make_fragments(style, containing_block, physical_content_size);
+    let fragments = replaced.make_fragments(style, physical_content_size);
 
     let clearance;
     if let Some(ref mut sequential_layout_state) = sequential_layout_state {
@@ -2022,11 +2022,9 @@ impl IndependentFormattingContext {
                         &content_box_sizes_and_pbm,
                     )
                     .to_physical_size(container_writing_mode);
-                let fragments = replaced.contents.make_fragments(
-                    &replaced.style,
-                    containing_block,
-                    content_size,
-                );
+                let fragments = replaced
+                    .contents
+                    .make_fragments(&replaced.style, content_size);
 
                 let content_rect = PhysicalRect::new(PhysicalPoint::zero(), content_size);
                 (fragments, content_rect, None)

--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -567,7 +567,6 @@ impl HoistedAbsolutelyPositionedBox {
                     content_size = computed_size.map(|size| size.to_numeric().unwrap());
                     fragments = replaced.contents.make_fragments(
                         &style,
-                        containing_block,
                         content_size.to_physical_size(containing_block_writing_mode),
                     );
                 },

--- a/components/layout_2020/taffy/layout.rs
+++ b/components/layout_2020/taffy/layout.rs
@@ -175,11 +175,9 @@ impl taffy::LayoutPartialTree for TaffyContainerContext<'_> {
                         // Create fragments if the RunMode if PerformLayout
                         // If the RunMode is ComputeSize then only the returned size will be used
                         if inputs.run_mode == RunMode::PerformLayout {
-                            child.child_fragments = replaced.contents.make_fragments(
-                                &replaced.style,
-                                containing_block,
-                                content_box_size,
-                            );
+                            child.child_fragments = replaced
+                                .contents
+                                .make_fragments(&replaced.style, content_box_size);
                         }
 
                         let computed_size = taffy::Size {

--- a/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-022.html.ini
+++ b/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-022.html.ini
@@ -1,2 +1,0 @@
-[replaced-element-022.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-024.html.ini
+++ b/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-024.html.ini
@@ -1,2 +1,0 @@
-[replaced-element-024.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-026.html.ini
+++ b/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-026.html.ini
@@ -1,2 +1,0 @@
-[replaced-element-026.html]
-  expected: FAIL


### PR DESCRIPTION
We were using the preferred aspect ratio provided by the `aspect-ratio` property instead of the natural aspect ratio. However, the preferred aspect ratio should only be used to size the replaced element. To paint the replaced contents into that element we need the natural ratio.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
