### PR TITLE
Refactor computation of preferred aspect ratios

### DIFF
--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -1924,13 +1924,10 @@ impl FlexItem<'_> {
                     let constraint_space = ConstraintSpace::new(
                         SizeConstraint::Definite(used_main_size),
                         item_writing_mode,
+                        self.preferred_aspect_ratio,
                     );
                     context
-                        .inline_content_sizes(
-                            flex_context.layout_context,
-                            &constraint_space,
-                            self.preferred_aspect_ratio,
-                        )
+                        .inline_content_sizes(flex_context.layout_context, &constraint_space)
                         .sizes
                         .shrink_to_fit(stretch_size)
                         .clamp_between_extremums(
@@ -2540,9 +2537,10 @@ impl FlexItemBox {
         // > aspect ratio.
         let main_content_size = if cross_axis_is_item_block_axis {
             let writing_mode = style.writing_mode;
-            let constraint_space = ConstraintSpace::new(cross_size, writing_mode);
+            let constraint_space =
+                ConstraintSpace::new(cross_size, writing_mode, preferred_aspect_ratio);
             self.independent_formatting_context
-                .inline_content_sizes(layout_context, &constraint_space, preferred_aspect_ratio)
+                .inline_content_sizes(layout_context, &constraint_space)
                 .sizes
                 .min_content
         } else {
@@ -2698,13 +2696,10 @@ impl FlexItemBox {
                             content_max_box_size.cross,
                         ),
                         writing_mode,
+                        preferred_aspect_ratio,
                     );
                     let max_content = flex_item
-                        .inline_content_sizes(
-                            layout_context,
-                            &constraint_space,
-                            preferred_aspect_ratio,
-                        )
+                        .inline_content_sizes(layout_context, &constraint_space)
                         .sizes
                         .max_content;
                     if let Some(ratio) = preferred_aspect_ratio {
@@ -2790,12 +2785,15 @@ impl FlexItemBox {
                         if item_with_auto_cross_size_stretches_to_container_size {
                             containing_block_inline_size_minus_pbm
                         } else {
-                            let containing_block_for_children =
-                                ConstraintSpace::new_for_style(&non_replaced.style);
+                            let constraint_space = ConstraintSpace::new(
+                                SizeConstraint::default(),
+                                non_replaced.style.writing_mode,
+                                non_replaced.preferred_aspect_ratio(),
+                            );
                             non_replaced
                                 .inline_content_sizes(
                                     flex_context.layout_context,
-                                    &containing_block_for_children,
+                                    &constraint_space,
                                 )
                                 .sizes
                                 .shrink_to_fit(containing_block_inline_size_minus_pbm)

--- a/components/layout_2020/flow/inline/mod.rs
+++ b/components/layout_2020/flow/inline/mod.rs
@@ -1965,7 +1965,7 @@ impl IndependentFormattingContext {
 
         // Lay out absolutely positioned children if this new atomic establishes a containing block
         // for absolutes.
-        let positioning_context = if matches!(self, IndependentFormattingContext::Replaced(_)) {
+        let positioning_context = if self.is_replaced() {
             None
         } else {
             if fragment

--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -395,7 +395,7 @@ fn calculate_inline_content_size_for_block_level_boxes(
                     containing_block,
                     &LogicalVec2::zero(),
                     false, /* auto_block_size_stretches_to_containing_block */
-                    |constraint_space| {
+                    |constraint_space, _| {
                         contents.inline_content_sizes(layout_context, constraint_space)
                     },
                 );

--- a/components/layout_2020/lib.rs
+++ b/components/layout_2020/lib.rs
@@ -35,24 +35,38 @@ use style::logical_geometry::WritingMode;
 use style::properties::ComputedValues;
 
 use crate::geom::{LogicalVec2, SizeConstraint};
+use crate::style_ext::AspectRatio;
 
 /// Represents the set of constraints that we use when computing the min-content
 /// and max-content inline sizes of an element.
 pub(crate) struct ConstraintSpace {
     pub block_size: SizeConstraint,
     pub writing_mode: WritingMode,
+    pub preferred_aspect_ratio: Option<AspectRatio>,
 }
 
 impl ConstraintSpace {
-    fn new(block_size: SizeConstraint, writing_mode: WritingMode) -> Self {
+    fn new(
+        block_size: SizeConstraint,
+        writing_mode: WritingMode,
+        preferred_aspect_ratio: Option<AspectRatio>,
+    ) -> Self {
         Self {
             block_size,
             writing_mode,
+            preferred_aspect_ratio,
         }
     }
 
-    fn new_for_style(style: &ComputedValues) -> Self {
-        Self::new(SizeConstraint::default(), style.writing_mode)
+    fn new_for_style_and_ratio(
+        style: &ComputedValues,
+        preferred_aspect_ratio: Option<AspectRatio>,
+    ) -> Self {
+        Self::new(
+            SizeConstraint::default(),
+            style.writing_mode,
+            preferred_aspect_ratio,
+        )
     }
 }
 

--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -551,8 +551,9 @@ impl HoistedAbsolutelyPositionedBox {
         // tentative block size.
         let mut inline_axis = inline_axis_solver.solve(Some(|| {
             let constraint_space = ConstraintSpace::new(block_axis.size, style.writing_mode);
+            let ratio = context.preferred_aspect_ratio(&pbm.padding_border_sums);
             context
-                .inline_content_sizes(layout_context, &constraint_space, &containing_block.into())
+                .inline_content_sizes(layout_context, &constraint_space, ratio)
                 .sizes
         }));
 

--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -550,10 +550,10 @@ impl HoistedAbsolutelyPositionedBox {
         // The inline axis can be fully resolved, computing intrinsic sizes using the
         // tentative block size.
         let mut inline_axis = inline_axis_solver.solve(Some(|| {
-            let constraint_space = ConstraintSpace::new(block_axis.size, style.writing_mode);
             let ratio = context.preferred_aspect_ratio(&pbm.padding_border_sums);
+            let constraint_space = ConstraintSpace::new(block_axis.size, style.writing_mode, ratio);
             context
-                .inline_content_sizes(layout_context, &constraint_space, ratio)
+                .inline_content_sizes(layout_context, &constraint_space)
                 .sizes
         }));
 

--- a/components/layout_2020/replaced.rs
+++ b/components/layout_2020/replaced.rs
@@ -282,7 +282,6 @@ impl ReplacedContent {
         &self,
         _: &LayoutContext,
         constraint_space: &ConstraintSpace,
-        preferred_aspect_ratio: Option<AspectRatio>,
     ) -> InlineContentSizesResult {
         let get_inline_fallback_size = || {
             let writing_mode = constraint_space.writing_mode;
@@ -292,13 +291,13 @@ impl ReplacedContent {
         };
         let inline_content_size = self.content_size(
             Direction::Inline,
-            preferred_aspect_ratio,
+            constraint_space.preferred_aspect_ratio,
             &|| constraint_space.block_size,
             &get_inline_fallback_size,
         );
         InlineContentSizesResult {
             sizes: inline_content_size.into(),
-            depends_on_block_constraints: preferred_aspect_ratio.is_some(),
+            depends_on_block_constraints: constraint_space.preferred_aspect_ratio.is_some(),
         }
     }
 

--- a/components/layout_2020/sizing.rs
+++ b/components/layout_2020/sizing.rs
@@ -13,7 +13,7 @@ use style::properties::ComputedValues;
 use style::Zero;
 
 use crate::geom::Size;
-use crate::style_ext::{Clamp, ComputedValuesExt, ContentBoxSizesAndPBM};
+use crate::style_ext::{AspectRatio, Clamp, ComputedValuesExt, ContentBoxSizesAndPBM};
 use crate::{ConstraintSpace, IndefiniteContainingBlock, LogicalVec2, SizeConstraint};
 
 #[derive(PartialEq)]
@@ -113,7 +113,8 @@ pub(crate) fn outer_inline(
     containing_block: &IndefiniteContainingBlock,
     auto_minimum: &LogicalVec2<Au>,
     auto_block_size_stretches_to_containing_block: bool,
-    get_content_size: impl FnOnce(&ConstraintSpace, &LogicalVec2<Au>) -> InlineContentSizesResult,
+    get_preferred_aspect_ratio: impl FnOnce(&LogicalVec2<Au>) -> Option<AspectRatio>,
+    get_content_size: impl FnOnce(&ConstraintSpace) -> InlineContentSizesResult,
 ) -> InlineContentSizesResult {
     let ContentBoxSizesAndPBM {
         content_box_size,
@@ -150,13 +151,11 @@ pub(crate) fn outer_inline(
         let max_block_size = content_max_box_size
             .block
             .maybe_resolve_extrinsic(available_block_size);
-        get_content_size(
-            &ConstraintSpace::new(
-                SizeConstraint::new(preferred_block_size, min_block_size, max_block_size),
-                style.writing_mode,
-            ),
-            &pbm.padding_border_sums,
-        )
+        get_content_size(&ConstraintSpace::new(
+            SizeConstraint::new(preferred_block_size, min_block_size, max_block_size),
+            style.writing_mode,
+            get_preferred_aspect_ratio(&pbm.padding_border_sums),
+        ))
     });
     let resolve_non_initial = |inline_size| {
         Some(match inline_size {

--- a/components/layout_2020/sizing.rs
+++ b/components/layout_2020/sizing.rs
@@ -113,7 +113,7 @@ pub(crate) fn outer_inline(
     containing_block: &IndefiniteContainingBlock,
     auto_minimum: &LogicalVec2<Au>,
     auto_block_size_stretches_to_containing_block: bool,
-    get_content_size: impl FnOnce(&ConstraintSpace) -> InlineContentSizesResult,
+    get_content_size: impl FnOnce(&ConstraintSpace, &LogicalVec2<Au>) -> InlineContentSizesResult,
 ) -> InlineContentSizesResult {
     let ContentBoxSizesAndPBM {
         content_box_size,
@@ -150,10 +150,13 @@ pub(crate) fn outer_inline(
         let max_block_size = content_max_box_size
             .block
             .maybe_resolve_extrinsic(available_block_size);
-        get_content_size(&ConstraintSpace::new(
-            SizeConstraint::new(preferred_block_size, min_block_size, max_block_size),
-            style.writing_mode,
-        ))
+        get_content_size(
+            &ConstraintSpace::new(
+                SizeConstraint::new(preferred_block_size, min_block_size, max_block_size),
+                style.writing_mode,
+            ),
+            &pbm.padding_border_sums,
+        )
     });
     let resolve_non_initial = |inline_size| {
         Some(match inline_size {

--- a/components/layout_2020/table/layout.rs
+++ b/components/layout_2020/table/layout.rs
@@ -296,12 +296,13 @@ impl<'a> TableLayout<'a> {
                     let mut inline_content_sizes = if is_in_fixed_mode {
                         ContentSizes::zero()
                     } else {
+                        let constraint_space = ConstraintSpace::new_for_style_and_ratio(
+                            &cell.style,
+                            None, /* TODO: support preferred aspect ratios on non-replaced boxes */
+                        );
                         cell.contents
                             .contents
-                            .inline_content_sizes(
-                                layout_context,
-                                &ConstraintSpace::new_for_style(&cell.style),
-                            )
+                            .inline_content_sizes(layout_context, &constraint_space)
                             .sizes
                     };
                     inline_content_sizes.min_content += padding_border_sums.inline;

--- a/components/layout_2020/taffy/layout.rs
+++ b/components/layout_2020/taffy/layout.rs
@@ -227,6 +227,7 @@ impl taffy::LayoutPartialTree for TaffyContainerContext<'_> {
                                     None,
                                 ),
                                 writing_mode: self.style.writing_mode,
+                                preferred_aspect_ratio: non_replaced.preferred_aspect_ratio(),
                             };
 
                             let result = non_replaced

--- a/components/layout_2020/taffy/layout.rs
+++ b/components/layout_2020/taffy/layout.rs
@@ -156,6 +156,7 @@ impl taffy::LayoutPartialTree for TaffyContainerContext<'_> {
                             .used_size_as_if_inline_element_from_content_box_sizes(
                                 containing_block,
                                 &replaced.style,
+                                replaced.preferred_aspect_ratio(&pbm.padding_border_sums),
                                 LogicalVec2 {
                                     inline: option_f32_to_size(content_box_known_dimensions.width),
                                     block: option_f32_to_size(content_box_known_dimensions.height),


### PR DESCRIPTION
Computing min/max-content sizes required a ContainingBlock in order to resolve the padding and border when determining the preferred aspect ratio. However, all callers already knew the padding and border, so they can compute the ratio themselves, and pass it directly instead of the ContainingBlock.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because there is no behavior impact

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
