### PR TITLE
Ensure taffy uses margin when calling `used_size_as_if_inline_element_from_content_box_sizes()`

### DIFF
--- a/components/layout_2020/taffy/layout.rs
+++ b/components/layout_2020/taffy/layout.rs
@@ -168,7 +168,7 @@ impl taffy::LayoutPartialTree for TaffyContainerContext<'_> {
                                     inline: Size::Initial,
                                     block: Size::Initial,
                                 },
-                                pbm.padding_border_sums,
+                                pbm.padding_border_sums + pbm.margin.auto_is(Au::zero).sum(),
                             )
                             .to_physical_size(self.style.writing_mode);
 


### PR DESCRIPTION
Ensures taffy uses margin when calling `used_size_as_if_inline_element_from_content_box_sizes()` by refactoring `pbm.padding_border_sums,` to `pbm.padding_border_sums + pbm.margin.auto_is(Au::zero).sum(),`


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #34417 
- [X] These changes do not require tests because they do not modify functionality

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
