### PR TITLE
Fix alignment of abspos child of flexbox with flipped direction

### DIFF
--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -832,7 +832,11 @@ impl<'a> AbsoluteAxisSolver<'a> {
             self.box_offsets.end.non_auto(),
         ) {
             (None, None) => solve_for_anchor(if self.flip_anchor {
-                Anchor::End(self.containing_size - self.static_position_rect_axis.origin)
+                Anchor::End(
+                    self.containing_size -
+                        self.static_position_rect_axis.origin -
+                        self.static_position_rect_axis.length,
+                )
             } else {
                 Anchor::Start(self.static_position_rect_axis.origin)
             }),
@@ -910,40 +914,58 @@ impl<'a> AbsoluteAxisSolver<'a> {
     }
 
     fn origin_for_alignment_or_justification(&self, margin_box_axis: RectAxis) -> Option<Au> {
-        let alignment_container = match (
+        let (alignment_container, flip_anchor) = match (
             self.box_offsets.start.non_auto(),
             self.box_offsets.end.non_auto(),
         ) {
-            (None, None) => self.static_position_rect_axis,
+            (None, None) => (self.static_position_rect_axis, self.flip_anchor),
             (Some(start), Some(end)) => {
                 let start = start.to_used_value(self.containing_size);
                 let end = end.to_used_value(self.containing_size);
-
-                RectAxis {
+                let alignment_container = RectAxis {
                     origin: start,
                     length: self.containing_size - (end + start),
-                }
+                };
+                (alignment_container, false)
             },
             _ => return None,
         };
 
-        let mut value_after_safety = self.alignment.value();
-        if self.alignment.flags() == AlignFlags::SAFE &&
-            margin_box_axis.length > alignment_container.length
+        // Here we resolve the alignment to either start, center, or end.
+        // Note we need to handle both self-alignment values (when some inset isn't auto)
+        // and distributed alignment values (when both insets are auto).
+        // The latter are treated as their fallback alignment.
+        let alignment = match self.alignment.value() {
+            // https://drafts.csswg.org/css-align/#valdef-self-position-end
+            // https://drafts.csswg.org/css-align/#valdef-self-position-flex-end
+            AlignFlags::END | AlignFlags::FLEX_END => AlignFlags::END,
+            // https://drafts.csswg.org/css-align/#valdef-self-position-center
+            // https://drafts.csswg.org/css-align/#valdef-align-content-space-around
+            // https://drafts.csswg.org/css-align/#valdef-align-content-space-evenly
+            AlignFlags::CENTER | AlignFlags::SPACE_AROUND | AlignFlags::SPACE_EVENLY => {
+                AlignFlags::CENTER
+            },
+            // TODO(#34282): handle missing values: self-start, self-end, left, right.
+            _ => AlignFlags::START,
+        };
+
+        if alignment == AlignFlags::START ||
+            self.alignment.flags() == AlignFlags::SAFE &&
+                margin_box_axis.length > alignment_container.length
         {
-            value_after_safety = AlignFlags::START;
+            // Aligning to start is no-op, so just return `None`. This should be equivalent
+            // to returning `Some(alignment_container.origin + free_space)` if `flip_anchor`,
+            // or `Some(alignment_container.origin)` otherwise.
+            return None;
         }
 
-        match value_after_safety {
-            AlignFlags::CENTER | AlignFlags::SPACE_AROUND | AlignFlags::SPACE_EVENLY => Some(
-                alignment_container.origin +
-                    ((alignment_container.length - margin_box_axis.length) / 2),
-            ),
-            AlignFlags::FLEX_END | AlignFlags::END => Some(
-                alignment_container.origin + alignment_container.length - margin_box_axis.length,
-            ),
-            _ => None,
-        }
+        let free_space = alignment_container.length - margin_box_axis.length;
+        Some(match alignment {
+            AlignFlags::CENTER => alignment_container.origin + free_space / 2,
+            AlignFlags::END if flip_anchor => alignment_container.origin,
+            AlignFlags::END => alignment_container.origin + free_space,
+            _ => unreachable!(),
+        })
     }
 
     fn solve_alignment(

--- a/tests/wpt/meta/css/css-flexbox/abspos/position-absolute-012.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/abspos/position-absolute-012.html.ini
@@ -8,12 +8,6 @@
   [.flexbox 37]
     expected: FAIL
 
-  [.flexbox 30]
-    expected: FAIL
-
-  [.flexbox 32]
-    expected: FAIL
-
   [.flexbox 33]
     expected: FAIL
 
@@ -32,22 +26,7 @@
   [.flexbox 85]
     expected: FAIL
 
-  [.flexbox 86]
-    expected: FAIL
-
-  [.flexbox 16]
-    expected: FAIL
-
-  [.flexbox 14]
-    expected: FAIL
-
-  [.flexbox 13]
-    expected: FAIL
-
   [.flexbox 96]
-    expected: FAIL
-
-  [.flexbox 94]
     expected: FAIL
 
   [.flexbox 93]
@@ -74,9 +53,6 @@
   [.flexbox 69]
     expected: FAIL
 
-  [.flexbox 70]
-    expected: FAIL
-
   [.flexbox 72]
     expected: FAIL
 
@@ -87,9 +63,6 @@
     expected: FAIL
 
   [.flexbox 77]
-    expected: FAIL
-
-  [.flexbox 78]
     expected: FAIL
 
   [.flexbox 45]
@@ -107,15 +80,6 @@
   [.flexbox 49]
     expected: FAIL
 
-  [.flexbox 5]
-    expected: FAIL
-
-  [.flexbox 6]
-    expected: FAIL
-
-  [.flexbox 8]
-    expected: FAIL
-
   [.flexbox 59]
     expected: FAIL
 
@@ -129,30 +93,6 @@
     expected: FAIL
 
   [.flexbox 57]
-    expected: FAIL
-
-  [.flexbox 29]
-    expected: FAIL
-
-  [.flexbox 24]
-    expected: FAIL
-
-  [.flexbox 22]
-    expected: FAIL
-
-  [.flexbox 21]
-    expected: FAIL
-
-  [.flexbox 7]
-    expected: FAIL
-
-  [.flexbox 15]
-    expected: FAIL
-
-  [.flexbox 23]
-    expected: FAIL
-
-  [.flexbox 31]
     expected: FAIL
 
   [.flexbox 34]
@@ -179,16 +119,16 @@
   [.flexbox 64]
     expected: FAIL
 
-  [.flexbox 71]
+  [.flexbox 39]
     expected: FAIL
 
-  [.flexbox 79]
+  [.flexbox 47]
     expected: FAIL
 
-  [.flexbox 87]
+  [.flexbox 55]
     expected: FAIL
 
-  [.flexbox 95]
+  [.flexbox 63]
     expected: FAIL
 
   [.flexbox 38]

--- a/tests/wpt/meta/css/css-flexbox/abspos/position-absolute-013.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/abspos/position-absolute-013.html.ini
@@ -14,18 +14,6 @@
   [.flexbox 306]
     expected: FAIL
 
-  [.flexbox 34]
-    expected: FAIL
-
-  [.flexbox 35]
-    expected: FAIL
-
-  [.flexbox 36]
-    expected: FAIL
-
-  [.flexbox 32]
-    expected: FAIL
-
   [.flexbox 396]
     expected: FAIL
 
@@ -36,12 +24,6 @@
     expected: FAIL
 
   [.flexbox 392]
-    expected: FAIL
-
-  [.flexbox 393]
-    expected: FAIL
-
-  [.flexbox 391]
     expected: FAIL
 
   [.flexbox 399]
@@ -68,18 +50,6 @@
   [.flexbox 373]
     expected: FAIL
 
-  [.flexbox 80]
-    expected: FAIL
-
-  [.flexbox 83]
-    expected: FAIL
-
-  [.flexbox 82]
-    expected: FAIL
-
-  [.flexbox 84]
-    expected: FAIL
-
   [.flexbox 182]
     expected: FAIL
 
@@ -93,15 +63,6 @@
     expected: FAIL
 
   [.flexbox 184]
-    expected: FAIL
-
-  [.flexbox 118]
-    expected: FAIL
-
-  [.flexbox 119]
-    expected: FAIL
-
-  [.flexbox 116]
     expected: FAIL
 
   [.flexbox 238]
@@ -119,13 +80,7 @@
   [.flexbox 234]
     expected: FAIL
 
-  [.flexbox 331]
-    expected: FAIL
-
   [.flexbox 332]
-    expected: FAIL
-
-  [.flexbox 333]
     expected: FAIL
 
   [.flexbox 334]
@@ -135,21 +90,6 @@
     expected: FAIL
 
   [.flexbox 338]
-    expected: FAIL
-
-  [.flexbox 45]
-    expected: FAIL
-
-  [.flexbox 44]
-    expected: FAIL
-
-  [.flexbox 46]
-    expected: FAIL
-
-  [.flexbox 43]
-    expected: FAIL
-
-  [.flexbox 48]
     expected: FAIL
 
   [.flexbox 248]
@@ -170,28 +110,13 @@
   [.flexbox 242]
     expected: FAIL
 
-  [.flexbox 379]
-    expected: FAIL
-
   [.flexbox 147]
     expected: FAIL
 
   [.flexbox 145]
     expected: FAIL
 
-  [.flexbox 143]
-    expected: FAIL
-
-  [.flexbox 141]
-    expected: FAIL
-
-  [.flexbox 140]
-    expected: FAIL
-
   [.flexbox 419]
-    expected: FAIL
-
-  [.flexbox 418]
     expected: FAIL
 
   [.flexbox 149]
@@ -201,12 +126,6 @@
     expected: FAIL
 
   [.flexbox 370]
-    expected: FAIL
-
-  [.flexbox 371]
-    expected: FAIL
-
-  [.flexbox 381]
     expected: FAIL
 
   [.flexbox 380]
@@ -251,34 +170,7 @@
   [.flexbox 361]
     expected: FAIL
 
-  [.flexbox 360]
-    expected: FAIL
-
-  [.flexbox 96]
-    expected: FAIL
-
-  [.flexbox 94]
-    expected: FAIL
-
-  [.flexbox 92]
-    expected: FAIL
-
-  [.flexbox 93]
-    expected: FAIL
-
-  [.flexbox 91]
-    expected: FAIL
-
-  [.flexbox 72]
-    expected: FAIL
-
-  [.flexbox 428]
-    expected: FAIL
-
   [.flexbox 429]
-    expected: FAIL
-
-  [.flexbox 420]
     expected: FAIL
 
   [.flexbox 422]
@@ -291,24 +183,6 @@
     expected: FAIL
 
   [.flexbox 427]
-    expected: FAIL
-
-  [.flexbox 108]
-    expected: FAIL
-
-  [.flexbox 103]
-    expected: FAIL
-
-  [.flexbox 106]
-    expected: FAIL
-
-  [.flexbox 105]
-    expected: FAIL
-
-  [.flexbox 104]
-    expected: FAIL
-
-  [.flexbox 323]
     expected: FAIL
 
   [.flexbox 322]
@@ -327,18 +201,6 @@
     expected: FAIL
 
   [.flexbox 329]
-    expected: FAIL
-
-  [.flexbox 59]
-    expected: FAIL
-
-  [.flexbox 56]
-    expected: FAIL
-
-  [.flexbox 57]
-    expected: FAIL
-
-  [.flexbox 55]
     expected: FAIL
 
   [.flexbox 258]
@@ -386,12 +248,6 @@
   [.flexbox 178]
     expected: FAIL
 
-  [.flexbox 11]
-    expected: FAIL
-
-  [.flexbox 19]
-    expected: FAIL
-
   [.flexbox 213]
     expected: FAIL
 
@@ -419,12 +275,6 @@
   [.flexbox 355]
     expected: FAIL
 
-  [.flexbox 358]
-    expected: FAIL
-
-  [.flexbox 67]
-    expected: FAIL
-
   [.flexbox 280]
     expected: FAIL
 
@@ -446,49 +296,16 @@
   [.flexbox 359]
     expected: FAIL
 
-  [.flexbox 132]
-    expected: FAIL
-
-  [.flexbox 130]
-    expected: FAIL
-
-  [.flexbox 131]
-    expected: FAIL
-
-  [.flexbox 139]
-    expected: FAIL
-
   [.flexbox 317]
     expected: FAIL
 
   [.flexbox 315]
     expected: FAIL
 
-  [.flexbox 312]
-    expected: FAIL
-
   [.flexbox 313]
     expected: FAIL
 
-  [.flexbox 310]
-    expected: FAIL
-
   [.flexbox 311]
-    expected: FAIL
-
-  [.flexbox 69]
-    expected: FAIL
-
-  [.flexbox 24]
-    expected: FAIL
-
-  [.flexbox 23]
-    expected: FAIL
-
-  [.flexbox 22]
-    expected: FAIL
-
-  [.flexbox 21]
     expected: FAIL
 
   [.flexbox 269]
@@ -507,9 +324,6 @@
     expected: FAIL
 
   [.flexbox 406]
-    expected: FAIL
-
-  [.flexbox 407]
     expected: FAIL
 
   [.flexbox 404]
@@ -569,9 +383,6 @@
   [.flexbox 345]
     expected: FAIL
 
-  [.flexbox 344]
-    expected: FAIL
-
   [.flexbox 347]
     expected: FAIL
 
@@ -582,12 +393,6 @@
     expected: FAIL
 
   [.flexbox 342]
-    expected: FAIL
-
-  [.flexbox 70]
-    expected: FAIL
-
-  [.flexbox 71]
     expected: FAIL
 
   [.flexbox 299]
@@ -602,9 +407,6 @@
   [.flexbox 297]
     expected: FAIL
 
-  [.flexbox 296]
-    expected: FAIL
-
   [.flexbox 295]
     expected: FAIL
 
@@ -612,15 +414,6 @@
     expected: FAIL
 
   [.flexbox 368]
-    expected: FAIL
-
-  [.flexbox 7]
-    expected: FAIL
-
-  [.flexbox 8]
-    expected: FAIL
-
-  [.flexbox 9]
     expected: FAIL
 
   [.flexbox 157]
@@ -642,69 +435,6 @@
     expected: FAIL
 
   [.flexbox 408]
-    expected: FAIL
-
-  [.flexbox 120]
-    expected: FAIL
-
-  [.flexbox 127]
-    expected: FAIL
-
-  [.flexbox 129]
-    expected: FAIL
-
-  [.flexbox 10]
-    expected: FAIL
-
-  [.flexbox 12]
-    expected: FAIL
-
-  [.flexbox 20]
-    expected: FAIL
-
-  [.flexbox 31]
-    expected: FAIL
-
-  [.flexbox 33]
-    expected: FAIL
-
-  [.flexbox 47]
-    expected: FAIL
-
-  [.flexbox 58]
-    expected: FAIL
-
-  [.flexbox 60]
-    expected: FAIL
-
-  [.flexbox 68]
-    expected: FAIL
-
-  [.flexbox 79]
-    expected: FAIL
-
-  [.flexbox 81]
-    expected: FAIL
-
-  [.flexbox 95]
-    expected: FAIL
-
-  [.flexbox 107]
-    expected: FAIL
-
-  [.flexbox 115]
-    expected: FAIL
-
-  [.flexbox 117]
-    expected: FAIL
-
-  [.flexbox 128]
-    expected: FAIL
-
-  [.flexbox 142]
-    expected: FAIL
-
-  [.flexbox 144]
     expected: FAIL
 
   [.flexbox 146]
@@ -809,58 +539,55 @@
   [.flexbox 285]
     expected: FAIL
 
-  [.flexbox 298]
+  [.flexbox 154]
     expected: FAIL
 
-  [.flexbox 300]
+  [.flexbox 156]
     expected: FAIL
 
-  [.flexbox 308]
+  [.flexbox 164]
     expected: FAIL
 
-  [.flexbox 319]
+  [.flexbox 175]
     expected: FAIL
 
-  [.flexbox 321]
+  [.flexbox 177]
     expected: FAIL
 
-  [.flexbox 335]
+  [.flexbox 191]
     expected: FAIL
 
-  [.flexbox 346]
+  [.flexbox 202]
     expected: FAIL
 
-  [.flexbox 348]
+  [.flexbox 204]
     expected: FAIL
 
-  [.flexbox 356]
+  [.flexbox 212]
     expected: FAIL
 
-  [.flexbox 367]
+  [.flexbox 223]
     expected: FAIL
 
-  [.flexbox 369]
+  [.flexbox 225]
     expected: FAIL
 
-  [.flexbox 383]
+  [.flexbox 239]
     expected: FAIL
 
-  [.flexbox 395]
+  [.flexbox 251]
     expected: FAIL
 
-  [.flexbox 403]
+  [.flexbox 259]
     expected: FAIL
 
-  [.flexbox 405]
+  [.flexbox 261]
     expected: FAIL
 
-  [.flexbox 416]
+  [.flexbox 272]
     expected: FAIL
 
-  [.flexbox 430]
-    expected: FAIL
-
-  [.flexbox 432]
+  [.flexbox 286]
     expected: FAIL
 
   [.flexbox 152]
@@ -915,4 +642,7 @@
     expected: FAIL
 
   [.flexbox 284]
+    expected: FAIL
+
+  [.flexbox 288]
     expected: FAIL


### PR DESCRIPTION
The containing block for the static position of an absolutely positioned element in flex layout is established by the flex container. However, if the flex container has static position, the actual containing block will be established by another ancestor.

If the flex container and the containing block have different directions, the static position needs especial handling when aligning the abspos. We were already trying to do so with the `flip_anchor` flag, but there were bugs.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
