### PR TITLE
ohos: Specify SDK version more accurately.

### DIFF
--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -61,7 +61,7 @@ jobs:
         id: setup_sdk
         uses: openharmony-rs/setup-ohos-sdk@v0.1
         with:
-          version: "5.0"
+          version: "5.0.0"
           fixup-path: true
       - name: Install node for hvigor
         uses: actions/setup-node@v4


### PR DESCRIPTION
SDK Version 5.0.1 was recently released and bumps the API-version to 13.
This means hvigor will refuse to package the app, since we currently specify that our app targets API 12.
Hence, we clarify our version by also specifying the patch level.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #34411 (Would be broken again once I update the SDK mirror)
- [x] There are tests for these changes 
