### PR TITLE
Net: retain referrer policy when loading an about:blank iframe

### DIFF
--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2985,7 +2985,7 @@ impl ScriptThread {
             load_data.inherited_secure_context,
         );
         if load_data.url.as_str() == "about:blank" {
-            self.start_page_load_about_blank(new_load, load_data.js_eval_result);
+            self.start_page_load_about_blank(new_load, load_data);
         } else if load_data.url.as_str() == "about:srcdoc" {
             self.page_load_about_srcdoc(new_load, load_data);
         } else {
@@ -4207,11 +4207,7 @@ impl ScriptThread {
 
     /// Synchronously fetch `about:blank`. Stores the `InProgressLoad`
     /// argument until a notification is received that the fetch is complete.
-    fn start_page_load_about_blank(
-        &self,
-        incomplete: InProgressLoad,
-        js_eval_result: Option<JsEvalResult>,
-    ) {
+    fn start_page_load_about_blank(&self, incomplete: InProgressLoad, load_data: LoadData) {
         let id = incomplete.pipeline_id;
 
         self.incomplete_loads.borrow_mut().push(incomplete);
@@ -4221,10 +4217,11 @@ impl ScriptThread {
 
         let mut meta = Metadata::default(url);
         meta.set_content_type(Some(&mime::TEXT_HTML));
+        meta.set_referrer_policy(load_data.referrer_policy);
 
         // If this page load is the result of a javascript scheme url, map
         // the evaluation result into a response.
-        let chunk = match js_eval_result {
+        let chunk = match load_data.js_eval_result {
             Some(JsEvalResult::Ok(content)) => content,
             Some(JsEvalResult::NoContent) => {
                 meta.status = http::StatusCode::NO_CONTENT.into();

--- a/tests/wpt/meta-legacy-layout/referrer-policy/generic/inheritance/iframe-inheritance-about-blank.html.ini
+++ b/tests/wpt/meta-legacy-layout/referrer-policy/generic/inheritance/iframe-inheritance-about-blank.html.ini
@@ -1,7 +1,3 @@
 [iframe-inheritance-about-blank.html]
   [The value of document.referrer in an about:blank iframe is the outer document's full URL, regardless of referrer policy]
     expected: FAIL
-
-  [The fetch() API in an about:blank iframe with a custom URL referrer is fetched with a 'Referer` header that uses the outer document's URL along with its referrer policy]
-    expected: FAIL
-

--- a/tests/wpt/meta-legacy-layout/referrer-policy/generic/inheritance/iframe-inheritance-javascript-child.html.ini
+++ b/tests/wpt/meta-legacy-layout/referrer-policy/generic/inheritance/iframe-inheritance-javascript-child.html.ini
@@ -1,9 +1,3 @@
 [iframe-inheritance-javascript-child.html]
-  [Referrer Policy: iframes with javascript url reuse referrer policy 1]
-    expected: FAIL
-
   [Referrer Policy: iframes with javascript url reuse referrer policy 2]
-    expected: FAIL
-
-  [Referrer Policy: iframes with javascript url reuse referrer policy]
     expected: FAIL

--- a/tests/wpt/meta-legacy-layout/referrer-policy/generic/inheritance/iframe-inheritance-javascript.html.ini
+++ b/tests/wpt/meta-legacy-layout/referrer-policy/generic/inheritance/iframe-inheritance-javascript.html.ini
@@ -1,3 +1,0 @@
-[iframe-inheritance-javascript.html]
-  [Referrer Policy: iframes with javascript url reuse referrer policy 1]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/referrer-policy/generic/inheritance/popup-inheritance-about-blank.html.ini
+++ b/tests/wpt/meta-legacy-layout/referrer-policy/generic/inheritance/popup-inheritance-about-blank.html.ini
@@ -1,7 +1,3 @@
 [popup-inheritance-about-blank.html]
-  [The fetch() API in an about:blank popup with a custom URL referrer is fetched with a 'Referer` header that uses the outer document's URL along with its referrer policy]
-    expected: FAIL
-
   [The value of document.referrer in an about:blank popup is the outer document's full URL, regardless of referrer policy]
     expected: FAIL
-

--- a/tests/wpt/meta/referrer-policy/generic/inheritance/iframe-inheritance-about-blank.html.ini
+++ b/tests/wpt/meta/referrer-policy/generic/inheritance/iframe-inheritance-about-blank.html.ini
@@ -1,7 +1,3 @@
 [iframe-inheritance-about-blank.html]
   [The value of document.referrer in an about:blank iframe is the outer document's full URL, regardless of referrer policy]
     expected: FAIL
-
-  [The fetch() API in an about:blank iframe with a custom URL referrer is fetched with a 'Referer` header that uses the outer document's URL along with its referrer policy]
-    expected: FAIL
-

--- a/tests/wpt/meta/referrer-policy/generic/inheritance/iframe-inheritance-javascript-child.html.ini
+++ b/tests/wpt/meta/referrer-policy/generic/inheritance/iframe-inheritance-javascript-child.html.ini
@@ -1,9 +1,3 @@
 [iframe-inheritance-javascript-child.html]
-  [Referrer Policy: iframes with javascript url reuse referrer policy 1]
-    expected: FAIL
-
   [Referrer Policy: iframes with javascript url reuse referrer policy 2]
-    expected: FAIL
-
-  [Referrer Policy: iframes with javascript url reuse referrer policy]
     expected: FAIL

--- a/tests/wpt/meta/referrer-policy/generic/inheritance/iframe-inheritance-javascript.html.ini
+++ b/tests/wpt/meta/referrer-policy/generic/inheritance/iframe-inheritance-javascript.html.ini
@@ -1,3 +1,0 @@
-[iframe-inheritance-javascript.html]
-  [Referrer Policy: iframes with javascript url reuse referrer policy 1]
-    expected: FAIL

--- a/tests/wpt/meta/referrer-policy/generic/inheritance/popup-inheritance-about-blank.html.ini
+++ b/tests/wpt/meta/referrer-policy/generic/inheritance/popup-inheritance-about-blank.html.ini
@@ -1,7 +1,3 @@
 [popup-inheritance-about-blank.html]
-  [The fetch() API in an about:blank popup with a custom URL referrer is fetched with a 'Referer` header that uses the outer document's URL along with its referrer policy]
-    expected: FAIL
-
   [The value of document.referrer in an about:blank popup is the outer document's full URL, regardless of referrer policy]
     expected: FAIL
-


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Aligns handling of the referrer policy in [start_page_load_about_blank](https://github.com/servo/servo/blob/main/components/script/script_thread.rs#L4223) with [page_load_about_srcdoc](https://github.com/servo/servo/blob/main/components/script/script_thread.rs#L4256) so that they both copy the referrer policy from `load_data` into `metadata` -> this results in it being correctly determined during [load](https://github.com/servo/servo/blob/main/components/script/script_thread.rs#L3854) of `about:blank`.

This fixes the last two unexpected failures introduced in https://github.com/servo/servo/pull/33977/#pullrequestreview-2394646698

[Try run](https://github.com/shanehandley/servo/actions/runs/12093407255)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes OR


<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
