### PR TITLE
ohos: Support swiping to go back

### DIFF
--- a/support/openharmony/entry/src/main/ets/pages/Index.ets
+++ b/support/openharmony/entry/src/main/ets/pages/Index.ets
@@ -67,6 +67,13 @@ struct Index {
   @LocalStorageProp('CommandlineArgs') CommandlineArgs: string = ""
   @State urlToLoad: string = this.InitialURI
 
+  // Called when the user swipes from the right or left edge to the middle
+  // Default behavior is bringing the app to the background.
+  onBackPress(): boolean | void {
+    this.xComponentContext?.goBack()
+    return true;
+  }
+
   build() {
     Column() {
       Row() {
@@ -76,7 +83,7 @@ struct Index {
           .width('12%')
           .fontSize(12)
           .onClick(()=>{
-            this.xComponentContext?.goBack()
+            this.onBackPress()
           })
         Button('⇨').backgroundColor(Color.White)
           .fontColor(Color.Black)


### PR DESCRIPTION
Override the `onBackPress` callback, which by default brings the application to the background and instead tell servo to go back one page.
Users can invoke this by swiping from the left (or right) edge to the middle. There is no equivalent callback / gesture to go forward. In the default browser swiping from the right side to the middle also invokes the goBack callback.


---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors


