### PR TITLE
script: Dirty video element when clearing video frame data.

### DIFF
--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -1985,7 +1985,8 @@ impl HTMLMediaElement {
 
     pub fn clear_current_frame_data(&self) {
         self.handle_resize(None, None);
-        self.video_renderer.lock().unwrap().current_frame = None
+        self.video_renderer.lock().unwrap().current_frame = None;
+        self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
     }
 
     fn handle_resize(&self, width: Option<u32>, height: Option<u32>) {


### PR DESCRIPTION
Layout uses the frame data to derive the size of the element. When the frame data is no longer available, such as in response to clearing the src attribute on the element, we need to ensure the element is laid out again.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #34434 
- [x] There are tests for these changes
