### PR TITLE
script: add PointerEvent

### DIFF
--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -465,6 +465,7 @@ pub mod permissions;
 pub mod permissionstatus;
 pub mod plugin;
 pub mod pluginarray;
+pub mod pointerevent;
 pub mod popstateevent;
 pub mod processinginstruction;
 pub mod progressevent;

--- a/components/script/dom/mouseevent.rs
+++ b/components/script/dom/mouseevent.rs
@@ -179,7 +179,7 @@ impl MouseEvent {
         ev
     }
 
-    // https://w3c.github.io/uievents/#initialize-a-mouseevent
+    /// <https://w3c.github.io/uievents/#initialize-a-mouseevent>
     #[allow(clippy::too_many_arguments)]
     pub fn initialize_mouse_event(
         &self,
@@ -201,6 +201,8 @@ impl MouseEvent {
         related_target: Option<&EventTarget>,
         point_in_target: Option<Point2D<f32>>,
     ) {
+        // TODO: InitMouseEvent has been deprecated. We should follow the link to create an UI
+        // Event instead.
         self.InitMouseEvent(
             type_,
             bool::from(can_bubble),

--- a/components/script/dom/mouseevent.rs
+++ b/components/script/dom/mouseevent.rs
@@ -157,7 +157,51 @@ impl MouseEvent {
         can_gc: CanGc,
     ) -> DomRoot<MouseEvent> {
         let ev = MouseEvent::new_uninitialized_with_proto(window, proto, can_gc);
-        ev.InitMouseEvent(
+        ev.initialize_mouse_event(
+            type_,
+            can_bubble,
+            cancelable,
+            view,
+            detail,
+            screen_x,
+            screen_y,
+            client_x,
+            client_y,
+            ctrl_key,
+            alt_key,
+            shift_key,
+            meta_key,
+            button,
+            buttons,
+            related_target,
+            point_in_target,
+        );
+        ev
+    }
+
+    // https://w3c.github.io/uievents/#initialize-a-mouseevent
+    #[allow(clippy::too_many_arguments)]
+    pub fn initialize_mouse_event(
+        &self,
+        type_: DOMString,
+        can_bubble: EventBubbles,
+        cancelable: EventCancelable,
+        view: Option<&Window>,
+        detail: i32,
+        screen_x: i32,
+        screen_y: i32,
+        client_x: i32,
+        client_y: i32,
+        ctrl_key: bool,
+        alt_key: bool,
+        shift_key: bool,
+        meta_key: bool,
+        button: i16,
+        buttons: u16,
+        related_target: Option<&EventTarget>,
+        point_in_target: Option<Point2D<f32>>,
+    ) {
+        self.InitMouseEvent(
             type_,
             bool::from(can_bubble),
             bool::from(cancelable),
@@ -174,12 +218,11 @@ impl MouseEvent {
             button,
             related_target,
         );
-        ev.buttons.set(buttons);
-        ev.point_in_target.set(point_in_target);
+        self.buttons.set(buttons);
+        self.point_in_target.set(point_in_target);
         // TODO: Set proper values in https://github.com/servo/servo/issues/24415
-        ev.page_x.set(client_x);
-        ev.page_y.set(client_y);
-        ev
+        self.page_x.set(client_x);
+        self.page_y.set(client_y);
     }
 
     pub fn point_in_target(&self) -> Option<Point2D<f32>> {

--- a/components/script/dom/pointerevent.rs
+++ b/components/script/dom/pointerevent.rs
@@ -2,35 +2,26 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::borrow::Borrow;
 use std::cell::Cell;
-use std::default::Default;
 
 use dom_struct::dom_struct;
 use euclid::default::Point2D;
 use js::rust::HandleObject;
-use servo_config::pref;
-
-use crate::dom::bindings::cell::{DomRefCell, Ref};
-use crate::dom::bindings::codegen::Bindings::EventBinding::Event_Binding::EventMethods;
-use crate::dom::bindings::codegen::Bindings::PointerEventBinding;
-use crate::dom::bindings::codegen::Bindings::PointerEventBinding::PointerEventInit;
-use crate::dom::bindings::codegen::Bindings::PointerEventBinding::PointerEventMethods;
-use crate::dom::bindings::codegen::Bindings::UIEventBinding::UIEventMethods;
-use crate::dom::bindings::error::Fallible;
-use crate::dom::bindings::inheritance::Castable;
-use crate::dom::bindings::num::Finite;
-use crate::dom::bindings::reflector::{reflect_dom_object_with_proto, DomObject};
-use crate::dom::bindings::root::{DomRoot, MutNullableDom};
-use crate::dom::bindings::str::DOMString;
-use crate::dom::event::{Event, EventBubbles, EventCancelable};
-use crate::dom::eventtarget::EventTarget;
-use crate::dom::mouseevent::MouseEvent;
-use crate::dom::node::Node;
-use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 use super::bindings::codegen::Bindings::MouseEventBinding::MouseEventMethods;
+use crate::dom::bindings::cell::DomRefCell;
+use crate::dom::bindings::codegen::Bindings::PointerEventBinding::{
+    PointerEventInit, PointerEventMethods,
+};
+use crate::dom::bindings::num::Finite;
+use crate::dom::bindings::reflector::reflect_dom_object_with_proto;
+use crate::dom::bindings::root::DomRoot;
+use crate::dom::bindings::str::DOMString;
+use crate::dom::event::{EventBubbles, EventCancelable};
+use crate::dom::eventtarget::EventTarget;
+use crate::dom::mouseevent::MouseEvent;
+use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct PointerEvent {

--- a/components/script/dom/pointerevent.rs
+++ b/components/script/dom/pointerevent.rs
@@ -231,7 +231,7 @@ impl PointerEvent {
 }
 
 impl PointerEventMethods<crate::DomTypeHolder> for PointerEvent {
-    // https://w3c.github.io/pointerevents/#dom-pointerevent-constructor
+    /// <https://w3c.github.io/pointerevents/#dom-pointerevent-constructor>
     fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
@@ -279,77 +279,77 @@ impl PointerEventMethods<crate::DomTypeHolder> for PointerEvent {
         )
     }
 
-    // https://w3c.github.io/pointerevents/#dom-pointerevent-pointerid
+    /// <https://w3c.github.io/pointerevents/#dom-pointerevent-pointerid>
     fn PointerId(&self) -> i32 {
         self.pointer_id.get()
     }
 
-    // https://w3c.github.io/pointerevents/#dom-pointerevent-width
+    /// <https://w3c.github.io/pointerevents/#dom-pointerevent-width>
     fn Width(&self) -> i32 {
         self.width.get()
     }
 
-    // https://w3c.github.io/pointerevents/#dom-pointerevent-height
+    /// <https://w3c.github.io/pointerevents/#dom-pointerevent-height>
     fn Height(&self) -> i32 {
         self.height.get()
     }
 
-    // https://w3c.github.io/pointerevents/#dom-pointerevent-pressure
+    /// <https://w3c.github.io/pointerevents/#dom-pointerevent-pressure>
     fn Pressure(&self) -> Finite<f32> {
         Finite::wrap(self.pressure.get())
     }
 
-    // https://w3c.github.io/pointerevents/#dom-pointerevent-tangentialpressure
+    /// <https://w3c.github.io/pointerevents/#dom-pointerevent-tangentialpressure>
     fn TangentialPressure(&self) -> Finite<f32> {
         Finite::wrap(self.tangential_pressure.get())
     }
 
-    // https://w3c.github.io/pointerevents/#dom-pointerevent-tiltx
+    /// <https://w3c.github.io/pointerevents/#dom-pointerevent-tiltx>
     fn TiltX(&self) -> i32 {
         self.tilt_x.get()
     }
 
-    // https://w3c.github.io/pointerevents/#dom-pointerevent-tilty
+    /// <https://w3c.github.io/pointerevents/#dom-pointerevent-tilty>
     fn TiltY(&self) -> i32 {
         self.tilt_y.get()
     }
 
-    // https://w3c.github.io/pointerevents/#dom-pointerevent-twist
+    /// <https://w3c.github.io/pointerevents/#dom-pointerevent-twist>
     fn Twist(&self) -> i32 {
         self.twist.get()
     }
 
-    // https://w3c.github.io/pointerevents/#dom-pointerevent-altitudeangle
+    /// <https://w3c.github.io/pointerevents/#dom-pointerevent-altitudeangle>
     fn AltitudeAngle(&self) -> Finite<f64> {
         Finite::wrap(self.altitude_angle.get())
     }
 
-    // https://w3c.github.io/pointerevents/#dom-pointerevent-azimuthangle
+    /// <https://w3c.github.io/pointerevents/#dom-pointerevent-azimuthangle>
     fn AzimuthAngle(&self) -> Finite<f64> {
         Finite::wrap(self.azimuth_angle.get())
     }
 
-    // https://w3c.github.io/pointerevents/#dom-pointerevent-pointertype
+    /// <https://w3c.github.io/pointerevents/#dom-pointerevent-pointertype>
     fn PointerType(&self) -> DOMString {
         self.pointer_type.borrow().clone()
     }
 
-    // https://w3c.github.io/pointerevents/#dom-pointerevent-isprimary
+    /// <https://w3c.github.io/pointerevents/#dom-pointerevent-isprimary>
     fn IsPrimary(&self) -> bool {
         self.is_primary.get()
     }
 
-    // https://w3c.github.io/pointerevents/#dom-pointerevent-getcoalescedevents
+    /// <https://w3c.github.io/pointerevents/#dom-pointerevent-getcoalescedevents>
     fn GetCoalescedEvents(&self) -> Vec<DomRoot<PointerEvent>> {
         self.coalesced_events.borrow().clone()
     }
 
-    // https://w3c.github.io/pointerevents/#dom-pointerevent-getpredictedevents
+    /// <https://w3c.github.io/pointerevents/#dom-pointerevent-getpredictedevents>
     fn GetPredictedEvents(&self) -> Vec<DomRoot<PointerEvent>> {
         self.predicted_events.borrow().clone()
     }
 
-    // https://dom.spec.whatwg.org/#dom-event-istrusted
+    /// <https://dom.spec.whatwg.org/#dom-event-istrusted>
     fn IsTrusted(&self) -> bool {
         self.mouseevent.IsTrusted()
     }

--- a/components/script/dom/pointerevent.rs
+++ b/components/script/dom/pointerevent.rs
@@ -1,0 +1,258 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::borrow::Borrow;
+use std::cell::Cell;
+use std::default::Default;
+
+use dom_struct::dom_struct;
+use euclid::default::Point2D;
+use js::rust::HandleObject;
+use servo_config::pref;
+
+use crate::dom::bindings::cell::{DomRefCell, Ref};
+use crate::dom::bindings::codegen::Bindings::EventBinding::Event_Binding::EventMethods;
+use crate::dom::bindings::codegen::Bindings::PointerEventBinding;
+use crate::dom::bindings::codegen::Bindings::PointerEventBinding::PointerEventInit;
+use crate::dom::bindings::codegen::Bindings::PointerEventBinding::PointerEventMethods;
+use crate::dom::bindings::codegen::Bindings::UIEventBinding::UIEventMethods;
+use crate::dom::bindings::error::Fallible;
+use crate::dom::bindings::inheritance::Castable;
+use crate::dom::bindings::num::Finite;
+use crate::dom::bindings::reflector::{reflect_dom_object_with_proto, DomObject};
+use crate::dom::bindings::root::{DomRoot, MutNullableDom};
+use crate::dom::bindings::str::DOMString;
+use crate::dom::event::{Event, EventBubbles, EventCancelable};
+use crate::dom::eventtarget::EventTarget;
+use crate::dom::mouseevent::MouseEvent;
+use crate::dom::node::Node;
+use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
+
+use super::bindings::codegen::Bindings::MouseEventBinding::MouseEventMethods;
+
+#[dom_struct]
+pub struct PointerEvent {
+    mouseevent: MouseEvent,
+    pointer_id: Cell<i32>,
+    width: Cell<i32>,
+    height: Cell<i32>,
+    pressure: Cell<f32>,
+    tangential_pressure: Cell<f32>,
+    tilt_x: Cell<i32>,
+    tilt_y: Cell<i32>,
+    twist: Cell<i32>,
+    altitude_angle: Cell<f64>,
+    azimuth_angle: Cell<f64>,
+    pointer_type: DomRefCell<DOMString>,
+    is_primary: Cell<bool>,
+    coalesced_events: DomRefCell<Vec<DomRoot<PointerEvent>>>,
+    predicted_events: DomRefCell<Vec<DomRoot<PointerEvent>>>,
+}
+
+impl PointerEvent {
+    pub fn new_inherited() -> PointerEvent {
+        PointerEvent {
+            mouseevent: MouseEvent::new_inherited(),
+            pointer_id: Cell::new(0),
+            width: Cell::new(0),
+            height: Cell::new(0),
+            pressure: Cell::new(0.),
+            tangential_pressure: Cell::new(0.),
+            tilt_x: Cell::new(0),
+            tilt_y: Cell::new(0),
+            twist: Cell::new(0),
+            altitude_angle: Cell::new(0.),
+            azimuth_angle: Cell::new(0.),
+            pointer_type: DomRefCell::new(DOMString::new()),
+            is_primary: Cell::new(false),
+            coalesced_events: DomRefCell::new(Vec::new()),
+            predicted_events: DomRefCell::new(Vec::new()),
+        }
+    }
+
+    pub fn new_uninitialized(window: &Window, can_gc: CanGc) -> DomRoot<PointerEvent> {
+        Self::new_uninitialized_with_proto(window, None, can_gc)
+    }
+
+    fn new_uninitialized_with_proto(
+        window: &Window,
+        proto: Option<HandleObject>,
+        can_gc: CanGc,
+    ) -> DomRoot<PointerEvent> {
+        reflect_dom_object_with_proto(
+            Box::new(PointerEvent::new_inherited()),
+            window,
+            proto,
+            can_gc,
+        )
+    }
+    //
+    // #[allow(clippy::too_many_arguments)]
+    // pub fn new(
+    //     window: &Window,
+    //     type_: DOMString,
+    //     can_bubble: EventBubbles,
+    //     cancelable: EventCancelable,
+    //     view: Option<&Window>,
+    //     detail: i32,
+    //     screen_x: i32,
+    //     screen_y: i32,
+    //     client_x: i32,
+    //     client_y: i32,
+    //     ctrl_key: bool,
+    //     alt_key: bool,
+    //     shift_key: bool,
+    //     meta_key: bool,
+    //     button: i16,
+    //     buttons: u16,
+    //     related_target: Option<&EventTarget>,
+    //     point_in_target: Option<Point2D<f32>>,
+    //     can_gc: CanGc,
+    // ) -> DomRoot<MouseEvent> {
+    //     Self::new_with_proto(
+    //         window,
+    //         None,
+    //         type_,
+    //         can_bubble,
+    //         cancelable,
+    //         view,
+    //         detail,
+    //         screen_x,
+    //         screen_y,
+    //         client_x,
+    //         client_y,
+    //         ctrl_key,
+    //         alt_key,
+    //         shift_key,
+    //         meta_key,
+    //         button,
+    //         buttons,
+    //         related_target,
+    //         point_in_target,
+    //         can_gc,
+    //     )
+    // }
+    //
+    // #[allow(clippy::too_many_arguments)]
+    // fn new_with_proto(
+    //     window: &Window,
+    //     proto: Option<HandleObject>,
+    //     type_: DOMString,
+    //     can_bubble: EventBubbles,
+    //     cancelable: EventCancelable,
+    //     view: Option<&Window>,
+    //     detail: i32,
+    //     screen_x: i32,
+    //     screen_y: i32,
+    //     client_x: i32,
+    //     client_y: i32,
+    //     ctrl_key: bool,
+    //     alt_key: bool,
+    //     shift_key: bool,
+    //     meta_key: bool,
+    //     button: i16,
+    //     buttons: u16,
+    //     related_target: Option<&EventTarget>,
+    //     point_in_target: Option<Point2D<f32>>,
+    //     can_gc: CanGc,
+    // ) -> DomRoot<MouseEvent> {
+    //     let ev = MouseEvent::new_uninitialized_with_proto(window, proto, can_gc);
+    //     ev.InitMouseEvent(
+    //         type_,
+    //         bool::from(can_bubble),
+    //         bool::from(cancelable),
+    //         view,
+    //         detail,
+    //         screen_x,
+    //         screen_y,
+    //         client_x,
+    //         client_y,
+    //         ctrl_key,
+    //         alt_key,
+    //         shift_key,
+    //         meta_key,
+    //         button,
+    //         related_target,
+    //     );
+    //     ev.buttons.set(buttons);
+    //     ev.point_in_target.set(point_in_target);
+    //     // TODO: Set proper values in https://github.com/servo/servo/issues/24415
+    //     ev.page_x.set(client_x);
+    //     ev.page_y.set(client_y);
+    //     ev
+    // }
+}
+
+impl PointerEventMethods<crate::DomTypeHolder> for PointerEvent {
+    fn PointerId(&self) -> i32 {
+        self.pointer_id.get()
+    }
+
+    fn Width(&self) -> i32 {
+        self.width.get()
+    }
+
+    fn Height(&self) -> i32 {
+        self.height.get()
+    }
+
+    fn Pressure(&self) -> Finite<f32> {
+        Finite::wrap(self.pressure.get())
+    }
+
+    fn TangentialPressure(&self) -> Finite<f32> {
+        Finite::wrap(self.tangential_pressure.get())
+    }
+
+    fn TiltX(&self) -> i32 {
+        self.tilt_x.get()
+    }
+
+    fn TiltY(&self) -> i32 {
+        self.tilt_y.get()
+    }
+
+    fn Twist(&self) -> i32 {
+        self.twist.get()
+    }
+
+    fn AltitudeAngle(&self) -> Finite<f64> {
+        Finite::wrap(self.altitude_angle.get())
+    }
+
+    fn AzimuthAngle(&self) -> Finite<f64> {
+        Finite::wrap(self.azimuth_angle.get())
+    }
+
+    fn PointerType(&self) -> DOMString {
+        self.pointer_type.borrow().clone()
+    }
+
+    fn IsPrimary(&self) -> bool {
+        self.is_primary.get()
+    }
+
+    fn GetCoalescedEvents(&self) -> Vec<DomRoot<PointerEvent>> {
+        self.coalesced_events.borrow().clone()
+    }
+
+    fn GetPredictedEvents(&self) -> Vec<DomRoot<PointerEvent>> {
+        self.predicted_events.borrow().clone()
+    }
+
+    fn IsTrusted(&self) -> bool {
+        self.mouseevent.IsTrusted()
+    }
+
+    fn Constructor(
+        global: &Window,
+        proto: Option<HandleObject>,
+        can_gc: CanGc,
+        type_: DOMString,
+        init: &PointerEventInit,
+    ) -> DomRoot<PointerEvent> {
+        todo!()
+    }
+}

--- a/components/script/dom/pointerevent.rs
+++ b/components/script/dom/pointerevent.rs
@@ -88,171 +88,278 @@ impl PointerEvent {
             can_gc,
         )
     }
-    //
-    // #[allow(clippy::too_many_arguments)]
-    // pub fn new(
-    //     window: &Window,
-    //     type_: DOMString,
-    //     can_bubble: EventBubbles,
-    //     cancelable: EventCancelable,
-    //     view: Option<&Window>,
-    //     detail: i32,
-    //     screen_x: i32,
-    //     screen_y: i32,
-    //     client_x: i32,
-    //     client_y: i32,
-    //     ctrl_key: bool,
-    //     alt_key: bool,
-    //     shift_key: bool,
-    //     meta_key: bool,
-    //     button: i16,
-    //     buttons: u16,
-    //     related_target: Option<&EventTarget>,
-    //     point_in_target: Option<Point2D<f32>>,
-    //     can_gc: CanGc,
-    // ) -> DomRoot<MouseEvent> {
-    //     Self::new_with_proto(
-    //         window,
-    //         None,
-    //         type_,
-    //         can_bubble,
-    //         cancelable,
-    //         view,
-    //         detail,
-    //         screen_x,
-    //         screen_y,
-    //         client_x,
-    //         client_y,
-    //         ctrl_key,
-    //         alt_key,
-    //         shift_key,
-    //         meta_key,
-    //         button,
-    //         buttons,
-    //         related_target,
-    //         point_in_target,
-    //         can_gc,
-    //     )
-    // }
-    //
-    // #[allow(clippy::too_many_arguments)]
-    // fn new_with_proto(
-    //     window: &Window,
-    //     proto: Option<HandleObject>,
-    //     type_: DOMString,
-    //     can_bubble: EventBubbles,
-    //     cancelable: EventCancelable,
-    //     view: Option<&Window>,
-    //     detail: i32,
-    //     screen_x: i32,
-    //     screen_y: i32,
-    //     client_x: i32,
-    //     client_y: i32,
-    //     ctrl_key: bool,
-    //     alt_key: bool,
-    //     shift_key: bool,
-    //     meta_key: bool,
-    //     button: i16,
-    //     buttons: u16,
-    //     related_target: Option<&EventTarget>,
-    //     point_in_target: Option<Point2D<f32>>,
-    //     can_gc: CanGc,
-    // ) -> DomRoot<MouseEvent> {
-    //     let ev = MouseEvent::new_uninitialized_with_proto(window, proto, can_gc);
-    //     ev.InitMouseEvent(
-    //         type_,
-    //         bool::from(can_bubble),
-    //         bool::from(cancelable),
-    //         view,
-    //         detail,
-    //         screen_x,
-    //         screen_y,
-    //         client_x,
-    //         client_y,
-    //         ctrl_key,
-    //         alt_key,
-    //         shift_key,
-    //         meta_key,
-    //         button,
-    //         related_target,
-    //     );
-    //     ev.buttons.set(buttons);
-    //     ev.point_in_target.set(point_in_target);
-    //     // TODO: Set proper values in https://github.com/servo/servo/issues/24415
-    //     ev.page_x.set(client_x);
-    //     ev.page_y.set(client_y);
-    //     ev
-    // }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        window: &Window,
+        proto: Option<HandleObject>,
+        type_: DOMString,
+        can_bubble: EventBubbles,
+        cancelable: EventCancelable,
+        view: Option<&Window>,
+        detail: i32,
+        screen_x: i32,
+        screen_y: i32,
+        client_x: i32,
+        client_y: i32,
+        ctrl_key: bool,
+        alt_key: bool,
+        shift_key: bool,
+        meta_key: bool,
+        button: i16,
+        buttons: u16,
+        related_target: Option<&EventTarget>,
+        point_in_target: Option<Point2D<f32>>,
+        pointer_id: i32,
+        width: i32,
+        height: i32,
+        pressure: f32,
+        tangential_pressure: f32,
+        tilt_x: i32,
+        tilt_y: i32,
+        twist: i32,
+        altitude_angle: f64,
+        azimuth_angle: f64,
+        pointer_type: DOMString,
+        is_primary: bool,
+        coalesced_events: Vec<DomRoot<PointerEvent>>,
+        predicted_events: Vec<DomRoot<PointerEvent>>,
+        can_gc: CanGc,
+    ) -> DomRoot<PointerEvent> {
+        Self::new_with_proto(
+            window,
+            proto,
+            type_,
+            can_bubble,
+            cancelable,
+            view,
+            detail,
+            screen_x,
+            screen_y,
+            client_x,
+            client_y,
+            ctrl_key,
+            alt_key,
+            shift_key,
+            meta_key,
+            button,
+            buttons,
+            related_target,
+            point_in_target,
+            pointer_id,
+            width,
+            height,
+            pressure,
+            tangential_pressure,
+            tilt_x,
+            tilt_y,
+            twist,
+            altitude_angle,
+            azimuth_angle,
+            pointer_type,
+            is_primary,
+            coalesced_events,
+            predicted_events,
+            can_gc,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn new_with_proto(
+        window: &Window,
+        proto: Option<HandleObject>,
+        type_: DOMString,
+        can_bubble: EventBubbles,
+        cancelable: EventCancelable,
+        view: Option<&Window>,
+        detail: i32,
+        screen_x: i32,
+        screen_y: i32,
+        client_x: i32,
+        client_y: i32,
+        ctrl_key: bool,
+        alt_key: bool,
+        shift_key: bool,
+        meta_key: bool,
+        button: i16,
+        buttons: u16,
+        related_target: Option<&EventTarget>,
+        point_in_target: Option<Point2D<f32>>,
+        pointer_id: i32,
+        width: i32,
+        height: i32,
+        pressure: f32,
+        tangential_pressure: f32,
+        tilt_x: i32,
+        tilt_y: i32,
+        twist: i32,
+        altitude_angle: f64,
+        azimuth_angle: f64,
+        pointer_type: DOMString,
+        is_primary: bool,
+        coalesced_events: Vec<DomRoot<PointerEvent>>,
+        predicted_events: Vec<DomRoot<PointerEvent>>,
+        can_gc: CanGc,
+    ) -> DomRoot<PointerEvent> {
+        let ev = PointerEvent::new_uninitialized_with_proto(window, proto, can_gc);
+        ev.mouseevent.initialize_mouse_event(
+            type_,
+            can_bubble,
+            cancelable,
+            view,
+            detail,
+            screen_x,
+            screen_y,
+            client_x,
+            client_y,
+            ctrl_key,
+            alt_key,
+            shift_key,
+            meta_key,
+            button,
+            buttons,
+            related_target,
+            point_in_target,
+        );
+        ev.pointer_id.set(pointer_id);
+        ev.width.set(width);
+        ev.height.set(height);
+        ev.pressure.set(pressure);
+        ev.tangential_pressure.set(tangential_pressure);
+        ev.tilt_x.set(tilt_x);
+        ev.tilt_y.set(tilt_y);
+        ev.twist.set(twist);
+        ev.altitude_angle.set(altitude_angle);
+        ev.azimuth_angle.set(azimuth_angle);
+        *ev.pointer_type.borrow_mut() = pointer_type;
+        ev.is_primary.set(is_primary);
+        *ev.coalesced_events.borrow_mut() = coalesced_events;
+        *ev.predicted_events.borrow_mut() = predicted_events;
+        ev
+    }
 }
 
 impl PointerEventMethods<crate::DomTypeHolder> for PointerEvent {
-    fn PointerId(&self) -> i32 {
-        self.pointer_id.get()
-    }
-
-    fn Width(&self) -> i32 {
-        self.width.get()
-    }
-
-    fn Height(&self) -> i32 {
-        self.height.get()
-    }
-
-    fn Pressure(&self) -> Finite<f32> {
-        Finite::wrap(self.pressure.get())
-    }
-
-    fn TangentialPressure(&self) -> Finite<f32> {
-        Finite::wrap(self.tangential_pressure.get())
-    }
-
-    fn TiltX(&self) -> i32 {
-        self.tilt_x.get()
-    }
-
-    fn TiltY(&self) -> i32 {
-        self.tilt_y.get()
-    }
-
-    fn Twist(&self) -> i32 {
-        self.twist.get()
-    }
-
-    fn AltitudeAngle(&self) -> Finite<f64> {
-        Finite::wrap(self.altitude_angle.get())
-    }
-
-    fn AzimuthAngle(&self) -> Finite<f64> {
-        Finite::wrap(self.azimuth_angle.get())
-    }
-
-    fn PointerType(&self) -> DOMString {
-        self.pointer_type.borrow().clone()
-    }
-
-    fn IsPrimary(&self) -> bool {
-        self.is_primary.get()
-    }
-
-    fn GetCoalescedEvents(&self) -> Vec<DomRoot<PointerEvent>> {
-        self.coalesced_events.borrow().clone()
-    }
-
-    fn GetPredictedEvents(&self) -> Vec<DomRoot<PointerEvent>> {
-        self.predicted_events.borrow().clone()
-    }
-
-    fn IsTrusted(&self) -> bool {
-        self.mouseevent.IsTrusted()
-    }
-
+    // https://w3c.github.io/pointerevents/#dom-pointerevent-constructor
     fn Constructor(
-        global: &Window,
+        window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
         type_: DOMString,
         init: &PointerEventInit,
     ) -> DomRoot<PointerEvent> {
-        todo!()
+        let bubbles = EventBubbles::from(init.parent.parent.parent.parent.bubbles);
+        let cancelable = EventCancelable::from(init.parent.parent.parent.parent.cancelable);
+        PointerEvent::new_with_proto(
+            window,
+            proto,
+            type_,
+            bubbles,
+            cancelable,
+            init.parent.parent.parent.view.as_deref(),
+            init.parent.parent.parent.detail,
+            init.parent.screenX,
+            init.parent.screenY,
+            init.parent.clientX,
+            init.parent.clientY,
+            init.parent.parent.ctrlKey,
+            init.parent.parent.altKey,
+            init.parent.parent.shiftKey,
+            init.parent.parent.metaKey,
+            init.parent.button,
+            init.parent.buttons,
+            init.parent.relatedTarget.as_deref(),
+            None,
+            init.pointerId,
+            init.width,
+            init.height,
+            *init.pressure,
+            *init.tangentialPressure,
+            init.tiltX.unwrap_or_default(),
+            init.tiltY.unwrap_or_default(),
+            init.twist,
+            *init.altitudeAngle.unwrap_or_default(),
+            *init.azimuthAngle.unwrap_or_default(),
+            init.pointerType.clone(),
+            init.isPrimary,
+            init.coalescedEvents.clone(),
+            init.predictedEvents.clone(),
+            can_gc,
+        )
+    }
+
+    // https://w3c.github.io/pointerevents/#dom-pointerevent-pointerid
+    fn PointerId(&self) -> i32 {
+        self.pointer_id.get()
+    }
+
+    // https://w3c.github.io/pointerevents/#dom-pointerevent-width
+    fn Width(&self) -> i32 {
+        self.width.get()
+    }
+
+    // https://w3c.github.io/pointerevents/#dom-pointerevent-height
+    fn Height(&self) -> i32 {
+        self.height.get()
+    }
+
+    // https://w3c.github.io/pointerevents/#dom-pointerevent-pressure
+    fn Pressure(&self) -> Finite<f32> {
+        Finite::wrap(self.pressure.get())
+    }
+
+    // https://w3c.github.io/pointerevents/#dom-pointerevent-tangentialpressure
+    fn TangentialPressure(&self) -> Finite<f32> {
+        Finite::wrap(self.tangential_pressure.get())
+    }
+
+    // https://w3c.github.io/pointerevents/#dom-pointerevent-tiltx
+    fn TiltX(&self) -> i32 {
+        self.tilt_x.get()
+    }
+
+    // https://w3c.github.io/pointerevents/#dom-pointerevent-tilty
+    fn TiltY(&self) -> i32 {
+        self.tilt_y.get()
+    }
+
+    // https://w3c.github.io/pointerevents/#dom-pointerevent-twist
+    fn Twist(&self) -> i32 {
+        self.twist.get()
+    }
+
+    // https://w3c.github.io/pointerevents/#dom-pointerevent-altitudeangle
+    fn AltitudeAngle(&self) -> Finite<f64> {
+        Finite::wrap(self.altitude_angle.get())
+    }
+
+    // https://w3c.github.io/pointerevents/#dom-pointerevent-azimuthangle
+    fn AzimuthAngle(&self) -> Finite<f64> {
+        Finite::wrap(self.azimuth_angle.get())
+    }
+
+    // https://w3c.github.io/pointerevents/#dom-pointerevent-pointertype
+    fn PointerType(&self) -> DOMString {
+        self.pointer_type.borrow().clone()
+    }
+
+    // https://w3c.github.io/pointerevents/#dom-pointerevent-isprimary
+    fn IsPrimary(&self) -> bool {
+        self.is_primary.get()
+    }
+
+    // https://w3c.github.io/pointerevents/#dom-pointerevent-getcoalescedevents
+    fn GetCoalescedEvents(&self) -> Vec<DomRoot<PointerEvent>> {
+        self.coalesced_events.borrow().clone()
+    }
+
+    // https://w3c.github.io/pointerevents/#dom-pointerevent-getpredictedevents
+    fn GetPredictedEvents(&self) -> Vec<DomRoot<PointerEvent>> {
+        self.predicted_events.borrow().clone()
+    }
+
+    // https://dom.spec.whatwg.org/#dom-event-istrusted
+    fn IsTrusted(&self) -> bool {
+        self.mouseevent.IsTrusted()
     }
 }

--- a/components/script/dom/webidls/PointerEvent.webidl
+++ b/components/script/dom/webidls/PointerEvent.webidl
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// https://w3c.github.io/pointerevents/#pointerevent-interface
+[Exposed=Window]
+interface PointerEvent : MouseEvent
+{
+  constructor(DOMString type, optional PointerEventInit eventInitDict = {});
+
+  readonly attribute long pointerId;
+
+  readonly attribute long width;
+  readonly attribute long height;
+  readonly attribute float pressure;
+  readonly attribute float tangentialPressure;
+  readonly attribute long tiltX;
+  readonly attribute long tiltY;
+  readonly attribute long twist;
+  readonly attribute double altitudeAngle;
+  readonly attribute double azimuthAngle;
+
+  readonly attribute DOMString pointerType;
+  readonly attribute boolean isPrimary;
+
+  sequence<PointerEvent> getCoalescedEvents();
+  sequence<PointerEvent> getPredictedEvents();
+};
+
+dictionary PointerEventInit : MouseEventInit
+{
+  long pointerId = 0;
+  long width = 1;
+  long height = 1;
+  float pressure = 0;
+  float tangentialPressure = 0;
+  long tiltX;
+  long tiltY;
+  long twist = 0;
+  double altitudeAngle;
+  double azimuthAngle;
+  DOMString pointerType = "";
+  boolean isPrimary = false;
+  sequence<PointerEvent> coalescedEvents = [];
+  sequence<PointerEvent> predictedEvents = [];
+};

--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -203,6 +203,8 @@ skip: true
   skip: false
 [permissions]
   skip: false
+[pointerevents]
+  skip: false
 [quirks]
   skip: false
 [referrer-policy]

--- a/tests/wpt/meta/pointerevents/compat/pointerevent_touch-action-verification.html.ini
+++ b/tests/wpt/meta/pointerevents/compat/pointerevent_touch-action-verification.html.ini
@@ -1,0 +1,12 @@
+[pointerevent_touch-action-verification.html]
+  [explicit-pinch-zoom]
+    expected: FAIL
+
+  [explicit-pinch-zoom-pan-x-pan-up]
+    expected: FAIL
+
+  [explicit-pinch-zoom-pan-x-pan-y]
+    expected: FAIL
+
+  [explicit-invalid-14]
+    expected: FAIL

--- a/tests/wpt/meta/pointerevents/idlharness.https.window.js.ini
+++ b/tests/wpt/meta/pointerevents/idlharness.https.window.js.ini
@@ -1,0 +1,204 @@
+[idlharness.https.window.html]
+  [PointerEvent interface: attribute persistentDeviceId]
+    expected: FAIL
+
+  [PointerEvent interface: new PointerEvent("type") must inherit property "persistentDeviceId" with the proper type]
+    expected: FAIL
+
+  [HTMLElement interface: attribute onpointerover]
+    expected: FAIL
+
+  [HTMLElement interface: attribute onpointerenter]
+    expected: FAIL
+
+  [HTMLElement interface: attribute onpointerdown]
+    expected: FAIL
+
+  [HTMLElement interface: attribute onpointermove]
+    expected: FAIL
+
+  [HTMLElement interface: attribute onpointerrawupdate]
+    expected: FAIL
+
+  [HTMLElement interface: attribute onpointerup]
+    expected: FAIL
+
+  [HTMLElement interface: attribute onpointercancel]
+    expected: FAIL
+
+  [HTMLElement interface: attribute onpointerout]
+    expected: FAIL
+
+  [HTMLElement interface: attribute onpointerleave]
+    expected: FAIL
+
+  [HTMLElement interface: attribute ongotpointercapture]
+    expected: FAIL
+
+  [HTMLElement interface: attribute onlostpointercapture]
+    expected: FAIL
+
+  [Window interface: attribute onpointerover]
+    expected: FAIL
+
+  [Window interface: attribute onpointerenter]
+    expected: FAIL
+
+  [Window interface: attribute onpointerdown]
+    expected: FAIL
+
+  [Window interface: attribute onpointermove]
+    expected: FAIL
+
+  [Window interface: attribute onpointerrawupdate]
+    expected: FAIL
+
+  [Window interface: attribute onpointerup]
+    expected: FAIL
+
+  [Window interface: attribute onpointercancel]
+    expected: FAIL
+
+  [Window interface: attribute onpointerout]
+    expected: FAIL
+
+  [Window interface: attribute onpointerleave]
+    expected: FAIL
+
+  [Window interface: attribute ongotpointercapture]
+    expected: FAIL
+
+  [Window interface: attribute onlostpointercapture]
+    expected: FAIL
+
+  [Window interface: window must inherit property "onpointerover" with the proper type]
+    expected: FAIL
+
+  [Window interface: window must inherit property "onpointerenter" with the proper type]
+    expected: FAIL
+
+  [Window interface: window must inherit property "onpointerdown" with the proper type]
+    expected: FAIL
+
+  [Window interface: window must inherit property "onpointermove" with the proper type]
+    expected: FAIL
+
+  [Window interface: window must inherit property "onpointerrawupdate" with the proper type]
+    expected: FAIL
+
+  [Window interface: window must inherit property "onpointerup" with the proper type]
+    expected: FAIL
+
+  [Window interface: window must inherit property "onpointercancel" with the proper type]
+    expected: FAIL
+
+  [Window interface: window must inherit property "onpointerout" with the proper type]
+    expected: FAIL
+
+  [Window interface: window must inherit property "onpointerleave" with the proper type]
+    expected: FAIL
+
+  [Window interface: window must inherit property "ongotpointercapture" with the proper type]
+    expected: FAIL
+
+  [Window interface: window must inherit property "onlostpointercapture" with the proper type]
+    expected: FAIL
+
+  [Navigator interface: attribute maxTouchPoints]
+    expected: FAIL
+
+  [Navigator interface: navigator must inherit property "maxTouchPoints" with the proper type]
+    expected: FAIL
+
+  [Document interface: attribute onpointerover]
+    expected: FAIL
+
+  [Document interface: attribute onpointerenter]
+    expected: FAIL
+
+  [Document interface: attribute onpointerdown]
+    expected: FAIL
+
+  [Document interface: attribute onpointermove]
+    expected: FAIL
+
+  [Document interface: attribute onpointerrawupdate]
+    expected: FAIL
+
+  [Document interface: attribute onpointerup]
+    expected: FAIL
+
+  [Document interface: attribute onpointercancel]
+    expected: FAIL
+
+  [Document interface: attribute onpointerout]
+    expected: FAIL
+
+  [Document interface: attribute onpointerleave]
+    expected: FAIL
+
+  [Document interface: attribute ongotpointercapture]
+    expected: FAIL
+
+  [Document interface: attribute onlostpointercapture]
+    expected: FAIL
+
+  [Document interface: document must inherit property "onpointerover" with the proper type]
+    expected: FAIL
+
+  [Document interface: document must inherit property "onpointerenter" with the proper type]
+    expected: FAIL
+
+  [Document interface: document must inherit property "onpointerdown" with the proper type]
+    expected: FAIL
+
+  [Document interface: document must inherit property "onpointermove" with the proper type]
+    expected: FAIL
+
+  [Document interface: document must inherit property "onpointerrawupdate" with the proper type]
+    expected: FAIL
+
+  [Document interface: document must inherit property "onpointerup" with the proper type]
+    expected: FAIL
+
+  [Document interface: document must inherit property "onpointercancel" with the proper type]
+    expected: FAIL
+
+  [Document interface: document must inherit property "onpointerout" with the proper type]
+    expected: FAIL
+
+  [Document interface: document must inherit property "onpointerleave" with the proper type]
+    expected: FAIL
+
+  [Document interface: document must inherit property "ongotpointercapture" with the proper type]
+    expected: FAIL
+
+  [Document interface: document must inherit property "onlostpointercapture" with the proper type]
+    expected: FAIL
+
+  [Element interface: operation setPointerCapture(long)]
+    expected: FAIL
+
+  [Element interface: operation releasePointerCapture(long)]
+    expected: FAIL
+
+  [Element interface: operation hasPointerCapture(long)]
+    expected: FAIL
+
+  [Element interface: document.body must inherit property "setPointerCapture(long)" with the proper type]
+    expected: FAIL
+
+  [Element interface: calling setPointerCapture(long) on document.body with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [Element interface: document.body must inherit property "releasePointerCapture(long)" with the proper type]
+    expected: FAIL
+
+  [Element interface: calling releasePointerCapture(long) on document.body with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [Element interface: document.body must inherit property "hasPointerCapture(long)" with the proper type]
+    expected: FAIL
+
+  [Element interface: calling hasPointerCapture(long) on document.body with too few arguments must throw TypeError]
+    expected: FAIL

--- a/tests/wpt/meta/pointerevents/inheritance.html.ini
+++ b/tests/wpt/meta/pointerevents/inheritance.html.ini
@@ -1,0 +1,6 @@
+[inheritance.html]
+  [Property touch-action has initial value auto]
+    expected: FAIL
+
+  [Property touch-action does not inherit]
+    expected: FAIL

--- a/tests/wpt/meta/pointerevents/parsing/touch-action-computed.html.ini
+++ b/tests/wpt/meta/pointerevents/parsing/touch-action-computed.html.ini
@@ -1,0 +1,18 @@
+[touch-action-computed.html]
+  [Property touch-action value 'auto']
+    expected: FAIL
+
+  [Property touch-action value 'none']
+    expected: FAIL
+
+  [Property touch-action value 'manipulation']
+    expected: FAIL
+
+  [Property touch-action value 'pan-x']
+    expected: FAIL
+
+  [Property touch-action value 'pan-y']
+    expected: FAIL
+
+  [Property touch-action value 'pan-x pan-y']
+    expected: FAIL

--- a/tests/wpt/meta/pointerevents/parsing/touch-action-valid.html.ini
+++ b/tests/wpt/meta/pointerevents/parsing/touch-action-valid.html.ini
@@ -1,0 +1,18 @@
+[touch-action-valid.html]
+  [e.style['touch-action'\] = "auto" should set the property value]
+    expected: FAIL
+
+  [e.style['touch-action'\] = "none" should set the property value]
+    expected: FAIL
+
+  [e.style['touch-action'\] = "manipulation" should set the property value]
+    expected: FAIL
+
+  [e.style['touch-action'\] = "pan-x" should set the property value]
+    expected: FAIL
+
+  [e.style['touch-action'\] = "pan-y" should set the property value]
+    expected: FAIL
+
+  [e.style['touch-action'\] = "pan-y pan-x" should set the property value]
+    expected: FAIL

--- a/tests/wpt/meta/pointerevents/persistentDeviceId/pointer-event-has-persistentdeviceid-from-pointer-event-init.tentative.html.ini
+++ b/tests/wpt/meta/pointerevents/persistentDeviceId/pointer-event-has-persistentdeviceid-from-pointer-event-init.tentative.html.ini
@@ -1,0 +1,6 @@
+[pointer-event-has-persistentdeviceid-from-pointer-event-init.tentative.html]
+  [PointerEvent.persistentDeviceId via PointerEventInit]
+    expected: FAIL
+
+  [No persistentDeviceId in PointerEventInit]
+    expected: FAIL

--- a/tests/wpt/meta/pointerevents/pointerevent_constructor.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_constructor.html.ini
@@ -1,0 +1,3 @@
+[pointerevent_constructor.html]
+  [getCoalescedEvents in event]
+    expected: FAIL

--- a/tests/wpt/meta/pointerevents/pointerevent_on_event_handlers.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_on_event_handlers.html.ini
@@ -1,0 +1,91 @@
+[pointerevent_on_event_handlers.html]
+  expected: TIMEOUT
+  [The default value of onpointerdown is always null]
+    expected: FAIL
+
+  [The onpointerdown content attribute must be compiled into the onpointerdown property]
+    expected: FAIL
+
+  [dispatching a pointerdown event must trigger element.onpointerdown]
+    expected: NOTRUN
+
+  [The default value of onpointerup is always null]
+    expected: FAIL
+
+  [The onpointerup content attribute must be compiled into the onpointerup property]
+    expected: FAIL
+
+  [dispatching a pointerup event must trigger element.onpointerup]
+    expected: NOTRUN
+
+  [The default value of onpointercancel is always null]
+    expected: FAIL
+
+  [The onpointercancel content attribute must be compiled into the onpointercancel property]
+    expected: FAIL
+
+  [dispatching a pointercancel event must trigger element.onpointercancel]
+    expected: NOTRUN
+
+  [The default value of onpointermove is always null]
+    expected: FAIL
+
+  [The onpointermove content attribute must be compiled into the onpointermove property]
+    expected: FAIL
+
+  [dispatching a pointermove event must trigger element.onpointermove]
+    expected: NOTRUN
+
+  [The default value of onpointerover is always null]
+    expected: FAIL
+
+  [The onpointerover content attribute must be compiled into the onpointerover property]
+    expected: FAIL
+
+  [dispatching a pointerover event must trigger element.onpointerover]
+    expected: NOTRUN
+
+  [The default value of onpointerout is always null]
+    expected: FAIL
+
+  [The onpointerout content attribute must be compiled into the onpointerout property]
+    expected: FAIL
+
+  [dispatching a pointerout event must trigger element.onpointerout]
+    expected: NOTRUN
+
+  [The default value of onpointerenter is always null]
+    expected: FAIL
+
+  [The onpointerenter content attribute must be compiled into the onpointerenter property]
+    expected: FAIL
+
+  [dispatching a pointerenter event must trigger element.onpointerenter]
+    expected: NOTRUN
+
+  [The default value of onpointerleave is always null]
+    expected: FAIL
+
+  [The onpointerleave content attribute must be compiled into the onpointerleave property]
+    expected: FAIL
+
+  [dispatching a pointerleave event must trigger element.onpointerleave]
+    expected: NOTRUN
+
+  [The default value of ongotpointercapture is always null]
+    expected: FAIL
+
+  [The ongotpointercapture content attribute must be compiled into the ongotpointercapture property]
+    expected: FAIL
+
+  [dispatching a gotpointercapture event must trigger element.ongotpointercapture]
+    expected: NOTRUN
+
+  [The default value of onlostpointercapture is always null]
+    expected: FAIL
+
+  [The onlostpointercapture content attribute must be compiled into the onlostpointercapture property]
+    expected: FAIL
+
+  [dispatching a lostpointercapture event must trigger element.onlostpointercapture]
+    expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_tiltX_tiltY_to_azimuth_altitude.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_tiltX_tiltY_to_azimuth_altitude.html.ini
@@ -1,0 +1,57 @@
+[pointerevent_tiltX_tiltY_to_azimuth_altitude.html]
+  [tiltX,tiltY to azimuth/altitude when tiltX=0 and tiltY=0]
+    expected: FAIL
+
+  [tiltX,tiltY to azimuth/altitude when tiltX=0 and tiltY=90]
+    expected: FAIL
+
+  [tiltX,tiltY to azimuth/altitude when tiltX=0 and tiltY=-90]
+    expected: FAIL
+
+  [tiltX,tiltY to azimuth/altitude when tiltX=-90 and tiltY=0]
+    expected: FAIL
+
+  [tiltX,tiltY to azimuth/altitude when tiltX=0 and tiltY=45]
+    expected: FAIL
+
+  [tiltX,tiltY to azimuth/altitude when tiltX=0 and tiltY=-45]
+    expected: FAIL
+
+  [tiltX,tiltY to azimuth/altitude when tiltX=45 and tiltY=0]
+    expected: FAIL
+
+  [tiltX,tiltY to azimuth/altitude when tiltX=-45 and tiltY=0]
+    expected: FAIL
+
+  [tiltX/tiltY to azimuth/altitude when tiltX/tiltY are not populated]
+    expected: FAIL
+
+  [azimuth/altitude to tiltX/tiltY when azimuth=0 and altitude=0]
+    expected: FAIL
+
+  [azimuth/altitude to tiltX/tiltY when azimuth=0 and altitude=0.7853981633974483]
+    expected: FAIL
+
+  [azimuth/altitude to tiltX/tiltY when azimuth=1.5707963267948966 and altitude=0]
+    expected: FAIL
+
+  [azimuth/altitude to tiltX/tiltY when azimuth=1.5707963267948966 and altitude=0.7853981633974483]
+    expected: FAIL
+
+  [azimuth/altitude to tiltX/tiltY when azimuth=3.141592653589793 and altitude=0]
+    expected: FAIL
+
+  [azimuth/altitude to tiltX/tiltY when azimuth=3.141592653589793 and altitude=0.7853981633974483]
+    expected: FAIL
+
+  [azimuth/altitude to tiltX/tiltY when azimuth=4.71238898038469 and altitude=0]
+    expected: FAIL
+
+  [azimuth/altitude to tiltX/tiltY when azimuth=4.71238898038469 and altitude=0.7853981633974483]
+    expected: FAIL
+
+  [If only one of the values (tiltX, tiltY) or (azimuthAngle, altitudeAngle) is available the other one is set to the default value]
+    expected: FAIL
+
+  [If one of the values in both sets is provided, the other value in the set is initialized with the default value]
+    expected: FAIL

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-illegal.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-illegal.html.ini
@@ -1,0 +1,9 @@
+[pointerevent_touch-action-illegal.html]
+  ['pan-x none' is corrected properly]
+    expected: FAIL
+
+  ['pan-y none' is corrected properly]
+    expected: FAIL
+
+  ['auto none' is corrected properly]
+    expected: FAIL

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-verification.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-verification.html.ini
@@ -1,0 +1,111 @@
+[pointerevent_touch-action-verification.html]
+  [default]
+    expected: FAIL
+
+  [stylesheet-none]
+    expected: FAIL
+
+  [explicit-auto]
+    expected: FAIL
+
+  [explicit-pan-x]
+    expected: FAIL
+
+  [explicit-pan-left]
+    expected: FAIL
+
+  [explicit-pan-right]
+    expected: FAIL
+
+  [explicit-pan-y]
+    expected: FAIL
+
+  [explicit-pan-up]
+    expected: FAIL
+
+  [explicit-pan-down]
+    expected: FAIL
+
+  [explicit-pan-x-pan-y]
+    expected: FAIL
+
+  [explicit-pan-y-pan-x]
+    expected: FAIL
+
+  [explicit-pan-left-pan-up]
+    expected: FAIL
+
+  [explicit-pan-left-pan-down]
+    expected: FAIL
+
+  [explicit-pan-right-pan-up]
+    expected: FAIL
+
+  [explicit-pan-right-pan-down]
+    expected: FAIL
+
+  [explicit-pan-up-pan-left]
+    expected: FAIL
+
+  [explicit-pan-up-pan-right]
+    expected: FAIL
+
+  [explicit-pan-down-pan-left]
+    expected: FAIL
+
+  [explicit-pan-down-pan-right]
+    expected: FAIL
+
+  [explicit-manipulation]
+    expected: FAIL
+
+  [explicit-none]
+    expected: FAIL
+
+  [explicit-invalid-1]
+    expected: FAIL
+
+  [explicit-invalid-2]
+    expected: FAIL
+
+  [explicit-invalid-3]
+    expected: FAIL
+
+  [explicit-invalid-4]
+    expected: FAIL
+
+  [explicit-invalid-5]
+    expected: FAIL
+
+  [explicit-invalid-6]
+    expected: FAIL
+
+  [explicit-invalid-7]
+    expected: FAIL
+
+  [explicit-invalid-8]
+    expected: FAIL
+
+  [explicit-invalid-9]
+    expected: FAIL
+
+  [explicit-invalid-10]
+    expected: FAIL
+
+  [explicit-invalid-11]
+    expected: FAIL
+
+  [explicit-invalid-12]
+    expected: FAIL
+
+  [explicit-invalid-13]
+    expected: FAIL
+
+  [not-inherited]
+    expected: FAIL
+
+  [inherit]
+    expected: FAIL
+
+  [initial]
+    expected: FAIL

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -13495,7 +13495,7 @@
      ]
     ],
     "interfaces.https.html": [
-     "dc853b1a823990fa2d1478533dc5bd17fb576a13",
+     "a70a25f44ce0c5aff0eac067afba5ac2d79141d6",
      [
       null,
       {}

--- a/tests/wpt/mozilla/tests/mozilla/interfaces.https.html
+++ b/tests/wpt/mozilla/tests/mozilla/interfaces.https.html
@@ -226,6 +226,7 @@ test_interfaces([
   "PerformanceResourceTiming",
   "Plugin",
   "PluginArray",
+  "PointerEvent",
   "PopStateEvent",
   "ProcessingInstruction",
   "ProgressEvent",


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This PR is the first step of adding `contextmenu` event, but it only adds the basic event type of `PointerEvent` for now.
Because the tests we need in WPT's `uievents` and `pointerevents` require `testderiver.js` to run. It also has some trouble on Servodriver executor. We will look into that next after this event is added.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [x] There are tests for these changes. `pointerevents` should run as expected.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
