### PR TITLE
Fix mach bootstrap for Python 3.13

### DIFF
--- a/tests/wpt/tests/tools/wptrunner/requirements.txt
+++ b/tests/wpt/tests/tools/wptrunner/requirements.txt
@@ -1,10 +1,11 @@
 html5lib==1.1
+legacy-cgi==2.6.1
 mozdebug==0.3.1
 mozinfo==1.2.3  # https://bugzilla.mozilla.org/show_bug.cgi?id=1621226
 mozlog==8.0.0
 mozprocess==1.3.1
 packaging==24.0
-pillow==10.3.0
+pillow==11.0.0
 requests==2.32.3
 six==1.16.0
 urllib3==2.2.2


### PR DESCRIPTION
The 'cgi' module was removed in Python 3.13. This broke mach bootstrap for Python 13.3. The `legacy-cgi` is a drop-in replacement for projects not ready to upgrade to a better approach. I've added that to the requirements. The newer version of the `pillow` module was also required.

The mach test-wpt command still doesn't work after this change but bootstrap at least works.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #34095

- [X] These changes do not require tests because it can be tested by running `./mach bootstrap` with Python 3.13 installed. We could set up CI to do that if needed.