### PR TITLE
Streams: fix fetch integration

### DIFF
--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -640,10 +640,10 @@ impl MessageListener {
 }
 
 /// Callback used to enqueue file chunks to streams as part of FileListener.
-fn stream_handle_incoming(stream: &ReadableStream, bytes: Fallible<Vec<u8>>, can_gc: CanGc) {
+fn stream_handle_incoming(stream: &ReadableStream, bytes: Fallible<Vec<u8>>) {
     match bytes {
         Ok(b) => {
-            stream.enqueue_native(b, can_gc);
+            stream.enqueue_native(b);
         },
         Err(e) => {
             stream.error_native(e);
@@ -666,7 +666,7 @@ impl FileListener {
 
                         let task = task!(enqueue_stream_chunk: move || {
                             let stream = trusted.root();
-                            stream_handle_incoming(&stream, Ok(blob_buf.bytes), CanGc::note());
+                            stream_handle_incoming(&stream, Ok(blob_buf.bytes));
                         });
 
                         let _ = self
@@ -690,7 +690,7 @@ impl FileListener {
 
                         let task = task!(enqueue_stream_chunk: move || {
                             let stream = trusted.root();
-                            stream_handle_incoming(&stream, Ok(bytes_in), CanGc::note());
+                            stream_handle_incoming(&stream, Ok(bytes_in));
                         });
 
                         let _ = self
@@ -756,7 +756,7 @@ impl FileListener {
                             let _ = self.task_source.queue_with_canceller(
                                 task!(error_stream: move || {
                                     let stream = trusted_stream.root();
-                                    stream_handle_incoming(&stream, error, CanGc::note());
+                                    stream_handle_incoming(&stream, error);
                                 }),
                                 &self.task_canceller,
                             );

--- a/components/script/dom/response.rs
+++ b/components/script/dom/response.rs
@@ -446,12 +446,12 @@ impl Response {
         *self.stream_consumer.borrow_mut() = sc;
     }
 
-    pub fn stream_chunk(&self, chunk: Vec<u8>, can_gc: CanGc) {
+    pub fn stream_chunk(&self, chunk: Vec<u8>) {
         // Note, are these two actually mutually exclusive?
         if let Some(stream_consumer) = self.stream_consumer.borrow().as_ref() {
             stream_consumer.consume_chunk(chunk.as_slice());
         } else if let Some(body) = self.body_stream.get() {
-            body.enqueue_native(chunk, can_gc);
+            body.enqueue_native(chunk);
         }
     }
 

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -279,7 +279,7 @@ impl FetchResponseListener for FetchContext {
 
     fn process_response_chunk(&mut self, _: RequestId, chunk: Vec<u8>) {
         let response = self.response_object.root();
-        response.stream_chunk(chunk, CanGc::note());
+        response.stream_chunk(chunk);
     }
 
     fn process_response_eof(


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Fixes how streams are enqueued to and read from from Rust code such as fetch and the body mixin:

- `new_from_bytes` should use `close_native`.
- read and done get functions should check that value is an object. 
- enqueue native should queue a native value(otherwise `get_in_memory_bytes` returns `None`). 
- remove now unsused `CanGC`, because the native calls do not need it. 
- Fixes a memory access crash due to wrong use of `Heap`. 
- Ensure enqueuing a native chunk fulfill pending read requests. 
- Note https://github.com/servo/servo/issues/34252#issuecomment-2516251401

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
