### PR TITLE
Add prefs to limit threadpool sizes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4131,6 +4131,7 @@ dependencies = [
  "net_traits",
  "profile",
  "profile_traits",
+ "rayon",
  "script",
  "script_layout_interface",
  "script_traits",

--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -198,6 +198,24 @@ mod gen {
                 #[serde(rename = "fonts.default-monospace-size")]
                 default_monospace_size: i64,
             },
+            /// Allows customizing the different threadpools used by servo
+            threadpools: {
+                /// Number of workers per threadpool, if we fail to detect how much
+                /// parallelism is available at runtime.
+                fallback_worker_num: i64,
+                image_cache_workers: {
+                    /// Maximum number of workers for the Image Cache thread pool
+                    max: i64,
+                },
+                async_runtime_workers: {
+                    /// Maximum number of workers for the Networking async runtime thread pool
+                    max: i64
+                },
+                resource_workers: {
+                    /// Maximum number of workers for the Core Resource Manager
+                    max: i64,
+                },
+            },
             css: {
                 animations: {
                     testing: {

--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -215,6 +215,10 @@ mod gen {
                     /// Maximum number of workers for the Core Resource Manager
                     max: i64,
                 },
+                webrender_workers: {
+                    /// Maximum number of workers for webrender
+                    max: i64,
+                },
             },
             css: {
                 animations: {

--- a/components/net/async_runtime.rs
+++ b/components/net/async_runtime.rs
@@ -1,10 +1,32 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-
+use std::cmp::Ord;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{LazyLock, Mutex};
+use std::thread;
 
-use tokio::runtime::Runtime;
+use tokio::runtime::{Builder, Runtime};
 
-pub static HANDLE: LazyLock<Mutex<Option<Runtime>>> =
-    LazyLock::new(|| Mutex::new(Some(Runtime::new().unwrap())));
+pub static HANDLE: LazyLock<Mutex<Option<Runtime>>> = LazyLock::new(|| {
+    Mutex::new(Some(
+        Builder::new_multi_thread()
+            .thread_name_fn(|| {
+                static ATOMIC_ID: AtomicUsize = AtomicUsize::new(0);
+                let id = ATOMIC_ID.fetch_add(1, Ordering::Relaxed);
+                format!("tokio-runtime-{}", id)
+            })
+            .worker_threads(
+                thread::available_parallelism()
+                    .map(|i| i.get())
+                    .unwrap_or(servo_config::pref!(threadpools.fallback_worker_num) as usize)
+                    .min(
+                        servo_config::pref!(threadpools.async_runtime_workers.max).max(1) as usize,
+                    ),
+            )
+            .enable_io()
+            .enable_time()
+            .build()
+            .unwrap(),
+    ))
+});

--- a/components/net/tests/fetch.rs
+++ b/components/net/tests/fetch.rs
@@ -226,7 +226,7 @@ fn test_file() {
         .origin(url.origin())
         .build();
 
-    let pool = CoreResourceThreadPool::new(1);
+    let pool = CoreResourceThreadPool::new(1, "CoreResourceTestPool".to_string());
     let pool_handle = Arc::new(pool);
     let mut context = new_fetch_context(None, None, Some(Arc::downgrade(&pool_handle)));
     let fetch_response = fetch_with_context(&mut request, &mut context);

--- a/components/net/tests/filemanager_thread.rs
+++ b/components/net/tests/filemanager_thread.rs
@@ -21,7 +21,7 @@ use crate::create_embedder_proxy;
 
 #[test]
 fn test_filemanager() {
-    let pool = CoreResourceThreadPool::new(1);
+    let pool = CoreResourceThreadPool::new(1, "CoreResourceTestPool".to_string());
     let pool_handle = Arc::new(pool);
     let filemanager = FileManager::new(create_embedder_proxy(), Arc::downgrade(&pool_handle));
     set_pref!(dom.testing.html_input_element.select_files.enabled, true);

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -69,6 +69,7 @@ media = { path = "../media" }
 mozangle = { workspace = true }
 net = { path = "../net" }
 net_traits = { workspace = true }
+rayon = { workspace = true }
 profile = { path = "../profile" }
 profile_traits = { workspace = true }
 script = { path = "../script" }

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -22,6 +22,7 @@ use std::cmp::max;
 use std::path::PathBuf;
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
+use std::thread;
 use std::vec::Drain;
 
 pub use base::id::TopLevelBrowsingContextId;
@@ -349,6 +350,17 @@ where
             } else {
                 UploadMethod::PixelBuffer(ONE_TIME_USAGE_HINT)
             };
+            let worker_threads = thread::available_parallelism()
+                .map(|i| i.get())
+                .unwrap_or(pref!(threadpools.fallback_worker_num) as usize)
+                .min(pref!(threadpools.webrender_workers.max).max(1) as usize);
+            let workers = Some(Arc::new(
+                rayon::ThreadPoolBuilder::new()
+                    .num_threads(worker_threads)
+                    .thread_name(|idx| format!("WRWorker#{}", idx))
+                    .build()
+                    .unwrap(),
+            ));
             webrender::create_webrender_instance(
                 webrender_gl.clone(),
                 render_notifier,
@@ -371,6 +383,7 @@ where
                     allow_texture_swizzling: pref!(gfx.texture_swizzling.enabled),
                     clear_color,
                     upload_method,
+                    workers,
                     ..Default::default()
                 },
                 None,

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -101,7 +101,6 @@ surfman = { workspace = true, features = ["sm-angle-default"] }
 serde_json = { workspace = true }
 webxr = { workspace = true, optional = true }
 
-
 [target.'cfg(not(any(target_os = "android", target_env = "ohos")))'.dependencies]
 # For optional feature servo_allocator/use-system-allocator
 servo_allocator = { path = "../../components/allocator" }

--- a/resources/prefs.json
+++ b/resources/prefs.json
@@ -128,5 +128,6 @@
   "threadpools.fallback_worker_num": 3,
   "threadpools.image_cache_workers.max": 4,
   "threadpools.resource_workers.max": 4,
+  "threadpools.webrender_workers.max": 4,
   "webgl.testing.context_creation_error": false
 }

--- a/resources/prefs.json
+++ b/resources/prefs.json
@@ -124,5 +124,9 @@
   "shell.native-orientation": "both",
   "shell.native-titlebar.enabled": true,
   "shell.searchpage": "https://duckduckgo.com/html/?q=%s",
+  "threadpools.async_runtime_workers.max": 6,
+  "threadpools.fallback_worker_num": 3,
+  "threadpools.image_cache_workers.max": 4,
+  "threadpools.resource_workers.max": 4,
   "webgl.testing.context_creation_error": false
 }


### PR DESCRIPTION
We should cap the number of pool threads, since we have quite a few thread pools, which seem to be over dimensioned (e.g. it does not make sense to have 128 threads for the image cache thread pool, just because the machine happens to have many cores). 
Adding preferences allows us to easily limit and experiment with the size of thread pools. 

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because: Thread-pool size is an option. We are sure the option works, but not what good values would be.


