### PR TITLE
Move stylo thread pool mutex to servo layout thread crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1617,7 +1617,7 @@ dependencies = [
 [[package]]
 name = "dom"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=eliminate-thread-pool-mutex#a25e05ca4a0f13e32651f1752c28b8ad4a45b8f4"
+source = "git+https://github.com/servo/stylo?branch=2024-11-01#18ca509a7dcfc0f175cddb36b57bc4cd9586f81e"
 dependencies = [
  "bitflags 2.6.0",
  "malloc_size_of",
@@ -4247,7 +4247,7 @@ dependencies = [
 [[package]]
 name = "malloc_size_of"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=eliminate-thread-pool-mutex#a25e05ca4a0f13e32651f1752c28b8ad4a45b8f4"
+source = "git+https://github.com/servo/stylo?branch=2024-11-01#18ca509a7dcfc0f175cddb36b57bc4cd9586f81e"
 dependencies = [
  "app_units",
  "cssparser",
@@ -6196,7 +6196,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.26.0"
-source = "git+https://github.com/servo/stylo?branch=eliminate-thread-pool-mutex#a25e05ca4a0f13e32651f1752c28b8ad4a45b8f4"
+source = "git+https://github.com/servo/stylo?branch=2024-11-01#18ca509a7dcfc0f175cddb36b57bc4cd9586f81e"
 dependencies = [
  "bitflags 2.6.0",
  "cssparser",
@@ -6484,7 +6484,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.0"
-source = "git+https://github.com/servo/stylo?branch=eliminate-thread-pool-mutex#a25e05ca4a0f13e32651f1752c28b8ad4a45b8f4"
+source = "git+https://github.com/servo/stylo?branch=2024-11-01#18ca509a7dcfc0f175cddb36b57bc4cd9586f81e"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -6493,7 +6493,7 @@ dependencies = [
 [[package]]
 name = "servo_atoms"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=eliminate-thread-pool-mutex#a25e05ca4a0f13e32651f1752c28b8ad4a45b8f4"
+source = "git+https://github.com/servo/stylo?branch=2024-11-01#18ca509a7dcfc0f175cddb36b57bc4cd9586f81e"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -6866,7 +6866,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "static_prefs"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=eliminate-thread-pool-mutex#a25e05ca4a0f13e32651f1752c28b8ad4a45b8f4"
+source = "git+https://github.com/servo/stylo?branch=2024-11-01#18ca509a7dcfc0f175cddb36b57bc4cd9586f81e"
 
 [[package]]
 name = "strck"
@@ -6925,7 +6925,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 [[package]]
 name = "style"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=eliminate-thread-pool-mutex#a25e05ca4a0f13e32651f1752c28b8ad4a45b8f4"
+source = "git+https://github.com/servo/stylo?branch=2024-11-01#18ca509a7dcfc0f175cddb36b57bc4cd9586f81e"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -6983,7 +6983,7 @@ dependencies = [
 [[package]]
 name = "style_config"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=eliminate-thread-pool-mutex#a25e05ca4a0f13e32651f1752c28b8ad4a45b8f4"
+source = "git+https://github.com/servo/stylo?branch=2024-11-01#18ca509a7dcfc0f175cddb36b57bc4cd9586f81e"
 dependencies = [
  "lazy_static",
 ]
@@ -6991,7 +6991,7 @@ dependencies = [
 [[package]]
 name = "style_derive"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=eliminate-thread-pool-mutex#a25e05ca4a0f13e32651f1752c28b8ad4a45b8f4"
+source = "git+https://github.com/servo/stylo?branch=2024-11-01#18ca509a7dcfc0f175cddb36b57bc4cd9586f81e"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -7021,7 +7021,7 @@ dependencies = [
 [[package]]
 name = "style_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=eliminate-thread-pool-mutex#a25e05ca4a0f13e32651f1752c28b8ad4a45b8f4"
+source = "git+https://github.com/servo/stylo?branch=2024-11-01#18ca509a7dcfc0f175cddb36b57bc4cd9586f81e"
 dependencies = [
  "app_units",
  "bitflags 2.6.0",
@@ -7384,7 +7384,7 @@ dependencies = [
 [[package]]
 name = "to_shmem"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=eliminate-thread-pool-mutex#a25e05ca4a0f13e32651f1752c28b8ad4a45b8f4"
+source = "git+https://github.com/servo/stylo?branch=2024-11-01#18ca509a7dcfc0f175cddb36b57bc4cd9586f81e"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -7397,7 +7397,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=eliminate-thread-pool-mutex#a25e05ca4a0f13e32651f1752c28b8ad4a45b8f4"
+source = "git+https://github.com/servo/stylo?branch=2024-11-01#18ca509a7dcfc0f175cddb36b57bc4cd9586f81e"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1617,7 +1617,7 @@ dependencies = [
 [[package]]
 name = "dom"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-11-01#16c1b6858581ab837f04a30cc5bc762ca1cbad23"
+source = "git+https://github.com/servo/stylo?branch=eliminate-thread-pool-mutex#a25e05ca4a0f13e32651f1752c28b8ad4a45b8f4"
 dependencies = [
  "bitflags 2.6.0",
  "malloc_size_of",
@@ -4247,7 +4247,7 @@ dependencies = [
 [[package]]
 name = "malloc_size_of"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-11-01#16c1b6858581ab837f04a30cc5bc762ca1cbad23"
+source = "git+https://github.com/servo/stylo?branch=eliminate-thread-pool-mutex#a25e05ca4a0f13e32651f1752c28b8ad4a45b8f4"
 dependencies = [
  "app_units",
  "cssparser",
@@ -6196,7 +6196,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.26.0"
-source = "git+https://github.com/servo/stylo?branch=2024-11-01#16c1b6858581ab837f04a30cc5bc762ca1cbad23"
+source = "git+https://github.com/servo/stylo?branch=eliminate-thread-pool-mutex#a25e05ca4a0f13e32651f1752c28b8ad4a45b8f4"
 dependencies = [
  "bitflags 2.6.0",
  "cssparser",
@@ -6484,7 +6484,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.0"
-source = "git+https://github.com/servo/stylo?branch=2024-11-01#16c1b6858581ab837f04a30cc5bc762ca1cbad23"
+source = "git+https://github.com/servo/stylo?branch=eliminate-thread-pool-mutex#a25e05ca4a0f13e32651f1752c28b8ad4a45b8f4"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -6493,7 +6493,7 @@ dependencies = [
 [[package]]
 name = "servo_atoms"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-11-01#16c1b6858581ab837f04a30cc5bc762ca1cbad23"
+source = "git+https://github.com/servo/stylo?branch=eliminate-thread-pool-mutex#a25e05ca4a0f13e32651f1752c28b8ad4a45b8f4"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -6866,7 +6866,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "static_prefs"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2024-11-01#16c1b6858581ab837f04a30cc5bc762ca1cbad23"
+source = "git+https://github.com/servo/stylo?branch=eliminate-thread-pool-mutex#a25e05ca4a0f13e32651f1752c28b8ad4a45b8f4"
 
 [[package]]
 name = "strck"
@@ -6925,7 +6925,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 [[package]]
 name = "style"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-11-01#16c1b6858581ab837f04a30cc5bc762ca1cbad23"
+source = "git+https://github.com/servo/stylo?branch=eliminate-thread-pool-mutex#a25e05ca4a0f13e32651f1752c28b8ad4a45b8f4"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -6983,7 +6983,7 @@ dependencies = [
 [[package]]
 name = "style_config"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-11-01#16c1b6858581ab837f04a30cc5bc762ca1cbad23"
+source = "git+https://github.com/servo/stylo?branch=eliminate-thread-pool-mutex#a25e05ca4a0f13e32651f1752c28b8ad4a45b8f4"
 dependencies = [
  "lazy_static",
 ]
@@ -6991,7 +6991,7 @@ dependencies = [
 [[package]]
 name = "style_derive"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-11-01#16c1b6858581ab837f04a30cc5bc762ca1cbad23"
+source = "git+https://github.com/servo/stylo?branch=eliminate-thread-pool-mutex#a25e05ca4a0f13e32651f1752c28b8ad4a45b8f4"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -7021,7 +7021,7 @@ dependencies = [
 [[package]]
 name = "style_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-11-01#16c1b6858581ab837f04a30cc5bc762ca1cbad23"
+source = "git+https://github.com/servo/stylo?branch=eliminate-thread-pool-mutex#a25e05ca4a0f13e32651f1752c28b8ad4a45b8f4"
 dependencies = [
  "app_units",
  "bitflags 2.6.0",
@@ -7384,7 +7384,7 @@ dependencies = [
 [[package]]
 name = "to_shmem"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2024-11-01#16c1b6858581ab837f04a30cc5bc762ca1cbad23"
+source = "git+https://github.com/servo/stylo?branch=eliminate-thread-pool-mutex#a25e05ca4a0f13e32651f1752c28b8ad4a45b8f4"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -7397,7 +7397,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2024-11-01#16c1b6858581ab837f04a30cc5bc762ca1cbad23"
+source = "git+https://github.com/servo/stylo?branch=eliminate-thread-pool-mutex#a25e05ca4a0f13e32651f1752c28b8ad4a45b8f4"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,25 +107,25 @@ rustls = { version = "0.21.12", features = ["dangerous_configuration"] }
 rustls-pemfile = "1.0.4"
 script_layout_interface = { path = "components/shared/script_layout" }
 script_traits = { path = "components/shared/script" }
-selectors = { git = "https://github.com/servo/stylo", branch = "2024-11-01" }
+selectors = { git = "https://github.com/servo/stylo", branch = "eliminate-thread-pool-mutex" }
 serde = "1.0.215"
 serde_bytes = "0.11"
 serde_json = "1.0"
 servo-media = { git = "https://github.com/servo/media" }
 servo-media-dummy = { git = "https://github.com/servo/media" }
 servo-media-gstreamer = { git = "https://github.com/servo/media" }
-servo_arc = { git = "https://github.com/servo/stylo", branch = "2024-11-01", features = ["servo"] }
-servo_atoms = { git = "https://github.com/servo/stylo", branch = "2024-11-01" }
+servo_arc = { git = "https://github.com/servo/stylo", branch = "eliminate-thread-pool-mutex", features = ["servo"] }
+servo_atoms = { git = "https://github.com/servo/stylo", branch = "eliminate-thread-pool-mutex" }
 smallbitvec = "2.5.3"
 smallvec = "1.13"
 static_assertions = "1.1"
 string_cache = "0.8"
 string_cache_codegen = "0.5"
-style = { git = "https://github.com/servo/stylo", branch = "2024-11-01", features = ["servo"] }
-style_config = { git = "https://github.com/servo/stylo", branch = "2024-11-01" }
-style_dom = { git = "https://github.com/servo/stylo", package = "dom", branch = "2024-11-01" }
-style_traits = { git = "https://github.com/servo/stylo", branch = "2024-11-01", features = ["servo"] }
-style_malloc_size_of = { package = "malloc_size_of", git = "https://github.com/servo/stylo", branch = "2024-11-01", features = ["servo"] }
+style = { git = "https://github.com/servo/stylo", branch = "eliminate-thread-pool-mutex", features = ["servo"] }
+style_config = { git = "https://github.com/servo/stylo", branch = "eliminate-thread-pool-mutex" }
+style_dom = { git = "https://github.com/servo/stylo", package = "dom", branch = "eliminate-thread-pool-mutex" }
+style_traits = { git = "https://github.com/servo/stylo", branch = "eliminate-thread-pool-mutex", features = ["servo"] }
+style_malloc_size_of = { package = "malloc_size_of", git = "https://github.com/servo/stylo", branch = "eliminate-thread-pool-mutex", features = ["servo"] }
 surfman = { git = "https://github.com/servo/surfman", rev = "c8d6b4b65aeab739ee7651602e29c8d58ceee123", features = ["chains"] }
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"
@@ -134,7 +134,7 @@ thin-vec = "0.2.13"
 tikv-jemalloc-sys = "0.6.0"
 tikv-jemallocator = "0.6.0"
 time_03 = { package = "time", version = "0.3", features = ["large-dates", "local-offset", "serde"] }
-to_shmem = { git = "https://github.com/servo/stylo", branch = "2024-11-01" }
+to_shmem = { git = "https://github.com/servo/stylo", branch = "eliminate-thread-pool-mutex" }
 tokio = "1"
 tokio-rustls = "0.24"
 tracing = "0.1.41"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,25 +107,25 @@ rustls = { version = "0.21.12", features = ["dangerous_configuration"] }
 rustls-pemfile = "1.0.4"
 script_layout_interface = { path = "components/shared/script_layout" }
 script_traits = { path = "components/shared/script" }
-selectors = { git = "https://github.com/servo/stylo", branch = "eliminate-thread-pool-mutex" }
+selectors = { git = "https://github.com/servo/stylo", branch = "2024-11-01" }
 serde = "1.0.215"
 serde_bytes = "0.11"
 serde_json = "1.0"
 servo-media = { git = "https://github.com/servo/media" }
 servo-media-dummy = { git = "https://github.com/servo/media" }
 servo-media-gstreamer = { git = "https://github.com/servo/media" }
-servo_arc = { git = "https://github.com/servo/stylo", branch = "eliminate-thread-pool-mutex", features = ["servo"] }
-servo_atoms = { git = "https://github.com/servo/stylo", branch = "eliminate-thread-pool-mutex" }
+servo_arc = { git = "https://github.com/servo/stylo", branch = "2024-11-01", features = ["servo"] }
+servo_atoms = { git = "https://github.com/servo/stylo", branch = "2024-11-01" }
 smallbitvec = "2.5.3"
 smallvec = "1.13"
 static_assertions = "1.1"
 string_cache = "0.8"
 string_cache_codegen = "0.5"
-style = { git = "https://github.com/servo/stylo", branch = "eliminate-thread-pool-mutex", features = ["servo"] }
-style_config = { git = "https://github.com/servo/stylo", branch = "eliminate-thread-pool-mutex" }
-style_dom = { git = "https://github.com/servo/stylo", package = "dom", branch = "eliminate-thread-pool-mutex" }
-style_traits = { git = "https://github.com/servo/stylo", branch = "eliminate-thread-pool-mutex", features = ["servo"] }
-style_malloc_size_of = { package = "malloc_size_of", git = "https://github.com/servo/stylo", branch = "eliminate-thread-pool-mutex", features = ["servo"] }
+style = { git = "https://github.com/servo/stylo", branch = "2024-11-01", features = ["servo"] }
+style_config = { git = "https://github.com/servo/stylo", branch = "2024-11-01" }
+style_dom = { git = "https://github.com/servo/stylo", package = "dom", branch = "2024-11-01" }
+style_traits = { git = "https://github.com/servo/stylo", branch = "2024-11-01", features = ["servo"] }
+style_malloc_size_of = { package = "malloc_size_of", git = "https://github.com/servo/stylo", branch = "2024-11-01", features = ["servo"] }
 surfman = { git = "https://github.com/servo/surfman", rev = "c8d6b4b65aeab739ee7651602e29c8d58ceee123", features = ["chains"] }
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"
@@ -134,7 +134,7 @@ thin-vec = "0.2.13"
 tikv-jemalloc-sys = "0.6.0"
 tikv-jemallocator = "0.6.0"
 time_03 = { package = "time", version = "0.3", features = ["large-dates", "local-offset", "serde"] }
-to_shmem = { git = "https://github.com/servo/stylo", branch = "eliminate-thread-pool-mutex" }
+to_shmem = { git = "https://github.com/servo/stylo", branch = "2024-11-01" }
 tokio = "1"
 tokio-rustls = "0.24"
 tracing = "0.1.41"

--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -1082,10 +1082,12 @@ impl LayoutThread {
             data.stylesheets_changed,
         );
 
-        let pool = STYLE_THREAD_POOL.lock().unwrap();
-        let thread_pool = pool.pool();
+        let thread_pool = STYLE_THREAD_POOL.pool();
         let (thread_pool, num_threads) = if self.parallel_flag {
-            (thread_pool.as_ref(), pool.num_threads.unwrap_or(1))
+            (
+                thread_pool.as_ref(),
+                STYLE_THREAD_POOL.num_threads.unwrap_or(1),
+            )
         } else {
             (None, 1)
         };

--- a/components/layout_thread_2020/lib.rs
+++ b/components/layout_thread_2020/lib.rs
@@ -796,8 +796,7 @@ impl LayoutThread {
 
         self.stylist.flush(&guards, Some(root_element), Some(&map));
 
-        let rayon_pool = STYLE_THREAD_POOL.lock().unwrap();
-        let rayon_pool = rayon_pool.pool();
+        let rayon_pool = STYLE_THREAD_POOL.pool();
         let rayon_pool = rayon_pool.as_ref();
 
         // Create a layout context for use throughout the following passes.


### PR DESCRIPTION
This was quite straightforward (just remove the Mutex and the calls to the lock methods). And StyleThreadPool already internally contains an RwLock. Perhaps this was previously required but isn't anymore?

Stylo PR:
- https://github.com/servo/stylo/pull/97

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___
