### PR TITLE
Rename 'cargo-clippy' mach command to just 'clippy'

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -55,6 +55,6 @@ jobs:
       # TODO: Do GitHub anotaions
       - name: Clippy
         run: |
-          python3 ./mach cargo-clippy --use-crown --locked -- -- --deny warnings
+          python3 ./mach clippy --use-crown --locked -- -- --deny warnings
       - name: Tidy
         run: python3 ./mach test-tidy --no-progress --all

--- a/python/servo/devenv_commands.py
+++ b/python/servo/devenv_commands.py
@@ -125,12 +125,12 @@ class MachCommands(CommandBase):
         self.ensure_clobbered()
         return self.run_cargo_build_like_command("fix", params, **kwargs)
 
-    @Command('cargo-clippy',
+    @Command('clippy',
              description='Run "cargo clippy"',
              category='devenv')
     @CommandArgument(
         'params', default=None, nargs='...',
-        help="Command-line arguments to be passed through to cargo-clippy")
+        help="Command-line arguments to be passed through to clippy")
     @CommandBase.common_command_arguments(build_configuration=True, build_type=False)
     def cargo_clippy(self, params, **kwargs):
         if not params:


### PR DESCRIPTION
There seems to be no need for the more verbose `cargo-clippy` name which is annoying to type (and also inconsistent with other mach command names).

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
