### PR TITLE
Remove layout blockers before invoking arbitrary content callbacks

### DIFF
--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -13529,6 +13529,13 @@
       {}
      ]
     ],
+    "layout_blocker_operations.html": [
+     "2df68bf1c13179688708c97eab19361608b0de82",
+     [
+      null,
+      {}
+     ]
+    ],
     "lenient_this.html": [
      "960c74613f3c2809bb1f2ee6121bf14f28267051",
      [

--- a/tests/wpt/mozilla/tests/mozilla/layout_blocker_operations.html
+++ b/tests/wpt/mozilla/tests/mozilla/layout_blocker_operations.html
@@ -1,0 +1,34 @@
+<html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<div id="foo"></div>
+
+<script>
+  function verifyLayoutAllowed(t) {
+      t.step(() => {
+          assert_equals(getComputedStyle(document.querySelector('#foo')).display, "block");
+          t.done();
+      })
+  }
+
+  var insertionTest;
+  async_test(function(t) {
+      insertionTest = t;
+      let script = document.createElement('script');
+      document.body.appendChild(script);
+      script.appendChild(document.createTextNode("verifyLayoutAllowed(insertionTest)"));
+  }, "Insertion");
+
+  var replacementTest;
+  async_test(function(t) {
+      replacementTest = t;
+      let script = document.createElement('script');
+      document.body.appendChild(script);
+      script.innerHTML = "verifyLayoutAllowed(replacementTest)";
+  }, "Replace");
+</script>
+</body>
+</html>


### PR DESCRIPTION
When manipulating the DOM tree we always want web content to only see stable states after any mutations are applied. We introduced script/layout blockers in 14b0de30dbf90793c3b6c9017e4c65df9281c5ae to catch cases where an unstable DOM could be exposed to web content. These restrictions were too strict, however; the spec mandates that steps like the `children changed` should be invoked synchronously (eg. step 9 of https://dom.spec.whatwg.org/#concept-node-insert), and it's possible to trigger web content from those steps in various ways (see the new test). Since we're careful to invoke such callbacks at times when the DOM is stable, this means that we need to remove the script/layout blockers right before invoking those callbacks, rather than after they have executed.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #34465 and fix #31142
- [x] There are tests for these changes