### PR TITLE
Bump MACOSX_DEPLOYMENT_TARGET to 13.0

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -29,7 +29,7 @@ linker = "lld-link.exe"
 linker = "lld-link.exe"
 
 [env]
-MACOSX_DEPLOYMENT_TARGET = "10.10"
+MACOSX_DEPLOYMENT_TARGET = "13.0"
 RUSTC_BOOTSTRAP = "crown,script,style_tests"
 
 [build]


### PR DESCRIPTION
The lowest version we test servo on in CI is macos 13.
This fixes some spurious compile errors on recent MacOS versions, when compiling mozjs from source.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix/avoid https://github.com/servo/mozjs/issues/504 when compiling mozjs from source

