### PR TITLE
mach: Make initialization of the `mach` script more similar to Firefox's

### DIFF
--- a/mach
+++ b/mach
@@ -1,13 +1,7 @@
-#!/bin/sh
+#!/usr/bin/env python3
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
-
-# The beginning of this script is both valid shell and valid python,
-# such that the script starts with the shell and is reexecuted with
-# the right python.
-''':' && if [ ! -z "$MSYSTEM" ] ; then exec python "$0" "$@" ; else which python3 > /dev/null 2> /dev/null && exec python3 "$0" "$@" || exec python "$0" "$@" ; fi
-'''
 
 import os
 import sys

--- a/mach.bat
+++ b/mach.bat
@@ -1,8 +1,9 @@
 @echo off
+set workdir=%~dp0
 
 where /Q py.exe
 IF %ERRORLEVEL% NEQ 0 (
-  python mach %*
+  python %workdir%mach %*
 ) ELSE (
-  py -3 mach %*
+  py -3 %workdir%mach %*
 )


### PR DESCRIPTION
These changes are not fixing any current issues. True, there could be some edge cases around portability where without these, users could encounter issues.

- the `.bat` copies [Firefox's mach.cmd](https://searchfox.org/mozilla-central/source/mach.cmd)
- the `sh` is just a not-necessary simplification, also following [Firefox's mach](https://searchfox.org/mozilla-central/source/mach)

(thanks @sagudev for drawing my attention to it)

p.s.: Unfortunately, none of my machines can run mach without issues, so I can't test it thoroughly. :/

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
