### PR TITLE
script: Update the rendering when receiving IPC messages instead of just reflowing

### DIFF
--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -16,6 +16,7 @@ use js::jsval::UndefinedValue;
 use js::rust::ToString;
 use uuid::Uuid;
 
+use crate::document_collection::DocumentCollection;
 use crate::dom::bindings::codegen::Bindings::CSSRuleListBinding::CSSRuleListMethods;
 use crate::dom::bindings::codegen::Bindings::CSSStyleDeclarationBinding::CSSStyleDeclarationMethods;
 use crate::dom::bindings::codegen::Bindings::CSSStyleRuleBinding::CSSStyleRuleMethods;
@@ -41,7 +42,6 @@ use crate::dom::types::HTMLElement;
 use crate::realms::enter_realm;
 use crate::script_module::ScriptFetchOptions;
 use crate::script_runtime::CanGc;
-use crate::script_thread::Documents;
 
 #[allow(unsafe_code)]
 pub fn handle_evaluate_js(
@@ -98,7 +98,7 @@ pub fn handle_evaluate_js(
 }
 
 pub fn handle_get_root_node(
-    documents: &Documents,
+    documents: &DocumentCollection,
     pipeline: PipelineId,
     reply: IpcSender<Option<NodeInfo>>,
 ) {
@@ -109,7 +109,7 @@ pub fn handle_get_root_node(
 }
 
 pub fn handle_get_document_element(
-    documents: &Documents,
+    documents: &DocumentCollection,
     pipeline: PipelineId,
     reply: IpcSender<Option<NodeInfo>>,
 ) {
@@ -121,7 +121,7 @@ pub fn handle_get_document_element(
 }
 
 fn find_node_by_unique_id(
-    documents: &Documents,
+    documents: &DocumentCollection,
     pipeline: PipelineId,
     node_id: &str,
 ) -> Option<DomRoot<Node>> {
@@ -134,7 +134,7 @@ fn find_node_by_unique_id(
 }
 
 pub fn handle_get_children(
-    documents: &Documents,
+    documents: &DocumentCollection,
     pipeline: PipelineId,
     node_id: String,
     reply: IpcSender<Option<Vec<NodeInfo>>>,
@@ -186,7 +186,7 @@ pub fn handle_get_children(
 }
 
 pub fn handle_get_attribute_style(
-    documents: &Documents,
+    documents: &DocumentCollection,
     pipeline: PipelineId,
     node_id: String,
     reply: IpcSender<Option<Vec<NodeStyle>>>,
@@ -218,7 +218,7 @@ pub fn handle_get_attribute_style(
 
 #[allow(crown::unrooted_must_root)]
 pub fn handle_get_stylesheet_style(
-    documents: &Documents,
+    documents: &DocumentCollection,
     pipeline: PipelineId,
     node_id: String,
     selector: String,
@@ -265,7 +265,7 @@ pub fn handle_get_stylesheet_style(
 
 #[allow(crown::unrooted_must_root)]
 pub fn handle_get_selectors(
-    documents: &Documents,
+    documents: &DocumentCollection,
     pipeline: PipelineId,
     node_id: String,
     reply: IpcSender<Option<Vec<(String, usize)>>>,
@@ -301,7 +301,7 @@ pub fn handle_get_selectors(
 }
 
 pub fn handle_get_computed_style(
-    documents: &Documents,
+    documents: &DocumentCollection,
     pipeline: PipelineId,
     node_id: String,
     reply: IpcSender<Option<Vec<NodeStyle>>>,
@@ -335,7 +335,7 @@ pub fn handle_get_computed_style(
 }
 
 pub fn handle_get_layout(
-    documents: &Documents,
+    documents: &DocumentCollection,
     pipeline: PipelineId,
     node_id: String,
     reply: IpcSender<Option<ComputedNodeLayout>>,
@@ -396,7 +396,7 @@ fn determine_auto_margins(node: &Node, can_gc: CanGc) -> AutoMargins {
 }
 
 pub fn handle_modify_attribute(
-    documents: &Documents,
+    documents: &DocumentCollection,
     pipeline: PipelineId,
     node_id: String,
     modifications: Vec<AttrModification>,
@@ -436,7 +436,7 @@ pub fn handle_modify_attribute(
 }
 
 pub fn handle_modify_rule(
-    documents: &Documents,
+    documents: &DocumentCollection,
     pipeline: PipelineId,
     node_id: String,
     modifications: Vec<RuleModification>,
@@ -474,7 +474,7 @@ pub fn handle_wants_live_notifications(global: &GlobalScope, send_notifications:
 }
 
 pub fn handle_set_timeline_markers(
-    documents: &Documents,
+    documents: &DocumentCollection,
     pipeline: PipelineId,
     marker_types: Vec<TimelineMarkerType>,
     reply: IpcSender<Option<TimelineMarker>>,
@@ -486,7 +486,7 @@ pub fn handle_set_timeline_markers(
 }
 
 pub fn handle_drop_timeline_markers(
-    documents: &Documents,
+    documents: &DocumentCollection,
     pipeline: PipelineId,
     marker_types: Vec<TimelineMarkerType>,
 ) {
@@ -495,13 +495,17 @@ pub fn handle_drop_timeline_markers(
     }
 }
 
-pub fn handle_request_animation_frame(documents: &Documents, id: PipelineId, actor_name: String) {
+pub fn handle_request_animation_frame(
+    documents: &DocumentCollection,
+    id: PipelineId,
+    actor_name: String,
+) {
     if let Some(doc) = documents.find_document(id) {
         doc.request_animation_frame(AnimationFrameCallback::DevtoolsFramerateTick { actor_name });
     }
 }
 
-pub fn handle_reload(documents: &Documents, id: PipelineId, can_gc: CanGc) {
+pub fn handle_reload(documents: &DocumentCollection, id: PipelineId, can_gc: CanGc) {
     if let Some(win) = documents.find_window(id) {
         win.Location().reload_without_origin_check(can_gc);
     }

--- a/components/script/document_collection.rs
+++ b/components/script/document_collection.rs
@@ -1,0 +1,177 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::collections::{hash_map, HashMap};
+
+use base::id::{BrowsingContextId, PipelineId};
+
+use crate::dom::bindings::inheritance::Castable;
+use crate::dom::bindings::root::{Dom, DomRoot};
+use crate::dom::bindings::trace::HashMapTracedValues;
+use crate::dom::document::Document;
+use crate::dom::globalscope::GlobalScope;
+use crate::dom::htmliframeelement::HTMLIFrameElement;
+use crate::dom::window::Window;
+
+/// The collection of all [`Document`]s managed by the [`crate::script_thread::SriptThread`].
+/// This is stored as a mapping of [`PipelineId`] to [`Document`], but for updating the
+/// rendering, [`Document`]s should be processed in order via [`Self::documents_in_order`].
+#[derive(JSTraceable)]
+#[crown::unrooted_must_root_lint::must_root]
+pub(crate) struct DocumentCollection {
+    map: HashMapTracedValues<PipelineId, Dom<Document>>,
+}
+
+impl DocumentCollection {
+    pub fn insert(&mut self, pipeline_id: PipelineId, doc: &Document) {
+        self.map.insert(pipeline_id, Dom::from_ref(doc));
+    }
+
+    pub fn remove(&mut self, pipeline_id: PipelineId) -> Option<DomRoot<Document>> {
+        self.map
+            .remove(&pipeline_id)
+            .map(|ref doc| DomRoot::from_ref(&**doc))
+    }
+
+    pub fn find_document(&self, pipeline_id: PipelineId) -> Option<DomRoot<Document>> {
+        self.map
+            .get(&pipeline_id)
+            .map(|doc| DomRoot::from_ref(&**doc))
+    }
+
+    pub fn find_window(&self, pipeline_id: PipelineId) -> Option<DomRoot<Window>> {
+        self.find_document(pipeline_id)
+            .map(|doc| DomRoot::from_ref(doc.window()))
+    }
+
+    pub fn find_global(&self, pipeline_id: PipelineId) -> Option<DomRoot<GlobalScope>> {
+        self.find_window(pipeline_id)
+            .map(|window| DomRoot::from_ref(window.upcast()))
+    }
+
+    pub fn find_iframe(
+        &self,
+        pipeline_id: PipelineId,
+        browsing_context_id: BrowsingContextId,
+    ) -> Option<DomRoot<HTMLIFrameElement>> {
+        self.find_document(pipeline_id)
+            .and_then(|doc| doc.find_iframe(browsing_context_id))
+    }
+
+    pub fn iter(&self) -> DocumentsIter<'_> {
+        DocumentsIter {
+            iter: self.map.iter(),
+        }
+    }
+
+    /// Return the documents managed by this [`crate::script_thread::ScriptThread`] in the
+    /// order specified by the *[update the rendering][update-the-rendering]* step of the
+    /// HTML specification:
+    ///
+    /// > Let docs be all fully active Document objects whose relevant agent's event loop is
+    /// > eventLoop, sorted arbitrarily except that the following conditions must be met:
+    /// >
+    /// > Any Document B whose container document is A must be listed after A in the list.
+    /// >
+    /// > If there are two documents A and B that both have the same non-null container
+    /// > document C, then the order of A and B in the list must match the shadow-including
+    /// > tree order of their respective navigable containers in C's node tree.
+    /// >
+    /// > In the steps below that iterate over docs, each Document must be processed in the
+    /// > order it is found in the list.
+    ///
+    /// [update-the-rendering]: https://html.spec.whatwg.org/multipage/#update-the-rendering
+    pub(crate) fn documents_in_order(&self) -> Vec<PipelineId> {
+        // TODO: This is a fairly expensive operation, because iterating iframes requires walking
+        // the *entire* DOM for a document. Instead this should be cached and marked as dirty when
+        // the DOM of a document changes or documents are added or removed from our set.
+        DocumentTree::new(self).documents_in_order()
+    }
+}
+
+impl Default for DocumentCollection {
+    #[allow(crown::unrooted_must_root)]
+    fn default() -> Self {
+        Self {
+            map: HashMapTracedValues::new(),
+        }
+    }
+}
+
+#[allow(crown::unrooted_must_root)]
+pub struct DocumentsIter<'a> {
+    iter: hash_map::Iter<'a, PipelineId, Dom<Document>>,
+}
+
+impl<'a> Iterator for DocumentsIter<'a> {
+    type Item = (PipelineId, DomRoot<Document>);
+
+    fn next(&mut self) -> Option<(PipelineId, DomRoot<Document>)> {
+        self.iter
+            .next()
+            .map(|(id, doc)| (*id, DomRoot::from_ref(&**doc)))
+    }
+}
+
+#[derive(Default)]
+struct DocumentTreeNode {
+    parent: Option<PipelineId>,
+    children: Vec<PipelineId>,
+}
+
+/// A tree representation of [`Document`]s managed by the [`ScriptThread`][st], which is used
+/// to generate an ordered set of [`Document`]s for the *update the rendering* step of the
+/// HTML5 specification.
+///
+/// FIXME: The [`ScriptThread`][st] only has a view of [`Document`]s managed by itself,
+/// so if there are interceding iframes managed by other `ScriptThread`s, then the
+/// order of the [`Document`]s may not be correct. Perhaps the Constellation could
+/// ensure that every [`ScriptThread`][st] has the full view of the frame tree.
+///
+/// [st]: crate::script_thread::ScriptThread
+#[derive(Default)]
+struct DocumentTree {
+    tree: HashMap<PipelineId, DocumentTreeNode>,
+}
+
+impl DocumentTree {
+    fn new(documents: &DocumentCollection) -> Self {
+        let mut tree = DocumentTree::default();
+        for (id, document) in documents.iter() {
+            let children: Vec<PipelineId> = document
+                .iter_iframes()
+                .filter_map(|iframe| iframe.pipeline_id())
+                .filter(|iframe_pipeline_id| documents.find_document(*iframe_pipeline_id).is_some())
+                .collect();
+            for child in &children {
+                tree.tree.entry(*child).or_default().parent = Some(id);
+            }
+            tree.tree.entry(id).or_default().children = children;
+        }
+        tree
+    }
+
+    fn documents_in_order(&self) -> Vec<PipelineId> {
+        let mut list = Vec::new();
+        for (id, node) in self.tree.iter() {
+            if node.parent.is_none() {
+                self.process_node_for_documents_in_order(*id, &mut list);
+            }
+        }
+        list
+    }
+
+    fn process_node_for_documents_in_order(&self, id: PipelineId, list: &mut Vec<PipelineId>) {
+        list.push(id);
+        for child in self
+            .tree
+            .get(&id)
+            .expect("Should have found child node")
+            .children
+            .iter()
+        {
+            self.process_node_for_documents_in_order(*child, list);
+        }
+    }
+}

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -2107,6 +2107,7 @@ impl Document {
 
     /// <https://html.spec.whatwg.org/multipage/#run-the-animation-frame-callbacks>
     pub(crate) fn run_the_animation_frame_callbacks(&self, can_gc: CanGc) {
+        let _realm = enter_realm(self);
         rooted_vec!(let mut animation_frame_list);
         mem::swap(
             &mut *animation_frame_list,

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1983,6 +1983,7 @@ impl Window {
         let mut issued_reflow = false;
         let condition = self.Document().needs_reflow();
         if !for_display || condition.is_some() {
+            debug!("Reflowing document ({:?})", self.pipeline_id());
             issued_reflow = self.force_reflow(reflow_goal, reason, condition);
 
             // We shouldn't need a reflow immediately after a
@@ -2000,8 +2001,8 @@ impl Window {
             );
         } else {
             debug!(
-                "Document doesn't need reflow - skipping it (reason {:?})",
-                reason
+                "Document ({:?}) doesn't need reflow - skipping it (reason {reason:?})",
+                self.pipeline_id()
             );
         }
 

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -51,6 +51,8 @@ mod init;
 #[warn(deprecated)]
 mod layout_image;
 
+#[warn(deprecated)]
+pub mod document_collection;
 pub mod layout_dom;
 #[warn(deprecated)]
 mod mem;

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -25,6 +25,7 @@ use servo_url::ServoUrl;
 use webdriver::common::{WebElement, WebFrame, WebWindow};
 use webdriver::error::ErrorStatus;
 
+use crate::document_collection::DocumentCollection;
 use crate::dom::bindings::codegen::Bindings::CSSStyleDeclarationBinding::CSSStyleDeclarationMethods;
 use crate::dom::bindings::codegen::Bindings::DOMRectBinding::DOMRectMethods;
 use crate::dom::bindings::codegen::Bindings::DocumentBinding::DocumentMethods;
@@ -61,10 +62,10 @@ use crate::dom::xmlserializer::XMLSerializer;
 use crate::realms::enter_realm;
 use crate::script_module::ScriptFetchOptions;
 use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
-use crate::script_thread::{Documents, ScriptThread};
+use crate::script_thread::ScriptThread;
 
 fn find_node_by_unique_id(
-    documents: &Documents,
+    documents: &DocumentCollection,
     pipeline: PipelineId,
     node_id: String,
 ) -> Result<DomRoot<Node>, ErrorStatus> {
@@ -346,7 +347,7 @@ pub fn handle_execute_async_script(
 }
 
 pub fn handle_get_browsing_context_id(
-    documents: &Documents,
+    documents: &DocumentCollection,
     pipeline: PipelineId,
     webdriver_frame_id: WebDriverFrameId,
     reply: IpcSender<Result<BrowsingContextId, ErrorStatus>>,
@@ -412,7 +413,7 @@ fn get_element_in_view_center_point(element: &Element, can_gc: CanGc) -> Option<
 }
 
 pub fn handle_get_element_in_view_center_point(
-    documents: &Documents,
+    documents: &DocumentCollection,
     pipeline: PipelineId,
     element_id: String,
     reply: IpcSender<Result<Option<(i64, i64)>, ErrorStatus>>,
@@ -429,7 +430,7 @@ pub fn handle_get_element_in_view_center_point(
 }
 
 pub fn handle_find_element_css(
-    documents: &Documents,
+    documents: &DocumentCollection,
     pipeline: PipelineId,
     selector: String,
     reply: IpcSender<Result<Option<String>, ErrorStatus>>,
@@ -450,7 +451,7 @@ pub fn handle_find_element_css(
 }
 
 pub fn handle_find_element_link_text(
-    documents: &Documents,
+    documents: &DocumentCollection,
     pipeline: PipelineId,
     selector: String,
     partial: bool,
@@ -469,7 +470,7 @@ pub fn handle_find_element_link_text(
 }
 
 pub fn handle_find_element_tag_name(
-    documents: &Documents,
+    documents: &DocumentCollection,
     pipeline: PipelineId,
     selector: String,
     reply: IpcSender<Result<Option<String>, ErrorStatus>>,
@@ -491,7 +492,7 @@ pub fn handle_find_element_tag_name(
 }
 
 pub fn handle_find_elements_css(
-    documents: &Documents,
+    documents: &DocumentCollection,
     pipeline: PipelineId,
     selector: String,
     reply: IpcSender<Result<Vec<String>, ErrorStatus>>,
@@ -517,7 +518,7 @@ pub fn handle_find_elements_css(
 }
 
 pub fn handle_find_elements_link_text(
-    documents: &Documents,
+    documents: &DocumentCollection,
     pipeline: PipelineId,
     selector: String,
     partial: bool,
@@ -536,7 +537,7 @@ pub fn handle_find_elements_link_text(
 }
 
 pub fn handle_find_elements_tag_name(
-    documents: &Documents,
+    documents: &DocumentCollection,
     pipeline: PipelineId,
     selector: String,
     reply: IpcSender<Result<Vec<String>, ErrorStatus>>,
@@ -558,7 +559,7 @@ pub fn handle_find_elements_tag_name(
 }
 
 pub fn handle_find_element_element_css(
-    documents: &Documents,
+    documents: &DocumentCollection,
     pipeline: PipelineId,
     element_id: String,
     selector: String,
@@ -576,7 +577,7 @@ pub fn handle_find_element_element_css(
 }
 
 pub fn handle_find_element_element_link_text(
-    documents: &Documents,
+    documents: &DocumentCollection,
     pipeline: PipelineId,
     element_id: String,
     selector: String,
@@ -592,7 +593,7 @@ pub fn handle_find_element_element_link_text(
 }
 
 pub fn handle_find_element_element_tag_name(
-    documents: &Documents,
+    documents: &DocumentCollection,
     pipeline: PipelineId,
     element_id: String,
     selector: String,
@@ -615,7 +616,7 @@ pub fn handle_find_element_element_tag_name(
 }
 
 pub fn handle_find_element_elements_css(
-    documents: &Documents,
+    documents: &DocumentCollection,
     pipeline: PipelineId,
     element_id: String,
     selector: String,
@@ -638,7 +639,7 @@ pub fn handle_find_element_elements_css(
 }
 
 pub fn handle_find_element_elements_link_text(
-    documents: &Documents,
+    documents: &DocumentCollection,
     pipeline: PipelineId,
     element_id: String,
     selector: String,
@@ -654,7 +655,7 @@ pub fn handle_find_element_elements_link_text(
 }
 
 pub fn handle_find_element_elements_tag_name(
-    documents: &Documents,
+    documents: &DocumentCollection,
     pipeline: PipelineId,
     element_id: String,
     selector: String,
@@ -677,7 +678,7 @@ pub fn handle_find_element_elements_tag_name(
 }
 
 pub fn handle_focus_element(
-    documents: &Documents,
+    documents: &DocumentCollection,
     pipeline: PipelineId,
     element_id: String,
     reply: IpcSender<Result<(), ErrorStatus>>,
@@ -700,7 +701,7 @@ pub fn handle_focus_element(
 }
 
 pub fn handle_get_active_element(
-    documents: &Documents,
+    documents: &DocumentCollection,
     pipeline: PipelineId,
     reply: IpcSender<Option<String>>,
 ) {
@@ -715,7 +716,7 @@ pub fn handle_get_active_element(
 }
 
 pub fn handle_get_page_source(
-    documents: &Documents,
+    documents: &DocumentCollection,
     pipeline: PipelineId,
     reply: IpcSender<Result<String, ErrorStatus>>,
     can_gc: CanGc,
@@ -744,7 +745,7 @@ pub fn handle_get_page_source(
 }
 
 pub fn handle_get_cookies(
-    documents: &Documents,
+    documents: &DocumentCollection,
     pipeline: PipelineId,
     reply: IpcSender<Vec<Serde<Cookie<'static>>>>,
 ) {
@@ -770,7 +771,7 @@ pub fn handle_get_cookies(
 
 // https://w3c.github.io/webdriver/webdriver-spec.html#get-cookie
 pub fn handle_get_cookie(
-    documents: &Documents,
+    documents: &DocumentCollection,
     pipeline: PipelineId,
     name: String,
     reply: IpcSender<Vec<Serde<Cookie<'static>>>>,
@@ -801,7 +802,7 @@ pub fn handle_get_cookie(
 
 // https://w3c.github.io/webdriver/webdriver-spec.html#add-cookie
 pub fn handle_add_cookie(
-    documents: &Documents,
+    documents: &DocumentCollection,
     pipeline: PipelineId,
     cookie: Cookie<'static>,
     reply: IpcSender<Result<(), WebDriverCookieError>>,
@@ -848,7 +849,7 @@ pub fn handle_add_cookie(
 }
 
 pub fn handle_delete_cookies(
-    documents: &Documents,
+    documents: &DocumentCollection,
     pipeline: PipelineId,
     reply: IpcSender<Result<(), ErrorStatus>>,
 ) {
@@ -868,7 +869,11 @@ pub fn handle_delete_cookies(
     reply.send(Ok(())).unwrap();
 }
 
-pub fn handle_get_title(documents: &Documents, pipeline: PipelineId, reply: IpcSender<String>) {
+pub fn handle_get_title(
+    documents: &DocumentCollection,
+    pipeline: PipelineId,
+    reply: IpcSender<String>,
+) {
     reply
         .send(
             // TODO: Return an error if the pipeline doesn't exist
@@ -881,7 +886,7 @@ pub fn handle_get_title(documents: &Documents, pipeline: PipelineId, reply: IpcS
 }
 
 pub fn handle_get_rect(
-    documents: &Documents,
+    documents: &DocumentCollection,
     pipeline: PipelineId,
     element_id: String,
     reply: IpcSender<Result<Rect<f64>, ErrorStatus>>,
@@ -927,7 +932,7 @@ pub fn handle_get_rect(
 }
 
 pub fn handle_get_bounding_client_rect(
-    documents: &Documents,
+    documents: &DocumentCollection,
     pipeline: PipelineId,
     element_id: String,
     reply: IpcSender<Result<Rect<f32>, ErrorStatus>>,
@@ -952,7 +957,7 @@ pub fn handle_get_bounding_client_rect(
 }
 
 pub fn handle_get_text(
-    documents: &Documents,
+    documents: &DocumentCollection,
     pipeline: PipelineId,
     node_id: String,
     reply: IpcSender<Result<String, ErrorStatus>>,
@@ -966,7 +971,7 @@ pub fn handle_get_text(
 }
 
 pub fn handle_get_name(
-    documents: &Documents,
+    documents: &DocumentCollection,
     pipeline: PipelineId,
     node_id: String,
     reply: IpcSender<Result<String, ErrorStatus>>,
@@ -980,7 +985,7 @@ pub fn handle_get_name(
 }
 
 pub fn handle_get_attribute(
-    documents: &Documents,
+    documents: &DocumentCollection,
     pipeline: PipelineId,
     node_id: String,
     name: String,
@@ -1000,7 +1005,7 @@ pub fn handle_get_attribute(
 
 #[allow(unsafe_code)]
 pub fn handle_get_property(
-    documents: &Documents,
+    documents: &DocumentCollection,
     pipeline: PipelineId,
     node_id: String,
     name: String,
@@ -1039,7 +1044,7 @@ pub fn handle_get_property(
 }
 
 pub fn handle_get_css(
-    documents: &Documents,
+    documents: &DocumentCollection,
     pipeline: PipelineId,
     node_id: String,
     name: String,
@@ -1061,7 +1066,11 @@ pub fn handle_get_css(
         .unwrap();
 }
 
-pub fn handle_get_url(documents: &Documents, pipeline: PipelineId, reply: IpcSender<ServoUrl>) {
+pub fn handle_get_url(
+    documents: &DocumentCollection,
+    pipeline: PipelineId,
+    reply: IpcSender<ServoUrl>,
+) {
     reply
         .send(
             // TODO: Return an error if the pipeline doesn't exist.
@@ -1075,7 +1084,7 @@ pub fn handle_get_url(documents: &Documents, pipeline: PipelineId, reply: IpcSen
 
 // https://w3c.github.io/webdriver/#element-click
 pub fn handle_element_click(
-    documents: &Documents,
+    documents: &DocumentCollection,
     pipeline: PipelineId,
     element_id: String,
     reply: IpcSender<Result<Option<String>, ErrorStatus>>,
@@ -1172,7 +1181,7 @@ pub fn handle_element_click(
 }
 
 pub fn handle_is_enabled(
-    documents: &Documents,
+    documents: &DocumentCollection,
     pipeline: PipelineId,
     element_id: String,
     reply: IpcSender<Result<bool, ErrorStatus>>,
@@ -1190,7 +1199,7 @@ pub fn handle_is_enabled(
 }
 
 pub fn handle_is_selected(
-    documents: &Documents,
+    documents: &DocumentCollection,
     pipeline: PipelineId,
     element_id: String,
     reply: IpcSender<Result<bool, ErrorStatus>>,


### PR DESCRIPTION
This change brings the `ScriptThread` closer to the specification and fixes
two issues:

1. A reflow of all `Document`s is currently done unconditionally after
   receiving IPC messages in the `ScriptThread`. Reflowing without first
   updating the animation timeline can lead to transitions finshing as
   soon as they start (because it looks like time advancement is
   measured between calls to `update-the-rendering`).
2. Fix an issue where not all `Pipeline`s were updated during *update
   the rendering*. The previous code only took into account top level
   frames and their children. It's not guaranteed that a particular
   `ScriptThread` is managing any top level frames, depending on the
   origins of those frames. We should update the rendering of those
   non-top-level iframes regardless.

   The new code attempts to order the frames according to the
   specification as much as possible without knowing the entire frame
   tree, without skipping any documents managed by the `ScriptThread` in
   question.

In addition, `Documents` is pulled out the `script_thread.rs` and
renamed to `DocumentCollection`. 

In general, these issues were always noticeable because they depend
on the order of operations in the `ScriptThread` and when IPC messages
arrive. It's difficult to test them, but it should make things work consistently
in one particular timing case.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #34303.
- [x] There are no new tests for these changes as transitions are covered by existing tests. In order to observe this issue a very particular timing situation has to happen where the transition has to be triggered by a reflow after receiving an IPC message. This isn't possible to guarantee with a WPT tests, so this is verified via manual testing.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
