### PR TITLE
Check maximum Python version in mach

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ For more detailed build instructions, see the Servo book under [Setting up your 
 
 ### macOS
 
-- Download and install [`python`](https://www.python.org/downloads/macos/), [Xcode](https://developer.apple.com/xcode/), and [`brew`](https://brew.sh/)
+- Download and install [`python`](https://www.python.org/downloads/macos/) (version 3.10 to 3.12), [Xcode](https://developer.apple.com/xcode/), and [`brew`](https://brew.sh/).
 - Install `rustup`: `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`
 - Restart your shell to make sure `cargo` is available
 - Install the other dependencies: `./mach bootstrap`
@@ -25,7 +25,7 @@ For more detailed build instructions, see the Servo book under [Setting up your 
 
 ### Linux
 
-- Install `curl` and `python`:
+- Install `curl` and `python` (version 3.10 to 3.12):
   - Arch: `sudo pacman -S --needed curl python python-pip`
   - Debian, Ubuntu: `sudo apt install curl python3-pip python3-venv python3-setuptools`
   - Fedora: `sudo dnf install curl python3 python3-pip python3-devel`
@@ -37,7 +37,7 @@ For more detailed build instructions, see the Servo book under [Setting up your 
 
 ### Windows
 
-- Download and install [`python`](https://www.python.org/downloads/windows/), [`choco`](https://chocolatey.org/install#individual), and [`rustup`](https://win.rustup.rs/)
+- Download and install [`python`](https://www.python.org/downloads/windows/) (version 3.10 to 3.12), [`choco`](https://chocolatey.org/install#individual), and [`rustup`](https://win.rustup.rs/)
   - Be sure to select *Quick install via the Visual Studio Community installer*
 - In the Visual Studio Installer, ensure the following components are installed:
   - **Windows 10 SDK (10.0.19041.0)** (`Microsoft.VisualStudio.Component.Windows10SDK.19041`)

--- a/mach
+++ b/mach
@@ -12,10 +12,14 @@
 import os
 import sys
 
-if sys.version_info < (3, 10):
-    print("mach does not support python < 3.10, please install python 3 >= 3.10")
+# Destructure because version_info > max_ver is true when running the same version.
+ver = (sys.version_info[0], sys.version_info[1])
+min_ver = (3, 10)
+max_ver = (3, 12) # WPT does not support Python 3.13. See issue #34095.
+if ver < min_ver or ver > max_ver:
+    print("mach does not support python {0}.{1}, please install 3.{2} <= python <= 3.{3}" \
+        .format(ver[0], ver[1], min_ver[1], max_ver[1]))
     sys.exit(1)
-
 
 def main(args):
     topdir = os.path.abspath(os.path.dirname(sys.argv[0]))


### PR DESCRIPTION
Mach is currently failing bootstrap and building if the Python version is greater than 3.12. This is because wpt does not support 3.13 yet. This causes confusion for people running recent distros that ship 3.13 by default.

I changed the logic so that mach checks both the minimum and the maximum supported versions of Python instead of just checking the minimum. It will now also tell you which maximum version is supported.

I also updated the README.md to specify the supported Python versions so that people don't accidentally install the wrong version.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes help with the confusion in #34095

<!-- Either: -->
- [X] These changes do not require tests because it is already checked by CI.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->