### PR TITLE
Don't run scripts while DOM tree is undergoing mutations

### DIFF
--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -746,21 +746,17 @@ impl VirtualMethods for HTMLIFrameElement {
             s.post_connection_steps();
         }
 
-        let iframe = Trusted::new(self);
-        document_from_node(self).add_delayed_task(task!(IFrameDelayedInitialize: move || {
-            let this = iframe.root();
-            // https://html.spec.whatwg.org/multipage/#the-iframe-element
-            // "When an iframe element is inserted into a document that has
-            // a browsing context, the user agent must create a new
-            // browsing context, set the element's nested browsing context
-            // to the newly-created browsing context, and then process the
-            // iframe attributes for the "first time"."
-            if this.upcast::<Node>().is_connected_with_browsing_context() {
-                debug!("iframe bound to browsing context.");
-                this.create_nested_browsing_context(CanGc::note());
-                this.process_the_iframe_attributes(ProcessingMode::FirstTime, CanGc::note());
-            }
-        }));
+        // https://html.spec.whatwg.org/multipage/#the-iframe-element
+        // "When an iframe element is inserted into a document that has
+        // a browsing context, the user agent must create a new
+        // browsing context, set the element's nested browsing context
+        // to the newly-created browsing context, and then process the
+        // iframe attributes for the "first time"."
+        if self.upcast::<Node>().is_connected_with_browsing_context() {
+            debug!("iframe bound to browsing context.");
+            self.create_nested_browsing_context(CanGc::note());
+            self.process_the_iframe_attributes(ProcessingMode::FirstTime, CanGc::note());
+        }
     }
 
     fn unbind_from_tree(&self, context: &UnbindContext) {

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -26,7 +26,6 @@ use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::HTMLIFrameElementBinding::HTMLIFrameElementMethods;
 use crate::dom::bindings::codegen::Bindings::WindowBinding::Window_Binding::WindowMethods;
 use crate::dom::bindings::inheritance::Castable;
-use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::DomObject;
 use crate::dom::bindings::root::{DomRoot, LayoutDom, MutNullableDom};
 use crate::dom::bindings::str::{DOMString, USVString};
@@ -38,9 +37,7 @@ use crate::dom::element::{
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::htmlelement::HTMLElement;
-use crate::dom::node::{
-    document_from_node, window_from_node, Node, NodeDamage, UnbindContext,
-};
+use crate::dom::node::{document_from_node, window_from_node, Node, NodeDamage, UnbindContext};
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::dom::windowproxy::WindowProxy;
 use crate::script_runtime::CanGc;

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -39,7 +39,7 @@ use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::node::{
-    document_from_node, window_from_node, BindContext, Node, NodeDamage, UnbindContext,
+    document_from_node, window_from_node, Node, NodeDamage, UnbindContext,
 };
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::dom::windowproxy::WindowProxy;
@@ -741,12 +741,11 @@ impl VirtualMethods for HTMLIFrameElement {
         }
     }
 
-    fn bind_to_tree(&self, context: &BindContext) {
+    fn post_connection_steps(&self) {
         if let Some(s) = self.super_type() {
-            s.bind_to_tree(context);
+            s.post_connection_steps();
         }
 
-        let tree_connected = context.tree_connected;
         let iframe = Trusted::new(self);
         document_from_node(self).add_delayed_task(task!(IFrameDelayedInitialize: move || {
             let this = iframe.root();
@@ -758,7 +757,6 @@ impl VirtualMethods for HTMLIFrameElement {
             // iframe attributes for the "first time"."
             if this.upcast::<Node>().is_connected_with_browsing_context() {
                 debug!("iframe bound to browsing context.");
-                debug_assert!(tree_connected, "is_connected_with_bc, but not tree_connected");
                 this.create_nested_browsing_context(CanGc::note());
                 this.process_the_iframe_attributes(ProcessingMode::FirstTime, CanGc::note());
             }

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -1196,6 +1196,9 @@ impl VirtualMethods for HTMLScriptElement {
 
         if self.upcast::<Node>().is_connected() && !self.parser_inserted.get() {
             let script = Trusted::new(self);
+            // This method can be invoked while there are script/layout blockers present
+            // as DOM mutations have not yet settled. We use a delayed task to avoid
+            // running any scripts until the DOM tree is safe for interactions.
             document_from_node(self).add_delayed_task(task!(ScriptPrepare: move || {
                 let this = script.root();
                 this.prepare(CanGc::note());

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -2129,6 +2129,22 @@ impl Node {
             MutationObserver::queue_a_mutation_record(parent, mutation);
         }
         node.owner_doc().remove_script_and_layout_blocker();
+
+        // Step 10. Let staticNodeList be a list of nodes, initially « ».
+        rooted_vec!(let mut static_node_list);
+
+        // Step 11. For each node of nodes, in tree order:
+        for node in new_nodes {
+            // Step 11.1 For each shadow-including inclusive descendant inclusiveDescendant of node,
+            //           in shadow-including tree order, append inclusiveDescendant to staticNodeList.
+            static_node_list.extend(node.traverse_preorder(ShadowIncluding::Yes))
+        }
+
+        // Step 12. For each node of staticNodeList, if node is connected, then run the
+        //          post-connection steps with node.
+        for node in static_node_list.iter().filter(|n| n.is_connected()) {
+            vtable_for(node).post_connection_steps();
+        }
     }
 
     /// <https://dom.spec.whatwg.org/#concept-node-replace-all>

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -2139,7 +2139,7 @@ impl Node {
             //           in shadow-including tree order, append inclusiveDescendant to staticNodeList.
             static_node_list.extend(
                 node.traverse_preorder(ShadowIncluding::Yes)
-                    .map(|n| Trusted::new(&*n))
+                    .map(|n| Trusted::new(&*n)),
             );
         }
 

--- a/components/script/dom/virtualmethods.rs
+++ b/components/script/dom/virtualmethods.rs
@@ -93,6 +93,15 @@ pub trait VirtualMethods {
         }
     }
 
+    /// Invoked during a DOM tree mutation after a node becomes connected, once all
+    /// related DOM tree mutations have been applied.
+    /// <https://dom.spec.whatwg.org/#concept-node-post-connection-ext>
+    fn post_connection_steps(&self) {
+        if let Some(s) = self.super_type() {
+            s.post_connection_steps();
+        }
+    }
+
     /// Called when a Node is appended to a tree, where 'tree_connected' indicates
     /// whether the tree is part of a Document.
     fn bind_to_tree(&self, context: &BindContext) {

--- a/tests/wpt/meta/dom/nodes/insertion-removing-steps/Node-appendChild-three-scripts-from-fragment.tentative.html.ini
+++ b/tests/wpt/meta/dom/nodes/insertion-removing-steps/Node-appendChild-three-scripts-from-fragment.tentative.html.ini
@@ -1,3 +1,0 @@
-[Node-appendChild-three-scripts-from-fragment.tentative.html]
-  [Node.appendChild: inserting three scripts from a document fragment]
-    expected: FAIL

--- a/tests/wpt/meta/dom/nodes/insertion-removing-steps/Node-appendChild-three-scripts.tentative.html.ini
+++ b/tests/wpt/meta/dom/nodes/insertion-removing-steps/Node-appendChild-three-scripts.tentative.html.ini
@@ -1,3 +1,0 @@
-[Node-appendChild-three-scripts.tentative.html]
-  [Node.appendChild: inserting three scripts from a div]
-    expected: FAIL

--- a/tests/wpt/meta/html/semantics/scripting-1/the-script-element/execution-timing/147.html.ini
+++ b/tests/wpt/meta/html/semantics/scripting-1/the-script-element/execution-timing/147.html.ini
@@ -1,3 +1,0 @@
-[147.html]
-  [scheduler: insert multiple inline scripts; first script moves subsequent scripts ]
-    expected: FAIL

--- a/tests/wpt/meta/shadow-dom/Document-prototype-currentScript.html.ini
+++ b/tests/wpt/meta/shadow-dom/Document-prototype-currentScript.html.ini
@@ -1,13 +1,7 @@
 [Document-prototype-currentScript.html]
-  expected: TIMEOUT
+  expected: ERROR
   [document.currentScript must not be set to a script element that loads an external script in an open shadow tree]
-    expected: TIMEOUT
+    expected: FAIL
 
   [document.currentScript must not be set to a script element that loads an external script in a closed shadow tree]
-    expected: NOTRUN
-
-  [document.currentScript must be set to a script element that loads an external script that was in an open shadow tree and then removed]
-    expected: NOTRUN
-
-  [document.currentScript must be set to a script element that loads an external script that was in a closed shadow tree and then removed]
-    expected: NOTRUN
+    expected: FAIL

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -13529,6 +13529,13 @@
       {}
      ]
     ],
+    "layout_blocker_operations.html": [
+     "2df68bf1c13179688708c97eab19361608b0de82",
+     [
+      null,
+      {}
+     ]
+    ],
     "lenient_this.html": [
      "960c74613f3c2809bb1f2ee6121bf14f28267051",
      [

--- a/tests/wpt/mozilla/tests/mozilla/layout_blocker_operations.html
+++ b/tests/wpt/mozilla/tests/mozilla/layout_blocker_operations.html
@@ -1,0 +1,34 @@
+<html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<div id="foo"></div>
+
+<script>
+  function verifyLayoutAllowed(t) {
+      t.step(() => {
+          assert_equals(getComputedStyle(document.querySelector('#foo')).display, "block");
+          t.done();
+      })
+  }
+
+  var insertionTest;
+  async_test(function(t) {
+      insertionTest = t;
+      let script = document.createElement('script');
+      document.body.appendChild(script);
+      script.appendChild(document.createTextNode("verifyLayoutAllowed(insertionTest)"));
+  }, "Insertion");
+
+  var replacementTest;
+  async_test(function(t) {
+      replacementTest = t;
+      let script = document.createElement('script');
+      document.body.appendChild(script);
+      script.innerHTML = "verifyLayoutAllowed(replacementTest)";
+  }, "Replace");
+</script>
+</body>
+</html>


### PR DESCRIPTION
When manipulating the DOM tree we always want web content to only see stable states after any mutations are applied. We introduced script/layout blockers in https://github.com/servo/servo/commit/14b0de30dbf90793c3b6c9017e4c65df9281c5ae to catch cases where an unstable DOM could be exposed to web content, and this PR addresses several cases where the conditions were violated.

First, we introduce a new virtual method that elements can hook—the [post-connection steps](https://dom.spec.whatwg.org/#concept-node-post-connection-ext). These are executed after all DOM mutations are finished, so it's safe to execute scirpts from them. `children_changed`'s execution time is less well-defined, but we can use `add_delayed_task` to ensure that the script executes ASAP once the DOM mutations have stabilized, which avoids any observable behaviour changes.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #34465
- [x] There are tests for these changes