### PR TITLE
layout: Add `LayoutBoxBase` and use it for `IndependentFormattingContext`

### DIFF
--- a/components/layout_2020/construct_modern.rs
+++ b/components/layout_2020/construct_modern.rs
@@ -15,9 +15,10 @@ use crate::dom_traversal::{Contents, NodeAndStyleInfo, TraversalHandler};
 use crate::flow::inline::construct::InlineFormattingContextBuilder;
 use crate::flow::{BlockContainer, BlockFormattingContext};
 use crate::formatting_contexts::{
-    IndependentFormattingContext, NonReplacedFormattingContext,
-    NonReplacedFormattingContextContents,
+    IndependentFormattingContext, IndependentFormattingContextContents,
+    IndependentNonReplacedContents,
 };
+use crate::layout_box_base::LayoutBoxBase;
 use crate::style_ext::DisplayGeneratingBox;
 
 /// <https://drafts.csswg.org/css-flexbox/#flex-items>
@@ -173,16 +174,12 @@ where
                         BlockContainer::InlineFormattingContext(inline_formatting_context),
                     );
                     let info = &self.info.new_anonymous(anonymous_style.clone().unwrap());
-                    let non_replaced = NonReplacedFormattingContext {
-                        base_fragment_info: info.into(),
-                        style: info.style.clone(),
-                        content_sizes_result: Default::default(),
-                        contents: NonReplacedFormattingContextContents::Flow(
-                            block_formatting_context,
+                    let formatting_context = IndependentFormattingContext {
+                        base: LayoutBoxBase::new(info.into(), info.style.clone()),
+                        contents: IndependentFormattingContextContents::NonReplaced(
+                            IndependentNonReplacedContents::Flow(block_formatting_context),
                         ),
                     };
-                    let formatting_context =
-                        IndependentFormattingContext::NonReplaced(non_replaced);
 
                     Some(ModernItem {
                         kind: ModernItemKind::InFlow,

--- a/components/layout_2020/dom_traversal.rs
+++ b/components/layout_2020/dom_traversal.rs
@@ -16,7 +16,7 @@ use style::values::generics::counters::{Content, ContentItem};
 use crate::context::LayoutContext;
 use crate::dom::{BoxSlot, LayoutBox, NodeExt};
 use crate::fragment_tree::{BaseFragmentInfo, FragmentFlags, Tag};
-use crate::replaced::ReplacedContent;
+use crate::replaced::ReplacedContents;
 use crate::style_ext::{Display, DisplayGeneratingBox, DisplayInside, DisplayOutside};
 
 #[derive(Clone, Copy, Debug)]
@@ -126,7 +126,7 @@ pub(super) enum Contents {
     NonReplaced(NonReplacedContents),
     /// Example: an `<img src=…>` element.
     /// <https://drafts.csswg.org/css2/conform.html#replaced-element>
-    Replaced(ReplacedContent),
+    Replaced(ReplacedContents),
 }
 
 #[derive(Debug)]
@@ -141,7 +141,7 @@ pub(super) enum NonReplacedContents {
 #[derive(Debug)]
 pub(super) enum PseudoElementContentItem {
     Text(String),
-    Replaced(ReplacedContent),
+    Replaced(ReplacedContents),
 }
 
 pub(super) trait TraversalHandler<'dom, Node>
@@ -216,7 +216,7 @@ fn traverse_element<'dom, Node>(
 ) where
     Node: NodeExt<'dom>,
 {
-    let replaced = ReplacedContent::for_element(element, context);
+    let replaced = ReplacedContents::for_element(element, context);
     let style = element.style(context);
     match Display::from(style.get_box().display) {
         Display::None => element.unset_all_boxes(),
@@ -421,7 +421,7 @@ where
                     },
                     ContentItem::Image(image) => {
                         if let Some(replaced_content) =
-                            ReplacedContent::from_image(element, context, image)
+                            ReplacedContents::from_image(element, context, image)
                         {
                             vec.push(PseudoElementContentItem::Replaced(replaced_content));
                         }

--- a/components/layout_2020/flow/inline/mod.rs
+++ b/components/layout_2020/flow/inline/mod.rs
@@ -111,13 +111,14 @@ use webrender_api::FontInstanceKey;
 use xi_unicode::linebreak_property;
 
 use super::float::{Clear, PlacementAmongFloats};
+use super::IndependentFormattingContextContents;
 use crate::cell::ArcRefCell;
 use crate::context::LayoutContext;
 use crate::flow::float::{FloatBox, SequentialLayoutState};
 use crate::flow::{CollapsibleWithParentStartMargin, FlowLayout};
 use crate::formatting_contexts::{
     Baselines, IndependentFormattingContext, IndependentLayoutResult,
-    NonReplacedFormattingContextContents,
+    IndependentNonReplacedContents,
 };
 use crate::fragment_tree::{
     BoxFragment, CollapsedBlockMargins, CollapsedMargin, Fragment, FragmentFlags,
@@ -2034,13 +2035,11 @@ impl IndependentFormattingContext {
         match self.style().clone_baseline_source() {
             BaselineSource::First => baselines.first,
             BaselineSource::Last => baselines.last,
-            BaselineSource::Auto => {
-                if let Self::NonReplaced(non_replaced) = self {
-                    if let NonReplacedFormattingContextContents::Flow(_) = non_replaced.contents {
-                        return baselines.last;
-                    }
-                }
-                baselines.first
+            BaselineSource::Auto => match &self.contents {
+                IndependentFormattingContextContents::NonReplaced(
+                    IndependentNonReplacedContents::Flow(_),
+                ) => baselines.last,
+                _ => baselines.first,
             },
         }
     }

--- a/components/layout_2020/flow/root.rs
+++ b/components/layout_2020/flow/root.rs
@@ -28,7 +28,7 @@ use crate::formatting_contexts::IndependentFormattingContext;
 use crate::fragment_tree::FragmentTree;
 use crate::geom::{LogicalVec2, PhysicalPoint, PhysicalRect, PhysicalSize};
 use crate::positioned::{AbsolutelyPositionedBox, PositioningContext};
-use crate::replaced::ReplacedContent;
+use crate::replaced::ReplacedContents;
 use crate::style_ext::{ComputedValuesExt, Display, DisplayGeneratingBox, DisplayInside};
 use crate::taffy::{TaffyItemBox, TaffyItemBoxInner};
 use crate::DefiniteContainingBlock;
@@ -222,7 +222,7 @@ impl BoxTree {
 
         loop {
             if let Some((primary_style, display_inside, update_point)) = update_point(dirty_node) {
-                let contents = ReplacedContent::for_element(dirty_node, context)
+                let contents = ReplacedContents::for_element(dirty_node, context)
                     .map_or_else(|| NonReplacedContents::OfElement.into(), Contents::Replaced);
                 let info = NodeAndStyleInfo::new(dirty_node, Arc::clone(&primary_style));
                 let out_of_flow_absolutely_positioned_box = ArcRefCell::new(
@@ -290,7 +290,7 @@ fn construct_for_root_element<'dom>(
         Display::GeneratingBox(display_generating_box) => display_generating_box.display_inside(),
     };
 
-    let contents = ReplacedContent::for_element(root_element, context)
+    let contents = ReplacedContents::for_element(root_element, context)
         .map_or_else(|| NonReplacedContents::OfElement.into(), Contents::Replaced);
     let root_box = if box_style.position.is_absolutely_positioned() {
         BlockLevelBox::OutOfFlowAbsolutelyPositionedBox(ArcRefCell::new(

--- a/components/layout_2020/layout_box_base.rs
+++ b/components/layout_2020/layout_box_base.rs
@@ -1,0 +1,61 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use atomic_refcell::AtomicRefCell;
+use serde::Serialize;
+use servo_arc::Arc;
+use style::properties::ComputedValues;
+
+use crate::fragment_tree::BaseFragmentInfo;
+use crate::geom::SizeConstraint;
+use crate::sizing::InlineContentSizesResult;
+use crate::ConstraintSpace;
+
+/// A box tree node that handles containing information about style and the original DOM
+/// node or pseudo-element that it is based on. This also handles caching of layout values
+/// such as the inline content sizes to avoid recalculating these values during layout
+/// passes.
+///
+/// In the future, this will hold layout results to support incremental layout.
+#[derive(Debug, Serialize)]
+pub(crate) struct LayoutBoxBase {
+    pub base_fragment_info: BaseFragmentInfo,
+    #[serde(skip_serializing)]
+    pub style: Arc<ComputedValues>,
+    #[serde(skip_serializing)]
+    pub cached_inline_content_size:
+        AtomicRefCell<Option<(SizeConstraint, InlineContentSizesResult)>>,
+}
+
+impl LayoutBoxBase {
+    pub(crate) fn new(base_fragment_info: BaseFragmentInfo, style: Arc<ComputedValues>) -> Self {
+        Self {
+            base_fragment_info,
+            style,
+            cached_inline_content_size: AtomicRefCell::default(),
+        }
+    }
+
+    /// Get the inline content sizes of a box tree node that extends this [`LayoutBoxBase`], fetch
+    /// the result from a cache when possible.
+    pub(crate) fn inline_content_sizes(
+        &self,
+        constraint_space: &ConstraintSpace,
+        inline_content_sizes_fn: impl FnOnce() -> InlineContentSizesResult,
+    ) -> InlineContentSizesResult {
+        let mut cache = self.cached_inline_content_size.borrow_mut();
+        if let Some((previous_cb_block_size, result)) = *cache {
+            if !result.depends_on_block_constraints ||
+                previous_cb_block_size == constraint_space.block_size
+            {
+                return result;
+            }
+            // TODO: Should we keep multiple caches for various block sizes?
+        }
+
+        let result = inline_content_sizes_fn();
+        *cache = Some((constraint_space.block_size, result));
+        result
+    }
+}

--- a/components/layout_2020/lib.rs
+++ b/components/layout_2020/lib.rs
@@ -14,6 +14,7 @@ pub mod flow;
 mod formatting_contexts;
 mod fragment_tree;
 pub mod geom;
+mod layout_box_base;
 mod taffy;
 #[macro_use]
 pub mod layout_debug;

--- a/components/layout_2020/lists.rs
+++ b/components/layout_2020/lists.rs
@@ -10,7 +10,7 @@ use style::values::computed::Image;
 use crate::context::LayoutContext;
 use crate::dom::NodeExt;
 use crate::dom_traversal::{NodeAndStyleInfo, PseudoElementContentItem};
-use crate::replaced::ReplacedContent;
+use crate::replaced::ReplacedContents;
 
 /// <https://drafts.csswg.org/css-lists/#content-property>
 pub(crate) fn make_marker<'dom, Node>(
@@ -32,7 +32,7 @@ where
     // https://drafts.csswg.org/css-lists/#marker-image
     let marker_image = || match &style.list_style_image {
         Image::Url(url) => Some(vec![
-            PseudoElementContentItem::Replaced(ReplacedContent::from_image_url(
+            PseudoElementContentItem::Replaced(ReplacedContents::from_image_url(
                 node, context, url,
             )?),
             PseudoElementContentItem::Text(" ".into()),

--- a/components/layout_2020/replaced.rs
+++ b/components/layout_2020/replaced.rs
@@ -34,7 +34,7 @@ use crate::style_ext::{AspectRatio, Clamp, ComputedValuesExt, ContentBoxSizesAnd
 use crate::{ConstraintSpace, ContainingBlock, SizeConstraint};
 
 #[derive(Debug, Serialize)]
-pub(crate) struct ReplacedContent {
+pub(crate) struct ReplacedContents {
     pub kind: ReplacedContentKind,
     natural_size: NaturalSizes,
     base_fragment_info: BaseFragmentInfo,
@@ -140,7 +140,7 @@ pub(crate) enum ReplacedContentKind {
     Video(Option<VideoInfo>),
 }
 
-impl ReplacedContent {
+impl ReplacedContents {
     pub fn for_element<'dom>(element: impl NodeExt<'dom>, context: &LayoutContext) -> Option<Self> {
         if let Some(ref data_attribute_string) = element.as_typeless_object_with_data_attribute() {
             if let Some(url) = try_to_parse_image_data_url(data_attribute_string) {

--- a/components/layout_2020/table/layout.rs
+++ b/components/layout_2020/table/layout.rs
@@ -1613,7 +1613,7 @@ impl<'a> TableLayout<'a> {
         parent_positioning_context: &mut PositioningContext,
     ) -> BoxFragment {
         let context = caption.context.borrow();
-        let mut positioning_context = PositioningContext::new_for_style(&context.style);
+        let mut positioning_context = PositioningContext::new_for_style(context.style());
         let containing_block = &ContainingBlock {
             inline_size: self.table_width + table_pbm.padding_border_sums.inline,
             block_size: AuOrAuto::Auto,
@@ -1711,7 +1711,7 @@ impl<'a> TableLayout<'a> {
         table_layout
             .fragments
             .extend(self.table.captions.iter().filter_map(|caption| {
-                if caption.context.borrow().style.clone_caption_side() != CaptionSide::Top {
+                if caption.context.borrow().style().clone_caption_side() != CaptionSide::Top {
                     return None;
                 }
 
@@ -1811,7 +1811,7 @@ impl<'a> TableLayout<'a> {
         table_layout
             .fragments
             .extend(self.table.captions.iter().filter_map(|caption| {
-                if caption.context.borrow().style.clone_caption_side() != CaptionSide::Bottom {
+                if caption.context.borrow().style().clone_caption_side() != CaptionSide::Bottom {
                     return None;
                 }
 

--- a/components/layout_2020/table/mod.rs
+++ b/components/layout_2020/table/mod.rs
@@ -82,7 +82,7 @@ use style_traits::dom::OpaqueNode;
 use super::flow::BlockFormattingContext;
 use crate::cell::ArcRefCell;
 use crate::flow::BlockContainer;
-use crate::formatting_contexts::NonReplacedFormattingContext;
+use crate::formatting_contexts::IndependentFormattingContext;
 use crate::fragment_tree::BaseFragmentInfo;
 
 pub type TableSize = Size2D<usize, UnknownUnit>;
@@ -320,5 +320,5 @@ impl TableTrackGroup {
 #[derive(Debug, Serialize)]
 pub struct TableCaption {
     /// The contents of this cell, with its own layout.
-    context: ArcRefCell<NonReplacedFormattingContext>,
+    context: ArcRefCell<IndependentFormattingContext>,
 }


### PR DESCRIPTION
Add a new struct `LayoutBoxBase`, that will be used throughout the box
tree. The idea of this struct is that we have a place to consistently
store common layout information (style and node information) and also to
cache layout results such as content sizes (inline and maybe later box
sizes) and eventually layout results.

In addition to the addition of this struct,
`IndependentFormattingContext` is flattened slightly so that it directly
holds the contents of both replaced and non-replaced elements.

This is only added to independent formatting contexts, but will later be
added to all block containers as well.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes. This does not introduce any changes to layout results and this is already covered by existing WPT tests.
