### PR TITLE
Don't trace SystemFontService loop

### DIFF
--- a/components/fonts/system_font_service.rs
+++ b/components/fonts/system_font_service.rs
@@ -145,10 +145,6 @@ impl SystemFontService {
         SystemFontServiceProxySender(sender)
     }
 
-    #[cfg_attr(
-        feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
-    )]
     fn run(&mut self) {
         loop {
             let msg = self.port.recv().unwrap();


### PR DESCRIPTION
Most of the time here is spent blocking on the channel, and after we received the message we already have a new span.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes ~~fix~~ are a minor improvement when viewing the tracing output in perfetto
