### PR TITLE
layout: Add `LayoutBox` to `TableSlotCell`

### DIFF
--- a/components/layout_2020/table/construct.rs
+++ b/components/layout_2020/table/construct.rs
@@ -979,11 +979,10 @@ where
 
         let block_container = builder.finish();
         self.table_traversal.builder.add_cell(TableSlotCell {
+            base: LayoutBoxBase::new(BaseFragmentInfo::anonymous(), anonymous_info.style),
             contents: BlockFormattingContext::from_block_container(block_container),
             colspan: 1,
             rowspan: 1,
-            style: anonymous_info.style,
-            base_fragment_info: BaseFragmentInfo::anonymous(),
         });
     }
 }
@@ -1041,11 +1040,10 @@ where
 
                     self.finish_current_anonymous_cell_if_needed();
                     self.table_traversal.builder.add_cell(TableSlotCell {
+                        base: LayoutBoxBase::new(info.into(), info.style.clone()),
                         contents,
                         colspan,
                         rowspan,
-                        style: info.style.clone(),
-                        base_fragment_info: info.into(),
                     });
 
                     // We are doing this until we have actually set a Box for this `BoxSlot`.

--- a/components/layout_2020/table/mod.rs
+++ b/components/layout_2020/table/mod.rs
@@ -84,6 +84,7 @@ use crate::cell::ArcRefCell;
 use crate::flow::BlockContainer;
 use crate::formatting_contexts::IndependentFormattingContext;
 use crate::fragment_tree::BaseFragmentInfo;
+use crate::layout_box_base::LayoutBoxBase;
 
 pub type TableSize = Size2D<usize, UnknownUnit>;
 
@@ -189,6 +190,9 @@ pub type TableSlotOffset = Vector2D<usize, UnknownUnit>;
 
 #[derive(Debug, Serialize)]
 pub struct TableSlotCell {
+    /// The [`LayoutBoxBase`] of this table cell.
+    base: LayoutBoxBase,
+
     /// The contents of this cell, with its own layout.
     contents: BlockFormattingContext,
 
@@ -198,33 +202,27 @@ pub struct TableSlotCell {
     /// Number of rows that the cell is to span. Zero means that the cell is to span all
     /// the remaining rows in the row group.
     rowspan: usize,
-
-    /// The style of this table cell.
-    #[serde(skip_serializing)]
-    style: Arc<ComputedValues>,
-
-    /// The [`BaseFragmentInfo`] of this cell.
-    base_fragment_info: BaseFragmentInfo,
 }
 
 impl TableSlotCell {
     pub fn mock_for_testing(id: usize, colspan: usize, rowspan: usize) -> Self {
         Self {
+            base: LayoutBoxBase::new(
+                BaseFragmentInfo::new_for_node(OpaqueNode(id)),
+                ComputedValues::initial_values_with_font_override(Font::initial_values()).to_arc(),
+            ),
             contents: BlockFormattingContext {
                 contents: BlockContainer::BlockLevelBoxes(Vec::new()),
                 contains_floats: false,
             },
             colspan,
             rowspan,
-            style: ComputedValues::initial_values_with_font_override(Font::initial_values())
-                .to_arc(),
-            base_fragment_info: BaseFragmentInfo::new_for_node(OpaqueNode(id)),
         }
     }
 
     /// Get the node id of this cell's [`BaseFragmentInfo`]. This is used for unit tests.
     pub fn node_id(&self) -> usize {
-        self.base_fragment_info.tag.map_or(0, |tag| tag.node.0)
+        self.base.base_fragment_info.tag.map_or(0, |tag| tag.node.0)
     }
 }
 


### PR DESCRIPTION
This allows cells to cache their inline content size and will eventually
allow them to participate in incremental layout.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes (covered by existing WPT tests -- no changes to layout results).

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
