### PR TITLE
Fix tracing enabling layout-2013 feature

### DIFF
--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -24,7 +24,7 @@ no-wgl = ["mozangle/egl", "mozangle/build_dlls", "surfman/sm-angle-default"]
 dynamic_freetype = ["webrender/dynamic_freetype"]
 profilemozjs = ["script/profilemozjs"]
 refcell_backtrace = ["script/refcell_backtrace"]
-tracing = ["dep:tracing", "compositing/tracing", "constellation/tracing", "fonts/tracing", "layout_thread_2013/tracing", "layout_thread_2020/tracing", "profile_traits/tracing", "script/tracing"]
+tracing = ["dep:tracing", "compositing/tracing", "constellation/tracing", "fonts/tracing", "layout_thread_2013?/tracing", "layout_thread_2020/tracing", "profile_traits/tracing", "script/tracing"]
 webdriver = ["webdriver_server"]
 webgl_backtrace = [
     "script/webgl_backtrace",


### PR DESCRIPTION
Without the `?` the layout_2013 cargo feature is selected if the tracing feature is selected.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix tracing enabling the layout-2013 feature

