### PR TITLE
net: correct handling of the empty string referrer policy

### DIFF
--- a/components/script/dom/request.rs
+++ b/components/script/dom/request.rs
@@ -801,7 +801,7 @@ impl From<NetTraitsRequestMode> for RequestMode {
 impl From<ReferrerPolicy> for MsgReferrerPolicy {
     fn from(policy: ReferrerPolicy) -> Self {
         match policy {
-            ReferrerPolicy::_empty => MsgReferrerPolicy::default(),
+            ReferrerPolicy::_empty => MsgReferrerPolicy::EmptyString,
             ReferrerPolicy::No_referrer => MsgReferrerPolicy::NoReferrer,
             ReferrerPolicy::No_referrer_when_downgrade => {
                 MsgReferrerPolicy::NoReferrerWhenDowngrade

--- a/tests/wpt/meta/fetch/api/request/request-init-001.sub.html.ini
+++ b/tests/wpt/meta/fetch/api/request/request-init-001.sub.html.ini
@@ -1,3 +1,0 @@
-[request-init-001.sub.html]
-  [Check referrerPolicy init value of  and associated getter]
-    expected: FAIL


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Maps `Bindings::RequestBinding::ReferrerPolicy::_empty` to `ReferrerPolicy::EmptyString`

This fixes handling of referrer policy when provided in `requestInit` when constructing `Request()`

[Try](https://github.com/shanehandley/servo/actions/runs/12209705310)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
