### PR TITLE
Add stub interface for AbortController

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -225,6 +225,10 @@ mod gen {
                         enabled: bool,
                     }
                 },
+                abort_controller: {
+                    /// Whether to expose the AbortControll/AbortSignal DOM interfaces.
+                    enabled: bool,
+                },
                 allow_scripts_to_close_windows: bool,
                 canvas_capture: {
                     enabled: bool,

--- a/components/script/dom/abortcontroller.rs
+++ b/components/script/dom/abortcontroller.rs
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use dom_struct::dom_struct;
+use js::jsapi::Value;
+use js::rust::{Handle, HandleObject};
+
+use crate::dom::bindings::codegen::Bindings::AbortControllerBinding::AbortControllerMethods;
+use crate::dom::bindings::reflector::{reflect_dom_object_with_proto, Reflector};
+use crate::dom::bindings::root::DomRoot;
+use crate::dom::globalscope::GlobalScope;
+use crate::script_runtime::{CanGc, JSContext};
+
+#[dom_struct]
+pub struct AbortController {
+    reflector_: Reflector,
+}
+
+impl AbortController {
+    fn new_inherited() -> AbortController {
+        AbortController {
+            reflector_: Reflector::new(),
+        }
+    }
+
+    fn new_with_proto(
+        global: &GlobalScope,
+        proto: Option<HandleObject>,
+        can_gc: CanGc,
+    ) -> DomRoot<AbortController> {
+        reflect_dom_object_with_proto(
+            Box::new(AbortController::new_inherited()),
+            global,
+            proto,
+            can_gc,
+        )
+    }
+}
+
+impl AbortControllerMethods<crate::DomTypeHolder> for AbortController {
+    /// <https://dom.spec.whatwg.org/#dom-abortcontroller-abortcontroller>
+    fn Constructor(
+        global: &GlobalScope,
+        proto: Option<HandleObject>,
+        can_gc: CanGc,
+    ) -> DomRoot<AbortController> {
+        AbortController::new_with_proto(global, proto, can_gc)
+    }
+
+    /// <https://dom.spec.whatwg.org/#dom-abortcontroller-abort>
+    fn Abort(&self, _cx: JSContext, _reason: Handle<'_, Value>) {}
+}

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -209,6 +209,7 @@ pub mod types {
     include!(concat!(env!("OUT_DIR"), "/InterfaceTypes.rs"));
 }
 
+pub mod abortcontroller;
 pub mod abstractrange;
 pub mod abstractworker;
 pub mod abstractworkerglobalscope;

--- a/components/script/dom/webidls/AbortController.webidl
+++ b/components/script/dom/webidls/AbortController.webidl
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// https://dom.spec.whatwg.org/#interface-abortcontroller
+[Exposed=*, Pref="dom.abort_controller.enabled"]
+interface AbortController {
+  constructor();
+
+  //[SameObject] readonly attribute AbortSignal signal;
+
+  undefined abort(optional any reason);
+};

--- a/resources/prefs.json
+++ b/resources/prefs.json
@@ -1,6 +1,7 @@
 {
   "devtools.server.enabled": false,
   "devtools.server.port": 0,
+  "dom.abort_controller.enabled": false,
   "dom.allow_scripts_to_close_windows": false,
   "dom.bluetooth.enabled": false,
   "dom.bluetooth.testing.enabled": false,


### PR DESCRIPTION
This takes the simplest changes from #32871 and puts the interface behind a pref so we can experiment with loading pages that require the interface's presence (eg. github and discord). I am able to successfully interact with the discord login page with `--pref dom.svg.enabled` and `--pref dom.abort_controller.enabled` applied.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #6098
- [x] These changes do not require tests because the interface is behind a preference and just a stub for right now