### PR TITLE
Traverse Shadow DOM boundaries when determining Element's `lang`

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -4146,7 +4146,7 @@ impl Element {
     // https://html.spec.whatwg.org/multipage/#language
     pub fn get_lang(&self) -> String {
         self.upcast::<Node>()
-            .inclusive_ancestors(ShadowIncluding::No)
+            .inclusive_ancestors(ShadowIncluding::Yes)
             .filter_map(|node| {
                 node.downcast::<Element>().and_then(|el| {
                     el.get_attribute(&ns!(xml), &local_name!("lang"))

--- a/tests/wpt/meta/html/dom/elements/global-attributes/lang-attribute-shadow.window.js.ini
+++ b/tests/wpt/meta/html/dom/elements/global-attributes/lang-attribute-shadow.window.js.ini
@@ -1,9 +1,0 @@
-[lang-attribute-shadow.window.html]
-  [lang on slot inherits from shadow host]
-    expected: FAIL
-
-  [lang only on host]
-    expected: FAIL
-
-  [lang on host and slotted element]
-    expected: FAIL


### PR DESCRIPTION
Small bugfix on `Element::get_lang()`. As the [associated spec states](https://html.spec.whatwg.org/multipage/#language), we
should be moving up the DOM tree *across Shadow DOM boundaries* to determine
what the current `lang` attribute is, if any.

This makes a few more WPT tests pass.


---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___
