### PR TITLE
layout: Have `SameFormattingContextBlock` be a `LayoutBoxBase`

### DIFF
--- a/components/layout_2020/flow/construct.rs
+++ b/components/layout_2020/flow/construct.rs
@@ -26,6 +26,7 @@ use crate::dom_traversal::{
 use crate::flow::float::FloatBox;
 use crate::flow::{BlockContainer, BlockFormattingContext, BlockLevelBox};
 use crate::formatting_contexts::IndependentFormattingContext;
+use crate::layout_box_base::LayoutBoxBase;
 use crate::positioned::AbsolutelyPositionedBox;
 use crate::style_ext::{ComputedValuesExt, DisplayGeneratingBox, DisplayInside, DisplayOutside};
 use crate::table::{AnonymousTableContent, Table};
@@ -654,9 +655,8 @@ where
                 let contents = intermediate_block_container.finish(context, info);
                 let contains_floats = contents.contains_floats();
                 ArcRefCell::new(BlockLevelBox::SameFormattingContextBlock {
-                    base_fragment_info: info.into(),
+                    base: LayoutBoxBase::new(info.into(), info.style.clone()),
                     contents,
-                    style: Arc::clone(&info.style),
                     contains_floats,
                 })
             },


### PR DESCRIPTION
This allows `SameFormattingContextBlock` to cache inline content sizes
and will eventually allow it to participate in incremental layout.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not introduce any changes to layout output, so are covered by existing WPT tests.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
