### PR TITLE
Add embedder event for preferred color scheme and respond to it in the LayoutThread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1617,7 +1617,7 @@ dependencies = [
 [[package]]
 name = "dom"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-12-04#35e0fa29e93a7e85f44d4ad0610748634f7979b5"
+source = "git+https://github.com/servo/stylo?branch=2024-12-04#098f1bef3e231bbf86038c0a2b1ddc31031dc422"
 dependencies = [
  "bitflags 2.6.0",
  "malloc_size_of",
@@ -1867,7 +1867,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4076,7 +4076,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -4248,7 +4248,7 @@ dependencies = [
 [[package]]
 name = "malloc_size_of"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-12-04#35e0fa29e93a7e85f44d4ad0610748634f7979b5"
+source = "git+https://github.com/servo/stylo?branch=2024-12-04#098f1bef3e231bbf86038c0a2b1ddc31031dc422"
 dependencies = [
  "app_units",
  "cssparser",
@@ -6198,7 +6198,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.26.0"
-source = "git+https://github.com/servo/stylo?branch=2024-12-04#35e0fa29e93a7e85f44d4ad0610748634f7979b5"
+source = "git+https://github.com/servo/stylo?branch=2024-12-04#098f1bef3e231bbf86038c0a2b1ddc31031dc422"
 dependencies = [
  "bitflags 2.6.0",
  "cssparser",
@@ -6486,7 +6486,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.0"
-source = "git+https://github.com/servo/stylo?branch=2024-12-04#35e0fa29e93a7e85f44d4ad0610748634f7979b5"
+source = "git+https://github.com/servo/stylo?branch=2024-12-04#098f1bef3e231bbf86038c0a2b1ddc31031dc422"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -6495,7 +6495,7 @@ dependencies = [
 [[package]]
 name = "servo_atoms"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-12-04#35e0fa29e93a7e85f44d4ad0610748634f7979b5"
+source = "git+https://github.com/servo/stylo?branch=2024-12-04#098f1bef3e231bbf86038c0a2b1ddc31031dc422"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -6868,7 +6868,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "static_prefs"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2024-12-04#35e0fa29e93a7e85f44d4ad0610748634f7979b5"
+source = "git+https://github.com/servo/stylo?branch=2024-12-04#098f1bef3e231bbf86038c0a2b1ddc31031dc422"
 
 [[package]]
 name = "strck"
@@ -6927,7 +6927,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 [[package]]
 name = "style"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-12-04#35e0fa29e93a7e85f44d4ad0610748634f7979b5"
+source = "git+https://github.com/servo/stylo?branch=2024-12-04#098f1bef3e231bbf86038c0a2b1ddc31031dc422"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -6985,7 +6985,7 @@ dependencies = [
 [[package]]
 name = "style_config"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-12-04#35e0fa29e93a7e85f44d4ad0610748634f7979b5"
+source = "git+https://github.com/servo/stylo?branch=2024-12-04#098f1bef3e231bbf86038c0a2b1ddc31031dc422"
 dependencies = [
  "lazy_static",
 ]
@@ -6993,7 +6993,7 @@ dependencies = [
 [[package]]
 name = "style_derive"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-12-04#35e0fa29e93a7e85f44d4ad0610748634f7979b5"
+source = "git+https://github.com/servo/stylo?branch=2024-12-04#098f1bef3e231bbf86038c0a2b1ddc31031dc422"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -7023,7 +7023,7 @@ dependencies = [
 [[package]]
 name = "style_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-12-04#35e0fa29e93a7e85f44d4ad0610748634f7979b5"
+source = "git+https://github.com/servo/stylo?branch=2024-12-04#098f1bef3e231bbf86038c0a2b1ddc31031dc422"
 dependencies = [
  "app_units",
  "bitflags 2.6.0",
@@ -7177,7 +7177,7 @@ dependencies = [
  "fastrand",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7386,7 +7386,7 @@ dependencies = [
 [[package]]
 name = "to_shmem"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2024-12-04#35e0fa29e93a7e85f44d4ad0610748634f7979b5"
+source = "git+https://github.com/servo/stylo?branch=2024-12-04#098f1bef3e231bbf86038c0a2b1ddc31031dc422"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -7399,7 +7399,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2024-12-04#35e0fa29e93a7e85f44d4ad0610748634f7979b5"
+source = "git+https://github.com/servo/stylo?branch=2024-12-04#098f1bef3e231bbf86038c0a2b1ddc31031dc422"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -8451,7 +8451,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/components/compositing/windowing.rs
+++ b/components/compositing/windowing.rs
@@ -14,8 +14,7 @@ use keyboard_types::{CompositionEvent, KeyboardEvent};
 use libc::c_void;
 use net::protocols::ProtocolRegistry;
 use script_traits::{
-    GamepadEvent, MediaSessionActionType, MouseButton, TouchEventType, TouchId, TraversalDirection,
-    WheelDelta,
+    GamepadEvent, MediaSessionActionType, MouseButton, Theme, TouchEventType, TouchId, TraversalDirection, WheelDelta
 };
 use servo_geometry::{DeviceIndependentIntRect, DeviceIndependentIntSize, DeviceIndependentPixel};
 use servo_url::ServoUrl;
@@ -55,6 +54,8 @@ pub enum EmbedderEvent {
     Refresh,
     /// Sent when the window is resized.
     WindowResize,
+    /// Sent when the platform theme changes.
+    ThemeChange(Theme),
     /// Sent when a navigation request from script is allowed/refused.
     AllowNavigationResponse(PipelineId, bool),
     /// Sent when a new URL is to be loaded.
@@ -141,6 +142,7 @@ impl Debug for EmbedderEvent {
             EmbedderEvent::Idle => write!(f, "Idle"),
             EmbedderEvent::Refresh => write!(f, "Refresh"),
             EmbedderEvent::WindowResize => write!(f, "Resize"),
+            EmbedderEvent::ThemeChange(..) => write!(f, "ThemeChange"),
             EmbedderEvent::Keyboard(..) => write!(f, "Keyboard"),
             EmbedderEvent::IMEComposition(..) => write!(f, "IMEComposition"),
             EmbedderEvent::AllowNavigationResponse(..) => write!(f, "AllowNavigationResponse"),

--- a/components/compositing/windowing.rs
+++ b/components/compositing/windowing.rs
@@ -14,7 +14,8 @@ use keyboard_types::{CompositionEvent, KeyboardEvent};
 use libc::c_void;
 use net::protocols::ProtocolRegistry;
 use script_traits::{
-    GamepadEvent, MediaSessionActionType, MouseButton, Theme, TouchEventType, TouchId, TraversalDirection, WheelDelta
+    GamepadEvent, MediaSessionActionType, MouseButton, Theme, TouchEventType, TouchId,
+    TraversalDirection, WheelDelta,
 };
 use servo_geometry::{DeviceIndependentIntRect, DeviceIndependentIntSize, DeviceIndependentPixel};
 use servo_url::ServoUrl;

--- a/components/constellation/tracing.rs
+++ b/components/constellation/tracing.rs
@@ -72,6 +72,7 @@ mod from_compositor {
                 Self::ClearCache => target!("ClearCache"),
                 Self::TraverseHistory(..) => target!("TraverseHistory"),
                 Self::WindowSize(..) => target!("WindowSize"),
+                Self::ThemeChange(..) => target!("ThemeChange"),
                 Self::TickAnimation(..) => target!("TickAnimation"),
                 Self::WebDriverCommand(..) => target!("WebDriverCommand"),
                 Self::Reload(..) => target!("Reload"),

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -81,7 +81,12 @@ use script_layout_interface::{
 };
 use script_traits::webdriver_msg::WebDriverScriptCommand;
 use script_traits::{
-    CompositorEvent, ConstellationControlMsg, DiscardBrowsingContext, DocumentActivity, EventResult, HistoryEntryReplacement, InitialScriptState, JsEvalResult, LayoutMsg, LoadData, LoadOrigin, MediaSessionActionType, MouseButton, MouseEventType, NewLayoutInfo, Painter, ProgressiveWebMetricType, ScriptMsg, ScriptToConstellationChan, ScrollState, StructuredSerializedData, Theme, TimerSchedulerMsg, TouchEventType, TouchId, UntrustedNodeAddress, UpdatePipelineIdReason, WheelDelta, WindowSizeData, WindowSizeType
+    CompositorEvent, ConstellationControlMsg, DiscardBrowsingContext, DocumentActivity,
+    EventResult, HistoryEntryReplacement, InitialScriptState, JsEvalResult, LayoutMsg, LoadData,
+    LoadOrigin, MediaSessionActionType, MouseButton, MouseEventType, NewLayoutInfo, Painter,
+    ProgressiveWebMetricType, ScriptMsg, ScriptToConstellationChan, ScrollState,
+    StructuredSerializedData, Theme, TimerSchedulerMsg, TouchEventType, TouchId,
+    UntrustedNodeAddress, UpdatePipelineIdReason, WheelDelta, WindowSizeData, WindowSizeType,
 };
 use servo_atoms::Atom;
 use servo_config::opts;
@@ -2367,7 +2372,6 @@ impl ScriptThread {
             msg @ ConstellationControlMsg::ExitFullScreen(..) |
             msg @ ConstellationControlMsg::SendEvent(..) |
             msg @ ConstellationControlMsg::TickAllAnimations(..) |
-            msg @ ConstellationControlMsg::ThemeChange(..) |
             msg @ ConstellationControlMsg::ExitScriptThread => {
                 panic!("should have handled {:?} already", msg)
             },

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -665,6 +665,15 @@ where
             EmbedderEvent::WindowResize => {
                 return self.compositor.on_resize_window_event();
             },
+            EmbedderEvent::ThemeChange(theme) => {
+                let msg = ConstellationMsg::ThemeChange(theme);
+                if let Err(e) = self.constellation_chan.send(msg) {
+                    warn!(
+                        "Sending platform theme change to constellation failed ({:?}).",
+                        e
+                    )
+                }
+            },
             EmbedderEvent::InvalidateNativeSurface => {
                 self.compositor.invalidate_native_surface();
             },

--- a/components/shared/compositing/constellation_msg.rs
+++ b/components/shared/compositing/constellation_msg.rs
@@ -12,7 +12,8 @@ use embedder_traits::Cursor;
 use ipc_channel::ipc::IpcSender;
 use keyboard_types::{CompositionEvent, KeyboardEvent};
 use script_traits::{
-    AnimationTickType, CompositorEvent, GamepadEvent, LogEntry, MediaSessionActionType, Theme, TraversalDirection, WebDriverCommandMsg, WindowSizeData, WindowSizeType
+    AnimationTickType, CompositorEvent, GamepadEvent, LogEntry, MediaSessionActionType, Theme,
+    TraversalDirection, WebDriverCommandMsg, WindowSizeData, WindowSizeType,
 };
 use servo_url::ServoUrl;
 

--- a/components/shared/compositing/constellation_msg.rs
+++ b/components/shared/compositing/constellation_msg.rs
@@ -12,8 +12,7 @@ use embedder_traits::Cursor;
 use ipc_channel::ipc::IpcSender;
 use keyboard_types::{CompositionEvent, KeyboardEvent};
 use script_traits::{
-    AnimationTickType, CompositorEvent, GamepadEvent, LogEntry, MediaSessionActionType,
-    TraversalDirection, WebDriverCommandMsg, WindowSizeData, WindowSizeType,
+    AnimationTickType, CompositorEvent, GamepadEvent, LogEntry, MediaSessionActionType, Theme, TraversalDirection, WebDriverCommandMsg, WindowSizeData, WindowSizeType
 };
 use servo_url::ServoUrl;
 
@@ -46,6 +45,8 @@ pub enum ConstellationMsg {
     TraverseHistory(TopLevelBrowsingContextId, TraversalDirection),
     /// Inform the constellation of a window being resized.
     WindowSize(TopLevelBrowsingContextId, WindowSizeData, WindowSizeType),
+    /// Inform the constellation of a theme change.
+    ThemeChange(Theme),
     /// Requests that the constellation instruct layout to begin a new tick of the animation.
     TickAnimation(PipelineId, AnimationTickType),
     /// Dispatch a webdriver command
@@ -110,6 +111,7 @@ impl ConstellationMsg {
             LoadUrl(..) => "LoadUrl",
             TraverseHistory(..) => "TraverseHistory",
             WindowSize(..) => "WindowSize",
+            ThemeChange(..) => "ThemeChange",
             TickAnimation(..) => "TickAnimation",
             WebDriverCommand(..) => "WebDriverCommand",
             Reload(..) => "Reload",

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -284,6 +284,8 @@ pub enum ConstellationControlMsg {
     AttachLayout(NewLayoutInfo),
     /// Window resized.  Sends a DOM event eventually, but first we combine events.
     Resize(PipelineId, WindowSizeData, WindowSizeType),
+    /// Theme changed.
+    ThemeChange(PipelineId, Theme),
     /// Notifies script that window has been resized but to not take immediate action.
     ResizeInactive(PipelineId, WindowSizeData),
     /// Window switched from fullscreen mode.
@@ -398,6 +400,7 @@ impl fmt::Debug for ConstellationControlMsg {
             NavigationResponse(..) => "NavigationResponse",
             AttachLayout(..) => "AttachLayout",
             Resize(..) => "Resize",
+            ThemeChange(..) => "ThemeChange",
             ResizeInactive(..) => "ResizeInactive",
             UnloadDocument(..) => "UnloadDocument",
             ExitPipeline(..) => "ExitPipeline",
@@ -774,6 +777,15 @@ pub enum WindowSizeType {
     Initial,
     /// Window resize.
     Resize,
+}
+
+/// The type of platform theme.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, MallocSizeOf, PartialEq, Serialize)]
+pub enum Theme {
+    /// Light theme.
+    Light,
+    /// Dark theme.
+    Dark,
 }
 
 /// Messages to the constellation originating from the WebDriver server.

--- a/components/shared/script_layout/lib.rs
+++ b/components/shared/script_layout/lib.rs
@@ -48,6 +48,7 @@ use style::invalidation::element::restyle_hints::RestyleHint;
 use style::media_queries::Device;
 use style::properties::style_structs::Font;
 use style::properties::PropertyId;
+use style::queries::values::PrefersColorScheme;
 use style::selector_parser::{PseudoElement, RestyleDamage, Snapshot};
 use style::stylesheets::Stylesheet;
 use style::Atom;
@@ -426,6 +427,8 @@ pub struct ScriptReflow {
     pub animation_timeline_value: f64,
     /// The set of animations for this document.
     pub animations: DocumentAnimationSet,
+    /// The theme for the window
+    pub theme: PrefersColorScheme,
 }
 
 /// A pending restyle.

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -487,6 +487,15 @@ impl WindowPortsMethods for Window {
                         .push(EmbedderEvent::WindowResize);
                 }
             },
+            winit::event::WindowEvent::ThemeChanged(theme) => {
+                let theme = match theme {
+                    winit::window::Theme::Light => servo::script_traits::Theme::Light,
+                    winit::window::Theme::Dark => servo::script_traits::Theme::Dark,
+                };
+                self.event_queue
+                    .borrow_mut()
+                    .push(EmbedderEvent::ThemeChange(theme));
+            },
             _ => {},
         }
     }

--- a/ports/servoshell/desktop/tracing.rs
+++ b/ports/servoshell/desktop/tracing.rs
@@ -199,6 +199,7 @@ mod to_servo {
                 Self::Idle => target!("Idle"),
                 Self::Refresh => target!("Refresh"),
                 Self::WindowResize => target!("WindowResize"),
+                Self::ThemeChange(..) => target!("ThemeChange"),
                 Self::AllowNavigationResponse(..) => target!("AllowNavigationResponse"),
                 Self::LoadUrl(..) => target!("LoadUrl"),
                 Self::MouseWindowEventClass(..) => target!("MouseWindowEventClass"),


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This addresses the first 2 checkboxes for issue #34425. I've added the 2 changes noted in that issue here
- Add an embedder event for setting the preferred color scheme
- Plumb this through to the layout thread where it should be set on the device, via a "reflow", similar to window size

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #34425 

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
