### PR TITLE
Retire deprecated MouseEvent::InitMouseEvent

### DIFF
--- a/components/script/dom/mouseevent.rs
+++ b/components/script/dom/mouseevent.rs
@@ -201,30 +201,37 @@ impl MouseEvent {
         related_target: Option<&EventTarget>,
         point_in_target: Option<Point2D<f32>>,
     ) {
-        // TODO: InitMouseEvent has been deprecated. We should follow the link to create an UI
-        // Event instead.
-        self.InitMouseEvent(
+        self.uievent.initialize_ui_event(
             type_,
-            bool::from(can_bubble),
-            bool::from(cancelable),
-            view,
-            detail,
-            screen_x,
-            screen_y,
-            client_x,
-            client_y,
-            ctrl_key,
-            alt_key,
-            shift_key,
-            meta_key,
-            button,
-            related_target,
+            view.map(|window| window.upcast::<EventTarget>()),
+            can_bubble,
+            cancelable,
         );
+
+        self.uievent.set_detail(detail);
+
+        self.screen_x.set(screen_x);
+        self.screen_y.set(screen_y);
+        self.client_x.set(client_x);
+        self.client_y.set(client_y);
+        self.page_x.set(self.PageX());
+        self.page_y.set(self.PageY());
+
+        // skip setting flags as they are absent
+        self.shift_key.set(shift_key);
+        self.ctrl_key.set(ctrl_key);
+        self.alt_key.set(alt_key);
+        self.meta_key.set(meta_key);
+
+        self.button.set(button);
         self.buttons.set(buttons);
+        // skip step 3: Initialize PointerLock attributes for MouseEvent with event,
+        // as movementX, movementY is absent
+
+        self.related_target.set(related_target);
+
+        // below is not in the spec
         self.point_in_target.set(point_in_target);
-        // TODO: Set proper values in https://github.com/servo/servo/issues/24415
-        self.page_x.set(client_x);
-        self.page_y.set(client_y);
     }
 
     pub fn point_in_target(&self) -> Option<Point2D<f32>> {

--- a/components/script/dom/uievent.rs
+++ b/components/script/dom/uievent.rs
@@ -113,6 +113,10 @@ impl UIEvent {
         }
         self.detail.set(0_i32);
     }
+
+    pub fn set_detail(&self, detail_: i32) {
+        self.detail.set(detail_);
+    }
 }
 
 impl UIEventMethods<crate::DomTypeHolder> for UIEvent {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
As discussed in https://github.com/servo/servo/issues/34448, we should stop using `MouseEvent::InitMouseEvent`.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #34448

<!-- Either: -->
- [X] There are tests for these changes (wpt/tests/css/cssom-view/mouseEvent.html)

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
