### PR TITLE
tidy: Update pattern for checking for missing specification links.

### DIFF
--- a/components/script/dom/gpucanvascontext.rs
+++ b/components/script/dom/gpucanvascontext.rs
@@ -29,6 +29,7 @@ impl GPUCanvasContext {
 }
 
 impl GPUCanvasContextMethods<crate::DomTypeHolder> for GPUCanvasContext {
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpucanvascontext-canvas>
     fn Canvas(&self) -> UnionTypes::HTMLCanvasElementOrOffscreenCanvas {
         unimplemented!()
     }

--- a/python/tidy/tests/speclink.rs
+++ b/python/tidy/tests/speclink.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-impl SpecLinkMethods for SpecLink {
+impl SpecLinkMethods<crate::DomTypeHolder> for SpecLink {
     amacro!("Macros inside impls should trigger spec checks.")
 
     // Method declarations should trigger spec checks.

--- a/python/tidy/tidy.py
+++ b/python/tidy/tidy.py
@@ -905,7 +905,7 @@ def check_spec(file_name, lines):
 
     brace_count = 0
     in_impl = False
-    pattern = "impl {}Methods for {} {{".format(file_name, file_name)
+    pattern = "impl {}Methods<crate::DomTypeHolder> for {} {{".format(file_name, file_name)
 
     for idx, line in enumerate(map(lambda line: line.decode("utf-8"), lines)):
         if "// check-tidy: no specs after this line" in line:


### PR DESCRIPTION
This wasn't updated after #34357, so we silently lost this check.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes