### PR TITLE
Rewrite From/TryFrom conversions on generated types to avoid future orphan rule violations

### DIFF
--- a/components/script/conversions.rs
+++ b/components/script/conversions.rs
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/// A version of the Into<T> trait from the standard library that can be used
+/// to convert between two types that are not defined in the script crate.
+/// This is intended to be used on dict/enum types generated from WebIDL once
+/// those types are moved out of the script crate.
+pub trait Convert<T> {
+    fn convert(self) -> T;
+}
+
+/// A version of the TryInto<T> trait from the standard library that can be used
+/// to convert between two types that are not defined in the script crate.
+/// This is intended to be used on dict/enum types generated from WebIDL once
+/// those types are moved out of the script crate.
+pub trait TryConvert<T> {
+    type Error;
+
+    fn try_convert(self) -> Result<T, Self::Error>;
+}

--- a/components/script/dom/audionode.rs
+++ b/components/script/dom/audionode.rs
@@ -11,6 +11,7 @@ use servo_media::audio::node::{
     ChannelInterpretation as ServoMediaChannelInterpretation,
 };
 
+use crate::conversions::Convert;
 use crate::dom::audioparam::AudioParam;
 use crate::dom::baseaudiocontext::BaseAudioContext;
 use crate::dom::bindings::codegen::Bindings::AudioNodeBinding::{
@@ -56,8 +57,8 @@ impl AudioNode {
         }
         let ch = ChannelInfo {
             count: options.count as u8,
-            mode: options.mode.into(),
-            interpretation: options.interpretation.into(),
+            mode: options.mode.convert(),
+            interpretation: options.interpretation.convert(),
             context_channel_count: context.channel_count() as u8,
         };
         let node_id = context
@@ -339,7 +340,7 @@ impl AudioNodeMethods<crate::DomTypeHolder> for AudioNode {
         };
 
         self.channel_count_mode.set(value);
-        self.message(AudioNodeMessage::SetChannelMode(value.into()));
+        self.message(AudioNodeMessage::SetChannelMode(value.convert()));
         Ok(())
     }
 
@@ -362,14 +363,14 @@ impl AudioNodeMethods<crate::DomTypeHolder> for AudioNode {
         };
 
         self.channel_interpretation.set(value);
-        self.message(AudioNodeMessage::SetChannelInterpretation(value.into()));
+        self.message(AudioNodeMessage::SetChannelInterpretation(value.convert()));
         Ok(())
     }
 }
 
-impl From<ChannelCountMode> for ServoMediaChannelCountMode {
-    fn from(mode: ChannelCountMode) -> Self {
-        match mode {
+impl Convert<ServoMediaChannelCountMode> for ChannelCountMode {
+    fn convert(self) -> ServoMediaChannelCountMode {
+        match self {
             ChannelCountMode::Max => ServoMediaChannelCountMode::Max,
             ChannelCountMode::Clamped_max => ServoMediaChannelCountMode::ClampedMax,
             ChannelCountMode::Explicit => ServoMediaChannelCountMode::Explicit,
@@ -377,9 +378,9 @@ impl From<ChannelCountMode> for ServoMediaChannelCountMode {
     }
 }
 
-impl From<ChannelInterpretation> for ServoMediaChannelInterpretation {
-    fn from(interpretation: ChannelInterpretation) -> Self {
-        match interpretation {
+impl Convert<ServoMediaChannelInterpretation> for ChannelInterpretation {
+    fn convert(self) -> ServoMediaChannelInterpretation {
+        match self {
             ChannelInterpretation::Discrete => ServoMediaChannelInterpretation::Discrete,
             ChannelInterpretation::Speakers => ServoMediaChannelInterpretation::Speakers,
         }

--- a/components/script/dom/audioparam.rs
+++ b/components/script/dom/audioparam.rs
@@ -10,6 +10,7 @@ use servo_media::audio::graph::NodeId;
 use servo_media::audio::node::{AudioNodeMessage, AudioNodeType};
 use servo_media::audio::param::{ParamRate, ParamType, RampKind, UserAutomationEvent};
 
+use crate::conversions::Convert;
 use crate::dom::baseaudiocontext::BaseAudioContext;
 use crate::dom::bindings::codegen::Bindings::AudioParamBinding::{
     AudioParamMethods, AutomationRate,
@@ -131,7 +132,7 @@ impl AudioParamMethods<crate::DomTypeHolder> for AudioParam {
         self.automation_rate.set(automation_rate);
         self.message_node(AudioNodeMessage::SetParamRate(
             self.param,
-            automation_rate.into(),
+            automation_rate.convert(),
         ));
 
         Ok(())
@@ -322,9 +323,9 @@ impl AudioParamMethods<crate::DomTypeHolder> for AudioParam {
 }
 
 // https://webaudio.github.io/web-audio-api/#enumdef-automationrate
-impl From<AutomationRate> for ParamRate {
-    fn from(rate: AutomationRate) -> Self {
-        match rate {
+impl Convert<ParamRate> for AutomationRate {
+    fn convert(self) -> ParamRate {
+        match self {
             AutomationRate::A_rate => ParamRate::ARate,
             AutomationRate::K_rate => ParamRate::KRate,
         }

--- a/components/script/dom/baseaudiocontext.rs
+++ b/components/script/dom/baseaudiocontext.rs
@@ -21,6 +21,7 @@ use servo_media::audio::graph::NodeId;
 use servo_media::{ClientContextId, ServoMedia};
 use uuid::Uuid;
 
+use crate::conversions::Convert;
 use crate::dom::analysernode::AnalyserNode;
 use crate::dom::audiobuffer::AudioBuffer;
 use crate::dom::audiobuffersourcenode::AudioBufferSourceNode;
@@ -129,7 +130,7 @@ impl BaseAudioContext {
             ClientContextId::build(pipeline_id.namespace_id.0, pipeline_id.index.0.get());
         let audio_context_impl = ServoMedia::get()
             .unwrap()
-            .create_audio_context(&client_context_id, options.into())
+            .create_audio_context(&client_context_id, options.convert())
             .map_err(|_| Error::NotSupported)?;
 
         Ok(BaseAudioContext {
@@ -613,9 +614,9 @@ impl BaseAudioContextMethods<crate::DomTypeHolder> for BaseAudioContext {
     }
 }
 
-impl From<BaseAudioContextOptions> for AudioContextOptions {
-    fn from(options: BaseAudioContextOptions) -> Self {
-        match options {
+impl Convert<AudioContextOptions> for BaseAudioContextOptions {
+    fn convert(self) -> AudioContextOptions {
+        match self {
             BaseAudioContextOptions::AudioContext(options) => {
                 AudioContextOptions::RealTimeAudioContext(options)
             },
@@ -626,9 +627,9 @@ impl From<BaseAudioContextOptions> for AudioContextOptions {
     }
 }
 
-impl From<ProcessingState> for AudioContextState {
-    fn from(state: ProcessingState) -> Self {
-        match state {
+impl Convert<AudioContextState> for ProcessingState {
+    fn convert(self) -> AudioContextState {
+        match self {
             ProcessingState::Suspended => AudioContextState::Suspended,
             ProcessingState::Running => AudioContextState::Running,
             ProcessingState::Closed => AudioContextState::Closed,

--- a/components/script/dom/biquadfilternode.rs
+++ b/components/script/dom/biquadfilternode.rs
@@ -13,6 +13,7 @@ use servo_media::audio::biquad_filter_node::{
 use servo_media::audio::node::{AudioNodeInit, AudioNodeMessage, AudioNodeType};
 use servo_media::audio::param::ParamType;
 
+use crate::conversions::Convert;
 use crate::dom::audionode::AudioNode;
 use crate::dom::audioparam::AudioParam;
 use crate::dom::baseaudiocontext::BaseAudioContext;
@@ -51,7 +52,7 @@ impl BiquadFilterNode {
                 .parent
                 .unwrap_or(2, ChannelCountMode::Max, ChannelInterpretation::Speakers);
         let filter = Cell::new(options.type_);
-        let options = options.into();
+        let options = options.convert();
         let node = AudioNode::new_inherited(
             AudioNodeInit::BiquadFilterNode(options),
             context,
@@ -181,26 +182,26 @@ impl BiquadFilterNodeMethods<crate::DomTypeHolder> for BiquadFilterNode {
     fn SetType(&self, filter: BiquadFilterType) {
         self.filter.set(filter);
         self.node.message(AudioNodeMessage::BiquadFilterNode(
-            BiquadFilterNodeMessage::SetFilterType(filter.into()),
+            BiquadFilterNodeMessage::SetFilterType(filter.convert()),
         ));
     }
 }
 
-impl<'a> From<&'a BiquadFilterOptions> for BiquadFilterNodeOptions {
-    fn from(options: &'a BiquadFilterOptions) -> Self {
-        Self {
-            gain: *options.gain,
-            q: *options.Q,
-            frequency: *options.frequency,
-            detune: *options.detune,
-            filter: options.type_.into(),
+impl<'a> Convert<BiquadFilterNodeOptions> for &'a BiquadFilterOptions {
+    fn convert(self) -> BiquadFilterNodeOptions {
+        BiquadFilterNodeOptions {
+            gain: *self.gain,
+            q: *self.Q,
+            frequency: *self.frequency,
+            detune: *self.detune,
+            filter: self.type_.convert(),
         }
     }
 }
 
-impl From<BiquadFilterType> for FilterType {
-    fn from(filter: BiquadFilterType) -> FilterType {
-        match filter {
+impl Convert<FilterType> for BiquadFilterType {
+    fn convert(self) -> FilterType {
+        match self {
             BiquadFilterType::Lowpass => FilterType::LowPass,
             BiquadFilterType::Highpass => FilterType::HighPass,
             BiquadFilterType::Bandpass => FilterType::BandPass,

--- a/components/script/dom/bluetooth.rs
+++ b/components/script/dom/bluetooth.rs
@@ -8,6 +8,7 @@ use bluetooth_traits::blocklist::{Blocklist, uuid_is_blocklisted};
 use bluetooth_traits::scanfilter::{BluetoothScanfilter, BluetoothScanfilterSequence};
 use bluetooth_traits::scanfilter::{RequestDeviceoptions, ServiceUUIDSequence};
 use crate::realms::{AlreadyInRealm, InRealm};
+use crate::conversions::Convert;
 use crate::dom::bindings::cell::{DomRefCell, Ref};
 use crate::dom::bindings::codegen::Bindings::BluetoothBinding::BluetoothDataFilterInit;
 use crate::dom::bindings::codegen::Bindings::BluetoothBinding::{BluetoothMethods, RequestDeviceOptions};
@@ -130,7 +131,7 @@ where
                 .handle_response(response, &promise, can_gc),
             // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetooth-requestdevice
             // Step 3 - 4.
-            Err(error) => promise.reject_error(Error::from(error)),
+            Err(error) => promise.reject_error(error.convert()),
         }
     }
 }
@@ -521,9 +522,9 @@ fn canonicalize_bluetooth_data_filter_init(
     Ok((data_prefix, mask))
 }
 
-impl From<BluetoothError> for Error {
-    fn from(error: BluetoothError) -> Self {
-        match error {
+impl Convert<Error> for BluetoothError {
+    fn convert(self) -> Error {
+        match self {
             BluetoothError::Type(message) => Error::Type(message),
             BluetoothError::Network => Error::Network,
             BluetoothError::NotFound => Error::NotFound,
@@ -706,7 +707,7 @@ impl PermissionAlgorithm for Bluetooth {
                 match receiver.recv().unwrap() {
                     Ok(true) => (),
                     Ok(false) => continue,
-                    Err(error) => return promise.reject_error(Error::from(error)),
+                    Err(error) => return promise.reject_error(error.convert()),
                 };
             }
 

--- a/components/script/dom/bluetoothdevice.rs
+++ b/components/script/dom/bluetoothdevice.rs
@@ -14,6 +14,7 @@ use dom_struct::dom_struct;
 use ipc_channel::ipc::IpcSender;
 use profile_traits::ipc;
 
+use crate::conversions::Convert;
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::BluetoothDeviceBinding::BluetoothDeviceMethods;
 use crate::dom::bindings::codegen::Bindings::BluetoothRemoteGATTServerBinding::BluetoothRemoteGATTServerMethods;
@@ -249,7 +250,7 @@ impl BluetoothDevice {
                 sender,
             ))
             .unwrap();
-        receiver.recv().unwrap().map_err(Error::from)
+        receiver.recv().unwrap().map_err(Convert::convert)
     }
 }
 

--- a/components/script/dom/mediadeviceinfo.rs
+++ b/components/script/dom/mediadeviceinfo.rs
@@ -5,6 +5,7 @@
 use dom_struct::dom_struct;
 use servo_media::streams::device_monitor::MediaDeviceKind as ServoMediaDeviceKind;
 
+use crate::conversions::Convert;
 use crate::dom::bindings::codegen::Bindings::MediaDeviceInfoBinding::{
     MediaDeviceInfoMethods, MediaDeviceKind,
 };
@@ -76,9 +77,9 @@ impl MediaDeviceInfoMethods<crate::DomTypeHolder> for MediaDeviceInfo {
     }
 }
 
-impl From<ServoMediaDeviceKind> for MediaDeviceKind {
-    fn from(kind: ServoMediaDeviceKind) -> MediaDeviceKind {
-        match kind {
+impl Convert<MediaDeviceKind> for ServoMediaDeviceKind {
+    fn convert(self) -> MediaDeviceKind {
+        match self {
             ServoMediaDeviceKind::AudioInput => MediaDeviceKind::Audioinput,
             ServoMediaDeviceKind::AudioOutput => MediaDeviceKind::Audiooutput,
             ServoMediaDeviceKind::VideoInput => MediaDeviceKind::Videoinput,

--- a/components/script/dom/mediadevices.rs
+++ b/components/script/dom/mediadevices.rs
@@ -9,6 +9,7 @@ use servo_media::streams::capture::{Constrain, ConstrainRange, MediaTrackConstra
 use servo_media::streams::MediaStreamType;
 use servo_media::ServoMedia;
 
+use crate::conversions::Convert;
 use crate::dom::bindings::codegen::Bindings::MediaDevicesBinding::{
     MediaDevicesMethods, MediaStreamConstraints,
 };
@@ -94,7 +95,7 @@ impl MediaDevicesMethods<crate::DomTypeHolder> for MediaDevices {
                     MediaDeviceInfo::new(
                         &self.global(),
                         &device.device_id,
-                        device.kind.into(),
+                        device.kind.convert(),
                         &device.label,
                         "",
                     )

--- a/components/script/dom/mediasession.rs
+++ b/components/script/dom/mediasession.rs
@@ -9,6 +9,7 @@ use embedder_traits::{MediaMetadata as EmbedderMediaMetadata, MediaSessionEvent}
 use script_traits::{MediaSessionActionType, ScriptMsg};
 
 use super::bindings::trace::HashMapTracedValues;
+use crate::conversions::Convert;
 use crate::dom::bindings::callback::ExceptionHandling;
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::HTMLMediaElementBinding::HTMLMediaElementMethods;
@@ -188,8 +189,8 @@ impl MediaSessionMethods<crate::DomTypeHolder> for MediaSession {
             Some(handler) => self
                 .action_handlers
                 .borrow_mut()
-                .insert(action.into(), handler.clone()),
-            None => self.action_handlers.borrow_mut().remove(&action.into()),
+                .insert(action.convert(), handler.clone()),
+            None => self.action_handlers.borrow_mut().remove(&action.convert()),
         };
     }
 
@@ -249,9 +250,9 @@ impl MediaSessionMethods<crate::DomTypeHolder> for MediaSession {
     }
 }
 
-impl From<MediaSessionAction> for MediaSessionActionType {
-    fn from(action: MediaSessionAction) -> MediaSessionActionType {
-        match action {
+impl Convert<MediaSessionActionType> for MediaSessionAction {
+    fn convert(self) -> MediaSessionActionType {
+        match self {
             MediaSessionAction::Play => MediaSessionActionType::Play,
             MediaSessionAction::Pause => MediaSessionActionType::Pause,
             MediaSessionAction::Seekbackward => MediaSessionActionType::SeekBackward,

--- a/components/script/dom/oscillatornode.rs
+++ b/components/script/dom/oscillatornode.rs
@@ -14,6 +14,7 @@ use servo_media::audio::oscillator_node::{
 };
 use servo_media::audio::param::ParamType;
 
+use crate::conversions::Convert;
 use crate::dom::audioparam::AudioParam;
 use crate::dom::audioscheduledsourcenode::AudioScheduledSourceNode;
 use crate::dom::baseaudiocontext::BaseAudioContext;
@@ -50,7 +51,7 @@ impl OscillatorNode {
                 .parent
                 .unwrap_or(2, ChannelCountMode::Max, ChannelInterpretation::Speakers);
         let source_node = AudioScheduledSourceNode::new_inherited(
-            AudioNodeInit::OscillatorNode(options.into()),
+            AudioNodeInit::OscillatorNode(options.convert()),
             context,
             node_options,
             0, /* inputs */
@@ -150,26 +151,26 @@ impl OscillatorNodeMethods<crate::DomTypeHolder> for OscillatorNode {
         self.source_node
             .node()
             .message(AudioNodeMessage::OscillatorNode(
-                OscillatorNodeMessage::SetOscillatorType(type_.into()),
+                OscillatorNodeMessage::SetOscillatorType(type_.convert()),
             ));
         Ok(())
     }
 }
 
-impl<'a> From<&'a OscillatorOptions> for ServoMediaOscillatorOptions {
-    fn from(options: &'a OscillatorOptions) -> Self {
-        Self {
-            oscillator_type: options.type_.into(),
-            freq: *options.frequency,
-            detune: *options.detune,
+impl<'a> Convert<ServoMediaOscillatorOptions> for &'a OscillatorOptions {
+    fn convert(self) -> ServoMediaOscillatorOptions {
+        ServoMediaOscillatorOptions {
+            oscillator_type: self.type_.convert(),
+            freq: *self.frequency,
+            detune: *self.detune,
             periodic_wave_options: None, // XXX
         }
     }
 }
 
-impl From<OscillatorType> for ServoMediaOscillatorType {
-    fn from(oscillator_type: OscillatorType) -> Self {
-        match oscillator_type {
+impl Convert<ServoMediaOscillatorType> for OscillatorType {
+    fn convert(self) -> ServoMediaOscillatorType {
+        match self {
             OscillatorType::Sine => ServoMediaOscillatorType::Sine,
             OscillatorType::Square => ServoMediaOscillatorType::Square,
             OscillatorType::Sawtooth => ServoMediaOscillatorType::Sawtooth,

--- a/components/script/dom/pannernode.rs
+++ b/components/script/dom/pannernode.rs
@@ -13,6 +13,7 @@ use servo_media::audio::panner_node::{
 };
 use servo_media::audio::param::{ParamDir, ParamType};
 
+use crate::conversions::Convert;
 use crate::dom::audionode::AudioNode;
 use crate::dom::audioparam::AudioParam;
 use crate::dom::baseaudiocontext::BaseAudioContext;
@@ -86,7 +87,7 @@ impl PannerNode {
         if *options.coneOuterGain < 0. || *options.coneOuterGain > 1. {
             return Err(Error::InvalidState);
         }
-        let options = options.into();
+        let options = options.convert();
         let node = AudioNode::new_inherited(
             AudioNodeInit::PannerNode(options),
             context,
@@ -255,7 +256,7 @@ impl PannerNodeMethods<crate::DomTypeHolder> for PannerNode {
     }
     // https://webaudio.github.io/web-audio-api/#dom-pannernode-distancemodel
     fn SetDistanceModel(&self, model: DistanceModelType) {
-        self.distance_model.set(model.into());
+        self.distance_model.set(model.convert());
         let msg = PannerNodeMessage::SetDistanceModel(self.distance_model.get());
         self.upcast::<AudioNode>()
             .message(AudioNodeMessage::PannerNode(msg));
@@ -269,7 +270,7 @@ impl PannerNodeMethods<crate::DomTypeHolder> for PannerNode {
     }
     // https://webaudio.github.io/web-audio-api/#dom-pannernode-panningmodel
     fn SetPanningModel(&self, model: PanningModelType) {
-        self.panning_model.set(model.into());
+        self.panning_model.set(model.convert());
         let msg = PannerNodeMessage::SetPanningModel(self.panning_model.get());
         self.upcast::<AudioNode>()
             .message(AudioNodeMessage::PannerNode(msg));
@@ -372,30 +373,30 @@ impl PannerNodeMethods<crate::DomTypeHolder> for PannerNode {
     }
 }
 
-impl<'a> From<&'a PannerOptions> for PannerNodeOptions {
-    fn from(options: &'a PannerOptions) -> Self {
-        Self {
-            panning_model: options.panningModel.into(),
-            distance_model: options.distanceModel.into(),
-            position_x: *options.positionX,
-            position_y: *options.positionY,
-            position_z: *options.positionZ,
-            orientation_x: *options.orientationX,
-            orientation_y: *options.orientationY,
-            orientation_z: *options.orientationZ,
-            ref_distance: *options.refDistance,
-            max_distance: *options.maxDistance,
-            rolloff_factor: *options.rolloffFactor,
-            cone_inner_angle: *options.coneInnerAngle,
-            cone_outer_angle: *options.coneOuterAngle,
-            cone_outer_gain: *options.coneOuterGain,
+impl<'a> Convert<PannerNodeOptions> for &'a PannerOptions {
+    fn convert(self) -> PannerNodeOptions {
+        PannerNodeOptions {
+            panning_model: self.panningModel.convert(),
+            distance_model: self.distanceModel.convert(),
+            position_x: *self.positionX,
+            position_y: *self.positionY,
+            position_z: *self.positionZ,
+            orientation_x: *self.orientationX,
+            orientation_y: *self.orientationY,
+            orientation_z: *self.orientationZ,
+            ref_distance: *self.refDistance,
+            max_distance: *self.maxDistance,
+            rolloff_factor: *self.rolloffFactor,
+            cone_inner_angle: *self.coneInnerAngle,
+            cone_outer_angle: *self.coneOuterAngle,
+            cone_outer_gain: *self.coneOuterGain,
         }
     }
 }
 
-impl From<DistanceModelType> for DistanceModel {
-    fn from(model: DistanceModelType) -> Self {
-        match model {
+impl Convert<DistanceModel> for DistanceModelType {
+    fn convert(self) -> DistanceModel {
+        match self {
             DistanceModelType::Linear => DistanceModel::Linear,
             DistanceModelType::Inverse => DistanceModel::Inverse,
             DistanceModelType::Exponential => DistanceModel::Exponential,
@@ -403,9 +404,9 @@ impl From<DistanceModelType> for DistanceModel {
     }
 }
 
-impl From<PanningModelType> for PanningModel {
-    fn from(model: PanningModelType) -> Self {
-        match model {
+impl Convert<PanningModel> for PanningModelType {
+    fn convert(self) -> PanningModel {
+        match self {
             PanningModelType::Equalpower => PanningModel::EqualPower,
             PanningModelType::HRTF => PanningModel::HRTF,
         }

--- a/components/script/dom/permissions.rs
+++ b/components/script/dom/permissions.rs
@@ -12,6 +12,7 @@ use js::jsapi::JSObject;
 use js::jsval::{ObjectValue, UndefinedValue};
 use servo_config::pref;
 
+use crate::conversions::Convert;
 use crate::dom::bindings::codegen::Bindings::PermissionStatusBinding::{
     PermissionDescriptor, PermissionName, PermissionState, PermissionStatusMethods,
 };
@@ -251,8 +252,7 @@ impl PermissionAlgorithm for Permissions {
             // Step 3.
             PermissionState::Prompt => {
                 let perm_name = status.get_query();
-                let prompt =
-                    PermissionPrompt::Request(embedder_traits::PermissionName::from(perm_name));
+                let prompt = PermissionPrompt::Request(perm_name.convert());
 
                 // https://w3c.github.io/permissions/#request-permission-to-use (Step 3 - 4)
                 let globalscope = GlobalScope::current().expect("No current global object");
@@ -305,7 +305,7 @@ pub fn get_descriptor_permission_state(
             .borrow_mut()
             .remove(&permission_name.to_string());
         prompt_user_from_embedder(
-            PermissionPrompt::Insecure(embedder_traits::PermissionName::from(permission_name)),
+            PermissionPrompt::Insecure(permission_name.convert()),
             &globalscope,
         )
     };
@@ -374,9 +374,9 @@ fn prompt_user_from_embedder(prompt: PermissionPrompt, gs: &GlobalScope) -> Perm
     }
 }
 
-impl From<PermissionName> for embedder_traits::PermissionName {
-    fn from(permission_name: PermissionName) -> Self {
-        match permission_name {
+impl Convert<embedder_traits::PermissionName> for PermissionName {
+    fn convert(self) -> embedder_traits::PermissionName {
+        match self {
             PermissionName::Geolocation => embedder_traits::PermissionName::Geolocation,
             PermissionName::Notifications => embedder_traits::PermissionName::Notifications,
             PermissionName::Push => embedder_traits::PermissionName::Push,

--- a/components/script/dom/request.rs
+++ b/components/script/dom/request.rs
@@ -24,6 +24,7 @@ use net_traits::ReferrerPolicy as MsgReferrerPolicy;
 use servo_url::ServoUrl;
 
 use crate::body::{consume_body, BodyMixin, BodyType, Extractable};
+use crate::conversions::Convert;
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::HeadersBinding::{HeadersInit, HeadersMethods};
 use crate::dom::bindings::codegen::Bindings::RequestBinding::{
@@ -302,12 +303,12 @@ impl RequestMethods<crate::DomTypeHolder> for Request {
 
         // Step 15
         if let Some(init_referrerpolicy) = init.referrerPolicy.as_ref() {
-            let init_referrer_policy = (*init_referrerpolicy).into();
+            let init_referrer_policy = (*init_referrerpolicy).convert();
             request.referrer_policy = init_referrer_policy;
         }
 
         // Step 16
-        let mode = init.mode.as_ref().map(|m| (*m).into()).or(fallback_mode);
+        let mode = init.mode.as_ref().map(|m| (*m).convert()).or(fallback_mode);
 
         // Step 17
         if let Some(NetTraitsRequestMode::Navigate) = mode {
@@ -321,13 +322,13 @@ impl RequestMethods<crate::DomTypeHolder> for Request {
 
         // Step 19
         if let Some(init_credentials) = init.credentials.as_ref() {
-            let credentials = (*init_credentials).into();
+            let credentials = (*init_credentials).convert();
             request.credentials_mode = credentials;
         }
 
         // Step 20
         if let Some(init_cache) = init.cache.as_ref() {
-            let cache = (*init_cache).into();
+            let cache = (*init_cache).convert();
             request.cache_mode = cache;
         }
 
@@ -342,7 +343,7 @@ impl RequestMethods<crate::DomTypeHolder> for Request {
 
         // Step 22
         if let Some(init_redirect) = init.redirect.as_ref() {
-            let redirect = (*init_redirect).into();
+            let redirect = (*init_redirect).convert();
             request.redirect_mode = redirect;
         }
 
@@ -546,7 +547,7 @@ impl RequestMethods<crate::DomTypeHolder> for Request {
 
     // https://fetch.spec.whatwg.org/#dom-request-destination
     fn Destination(&self) -> RequestDestination {
-        self.request.borrow().destination.into()
+        self.request.borrow().destination.convert()
     }
 
     // https://fetch.spec.whatwg.org/#dom-request-referrer
@@ -564,30 +565,30 @@ impl RequestMethods<crate::DomTypeHolder> for Request {
 
     // https://fetch.spec.whatwg.org/#dom-request-referrerpolicy
     fn ReferrerPolicy(&self) -> ReferrerPolicy {
-        self.request.borrow().referrer_policy.into()
+        self.request.borrow().referrer_policy.convert()
     }
 
     // https://fetch.spec.whatwg.org/#dom-request-mode
     fn Mode(&self) -> RequestMode {
-        self.request.borrow().mode.clone().into()
+        self.request.borrow().mode.clone().convert()
     }
 
     // https://fetch.spec.whatwg.org/#dom-request-credentials
     fn Credentials(&self) -> RequestCredentials {
         let r = self.request.borrow().clone();
-        r.credentials_mode.into()
+        r.credentials_mode.convert()
     }
 
     // https://fetch.spec.whatwg.org/#dom-request-cache
     fn Cache(&self) -> RequestCache {
         let r = self.request.borrow().clone();
-        r.cache_mode.into()
+        r.cache_mode.convert()
     }
 
     // https://fetch.spec.whatwg.org/#dom-request-redirect
     fn Redirect(&self) -> RequestRedirect {
         let r = self.request.borrow().clone();
-        r.redirect_mode.into()
+        r.redirect_mode.convert()
     }
 
     // https://fetch.spec.whatwg.org/#dom-request-integrity
@@ -669,9 +670,9 @@ impl BodyMixin for Request {
     }
 }
 
-impl From<RequestCache> for NetTraitsRequestCache {
-    fn from(cache: RequestCache) -> Self {
-        match cache {
+impl Convert<NetTraitsRequestCache> for RequestCache {
+    fn convert(self) -> NetTraitsRequestCache {
+        match self {
             RequestCache::Default => NetTraitsRequestCache::Default,
             RequestCache::No_store => NetTraitsRequestCache::NoStore,
             RequestCache::Reload => NetTraitsRequestCache::Reload,
@@ -682,9 +683,9 @@ impl From<RequestCache> for NetTraitsRequestCache {
     }
 }
 
-impl From<NetTraitsRequestCache> for RequestCache {
-    fn from(cache: NetTraitsRequestCache) -> Self {
-        match cache {
+impl Convert<RequestCache> for NetTraitsRequestCache {
+    fn convert(self) -> RequestCache {
+        match self {
             NetTraitsRequestCache::Default => RequestCache::Default,
             NetTraitsRequestCache::NoStore => RequestCache::No_store,
             NetTraitsRequestCache::Reload => RequestCache::Reload,
@@ -695,9 +696,9 @@ impl From<NetTraitsRequestCache> for RequestCache {
     }
 }
 
-impl From<RequestCredentials> for NetTraitsRequestCredentials {
-    fn from(credentials: RequestCredentials) -> Self {
-        match credentials {
+impl Convert<NetTraitsRequestCredentials> for RequestCredentials {
+    fn convert(self) -> NetTraitsRequestCredentials {
+        match self {
             RequestCredentials::Omit => NetTraitsRequestCredentials::Omit,
             RequestCredentials::Same_origin => NetTraitsRequestCredentials::CredentialsSameOrigin,
             RequestCredentials::Include => NetTraitsRequestCredentials::Include,
@@ -705,9 +706,9 @@ impl From<RequestCredentials> for NetTraitsRequestCredentials {
     }
 }
 
-impl From<NetTraitsRequestCredentials> for RequestCredentials {
-    fn from(credentials: NetTraitsRequestCredentials) -> Self {
-        match credentials {
+impl Convert<RequestCredentials> for NetTraitsRequestCredentials {
+    fn convert(self) -> RequestCredentials {
+        match self {
             NetTraitsRequestCredentials::Omit => RequestCredentials::Omit,
             NetTraitsRequestCredentials::CredentialsSameOrigin => RequestCredentials::Same_origin,
             NetTraitsRequestCredentials::Include => RequestCredentials::Include,
@@ -715,9 +716,9 @@ impl From<NetTraitsRequestCredentials> for RequestCredentials {
     }
 }
 
-impl From<RequestDestination> for NetTraitsRequestDestination {
-    fn from(destination: RequestDestination) -> Self {
-        match destination {
+impl Convert<NetTraitsRequestDestination> for RequestDestination {
+    fn convert(self) -> NetTraitsRequestDestination {
+        match self {
             RequestDestination::_empty => NetTraitsRequestDestination::None,
             RequestDestination::Audio => NetTraitsRequestDestination::Audio,
             RequestDestination::Document => NetTraitsRequestDestination::Document,
@@ -741,9 +742,9 @@ impl From<RequestDestination> for NetTraitsRequestDestination {
     }
 }
 
-impl From<NetTraitsRequestDestination> for RequestDestination {
-    fn from(destination: NetTraitsRequestDestination) -> Self {
-        match destination {
+impl Convert<RequestDestination> for NetTraitsRequestDestination {
+    fn convert(self) -> RequestDestination {
+        match self {
             NetTraitsRequestDestination::None => RequestDestination::_empty,
             NetTraitsRequestDestination::Audio => RequestDestination::Audio,
             NetTraitsRequestDestination::Document => RequestDestination::Document,
@@ -773,9 +774,9 @@ impl From<NetTraitsRequestDestination> for RequestDestination {
     }
 }
 
-impl From<RequestMode> for NetTraitsRequestMode {
-    fn from(mode: RequestMode) -> Self {
-        match mode {
+impl Convert<NetTraitsRequestMode> for RequestMode {
+    fn convert(self) -> NetTraitsRequestMode {
+        match self {
             RequestMode::Navigate => NetTraitsRequestMode::Navigate,
             RequestMode::Same_origin => NetTraitsRequestMode::SameOrigin,
             RequestMode::No_cors => NetTraitsRequestMode::NoCors,
@@ -784,9 +785,9 @@ impl From<RequestMode> for NetTraitsRequestMode {
     }
 }
 
-impl From<NetTraitsRequestMode> for RequestMode {
-    fn from(mode: NetTraitsRequestMode) -> Self {
-        match mode {
+impl Convert<RequestMode> for NetTraitsRequestMode {
+    fn convert(self) -> RequestMode {
+        match self {
             NetTraitsRequestMode::Navigate => RequestMode::Navigate,
             NetTraitsRequestMode::SameOrigin => RequestMode::Same_origin,
             NetTraitsRequestMode::NoCors => RequestMode::No_cors,
@@ -798,9 +799,9 @@ impl From<NetTraitsRequestMode> for RequestMode {
     }
 }
 
-impl From<ReferrerPolicy> for MsgReferrerPolicy {
-    fn from(policy: ReferrerPolicy) -> Self {
-        match policy {
+impl Convert<MsgReferrerPolicy> for ReferrerPolicy {
+    fn convert(self) -> MsgReferrerPolicy {
+        match self {
             ReferrerPolicy::_empty => MsgReferrerPolicy::EmptyString,
             ReferrerPolicy::No_referrer => MsgReferrerPolicy::NoReferrer,
             ReferrerPolicy::No_referrer_when_downgrade => {
@@ -818,9 +819,9 @@ impl From<ReferrerPolicy> for MsgReferrerPolicy {
     }
 }
 
-impl From<MsgReferrerPolicy> for ReferrerPolicy {
-    fn from(policy: MsgReferrerPolicy) -> Self {
-        match policy {
+impl Convert<ReferrerPolicy> for MsgReferrerPolicy {
+    fn convert(self) -> ReferrerPolicy {
+        match self {
             MsgReferrerPolicy::EmptyString => ReferrerPolicy::_empty,
             MsgReferrerPolicy::NoReferrer => ReferrerPolicy::No_referrer,
             MsgReferrerPolicy::NoReferrerWhenDowngrade => {
@@ -838,9 +839,9 @@ impl From<MsgReferrerPolicy> for ReferrerPolicy {
     }
 }
 
-impl From<RequestRedirect> for NetTraitsRequestRedirect {
-    fn from(redirect: RequestRedirect) -> Self {
-        match redirect {
+impl Convert<NetTraitsRequestRedirect> for RequestRedirect {
+    fn convert(self) -> NetTraitsRequestRedirect {
+        match self {
             RequestRedirect::Follow => NetTraitsRequestRedirect::Follow,
             RequestRedirect::Error => NetTraitsRequestRedirect::Error,
             RequestRedirect::Manual => NetTraitsRequestRedirect::Manual,
@@ -848,9 +849,9 @@ impl From<RequestRedirect> for NetTraitsRequestRedirect {
     }
 }
 
-impl From<NetTraitsRequestRedirect> for RequestRedirect {
-    fn from(redirect: NetTraitsRequestRedirect) -> Self {
-        match redirect {
+impl Convert<RequestRedirect> for NetTraitsRequestRedirect {
+    fn convert(self) -> RequestRedirect {
+        match self {
             NetTraitsRequestRedirect::Follow => RequestRedirect::Follow,
             NetTraitsRequestRedirect::Error => RequestRedirect::Error,
             NetTraitsRequestRedirect::Manual => RequestRedirect::Manual,

--- a/components/script/dom/rtcdatachannel.rs
+++ b/components/script/dom/rtcdatachannel.rs
@@ -16,6 +16,7 @@ use servo_media::webrtc::{
     DataChannelId, DataChannelInit, DataChannelMessage, DataChannelState, WebRtcError,
 };
 
+use crate::conversions::Convert;
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::RTCDataChannelBinding::{
     RTCDataChannelInit, RTCDataChannelMethods, RTCDataChannelState,
@@ -61,7 +62,7 @@ impl RTCDataChannel {
         options: &RTCDataChannelInit,
         servo_media_id: Option<DataChannelId>,
     ) -> RTCDataChannel {
-        let mut init: DataChannelInit = options.into();
+        let mut init: DataChannelInit = options.convert();
         init.label = label.to_string();
 
         let controller = peer_connection.get_webrtc_controller().borrow();
@@ -215,7 +216,7 @@ impl RTCDataChannel {
             );
             event.upcast::<Event>().fire(self.upcast(), can_gc);
         };
-        self.ready_state.set(state.into());
+        self.ready_state.set(state.convert());
     }
 
     fn send(&self, source: &SendSource) -> Fallible<()> {
@@ -364,23 +365,23 @@ impl RTCDataChannelMethods<crate::DomTypeHolder> for RTCDataChannel {
     }
 }
 
-impl From<&RTCDataChannelInit> for DataChannelInit {
-    fn from(init: &RTCDataChannelInit) -> DataChannelInit {
+impl Convert<DataChannelInit> for &RTCDataChannelInit {
+    fn convert(self) -> DataChannelInit {
         DataChannelInit {
             label: String::new(),
-            id: init.id,
-            max_packet_life_time: init.maxPacketLifeTime,
-            max_retransmits: init.maxRetransmits,
-            negotiated: init.negotiated,
-            ordered: init.ordered,
-            protocol: init.protocol.to_string(),
+            id: self.id,
+            max_packet_life_time: self.maxPacketLifeTime,
+            max_retransmits: self.maxRetransmits,
+            negotiated: self.negotiated,
+            ordered: self.ordered,
+            protocol: self.protocol.to_string(),
         }
     }
 }
 
-impl From<DataChannelState> for RTCDataChannelState {
-    fn from(state: DataChannelState) -> RTCDataChannelState {
-        match state {
+impl Convert<RTCDataChannelState> for DataChannelState {
+    fn convert(self) -> RTCDataChannelState {
+        match self {
             DataChannelState::Connecting | DataChannelState::__Unknown(_) => {
                 RTCDataChannelState::Connecting
             },

--- a/components/script/dom/testrunner.rs
+++ b/components/script/dom/testrunner.rs
@@ -7,8 +7,9 @@ use dom_struct::dom_struct;
 use ipc_channel::ipc::IpcSender;
 use profile_traits::ipc;
 
+use crate::conversions::Convert;
 use crate::dom::bindings::codegen::Bindings::TestRunnerBinding::TestRunnerMethods;
-use crate::dom::bindings::error::{Error, ErrorResult};
+use crate::dom::bindings::error::ErrorResult;
 use crate::dom::bindings::reflector::{reflect_dom_object, DomObject, Reflector};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
@@ -46,7 +47,7 @@ impl TestRunnerMethods<crate::DomTypeHolder> for TestRunner {
             .unwrap();
         match receiver.recv().unwrap() {
             Ok(()) => Ok(()),
-            Err(error) => Err(Error::from(error)),
+            Err(error) => Err(error.convert()),
         }
     }
 }

--- a/components/script/dom/webgpu/gpubindgroup.rs
+++ b/components/script/dom/webgpu/gpubindgroup.rs
@@ -8,6 +8,7 @@ use dom_struct::dom_struct;
 use webgpu::wgc::binding_model::BindGroupDescriptor;
 use webgpu::{WebGPU, WebGPUBindGroup, WebGPUDevice, WebGPURequest};
 
+use crate::conversions::Convert;
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
     GPUBindGroupDescriptor, GPUBindGroupMethods,
@@ -81,11 +82,11 @@ impl GPUBindGroup {
         let entries = descriptor
             .entries
             .iter()
-            .map(|bind| bind.into())
+            .map(|bind| bind.convert())
             .collect::<Vec<_>>();
 
         let desc = BindGroupDescriptor {
-            label: (&descriptor.parent).into(),
+            label: (&descriptor.parent).convert(),
             layout: descriptor.layout.id().0,
             entries: Cow::Owned(entries),
         };

--- a/components/script/dom/webgpu/gpubindgrouplayout.rs
+++ b/components/script/dom/webgpu/gpubindgrouplayout.rs
@@ -8,6 +8,7 @@ use dom_struct::dom_struct;
 use webgpu::wgc::binding_model::BindGroupLayoutDescriptor;
 use webgpu::{WebGPU, WebGPUBindGroupLayout, WebGPURequest};
 
+use crate::conversions::Convert;
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
     GPUBindGroupLayoutDescriptor, GPUBindGroupLayoutMethods,
@@ -80,7 +81,7 @@ impl GPUBindGroupLayout {
 
         let desc = match entries {
             Ok(entries) => Some(BindGroupLayoutDescriptor {
-                label: (&descriptor.parent).into(),
+                label: (&descriptor.parent).convert(),
                 entries: Cow::Owned(entries),
             }),
             Err(error) => {

--- a/components/script/dom/webgpu/gpubuffer.rs
+++ b/components/script/dom/webgpu/gpubuffer.rs
@@ -12,6 +12,7 @@ use js::typedarray::ArrayBuffer;
 use webgpu::wgc::device::HostMap;
 use webgpu::{wgt, Mapping, WebGPU, WebGPUBuffer, WebGPURequest, WebGPUResponse};
 
+use crate::conversions::Convert;
 use crate::dom::bindings::buffer_source::DataBlock;
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
@@ -136,7 +137,7 @@ impl GPUBuffer {
         descriptor: &GPUBufferDescriptor,
     ) -> Fallible<DomRoot<GPUBuffer>> {
         let desc = wgt::BufferDescriptor {
-            label: (&descriptor.parent).into(),
+            label: (&descriptor.parent).convert(),
             size: descriptor.size as wgt::BufferAddress,
             usage: wgt::BufferUsages::from_bits_retain(descriptor.usage),
             mapped_at_creation: descriptor.mappedAtCreation,

--- a/components/script/dom/webgpu/gpucanvascontext.rs
+++ b/components/script/dom/webgpu/gpucanvascontext.rs
@@ -20,6 +20,7 @@ use webrender_api::ImageKey;
 
 use super::gpuconvert::convert_texture_descriptor;
 use super::gputexture::GPUTexture;
+use crate::conversions::Convert;
 use crate::dom::bindings::codegen::Bindings::GPUCanvasContextBinding::GPUCanvasContextMethods;
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::GPUTexture_Binding::GPUTextureMethods;
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
@@ -196,7 +197,7 @@ impl GPUCanvasContext {
             drawing_buffer.config = Some(ContextConfiguration {
                 device_id: configuration.device.id().0,
                 queue_id: configuration.device.queue_id().0,
-                format: configuration.format.into(),
+                format: configuration.format.convert(),
                 is_opaque: matches!(configuration.alphaMode, GPUCanvasAlphaMode::Opaque),
             });
         } else {

--- a/components/script/dom/webgpu/gpucommandencoder.rs
+++ b/components/script/dom/webgpu/gpucommandencoder.rs
@@ -9,6 +9,7 @@ use webgpu::{
     WebGPURenderPass, WebGPURequest,
 };
 
+use crate::conversions::{Convert, TryConvert};
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
     GPUCommandBufferDescriptor, GPUCommandEncoderDescriptor, GPUCommandEncoderMethods,
@@ -93,7 +94,7 @@ impl GPUCommandEncoder {
                 device_id: device.id().0,
                 command_encoder_id,
                 desc: wgt::CommandEncoderDescriptor {
-                    label: (&descriptor.parent).into(),
+                    label: (&descriptor.parent).convert(),
                 },
             })
             .expect("Failed to create WebGPU command encoder");
@@ -131,7 +132,7 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
         if let Err(e) = self.channel.0.send(WebGPURequest::BeginComputePass {
             command_encoder_id: self.id().0,
             compute_pass_id,
-            label: (&descriptor.parent).into(),
+            label: (&descriptor.parent).convert(),
             device_id: self.device.id().0,
         }) {
             warn!("Failed to send WebGPURequest::BeginComputePass {e:?}");
@@ -179,7 +180,7 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
                     clear_value: color
                         .clearValue
                         .as_ref()
-                        .map(|color| (color).try_into())
+                        .map(|color| (color).try_convert())
                         .transpose()?
                         .unwrap_or_default(),
                     read_only: false,
@@ -196,7 +197,7 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
         if let Err(e) = self.channel.0.send(WebGPURequest::BeginRenderPass {
             command_encoder_id: self.id().0,
             render_pass_id,
-            label: (&descriptor.parent).into(),
+            label: (&descriptor.parent).convert(),
             depth_stencil_attachment,
             color_attachments,
             device_id: self.device.id().0,
@@ -246,9 +247,9 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
             .0
             .send(WebGPURequest::CopyBufferToTexture {
                 command_encoder_id: self.encoder.0,
-                source: source.into(),
-                destination: destination.try_into()?,
-                copy_size: (&copy_size).try_into()?,
+                source: source.convert(),
+                destination: destination.try_convert()?,
+                copy_size: (&copy_size).try_convert()?,
             })
             .expect("Failed to send CopyBufferToTexture");
 
@@ -266,9 +267,9 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
             .0
             .send(WebGPURequest::CopyTextureToBuffer {
                 command_encoder_id: self.encoder.0,
-                source: source.try_into()?,
-                destination: destination.into(),
-                copy_size: (&copy_size).try_into()?,
+                source: source.try_convert()?,
+                destination: destination.convert(),
+                copy_size: (&copy_size).try_convert()?,
             })
             .expect("Failed to send CopyTextureToBuffer");
 
@@ -286,9 +287,9 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
             .0
             .send(WebGPURequest::CopyTextureToTexture {
                 command_encoder_id: self.encoder.0,
-                source: source.try_into()?,
-                destination: destination.try_into()?,
-                copy_size: (&copy_size).try_into()?,
+                source: source.try_convert()?,
+                destination: destination.try_convert()?,
+                copy_size: (&copy_size).try_convert()?,
             })
             .expect("Failed to send CopyTextureToTexture");
 
@@ -303,7 +304,7 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
                 command_encoder_id: self.encoder.0,
                 device_id: self.device.id().0,
                 desc: wgt::CommandBufferDescriptor {
-                    label: (&descriptor.parent).into(),
+                    label: (&descriptor.parent).convert(),
                 },
             })
             .expect("Failed to send Finish");

--- a/components/script/dom/webgpu/gpucomputepipeline.rs
+++ b/components/script/dom/webgpu/gpucomputepipeline.rs
@@ -7,6 +7,7 @@ use ipc_channel::ipc::IpcSender;
 use webgpu::wgc::pipeline::ComputePipelineDescriptor;
 use webgpu::{WebGPU, WebGPUBindGroupLayout, WebGPUComputePipeline, WebGPURequest, WebGPUResponse};
 
+use crate::conversions::Convert;
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
     GPUComputePipelineDescriptor, GPUComputePipelineMethods,
@@ -79,9 +80,9 @@ impl GPUComputePipeline {
         let pipeline_layout = device.get_pipeline_layout_data(&descriptor.parent.layout);
 
         let desc = ComputePipelineDescriptor {
-            label: (&descriptor.parent.parent).into(),
+            label: (&descriptor.parent.parent).convert(),
             layout: pipeline_layout.explicit(),
-            stage: (&descriptor.compute).into(),
+            stage: (&descriptor.compute).convert(),
             cache: None,
         };
 

--- a/components/script/dom/webgpu/gpuconvert.rs
+++ b/components/script/dom/webgpu/gpuconvert.rs
@@ -11,6 +11,7 @@ use webgpu::wgc::pipeline::ProgrammableStageDescriptor;
 use webgpu::wgc::resource::TextureDescriptor;
 use webgpu::wgt::{self, AstcBlock, AstcChannel};
 
+use crate::conversions::{Convert, TryConvert};
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
     GPUAddressMode, GPUBindGroupEntry, GPUBindGroupLayoutEntry, GPUBindingResource,
     GPUBlendComponent, GPUBlendFactor, GPUBlendOperation, GPUBufferBindingType, GPUColor,
@@ -24,9 +25,9 @@ use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
 use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::types::GPUDevice;
 
-impl From<GPUTextureFormat> for wgt::TextureFormat {
-    fn from(format: GPUTextureFormat) -> Self {
-        match format {
+impl Convert<wgt::TextureFormat> for GPUTextureFormat {
+    fn convert(self) -> wgt::TextureFormat {
+        match self {
             GPUTextureFormat::R8unorm => wgt::TextureFormat::R8Unorm,
             GPUTextureFormat::R8snorm => wgt::TextureFormat::R8Snorm,
             GPUTextureFormat::R8uint => wgt::TextureFormat::R8Uint,
@@ -210,11 +211,11 @@ impl From<GPUTextureFormat> for wgt::TextureFormat {
     }
 }
 
-impl TryFrom<&GPUExtent3D> for wgt::Extent3d {
+impl TryConvert<wgt::Extent3d> for &GPUExtent3D {
     type Error = Error;
 
-    fn try_from(size: &GPUExtent3D) -> Result<Self, Self::Error> {
-        match *size {
+    fn try_convert(self) -> Result<wgt::Extent3d, Self::Error> {
+        match *self {
             GPUExtent3D::GPUExtent3DDict(ref dict) => Ok(wgt::Extent3d {
                 width: dict.width,
                 height: dict.height,
@@ -238,19 +239,19 @@ impl TryFrom<&GPUExtent3D> for wgt::Extent3d {
     }
 }
 
-impl From<&GPUImageDataLayout> for wgt::ImageDataLayout {
-    fn from(data_layout: &GPUImageDataLayout) -> Self {
+impl Convert<wgt::ImageDataLayout> for &GPUImageDataLayout {
+    fn convert(self) -> wgt::ImageDataLayout {
         wgt::ImageDataLayout {
-            offset: data_layout.offset as wgt::BufferAddress,
-            bytes_per_row: data_layout.bytesPerRow,
-            rows_per_image: data_layout.rowsPerImage,
+            offset: self.offset as wgt::BufferAddress,
+            bytes_per_row: self.bytesPerRow,
+            rows_per_image: self.rowsPerImage,
         }
     }
 }
 
-impl From<GPUVertexFormat> for wgt::VertexFormat {
-    fn from(format: GPUVertexFormat) -> Self {
-        match format {
+impl Convert<wgt::VertexFormat> for GPUVertexFormat {
+    fn convert(self) -> wgt::VertexFormat {
+        match self {
             GPUVertexFormat::Uint8x2 => wgt::VertexFormat::Uint8x2,
             GPUVertexFormat::Uint8x4 => wgt::VertexFormat::Uint8x4,
             GPUVertexFormat::Sint8x2 => wgt::VertexFormat::Sint8x2,
@@ -285,34 +286,34 @@ impl From<GPUVertexFormat> for wgt::VertexFormat {
     }
 }
 
-impl From<&GPUPrimitiveState> for wgt::PrimitiveState {
-    fn from(primitive_state: &GPUPrimitiveState) -> Self {
+impl Convert<wgt::PrimitiveState> for &GPUPrimitiveState {
+    fn convert(self) -> wgt::PrimitiveState {
         wgt::PrimitiveState {
-            topology: wgt::PrimitiveTopology::from(&primitive_state.topology),
-            strip_index_format: primitive_state.stripIndexFormat.map(|index_format| {
-                match index_format {
+            topology: self.topology.convert(),
+            strip_index_format: self
+                .stripIndexFormat
+                .map(|index_format| match index_format {
                     GPUIndexFormat::Uint16 => wgt::IndexFormat::Uint16,
                     GPUIndexFormat::Uint32 => wgt::IndexFormat::Uint32,
-                }
-            }),
-            front_face: match primitive_state.frontFace {
+                }),
+            front_face: match self.frontFace {
                 GPUFrontFace::Ccw => wgt::FrontFace::Ccw,
                 GPUFrontFace::Cw => wgt::FrontFace::Cw,
             },
-            cull_mode: match primitive_state.cullMode {
+            cull_mode: match self.cullMode {
                 GPUCullMode::None => None,
                 GPUCullMode::Front => Some(wgt::Face::Front),
                 GPUCullMode::Back => Some(wgt::Face::Back),
             },
-            unclipped_depth: primitive_state.clampDepth,
+            unclipped_depth: self.clampDepth,
             ..Default::default()
         }
     }
 }
 
-impl From<&GPUPrimitiveTopology> for wgt::PrimitiveTopology {
-    fn from(primitive_topology: &GPUPrimitiveTopology) -> Self {
-        match primitive_topology {
+impl Convert<wgt::PrimitiveTopology> for &GPUPrimitiveTopology {
+    fn convert(self) -> wgt::PrimitiveTopology {
+        match self {
             GPUPrimitiveTopology::Point_list => wgt::PrimitiveTopology::PointList,
             GPUPrimitiveTopology::Line_list => wgt::PrimitiveTopology::LineList,
             GPUPrimitiveTopology::Line_strip => wgt::PrimitiveTopology::LineStrip,
@@ -322,9 +323,9 @@ impl From<&GPUPrimitiveTopology> for wgt::PrimitiveTopology {
     }
 }
 
-impl From<GPUAddressMode> for wgt::AddressMode {
-    fn from(address_mode: GPUAddressMode) -> Self {
-        match address_mode {
+impl Convert<wgt::AddressMode> for GPUAddressMode {
+    fn convert(self) -> wgt::AddressMode {
+        match self {
             GPUAddressMode::Clamp_to_edge => wgt::AddressMode::ClampToEdge,
             GPUAddressMode::Repeat => wgt::AddressMode::Repeat,
             GPUAddressMode::Mirror_repeat => wgt::AddressMode::MirrorRepeat,
@@ -332,18 +333,18 @@ impl From<GPUAddressMode> for wgt::AddressMode {
     }
 }
 
-impl From<GPUFilterMode> for wgt::FilterMode {
-    fn from(filter_mode: GPUFilterMode) -> Self {
-        match filter_mode {
+impl Convert<wgt::FilterMode> for GPUFilterMode {
+    fn convert(self) -> wgt::FilterMode {
+        match self {
             GPUFilterMode::Nearest => wgt::FilterMode::Nearest,
             GPUFilterMode::Linear => wgt::FilterMode::Linear,
         }
     }
 }
 
-impl From<GPUTextureViewDimension> for wgt::TextureViewDimension {
-    fn from(view_dimension: GPUTextureViewDimension) -> Self {
-        match view_dimension {
+impl Convert<wgt::TextureViewDimension> for GPUTextureViewDimension {
+    fn convert(self) -> wgt::TextureViewDimension {
+        match self {
             GPUTextureViewDimension::_1d => wgt::TextureViewDimension::D1,
             GPUTextureViewDimension::_2d => wgt::TextureViewDimension::D2,
             GPUTextureViewDimension::_2d_array => wgt::TextureViewDimension::D2Array,
@@ -354,9 +355,9 @@ impl From<GPUTextureViewDimension> for wgt::TextureViewDimension {
     }
 }
 
-impl From<GPUCompareFunction> for wgt::CompareFunction {
-    fn from(compare: GPUCompareFunction) -> Self {
-        match compare {
+impl Convert<wgt::CompareFunction> for GPUCompareFunction {
+    fn convert(self) -> wgt::CompareFunction {
+        match self {
             GPUCompareFunction::Never => wgt::CompareFunction::Never,
             GPUCompareFunction::Less => wgt::CompareFunction::Less,
             GPUCompareFunction::Equal => wgt::CompareFunction::Equal,
@@ -369,9 +370,9 @@ impl From<GPUCompareFunction> for wgt::CompareFunction {
     }
 }
 
-impl From<&GPUBlendFactor> for wgt::BlendFactor {
-    fn from(factor: &GPUBlendFactor) -> Self {
-        match factor {
+impl Convert<wgt::BlendFactor> for &GPUBlendFactor {
+    fn convert(self) -> wgt::BlendFactor {
+        match self {
             GPUBlendFactor::Zero => wgt::BlendFactor::Zero,
             GPUBlendFactor::One => wgt::BlendFactor::One,
             GPUBlendFactor::Src => wgt::BlendFactor::Src,
@@ -389,12 +390,12 @@ impl From<&GPUBlendFactor> for wgt::BlendFactor {
     }
 }
 
-impl From<&GPUBlendComponent> for wgt::BlendComponent {
-    fn from(blend_component: &GPUBlendComponent) -> Self {
+impl Convert<wgt::BlendComponent> for &GPUBlendComponent {
+    fn convert(self) -> wgt::BlendComponent {
         wgt::BlendComponent {
-            src_factor: wgt::BlendFactor::from(&blend_component.srcFactor),
-            dst_factor: wgt::BlendFactor::from(&blend_component.dstFactor),
-            operation: match blend_component.operation {
+            src_factor: self.srcFactor.convert(),
+            dst_factor: self.dstFactor.convert(),
+            operation: match self.operation {
                 GPUBlendOperation::Add => wgt::BlendOperation::Add,
                 GPUBlendOperation::Subtract => wgt::BlendOperation::Subtract,
                 GPUBlendOperation::Reverse_subtract => wgt::BlendOperation::ReverseSubtract,
@@ -421,9 +422,9 @@ pub fn convert_store_op(op: Option<GPUStoreOp>) -> wgpu_com::StoreOp {
     }
 }
 
-impl From<GPUStencilOperation> for wgt::StencilOperation {
-    fn from(operation: GPUStencilOperation) -> Self {
-        match operation {
+impl Convert<wgt::StencilOperation> for GPUStencilOperation {
+    fn convert(self) -> wgt::StencilOperation {
+        match self {
             GPUStencilOperation::Keep => wgt::StencilOperation::Keep,
             GPUStencilOperation::Zero => wgt::StencilOperation::Zero,
             GPUStencilOperation::Replace => wgt::StencilOperation::Replace,
@@ -436,20 +437,20 @@ impl From<GPUStencilOperation> for wgt::StencilOperation {
     }
 }
 
-impl From<&GPUImageCopyBuffer> for wgpu_com::ImageCopyBuffer {
-    fn from(ic_buffer: &GPUImageCopyBuffer) -> Self {
+impl Convert<wgpu_com::ImageCopyBuffer> for &GPUImageCopyBuffer {
+    fn convert(self) -> wgpu_com::ImageCopyBuffer {
         wgpu_com::ImageCopyBuffer {
-            buffer: ic_buffer.buffer.id().0,
-            layout: wgt::ImageDataLayout::from(&ic_buffer.parent),
+            buffer: self.buffer.id().0,
+            layout: self.parent.convert(),
         }
     }
 }
 
-impl TryFrom<&GPUOrigin3D> for wgt::Origin3d {
+impl TryConvert<wgt::Origin3d> for &GPUOrigin3D {
     type Error = Error;
 
-    fn try_from(origin: &GPUOrigin3D) -> Result<Self, Self::Error> {
-        match origin {
+    fn try_convert(self) -> Result<wgt::Origin3d, Self::Error> {
+        match self {
             GPUOrigin3D::RangeEnforcedUnsignedLongSequence(v) => {
                 // https://gpuweb.github.io/gpuweb/#abstract-opdef-validate-gpuorigin3d-shape
                 if v.len() > 3 {
@@ -473,20 +474,20 @@ impl TryFrom<&GPUOrigin3D> for wgt::Origin3d {
     }
 }
 
-impl TryFrom<&GPUImageCopyTexture> for wgpu_com::ImageCopyTexture {
+impl TryConvert<wgpu_com::ImageCopyTexture> for &GPUImageCopyTexture {
     type Error = Error;
 
-    fn try_from(ic_texture: &GPUImageCopyTexture) -> Result<Self, Self::Error> {
+    fn try_convert(self) -> Result<wgpu_com::ImageCopyTexture, Self::Error> {
         Ok(wgpu_com::ImageCopyTexture {
-            texture: ic_texture.texture.id().0,
-            mip_level: ic_texture.mipLevel,
-            origin: ic_texture
+            texture: self.texture.id().0,
+            mip_level: self.mipLevel,
+            origin: self
                 .origin
                 .as_ref()
-                .map(wgt::Origin3d::try_from)
+                .map(TryConvert::<wgt::Origin3d>::try_convert)
                 .transpose()?
                 .unwrap_or_default(),
-            aspect: match ic_texture.aspect {
+            aspect: match self.aspect {
                 GPUTextureAspect::All => wgt::TextureAspect::All,
                 GPUTextureAspect::Stencil_only => wgt::TextureAspect::StencilOnly,
                 GPUTextureAspect::Depth_only => wgt::TextureAspect::DepthOnly,
@@ -495,12 +496,12 @@ impl TryFrom<&GPUImageCopyTexture> for wgpu_com::ImageCopyTexture {
     }
 }
 
-impl<'a> From<&GPUObjectDescriptorBase> for Option<Cow<'a, str>> {
-    fn from(val: &GPUObjectDescriptorBase) -> Self {
-        if val.label.is_empty() {
+impl<'a> Convert<Option<Cow<'a, str>>> for &GPUObjectDescriptorBase {
+    fn convert(self) -> Option<Cow<'a, str>> {
+        if self.label.is_empty() {
             None
         } else {
-            Some(Cow::Owned(val.label.to_string()))
+            Some(Cow::Owned(self.label.to_string()))
         }
     }
 }
@@ -541,7 +542,7 @@ pub fn convert_bind_group_layout_entry(
                 GPUStorageTextureAccess::Read_write => wgt::StorageTextureAccess::ReadWrite,
             },
             format: device.validate_texture_format_required_features(&storage.format)?,
-            view_dimension: storage.viewDimension.into(),
+            view_dimension: storage.viewDimension.convert(),
         })
     } else if let Some(texture) = &bgle.texture {
         Some(wgt::BindingType::Texture {
@@ -554,7 +555,7 @@ pub fn convert_bind_group_layout_entry(
                 GPUTextureSampleType::Sint => wgt::TextureSampleType::Sint,
                 GPUTextureSampleType::Uint => wgt::TextureSampleType::Uint,
             },
-            view_dimension: texture.viewDimension.into(),
+            view_dimension: texture.viewDimension.convert(),
             multisampled: texture.multisampled,
         })
     } else {
@@ -584,13 +585,13 @@ pub fn convert_texture_descriptor(
     descriptor: &GPUTextureDescriptor,
     device: &GPUDevice,
 ) -> Fallible<(TextureDescriptor<'static>, wgt::Extent3d)> {
-    let size = (&descriptor.size).try_into()?;
+    let size = (&descriptor.size).try_convert()?;
     let desc = TextureDescriptor {
-        label: (&descriptor.parent).into(),
+        label: (&descriptor.parent).convert(),
         size,
         mip_level_count: descriptor.mipLevelCount,
         sample_count: descriptor.sampleCount,
-        dimension: descriptor.dimension.into(),
+        dimension: descriptor.dimension.convert(),
         format: device.validate_texture_format_required_features(&descriptor.format)?,
         usage: wgt::TextureUsages::from_bits_retain(descriptor.usage),
         view_formats: descriptor
@@ -602,11 +603,11 @@ pub fn convert_texture_descriptor(
     Ok((desc, size))
 }
 
-impl TryFrom<&GPUColor> for wgt::Color {
+impl TryConvert<wgt::Color> for &GPUColor {
     type Error = Error;
 
-    fn try_from(color: &GPUColor) -> Result<Self, Self::Error> {
-        match color {
+    fn try_convert(self) -> Result<wgt::Color, Self::Error> {
+        match self {
             GPUColor::DoubleSequence(s) => {
                 // https://gpuweb.github.io/gpuweb/#abstract-opdef-validate-gpucolor-shape
                 if s.len() != 4 {
@@ -630,17 +631,16 @@ impl TryFrom<&GPUColor> for wgt::Color {
     }
 }
 
-impl<'a> From<&GPUProgrammableStage> for ProgrammableStageDescriptor<'a> {
-    fn from(stage: &GPUProgrammableStage) -> Self {
-        Self {
-            module: stage.module.id().0,
-            entry_point: stage
+impl<'a> Convert<ProgrammableStageDescriptor<'a>> for &GPUProgrammableStage {
+    fn convert(self) -> ProgrammableStageDescriptor<'a> {
+        ProgrammableStageDescriptor {
+            module: self.module.id().0,
+            entry_point: self
                 .entryPoint
                 .as_ref()
                 .map(|ep| Cow::Owned(ep.to_string())),
             constants: Cow::Owned(
-                stage
-                    .constants
+                self.constants
                     .as_ref()
                     .map(|records| records.iter().map(|(k, v)| (k.0.clone(), **v)).collect())
                     .unwrap_or_default(),
@@ -650,11 +650,11 @@ impl<'a> From<&GPUProgrammableStage> for ProgrammableStageDescriptor<'a> {
     }
 }
 
-impl From<&GPUBindGroupEntry> for BindGroupEntry<'_> {
-    fn from(entry: &GPUBindGroupEntry) -> Self {
-        Self {
-            binding: entry.binding,
-            resource: match entry.resource {
+impl<'a> Convert<BindGroupEntry<'a>> for &GPUBindGroupEntry {
+    fn convert(self) -> BindGroupEntry<'a> {
+        BindGroupEntry {
+            binding: self.binding,
+            resource: match self.resource {
                 GPUBindingResource::GPUSampler(ref s) => BindingResource::Sampler(s.id().0),
                 GPUBindingResource::GPUTextureView(ref t) => BindingResource::TextureView(t.id().0),
                 GPUBindingResource::GPUBufferBinding(ref b) => {
@@ -669,9 +669,9 @@ impl From<&GPUBindGroupEntry> for BindGroupEntry<'_> {
     }
 }
 
-impl From<GPUTextureDimension> for wgt::TextureDimension {
-    fn from(dimension: GPUTextureDimension) -> Self {
-        match dimension {
+impl Convert<wgt::TextureDimension> for GPUTextureDimension {
+    fn convert(self) -> wgt::TextureDimension {
+        match self {
             GPUTextureDimension::_1d => wgt::TextureDimension::D1,
             GPUTextureDimension::_2d => wgt::TextureDimension::D2,
             GPUTextureDimension::_3d => wgt::TextureDimension::D3,

--- a/components/script/dom/webgpu/gpudevice.rs
+++ b/components/script/dom/webgpu/gpudevice.rs
@@ -23,6 +23,7 @@ use super::gpu::AsyncWGPUListener;
 use super::gpudevicelostinfo::GPUDeviceLostInfo;
 use super::gpupipelineerror::GPUPipelineError;
 use super::gpusupportedlimits::GPUSupportedLimits;
+use crate::conversions::Convert;
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::EventBinding::EventInit;
 use crate::dom::bindings::codegen::Bindings::EventTargetBinding::EventTargetMethods;
@@ -215,7 +216,7 @@ impl GPUDevice {
         &self,
         format: &GPUTextureFormat,
     ) -> Fallible<TextureFormat> {
-        let texture_format: TextureFormat = (*format).into();
+        let texture_format: TextureFormat = (*format).convert();
         if self
             .features
             .wgpu_features()
@@ -258,11 +259,11 @@ impl GPUDevice {
         let pipeline_layout = self.get_pipeline_layout_data(&descriptor.parent.layout);
 
         let desc = wgpu_pipe::RenderPipelineDescriptor {
-            label: (&descriptor.parent.parent).into(),
+            label: (&descriptor.parent.parent).convert(),
             layout: pipeline_layout.explicit(),
             cache: None,
             vertex: wgpu_pipe::VertexState {
-                stage: (&descriptor.vertex.parent).into(),
+                stage: (&descriptor.vertex.parent).convert(),
                 buffers: Cow::Owned(
                     descriptor
                         .vertex
@@ -279,7 +280,7 @@ impl GPUDevice {
                                     .attributes
                                     .iter()
                                     .map(|att| wgt::VertexAttribute {
-                                        format: att.format.into(),
+                                        format: att.format.convert(),
                                         offset: att.offset,
                                         shader_location: att.shaderLocation,
                                     })
@@ -294,7 +295,7 @@ impl GPUDevice {
                 .as_ref()
                 .map(|stage| -> Fallible<wgpu_pipe::FragmentState> {
                     Ok(wgpu_pipe::FragmentState {
-                        stage: (&stage.parent).into(),
+                        stage: (&stage.parent).convert(),
                         targets: Cow::Owned(
                             stage
                                 .targets
@@ -309,8 +310,8 @@ impl GPUDevice {
                                                 ),
                                                 blend: state.blend.as_ref().map(|blend| {
                                                     wgt::BlendState {
-                                                        color: (&blend.color).into(),
-                                                        alpha: (&blend.alpha).into(),
+                                                        color: (&blend.color).convert(),
+                                                        alpha: (&blend.alpha).convert(),
                                                     }
                                                 }),
                                             })
@@ -321,7 +322,7 @@ impl GPUDevice {
                     })
                 })
                 .transpose()?,
-            primitive: (&descriptor.primitive).into(),
+            primitive: (&descriptor.primitive).convert(),
             depth_stencil: descriptor
                 .depthStencil
                 .as_ref()
@@ -330,20 +331,20 @@ impl GPUDevice {
                         .map(|format| wgt::DepthStencilState {
                             format,
                             depth_write_enabled: dss_desc.depthWriteEnabled,
-                            depth_compare: dss_desc.depthCompare.into(),
+                            depth_compare: dss_desc.depthCompare.convert(),
                             stencil: wgt::StencilState {
                                 front: wgt::StencilFaceState {
-                                    compare: dss_desc.stencilFront.compare.into(),
+                                    compare: dss_desc.stencilFront.compare.convert(),
 
-                                    fail_op: dss_desc.stencilFront.failOp.into(),
-                                    depth_fail_op: dss_desc.stencilFront.depthFailOp.into(),
-                                    pass_op: dss_desc.stencilFront.passOp.into(),
+                                    fail_op: dss_desc.stencilFront.failOp.convert(),
+                                    depth_fail_op: dss_desc.stencilFront.depthFailOp.convert(),
+                                    pass_op: dss_desc.stencilFront.passOp.convert(),
                                 },
                                 back: wgt::StencilFaceState {
-                                    compare: dss_desc.stencilBack.compare.into(),
-                                    fail_op: dss_desc.stencilBack.failOp.into(),
-                                    depth_fail_op: dss_desc.stencilBack.depthFailOp.into(),
-                                    pass_op: dss_desc.stencilBack.passOp.into(),
+                                    compare: dss_desc.stencilBack.compare.convert(),
+                                    fail_op: dss_desc.stencilBack.failOp.convert(),
+                                    depth_fail_op: dss_desc.stencilBack.depthFailOp.convert(),
+                                    pass_op: dss_desc.stencilBack.passOp.convert(),
                                 },
                                 read_mask: dss_desc.stencilReadMask,
                                 write_mask: dss_desc.stencilWriteMask,

--- a/components/script/dom/webgpu/gpuerror.rs
+++ b/components/script/dom/webgpu/gpuerror.rs
@@ -6,6 +6,7 @@ use dom_struct::dom_struct;
 use js::rust::HandleObject;
 use webgpu::{Error, ErrorFilter};
 
+use crate::conversions::Convert;
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{GPUErrorFilter, GPUErrorMethods};
 use crate::dom::bindings::reflector::{reflect_dom_object_with_proto, Reflector};
 use crate::dom::bindings::root::DomRoot;
@@ -79,9 +80,9 @@ impl GPUErrorMethods<crate::DomTypeHolder> for GPUError {
     }
 }
 
-impl From<ErrorFilter> for GPUErrorFilter {
-    fn from(filter: ErrorFilter) -> Self {
-        match filter {
+impl Convert<GPUErrorFilter> for ErrorFilter {
+    fn convert(self) -> GPUErrorFilter {
+        match self {
             ErrorFilter::Validation => GPUErrorFilter::Validation,
             ErrorFilter::OutOfMemory => GPUErrorFilter::Out_of_memory,
             ErrorFilter::Internal => GPUErrorFilter::Internal,

--- a/components/script/dom/webgpu/gpupipelinelayout.rs
+++ b/components/script/dom/webgpu/gpupipelinelayout.rs
@@ -8,6 +8,7 @@ use dom_struct::dom_struct;
 use webgpu::wgc::binding_model::PipelineLayoutDescriptor;
 use webgpu::{WebGPU, WebGPUBindGroupLayout, WebGPUPipelineLayout, WebGPURequest};
 
+use crate::conversions::Convert;
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
     GPUPipelineLayoutDescriptor, GPUPipelineLayoutMethods,
@@ -87,7 +88,7 @@ impl GPUPipelineLayout {
             .collect::<Vec<_>>();
 
         let desc = PipelineLayoutDescriptor {
-            label: (&descriptor.parent).into(),
+            label: (&descriptor.parent).convert(),
             bind_group_layouts: Cow::Owned(bgls.iter().map(|l| l.0).collect::<Vec<_>>()),
             push_constant_ranges: Cow::Owned(vec![]),
         };

--- a/components/script/dom/webgpu/gpuqueue.rs
+++ b/components/script/dom/webgpu/gpuqueue.rs
@@ -9,6 +9,7 @@ use ipc_channel::ipc::IpcSharedMemory;
 use webgpu::{wgt, WebGPU, WebGPUQueue, WebGPURequest, WebGPUResponse};
 
 use super::gpu::{response_async, AsyncWGPUListener};
+use crate::conversions::{Convert, TryConvert};
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
     GPUExtent3D, GPUImageCopyTexture, GPUImageDataLayout, GPUQueueMethods, GPUSize64,
@@ -162,9 +163,9 @@ impl GPUQueueMethods<crate::DomTypeHolder> for GPUQueue {
             return Err(Error::Operation);
         }
 
-        let texture_cv = destination.try_into()?;
-        let texture_layout = data_layout.into();
-        let write_size = (&size).try_into()?;
+        let texture_cv = destination.try_convert()?;
+        let texture_layout = data_layout.convert();
+        let write_size = (&size).try_convert()?;
         let final_data = IpcSharedMemory::from_bytes(&bytes);
 
         if let Err(e) = self.channel.0.send(WebGPURequest::WriteTexture {

--- a/components/script/dom/webgpu/gpurenderbundleencoder.rs
+++ b/components/script/dom/webgpu/gpurenderbundleencoder.rs
@@ -10,6 +10,7 @@ use webgpu::wgc::command::{
 };
 use webgpu::{wgt, WebGPU, WebGPURenderBundle, WebGPURequest};
 
+use crate::conversions::Convert;
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
     GPUIndexFormat, GPURenderBundleDescriptor, GPURenderBundleEncoderDescriptor,
@@ -81,7 +82,7 @@ impl GPURenderBundleEncoder {
         descriptor: &GPURenderBundleEncoderDescriptor,
     ) -> Fallible<DomRoot<GPURenderBundleEncoder>> {
         let desc = RenderBundleEncoderDescriptor {
-            label: (&descriptor.parent.parent).into(),
+            label: (&descriptor.parent.parent).convert(),
             color_formats: Cow::Owned(
                 descriptor
                     .parent
@@ -252,7 +253,7 @@ impl GPURenderBundleEncoderMethods<crate::DomTypeHolder> for GPURenderBundleEnco
     /// <https://gpuweb.github.io/gpuweb/#dom-gpurenderbundleencoder-finish>
     fn Finish(&self, descriptor: &GPURenderBundleDescriptor) -> DomRoot<GPURenderBundle> {
         let desc = wgt::RenderBundleDescriptor {
-            label: (&descriptor.parent).into(),
+            label: (&descriptor.parent).convert(),
         };
         let encoder = self.render_bundle_encoder.borrow_mut().take().unwrap();
         let render_bundle_id = self.global().wgpu_id_hub().create_render_bundle_id();

--- a/components/script/dom/webgpu/gpurenderpassencoder.rs
+++ b/components/script/dom/webgpu/gpurenderpassencoder.rs
@@ -5,6 +5,7 @@
 use dom_struct::dom_struct;
 use webgpu::{wgt, RenderCommand, WebGPU, WebGPURenderPass, WebGPURequest};
 
+use crate::conversions::TryConvert;
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
     GPUColor, GPUIndexFormat, GPURenderPassEncoderMethods,
@@ -130,7 +131,7 @@ impl GPURenderPassEncoderMethods<crate::DomTypeHolder> for GPURenderPassEncoder 
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpurenderpassencoder-setblendcolor>
     fn SetBlendConstant(&self, color: GPUColor) -> Fallible<()> {
-        self.send_render_command(RenderCommand::SetBlendConstant((&color).try_into()?));
+        self.send_render_command(RenderCommand::SetBlendConstant((&color).try_convert()?));
         Ok(())
     }
 

--- a/components/script/dom/webgpu/gpusampler.rs
+++ b/components/script/dom/webgpu/gpusampler.rs
@@ -6,6 +6,7 @@ use dom_struct::dom_struct;
 use webgpu::wgc::resource::SamplerDescriptor;
 use webgpu::{WebGPU, WebGPUDevice, WebGPURequest, WebGPUSampler};
 
+use crate::conversions::Convert;
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
     GPUSamplerDescriptor, GPUSamplerMethods,
@@ -79,18 +80,18 @@ impl GPUSampler {
         let sampler_id = device.global().wgpu_id_hub().create_sampler_id();
         let compare_enable = descriptor.compare.is_some();
         let desc = SamplerDescriptor {
-            label: (&descriptor.parent).into(),
+            label: (&descriptor.parent).convert(),
             address_modes: [
-                descriptor.addressModeU.into(),
-                descriptor.addressModeV.into(),
-                descriptor.addressModeW.into(),
+                descriptor.addressModeU.convert(),
+                descriptor.addressModeV.convert(),
+                descriptor.addressModeW.convert(),
             ],
-            mag_filter: descriptor.magFilter.into(),
-            min_filter: descriptor.minFilter.into(),
-            mipmap_filter: descriptor.mipmapFilter.into(),
+            mag_filter: descriptor.magFilter.convert(),
+            min_filter: descriptor.minFilter.convert(),
+            mipmap_filter: descriptor.mipmapFilter.convert(),
             lod_min_clamp: *descriptor.lodMinClamp,
             lod_max_clamp: *descriptor.lodMaxClamp,
-            compare: descriptor.compare.map(Into::into),
+            compare: descriptor.compare.map(Convert::convert),
             anisotropy_clamp: 1,
             border_color: None,
         };

--- a/components/script/dom/webgpu/gputexture.rs
+++ b/components/script/dom/webgpu/gputexture.rs
@@ -9,6 +9,7 @@ use webgpu::wgc::resource;
 use webgpu::{wgt, WebGPU, WebGPURequest, WebGPUTexture, WebGPUTextureView};
 
 use super::gpuconvert::convert_texture_descriptor;
+use crate::conversions::Convert;
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
     GPUTextureAspect, GPUTextureDescriptor, GPUTextureDimension, GPUTextureFormat,
@@ -180,12 +181,12 @@ impl GPUTextureMethods<crate::DomTypeHolder> for GPUTexture {
             !matches!(descriptor.arrayLayerCount, Some(0))
         {
             Some(resource::TextureViewDescriptor {
-                label: (&descriptor.parent).into(),
+                label: (&descriptor.parent).convert(),
                 format: descriptor
                     .format
                     .map(|f| self.device.validate_texture_format_required_features(&f))
                     .transpose()?,
-                dimension: descriptor.dimension.map(|dimension| dimension.into()),
+                dimension: descriptor.dimension.map(|dimension| dimension.convert()),
                 range: wgt::ImageSubresourceRange {
                     aspect: match descriptor.aspect {
                         GPUTextureAspect::All => wgt::TextureAspect::All,

--- a/components/script/dom/webxr/fakexrdevice.rs
+++ b/components/script/dom/webxr/fakexrdevice.rs
@@ -15,6 +15,7 @@ use webxr_api::{
     MockViewInit, MockViewsInit, MockWorld, TargetRayMode, Triangle, Visibility,
 };
 
+use crate::conversions::Convert;
 use crate::dom::bindings::codegen::Bindings::DOMPointBinding::DOMPointInit;
 use crate::dom::bindings::codegen::Bindings::FakeXRDeviceBinding::{
     FakeXRBoundsPoint, FakeXRDeviceMethods, FakeXRRegionType, FakeXRRigidTransformInit,
@@ -147,7 +148,7 @@ pub fn get_world(world: &FakeXRWorldInit) -> Fallible<MockWorld> {
         .hitTestRegions
         .iter()
         .map(|region| {
-            let ty = region.type_.into();
+            let ty = region.type_.convert();
             let faces = region
                 .faces
                 .iter()
@@ -172,9 +173,9 @@ pub fn get_world(world: &FakeXRWorldInit) -> Fallible<MockWorld> {
     Ok(MockWorld { regions })
 }
 
-impl From<FakeXRRegionType> for EntityType {
-    fn from(x: FakeXRRegionType) -> Self {
-        match x {
+impl Convert<EntityType> for FakeXRRegionType {
+    fn convert(self) -> EntityType {
+        match self {
             FakeXRRegionType::Point => EntityType::Point,
             FakeXRRegionType::Plane => EntityType::Plane,
             FakeXRRegionType::Mesh => EntityType::Mesh,
@@ -255,8 +256,8 @@ impl FakeXRDeviceMethods<crate::DomTypeHolder> for FakeXRDevice {
         let id = self.next_input_id.get();
         self.next_input_id.set(InputId(id.0 + 1));
 
-        let handedness = init.handedness.into();
-        let target_ray_mode = init.targetRayMode.into();
+        let handedness = init.handedness.convert();
+        let target_ray_mode = init.targetRayMode.convert();
 
         let pointer_origin = Some(get_origin(&init.pointerOrigin)?);
 
@@ -346,9 +347,9 @@ impl FakeXRDeviceMethods<crate::DomTypeHolder> for FakeXRDevice {
     }
 }
 
-impl From<XRHandedness> for Handedness {
-    fn from(h: XRHandedness) -> Self {
-        match h {
+impl Convert<Handedness> for XRHandedness {
+    fn convert(self) -> Handedness {
+        match self {
             XRHandedness::None => Handedness::None,
             XRHandedness::Left => Handedness::Left,
             XRHandedness::Right => Handedness::Right,
@@ -356,9 +357,9 @@ impl From<XRHandedness> for Handedness {
     }
 }
 
-impl From<XRTargetRayMode> for TargetRayMode {
-    fn from(t: XRTargetRayMode) -> Self {
-        match t {
+impl Convert<TargetRayMode> for XRTargetRayMode {
+    fn convert(self) -> TargetRayMode {
+        match self {
             XRTargetRayMode::Gaze => TargetRayMode::Gaze,
             XRTargetRayMode::Tracked_pointer => TargetRayMode::TrackedPointer,
             XRTargetRayMode::Screen => TargetRayMode::Screen,

--- a/components/script/dom/webxr/fakexrinputcontroller.rs
+++ b/components/script/dom/webxr/fakexrinputcontroller.rs
@@ -9,6 +9,7 @@ use webxr_api::{
     SelectKind, TargetRayMode,
 };
 
+use crate::conversions::Convert;
 use crate::dom::bindings::codegen::Bindings::FakeXRDeviceBinding::FakeXRRigidTransformInit;
 use crate::dom::bindings::codegen::Bindings::FakeXRInputControllerBinding::{
     FakeXRButtonStateInit, FakeXRButtonType, FakeXRInputControllerMethods,
@@ -165,9 +166,9 @@ impl FakeXRInputControllerMethods<crate::DomTypeHolder> for FakeXRInputControlle
     }
 }
 
-impl From<FakeXRButtonType> for MockButtonType {
-    fn from(b: FakeXRButtonType) -> Self {
-        match b {
+impl Convert<MockButtonType> for FakeXRButtonType {
+    fn convert(self) -> MockButtonType {
+        match self {
             FakeXRButtonType::Grip => MockButtonType::Grip,
             FakeXRButtonType::Touchpad => MockButtonType::Touchpad,
             FakeXRButtonType::Thumbstick => MockButtonType::Thumbstick,
@@ -182,7 +183,7 @@ pub fn init_to_mock_buttons(buttons: &[FakeXRButtonStateInit]) -> Vec<MockButton
     let supported: Vec<MockButton> = buttons
         .iter()
         .map(|b| MockButton {
-            button_type: b.buttonType.into(),
+            button_type: b.buttonType.convert(),
             pressed: b.pressed,
             touched: b.touched,
             pressed_value: *b.pressedValue,

--- a/components/script/dom/webxr/xrsession.rs
+++ b/components/script/dom/webxr/xrsession.rs
@@ -24,6 +24,7 @@ use webxr_api::{
     SelectEvent, SelectKind, Session, SessionId, View, Viewer, Visibility,
 };
 
+use crate::conversions::Convert;
 use crate::dom::bindings::trace::HashMapTracedValues;
 use crate::dom::bindings::buffer_source::create_buffer_source;
 use crate::dom::bindings::callback::ExceptionHandling;
@@ -124,7 +125,7 @@ impl XRSession {
     ) -> XRSession {
         XRSession {
             eventtarget: EventTarget::new_inherited(),
-            blend_mode: session.environment_blend_mode().into(),
+            blend_mode: session.environment_blend_mode().convert(),
             mode,
             visibility_state: Cell::new(XRVisibilityState::Visible),
             viewer_space: Default::default(),
@@ -1100,9 +1101,9 @@ pub fn cast_transform<T, U, V, W>(
     unsafe { mem::transmute(transform) }
 }
 
-impl From<EnvironmentBlendMode> for XREnvironmentBlendMode {
-    fn from(x: EnvironmentBlendMode) -> Self {
-        match x {
+impl Convert<XREnvironmentBlendMode> for EnvironmentBlendMode {
+    fn convert(self) -> XREnvironmentBlendMode {
+        match self {
             EnvironmentBlendMode::Opaque => XREnvironmentBlendMode::Opaque,
             EnvironmentBlendMode::AlphaBlend => XREnvironmentBlendMode::Alpha_blend,
             EnvironmentBlendMode::Additive => XREnvironmentBlendMode::Additive,

--- a/components/script/dom/webxr/xrsystem.rs
+++ b/components/script/dom/webxr/xrsystem.rs
@@ -13,6 +13,7 @@ use profile_traits::ipc;
 use servo_config::pref;
 use webxr_api::{Error as XRError, Frame, Session, SessionInit, SessionMode};
 
+use crate::conversions::Convert;
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::XRSystemBinding::{
     XRSessionInit, XRSessionMode, XRSystemMethods,
@@ -100,9 +101,9 @@ impl XRSystem {
     }
 }
 
-impl From<XRSessionMode> for SessionMode {
-    fn from(mode: XRSessionMode) -> SessionMode {
-        match mode {
+impl Convert<SessionMode> for XRSessionMode {
+    fn convert(self) -> SessionMode {
+        match self {
             XRSessionMode::Immersive_vr => SessionMode::ImmersiveVR,
             XRSessionMode::Immersive_ar => SessionMode::ImmersiveAR,
             XRSessionMode::Inline => SessionMode::Inline,
@@ -148,7 +149,7 @@ impl XRSystemMethods<crate::DomTypeHolder> for XRSystem {
             }),
         );
         if let Some(mut r) = window.webxr_registry() {
-            r.supports_session(mode.into(), sender);
+            r.supports_session(mode.convert(), sender);
         }
 
         promise
@@ -266,7 +267,7 @@ impl XRSystemMethods<crate::DomTypeHolder> for XRSystem {
             }),
         );
         if let Some(mut r) = window.webxr_registry() {
-            r.request_session(mode.into(), init, sender, frame_sender);
+            r.request_session(mode.convert(), init, sender, frame_sender);
         }
         promise
     }

--- a/components/script/dom/worklet.rs
+++ b/components/script/dom/worklet.rs
@@ -30,6 +30,7 @@ use style::thread_state::{self, ThreadState};
 use swapper::{swapper, Swapper};
 use uuid::Uuid;
 
+use crate::conversions::Convert;
 use crate::dom::bindings::codegen::Bindings::RequestBinding::RequestCredentials;
 use crate::dom::bindings::codegen::Bindings::WindowBinding::Window_Binding::WindowMethods;
 use crate::dom::bindings::codegen::Bindings::WorkletBinding::{WorkletMethods, WorkletOptions};
@@ -655,7 +656,7 @@ impl WorkletThread {
         )
         .destination(Destination::Script)
         .mode(RequestMode::CorsMode)
-        .credentials_mode(credentials.into())
+        .credentials_mode(credentials.convert())
         .origin(origin);
 
         let script = load_whole_resource(

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -34,6 +34,8 @@ mod body;
 #[warn(deprecated)]
 pub mod clipboard_provider;
 #[warn(deprecated)]
+pub mod conversions;
+#[warn(deprecated)]
 mod devtools;
 #[warn(deprecated)]
 pub mod document_loader;

--- a/components/script/security_manager.rs
+++ b/components/script/security_manager.rs
@@ -8,6 +8,7 @@ use serde::Serialize;
 use servo_atoms::Atom;
 use servo_url::ServoUrl;
 
+use crate::conversions::Convert;
 use crate::dom::bindings::codegen::Bindings::EventBinding::EventInit;
 use crate::dom::bindings::codegen::Bindings::SecurityPolicyViolationEventBinding::{
     SecurityPolicyViolationEventDisposition, SecurityPolicyViolationEventInit,
@@ -111,7 +112,7 @@ impl CSPViolationReporter {
             Atom::from("securitypolicyviolation"),
             EventBubbles::Bubbles,
             EventCancelable::Cancelable,
-            &report.into(),
+            &report.convert(),
             can_gc,
         );
 
@@ -149,21 +150,21 @@ impl TaskOnce for CSPViolationReporter {
     }
 }
 
-impl From<SecurityPolicyViolationReport> for SecurityPolicyViolationEventInit {
-    fn from(value: SecurityPolicyViolationReport) -> Self {
+impl Convert<SecurityPolicyViolationEventInit> for SecurityPolicyViolationReport {
+    fn convert(self) -> SecurityPolicyViolationEventInit {
         SecurityPolicyViolationEventInit {
-            sample: value.sample.unwrap_or_default().into(),
-            blockedURI: value.blocked_url.into(),
-            referrer: value.referrer.into(),
-            statusCode: value.status_code,
-            documentURI: value.document_url.into(),
-            sourceFile: value.source_file.into(),
-            violatedDirective: value.violated_directive.into(),
-            effectiveDirective: value.effective_directive.into(),
-            lineNumber: value.line_number,
-            columnNumber: value.column_number,
-            originalPolicy: value.original_policy.into(),
-            disposition: value.disposition,
+            sample: self.sample.unwrap_or_default().into(),
+            blockedURI: self.blocked_url.into(),
+            referrer: self.referrer.into(),
+            statusCode: self.status_code,
+            documentURI: self.document_url.into(),
+            sourceFile: self.source_file.into(),
+            violatedDirective: self.violated_directive.into(),
+            effectiveDirective: self.effective_directive.into(),
+            lineNumber: self.line_number,
+            columnNumber: self.column_number,
+            originalPolicy: self.original_policy.into(),
+            disposition: self.disposition,
             parent: EventInit::empty(),
         }
     }


### PR DESCRIPTION
As part of #1799, the generated types for dictionaries and enums will move to a different crate. This means that the From implementations that convert between these types and types from other crates (eg. webxr, webgpu, media) are no longer allowed by the compiler. Rather than move these implementations into the crate with the generated types, we can introduce a trait that allows us to keep the conversion code in the script crate next to the DOM interface implementations that use them.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #1799, fix #34159
- [x] There are tests for these changes (existing coverage should remain unchanged)