### PR TITLE
script: Remove 'pending reflow' concept and some explicit reflows

### DIFF
--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -442,8 +442,6 @@ impl HTMLIFrameElement {
         }
 
         self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
-        let window = window_from_node(self);
-        window.add_pending_reflow();
     }
 
     fn new_inherited(

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -503,9 +503,7 @@ impl HTMLImageElement {
                 .fire_event(atom!("loadend"), can_gc);
         }
 
-        // Trigger reflow
-        let window = window_from_node(self);
-        window.add_pending_reflow();
+        self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
     }
 
     fn process_image_response_for_environment_change(

--- a/components/script/layout_dom/document.rs
+++ b/components/script/layout_dom/document.rs
@@ -49,14 +49,6 @@ impl<'ld> ServoLayoutDocument<'ld> {
             .next()
     }
 
-    pub fn needs_paint_from_layout(&self) {
-        self.document.needs_paint_from_layout()
-    }
-
-    pub fn will_paint(&self) {
-        self.document.will_paint()
-    }
-
     pub fn style_shared_lock(&self) -> &StyleSharedRwLock {
         self.document.style_shared_lock()
     }

--- a/tests/wpt/meta/css/css-ui/transparent-accent-color-001.html.ini
+++ b/tests/wpt/meta/css/css-ui/transparent-accent-color-001.html.ini
@@ -1,2 +1,0 @@
-[transparent-accent-color-001.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/css/css-ui/transparent-accent-color-002.html.ini
+++ b/tests/wpt/meta/css/css-ui/transparent-accent-color-002.html.ini
@@ -1,2 +1,0 @@
-[transparent-accent-color-002.html]
-  expected: TIMEOUT


### PR DESCRIPTION
The `pending reflow` concept isn't necessary now that *update the
rendering* is taking care of triggering reflows at the correct time.
`Window::reflow` already avoids reflows if the page is not dirty, so
pending reflows is now just an extraneous check as long as *update the
rendering* runs properly.

This change also removes some explicit reflows, which now wait until the
appropriate moment during *update the rendering*. This should remove
some extra reflows that are not necessary.

Servo needs some way to track that resizing the web view needs to
re-layout due to the initial containing block changing. Move handling
of `Document::needs_paint` to the script thread and use this, expanding
the rustdoc to explain what it is for a bit more clearly.

This is part of #31242 and an important part of removing
`note_rendering_opportunity` from Servo.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #31242.
- [x] There changes are covered by existing WPT tests.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
