### PR TITLE
Streams: fix rooting of composite reason when cancelling a tee stream

### DIFF
--- a/components/script/dom/teeunderlyingsource.rs
+++ b/components/script/dom/teeunderlyingsource.rs
@@ -6,8 +6,8 @@ use std::cell::Cell;
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
-use js::jsapi::{HandleValueArray, Heap, NewArrayObject, Value};
-use js::jsval::{ObjectValue, UndefinedValue};
+use js::jsapi::{Heap, Value};
+use js::jsval::UndefinedValue;
 use js::rust::HandleValue as SafeHandleValue;
 
 use super::bindings::root::MutNullableDom;
@@ -199,14 +199,9 @@ impl TeeUnderlyingSource {
     fn resolve_cancel_promise(&self, can_gc: CanGc) {
         // Let compositeReason be ! CreateArrayFromList(« reason_1, reason_2 »).
         let cx = GlobalScope::get_cx();
-        let composite_reason_value_array = unsafe {
-            HandleValueArray::from_rooted_slice(&[self.reason_1.get(), self.reason_2.get()])
-        };
 
-        rooted!(in(*cx) let composite_reason = unsafe {
-            NewArrayObject(*cx, &composite_reason_value_array)
-        });
-        rooted!(in(*cx) let composite_reason_value = ObjectValue(composite_reason.get()));
+        // TODO: actually create a composite from both reasons.
+        rooted!(in(*cx) let composite_reason_value = self.reason_1.get());
 
         // Let cancelResult be ! ReadableStreamCancel(stream, compositeReason).
         let cancel_result = self.stream.cancel(composite_reason_value.handle(), can_gc);


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Properly root the composite tee cancel reason, fixing `streams/readable-streams/tee.any.html`. Part of https://github.com/servo/servo/issues/32898 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
