### PR TITLE
Bump bindgen to 0.71.1

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -28,6 +28,8 @@ env:
   # SCCACHE_GHA_ENABLED: "true"
   # RUSTC_WRAPPER: "sccache"
   # CCACHE: "sccache"
+  # Increment this to purge the cache (https://github.com/mozilla/sccache/blob/main/docs/GHA.md)
+  SCCACHE_GHA_VERSION: 2
   CARGO_INCREMENTAL: 0
 
 jobs:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -24,10 +24,9 @@ on:
 env:
   RUST_BACKTRACE: 1
   SHELL: /bin/bash
-  # FIXME: Temporarily commented to see if it helps with #34571.
-  # SCCACHE_GHA_ENABLED: "true"
-  # RUSTC_WRAPPER: "sccache"
-  # CCACHE: "sccache"
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
+  CCACHE: "sccache"
   # Increment this to purge the cache (https://github.com/mozilla/sccache/blob/main/docs/GHA.md)
   SCCACHE_GHA_VERSION: 2
   CARGO_INCREMENTAL: 0
@@ -58,9 +57,8 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 2
-      # FIXME: Temporarily commented to see if it helps with #34571.
-      # - name: Run sccache-cache
-      #   uses: mozilla-actions/sccache-action@v0.0.6
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.7
       - name: Install crown
         run: cargo install --path support/crown
       - name: Bootstrap Python

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,8 @@ env:
   RUST_BACKTRACE: 1
   SHELL: /bin/bash
   SCCACHE_GHA_ENABLED: "true"
+  # Increment this to purge the cache (https://github.com/mozilla/sccache/blob/main/docs/GHA.md)
+  SCCACHE_GHA_VERSION: 2
   RUSTC_WRAPPER: "sccache"
   CCACHE: "sccache"
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -75,6 +75,8 @@ on:
 env:
   RUST_BACKTRACE: 1
   SHELL: /bin/bash
+  # Increment this to purge the cache (https://github.com/mozilla/sccache/blob/main/docs/GHA.md)
+  SCCACHE_GHA_VERSION: 2
 
 jobs:
   # Runs the underlying job (“workload”) on a self-hosted runner if available,

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -52,6 +52,8 @@ on:
 env:
   RUST_BACKTRACE: 1
   SHELL: /bin/bash
+  # Increment this to purge the cache (https://github.com/mozilla/sccache/blob/main/docs/GHA.md)
+  SCCACHE_GHA_VERSION: 2
   SCCACHE_GHA_ENABLED: "true"
   RUSTC_WRAPPER: "sccache"
   CCACHE: "sccache"

--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -25,6 +25,8 @@ on:
 env:
   RUST_BACKTRACE: 1
   SHELL: /bin/bash
+  # Increment this to purge the cache (https://github.com/mozilla/sccache/blob/main/docs/GHA.md)
+  SCCACHE_GHA_VERSION: 2
   SCCACHE_GHA_ENABLED: "true"
   RUSTC_WRAPPER: "sccache"
   CCACHE: "sccache"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -422,23 +422,20 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.69.5"
+version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
 dependencies = [
  "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
- "lazy_static",
- "lazycell",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 2.1.0",
  "shlex",
  "syn",
- "which",
 ]
 
 [[package]]
@@ -755,9 +752,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.4"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9157bbaa6b165880c27a4293a474c91cdcf265cc68cc829bf10be0964a391caf"
+checksum = "27f657647bcff5394bf56c7317665bbf790a137a50eaaa5c6bfbb9e27a518f2d"
 dependencies = [
  "jobserver",
  "libc",
@@ -3032,15 +3029,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "315f4e893d1caac3a97b9e6cbcf211a7012c6615cd688e4430f0cd5712ac3a3f"
 
 [[package]]
-name = "home"
-version = "0.5.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
-dependencies = [
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "html5ever"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4017,12 +4005,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "leak"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4461,14 +4443,13 @@ dependencies = [
 
 [[package]]
 name = "mozangle"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77f793a01513d52fdaeaa687359ce3a9f032fe5cc60ce542744ff04f08b3925e"
+checksum = "0ab823731ea6297e7280dade983df955d1a8209d2deb44f505932b8873168992"
 dependencies = [
  "bindgen",
  "cc",
  "gl_generator",
- "lazy_static",
  "libz-sys",
  "walkdir",
 ]
@@ -4476,7 +4457,7 @@ dependencies = [
 [[package]]
 name = "mozjs"
 version = "0.14.1"
-source = "git+https://github.com/servo/mozjs#d6c3bd9a9a86a53c627355241b015fa7768ed688"
+source = "git+https://github.com/servo/mozjs#8ac195873f25c66c891478a291d762998fb151fe"
 dependencies = [
  "bindgen",
  "cc",
@@ -4488,8 +4469,8 @@ dependencies = [
 
 [[package]]
 name = "mozjs_sys"
-version = "0.128.3-6"
-source = "git+https://github.com/servo/mozjs#d6c3bd9a9a86a53c627355241b015fa7768ed688"
+version = "0.128.3-8"
+source = "git+https://github.com/servo/mozjs#8ac195873f25c66c891478a291d762998fb151fe"
 dependencies = [
  "bindgen",
  "cc",
@@ -4522,7 +4503,7 @@ dependencies = [
  "hexf-parse",
  "indexmap",
  "log",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "serde",
  "spirv",
  "termcolor",
@@ -5895,6 +5876,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6217,9 +6204,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.24"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
@@ -8352,7 +8339,7 @@ dependencies = [
  "parking_lot",
  "profiling",
  "ron",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "serde",
  "smallvec",
  "thiserror",
@@ -8393,7 +8380,7 @@ dependencies = [
  "profiling",
  "range-alloc",
  "raw-window-handle",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "smallvec",
  "thiserror",
  "wasm-bindgen",
@@ -8412,18 +8399,6 @@ dependencies = [
  "js-sys",
  "serde",
  "web-sys",
-]
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ markup5ever = "0.14"
 memmap2 = "0.9.5"
 mime = "0.3.13"
 mime_guess = "2.0.5"
-mozangle = "0.5.2"
+mozangle = "0.5.3"
 net_traits = { path = "components/shared/net" }
 nix = "0.29"
 num-traits = "0.2"

--- a/deny.toml
+++ b/deny.toml
@@ -150,6 +150,9 @@ skip = [
 
     # some non-servo crates still use 0.14
     "glow",
+
+    # wgpu crates still depend on 1.1.0
+    "rustc-hash",
 ]
 
 # github.com organizations to allow git sources for


### PR DESCRIPTION
This change updates mozangle and mozjs to their new releases for the bindgen bump to 0.71.1

- [x] New release of mozangle (https://github.com/servo/mozangle/pull/91)
- [x] New release of mozjs (https://github.com/servo/mozjs/pull/530)

This PR also re-enables sccache for android and sets the `SCCACHE_GHA_VERSION` variable which can be incremented to invalidate the cache.


---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

