### PR TITLE
layout: Clean up inline layout data types a bit

### DIFF
--- a/components/layout_2020/dom.rs
+++ b/components/layout_2020/dom.rs
@@ -22,7 +22,6 @@ use crate::cell::ArcRefCell;
 use crate::context::LayoutContext;
 use crate::dom_traversal::WhichPseudoElement;
 use crate::flexbox::FlexLevelBox;
-use crate::flow::inline::inline_box::InlineBox;
 use crate::flow::inline::InlineItem;
 use crate::flow::BlockLevelBox;
 use crate::geom::PhysicalSize;
@@ -41,8 +40,6 @@ pub struct InnerDOMLayoutData {
 pub(super) enum LayoutBox {
     DisplayContents,
     BlockLevel(ArcRefCell<BlockLevelBox>),
-    #[allow(dead_code)]
-    InlineBox(ArcRefCell<InlineBox>),
     InlineLevel(ArcRefCell<InlineItem>),
     FlexLevel(ArcRefCell<FlexLevelBox>),
     TaffyItemBox(ArcRefCell<TaffyItemBox>),

--- a/components/layout_2020/flow/construct.rs
+++ b/components/layout_2020/flow/construct.rs
@@ -448,7 +448,8 @@ where
 
         // Otherwise, this is just a normal inline box. Whatever happened before, all we need to do
         // before recurring is to remember this ongoing inline level box.
-        self.inline_formatting_context_builder
+        let inline_item = self
+            .inline_formatting_context_builder
             .start_inline_box(InlineBox::new(info));
 
         if is_list_item {
@@ -467,9 +468,8 @@ where
 
         self.finish_anonymous_table_if_needed();
 
-        box_slot.set(LayoutBox::InlineBox(
-            self.inline_formatting_context_builder.end_inline_box(),
-        ));
+        self.inline_formatting_context_builder.end_inline_box();
+        box_slot.set(LayoutBox::InlineLevel(inline_item));
     }
 
     fn handle_block_level_element(

--- a/components/layout_2020/flow/inline/inline_box.rs
+++ b/components/layout_2020/flow/inline/inline_box.rs
@@ -82,7 +82,10 @@ impl InlineBoxes {
             .push(InlineBoxTreePathToken::End(identifier));
     }
 
-    pub(super) fn start_inline_box(&mut self, mut inline_box: InlineBox) -> InlineBoxIdentifier {
+    pub(super) fn start_inline_box(
+        &mut self,
+        mut inline_box: InlineBox,
+    ) -> (InlineBoxIdentifier, ArcRefCell<InlineBox>) {
         assert!(self.inline_boxes.len() <= u32::MAX as usize);
         assert!(self.inline_box_tree.len() <= u32::MAX as usize);
 
@@ -94,11 +97,13 @@ impl InlineBoxes {
             index_in_inline_boxes,
         };
         inline_box.identifier = identifier;
+        let inline_box = ArcRefCell::new(inline_box);
 
-        self.inline_boxes.push(ArcRefCell::new(inline_box));
+        self.inline_boxes.push(inline_box.clone());
         self.inline_box_tree
             .push(InlineBoxTreePathToken::Start(identifier));
-        identifier
+
+        (identifier, inline_box)
     }
 
     pub(super) fn get_path(

--- a/components/layout_2020/flow/root.rs
+++ b/components/layout_2020/flow/root.rs
@@ -185,7 +185,6 @@ impl BoxTree {
                         },
                         _ => return None,
                     },
-                    LayoutBox::InlineBox(_) => return None,
                     LayoutBox::InlineLevel(inline_level_box) => match &*inline_level_box.borrow() {
                         InlineItem::OutOfFlowAbsolutelyPositionedBox(_, text_offset_index)
                             if box_style.position.is_absolutely_positioned() =>


### PR DESCRIPTION
- Remove the `LayoutBox::InlineBox` variant that was only used for
  inline level boxes. Now they are stored in `LayoutBox::InlineLevel`
  along with other kinds of out-of-flow and atomic inline items.
- Reduce the size of `InlineItem` by 260 bytes per item by using atomic
  indirection / pointers. This adds a bit of overhead to access items in
  exchange for a lot of memory saved.

Co-authored-by: Oriol Brufau <obrufau@igalia.com>
Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are covered by existing WPT tests. This should not introduce any changes to layout results.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
