### PR TITLE
layout: Make a new `ContainingBlockSize` type

### DIFF
--- a/components/layout_2020/flexbox/mod.rs
+++ b/components/layout_2020/flexbox/mod.rs
@@ -190,7 +190,7 @@ impl CachedBlockSizeContribution {
         &self,
         item_as_containing_block: &ContainingBlock,
     ) -> bool {
-        item_as_containing_block.inline_size == self.containing_block_inline_size &&
-            item_as_containing_block.block_size.is_auto()
+        item_as_containing_block.size.inline == self.containing_block_inline_size &&
+            item_as_containing_block.size.block.is_auto()
     }
 }

--- a/components/layout_2020/flow/float.rs
+++ b/components/layout_2020/flow/float.rs
@@ -1190,6 +1190,6 @@ impl SequentialLayoutState {
                 .size
                 .to_logical(container_writing_mode),
         }
-        .to_physical(Some(containing_block));
+        .as_physical(Some(containing_block));
     }
 }

--- a/components/layout_2020/flow/inline/mod.rs
+++ b/components/layout_2020/flow/inline/mod.rs
@@ -905,11 +905,11 @@ impl<'layout_dta> InlineFormattingContextLayout<'layout_dta> {
         let physical_line_rect = LogicalRect {
             start_corner,
             size: LogicalVec2 {
-                inline: self.containing_block.inline_size,
+                inline: self.containing_block.size.inline,
                 block: effective_block_advance.resolve(),
             },
         }
-        .to_physical(Some(self.containing_block));
+        .as_physical(Some(self.containing_block));
         self.fragments
             .push(Fragment::Positioning(PositioningFragment::new_anonymous(
                 physical_line_rect,
@@ -975,7 +975,7 @@ impl<'layout_dta> InlineFormattingContextLayout<'layout_dta> {
                 placement_among_floats.start_corner.inline,
                 placement_among_floats.size.inline,
             ),
-            None => (Au::zero(), self.containing_block.inline_size),
+            None => (Au::zero(), self.containing_block.size.inline),
         };
 
         // Properly handling text-indent requires that we do not align the text
@@ -1061,7 +1061,7 @@ impl<'layout_dta> InlineFormattingContextLayout<'layout_dta> {
 
         let available_inline_size = match self.current_line.placement_among_floats.get() {
             Some(placement_among_floats) => placement_among_floats.size.inline,
-            None => self.containing_block.inline_size,
+            None => self.containing_block.size.inline,
         } - line_inline_size_without_trailing_whitespace;
 
         // If this float doesn't fit on the current line or a previous float didn't fit on
@@ -1146,7 +1146,7 @@ impl<'layout_dta> InlineFormattingContextLayout<'layout_dta> {
                 .size
         } else {
             LogicalVec2 {
-                inline: self.containing_block.inline_size,
+                inline: self.containing_block.size.inline,
                 block: MAX_AU,
             }
         };
@@ -1179,7 +1179,7 @@ impl<'layout_dta> InlineFormattingContextLayout<'layout_dta> {
 
         // If the potential line is larger than the containing block we do not even need to consider
         // floats. We definitely have to do a linebreak.
-        if potential_line_size.inline > self.containing_block.inline_size {
+        if potential_line_size.inline > self.containing_block.size.inline {
             return true;
         }
 
@@ -1605,7 +1605,7 @@ impl InlineFormattingContext {
                 .get_inherited_text()
                 .text_indent
                 .length
-                .to_used_value(containing_block.inline_size)
+                .to_used_value(containing_block.size.inline)
         } else {
             Au::zero()
         };

--- a/components/layout_2020/lib.rs
+++ b/components/layout_2020/lib.rs
@@ -32,6 +32,7 @@ use app_units::Au;
 pub use flow::BoxTree;
 pub use fragment_tree::FragmentTree;
 use geom::AuOrAuto;
+use serde::Serialize;
 use style::logical_geometry::WritingMode;
 use style::properties::ComputedValues;
 
@@ -95,8 +96,8 @@ impl<'a> From<&'_ ContainingBlock<'a>> for IndefiniteContainingBlock {
     fn from(containing_block: &ContainingBlock<'a>) -> Self {
         Self {
             size: LogicalVec2 {
-                inline: AuOrAuto::LengthPercentage(containing_block.inline_size),
-                block: containing_block.block_size,
+                inline: AuOrAuto::LengthPercentage(containing_block.size.inline),
+                block: containing_block.size.block,
             },
             writing_mode: containing_block.style.writing_mode,
         }
@@ -114,9 +115,14 @@ impl<'a> From<&'_ DefiniteContainingBlock<'a>> for IndefiniteContainingBlock {
     }
 }
 
-pub struct ContainingBlock<'a> {
-    inline_size: Au,
-    block_size: AuOrAuto,
+#[derive(Debug, Serialize)]
+pub(crate) struct ContainingBlockSize {
+    inline: Au,
+    block: AuOrAuto,
+}
+
+pub(crate) struct ContainingBlock<'a> {
+    size: ContainingBlockSize,
     style: &'a ComputedValues,
 }
 
@@ -128,8 +134,10 @@ struct DefiniteContainingBlock<'a> {
 impl<'a> From<&'_ DefiniteContainingBlock<'a>> for ContainingBlock<'a> {
     fn from(definite: &DefiniteContainingBlock<'a>) -> Self {
         ContainingBlock {
-            inline_size: definite.size.inline,
-            block_size: AuOrAuto::LengthPercentage(definite.size.block),
+            size: ContainingBlockSize {
+                inline: definite.size.inline,
+                block: AuOrAuto::LengthPercentage(definite.size.block),
+            },
             style: definite.style,
         }
     }

--- a/components/layout_2020/replaced.rs
+++ b/components/layout_2020/replaced.rs
@@ -521,9 +521,10 @@ impl ReplacedContents {
         };
 
         // <https://drafts.csswg.org/css-sizing-4/#stretch-fit-sizing>
-        let inline_stretch_size = Au::zero().max(containing_block.inline_size - pbm_sums.inline);
+        let inline_stretch_size = Au::zero().max(containing_block.size.inline - pbm_sums.inline);
         let block_stretch_size = containing_block
-            .block_size
+            .size
+            .block
             .non_auto()
             .map(|block_size| Au::zero().max(block_size - pbm_sums.block));
 

--- a/components/layout_2020/style_ext.rs
+++ b/components/layout_2020/style_ext.rs
@@ -440,8 +440,8 @@ impl ComputedValuesExt for ComputedValues {
         let min_size = self
             .min_box_size(containing_block.style.writing_mode)
             .map_inline_and_block_sizes(
-                |lp| lp.to_used_value(containing_block.inline_size),
-                |lp| lp.to_used_value(containing_block.block_size.auto_is(Au::zero)),
+                |lp| lp.to_used_value(containing_block.size.inline),
+                |lp| lp.to_used_value(containing_block.size.block.auto_is(Au::zero)),
             );
         self.content_min_box_size_for_min_size(min_size, pbm)
     }
@@ -571,7 +571,7 @@ impl ComputedValuesExt for ComputedValues {
     fn padding_border_margin(&self, containing_block: &ContainingBlock) -> PaddingBorderMargin {
         self.padding_border_margin_with_writing_mode_and_containing_block_inline_size(
             containing_block.style.writing_mode,
-            containing_block.inline_size,
+            containing_block.size.inline,
         )
     }
 

--- a/components/layout_2020/taffy/layout.rs
+++ b/components/layout_2020/taffy/layout.rs
@@ -27,7 +27,7 @@ use crate::geom::{
 use crate::positioned::{AbsolutelyPositionedBox, PositioningContext, PositioningContextLength};
 use crate::sizing::{ContentSizes, InlineContentSizesResult};
 use crate::style_ext::ComputedValuesExt;
-use crate::{ConstraintSpace, ContainingBlock};
+use crate::{ConstraintSpace, ContainingBlock, ContainingBlockSize};
 
 const DUMMY_NODE_ID: taffy::NodeId = taffy::NodeId::new(u64::MAX);
 
@@ -256,8 +256,10 @@ impl taffy::LayoutPartialTree for TaffyContainerContext<'_> {
                         let maybe_block_size =
                             option_f32_to_lpa(content_box_known_dimensions.height);
                         let content_box_size_override = ContainingBlock {
-                            inline_size: Au::from_f32_px(inline_size),
-                            block_size: maybe_block_size,
+                            size: ContainingBlockSize {
+                                inline: Au::from_f32_px(inline_size),
+                                block: maybe_block_size,
+                            },
                             style,
                         };
 
@@ -355,8 +357,10 @@ impl TaffyContainer {
         };
 
         let containing_block = &ContainingBlock {
-            inline_size: Au::zero(),
-            block_size: GenericLengthPercentageOrAuto::Auto,
+            size: ContainingBlockSize {
+                inline: Au::zero(),
+                block: GenericLengthPercentageOrAuto::Auto,
+            },
             style,
         };
 
@@ -434,17 +438,17 @@ impl TaffyContainer {
 
         let known_dimensions = taffy::Size {
             width: Some(
-                (content_box_size_override.inline_size + pbm.padding_border_sums.inline)
+                (content_box_size_override.size.inline + pbm.padding_border_sums.inline)
                     .to_f32_px(),
             ),
-            height: auto_or_to_option(content_box_size_override.block_size)
+            height: auto_or_to_option(content_box_size_override.size.block)
                 .map(Au::to_f32_px)
                 .maybe_add(pbm.padding_border_sums.block.to_f32_px()),
         };
 
         let taffy_containing_block = taffy::Size {
-            width: Some(containing_block.inline_size.to_f32_px()),
-            height: auto_or_to_option(containing_block.block_size).map(Au::to_f32_px),
+            width: Some(containing_block.size.inline.to_f32_px()),
+            height: auto_or_to_option(containing_block.size.block).map(Au::to_f32_px),
         };
 
         let layout_input = taffy::LayoutInput {


### PR DESCRIPTION
This might make caching these values a bit easier in the future.
Correcting the visibility of `ContainingBlock` also exposed some new
rustc and clippy warnings that are fixed here.

Co-authored-by: Oriol Brufau <obrufau@igalia.com>
Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] This change is covered by existing WPT tests. It should not introduce any functional changes.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
