### PR TITLE
Iterate PR commits in reverse (oldest->newest) when preparing WPT export

### DIFF
--- a/python/wpt/exporter/step.py
+++ b/python/wpt/exporter/step.py
@@ -105,7 +105,9 @@ class CreateOrUpdateBranchForPRStep(Step):
         ).splitlines()
 
         filtered_commits = []
-        for sha in commit_shas:
+        # We must iterate the commits in reverse to ensure we apply older changes first,
+        # in case later commits would conflict.
+        for sha in reversed(commit_shas):
             # Specifying the path here does a few things. First, it excludes any
             # changes that do not touch WPT files at all. Secondly, when a file is
             # moved in or out of the WPT directory the filename which is outside the


### PR DESCRIPTION
The logs from https://github.com/servo/servo/actions/runs/12262866391/job/34213142613?pr=34550 show that my commits from #34550 are being applied newest first, which leads to conflicts when trying to replicate the state to the WPT tree.