### PR TITLE
Update response handling in main_fetch

### DIFF
--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -1086,16 +1086,8 @@ pub async fn http_redirect_fetch(
     let recursive_flag = request.redirect_mode != RedirectMode::Manual;
 
     // Step 22: Return the result of running main fetch given fetchParams and recursive.
-    let fetch_response = main_fetch(
-        request,
-        cache,
-        cors_flag,
-        recursive_flag,
-        target,
-        done_chan,
-        context,
-    )
-    .await;
+    let fetch_response =
+        main_fetch(request, cache, recursive_flag, target, done_chan, context).await;
 
     // TODO: timing allow check
     context

--- a/tests/wpt/meta/css/cssom/stylesheet-same-origin.sub.html.ini
+++ b/tests/wpt/meta/css/cssom/stylesheet-same-origin.sub.html.ini
@@ -1,7 +1,3 @@
 [stylesheet-same-origin.sub.html]
-  [Origin-clean check in cross-origin CSSOM Stylesheets (redirect from cross-origin to same-origin)]
-    expected: FAIL
-
   [Origin-clean check in loading error CSSOM Stylesheets]
     expected: FAIL
-

--- a/tests/wpt/meta/fetch/api/redirect/redirect-back-to-original-origin.any.js.ini
+++ b/tests/wpt/meta/fetch/api/redirect/redirect-back-to-original-origin.any.js.ini
@@ -1,12 +1,6 @@
 [redirect-back-to-original-origin.any.html]
-  [original => remote => original with mode: "no-cors"]
-    expected: FAIL
-
 
 [redirect-back-to-original-origin.any.worker.html]
-  [original => remote => original with mode: "no-cors"]
-    expected: FAIL
-
 
 [redirect-back-to-original-origin.any.serviceworker.html]
   expected: ERROR

--- a/tests/wpt/meta/fetch/images/canvas-remote-read-remote-image-redirect.html.ini
+++ b/tests/wpt/meta/fetch/images/canvas-remote-read-remote-image-redirect.html.ini
@@ -1,3 +1,0 @@
-[canvas-remote-read-remote-image-redirect.html]
-  [Load a no-cors image from a same-origin URL that redirects to a cross-origin URL that redirects to the initial origin]
-    expected: FAIL


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Updates a branch condition when handling a fetch response in `main_fetch`.

We have the `cors_flag` argument which should reflect that request's response tainting is not `ResponseTainting::CorsTainting` however in the current state, this branch is triggered for both `ResponseTainting::Basic` and `ResponseTainting::Origin` but according to the spec `::Origin` should not be included here.

I've tried to simplify things so that they map to the spec more tightly. 

This was the only use of the `cors_flag` argument in `main_fetch`.

[Try](https://github.com/shanehandley/servo/actions/runs/12269549527)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
