### PR TITLE
layout: Fix ordering of padding, border, and margin in inline BiDi

### DIFF
--- a/components/layout_2020/flow/inline/mod.rs
+++ b/components/layout_2020/flow/inline/mod.rs
@@ -48,8 +48,8 @@
 //! a linear series of items that describe the line's hierarchy of inline boxes and content. The
 //! item types are:
 //!
-//!  - [`LineItem::LeftInlineBoxPaddingBorderMargin`]
-//!  - [`LineItem::RightInlineBoxPaddingBorderMargin`]
+//!  - [`LineItem::InlineStartBoxPaddingBorderMargin`]
+//!  - [`LineItem::InlineEndBoxPaddingBorderMargin`]
 //!  - [`LineItem::TextRun`]
 //!  - [`LineItem::Atomic`]
 //!  - [`LineItem::AbsolutelyPositioned`]
@@ -92,7 +92,6 @@ use serde::Serialize;
 use servo_arc::Arc;
 use style::computed_values::text_wrap_mode::T as TextWrapMode;
 use style::computed_values::vertical_align::T as VerticalAlign;
-use style::computed_values::direction::T as ComputedCSSDirection;
 use style::computed_values::white_space_collapse::T as WhiteSpaceCollapse;
 use style::context::QuirksMode;
 use style::properties::style_structs::InheritedText;
@@ -728,27 +727,15 @@ impl<'layout_dta> InlineFormattingContextLayout<'layout_dta> {
             );
         }
 
-        // Boxes Padding - Border - Margin (PBM) and positioning context should follow
-        // visual, not logical order.
-        // https://drafts.csswg.org/css-writing-modes-4/#bidi-fragment-boxes
-        // 2.4.5.2. Box Model of Reordering-induced Box Fragments
-        let css_direction: ComputedCSSDirection = inline_box_state.base.style.clone_direction();
-
         if inline_box.is_first_fragment {
             self.current_line_segment.inline_size += inline_box_state.pbm.padding.inline_start +
                 inline_box_state.pbm.border.inline_start +
                 inline_box_state.pbm.margin.inline_start.auto_is(Au::zero);
             self.current_line_segment
                 .line_items
-                .push(match css_direction {
-                        ComputedCSSDirection::Ltr => {
-                            LineItem::LeftInlineBoxPaddingBorderMargin(inline_box.identifier)
-                        },
-                        ComputedCSSDirection::Rtl => {
-                            LineItem::RightInlineBoxPaddingBorderMargin(inline_box.identifier)
-                        }
-                    }
-                );
+                .push(LineItem::InlineStartBoxPaddingBorderMargin(
+                    inline_box.identifier,
+                ));
         }
 
         let inline_box_state = Rc::new(inline_box_state);
@@ -784,12 +771,6 @@ impl<'layout_dta> InlineFormattingContextLayout<'layout_dta> {
             self.propagate_current_nesting_level_white_space_style();
         }
 
-        // Boxes Padding - Border - Margin (PBM) and positioning context should follow
-        // visual, not logical order.
-        // https://drafts.csswg.org/css-writing-modes-4/#bidi-fragment-boxes
-        // 2.4.5.2. Box Model of Reordering-induced Box Fragments
-        let css_direction: ComputedCSSDirection = inline_box_state.base.style.clone_direction();
-
         if inline_box_state.is_last_fragment {
             let pbm_end = inline_box_state.pbm.padding.inline_end +
                 inline_box_state.pbm.border.inline_end +
@@ -797,15 +778,9 @@ impl<'layout_dta> InlineFormattingContextLayout<'layout_dta> {
             self.current_line_segment.inline_size += pbm_end;
             self.current_line_segment
                 .line_items
-                .push(match css_direction {
-                    ComputedCSSDirection::Ltr => {
-                        LineItem::RightInlineBoxPaddingBorderMargin(inline_box_state.identifier)
-                    },
-                    ComputedCSSDirection::Rtl => {
-                        LineItem::LeftInlineBoxPaddingBorderMargin(inline_box_state.identifier)
-                    }
-                }
-            )
+                .push(LineItem::InlineEndBoxPaddingBorderMargin(
+                    inline_box_state.identifier,
+                ))
         }
     }
 

--- a/tests/wpt/meta/css/CSS2/box/rtl-basic.xht.ini
+++ b/tests/wpt/meta/css/CSS2/box/rtl-basic.xht.ini
@@ -1,2 +1,0 @@
-[rtl-basic.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/box/rtl-ib.xht.ini
+++ b/tests/wpt/meta/css/CSS2/box/rtl-ib.xht.ini
@@ -1,2 +1,0 @@
-[rtl-ib.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/box/rtl-linebreak.xht.ini
+++ b/tests/wpt/meta/css/CSS2/box/rtl-linebreak.xht.ini
@@ -1,2 +1,0 @@
-[rtl-linebreak.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/box/rtl-span-only-ib.xht.ini
+++ b/tests/wpt/meta/css/CSS2/box/rtl-span-only-ib.xht.ini
@@ -1,2 +1,0 @@
-[rtl-span-only-ib.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/box/rtl-span-only.xht.ini
+++ b/tests/wpt/meta/css/CSS2/box/rtl-span-only.xht.ini
@@ -1,2 +1,0 @@
-[rtl-span-only.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-empty-002.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-empty-002.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-empty-002.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-empty-004.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-empty-004.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-empty-004.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/visuren/emptyspan-2.html.ini
+++ b/tests/wpt/meta/css/CSS2/visuren/emptyspan-2.html.ini
@@ -1,2 +1,0 @@
-[emptyspan-2.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/visuren/emptyspan-4.html.ini
+++ b/tests/wpt/meta/css/CSS2/visuren/emptyspan-4.html.ini
@@ -1,2 +1,0 @@
-[emptyspan-4.html]
-  expected: FAIL


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Previously visual order of inline box elements was not maintained in Layout 2020.
https://drafts.csswg.org/css-writing-modes-4/#bidi-fragment-boxes
2.4.5.2. Box Model of Reordering-induced Box Fragments

This commit adds naive implementation and allows following WPT tests to pass:
https://wpt.fyi/results/css/CSS2/box?label=master&product=chrome%5Bexperimental%5D&product=edge%5Bexperimental%5D&product=firefox%5Bexperimental%5D&product=safari%5Bexperimental%5D&product=servo&aligned

Probably we still can have some problems. Especially related to vertical writing modes. 
That issues I would like to solve in the separate commits.

Manual testing on local machine on following folder provided following results:
tests/wpt/tests/css/CSS2
Ran 6261 tests finished in 1425.6 seconds.
  • 8 ran as expected.
  • 65 tests failed unexpectedly
  • 35 tests passed unexpectedly
  
That is fairly unexpected. Will see what github actions will provide.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
