### PR TITLE
layout: Fix CSS `attr()` function case sensitivity matching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3915,6 +3915,7 @@ dependencies = [
  "range",
  "rayon",
  "script_layout_interface",
+ "selectors",
  "serde",
  "serde_json",
  "servo_arc",

--- a/components/layout_2020/Cargo.toml
+++ b/components/layout_2020/Cargo.toml
@@ -40,6 +40,7 @@ pixels = { path = "../pixels" }
 range = { path = "../range" }
 rayon = { workspace = true }
 script_layout_interface = { workspace = true }
+selectors = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 servo_arc = { workspace = true }

--- a/components/script/layout_dom/element.rs
+++ b/components/script/layout_dom/element.rs
@@ -847,8 +847,7 @@ impl<'dom> ::selectors::Element for ServoThreadSafeLayoutElement<'dom> {
     }
 
     fn is_html_element_in_html_document(&self) -> bool {
-        debug!("ServoThreadSafeLayoutElement::is_html_element_in_html_document called");
-        true
+        self.element.is_html_element_in_html_document()
     }
 
     #[inline]

--- a/tests/wpt/meta/css/CSS2/generated-content/content-attr-case-001.html.ini
+++ b/tests/wpt/meta/css/CSS2/generated-content/content-attr-case-001.html.ini
@@ -1,2 +1,0 @@
-[content-attr-case-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-content/attr-case-sensitivity-001.html.ini
+++ b/tests/wpt/meta/css/css-content/attr-case-sensitivity-001.html.ini
@@ -1,2 +1,0 @@
-[attr-case-sensitivity-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-content/attr-case-sensitivity-002.html.ini
+++ b/tests/wpt/meta/css/css-content/attr-case-sensitivity-002.html.ini
@@ -1,2 +1,0 @@
-[attr-case-sensitivity-002.html]
-  expected: FAIL


### PR DESCRIPTION
Fix how `attr()` being resolved in the pseudo element by considering the case sensitivity of `attr-name` the document language. 

See https://drafts.csswg.org/css-values-5/#typedef-attr-name.

These changes add naive implementations and allow the following WPT tests to pass.
- `/css/css-content/attr-case-sensitivity-001.html`
- `/css/css-content/attr-case-sensitivity-002.html`
- `/css/CSS2/generated-content/content-attr-case-001.html`

The changes is related to the issue #23365 that mentions the `attr` function. I believe previous addition of `attr` already fixed the issue, but left the case sensitivity handling omitted.

More things about the function can also be considered:
- [Resolving it according to the spec](https://drafts.csswg.org/css-values-5/#attr-substitution).
- [Security of the function](https://drafts.csswg.org/css-values-5/#attr-security).

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #23365 
- [X] There are tests for these changes 

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
