### PR TITLE
script: Remove `note_rendering_opportunity` and `rendering_opportunity`

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -2064,6 +2064,12 @@ impl Document {
         }
     }
 
+    /// Whether or not this `Document` has any active requestAnimationFrame callbacks
+    /// registered.
+    pub(crate) fn has_active_request_animation_frame_callbacks(&self) -> bool {
+        !self.animation_frame_list.borrow().is_empty()
+    }
+
     /// <https://html.spec.whatwg.org/multipage/#dom-window-requestanimationframe>
     pub(crate) fn request_animation_frame(&self, callback: AnimationFrameCallback) -> u32 {
         let ident = self.animation_frame_ident.get() + 1;

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -2129,8 +2129,6 @@ impl Node {
             MutationObserver::queue_a_mutation_record(parent, mutation);
         }
         node.owner_doc().remove_script_and_layout_blocker();
-
-        ScriptThread::note_rendering_opportunity(window_from_node(parent).pipeline_id());
     }
 
     /// <https://dom.spec.whatwg.org/#concept-node-replace-all>
@@ -2254,7 +2252,6 @@ impl Node {
             MutationObserver::queue_a_mutation_record(parent, mutation);
         }
         parent.owner_doc().remove_script_and_layout_blocker();
-        ScriptThread::note_rendering_opportunity(window_from_node(parent).pipeline_id());
     }
 
     /// <https://dom.spec.whatwg.org/#concept-node-clone>

--- a/components/script/dom/resizeobserver.rs
+++ b/components/script/dom/resizeobserver.rs
@@ -26,7 +26,6 @@ use crate::dom::resizeobserverentry::ResizeObserverEntry;
 use crate::dom::resizeobserversize::{ResizeObserverSize, ResizeObserverSizeImpl};
 use crate::dom::window::Window;
 use crate::script_runtime::CanGc;
-use crate::script_thread::ScriptThread;
 
 /// <https://drafts.csswg.org/resize-observer/#calculate-depth-for-node>
 #[derive(Debug, Default, PartialEq, PartialOrd)]
@@ -191,10 +190,6 @@ impl ResizeObserverMethods<crate::DomTypeHolder> for ResizeObserver {
         self.observation_targets
             .borrow_mut()
             .push((resize_observation, Dom::from_ref(target)));
-
-        // Note: noting a rendering opportunity here is necessary
-        // to make /resize-observer/iframe-same-origin.html PASS.
-        ScriptThread::note_rendering_opportunity(window_from_node(target).pipeline_id());
     }
 
     /// <https://drafts.csswg.org/resize-observer/#dom-resizeobserver-unobserve>

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1809,6 +1809,10 @@ impl Window {
         ScriptThread::handle_tick_all_animations_for_testing(pipeline_id);
     }
 
+    pub(crate) fn reflows_suppressed(&self) -> bool {
+        self.suppress_reflow.get()
+    }
+
     /// Reflows the page unconditionally if possible and not suppressed. This method will wait for
     /// the layout to complete. If there is no window size yet, the page is presumed invisible and
     /// no reflow is performed. If reflow is suppressed, no reflow will be performed for ForDisplay

--- a/components/script/task_source/rendering.rs
+++ b/components/script/task_source/rendering.rs
@@ -43,3 +43,19 @@ impl TaskSource for RenderingTaskSource {
         self.0.send(msg_task).map_err(|_| ())
     }
 }
+
+impl RenderingTaskSource {
+    /// This queues a task that will not be cancelled when its associated
+    /// global scope gets destroyed.
+    pub fn queue_unconditionally<T>(&self, task: T) -> Result<(), ()>
+    where
+        T: TaskOnce + 'static,
+    {
+        self.0.send(CommonScriptMsg::Task(
+            ScriptThreadEventCategory::NetworkEvent,
+            Box::new(task),
+            Some(self.1),
+            RenderingTaskSource::NAME,
+        ))
+    }
+}


### PR DESCRIPTION
A rendering opportunity is now unconditionally triggered by handling IPC
messages in the `ScriptThread`, unless animations are running in which
case it's driven by the compositor. We can now remove calls to
`note_rendering_opportunity` and `rendering_opportunity`.

There is one tricky case, which is when a promise completion during a
microtask checkpoint dirties the page again. In this case we need to
trigger a new rendering opportunity, unless animations are running.  In
a followup change, when not driven by the compositor, rendering
opportunities will be driven by a timed task, meaning we can remove this
workaround.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #31242.
- [x] These changes are covered by existing WPT tests. They should not affect layout results.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
