### PR TITLE
android: Fix flinging downwards 

### DIFF
--- a/support/android/apk/servoview/src/main/java/org/servo/servoview/ServoView.java
+++ b/support/android/apk/servoview/src/main/java/org/servo/servoview/ServoView.java
@@ -299,7 +299,7 @@ public class ServoView extends SurfaceView
     }
 
     public boolean onScroll(MotionEvent e1, MotionEvent e2, float distanceX, float distanceY) {
-        mServo.scroll((int) -distanceX, (int) -distanceY, (int) e1.getX(), (int) e1.getY());
+        mServo.scroll((int) -distanceX, (int) -distanceY, (int) e2.getX(), (int) e2.getY());
         return true;
     }
 

--- a/support/android/apk/servoview/src/main/java/org/servo/servoview/ServoView.java
+++ b/support/android/apk/servoview/src/main/java/org/servo/servoview/ServoView.java
@@ -162,7 +162,17 @@ public class ServoView extends SurfaceView
         boolean zoomNecessary = mZooming && mZoomFactor != 1;
 
         if (scrollNecessary) {
-            mServo.scroll(dx, dy, mCurX, mCurY);
+            // We need to ensure x and y are inside the window, otherwise servo will not scroll!
+            // Our fling implementation will set `mCurX` and `mCurY` to a very high initial value
+            // when flinging with a negative velocity, since we don't know the size of our
+            // content page, because the android `OverScroller` needs to know the size of the page.
+            // Setting the page size to a ridiculously high value ensures that flinging will
+            // not be cut of short, even if we fling farther then the edge of the screen,
+            // starting from the touch up point.
+            int x = Math.min(mCurX, this.getHeight());
+            int y = Math.min(mCurY, this.getWidth());
+
+            mServo.scroll(dx, dy, x, y);
         }
 
         if (zoomNecessary) {


### PR DESCRIPTION
We need to ensure x and y are inside the window, otherwise servo will
not scroll!

[Our android fling implementation] will set `mCurX` and `mCurY` to a very high
initial value when flinging with a negative velocity, since we don't
know the size of our content page and the android `OverScroller`
needs to know the size of the page.

Setting the page size to a ridiculously high value ensures that flinging
will not be cut of short, even if we fling farther than the edge of the
screen, starting from the touch up point.

Additionally, also a minor fix to the scrolling source point: Scrolling should be based on `e2`, the second event, since dX and dY are relative to e2 and not e1.

[Our android fling implementation]: https://github.com/servo/servo/blob/25f242b652458fb91d7c923e48e7e61c8954fb01/support/android/apk/servoview/src/main/java/org/servo/servoview/ServoView.java#L241-L249

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix flinging on android
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

