### PR TITLE
Make sure to cache `inline_content_sizes()`

### DIFF
--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -2794,7 +2794,7 @@ impl FlexItemBox {
                                 style.writing_mode,
                                 non_replaced.preferred_aspect_ratio(),
                             );
-                            non_replaced
+                            self.independent_formatting_context
                                 .inline_content_sizes(
                                     flex_context.layout_context,
                                     &constraint_space,

--- a/components/layout_2020/flow/construct.rs
+++ b/components/layout_2020/flow/construct.rs
@@ -713,7 +713,7 @@ where
                 );
                 ArcRefCell::new(BlockLevelBox::OutsideMarker(OutsideMarker {
                     marker_style,
-                    list_item_style: info.style.clone(),
+                    base: LayoutBoxBase::new(info.into(), info.style.clone()),
                     block_container,
                 }))
             },

--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -220,12 +220,15 @@ pub(crate) struct CollapsibleWithParentStartMargin(bool);
 pub(crate) struct OutsideMarker {
     #[serde(skip_serializing)]
     pub marker_style: Arc<ComputedValues>,
-    #[serde(skip_serializing)]
-    pub list_item_style: Arc<ComputedValues>,
+    pub base: LayoutBoxBase,
     pub block_container: BlockContainer,
 }
 
 impl OutsideMarker {
+    fn list_item_style(&self) -> &ComputedValues {
+        &self.base.style
+    }
+
     fn layout(
         &self,
         layout_context: &LayoutContext<'_>,
@@ -238,9 +241,10 @@ impl OutsideMarker {
             &self.marker_style,
             None, /* TODO: support preferred aspect ratios on non-replaced boxes */
         );
-        let content_sizes = self
-            .block_container
-            .inline_content_sizes(layout_context, &constraint_space);
+        let content_sizes = self.base.inline_content_sizes(&constraint_space, || {
+            self.block_container
+                .inline_content_sizes(layout_context, &constraint_space)
+        });
         let containing_block_for_children = ContainingBlock {
             inline_size: content_sizes.sizes.max_content,
             block_size: AuOrAuto::auto(),
@@ -285,7 +289,9 @@ impl OutsideMarker {
         // TODO: This is the wrong containing block, as it should be the containing block of the
         // parent of this list item. What this means in practice is that the writing mode could be
         // wrong and padding defined as a percentage will be resolved incorrectly.
-        let pbm_of_list_item = self.list_item_style.padding_border_margin(containing_block);
+        let pbm_of_list_item = self
+            .list_item_style()
+            .padding_border_margin(containing_block);
         let content_rect = LogicalRect {
             start_corner: LogicalVec2 {
                 inline: -max_inline_size -
@@ -2082,8 +2088,7 @@ impl IndependentFormattingContext {
                         writing_mode,
                         non_replaced.preferred_aspect_ratio(),
                     );
-                    non_replaced
-                        .inline_content_sizes(layout_context, &constraint_space)
+                    self.inline_content_sizes(layout_context, &constraint_space)
                         .sizes
                 });
 

--- a/components/layout_2020/taffy/layout.rs
+++ b/components/layout_2020/taffy/layout.rs
@@ -232,7 +232,7 @@ impl taffy::LayoutPartialTree for TaffyContainerContext<'_> {
                                 preferred_aspect_ratio: non_replaced.preferred_aspect_ratio(),
                             };
 
-                            let result = non_replaced
+                            let result = independent_context
                                 .inline_content_sizes(self.layout_context, &constraint_space);
                             let adjusted_available_space = inputs
                                 .available_space


### PR DESCRIPTION
The refactoring in 264c0f972fd1a732ee1d1490d78a1d26a65c6f5f stopped caching the `inline_content_sizes()` calls from:
- `FlexItemBox::layout_for_block_content_size()`
- `IndependentFormattingContext::layout_float_or_atomic_inline()`
- `TaffyContainerContext::compute_child_layout()`

Also, the call from `OutsideMarker::layout()` was never cached.

This patch caches all of them.

It's not clear at all which `inline_content_sizes()` are cached and which aren't, so I plan to improve the situation in a follow-up.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because there should be no behavior change

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
