### PR TITLE
Replace unsafe uses of HandleValueArray.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -30,7 +30,7 @@ linker = "lld-link.exe"
 
 [env]
 MACOSX_DEPLOYMENT_TARGET = "13.0"
-RUSTC_BOOTSTRAP = "crown,script,style_tests"
+RUSTC_BOOTSTRAP = "crown,script,style_tests,mozjs"
 
 [build]
 rustdocflags = ["--document-private-items"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4475,7 +4475,7 @@ dependencies = [
 [[package]]
 name = "mozjs"
 version = "0.14.1"
-source = "git+https://github.com/servo/mozjs#18ab014e77eee726545ed544ea83d555bdfa46a3"
+source = "git+https://github.com/servo/mozjs#d6c3bd9a9a86a53c627355241b015fa7768ed688"
 dependencies = [
  "bindgen",
  "cc",
@@ -4487,8 +4487,8 @@ dependencies = [
 
 [[package]]
 name = "mozjs_sys"
-version = "0.128.3-5"
-source = "git+https://github.com/servo/mozjs#18ab014e77eee726545ed544ea83d555bdfa46a3"
+version = "0.128.3-6"
+source = "git+https://github.com/servo/mozjs#d6c3bd9a9a86a53c627355241b015fa7768ed688"
 dependencies = [
  "bindgen",
  "cc",

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -72,7 +72,7 @@ image = { workspace = true }
 indexmap = { workspace = true }
 ipc-channel = { workspace = true }
 itertools = { workspace = true }
-js = { package = "mozjs", git = "https://github.com/servo/mozjs", features = ["streams"] }
+js = { package = "mozjs", git = "https://github.com/servo/mozjs", features = ["streams", "crown"] }
 jstraceable_derive = { path = "../jstraceable_derive" }
 keyboard-types = { workspace = true }
 libc = { workspace = true }

--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -8170,7 +8170,10 @@ class CGIterableMethodGenerator(CGGeneric):
                 rooted!(in(*cx) let arg0 = ObjectValue(arg0));
                 rooted!(in(*cx) let mut call_arg1 = UndefinedValue());
                 rooted!(in(*cx) let mut call_arg2 = UndefinedValue());
-                let mut call_args = [UndefinedValue(), UndefinedValue(), ObjectValue(*_obj)];
+                rooted_vec!(let mut call_args);
+                call_args.push(UndefinedValue());
+                call_args.push(UndefinedValue());
+                call_args.push(ObjectValue(*_obj));
                 rooted!(in(*cx) let mut ignoredReturnVal = UndefinedValue());
 
                 // This has to be a while loop since get_iterable_length() may change during
@@ -8186,8 +8189,8 @@ class CGIterableMethodGenerator(CGGeneric):
                   (*this).get_key_at_index(i).to_jsval(*cx, call_arg2.handle_mut());
                   call_args[0] = call_arg1.handle().get();
                   call_args[1] = call_arg2.handle().get();
-                  let call_args = HandleValueArray { length_: 3, elements_: call_args.as_ptr() };
-                  if !Call(*cx, arg1, arg0.handle(), &call_args,
+                  let call_args_handle = HandleValueArray::from(&call_args);
+                  if !Call(*cx, arg1, arg0.handle(), &call_args_handle,
                            ignoredReturnVal.handle_mut()) {
                     return false;
                   }

--- a/components/script/dom/bindings/proxyhandler.rs
+++ b/components/script/dom/bindings/proxyhandler.rs
@@ -486,7 +486,7 @@ pub unsafe fn cross_origin_get(
         *cx,
         receiver,
         getter_jsval.handle().into(),
-        &jsapi::HandleValueArray::new(),
+        &jsapi::HandleValueArray::empty(),
         vp,
     )
 }

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -722,7 +722,7 @@ impl CustomElementDefinition {
         {
             // Go into the constructor's realm
             let _ac = JSAutoRealm::new(*cx, self.constructor.callback());
-            let args = HandleValueArray::new();
+            let args = HandleValueArray::empty();
             if unsafe { !Construct1(*cx, constructor.handle(), &args, element.handle_mut()) } {
                 return Err(Error::JSFailed);
             }
@@ -907,7 +907,7 @@ fn run_upgrade_constructor(
 
         // Go into the constructor's realm
         let _ac = JSAutoRealm::new(*cx, constructor.callback());
-        let args = HandleValueArray::new();
+        let args = HandleValueArray::empty();
         // Step 8.2
         if unsafe {
             !Construct1(

--- a/components/script/dom/gamepadbuttonlist.rs
+++ b/components/script/dom/gamepadbuttonlist.rs
@@ -73,7 +73,7 @@ impl GamepadButtonList {
             GamepadButton::new(global, false, false), // Right button in left cluster
             GamepadButton::new(global, false, false), // Center button in center cluster
         ];
-        rooted_vec!(let buttons <- standard_buttons.iter().map(|b| DomRoot::as_traced(b)));
+        rooted_vec!(let buttons <- standard_buttons.iter().map(DomRoot::as_traced));
         Self::new(global, buttons.r())
     }
 }

--- a/components/script/dom/gamepadbuttonlist.rs
+++ b/components/script/dom/gamepadbuttonlist.rs
@@ -73,7 +73,7 @@ impl GamepadButtonList {
             GamepadButton::new(global, false, false), // Right button in left cluster
             GamepadButton::new(global, false, false), // Center button in center cluster
         ];
-        rooted_vec!(let buttons <- standard_buttons.iter().map(|button| DomRoot::from_ref(&**button)));
+        rooted_vec!(let buttons <- standard_buttons.iter().map(|b| DomRoot::as_traced(b)));
         Self::new(global, buttons.r())
     }
 }

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -2141,7 +2141,7 @@ impl Node {
             Node::adopt(node, &parent.owner_doc());
         }
         // Step 2.
-        rooted_vec!(let removed_nodes <- parent.children());
+        rooted_vec!(let removed_nodes <- parent.children().map(|c| DomRoot::as_traced(&c)));
         // Step 3.
         rooted_vec!(let mut added_nodes);
         let added_nodes = if let Some(node) = node.as_ref() {

--- a/components/script/dom/paintworkletglobalscope.rs
+++ b/components/script/dom/paintworkletglobalscope.rs
@@ -268,7 +268,7 @@ impl PaintWorkletGlobalScope {
             Entry::Occupied(entry) => paint_instance.set(entry.get().get()),
             Entry::Vacant(entry) => {
                 // Step 5.2-5.3
-                let args = HandleValueArray::new();
+                let args = HandleValueArray::empty();
                 rooted!(in(*cx) let mut result = null_mut::<JSObject>());
                 unsafe {
                     Construct1(*cx, class_constructor.handle(), &args, result.handle_mut());
@@ -306,23 +306,22 @@ impl PaintWorkletGlobalScope {
         // TODO: Step 10
         // Steps 11-12
         debug!("Invoking paint function {}.", name);
-        rooted_vec!(let arguments_values <- arguments.iter().cloned()
-                    .map(|argument| CSSStyleValue::new(self.upcast(), argument)));
-        let arguments_value_vec: Vec<JSVal> = arguments_values
-            .iter()
-            .map(|argument| ObjectValue(argument.reflector().get_jsobject().get()))
-            .collect();
-        let arguments_value_array =
-            unsafe { HandleValueArray::from_rooted_slice(&arguments_value_vec) };
+        rooted_vec!(let mut arguments_values);
+        for argument in arguments {
+            let style_value = CSSStyleValue::new(self.upcast(), argument.clone());
+            arguments_values.push(ObjectValue(style_value.reflector().get_jsobject().get()));
+        }
+        let arguments_value_array = HandleValueArray::from(&arguments_values);
         rooted!(in(*cx) let argument_object = unsafe { NewArrayObject(*cx, &arguments_value_array) });
 
-        let args_slice = [
-            ObjectValue(rendering_context.reflector().get_jsobject().get()),
-            ObjectValue(paint_size.reflector().get_jsobject().get()),
-            ObjectValue(properties.reflector().get_jsobject().get()),
-            ObjectValue(argument_object.get()),
-        ];
-        let args = unsafe { HandleValueArray::from_rooted_slice(&args_slice) };
+        rooted_vec!(let mut callback_args);
+        callback_args.push(ObjectValue(
+            rendering_context.reflector().get_jsobject().get(),
+        ));
+        callback_args.push(ObjectValue(paint_size.reflector().get_jsobject().get()));
+        callback_args.push(ObjectValue(properties.reflector().get_jsobject().get()));
+        callback_args.push(ObjectValue(argument_object.get()));
+        let args = HandleValueArray::from(&callback_args);
 
         rooted!(in(*cx) let mut result = UndefinedValue());
         unsafe {

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -252,7 +252,7 @@ pub unsafe fn jsval_to_webdriver(
                 cx,
                 object.handle(),
                 name.as_ptr(),
-                &HandleValueArray::new(),
+                &HandleValueArray::empty(),
                 value.handle_mut(),
             ) {
                 jsval_to_webdriver(cx, global_scope, value.handle())


### PR DESCRIPTION
Incorporates the changes from https://github.com/servo/mozjs/pull/533 and rewrites all unsafe uses of HandleValueArray to use the new safe From implementations.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #28554 
- [x] There are tests for these changes (existing WPT suite)
