### PR TITLE
Remove taffy-specific layout caching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7132,9 +7132,9 @@ dependencies = [
 
 [[package]]
 name = "taffy"
-version = "0.6.3"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136661daffcdfb128afb0d45a8f7e88078739196d64d7ffa47f8513f4a00a6d7"
+checksum = "bf595259ca079fc86dc249d8ece0b4e822b83035daa0c0491aa4c12b1232b36c"
 dependencies = [
  "arrayvec",
  "grid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,7 +129,7 @@ style_malloc_size_of = { package = "malloc_size_of", git = "https://github.com/s
 surfman = { git = "https://github.com/servo/surfman", rev = "c8d6b4b65aeab739ee7651602e29c8d58ceee123", features = ["chains"] }
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"
-taffy = { version = "0.6.3", default-features = false, features = ["std", "serde", "grid"] }
+taffy = { version = "0.7", default-features = false, features = ["std", "serde", "grid"] }
 thin-vec = "0.2.13"
 tikv-jemalloc-sys = "0.6.0"
 tikv-jemallocator = "0.6.0"

--- a/components/layout_2020/taffy/layout.rs
+++ b/components/layout_2020/taffy/layout.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use app_units::Au;
-use atomic_refcell::{AtomicRef, AtomicRefCell, AtomicRefMut};
+use atomic_refcell::{AtomicRef, AtomicRefCell};
 use style::properties::ComputedValues;
 use style::values::generics::length::{GenericLengthPercentageOrAuto, LengthPercentageOrAuto};
 use style::values::specified::align::AlignFlags;
@@ -92,7 +92,6 @@ impl taffy::TraversePartialTree for TaffyContainerContext<'_> {
 
 impl taffy::LayoutPartialTree for TaffyContainerContext<'_> {
     type CoreContainerStyle<'a> = TaffyStyloStyle<&'a ComputedValues> where Self: 'a;
-    type CacheMut<'b> = AtomicRefMut<'b, taffy::Cache> where Self: 'b;
 
     fn get_core_container_style(&self, _node_id: taffy::NodeId) -> Self::CoreContainerStyle<'_> {
         TaffyStyloStyle(self.style)
@@ -101,12 +100,6 @@ impl taffy::LayoutPartialTree for TaffyContainerContext<'_> {
     fn set_unrounded_layout(&mut self, node_id: taffy::NodeId, layout: &taffy::Layout) {
         let id = usize::from(node_id);
         (*self.source_child_nodes[id]).borrow_mut().taffy_layout = *layout;
-    }
-
-    fn get_cache_mut(&mut self, node_id: taffy::NodeId) -> AtomicRefMut<'_, taffy::Cache> {
-        let id = usize::from(node_id);
-        let mut_ref: AtomicRefMut<'_, _> = (*self.source_child_nodes[id]).borrow_mut();
-        AtomicRefMut::map(mut_ref, |node| &mut node.taffy_layout_cache)
     }
 
     fn compute_child_layout(

--- a/components/layout_2020/taffy/mod.rs
+++ b/components/layout_2020/taffy/mod.rs
@@ -73,7 +73,6 @@ impl TaffyContainer {
 
 #[derive(Serialize)]
 pub(crate) struct TaffyItemBox {
-    pub(crate) taffy_layout_cache: taffy::Cache,
     pub(crate) taffy_layout: taffy::Layout,
     pub(crate) child_fragments: Vec<Fragment>,
     #[serde(skip_serializing)]
@@ -92,7 +91,6 @@ pub(crate) enum TaffyItemBoxInner {
 impl fmt::Debug for TaffyItemBox {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("TaffyItemBox")
-            .field("taffy_layout_cache", &self.taffy_layout_cache)
             .field("taffy_layout", &self.taffy_layout)
             .field("child_fragments", &self.child_fragments.len())
             .field("style", &self.style)
@@ -111,7 +109,6 @@ impl TaffyItemBox {
         };
 
         Self {
-            taffy_layout_cache: Default::default(),
             taffy_layout: Default::default(),
             child_fragments: Vec::new(),
             positioning_context: PositioningContext::new_for_containing_block_for_all_descendants(),


### PR DESCRIPTION
`layout_2020`s caching is now good enough (and still improving) that I think we can just use that for taffy-based layout, same as the other layout modes.

This PR also includes a Taffy version bump to update Taffy's API to allow for the possibility of not implementing the caching methods.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
