### PR TITLE
Upgrade Rust to 1.82.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ authors = ["The Servo Project Developers"]
 license = "MPL-2.0"
 edition = "2021"
 publish = false
-rust-version = "1.81.0"
+rust-version = "1.82.0"
 
 [workspace.dependencies]
 accountable-refcell = "0.2.0"

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -1177,6 +1177,8 @@ where
     )]
     fn handle_request(&mut self) {
         #[derive(Debug)]
+        // FIXME: https://github.com/servo/servo/issues/34591
+        #[expect(clippy::large_enum_variant)]
         enum Request {
             PipelineNamespace(PipelineNamespaceRequest),
             Script((PipelineId, FromScriptMsg)),

--- a/components/constellation/session_history.rs
+++ b/components/constellation/session_history.rs
@@ -132,6 +132,8 @@ pub struct SessionHistoryChange {
 }
 
 /// Represents a pipeline or discarded pipeline in a history entry.
+// FIXME: https://github.com/servo/servo/issues/34591
+#[expect(clippy::large_enum_variant)]
 #[derive(Clone, Debug)]
 pub enum NeedsToReload {
     /// Represents a pipeline that has not been discarded
@@ -176,6 +178,8 @@ impl PartialEq for NeedsToReload {
 }
 
 /// Represents a the difference between two adjacent session history entries.
+// FIXME: https://github.com/servo/servo/issues/34591
+#[expect(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub enum SessionHistoryDiff {
     /// Represents a diff where the active pipeline of an entry changed.

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -52,6 +52,8 @@ pub enum DevtoolsControlMsg {
 }
 
 /// Events that the devtools server must act upon.
+// FIXME: https://github.com/servo/servo/issues/34591
+#[expect(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub enum ChromeToDevtoolsControlMsg {
     /// A new client has connected to the server.

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -183,6 +183,8 @@ impl From<ReferrerPolicy> for ReferrerPolicyHeader {
     }
 }
 
+// FIXME: https://github.com/servo/servo/issues/34591
+#[expect(clippy::large_enum_variant)]
 #[derive(Debug, Deserialize, Serialize)]
 pub enum FetchResponseMsg {
     // todo: should have fields for transmitted/total bytes
@@ -239,6 +241,8 @@ pub enum FilteredMetadata {
     OpaqueRedirect(ServoUrl),
 }
 
+// FIXME: https://github.com/servo/servo/issues/34591
+#[expect(clippy::large_enum_variant)]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum FetchMetadata {
     Unfiltered(Metadata),
@@ -502,6 +506,8 @@ pub enum CoreResourceMsg {
     Exit(IpcSender<()>),
 }
 
+// FIXME: https://github.com/servo/servo/issues/34591
+#[expect(clippy::large_enum_variant)]
 enum ToFetchThreadMessage {
     StartFetch(
         /* request_builder */ RequestBuilder,

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -271,6 +271,8 @@ pub enum UpdatePipelineIdReason {
 }
 
 /// Messages sent from the constellation or layout to the script thread.
+// FIXME: https://github.com/servo/servo/issues/34591
+#[expect(clippy::large_enum_variant)]
 #[derive(Deserialize, Serialize)]
 pub enum ConstellationControlMsg {
     /// Takes the associated window proxy out of "delaying-load-events-mode",

--- a/components/webgpu/ipc_messages/recv.rs
+++ b/components/webgpu/ipc_messages/recv.rs
@@ -42,6 +42,8 @@ pub struct ContextConfiguration {
     pub is_opaque: bool,
 }
 
+// FIXME: https://github.com/servo/servo/issues/34591
+#[expect(clippy::large_enum_variant)]
 #[derive(Debug, Deserialize, Serialize)]
 pub enum WebGPURequest {
     BufferMapAsync {

--- a/ports/servoshell/panic_hook.rs
+++ b/ports/servoshell/panic_hook.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::io::Write;
-use std::panic::PanicInfo;
+use std::panic::PanicHookInfo;
 use std::{env, thread};
 
 use log::{error, warn};
@@ -11,7 +11,7 @@ use servo::config::opts;
 
 use crate::crash_handler::raise_signal_or_exit_with_error;
 
-pub(crate) fn panic_hook(info: &PanicInfo) {
+pub(crate) fn panic_hook(info: &PanicHookInfo) {
     warn!("Panic hook called.");
     let msg = match info.payload().downcast_ref::<&'static str>() {
         Some(s) => *s,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 # Be sure to update shell.nix and support/crown/rust-toolchain.toml when bumping this!
-channel = "1.81.0"
+channel = "1.82.0"
 
 components = [
     "clippy",

--- a/support/crown/rust-toolchain.toml
+++ b/support/crown/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.81.0"
+channel = "1.82.0"
 
 components = [
     "clippy",


### PR DESCRIPTION
Silences the new `clippy::large_enum_variant` lint and creates a tracking issue, so that we don't forget to investigate the individual enums.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes 
