### PR TITLE
Distinguish cached `inline_content_sizes()` from uncached ones

### DIFF
--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -38,7 +38,9 @@ use crate::geom::{AuOrAuto, LogicalRect, LogicalSides, LogicalVec2, Size};
 use crate::positioned::{
     relative_adjustement, AbsolutelyPositionedBox, PositioningContext, PositioningContextLength,
 };
-use crate::sizing::{ContentSizes, InlineContentSizesResult, IntrinsicSizingMode};
+use crate::sizing::{
+    ComputeInlineContentSizes, ContentSizes, InlineContentSizesResult, IntrinsicSizingMode,
+};
 use crate::style_ext::{
     AspectRatio, Clamp, ComputedValuesExt, ContentBoxSizesAndPBMDeprecated, PaddingBorderMargin,
 };
@@ -411,17 +413,17 @@ struct FlexItemBoxInlineContentSizesInfo {
     depends_on_block_constraints: bool,
 }
 
-impl FlexContainer {
+impl ComputeInlineContentSizes for FlexContainer {
     #[cfg_attr(
         feature = "tracing",
         tracing::instrument(
-            name = "FlexContainer::inline_content_sizes",
+            name = "FlexContainer::compute_inline_content_sizes",
             skip_all,
             fields(servo_profiling = true),
             level = "trace",
         )
     )]
-    pub fn inline_content_sizes(
+    fn compute_inline_content_sizes(
         &self,
         layout_context: &LayoutContext,
         constraint_space: &ConstraintSpace,
@@ -437,7 +439,9 @@ impl FlexContainer {
             FlexAxis::Column => self.cross_content_sizes(layout_context, &constraint_space.into()),
         }
     }
+}
 
+impl FlexContainer {
     fn cross_content_sizes(
         &self,
         layout_context: &LayoutContext,

--- a/components/layout_2020/flow/inline/mod.rs
+++ b/components/layout_2020/flow/inline/mod.rs
@@ -126,7 +126,7 @@ use crate::fragment_tree::{
 };
 use crate::geom::{LogicalRect, LogicalVec2, ToLogical};
 use crate::positioned::{AbsolutelyPositionedBox, PositioningContext};
-use crate::sizing::{ContentSizes, InlineContentSizesResult};
+use crate::sizing::{ComputeInlineContentSizes, ContentSizes, InlineContentSizesResult};
 use crate::style_ext::{ComputedValuesExt, PaddingBorderMargin};
 use crate::{ConstraintSpace, ContainingBlock};
 
@@ -1579,17 +1579,6 @@ impl InlineFormattingContext {
         }
     }
 
-    // This works on an already-constructed `InlineFormattingContext`,
-    // Which would have to change if/when
-    // `BlockContainer::construct` parallelize their construction.
-    pub(super) fn inline_content_sizes(
-        &self,
-        layout_context: &LayoutContext,
-        constraint_space: &ConstraintSpace,
-    ) -> InlineContentSizesResult {
-        ContentSizesComputation::compute(self, layout_context, constraint_space)
-    }
-
     pub(super) fn layout(
         &self,
         layout_context: &LayoutContext,
@@ -2192,6 +2181,19 @@ fn inline_container_needs_strut(
 
     pbm.map(|pbm| !pbm.padding_border_sums.inline.is_zero())
         .unwrap_or(false)
+}
+
+impl ComputeInlineContentSizes for InlineFormattingContext {
+    // This works on an already-constructed `InlineFormattingContext`,
+    // Which would have to change if/when
+    // `BlockContainer::construct` parallelize their construction.
+    fn compute_inline_content_sizes(
+        &self,
+        layout_context: &LayoutContext,
+        constraint_space: &ConstraintSpace,
+    ) -> InlineContentSizesResult {
+        ContentSizesComputation::compute(self, layout_context, constraint_space)
+    }
 }
 
 /// A struct which takes care of computing [`ContentSizes`] for an [`InlineFormattingContext`].

--- a/components/layout_2020/sizing.rs
+++ b/components/layout_2020/sizing.rs
@@ -12,6 +12,7 @@ use serde::Serialize;
 use style::properties::ComputedValues;
 use style::Zero;
 
+use crate::context::LayoutContext;
 use crate::geom::Size;
 use crate::style_ext::{AspectRatio, Clamp, ComputedValuesExt, ContentBoxSizesAndPBM};
 use crate::{ConstraintSpace, IndefiniteContainingBlock, LogicalVec2, SizeConstraint};
@@ -215,4 +216,12 @@ pub(crate) fn outer_inline(
 pub(crate) struct InlineContentSizesResult {
     pub sizes: ContentSizes,
     pub depends_on_block_constraints: bool,
+}
+
+pub(crate) trait ComputeInlineContentSizes {
+    fn compute_inline_content_sizes(
+        &self,
+        layout_context: &LayoutContext,
+        constraint_space: &ConstraintSpace,
+    ) -> InlineContentSizesResult;
 }

--- a/components/layout_2020/taffy/layout.rs
+++ b/components/layout_2020/taffy/layout.rs
@@ -25,7 +25,7 @@ use crate::geom::{
     SizeConstraint,
 };
 use crate::positioned::{AbsolutelyPositionedBox, PositioningContext, PositioningContextLength};
-use crate::sizing::{ContentSizes, InlineContentSizesResult};
+use crate::sizing::{ComputeInlineContentSizes, ContentSizes, InlineContentSizesResult};
 use crate::style_ext::ComputedValuesExt;
 use crate::{ConstraintSpace, ContainingBlock, ContainingBlockSize};
 
@@ -332,8 +332,8 @@ impl taffy::LayoutGridContainer for TaffyContainerContext<'_> {
     }
 }
 
-impl TaffyContainer {
-    pub fn inline_content_sizes(
+impl ComputeInlineContentSizes for TaffyContainer {
+    fn compute_inline_content_sizes(
         &self,
         layout_context: &LayoutContext,
         _constraint_space: &ConstraintSpace,
@@ -407,7 +407,9 @@ impl TaffyContainer {
             depends_on_block_constraints: true,
         }
     }
+}
 
+impl TaffyContainer {
     /// <https://drafts.csswg.org/css-grid/#layout-algorithm>
     pub(crate) fn layout(
         &self,


### PR DESCRIPTION
Several structs and enums had a `inline_content_sizes()` method, but it wasn't clear which ones would try to cache the result, and which ones would always compute it.

Therefore, this performs some clarifying renaming:
 - Cached ones stay as `inline_content_sizes()`
 - Uncached ones become `compute_inline_content_sizes()`

Also, to simplify calls to `LayoutBoxBase::inline_content_sizes()`, `compute_inline_content_sizes()` is moved into a new trait.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because there is no change in behavior

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
