### PR TITLE
script: No longer do explicit reflows for display

### DIFF
--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -728,6 +728,7 @@ malloc_size_of_is_style_malloc_size_of!(style::dom::OpaqueNode);
 malloc_size_of_is_style_malloc_size_of!(style::invalidation::element::restyle_hints::RestyleHint);
 malloc_size_of_is_style_malloc_size_of!(style::media_queries::MediaList);
 malloc_size_of_is_style_malloc_size_of!(style::properties::style_structs::Font);
+malloc_size_of_is_style_malloc_size_of!(style::queries::values::PrefersColorScheme);
 malloc_size_of_is_style_malloc_size_of!(style::selector_parser::PseudoElement);
 malloc_size_of_is_style_malloc_size_of!(style::selector_parser::RestyleDamage);
 malloc_size_of_is_style_malloc_size_of!(style::selector_parser::Snapshot);

--- a/components/script/dom/activation.rs
+++ b/components/script/dom/activation.rs
@@ -2,14 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use script_layout_interface::ReflowGoal;
-
 use crate::dom::element::Element;
 use crate::dom::event::Event;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::htmlinputelement::InputActivationState;
-use crate::dom::node::window_from_node;
-use crate::dom::window::ReflowReason;
 use crate::script_runtime::CanGc;
 
 /// Trait for elements with defined activation behavior
@@ -35,23 +31,9 @@ pub trait Activatable {
     // https://html.spec.whatwg.org/multipage/#concept-selector-active
     fn enter_formal_activation_state(&self) {
         self.as_element().set_active_state(true);
-
-        let win = window_from_node(self.as_element());
-        win.reflow(
-            ReflowGoal::Full,
-            ReflowReason::ElementStateChanged,
-            CanGc::note(),
-        );
     }
 
     fn exit_formal_activation_state(&self) {
         self.as_element().set_active_state(false);
-
-        let win = window_from_node(self.as_element());
-        win.reflow(
-            ReflowGoal::Full,
-            ReflowReason::ElementStateChanged,
-            CanGc::note(),
-        );
     }
 }

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -26,7 +26,6 @@ use js::jsval::JSVal;
 use js::rust::HandleObject;
 use net_traits::request::CorsSettings;
 use net_traits::ReferrerPolicy;
-use script_layout_interface::ReflowGoal;
 use selectors::attr::{AttrSelectorOperation, CaseSensitivity, NamespaceConstraint};
 use selectors::bloom::{BloomFilter, BLOOM_HASH_MASK};
 use selectors::matching::{ElementSelectorFlags, MatchingContext};
@@ -149,7 +148,6 @@ use crate::dom::text::Text;
 use crate::dom::validation::Validatable;
 use crate::dom::validitystate::ValidationFlags;
 use crate::dom::virtualmethods::{vtable_for, VirtualMethods};
-use crate::dom::window::ReflowReason;
 use crate::script_runtime::CanGc;
 use crate::script_thread::ScriptThread;
 use crate::stylesheet_loader::StylesheetOwner;
@@ -4429,11 +4427,6 @@ impl TaskOnce for ElementPerformFullscreenEnter {
         // Step 7.5
         element.set_fullscreen_state(true);
         document.set_fullscreen_element(Some(&element));
-        document.window().reflow(
-            ReflowGoal::Full,
-            ReflowReason::ElementStateChanged,
-            CanGc::note(),
-        );
 
         // Step 7.6
         document
@@ -4467,13 +4460,6 @@ impl TaskOnce for ElementPerformFullscreenExit {
         // TODO Step 9.1-5
         // Step 9.6
         element.set_fullscreen_state(false);
-
-        document.window().reflow(
-            ReflowGoal::Full,
-            ReflowReason::ElementStateChanged,
-            CanGc::note(),
-        );
-
         document.set_fullscreen_element(None);
 
         // Step 9.8

--- a/components/script/dom/htmlbodyelement.rs
+++ b/components/script/dom/htmlbodyelement.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::time::Duration;
-
 use dom_struct::dom_struct;
 use embedder_traits::EmbedderMsg;
 use html5ever::{local_name, namespace_url, ns, LocalName, Prefix};
@@ -25,9 +23,6 @@ use crate::dom::htmlelement::HTMLElement;
 use crate::dom::node::{document_from_node, window_from_node, BindContext, Node};
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::script_runtime::CanGc;
-
-/// How long we should wait before performing the initial reflow after `<body>` is parsed.
-const INITIAL_REFLOW_DELAY: Duration = Duration::from_millis(200);
 
 #[dom_struct]
 pub struct HTMLBodyElement {
@@ -158,11 +153,9 @@ impl VirtualMethods for HTMLBodyElement {
         }
 
         let window = window_from_node(self);
-        let document = window.Document();
-        document.set_reflow_timeout(INITIAL_REFLOW_DELAY);
+        window.prevent_layout_until_load_event();
         if window.is_top_level() {
-            let msg = EmbedderMsg::HeadParsed;
-            window.send_to_embedder(msg);
+            window.send_to_embedder(EmbedderMsg::HeadParsed);
         }
     }
 

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -618,7 +618,9 @@ impl ServoParser {
             assert!(!self.suspended.get());
             assert!(!self.aborted.get());
 
-            self.document.reflow_if_reflow_timer_expired(can_gc);
+            self.document
+                .window()
+                .reflow_if_reflow_timer_expired(can_gc);
             let script = match feed(&self.tokenizer) {
                 TokenizerResult::Done => return,
                 TokenizerResult::Script(script) => script,


### PR DESCRIPTION
These all happen now in *update the rendering*, typically after the
message that triggered this code is processed, though in two cases
reflow needs to be triggered explicitly. This makes `ReflowReason`
redundant though perhaps `ReflowCondition` can be expanded later to give
more insight into why the page is dirty.

- Handling of the "reflow timer" concept has been explained a bit more via
  data structures and rustdoc comments.
- Theme changes are cleaned up a little to simplify what happens during
  reflow and to avoid unecessary reflows when the theme doesn't change.

Notably, layout queries and scrolling still trigger normal reflows and
don't update the rendering. This needs more investigation as it's
unclear to me currently whether or not they should update the rendering
and simply delay event dispatch or only reflow.

In general, this is a simplfication of the code.

Fixes #31871.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #31871.
- [x] These changes are covered by existing WPT tests. In some cases behavior
      may be different, but they do not introduce any changes to layout results as
      far as I can tell.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
