### PR TITLE
WIP: force CI to build mozjs from source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4475,7 +4475,7 @@ dependencies = [
 [[package]]
 name = "mozjs"
 version = "0.14.1"
-source = "git+https://github.com/servo/mozjs#18ab014e77eee726545ed544ea83d555bdfa46a3"
+source = "git+https://github.com/jschwe/mozjs?branch=dummt_version_bump#3ce0a13cca86fbbc0da6a7a1780c5e615154fbb1"
 dependencies = [
  "bindgen",
  "cc",
@@ -4487,8 +4487,8 @@ dependencies = [
 
 [[package]]
 name = "mozjs_sys"
-version = "0.128.3-5"
-source = "git+https://github.com/servo/mozjs#18ab014e77eee726545ed544ea83d555bdfa46a3"
+version = "0.128.3-9999"
+source = "git+https://github.com/jschwe/mozjs?branch=dummt_version_bump#3ce0a13cca86fbbc0da6a7a1780c5e615154fbb1"
 dependencies = [
  "bindgen",
  "cc",

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -72,7 +72,7 @@ image = { workspace = true }
 indexmap = { workspace = true }
 ipc-channel = { workspace = true }
 itertools = { workspace = true }
-js = { package = "mozjs", git = "https://github.com/servo/mozjs", features = ["streams"] }
+js = { package = "mozjs", git = "https://github.com/jschwe/mozjs", features = ["streams"], branch = "dummt_version_bump" }
 jstraceable_derive = { path = "../jstraceable_derive" }
 keyboard-types = { workspace = true }
 libc = { workspace = true }


### PR DESCRIPTION
Check if our CI can build mozjs from source successfully, when there are no prebuilt artifacts available


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
