### PR TITLE
Fix devtools timeout with Firefox 133

### DIFF
--- a/components/devtools/actors/root.rs
+++ b/components/devtools/actors/root.rs
@@ -115,6 +115,13 @@ struct GetProcessResponse {
     process_descriptor: ProcessActorMsg,
 }
 
+#[derive(Serialize)]
+struct ErrorResponse {
+    from: String,
+    error: String,
+    message: String,
+}
+
 pub struct RootActor {
     pub tabs: Vec<String>,
     pub workers: Vec<String>,
@@ -249,7 +256,19 @@ impl Actor for RootActor {
                 ActorMessageStatus::Processed
             },
 
-            _ => ActorMessageStatus::Ignored,
+            _ => {
+                let reply = ErrorResponse {
+                    from: self.name(),
+                    error: "unrecognizedPacketType".to_owned(),
+                    message: format!(
+                        "Actor {} does not recognize the packet type '{}'",
+                        self.name(),
+                        msg_type,
+                    ),
+                };
+                let _ = stream.write_json_packet(&reply);
+                ActorMessageStatus::Ignored
+            },
         })
     }
 }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Firefox 133 added a new [`connect` protocol message](https://bugzilla.mozilla.org/show_bug.cgi?id=1921118) that causes the remote debug connection to timeout. Firefox expects to receive an error or response for this message, but Servo ignores it:

```
$ RUST_LOG='devtools=debug' ./mach run -r --devtools=6080
[2024-12-12T19:03:28Z DEBUG devtools] connection established to 127.0.0.1:51835
[2024-12-12T19:03:28Z DEBUG devtools::protocol] <- {"from":"root","applicationType":"browser","traits":{"sources":false,"highlightable":true,"customHighlighters":true,"networkMonitor":false}}
[2024-12-12T19:03:28Z DEBUG devtools::protocol] {"type":"connect","frontendVersion":"133.0","to":"root"}
[2024-12-12T19:03:28Z DEBUG devtools::actor] unexpected message type "connect" found for actor "root"
```

Ironically, this new message was added for Servo.

This PR fixes the timeout by responding to unknown messages with an error.

See also: #32404

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because the `devtools` package contains no tests.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
