### PR TITLE
config: move all opts items to opts module

### DIFF
--- a/components/config/opts.rs
+++ b/components/config/opts.rs
@@ -454,7 +454,8 @@ pub fn default_opts() -> Opts {
     }
 }
 
-pub fn from_cmdline_args(mut opts: Options, args: &[String]) -> ArgumentParsingResult {
+pub fn from_cmdline_args(args: &[String]) -> ArgumentParsingResult {
+    let mut opts = Options::new();
     let (app_name, args) = args.split_first().unwrap();
 
     opts.optflag("", "legacy-layout", "Use the legacy layout engine");

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -240,7 +240,6 @@ where
     pub fn new(
         mut embedder: Box<dyn EmbedderMethods>,
         window: Rc<Window>,
-        user_agent: Option<String>,
         composite_target: CompositeTarget,
     ) -> InitializedServo<Window> {
         // Global configuration options, parsed from the command line.
@@ -259,7 +258,7 @@ where
             media_platform::init();
         }
 
-        let user_agent = match user_agent {
+        let user_agent = match &opts.user_agent {
             Some(ref ua) if ua == "ios" => default_user_agent_string_for(UserAgent::iOS).into(),
             Some(ref ua) if ua == "android" => {
                 default_user_agent_string_for(UserAgent::Android).into()
@@ -270,7 +269,7 @@ where
             Some(ref ua) if ua == "ohos" => {
                 default_user_agent_string_for(UserAgent::OpenHarmony).into()
             },
-            Some(ua) => ua.into(),
+            Some(ua) => ua.clone().into(),
             None => embedder
                 .get_user_agent_string()
                 .map(Into::into)

--- a/ports/servoshell/desktop/cli.rs
+++ b/ports/servoshell/desktop/cli.rs
@@ -4,10 +4,7 @@
 
 use std::{env, panic, process};
 
-use getopts::Options;
-use log::error;
 use servo::config::opts::{self, ArgumentParsingResult};
-use servo::servo_config::pref;
 
 use crate::desktop::app::App;
 use crate::panic_hook;
@@ -19,43 +16,10 @@ pub fn main() {
 
     // Parse the command line options and store them globally
     let args: Vec<String> = env::args().collect();
-    let mut opts = Options::new();
-    opts.optflag(
-        "",
-        "clean-shutdown",
-        "Do not shutdown until all threads have finished (macos only)",
-    );
-    opts.optflag("b", "no-native-titlebar", "Do not use native titlebar");
-    opts.optopt("", "device-pixel-ratio", "Device pixels per px", "");
-    opts.optopt(
-        "u",
-        "user-agent",
-        "Set custom user agent string (or ios / android / desktop for platform default)",
-        "NCSA Mosaic/1.0 (X11;SunOS 4.1.4 sun4m)",
-    );
-    opts.optmulti(
-        "",
-        "pref",
-        "A preference to set to enable",
-        "dom.bluetooth.enabled",
-    );
-    opts.optmulti(
-        "",
-        "pref",
-        "A preference to set to disable",
-        "dom.webgpu.enabled=false",
-    );
-    opts.optmulti(
-        "",
-        "prefs-file",
-        "Load in additional prefs from a file.",
-        "--prefs-file /path/to/prefs.json",
-    );
-
     let opts_matches;
     let content_process_token;
 
-    match opts::from_cmdline_args(opts, &args) {
+    match opts::from_cmdline_args(&args) {
         ArgumentParsingResult::ContentProcess(matches, token) => {
             opts_matches = matches;
             content_process_token = Some(token);

--- a/ports/servoshell/desktop/cli.rs
+++ b/ports/servoshell/desktop/cli.rs
@@ -81,30 +81,7 @@ pub fn main() {
         process::exit(0);
     }
 
-    let clean_shutdown = opts_matches.opt_present("clean-shutdown");
-    let do_not_use_native_titlebar =
-        opts_matches.opt_present("no-native-titlebar") || !(pref!(shell.native_titlebar.enabled));
-    let device_pixel_ratio_override = opts_matches.opt_str("device-pixel-ratio").map(|dppx_str| {
-        dppx_str.parse().unwrap_or_else(|err| {
-            error!("Error parsing option: --device-pixel-ratio ({})", err);
-            process::exit(1);
-        })
-    });
+    App::run();
 
-    let user_agent = opts_matches.opt_str("u");
-
-    let url_opt = if !opts_matches.free.is_empty() {
-        Some(&opts_matches.free[0][..])
-    } else {
-        None
-    };
-
-    App::run(
-        do_not_use_native_titlebar,
-        device_pixel_ratio_override,
-        user_agent,
-        url_opt.map(|s| s.to_string()),
-    );
-
-    crate::platform::deinit(clean_shutdown)
+    crate::platform::deinit(opts::get().clean_shutdown)
 }

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -60,8 +60,6 @@ impl Window {
     pub fn new(
         window_size: Size2D<u32, DeviceIndependentPixel>,
         event_loop: &winit::event_loop::EventLoop<WakerEvent>,
-        no_native_titlebar: bool,
-        device_pixel_ratio_override: Option<f32>,
     ) -> Window {
         let opts = opts::get();
 
@@ -69,12 +67,12 @@ impl Window {
         // `load_end()`. This avoids an ugly flash of unstyled content (especially important since
         // unstyled content is white and chrome often has a transparent background). See issue
         // #9996.
-        let visible = opts.output_file.is_none() && !no_native_titlebar;
+        let visible = opts.output_file.is_none() && opts.native_titlebar;
 
         let window_attr = winit::window::Window::default_attributes()
             .with_title("Servo".to_string())
-            .with_decorations(!no_native_titlebar)
-            .with_transparent(no_native_titlebar)
+            .with_decorations(opts.native_titlebar)
+            .with_transparent(!opts.native_titlebar)
             .with_inner_size(LogicalSize::new(window_size.width, window_size.height))
             .with_visible(visible);
 
@@ -142,7 +140,7 @@ impl Window {
             inner_size: Cell::new(inner_size),
             monitor,
             screen_size,
-            device_pixel_ratio_override,
+            device_pixel_ratio_override: opts.device_pixel_ratio,
             xr_window_poses: RefCell::new(vec![]),
             modifiers_state: Cell::new(ModifiersState::empty()),
             toolbar_height: Cell::new(Default::default()),

--- a/ports/servoshell/desktop/headless_window.rs
+++ b/ports/servoshell/desktop/headless_window.rs
@@ -35,10 +35,7 @@ pub struct Window {
 
 impl Window {
     #[allow(clippy::new_ret_no_self)]
-    pub fn new(
-        size: Size2D<u32, DeviceIndependentPixel>,
-        device_pixel_ratio_override: Option<f32>,
-    ) -> Rc<dyn WindowPortsMethods> {
+    pub fn new(size: Size2D<u32, DeviceIndependentPixel>) -> Rc<dyn WindowPortsMethods> {
         // Initialize surfman
         let connection = Connection::new().expect("Failed to create connection");
         let adapter = connection
@@ -51,7 +48,7 @@ impl Window {
             .expect("Failed to create WR surfman");
 
         let device_pixel_ratio_override: Option<Scale<f32, DeviceIndependentPixel, DevicePixel>> =
-            device_pixel_ratio_override.map(Scale::new);
+            opts::get().device_pixel_ratio.map(Scale::new);
         let hidpi_factor = device_pixel_ratio_override.unwrap_or_else(Scale::identity);
 
         let size = size.to_i32();


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
There are some opt items are located in servoshell instead of config crate. This makes it difficult to refactor winit API mentioned in #34522. We should properly add them to `Opts` already.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors


<!-- Either: -->
- [x] These changes do not require tests because these are existing opts. The build should be able to be built though.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
