### PR TITLE
layout: Send back layout results directly and remove channels

### DIFF
--- a/components/shared/script_layout/lib.rs
+++ b/components/shared/script_layout/lib.rs
@@ -21,7 +21,6 @@ use base::cross_process_instant::CrossProcessInstant;
 use base::id::{BrowsingContextId, PipelineId};
 use base::Epoch;
 use canvas_traits::canvas::{CanvasId, CanvasMsg};
-use crossbeam_channel::Sender;
 use euclid::default::{Point2D, Rect};
 use euclid::Size2D;
 use fonts::SystemFontServiceProxy;
@@ -238,7 +237,7 @@ pub trait Layout {
     fn remove_stylesheet(&mut self, stylesheet: ServoArc<Stylesheet>);
 
     /// Requests a reflow.
-    fn reflow(&mut self, script_reflow: ScriptReflow);
+    fn reflow(&mut self, reflow_request: ReflowRequest) -> Option<ReflowResult>;
 
     /// Tells layout that script has added some paint worklet modules.
     fn register_paint_worklet_modules(
@@ -403,14 +402,14 @@ pub struct Reflow {
 
 /// Information derived from a layout pass that needs to be returned to the script thread.
 #[derive(Debug, Default)]
-pub struct ReflowComplete {
+pub struct ReflowResult {
     /// The list of images that were encountered that are in progress.
     pub pending_images: Vec<PendingImage>,
 }
 
 /// Information needed for a script-initiated reflow.
 #[derive(Debug)]
-pub struct ScriptReflow {
+pub struct ReflowRequest {
     /// General reflow data.
     pub reflow_info: Reflow,
     /// The document node.
@@ -421,8 +420,6 @@ pub struct ScriptReflow {
     pub stylesheets_changed: bool,
     /// The current window size.
     pub window_size: WindowSizeData,
-    /// The channel that we send a notification to.
-    pub script_join_chan: Sender<ReflowComplete>,
     /// The goal of this reflow.
     pub reflow_goal: ReflowGoal,
     /// The number of objects in the dom #10110


### PR DESCRIPTION
This eliminates the way that crossbeam channels are used to send layout
results back to script, which should increase the efficiency of layout.
If asynchronous layout is re-established it can be written as a layer on
top of the layout interface, that way layout doesn't have to know so
many details of how the asynchronocity works.

This is preparation for allowing layout to send back iframe sizes synchronously
to script.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are covered by existing WPT tests.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
