### PR TITLE
Allow null principals to subsume any other principal.

### DIFF
--- a/components/script/dom/bindings/principals.rs
+++ b/components/script/dom/bindings/principals.rs
@@ -198,7 +198,6 @@ pub unsafe extern "C" fn subsumes(obj: *mut JSPrincipals, other: *mut JSPrincipa
         let other_origin = other.origin();
         obj_origin.same_origin_domain(&other_origin)
     } else {
-        warn!("Received null JSPrincipals asrgument.");
-        false
+        true
     }
 }


### PR DESCRIPTION


---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #32999
- [x] There are tests for these changes
