### PR TITLE
Allow a null principal to subsumes others when appropriate

### DIFF
--- a/components/script/dom/bindings/principals.rs
+++ b/components/script/dom/bindings/principals.rs
@@ -191,14 +191,22 @@ unsafe extern "C" fn principals_is_system_or_addon_principal(_: *mut JSPrincipal
 
 //TODO is same_origin_domain equivalent to subsumes for our purposes
 pub unsafe extern "C" fn subsumes(obj: *mut JSPrincipals, other: *mut JSPrincipals) -> bool {
-    if let (Some(obj), Some(other)) = (NonNull::new(obj), NonNull::new(other)) {
-        let obj = ServoJSPrincipalsRef::from_raw_nonnull(obj);
-        let other = ServoJSPrincipalsRef::from_raw_nonnull(other);
-        let obj_origin = obj.origin();
-        let other_origin = other.origin();
-        obj_origin.same_origin_domain(&other_origin)
-    } else {
-        warn!("Received null JSPrincipals asrgument.");
-        false
+    match (NonNull::new(obj), NonNull::new(other)) {
+        (Some(obj), Some(other)) => {
+            let obj = ServoJSPrincipalsRef::from_raw_nonnull(obj);
+            let other = ServoJSPrincipalsRef::from_raw_nonnull(other);
+            let obj_origin = obj.origin();
+            let other_origin = other.origin();
+            obj_origin.same_origin_domain(&other_origin)
+        },
+        (None, Some(_)) => {
+            // See https://github.com/servo/servo/issues/32999#issuecomment-2542522289 for why
+            // it's safe to consider the null principal here subsumes all others.
+            true
+        },
+        _ => {
+            warn!("Received null JSPrincipal argument.");
+            false
+        },
     }
 }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Applies the recommendation from https://github.com/servo/servo/issues/32999#issuecomment-2542522289

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #32999 (GitHub issue number if applicable)


