### PR TITLE
Set a Rust edition for blurmac

### DIFF
--- a/third_party/blurmac/Cargo.toml
+++ b/third_party/blurmac/Cargo.toml
@@ -7,6 +7,7 @@ keywords = ["bluetooth", "ble", "macOS", "CoreBluetooth"]
 repository = "https://github.com/akosthekiss/blurmac"
 authors = ["Akos Kiss <akiss@inf.u-szeged.hu>"]
 license = "BSD-3-Clause"
+edition = "2018"
 
 [lib]
 name = "blurmac"


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Add a rust edition to blurmac to avoid a cargo warning

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
