### PR TITLE
ci: add retries and caching for `gradle` installation

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -79,6 +79,14 @@ jobs:
         id: setup-ndk
         with:
           ndk-version: r26c
+      - name: Setup Gradle caches
+        uses: gradle/actions/setup-gradle@v4
+      - name: Trigger initial download of Gradle with retries
+        run: |
+          for i in {1..4}; do
+            ./gradlew --version && break || { echo "Downloading Gradle failed (attempt $i)." && sleep $((3 ** $i)); };
+          done
+        working-directory: ./support/android/apk/
       - name: Setup Key Store for APK Signing
         env:
           KEYSTORE_BASE64: ${{ secrets.APK_KEYSTORE_BASE64 }}


### PR DESCRIPTION
This change uses Gradle's official `setup-gradle` action to allow the caching of the downloaded gradle distribution and java dependencies in the GitHub Actions cache. However, since the initial download of gradle distribution is still handled by the `gradlew` wrapper script which doesn't retry on network failures, this change also adds a simple retry mechanism using shell scripting.

Fixes #34600

---

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #34600 
- [x] These changes do not require tests because these are CI configuration changes and have been tested manually on a fork.
