### PR TITLE
Prompt user for credentials when http request needs it

### DIFF
--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -1596,13 +1596,13 @@ async fn http_network_or_cache_fetch(
         if !http_request.use_url_credentials || authentication_fetch_flag {
             // TODO(#33616, #27439): Prompt the user for username and password from the window
             let credentials = prompt_user_for_credentials(&context.state.embedder_proxy);
-            if let Some((_username, _password)) = credentials {
-            } else {
-                // Wrong, but will have to do until we are able to prompt the user
-                // otherwise this creates an infinite loop
-                // We basically pretend that the user declined to enter credentials (#33616)
-                return response;
+            if let Some((username, password)) = credentials {
+                dbg!(username, password);
             }
+            // Wrong, but will have to do until we are able to prompt the user
+            // otherwise this creates an infinite loop
+            // We basically pretend that the user declined to enter credentials (#33616)
+            return response;
         }
 
         // Make sure this is set to None,
@@ -1634,11 +1634,13 @@ async fn http_network_or_cache_fetch(
 
         // TODO(#33616): Step 15.3 If fetchParams is canceled, then return
         // the appropriate network error for fetchParams.
-        // TODO(#33616): Step 15.4 Prompt the end user as appropriate in request’s window and store the
-        // result as a proxy-authentication entry.
 
-        // Step 15.5 Set response to the result of running HTTP-network-or-cache fetch given fetchParams.
-
+        // TODO(#33616): Step 15.4 Prompt the end user as appropriate in request’s window
+        let credentials = prompt_user_for_credentials(&context.state.embedder_proxy);
+        if let Some((_username, _password)) = credentials {
+            // TODO(#33616): store the result as a proxy-authentication entry.
+            // Step 15.5 Set response to the result of running HTTP-network-or-cache fetch given fetchParams.
+        }
         // Wrong, but will have to do until we are able to prompt the user
         // otherwise this creates an infinite loop
         // We basically pretend that the user declined to enter credentials (#33616)

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -51,7 +51,7 @@ use net_traits::request::{
 };
 use net_traits::response::{HttpsState, Response, ResponseBody, ResponseType};
 use net_traits::{
-    user_info_percent_encode, CookieSource, FetchMetadata, NetworkError, RedirectEndValue,
+    CookieSource, FetchMetadata, NetworkError, RedirectEndValue,
     RedirectStartValue, ReferrerPolicy, ResourceAttribute, ResourceFetchTiming, ResourceTimeValue,
 };
 use servo_arc::Arc;
@@ -1582,16 +1582,13 @@ async fn http_network_or_cache_fetch(
                 return response;
             };
 
-            let username = user_info_percent_encode(&username);
-            let password = Some(user_info_percent_encode(&password));
-
             http_request
                 .current_url_mut()
                 .set_username(&username)
                 .unwrap();
             http_request
                 .current_url_mut()
-                .set_password(password.as_deref())
+                .set_password(Some(&password))
                 .unwrap();
         }
 

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -51,8 +51,8 @@ use net_traits::request::{
 };
 use net_traits::response::{HttpsState, Response, ResponseBody, ResponseType};
 use net_traits::{
-    CookieSource, FetchMetadata, NetworkError, RedirectEndValue,
-    RedirectStartValue, ReferrerPolicy, ResourceAttribute, ResourceFetchTiming, ResourceTimeValue,
+    CookieSource, FetchMetadata, NetworkError, RedirectEndValue, RedirectStartValue,
+    ReferrerPolicy, ResourceAttribute, ResourceFetchTiming, ResourceTimeValue,
 };
 use servo_arc::Arc;
 use servo_url::{ImmutableOrigin, ServoUrl};
@@ -1582,14 +1582,15 @@ async fn http_network_or_cache_fetch(
                 return response;
             };
 
-            http_request
-                .current_url_mut()
-                .set_username(&username)
-                .unwrap();
-            http_request
-                .current_url_mut()
-                .set_password(Some(&password))
-                .unwrap();
+            if let Err(err) = http_request.current_url_mut().set_username(&username) {
+                error!("error setting username for url: {:?}", err);
+                return response;
+            };
+
+            if let Err(err) = http_request.current_url_mut().set_password(Some(&password)) {
+                error!("error setting password for url: {:?}", err);
+                return response;
+            };
         }
 
         // Make sure this is set to None,

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -1653,7 +1653,7 @@ async fn http_network_or_cache_fetch(
         // Step 15.5 Set response to the result of running HTTP-network-or-cache fetch given fetchParams.
         response = http_network_or_cache_fetch(
             http_request,
-            true, /* authentication flag */
+            false, /* authentication flag */
             cors_flag,
             done_chan,
             context,

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -200,7 +200,7 @@ fn create_http_states(
             override_manager.clone(),
         )),
         override_manager,
-        embedder_proxy: Mutex::new(Some(embedder_proxy.clone())),
+        embedder_proxy: Mutex::new(embedder_proxy.clone()),
     };
 
     let override_manager = CertificateErrorOverrideManager::new();
@@ -217,7 +217,7 @@ fn create_http_states(
             override_manager.clone(),
         )),
         override_manager,
-        embedder_proxy: Mutex::new(Some(embedder_proxy)),
+        embedder_proxy: Mutex::new(embedder_proxy),
     };
 
     (Arc::new(http_state), Arc::new(private_http_state))

--- a/components/net/tests/fetch.rs
+++ b/components/net/tests/fetch.rs
@@ -29,7 +29,6 @@ use net::filemanager_thread::FileManager;
 use net::hsts::HstsEntry;
 use net::protocols::ProtocolRegistry;
 use net::resource_thread::CoreResourceThreadPool;
-use net::test::HttpState;
 use net_traits::filemanager_thread::FileTokenCheck;
 use net_traits::http_status::HttpStatus;
 use net_traits::request::{
@@ -47,8 +46,8 @@ use uuid::Uuid;
 
 use crate::http_loader::{expect_devtools_http_request, expect_devtools_http_response};
 use crate::{
-    create_embedder_proxy, fetch, fetch_with_context, fetch_with_cors_cache, make_server,
-    make_ssl_server, new_fetch_context, DEFAULT_USER_AGENT,
+    create_embedder_proxy, create_http_state, fetch, fetch_with_context, fetch_with_cors_cache,
+    make_server, make_ssl_server, new_fetch_context, DEFAULT_USER_AGENT,
 };
 
 // TODO write a struct that impls Handler for storing test values
@@ -669,7 +668,7 @@ fn test_fetch_with_hsts() {
     let (server, url) = make_ssl_server(handler);
 
     let mut context = FetchContext {
-        state: Arc::new(HttpState::default()),
+        state: Arc::new(create_http_state(None)),
         user_agent: DEFAULT_USER_AGENT.into(),
         devtools_chan: None,
         filemanager: Arc::new(Mutex::new(FileManager::new(
@@ -724,7 +723,7 @@ fn test_load_adds_host_to_hsts_list_when_url_is_https() {
     url.as_mut_url().set_scheme("https").unwrap();
 
     let mut context = FetchContext {
-        state: Arc::new(HttpState::default()),
+        state: Arc::new(create_http_state(None)),
         user_agent: DEFAULT_USER_AGENT.into(),
         devtools_chan: None,
         filemanager: Arc::new(Mutex::new(FileManager::new(
@@ -781,7 +780,7 @@ fn test_fetch_self_signed() {
     url.as_mut_url().set_scheme("https").unwrap();
 
     let mut context = FetchContext {
-        state: Arc::new(HttpState::default()),
+        state: Arc::new(create_http_state(None)),
         user_agent: DEFAULT_USER_AGENT.into(),
         devtools_chan: None,
         filemanager: Arc::new(Mutex::new(FileManager::new(

--- a/components/net/tests/http_loader.rs
+++ b/components/net/tests/http_loader.rs
@@ -6,10 +6,10 @@
 
 use std::collections::HashMap;
 use std::io::Write;
-use std::str;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::Duration;
+use std::{str, thread};
 
 use base::id::TEST_PIPELINE_ID;
 use cookie::Cookie as CookiePair;
@@ -18,6 +18,7 @@ use devtools_traits::{
     ChromeToDevtoolsControlMsg, DevtoolsControlMsg, HttpRequest as DevtoolsHttpRequest,
     HttpResponse as DevtoolsHttpResponse, NetworkEvent,
 };
+use embedder_traits::PromptCredentialsInput;
 use flate2::write::{GzEncoder, ZlibEncoder};
 use flate2::Compression;
 use headers::authorization::Basic;
@@ -1478,4 +1479,177 @@ fn test_origin_serialization_compatability() {
     ensure_serialiations_match("http://example.com:1234");
 
     ensure_serialiations_match("data:,dataurltexta");
+}
+
+#[test]
+fn test_user_credentials_prompt() {
+    // functions to look at
+    // test_if_auth_creds_not_in_url_but_in_cache_it_sets_it
+    // test_auth_ui_needs_www_auth
+
+    let handler = move |request: HyperRequest<Body>, response: &mut HyperResponse<Body>| {
+        let expected = Authorization::basic("username", "test");
+        // let auth = request.headers()
+        //     .typed_get::<Authorization<Basic>>()
+        //     .unwrap();
+        dbg!(request.headers());
+        let url = request.uri();
+        dbg!(url);
+
+        // if auth == expected {
+        if false {
+            *response.status_mut() = StatusCode::OK;
+        } else {
+            // *response.status_mut() = StatusCode::UNAUTHORIZED;
+            *response.status_mut() = StatusCode::PROXY_AUTHENTICATION_REQUIRED;
+            // (*response.headers_mut()).append(
+            //     http::header::WWW_AUTHENTICATE,
+            //     r#"Basic realm="Demo Realm""#.parse().unwrap(),
+            // );
+            // (*response.headers_mut()).append(
+            //     http::header::CONTENT_TYPE,
+            //     r#"application/json"#.parse().unwrap(),
+            //     );
+        }
+    };
+    let (server, url) = make_server(handler);
+
+    let mut request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
+        .method(Method::GET)
+        .body(None)
+        .destination(Destination::Document)
+        .origin(mock_origin())
+        .pipeline_id(Some(TEST_PIPELINE_ID))
+        .credentials_mode(CredentialsMode::Include)
+        .build();
+
+    // create an embedder but I have to get the send and receive channels
+    // put the receive channel in a new thread
+    // this thread will handle the embedder prompt message that gets sent from the send channel
+    // and return some credentials for the server
+    // pass embedder into new fetch context
+    //
+    // make the request
+
+    let (sender, receiver) = unbounded();
+    // let another_receiver = receiver.clone();
+    let event_loop_waker = || {
+        struct DummyEventLoopWaker {}
+        impl DummyEventLoopWaker {
+            fn new() -> DummyEventLoopWaker {
+                DummyEventLoopWaker {}
+            }
+        }
+        impl embedder_traits::EventLoopWaker for DummyEventLoopWaker {
+            fn wake(&self) {}
+            fn clone_box(&self) -> Box<dyn embedder_traits::EventLoopWaker> {
+                Box::new(DummyEventLoopWaker {})
+            }
+        }
+
+        Box::new(DummyEventLoopWaker::new())
+    };
+
+    let embedder_proxy = embedder_traits::EmbedderProxy {
+        sender: sender.clone(),
+        event_loop_waker: event_loop_waker(),
+    };
+
+    thread::spawn(move || {
+        let msg = receiver.recv().unwrap();
+        match msg {
+            (_browser_context_id, embedder_msg) => match embedder_msg {
+                embedder_traits::EmbedderMsg::Prompt(prompt_definition, _prompt_origin) => {
+                    match prompt_definition {
+                        embedder_traits::PromptDefinition::Credentials(ipc_sender) => {
+                            ipc_sender.send(PromptCredentialsInput {
+                                username: Some("username".to_string()),
+                                password: Some("test".to_string()),
+                            }).unwrap();
+                        },
+                        _ => unreachable!(),
+                    }
+                },
+                _ => unreachable!(),
+            },
+
+            // (msg, ShutdownState::NotShuttingDown) => {
+            // },
+            _ => unreachable!(),
+        }
+    });
+
+    let mut context = new_fetch_context(None, Some(embedder_proxy), None);
+
+    let response = fetch_with_context(&mut request, &mut context);
+
+    let _ = server.close();
+    dbg!(&response);
+    assert!(response
+        .internal_response
+        .unwrap()
+        .status
+        .code()
+        .is_success());
+
+}
+
+#[test]
+fn another_test() {
+
+    // let auth_entry = AuthCacheEntry {
+    //     user_name: "username".to_owned(),
+    //     password: "test".to_owned(),
+    // };
+
+    // context
+    //     .state
+    //     .auth_cache
+    //     .write()
+    //     .unwrap()
+    //     .entries
+    //     .insert(url.origin().clone().ascii_serialization(), auth_entry);
+    let handler = move |request: HyperRequest<Body>, _response: &mut HyperResponse<Body>| {
+        let expected = Authorization::basic("username", "test");
+        assert_eq!(
+            request.headers().typed_get::<Authorization<Basic>>(),
+            Some(expected)
+        );
+    };
+    let (server, url) = make_server(handler);
+
+    let mut request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
+        .method(Method::GET)
+        .body(None)
+        .destination(Destination::Document)
+        .origin(mock_origin())
+        .pipeline_id(Some(TEST_PIPELINE_ID))
+        .credentials_mode(CredentialsMode::Include)
+        .build();
+
+    let mut context = new_fetch_context(None, None, None);
+
+    let auth_entry = AuthCacheEntry {
+        user_name: "username".to_owned(),
+        password: "test".to_owned(),
+    };
+
+    context
+        .state
+        .auth_cache
+        .write()
+        .unwrap()
+        .entries
+        .insert(url.origin().clone().ascii_serialization(), auth_entry);
+
+    let response = fetch_with_context(&mut request, &mut context);
+
+    let _ = server.close();
+
+    assert!(response
+        .internal_response
+        .unwrap()
+        .status
+        .code()
+        .is_success());
 }

--- a/components/net/tests/http_loader.rs
+++ b/components/net/tests/http_loader.rs
@@ -1563,7 +1563,7 @@ fn test_prompt_credentials_when_client_receives_unauthorized_response() {
 
     let response = fetch_with_context(&mut request, &mut context);
 
-    let _ = server.close();
+    server.close();
 
     assert!(response
         .internal_response
@@ -1604,7 +1604,7 @@ fn test_prompt_credentials_user_cancels_dialog_input() {
 
     let response = fetch_with_context(&mut request, &mut context);
 
-    let _ = server.close();
+    server.close();
 
     assert!(response
         .internal_response
@@ -1649,7 +1649,7 @@ fn test_prompt_credentials_user_input_incorrect_credentials() {
 
     let response = fetch_with_context(&mut request, &mut context);
 
-    let _ = server.close();
+    server.close();
 
     assert!(response
         .internal_response

--- a/components/net/tests/main.rs
+++ b/components/net/tests/main.rs
@@ -19,11 +19,12 @@ mod resource_thread;
 mod subresource_integrity;
 
 use core::convert::Infallible;
+use std::collections::HashMap;
 use std::fs::File;
 use std::io::{self, BufReader};
 use std::net::TcpListener as StdTcpListener;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, LazyLock, Mutex, Weak};
+use std::sync::{Arc, LazyLock, Mutex, RwLock, Weak};
 
 use crossbeam_channel::{unbounded, Sender};
 use devtools_traits::DevtoolsControlMsg;
@@ -34,6 +35,7 @@ use hyper::server::conn::Http;
 use hyper::server::Server as HyperServer;
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Request as HyperRequest, Response as HyperResponse};
+use net::connector::{create_http_client, create_tls_config};
 use net::fetch::cors_cache::CorsCache;
 use net::fetch::methods::{self, CancellationListener, FetchContext};
 use net::filemanager_thread::FileManager;
@@ -95,6 +97,25 @@ fn create_embedder_proxy() -> EmbedderProxy {
     }
 }
 
+fn create_http_state(fc: Option<EmbedderProxy>) -> HttpState {
+    let override_manager = net::connector::CertificateErrorOverrideManager::new();
+    HttpState {
+        hsts_list: RwLock::new(net::hsts::HstsList::default()),
+        cookie_jar: RwLock::new(net::cookie_storage::CookieStorage::new(150)),
+        auth_cache: RwLock::new(net::resource_thread::AuthCache::default()),
+        history_states: RwLock::new(HashMap::new()),
+        http_cache: RwLock::new(net::http_cache::HttpCache::default()),
+        http_cache_state: Mutex::new(HashMap::new()),
+        client: create_http_client(create_tls_config(
+            net::connector::CACertificates::Default,
+            false, /* ignore_certificate_errors */
+            override_manager.clone(),
+        )),
+        override_manager,
+        embedder_proxy: Mutex::new(fc.unwrap_or_else(|| create_embedder_proxy())),
+    }
+}
+
 fn new_fetch_context(
     dc: Option<Sender<DevtoolsControlMsg>>,
     fc: Option<EmbedderProxy>,
@@ -103,7 +124,7 @@ fn new_fetch_context(
     let sender = fc.unwrap_or_else(|| create_embedder_proxy());
 
     FetchContext {
-        state: Arc::new(HttpState::default()),
+        state: Arc::new(create_http_state(Some(sender.clone()))),
         user_agent: DEFAULT_USER_AGENT.into(),
         devtools_chan: dc.map(|dc| Arc::new(Mutex::new(dc))),
         filemanager: Arc::new(Mutex::new(FileManager::new(

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -131,6 +131,16 @@ pub enum PromptDefinition {
     YesNo(String, IpcSender<PromptResult>),
     /// Ask the user to enter text.
     Input(String, String, IpcSender<Option<String>>),
+    /// Ask user to enter their username and password
+    Credentials(String, IpcSender<PromptCredentialsInput>),
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct PromptCredentialsInput {
+    /// username for http request authentication
+    pub username: Option<String>,
+    /// password for http request authentication
+    pub password: Option<String>,
 }
 
 #[derive(Deserialize, PartialEq, Serialize)]

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -132,14 +132,14 @@ pub enum PromptDefinition {
     /// Ask the user to enter text.
     Input(String, String, IpcSender<Option<String>>),
     /// Ask user to enter their username and password
-    Credentials(String, IpcSender<PromptCredentialsInput>),
+    Credentials(IpcSender<PromptCredentialsInput>),
 }
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct PromptCredentialsInput {
-    /// username for http request authentication
+    /// Username for http request authentication
     pub username: Option<String>,
-    /// password for http request authentication
+    /// Password for http request authentication
     pub password: Option<String>,
 }
 

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -945,31 +945,5 @@ pub fn http_percent_encode(bytes: &[u8]) -> String {
     percent_encoding::percent_encode(bytes, HTTP_VALUE).to_string()
 }
 
-pub fn user_info_percent_encode<T: AsRef<[u8]>>(bytes: T) -> String {
-    // This encoding set is used for encoding user credentials for a http request
-    // https://url.spec.whatwg.org/#userinfo-percent-encode-set
-    const USER_INFO_PERCENT_ENCODE_SET: &percent_encoding::AsciiSet = &percent_encoding::CONTROLS
-        .add(b' ')
-        .add(b'"')
-        .add(b'#')
-        .add(b'<')
-        .add(b'>')
-        .add(b'?')
-        .add(b'`')
-        .add(b'{')
-        .add(b'}')
-        .add(b'/')
-        .add(b';')
-        .add(b'=')
-        .add(b'@')
-        .add(b'[')
-        .add(b'\\')
-        .add(b']')
-        .add(b'^')
-        .add(b'|');
-
-    percent_encoding::percent_encode(bytes.as_ref(), USER_INFO_PERCENT_ENCODE_SET).to_string()
-}
-
 pub static PRIVILEGED_SECRET: LazyLock<u32> =
     LazyLock::new(|| servo_rand::ServoRng::default().next_u32());

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -945,5 +945,31 @@ pub fn http_percent_encode(bytes: &[u8]) -> String {
     percent_encoding::percent_encode(bytes, HTTP_VALUE).to_string()
 }
 
+pub fn user_info_percent_encode<T: AsRef<[u8]>>(bytes: T) -> String {
+    // This encoding set is used for encoding user credentials for a http request
+    // https://url.spec.whatwg.org/#userinfo-percent-encode-set
+    const USER_INFO_PERCENT_ENCODE_SET: &percent_encoding::AsciiSet = &percent_encoding::CONTROLS
+        .add(b' ')
+        .add(b'"')
+        .add(b'#')
+        .add(b'<')
+        .add(b'>')
+        .add(b'?')
+        .add(b'`')
+        .add(b'{')
+        .add(b'}')
+        .add(b'/')
+        .add(b';')
+        .add(b'=')
+        .add(b'@')
+        .add(b'[')
+        .add(b'\\')
+        .add(b']')
+        .add(b'^')
+        .add(b'|');
+
+    percent_encoding::percent_encode(bytes.as_ref(), USER_INFO_PERCENT_ENCODE_SET).to_string()
+}
+
 pub static PRIVILEGED_SECRET: LazyLock<u32> =
     LazyLock::new(|| servo_rand::ServoRng::default().next_u32());

--- a/ports/servoshell/desktop/webview.rs
+++ b/ports/servoshell/desktop/webview.rs
@@ -697,7 +697,7 @@ where
                             PromptDefinition::Input(_message, default, sender) => {
                                 sender.send(Some(default.to_owned()))
                             },
-                            PromptDefinition::Credentials(_message, sender) => {
+                            PromptDefinition::Credentials(sender) => {
                                 sender.send(PromptCredentialsInput {
                                     username: None,
                                     password: None,
@@ -757,10 +757,8 @@ where
                                     let result = tinyfiledialogs::input_box("", &message, &default);
                                     sender.send(result)
                                 },
-                                PromptDefinition::Credentials(mut message, sender) => {
-                                    if origin == PromptOrigin::Untrusted {
-                                        message = tiny_dialog_escape(&message);
-                                    }
+                                PromptDefinition::Credentials(sender) => {
+                                    // TODO: figure out how to make the message a localized string
                                     let username = tinyfiledialogs::input_box("", "username", "");
                                     let password = tinyfiledialogs::input_box("", "password", "");
                                     sender.send(PromptCredentialsInput { username, password })

--- a/ports/servoshell/egl/servo_glue.rs
+++ b/ports/servoshell/egl/servo_glue.rs
@@ -514,7 +514,7 @@ impl ServoGlue {
                             sender.send(cb.prompt_input(message, default, trusted))
                         },
                         PromptDefinition::Credentials(_) => {
-                            warn!("implement credentials prompt for open harmony OS");
+                            warn!("implement credentials prompt for OpenHarmony OS and Android");
                         },
                     };
                     if let Err(e) = res {

--- a/ports/servoshell/egl/servo_glue.rs
+++ b/ports/servoshell/egl/servo_glue.rs
@@ -17,8 +17,7 @@ use servo::compositing::windowing::{
 };
 use servo::embedder_traits::{
     ContextMenuResult, EmbedderMsg, EmbedderProxy, EventLoopWaker, MediaSessionEvent,
-    PermissionPrompt, PermissionRequest, PromptCredentialsInput, PromptDefinition, PromptOrigin,
-    PromptResult,
+    PermissionPrompt, PermissionRequest, PromptDefinition, PromptOrigin, PromptResult,
 };
 use servo::euclid::{Box2D, Point2D, Rect, Scale, Size2D, Vector2D};
 use servo::keyboard_types::{Key, KeyState, KeyboardEvent};

--- a/ports/servoshell/egl/servo_glue.rs
+++ b/ports/servoshell/egl/servo_glue.rs
@@ -515,6 +515,7 @@ impl ServoGlue {
                         },
                         PromptDefinition::Credentials(_) => {
                             warn!("implement credentials prompt for OpenHarmony OS and Android");
+                            Ok(())
                         },
                     };
                     if let Err(e) = res {

--- a/ports/servoshell/egl/servo_glue.rs
+++ b/ports/servoshell/egl/servo_glue.rs
@@ -17,7 +17,8 @@ use servo::compositing::windowing::{
 };
 use servo::embedder_traits::{
     ContextMenuResult, EmbedderMsg, EmbedderProxy, EventLoopWaker, MediaSessionEvent,
-    PermissionPrompt, PermissionRequest, PromptDefinition, PromptOrigin, PromptResult,
+    PermissionPrompt, PermissionRequest, PromptCredentialsInput, PromptDefinition, PromptOrigin,
+    PromptResult,
 };
 use servo::euclid::{Box2D, Point2D, Rect, Scale, Size2D, Vector2D};
 use servo::keyboard_types::{Key, KeyState, KeyboardEvent};
@@ -511,6 +512,9 @@ impl ServoGlue {
                         },
                         PromptDefinition::Input(message, default, sender) => {
                             sender.send(cb.prompt_input(message, default, trusted))
+                        },
+                        PromptDefinition::Credentials(_) => {
+                            warn!("implement credentials prompt for open harmony OS");
                         },
                     };
                     if let Err(e) = res {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This adds two prompts that will ask the user for their username and password if a http request requires it.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #27439  (GitHub issue number if applicable)

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
