### PR TITLE
Implement `console.trace`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,7 +429,7 @@ dependencies = [
  "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "regex",
@@ -1868,7 +1868,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4449,7 +4449,7 @@ dependencies = [
 [[package]]
 name = "mozjs"
 version = "0.14.1"
-source = "git+https://github.com/servo/mozjs#8ac195873f25c66c891478a291d762998fb151fe"
+source = "git+https://github.com/servo/mozjs#bb560b6276cc587b4706b3162160cf945210335a"
 dependencies = [
  "bindgen",
  "cc",
@@ -4462,7 +4462,7 @@ dependencies = [
 [[package]]
 name = "mozjs_sys"
 version = "0.128.3-8"
-source = "git+https://github.com/servo/mozjs#8ac195873f25c66c891478a291d762998fb151fe"
+source = "git+https://github.com/servo/mozjs#bb560b6276cc587b4706b3162160cf945210335a"
 dependencies = [
  "bindgen",
  "cc",
@@ -5892,7 +5892,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7157,7 +7157,7 @@ dependencies = [
  "fastrand",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8416,7 +8416,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/components/devtools/actors/console.rs
+++ b/components/devtools/actors/console.rs
@@ -284,7 +284,7 @@ impl ConsoleActor {
         .to_owned();
 
         let console_api = ConsoleLog {
-            level: level,
+            level,
             filename: console_message.filename,
             line_number: console_message.line_number as u32,
             column_number: console_message.column_number as u32,

--- a/components/devtools/actors/console.rs
+++ b/components/devtools/actors/console.rs
@@ -284,15 +284,16 @@ impl ConsoleActor {
         .to_owned();
 
         let console_api = ConsoleLog {
-            level: level.clone(),
-            filename: console_message.filename.clone(),
+            level: level,
+            filename: console_message.filename,
             line_number: console_message.line_number as u32,
             column_number: console_message.column_number as u32,
             time_stamp: SystemTime::now()
                 .duration_since(UNIX_EPOCH)
                 .unwrap_or_default()
                 .as_millis() as u64,
-            arguments: vec![console_message.message.clone()],
+            arguments: vec![console_message.message],
+            stacktrace: console_message.stacktrace,
         };
 
         self.cached_events

--- a/components/devtools/actors/console.rs
+++ b/components/devtools/actors/console.rs
@@ -278,7 +278,8 @@ impl ConsoleActor {
             LogLevel::Warn => "warn",
             LogLevel::Error => "error",
             LogLevel::Clear => "clear",
-            _ => "log",
+            LogLevel::Trace => "trace",
+            LogLevel::Log => "log",
         }
         .to_owned();
 

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -694,6 +694,7 @@ fn run_server(
                     filename: css_error.filename,
                     line_number: css_error.line as usize,
                     column_number: css_error.column as usize,
+                    stacktrace: vec![],
                 };
                 handle_console_message(
                     actors.clone(),

--- a/components/script/dom/console.rs
+++ b/components/script/dom/console.rs
@@ -267,7 +267,10 @@ impl consoleMethods<crate::DomTypeHolder> for Console {
     // https://developer.mozilla.org/en-US/docs/Web/API/Console/assert
     fn Assert(_cx: JSContext, global: &GlobalScope, condition: bool, messages: Vec<HandleValue>) {
         if !condition {
-            let message = DOMString::from(format!("Assertion failed: {}", stringify_handle_values(messages)));
+            let message = DOMString::from(format!(
+                "Assertion failed: {}",
+                stringify_handle_values(messages)
+            ));
             console_message(global, message, LogLevel::Error);
         }
     }

--- a/components/script/dom/console.rs
+++ b/components/script/dom/console.rs
@@ -27,8 +27,8 @@ const MAX_LOG_DEPTH: usize = 10;
 /// The maximum elements in an object logged by console methods.
 const MAX_LOG_CHILDREN: usize = 15;
 
-// https://developer.mozilla.org/en-US/docs/Web/API/Console
-pub struct Console(());
+/// <https://developer.mozilla.org/en-US/docs/Web/API/Console>
+pub struct Console;
 
 impl Console {
     #[allow(unsafe_code)]
@@ -260,16 +260,11 @@ impl consoleMethods<crate::DomTypeHolder> for Console {
     }
 
     // https://developer.mozilla.org/en-US/docs/Web/API/Console/assert
-    fn Assert(_cx: JSContext, global: &GlobalScope, condition: bool, message: HandleValue) {
+    fn Assert(_cx: JSContext, global: &GlobalScope, condition: bool, messages: Vec<HandleValue>) {
         if !condition {
-            let message = if message.is_undefined() {
-                DOMString::from("no message")
-            } else {
-                stringify_handle_value(message)
-            };
-            let message = DOMString::from(format!("Assertion failed: {}", message));
-            console_message(global, message, LogLevel::Error)
-        };
+            let message = DOMString::from(format!("Assertion failed: {}", stringify_handle_values(messages)));
+            console_message(global, message, LogLevel::Error);
+        }
     }
 
     // https://console.spec.whatwg.org/#time

--- a/components/script/dom/console.rs
+++ b/components/script/dom/console.rs
@@ -259,6 +259,11 @@ impl consoleMethods<crate::DomTypeHolder> for Console {
         console_messages(global, messages, LogLevel::Error)
     }
 
+    /// <https://console.spec.whatwg.org/#trace>
+    fn Trace(_cx: JSContext, global: &GlobalScope, messages: Vec<HandleValue>) {
+        console_messages(global, messages, LogLevel::Trace)
+    }
+
     // https://developer.mozilla.org/en-US/docs/Web/API/Console/assert
     fn Assert(_cx: JSContext, global: &GlobalScope, condition: bool, messages: Vec<HandleValue>) {
         if !condition {

--- a/components/script/dom/console.rs
+++ b/components/script/dom/console.rs
@@ -339,11 +339,11 @@ impl consoleMethods<crate::DomTypeHolder> for Console {
 
 #[allow(unsafe_code)]
 fn get_js_stack(cx: *mut jsapi::JSContext) -> Vec<StackFrame> {
-    const MAX_FRAME_COUNT: Option<u32> = Some(128);
+    const MAX_FRAME_COUNT: u32 = 128;
 
     let mut frames = vec![];
     rooted!(in(cx) let mut handle =  ptr::null_mut());
-    let captured_js_stack = unsafe { CapturedJSStack::new(cx, handle, MAX_FRAME_COUNT) };
+    let captured_js_stack = unsafe { CapturedJSStack::new(cx, handle, Some(MAX_FRAME_COUNT)) };
     let Some(captured_js_stack) = captured_js_stack else {
         return frames;
     };

--- a/components/script/dom/webidls/Console.webidl
+++ b/components/script/dom/webidls/Console.webidl
@@ -15,7 +15,7 @@ namespace console {
   undefined info(any... messages);
   undefined log(any... messages);
   // undefined table(optional any tabularData, optional sequence<DOMString> properties);
-  // undefined trace(any... data);
+  undefined trace(any... data);
   undefined warn(any... messages);
   // undefined dir(optional any item, optional object? options);
   // undefined dirxml(any... data);

--- a/components/script/dom/webidls/Console.webidl
+++ b/components/script/dom/webidls/Console.webidl
@@ -8,7 +8,7 @@
  Exposed=*]
 namespace console {
   // Logging
-  undefined assert(boolean condition, optional any message);
+  undefined assert(optional boolean condition = false, any... data);
   undefined clear();
   undefined debug(any... messages);
   undefined error(any... messages);

--- a/components/script/dom/webidls/Console.webidl
+++ b/components/script/dom/webidls/Console.webidl
@@ -5,16 +5,20 @@
 // https://console.spec.whatwg.org/
 
 [ClassString="Console",
- Exposed=(Window,Worker,Worklet)]
+ Exposed=*]
 namespace console {
   // Logging
-  undefined log(any... messages);
-  undefined debug(any... messages);
-  undefined info(any... messages);
-  undefined warn(any... messages);
-  undefined error(any... messages);
   undefined assert(boolean condition, optional any message);
   undefined clear();
+  undefined debug(any... messages);
+  undefined error(any... messages);
+  undefined info(any... messages);
+  undefined log(any... messages);
+  // undefined table(optional any tabularData, optional sequence<DOMString> properties);
+  // undefined trace(any... data);
+  undefined warn(any... messages);
+  // undefined dir(optional any item, optional object? options);
+  // undefined dirxml(any... data);
 
   // Counting
   undefined count(optional DOMString label = "default");

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -280,6 +280,7 @@ pub enum LogLevel {
     Warn,
     Error,
     Clear,
+    Trace,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -291,6 +291,15 @@ pub struct ConsoleMessage {
     pub filename: String,
     pub line_number: usize,
     pub column_number: usize,
+    pub stacktrace: Vec<StackFrame>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct StackFrame {
+    pub filename: String,
+
+    #[serde(rename = "functionName")]
+    pub function_name: String,
 }
 
 bitflags! {
@@ -328,7 +337,7 @@ pub struct ConsoleLog {
     pub column_number: u32,
     pub time_stamp: u64,
     pub arguments: Vec<String>,
-    // pub stacktrace: Vec<...>,
+    pub stacktrace: Vec<StackFrame>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -300,6 +300,12 @@ pub struct StackFrame {
 
     #[serde(rename = "functionName")]
     pub function_name: String,
+
+    #[serde(rename = "columnNumber")]
+    pub column_number: u32,
+
+    #[serde(rename = "lineNumber")]
+    pub line_number: u32,
 }
 
 bitflags! {

--- a/tests/wpt/meta/console/idlharness.any.js.ini
+++ b/tests/wpt/meta/console/idlharness.any.js.ini
@@ -1,11 +1,5 @@
 [idlharness.any.html]
-  [console namespace: operation assert(optional boolean, any...)]
-    expected: FAIL
-
   [console namespace: operation table(optional any, optional sequence<DOMString>)]
-    expected: FAIL
-
-  [console namespace: operation trace(any...)]
     expected: FAIL
 
   [console namespace: operation dir(optional any, optional object?)]
@@ -16,13 +10,7 @@
 
 
 [idlharness.any.worker.html]
-  [console namespace: operation assert(optional boolean, any...)]
-    expected: FAIL
-
   [console namespace: operation table(optional any, optional sequence<DOMString>)]
-    expected: FAIL
-
-  [console namespace: operation trace(any...)]
     expected: FAIL
 
   [console namespace: operation dir(optional any, optional object?)]


### PR DESCRIPTION
Implements https://console.spec.whatwg.org/#trace

Depends on https://github.com/servo/mozjs/pull/539

A call to `console.trace` includes a stack trace in the devtools:
![image](https://github.com/user-attachments/assets/40b976b5-0855-4bf1-959f-0b1d5ab0fb57)


As a bonus, this fixes the signature of [`console.assert`](https://console.spec.whatwg.org/#assert).

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because the exact behaviour of `console.trace` is basically unspecified.
