### PR TITLE
Revert use of h2 in websocket ALPN.

### DIFF
--- a/components/net/websocket_loader.rs
+++ b/components/net/websocket_loader.rs
@@ -391,7 +391,7 @@ fn connect(
         ignore_certificate_errors,
         http_state.override_manager.clone(),
     );
-    tls_config.alpn_protocols = vec!["h2".to_string().into(), "http/1.1".to_string().into()];
+    tls_config.alpn_protocols = vec!["http/1.1".to_string().into()];
 
     let resource_event_sender2 = resource_event_sender.clone();
     match HANDLE.lock().unwrap().as_mut() {


### PR DESCRIPTION
This is fixing a regression from #30025. Previously, the websocket loader used an [ALPN that excluded HTTP/2 connections](https://github.com/servo/servo/commit/bce7622cde4cd10f6b3edf852d97ae9a540a0076#diff-61e97333cfb2db04b80e7ecf9e1420bafc5919eb5bb3b6a8483a620bcc388250L402). With this PR applied the Discord websocket connection can complete successfully.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #34520.
- [x] These changes do not require tests because there is no test harness available for this level of network negotiation.