### PR TITLE
ci: fix wpt export job

### DIFF
--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -1,5 +1,9 @@
 name: Setup Python and uv
 inputs:
+  python-version-file-path:
+    required: false
+    description: "Path to the the .python-version file"
+    default: '.python-version'
   skip-python-setup:
     required: false
     description: "Whether to skip installing python using Github's `setup-python` action"
@@ -13,7 +17,7 @@ runs:
       if: ${{ inputs.skip-python-setup != 'true' }}
       uses: actions/setup-python@v5
       with:
-        python-version-file: '.python-version'
+        python-version-file: ${{ inputs.python-version-file-path }}
     - name: Install uv
       uses: astral-sh/setup-uv@v4
       with:

--- a/.github/workflows/pull-request-wpt-export.yml
+++ b/.github/workflows/pull-request-wpt-export.yml
@@ -30,6 +30,8 @@ jobs:
           token: ${{ secrets.WPT_SYNC_TOKEN }}
       - name: Setup Python
         uses: ./servo/.github/actions/setup-python
+        with:
+          python-version-file-path: ./servo/.python-version
       - name: Install requirements
         run: |
           uv venv


### PR DESCRIPTION
The path to `.python-version` used by our setup-python action is
relative to the current working directory, which is not the servo
repo when WPT Export job runs.

Fixes #34639.

Signed-off-by: Mukilan Thiyagarajan <mukilan@igalia.com>

---

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #34639

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

