### PR TITLE
script: Manage `<iframe>` sizes in `Window`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6088,6 +6088,7 @@ dependencies = [
  "canvas_traits",
  "crossbeam-channel",
  "euclid",
+ "fnv",
  "fonts",
  "fonts_traits",
  "html5ever",

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -1865,6 +1865,7 @@ where
                     pipeline.title = title;
                 }
             },
+            FromScriptMsg::IFrameSizes(iframe_sizes) => self.handle_iframe_size_msg(iframe_sizes),
         }
     }
 
@@ -2138,11 +2139,6 @@ where
     fn handle_request_from_layout(&mut self, message: FromLayoutMsg) {
         trace_layout_msg!(message, "{message:?}");
         match message {
-            // Layout sends new sizes for all subframes. This needs to be reflected by all
-            // frame trees in the navigation context containing the subframe.
-            FromLayoutMsg::IFrameSizes(iframe_sizes) => {
-                self.handle_iframe_size_msg(iframe_sizes);
-            },
             FromLayoutMsg::PendingPaintMetric(pipeline_id, epoch) => {
                 self.handle_pending_paint_metric(pipeline_id, epoch);
             },

--- a/components/constellation/tracing.rs
+++ b/components/constellation/tracing.rs
@@ -189,6 +189,7 @@ mod from_script {
                 #[cfg(feature = "webgpu")]
                 Self::GetWebGPUChan(..) => target!("GetWebGPUChan"),
                 Self::TitleChanged(..) => target!("TitleChanged"),
+                Self::IFrameSizes(..) => target!("IFrameSizes"),
             }
         }
     }
@@ -257,7 +258,6 @@ mod from_layout {
     impl LogTarget for script_traits::LayoutMsg {
         fn log_target(&self) -> &'static str {
             match self {
-                Self::IFrameSizes(..) => target!("IFrameSizes"),
                 Self::PendingPaintMetric(..) => target!("PendingPaintMetric"),
             }
         }

--- a/components/layout_2020/context.rs
+++ b/components/layout_2020/context.rs
@@ -11,7 +11,7 @@ use net_traits::image_cache::{
     ImageCache, ImageCacheResult, ImageOrMetadataAvailable, UsePlaceholder,
 };
 use parking_lot::{Mutex, RwLock};
-use script_layout_interface::{PendingImage, PendingImageState};
+use script_layout_interface::{IFrameSizes, PendingImage, PendingImageState};
 use servo_url::{ImmutableOrigin, ServoUrl};
 use style::context::SharedStyleContext;
 use style::dom::OpaqueNode;
@@ -34,6 +34,9 @@ pub struct LayoutContext<'a> {
 
     /// A list of in-progress image loads to be shared with the script thread.
     pub pending_images: Mutex<Vec<PendingImage>>,
+
+    /// A collection of `<iframe>` sizes to send back to script.
+    pub iframe_sizes: Mutex<IFrameSizes>,
 
     pub webrender_image_cache:
         Arc<RwLock<FnvHashMap<(ServoUrl, UsePlaceholder), WebRenderImageInfo>>>,

--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -1987,8 +1987,11 @@ impl FlexItem<'_> {
                     }
                 }
 
-                let fragments = replaced
-                    .make_fragments(item_style, size.to_physical_size(container_writing_mode));
+                let fragments = replaced.make_fragments(
+                    flex_context.layout_context,
+                    item_style,
+                    size.to_physical_size(container_writing_mode),
+                );
 
                 Some(FlexItemLayoutResult {
                     hypothetical_cross_size,

--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -1399,6 +1399,7 @@ impl ReplacedContents {
     fn layout_in_flow_block_level(
         &self,
         base: &LayoutBoxBase,
+        layout_context: &LayoutContext,
         containing_block: &ContainingBlock,
         mut sequential_layout_state: Option<&mut SequentialLayoutState>,
     ) -> BoxFragment {
@@ -1420,7 +1421,7 @@ impl ReplacedContents {
 
         let containing_block_writing_mode = containing_block.style.writing_mode;
         let physical_content_size = content_size.to_physical_size(containing_block_writing_mode);
-        let fragments = self.make_fragments(&base.style, physical_content_size);
+        let fragments = self.make_fragments(layout_context, &base.style, physical_content_size);
 
         let clearance;
         if let Some(ref mut sequential_layout_state) = sequential_layout_state {
@@ -2071,7 +2072,12 @@ impl IndependentFormattingContext {
                     sequential_layout_state,
                 ),
             IndependentFormattingContextContents::Replaced(contents) => contents
-                .layout_in_flow_block_level(&self.base, containing_block, sequential_layout_state),
+                .layout_in_flow_block_level(
+                    &self.base,
+                    layout_context,
+                    containing_block,
+                    sequential_layout_state,
+                ),
         }
     }
     pub(crate) fn layout_float_or_atomic_inline(
@@ -2099,7 +2105,7 @@ impl IndependentFormattingContext {
                         &content_box_sizes_and_pbm,
                     )
                     .to_physical_size(container_writing_mode);
-                let fragments = replaced.make_fragments(style, content_size);
+                let fragments = replaced.make_fragments(layout_context, style, content_size);
 
                 let content_rect = PhysicalRect::new(PhysicalPoint::zero(), content_size);
                 (fragments, content_rect, None)

--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -572,6 +572,7 @@ impl HoistedAbsolutelyPositionedBox {
                         block: block_axis.size.to_definite().unwrap(),
                     };
                     fragments = replaced.make_fragments(
+                        layout_context,
                         &style,
                         content_size.to_physical_size(containing_block_writing_mode),
                     );

--- a/components/layout_2020/taffy/layout.rs
+++ b/components/layout_2020/taffy/layout.rs
@@ -174,8 +174,11 @@ impl taffy::LayoutPartialTree for TaffyContainerContext<'_> {
                         // Create fragments if the RunMode if PerformLayout
                         // If the RunMode is ComputeSize then only the returned size will be used
                         if inputs.run_mode == RunMode::PerformLayout {
-                            child.child_fragments =
-                                replaced.make_fragments(style, content_box_size);
+                            child.child_fragments = replaced.make_fragments(
+                                self.layout_context,
+                                style,
+                                content_box_size,
+                            );
                         }
 
                         let computed_size = taffy::Size {

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -196,7 +196,7 @@ impl HTMLIFrameElement {
 
         let window_size = WindowSizeData {
             initial_viewport: window
-                .inner_window_dimensions_query(browsing_context_id, can_gc)
+                .get_iframe_size_if_known(browsing_context_id, can_gc)
                 .unwrap_or_default(),
             device_pixel_ratio: window.device_pixel_ratio(),
         };

--- a/components/shared/script/script_msg.rs
+++ b/components/shared/script/script_msg.rs
@@ -46,8 +46,6 @@ pub struct IFrameSizeMsg {
 /// Messages from the layout to the constellation.
 #[derive(Deserialize, Serialize)]
 pub enum LayoutMsg {
-    /// Inform the constellation of the size of the iframe's viewport.
-    IFrameSizes(Vec<IFrameSizeMsg>),
     /// Requests that the constellation inform the compositor that it needs to record
     /// the time when the frame with the given ID (epoch) is painted.
     PendingPaintMetric(PipelineId, Epoch),
@@ -57,7 +55,6 @@ impl fmt::Debug for LayoutMsg {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         use self::LayoutMsg::*;
         let variant = match *self {
-            IFrameSizes(..) => "IFrameSizes",
             PendingPaintMetric(..) => "PendingPaintMetric",
         };
         write!(formatter, "LayoutMsg::{}", variant)
@@ -260,6 +257,8 @@ pub enum ScriptMsg {
     GetWebGPUChan(IpcSender<Option<WebGPU>>),
     /// Notify the constellation of a pipeline's document's title.
     TitleChanged(PipelineId, String),
+    /// Notify the constellation that the size of some `<iframe>`s has changed.
+    IFrameSizes(Vec<IFrameSizeMsg>),
 }
 
 impl fmt::Debug for ScriptMsg {
@@ -320,6 +319,7 @@ impl fmt::Debug for ScriptMsg {
             #[cfg(feature = "webgpu")]
             GetWebGPUChan(..) => "GetWebGPUChan",
             TitleChanged(..) => "TitleChanged",
+            IFrameSizes(..) => "IFramSizes",
         };
         write!(formatter, "ScriptMsg::{}", variant)
     }

--- a/components/shared/script_layout/Cargo.toml
+++ b/components/shared/script_layout/Cargo.toml
@@ -18,6 +18,7 @@ atomic_refcell = { workspace = true }
 canvas_traits = { workspace = true }
 crossbeam-channel = { workspace = true }
 euclid = { workspace = true }
+fnv = { workspace = true }
 fonts = { path = "../../fonts" }
 fonts_traits = { workspace = true }
 html5ever = { workspace = true }


### PR DESCRIPTION
Manage `<iframe>` size updates in `Window`. In addition to removing
duplicated code, this will allow setting `<iframe>` sizes synchronously
on child `Pipeline`s of the same origin in the same script thread in a
followup change. The goal is remove flakiness from `<iframe>` sizing.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] This change is covered by existing WPT tests. It doesn't change observable behavior as it simply sends the same IPC messages, but later in thr process of relayout.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
