### PR TITLE
script: Fix assertion verifying that reflow isn't necessary after reflow

### DIFF
--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1980,23 +1980,22 @@ impl Window {
         let mut issued_reflow = false;
         let condition = self.Document().needs_reflow();
         let updating_the_rendering = reflow_goal == ReflowGoal::UpdateTheRendering;
+        let for_display = reflow_goal.needs_display();
         if !updating_the_rendering || condition.is_some() {
             debug!("Reflowing document ({:?})", self.pipeline_id());
             issued_reflow = self.force_reflow(reflow_goal, condition);
 
-            // We shouldn't need a reflow immediately after a
-            // reflow, except if we're waiting for a deferred paint.
-            let condition = self.Document().needs_reflow();
-            assert!(
-                {
-                    condition.is_none() ||
-                        (!updating_the_rendering &&
-                            condition == Some(ReflowTriggerCondition::PaintPostponed)) ||
-                        self.layout_blocker.get().layout_blocked()
-                },
-                "condition was {:?}",
-                condition
-            );
+            // We shouldn't need a reflow immediately after a completed reflow, unless the reflow didn't
+            // display anything and it wasn't for display. Queries can cause this to happen.
+            if issued_reflow {
+                let condition = self.Document().needs_reflow();
+                let display_is_pending = condition == Some(ReflowTriggerCondition::PaintPostponed);
+                assert!(
+                    condition.is_none() || (display_is_pending && !for_display),
+                    "Needed reflow after reflow: {:?}",
+                    condition
+                );
+            }
         } else {
             debug!(
                 "Document ({:?}) doesn't need reflow - skipping it (goal {reflow_goal:?})",


### PR DESCRIPTION
A reflow might still be necessary if it's necessary for display and the
reflow itself wasn't for display. After this happens a display becomes
necessary and the page is still dirty for layout purposes.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #34621.
- [x] There are tests for these changes. Existing WPT tests cover this and the assertion is a runtime test itself.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
