### PR TITLE
Update deprecated use of PanicInfo to PanicHookInfo

### DIFF
--- a/components/layout_2020/tests/floats.rs
+++ b/components/layout_2020/tests/floats.rs
@@ -6,7 +6,7 @@
 
 use std::f32::INFINITY;
 use std::ops::Range;
-use std::panic::{self, PanicInfo};
+use std::panic::{self, PanicHookInfo};
 use std::sync::{Mutex, MutexGuard};
 use std::{thread, u32};
 
@@ -28,7 +28,7 @@ static PANIC_HOOK_MUTEX: Mutex<()> = Mutex::new(());
 struct PanicMsgSuppressor<'a> {
     #[allow(dead_code)]
     mutex_guard: MutexGuard<'a, ()>,
-    prev_hook: Option<Box<dyn Fn(&PanicInfo<'_>) + 'static + Sync + Send>>,
+    prev_hook: Option<Box<dyn Fn(&PanicHookInfo<'_>) + 'static + Sync + Send>>,
 }
 
 impl<'a> PanicMsgSuppressor<'a> {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #34642

<!-- Either: -->
- [X] These changes do not require tests because it replaces a simple deprecated struct
