### PR TITLE
libservo: update stylo preferences in multiprocess mode.

### DIFF
--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -1209,9 +1209,7 @@ pub fn run_content_process(token: String) {
 
     let unprivileged_content = unprivileged_content_receiver.recv().unwrap();
     opts::set_options(unprivileged_content.opts());
-    prefs::pref_map()
-        .set_all(unprivileged_content.prefs())
-        .expect("Failed to set preferences");
+    prefs::add_user_prefs(unprivileged_content.prefs());
 
     // Enter the sandbox if necessary.
     if opts::get().sandbox {


### PR DESCRIPTION
When servo is run in multiprocess mode, the content process receives the preferences via IPC from the main process. However, currently these preferences are only used to update  Servo's own preferences by explictly calling `Preferences::set_all()`. This doesn't ensure that stylo's copy of preferences is also updated.

This change replaces the call to `Preference::set_all()` with call to `add_user_prefs` which does ensure both Servo's and Stylos' preferences are updated.

Fixes #34660.

---

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #34660 
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

