### PR TITLE
tidy: Make the tidy tests pass tidy

### DIFF
--- a/python/tidy/test.py
+++ b/python/tidy/test.py
@@ -17,6 +17,7 @@ from . import tidy
 
 BASE_PATH = 'python/tidy/tests/'
 
+
 def test_file_path(name):
     return os.path.join(BASE_PATH, name)
 
@@ -46,8 +47,10 @@ class CheckTidiness(unittest.TestCase):
         }
         errors = tidy.check_directory_files(dirs, print_text=False)
         error_dir = os.path.join(BASE_PATH, "dir_check/webidl_plus")
-        self.assertEqual("Unexpected extension found for test.rs. We only expect files with webidl, test extensions in {0}".format(error_dir), next(errors)[2])
-        self.assertEqual("Unexpected extension found for test2.rs. We only expect files with webidl, test extensions in {0}".format(error_dir), next(errors)[2])
+        self.assertEqual("Unexpected extension found for test.rs. We only expect files with webidl, "
+                         + f"test extensions in {error_dir}", next(errors)[2])
+        self.assertEqual("Unexpected extension found for test2.rs. We only expect files with webidl, "
+                         + f"test extensions in {error_dir}", next(errors)[2])
         self.assertNoMoreErrors(errors)
 
     def test_spaces_correctnes(self):
@@ -76,12 +79,22 @@ class CheckTidiness(unittest.TestCase):
         self.assertNoMoreErrors(errors)
 
     def test_license(self):
-        errors = tidy.collect_errors_for_files(iterFile('incorrect_license.rs'), [], [tidy.check_license], print_text=False)
+        errors = tidy.collect_errors_for_files(
+            iterFile('incorrect_license.rs'),
+            [],
+            [tidy.check_license],
+            print_text=False
+        )
         self.assertEqual('incorrect license', next(errors)[2])
         self.assertNoMoreErrors(errors)
 
     def test_shebang_license(self):
-        errors = tidy.collect_errors_for_files(iterFile('shebang_license.py'), [], [tidy.check_license], print_text=False)
+        errors = tidy.collect_errors_for_files(
+            iterFile('shebang_license.py'),
+            [],
+            [tidy.check_license],
+            print_text=False
+        )
         self.assertEqual('missing blank line after shebang', next(errors)[2])
         self.assertNoMoreErrors(errors)
 
@@ -96,11 +109,21 @@ class CheckTidiness(unittest.TestCase):
         self.assertNoMoreErrors(errors)
 
     def test_apache2_incomplete(self):
-        errors = tidy.collect_errors_for_files(iterFile('apache2_license.rs'), [], [tidy.check_license], print_text=False)
+        errors = tidy.collect_errors_for_files(
+            iterFile('apache2_license.rs'),
+            [],
+            [tidy.check_license],
+            print_text=False
+        )
         self.assertEqual('incorrect license', next(errors)[2])
 
     def test_rust(self):
-        errors = tidy.collect_errors_for_files(iterFile('rust_tidy.rs'), [], [tidy.check_rust], print_text=False)
+        errors = tidy.collect_errors_for_files(
+            iterFile('rust_tidy.rs'),
+            [],
+            [tidy.check_rust],
+            print_text=False
+        )
         self.assertTrue('mod declaration is not in alphabetical order' in next(errors)[2])
         self.assertEqual('mod declaration spans multiple lines', next(errors)[2])
         self.assertTrue('derivable traits list is not in alphabetical order' in next(errors)[2])
@@ -127,7 +150,12 @@ class CheckTidiness(unittest.TestCase):
         self.assertEqual('Banned type Cell<JSVal> detected. Use MutDom<JSVal> instead', next(ban_errors)[2])
         self.assertNoMoreErrors(ban_errors)
 
-        ban_errors = tidy.collect_errors_for_files(iterFile('ban-domrefcell.rs'), [], [tidy.check_rust], print_text=False)
+        ban_errors = tidy.collect_errors_for_files(iterFile(
+            'ban-domrefcell.rs'),
+            [],
+            [tidy.check_rust],
+            print_text=False
+        )
         self.assertEqual('Banned type DomRefCell<Dom<T>> detected. Use MutDom<T> instead', next(ban_errors)[2])
         self.assertNoMoreErrors(ban_errors)
 
@@ -178,7 +206,13 @@ class CheckTidiness(unittest.TestCase):
         file_path = os.path.join(BASE_PATH, 'test_ignored')
         file_list = tidy.FileList(file_path, only_changed_files=False, exclude_dirs=[], progress=False)
         lst = list(file_list)
-        self.assertEqual([os.path.join(file_path, 'whee', 'test.rs'), os.path.join(file_path, 'whee', 'foo', 'bar.rs')], lst)
+        self.assertEqual(
+            [
+                os.path.join(file_path, 'whee', 'test.rs'),
+                os.path.join(file_path, 'whee', 'foo', 'bar.rs')
+            ],
+            lst
+        )
         file_list = tidy.FileList(file_path, only_changed_files=False,
                                   exclude_dirs=[os.path.join(file_path, 'whee', 'foo')],
                                   progress=False)

--- a/servo-tidy.toml
+++ b/servo-tidy.toml
@@ -27,8 +27,6 @@ files = [
     "./tests/wpt/mozilla/tests/css/fonts",
     "./tests/wpt/mozilla/tests/css/pre_with_tab.html",
     "./tests/wpt/mozilla/tests/mozilla/textarea_placeholder.html",
-    # The tidy tests currently don't pass tidy.
-    "./python/tidy/test.py",
 ]
 # Directories that are ignored for the non-WPT tidy check.
 directories = [


### PR DESCRIPTION
The issue here is mainly that some of the lines are longer than 120
characters. Just add linebreak where appropriate.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
