### PR TITLE
ci: Set CCACHE only for github hosted runner

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -45,7 +45,6 @@ on:
 env:
   RUST_BACKTRACE: 1
   SHELL: /bin/bash
-  CCACHE: "ccache"
   CARGO_TARGET_DIR: C:\\a\\servo\\servo\\target
   # clang_sys will search msys path before Program Files\LLVM
   # so we need to override this behaviour until we update clang-sys
@@ -102,6 +101,9 @@ jobs:
         # FIXME: “Error: Restoring cache failed: Error: Unable to locate executable file: sh.”
         if: ${{ ! fromJSON(needs.runner-select.outputs.is-self-hosted) }}
         uses: hendrikmuhs/ccache-action@v1.2
+      - if: ${{ ! fromJSON(needs.runner-select.outputs.is-self-hosted) }}
+        run: |
+          echo CCACHE=ccache >> $GITHUB_ENV
 
       # Install missing tools in a GitHub-hosted runner.
       # Workaround for https://github.com/actions/runner-images/issues/10001:


### PR DESCRIPTION
I believe this should fix https://github.com/servo/servo/issues/34603#issuecomment-2544621524, same tricks as in linux workflow: https://github.com/servo/servo/blob/9c59802a27f018362a565f7d5dd191b403466e81/.github/workflows/linux.yml#L109-L111
Alternative would be to actually install ccache in windows images, but that could/will take a long time and I am not sure if we have persistent storage on self hosted anyway cc @delan?



---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because it's CI and I do not have time to manually test
<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
