### PR TITLE
ci: increment SCCACHE_GHA_VERSION to purge caches

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -28,7 +28,7 @@ env:
   RUSTC_WRAPPER: "sccache"
   CCACHE: "sccache"
   # Increment this to purge the cache (https://github.com/mozilla/sccache/blob/main/docs/GHA.md)
-  SCCACHE_GHA_VERSION: 2
+  SCCACHE_GHA_VERSION: 3
   CARGO_INCREMENTAL: 0
 
 jobs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ env:
   SHELL: /bin/bash
   SCCACHE_GHA_ENABLED: "true"
   # Increment this to purge the cache (https://github.com/mozilla/sccache/blob/main/docs/GHA.md)
-  SCCACHE_GHA_VERSION: 2
+  SCCACHE_GHA_VERSION: 3
   RUSTC_WRAPPER: "sccache"
   CCACHE: "sccache"
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -76,7 +76,7 @@ env:
   RUST_BACKTRACE: 1
   SHELL: /bin/bash
   # Increment this to purge the cache (https://github.com/mozilla/sccache/blob/main/docs/GHA.md)
-  SCCACHE_GHA_VERSION: 2
+  SCCACHE_GHA_VERSION: 3
 
 jobs:
   # Runs the underlying job (“workload”) on a self-hosted runner if available,

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -53,7 +53,7 @@ env:
   RUST_BACKTRACE: 1
   SHELL: /bin/bash
   # Increment this to purge the cache (https://github.com/mozilla/sccache/blob/main/docs/GHA.md)
-  SCCACHE_GHA_VERSION: 2
+  SCCACHE_GHA_VERSION: 3
   SCCACHE_GHA_ENABLED: "true"
   RUSTC_WRAPPER: "sccache"
   CCACHE: "sccache"

--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -26,7 +26,7 @@ env:
   RUST_BACKTRACE: 1
   SHELL: /bin/bash
   # Increment this to purge the cache (https://github.com/mozilla/sccache/blob/main/docs/GHA.md)
-  SCCACHE_GHA_VERSION: 2
+  SCCACHE_GHA_VERSION: 3
   SCCACHE_GHA_ENABLED: "true"
   RUSTC_WRAPPER: "sccache"
   CCACHE: "sccache"


### PR DESCRIPTION
There are build failures again with similar errors seen in #34571. Incrementing the SCCACHE_GHA_VERSION should purge the cache for now, but this is just a temporary fix. If this happens again, we'll need to look into disabling sccache until #34571 is resolved.

---

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)
- [ ] These changes do not require tests because ___
