### PR TITLE
Fix mozjs build on Windows

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -832,6 +832,10 @@ class CommandBase(object):
         if with_debug_assertions or self.config["build"]["debug-assertions"]:
             env['RUSTFLAGS'] = env.get('RUSTFLAGS', "") + " -C debug_assertions"
 
+        # mozjs gets its Python from `env['PYTHON3']`, which defaults to `python3`,
+        # but uv venv on Windows only provides a `python`, not `python3`.
+        env['PYTHON3'] = "python"
+
         return call(["cargo", command] + args + cargo_args, env=env, verbose=verbose)
 
     def android_adb_path(self, env):


### PR DESCRIPTION
This patch tells mozjs to find Python at `python`, which is provided by our uv venv (#34504) on both Linux and Windows. Otherwise mozjs defaults to `python3`, which on Windows no longer exists and may be a [Microsoft Store alias](https://stackoverflow.com/q/58754860).

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #34679 