### PR TITLE
Replace HistoryEntryReplacement with NavigationHistoryBehavior

### DIFF
--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -15,7 +15,7 @@ use js::rust::HandleObject;
 use mime::{self, Mime};
 use net_traits::http_percent_encode;
 use net_traits::request::Referrer;
-use script_traits::{HistoryEntryReplacement, LoadData, LoadOrigin};
+use script_traits::{LoadData, LoadOrigin, NavigationHistoryBehavior};
 use servo_atoms::Atom;
 use servo_rand::random;
 use style::attr::AttrValue;
@@ -1030,7 +1030,7 @@ impl HTMLFormElement {
             window
                 .root()
                 .load_url(
-                    HistoryEntryReplacement::Disabled,
+                    NavigationHistoryBehavior::Push,
                     false,
                     load_data,
                     CanGc::note(),

--- a/components/script/dom/htmlmetaelement.rs
+++ b/components/script/dom/htmlmetaelement.rs
@@ -10,7 +10,7 @@ use dom_struct::dom_struct;
 use html5ever::{LocalName, Prefix};
 use js::rust::HandleObject;
 use regex::bytes::Regex;
-use script_traits::HistoryEntryReplacement;
+use script_traits::NavigationHistoryBehavior;
 use servo_url::ServoUrl;
 use style::str::HTML_SPACE_CHARACTERS;
 
@@ -49,7 +49,7 @@ impl RefreshRedirectDue {
     pub fn invoke(self, can_gc: CanGc) {
         self.window.Location().navigate(
             self.url.clone(),
-            HistoryEntryReplacement::Enabled,
+            NavigationHistoryBehavior::Replace,
             NavigationType::DeclarativeRefresh,
             can_gc,
         );

--- a/components/script/dom/location.rs
+++ b/components/script/dom/location.rs
@@ -4,7 +4,7 @@
 
 use dom_struct::dom_struct;
 use net_traits::request::Referrer;
-use script_traits::{HistoryEntryReplacement, LoadData, LoadOrigin};
+use script_traits::{LoadData, LoadOrigin, NavigationHistoryBehavior};
 use servo_url::{MutableOrigin, ServoUrl};
 
 use crate::dom::bindings::codegen::Bindings::LocationBinding::LocationMethods;
@@ -69,7 +69,7 @@ impl Location {
     pub fn navigate(
         &self,
         url: ServoUrl,
-        replacement_flag: HistoryEntryReplacement,
+        history_handling: NavigationHistoryBehavior,
         navigation_type: NavigationType,
         can_gc: CanGc,
     ) {
@@ -131,7 +131,7 @@ impl Location {
             None, // Top navigation doesn't inherit secure context
         );
         self.window
-            .load_url(replacement_flag, reload_triggered, load_data, can_gc);
+            .load_url(history_handling, reload_triggered, load_data, can_gc);
     }
 
     /// Get if this `Location`'s [relevant `Document`][1] is non-null.
@@ -233,7 +233,7 @@ impl Location {
                 // Step 6: Location-object navigate to copyURL.
                 self.navigate(
                     copy_url,
-                    HistoryEntryReplacement::Disabled,
+                    NavigationHistoryBehavior::Push,
                     NavigationType::Normal,
                     can_gc,
                 );
@@ -254,7 +254,7 @@ impl Location {
         let url = self.window.get_url();
         self.navigate(
             url,
-            HistoryEntryReplacement::Enabled,
+            NavigationHistoryBehavior::Replace,
             NavigationType::ReloadByConstellation,
             can_gc,
         );
@@ -290,7 +290,7 @@ impl LocationMethods<crate::DomTypeHolder> for Location {
         let url = self.get_url_if_same_origin()?;
         self.navigate(
             url,
-            HistoryEntryReplacement::Enabled,
+            NavigationHistoryBehavior::Replace,
             NavigationType::ReloadByScript,
             can_gc,
         );
@@ -312,7 +312,7 @@ impl LocationMethods<crate::DomTypeHolder> for Location {
             // the replacement flag set.
             self.navigate(
                 url,
-                HistoryEntryReplacement::Enabled,
+                NavigationHistoryBehavior::Replace,
                 NavigationType::Normal,
                 can_gc,
             );
@@ -424,7 +424,7 @@ impl LocationMethods<crate::DomTypeHolder> for Location {
             // Step 3: Location-object navigate to the resulting URL record.
             self.navigate(
                 url,
-                HistoryEntryReplacement::Disabled,
+                NavigationHistoryBehavior::Push,
                 NavigationType::Normal,
                 can_gc,
             );

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -56,7 +56,7 @@ use script_layout_interface::{
 };
 use script_traits::webdriver_msg::{WebDriverJSError, WebDriverJSResult};
 use script_traits::{
-    ConstellationControlMsg, DocumentState, HistoryEntryReplacement, IFrameSizeMsg, LoadData,
+    ConstellationControlMsg, DocumentState, IFrameSizeMsg, LoadData, NavigationHistoryBehavior,
     ScriptMsg, ScriptToConstellationChan, ScrollState, StructuredSerializedData, Theme,
     TimerSchedulerMsg, WindowSizeData, WindowSizeType,
 };
@@ -2387,7 +2387,7 @@ impl Window {
     /// <https://html.spec.whatwg.org/multipage/#navigating-across-documents>
     pub fn load_url(
         &self,
-        replace: HistoryEntryReplacement,
+        history_handling: NavigationHistoryBehavior,
         force_reload: bool,
         load_data: LoadData,
         can_gc: CanGc,
@@ -2403,7 +2403,7 @@ impl Window {
             if let Some(fragment) = load_data.url.fragment() {
                 self.send_to_constellation(ScriptMsg::NavigatedToFragment(
                     load_data.url.clone(),
-                    replace,
+                    history_handling,
                 ));
                 doc.check_and_scroll_fragment(fragment, can_gc);
                 let this = Trusted::new(self);
@@ -2462,7 +2462,7 @@ impl Window {
                 window_proxy.browsing_context_id(),
                 pipeline_id,
                 load_data,
-                replace,
+                history_handling,
             );
         };
     }

--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -31,8 +31,8 @@ use js::JSCLASS_IS_GLOBAL;
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 use net_traits::request::Referrer;
 use script_traits::{
-    AuxiliaryBrowsingContextLoadInfo, HistoryEntryReplacement, LoadData, LoadOrigin, NewLayoutInfo,
-    ScriptMsg,
+    AuxiliaryBrowsingContextLoadInfo, LoadData, LoadOrigin, NavigationHistoryBehavior,
+    NewLayoutInfo, ScriptMsg,
 };
 use serde::{Deserialize, Serialize};
 use servo_url::{ImmutableOrigin, ServoUrl};
@@ -526,12 +526,13 @@ impl WindowProxy {
                 referrer_policy,
                 Some(secure),
             );
-            let replacement_flag = if new {
-                HistoryEntryReplacement::Enabled
+            let history_handling = if new {
+                NavigationHistoryBehavior::Replace
             } else {
-                HistoryEntryReplacement::Disabled
+                NavigationHistoryBehavior::Push
             };
-            target_window.load_url(replacement_flag, false, load_data, can_gc);
+
+            target_window.load_url(history_handling, false, load_data, can_gc);
         }
         if noopener {
             // Step 15 (Dis-owning has been done in create_auxiliary_browsing_context).

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -82,9 +82,9 @@ use script_layout_interface::{
 use script_traits::webdriver_msg::WebDriverScriptCommand;
 use script_traits::{
     CompositorEvent, ConstellationControlMsg, DiscardBrowsingContext, DocumentActivity,
-    EventResult, HistoryEntryReplacement, InitialScriptState, JsEvalResult, LayoutMsg, LoadData,
-    LoadOrigin, MediaSessionActionType, MouseButton, MouseEventType, NewLayoutInfo, Painter,
-    ProgressiveWebMetricType, ScriptMsg, ScriptToConstellationChan, ScrollState,
+    EventResult, InitialScriptState, JsEvalResult, LayoutMsg, LoadData, LoadOrigin,
+    MediaSessionActionType, MouseButton, MouseEventType, NavigationHistoryBehavior, NewLayoutInfo,
+    Painter, ProgressiveWebMetricType, ScriptMsg, ScriptToConstellationChan, ScrollState,
     StructuredSerializedData, Theme, TimerSchedulerMsg, TouchEventType, TouchId,
     UntrustedNodeAddress, UpdatePipelineIdReason, WheelDelta, WindowSizeData, WindowSizeType,
 };
@@ -915,7 +915,7 @@ impl ScriptThread {
         browsing_context: BrowsingContextId,
         pipeline_id: PipelineId,
         mut load_data: LoadData,
-        replace: HistoryEntryReplacement,
+        history_handling: NavigationHistoryBehavior,
     ) {
         with_script_thread(|script_thread| {
             let is_javascript = load_data.url.scheme() == "javascript";
@@ -936,7 +936,7 @@ impl ScriptThread {
                         if ScriptThread::check_load_origin(&load_data.load_origin, &window.get_url().origin()) {
                             ScriptThread::eval_js_url(&trusted_global.root(), &mut load_data, CanGc::note());
                             sender
-                                .send((pipeline_id, ScriptMsg::LoadUrl(load_data, replace)))
+                                .send((pipeline_id, ScriptMsg::LoadUrl(load_data, history_handling)))
                                 .unwrap();
                         }
                     }
@@ -955,7 +955,7 @@ impl ScriptThread {
 
                 script_thread
                     .script_sender
-                    .send((pipeline_id, ScriptMsg::LoadUrl(load_data, replace)))
+                    .send((pipeline_id, ScriptMsg::LoadUrl(load_data, history_handling)))
                     .expect("Sending a LoadUrl message to the constellation failed");
             }
         });
@@ -2242,12 +2242,12 @@ impl ScriptThread {
                 parent_pipeline_id,
                 browsing_context_id,
                 load_data,
-                replace,
+                history_handling,
             ) => self.handle_navigate_iframe(
                 parent_pipeline_id,
                 browsing_context_id,
                 load_data,
-                replace,
+                history_handling,
                 can_gc,
             ),
             ConstellationControlMsg::UnloadDocument(pipeline_id) => {
@@ -3923,7 +3923,7 @@ impl ScriptThread {
         parent_pipeline_id: PipelineId,
         browsing_context_id: BrowsingContextId,
         load_data: LoadData,
-        replace: HistoryEntryReplacement,
+        history_handling: NavigationHistoryBehavior,
         can_gc: CanGc,
     ) {
         let iframe = self
@@ -3931,7 +3931,7 @@ impl ScriptThread {
             .borrow()
             .find_iframe(parent_pipeline_id, browsing_context_id);
         if let Some(iframe) = iframe {
-            iframe.navigate_or_reload_child_browsing_context(load_data, replace, can_gc);
+            iframe.navigate_or_reload_child_browsing_context(load_data, history_handling, can_gc);
         }
     }
 

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -64,9 +64,9 @@ use webrender_traits::{
 };
 
 pub use crate::script_msg::{
-    DOMMessage, EventResult, HistoryEntryReplacement, IFrameSizeMsg, Job, JobError, JobResult,
-    JobResultValue, JobType, LayoutMsg, LogEntry, SWManagerMsg, SWManagerSenders, ScopeThings,
-    ScriptMsg, ServiceWorkerMsg, TraversalDirection,
+    DOMMessage, EventResult, IFrameSizeMsg, Job, JobError, JobResult, JobResultValue, JobType,
+    LayoutMsg, LogEntry, SWManagerMsg, SWManagerSenders, ScopeThings, ScriptMsg, ServiceWorkerMsg,
+    TraversalDirection,
 };
 use crate::serializable::{BlobData, BlobImpl};
 use crate::transferable::MessagePortImpl;
@@ -233,6 +233,21 @@ pub enum DiscardBrowsingContext {
     No,
 }
 
+/// <https://html.spec.whatwg.org/multipage/#navigation-supporting-concepts:navigationhistorybehavior>
+#[derive(Debug, Default, Deserialize, PartialEq, Serialize)]
+pub enum NavigationHistoryBehavior {
+    /// The default value, which will be converted very early in the navigate algorithm into "push"
+    /// or "replace". Usually it becomes "push", but under certain circumstances it becomes
+    /// "replace" instead.
+    #[default]
+    Auto,
+    /// A regular navigation which adds a new session history entry, and will clear the forward
+    /// session history.
+    Push,
+    /// A navigation that will replace the active session history entry.
+    Replace,
+}
+
 /// Is a document fully active, active or inactive?
 /// A document is active if it is the current active document in its session history,
 /// it is fuly active if it is active and all of its ancestors are active,
@@ -316,7 +331,7 @@ pub enum ConstellationControlMsg {
         PipelineId,
         BrowsingContextId,
         LoadData,
-        HistoryEntryReplacement,
+        NavigationHistoryBehavior,
     ),
     /// Post a message to a given window.
     PostMessage {
@@ -721,9 +736,9 @@ pub struct IFrameLoadInfo {
     pub is_private: bool,
     ///  Whether this iframe should be considered secure
     pub inherited_secure_context: Option<bool>,
-    /// Wether this load should replace the current entry (reload). If true, the current
+    /// Whether this load should replace the current entry (reload). If true, the current
     /// entry will be replaced instead of a new entry being added.
-    pub replace: HistoryEntryReplacement,
+    pub history_handling: NavigationHistoryBehavior,
 }
 
 /// Specifies the information required to load a URL in an iframe.

--- a/components/shared/script/script_msg.rs
+++ b/components/shared/script/script_msg.rs
@@ -28,8 +28,8 @@ use webgpu::{wgc, WebGPU, WebGPUResponse};
 
 use crate::{
     AnimationState, AuxiliaryBrowsingContextLoadInfo, BroadcastMsg, DocumentState,
-    IFrameLoadInfoWithData, LoadData, MessagePortMsg, PortMessageTask, StructuredSerializedData,
-    WindowSizeType, WorkerGlobalScopeInit, WorkerScriptLoadOrigin,
+    IFrameLoadInfoWithData, LoadData, MessagePortMsg, NavigationHistoryBehavior, PortMessageTask,
+    StructuredSerializedData, WindowSizeType, WorkerGlobalScopeInit, WorkerScriptLoadOrigin,
 };
 
 /// An iframe sizing operation.
@@ -81,15 +81,6 @@ pub enum LogEntry {
     Error(String),
     /// warning, with a reason
     Warn(String),
-}
-
-/// <https://html.spec.whatwg.org/multipage/#replacement-enabled>
-#[derive(Debug, Deserialize, Serialize)]
-pub enum HistoryEntryReplacement {
-    /// Traverse the history with replacement enabled.
-    Enabled,
-    /// Traverse the history with replacement disabled.
-    Disabled,
 }
 
 /// Messages from the script to the constellation.
@@ -181,7 +172,7 @@ pub enum ScriptMsg {
     LoadComplete,
     /// A new load has been requested, with an option to replace the current entry once loaded
     /// instead of adding a new entry.
-    LoadUrl(LoadData, HistoryEntryReplacement),
+    LoadUrl(LoadData, NavigationHistoryBehavior),
     /// Abort loading after sending a LoadUrl message.
     AbortLoadUrl,
     /// Post a message to the currently active window of a given browsing context.
@@ -199,7 +190,7 @@ pub enum ScriptMsg {
         data: StructuredSerializedData,
     },
     /// Inform the constellation that a fragment was navigated to and whether or not it was a replacement navigation.
-    NavigatedToFragment(ServoUrl, HistoryEntryReplacement),
+    NavigatedToFragment(ServoUrl, NavigationHistoryBehavior),
     /// HTMLIFrameElement Forward or Back traversal.
     TraverseHistory(TraversalDirection),
     /// Inform the constellation of a pushed history state.


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
In https://github.com/whatwg/html/pull/8502 references to "history handling" were replaced with usage of `NavigationHistoryBehavior` from the Navigation API.

The intent of this change is to move from `HistoryEntryReplacement` to `NavigationHistoryBehavior` without any changes to functionality, just to nudge Servo's navigation code a little closer to the spec.

[Try](https://github.com/shanehandley/servo/actions/runs/12387936450)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
