### PR TITLE
CI: simplify self-hosted check

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -98,7 +98,7 @@ jobs:
     secrets: inherit
     with:
       unique-id: ${{ needs.runner-select.outputs.unique-id }}
-      is-self-hosted: ${{ fromJSON(needs.runner-select.outputs.is-self-hosted) }}
+      is-self-hosted: ${{ runner.environment == 'self-hosted' }}
 
   build:
     needs:
@@ -106,7 +106,7 @@ jobs:
     name: Linux Build [${{ needs.runner-select.outputs.unique-id }}]
     runs-on: ${{ needs.runner-select.outputs.selected-runner-label }}
     steps:
-      - if: ${{ ! fromJSON(needs.runner-select.outputs.is-self-hosted) }}
+      - if: ${{ runner.environment != 'self-hosted' }}
         run: |
           echo SCCACHE_GHA_ENABLED=true >> $GITHUB_ENV
           echo RUSTC_WRAPPER=sccache >> $GITHUB_ENV
@@ -114,20 +114,20 @@ jobs:
           echo CARGO_INCREMENTAL=0 >> $GITHUB_ENV
 
       - uses: actions/checkout@v4
-        if: ${{ ! fromJSON(needs.runner-select.outputs.is-self-hosted) && github.event_name != 'pull_request_target' }}
+        if: ${{ runner.environment != 'self-hosted' && github.event_name != 'pull_request_target' }}
       # This is necessary to checkout the pull request if this run was triggered via a
       # `pull_request_target` event.
       - uses: actions/checkout@v4
-        if: ${{ ! fromJSON(needs.runner-select.outputs.is-self-hosted) && github.event_name == 'pull_request_target' }}
+        if: ${{ runner.environment != 'self-hosted' && github.event_name == 'pull_request_target' }}
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
       # Faster checkout for self-hosted runner that uses prebaked repo.
-      - if: ${{ fromJSON(needs.runner-select.outputs.is-self-hosted) && github.event_name != 'pull_request_target' }}
+      - if: ${{ runner.environment == 'self-hosted' && github.event_name != 'pull_request_target' }}
         run: git fetch --depth=1 origin $GITHUB_SHA
-      - if: ${{ fromJSON(needs.runner-select.outputs.is-self-hosted) && github.event_name == 'pull_request_target' }}
+      - if: ${{ runner.environment == 'self-hosted' && github.event_name == 'pull_request_target' }}
         run: git fetch --depth=1 origin ${{ github.event.pull_request.head.sha }}
-      - if: ${{ fromJSON(needs.runner-select.outputs.is-self-hosted) }}
+      - if: ${{ runner.environment == 'self-hosted' }}
         # Same as `git switch --detach FETCH_HEAD`, but fixes up dirty working
         # trees, in case the runner image was baked with a dirty working tree.
         run: |
@@ -136,17 +136,17 @@ jobs:
 
       # Install missing tools in a GitHub-hosted runner.
       - name: Run sccache-cache
-        if: ${{ ! fromJSON(needs.runner-select.outputs.is-self-hosted) }}
+        if: ${{ runner.environment != 'self-hosted' }}
         uses: mozilla-actions/sccache-action@v0.0.6
       - name: Set LIBCLANG_PATH env # needed for bindgen in mozangle
-        if: ${{ ! fromJSON(needs.runner-select.outputs.is-self-hosted) && !inputs.upload }} # not needed on ubuntu 20.04 used for nightly
+        if: ${{ runner.environment != 'self-hosted' && !inputs.upload }} # not needed on ubuntu 20.04 used for nightly
         run: echo "LIBCLANG_PATH=/usr/lib/llvm-14/lib" >> $GITHUB_ENV
       - name: Setup Python
         uses: ./.github/actions/setup-python
         with:
-          skip-python-setup: ${{ fromJSON(needs.runner-select.outputs.is-self-hosted) }}
+          skip-python-setup: ${{ runner.environment == 'self-hosted' }}
       - name: Bootstrap dependencies
-        if: ${{ ! fromJSON(needs.runner-select.outputs.is-self-hosted) }}
+        if: ${{ runner.environment != 'self-hosted' }}
         run: |
           sudo apt update
           python3 ./mach bootstrap --skip-lints

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -98,7 +98,7 @@ jobs:
     secrets: inherit
     with:
       unique-id: ${{ needs.runner-select.outputs.unique-id }}
-      is-self-hosted: ${{ runner.environment == 'self-hosted' }}
+      is-self-hosted: ${{ fromJSON(needs.runner-select.outputs.is-self-hosted) }}
 
   build:
     needs:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -69,7 +69,7 @@ jobs:
     secrets: inherit
     with:
       unique-id: ${{ needs.runner-select.outputs.unique-id }}
-      is-self-hosted: ${{ fromJSON(needs.runner-select.outputs.is-self-hosted) }}
+      is-self-hosted: ${{ runner.environment == 'self-hosted' }}
 
   build:
     needs:
@@ -77,20 +77,20 @@ jobs:
     name: Windows Build [${{ needs.runner-select.outputs.unique-id }}]
     runs-on: ${{ needs.runner-select.outputs.selected-runner-label }}
     steps:
-      - if: ${{ ! fromJSON(needs.runner-select.outputs.is-self-hosted) && github.event_name != 'pull_request_target' }}
+      - if: ${{ runner.environment != 'self-hosted' && github.event_name != 'pull_request_target' }}
         uses: actions/checkout@v4
-      - if: ${{ ! fromJSON(needs.runner-select.outputs.is-self-hosted) && github.event_name == 'pull_request_target' }}
+      - if: ${{ runner.environment != 'self-hosted' && github.event_name == 'pull_request_target' }}
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
 
       # Faster checkout for self-hosted runner that uses prebaked repo.
-      - if: ${{ fromJSON(needs.runner-select.outputs.is-self-hosted) && github.event_name != 'pull_request_target' }}
+      - if: ${{ runner.environment == 'self-hosted' && github.event_name != 'pull_request_target' }}
         run: git fetch --depth=1 origin $env:GITHUB_SHA
-      - if: ${{ fromJSON(needs.runner-select.outputs.is-self-hosted) && github.event_name == 'pull_request_target' }}
+      - if: ${{ runner.environment == 'self-hosted' && github.event_name == 'pull_request_target' }}
         run: git fetch --depth=1 origin ${{ github.event.pull_request.head.sha }}
-      - if: ${{ fromJSON(needs.runner-select.outputs.is-self-hosted) }}
+      - if: ${{ runner.environment == 'self-hosted' }}
         # Same as `git switch --detach FETCH_HEAD`, but fixes up dirty working
         # trees, in case the runner image was baked with a dirty working tree.
         run: |
@@ -99,19 +99,19 @@ jobs:
 
       - name: ccache
         # FIXME: “Error: Restoring cache failed: Error: Unable to locate executable file: sh.”
-        if: ${{ ! fromJSON(needs.runner-select.outputs.is-self-hosted) }}
+        if: ${{ runner.environment != 'self-hosted' }}
         uses: hendrikmuhs/ccache-action@v1.2
-      - if: ${{ ! fromJSON(needs.runner-select.outputs.is-self-hosted) }}
+      - if: ${{ runner.environment != 'self-hosted' }}
         run: |
           echo CCACHE=ccache >> $GITHUB_ENV
 
       # Install missing tools in a GitHub-hosted runner.
       # Workaround for https://github.com/actions/runner-images/issues/10001:
       - name: Upgrade llvm
-        if: ${{ ! fromJSON(needs.runner-select.outputs.is-self-hosted) }}
+        if: ${{ runner.environment != 'self-hosted' }}
         run: choco upgrade llvm
       - name: Install wixtoolset
-        if: ${{ ! fromJSON(needs.runner-select.outputs.is-self-hosted) }}
+        if: ${{ runner.environment != 'self-hosted' }}
         run: |
           choco install wixtoolset
           echo "C:\\Program Files (x86)\\WiX Toolset v3.11\\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
@@ -119,16 +119,16 @@ jobs:
       - name: Setup Python
         uses: ./.github/actions/setup-python
         with:
-          skip-python-setup: ${{ fromJSON(needs.runner-select.outputs.is-self-hosted) }}
+          skip-python-setup: ${{ runner.environment == 'self-hosted' }}
       - name: Bootstrap
-        if: ${{ ! fromJSON(needs.runner-select.outputs.is-self-hosted) }}
+        if: ${{ runner.environment != 'self-hosted' }}
         run: |
           python mach fetch
           python mach bootstrap-gstreamer
       # For some reason WiX isn't currently on the GitHub runner path. This is a
       # temporary workaround until that is fixed.
       - name: Add WiX to Path
-        if: ${{ ! fromJSON(needs.runner-select.outputs.is-self-hosted) }}
+        if: ${{ runner.environment != 'self-hosted' }}
         run: |
           "$env:WIX\bin" >> $env:GITHUB_PATH
 
@@ -139,7 +139,7 @@ jobs:
         run: cargo install --path support/crown --force
 
       - name: Debug logging for incremental builds
-        if: ${{ fromJSON(needs.runner-select.outputs.is-self-hosted) }}
+        if: ${{ runner.environment == 'self-hosted' }}
         run: |
           cat C:\init\incremental_build_debug.txt
           echo "`$env:LIBCLANG_PATH now = $env:LIBCLANG_PATH"
@@ -150,7 +150,7 @@ jobs:
           python mach build --use-crown --locked --${{ inputs.profile }}
           cp C:\a\servo\servo\target\cargo-timings C:\a\servo\servo\target\cargo-timings-windows -Recurse
       - name: Copy resources
-        if: ${{ ! fromJSON(needs.runner-select.outputs.is-self-hosted) }}
+        if: ${{ runner.environment != 'self-hosted' }}
         # GitHub-hosted runners check out the repo on D: drive.
         run: cp D:\a\servo\servo\resources C:\a\servo\servo -Recurse
       - name: Smoketest

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -69,7 +69,7 @@ jobs:
     secrets: inherit
     with:
       unique-id: ${{ needs.runner-select.outputs.unique-id }}
-      is-self-hosted: ${{ runner.environment == 'self-hosted' }}
+      is-self-hosted: ${{ fromJSON(needs.runner-select.outputs.is-self-hosted) }}
 
   build:
     needs:


### PR DESCRIPTION
See also the official documentation on the
runner context:

https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#runner-context

> The environment of the runner executing the job. Possible values are: `github-hosted` for GitHub-hosted runners provided by GitHub, and `self-hosted` for self-hosted runners configured by the repository owner.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes
