### PR TITLE
Disable sccache in CI

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -24,11 +24,6 @@ on:
 env:
   RUST_BACKTRACE: 1
   SHELL: /bin/bash
-  SCCACHE_GHA_ENABLED: "true"
-  RUSTC_WRAPPER: "sccache"
-  CCACHE: "sccache"
-  # Increment this to purge the cache (https://github.com/mozilla/sccache/blob/main/docs/GHA.md)
-  SCCACHE_GHA_VERSION: 3
   CARGO_INCREMENTAL: 0
 
 jobs:
@@ -57,8 +52,6 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 2
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.7
       - name: Install crown
         run: cargo install --path support/crown
       - name: Setup Python

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,11 +6,6 @@ on:
 env:
   RUST_BACKTRACE: 1
   SHELL: /bin/bash
-  SCCACHE_GHA_ENABLED: "true"
-  # Increment this to purge the cache (https://github.com/mozilla/sccache/blob/main/docs/GHA.md)
-  SCCACHE_GHA_VERSION: 3
-  RUSTC_WRAPPER: "sccache"
-  CCACHE: "sccache"
   CARGO_INCREMENTAL: 0
 
 jobs:
@@ -29,8 +24,6 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 2 # This is necessary for `test-tidy`.
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.6
       - name: Set LIBCLANG_PATH env # needed for bindgen in mozangle
         run: echo "LIBCLANG_PATH=/usr/lib/llvm-14/lib" >> $GITHUB_ENV
       - name: Setup Python

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -75,8 +75,6 @@ on:
 env:
   RUST_BACKTRACE: 1
   SHELL: /bin/bash
-  # Increment this to purge the cache (https://github.com/mozilla/sccache/blob/main/docs/GHA.md)
-  SCCACHE_GHA_VERSION: 3
 
 jobs:
   # Runs the underlying job (“workload”) on a self-hosted runner if available,
@@ -106,13 +104,6 @@ jobs:
     name: Linux Build [${{ needs.runner-select.outputs.unique-id }}]
     runs-on: ${{ needs.runner-select.outputs.selected-runner-label }}
     steps:
-      - if: ${{ runner.environment != 'self-hosted' }}
-        run: |
-          echo SCCACHE_GHA_ENABLED=true >> $GITHUB_ENV
-          echo RUSTC_WRAPPER=sccache >> $GITHUB_ENV
-          echo CCACHE=sccache >> $GITHUB_ENV
-          echo CARGO_INCREMENTAL=0 >> $GITHUB_ENV
-
       - uses: actions/checkout@v4
         if: ${{ runner.environment != 'self-hosted' && github.event_name != 'pull_request_target' }}
       # This is necessary to checkout the pull request if this run was triggered via a
@@ -134,10 +125,6 @@ jobs:
           git switch --detach
           git reset --hard FETCH_HEAD
 
-      # Install missing tools in a GitHub-hosted runner.
-      - name: Run sccache-cache
-        if: ${{ runner.environment != 'self-hosted' }}
-        uses: mozilla-actions/sccache-action@v0.0.6
       - name: Set LIBCLANG_PATH env # needed for bindgen in mozangle
         if: ${{ runner.environment != 'self-hosted' && !inputs.upload }} # not needed on ubuntu 20.04 used for nightly
         run: echo "LIBCLANG_PATH=/usr/lib/llvm-14/lib" >> $GITHUB_ENV

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -52,11 +52,6 @@ on:
 env:
   RUST_BACKTRACE: 1
   SHELL: /bin/bash
-  # Increment this to purge the cache (https://github.com/mozilla/sccache/blob/main/docs/GHA.md)
-  SCCACHE_GHA_VERSION: 4
-  SCCACHE_GHA_ENABLED: "true"
-  RUSTC_WRAPPER: "sccache"
-  CCACHE: "sccache"
   CARGO_INCREMENTAL: 0
 
 jobs:
@@ -81,8 +76,6 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Setup Python
         uses: ./.github/actions/setup-python
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.6
       - name: Install crown
         run: cargo install --path support/crown
       - name: Bootstrap

--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -25,11 +25,6 @@ on:
 env:
   RUST_BACKTRACE: 1
   SHELL: /bin/bash
-  # Increment this to purge the cache (https://github.com/mozilla/sccache/blob/main/docs/GHA.md)
-  SCCACHE_GHA_VERSION: 3
-  SCCACHE_GHA_ENABLED: "true"
-  RUSTC_WRAPPER: "sccache"
-  CCACHE: "sccache"
   CARGO_INCREMENTAL: 0
 
 jobs:
@@ -51,8 +46,6 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 2
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.6
       - name: Install crown
         run: cargo install --path support/crown
       - name: Setup Python


### PR DESCRIPTION
We have been having intermittent issues with sccache since around the recent v0.9 release of sccache which only appear when building mozjs from source.
Due to recent changes with readablestreams, we are not using the prebuilt mozjs artifacts anymore and always building from source, causing these problems to regularly block the merge queue. Bumping SCCACHE_GHA_VERSION helps but has been observed to only be a temporary solution until the next breakage.

Closes #34571


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #34571
- [x] There are tests for these changes 
