### PR TITLE
Reapply "Fix mozjs build on Windows (#34680)"

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -832,6 +832,10 @@ class CommandBase(object):
         if with_debug_assertions or self.config["build"]["debug-assertions"]:
             env['RUSTFLAGS'] = env.get('RUSTFLAGS', "") + " -C debug_assertions"
 
+        # mozjs gets its Python from `env['PYTHON3']`, which defaults to `python3`,
+        # but uv venv on Windows only provides a `python`, not `python3`.
+        env['PYTHON3'] = "python"
+
         return call(["cargo", command] + args + cargo_args, env=env, verbose=verbose)
 
     def android_adb_path(self, env):


### PR DESCRIPTION
This reverts commit bc0c8366f82ab8b8651c2346fbadcfea900ca789, relanding commit 11424f90b3cb0fe5688fce68139744f919c5be21.

Reason: it wasn't the cause behind #34688.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because it's a reland

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
