### PR TITLE
layout: Fix intrinsic contributions of tables

### DIFF
--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -411,6 +411,7 @@ fn compute_inline_content_sizes_for_block_level_boxes(
                     containing_block,
                     &LogicalVec2::zero(),
                     false,    /* auto_block_size_stretches_to_containing_block */
+                    false,    /* is_table */
                     |_| None, /* TODO: support preferred aspect ratios on non-replaced boxes */
                     |constraint_space| {
                         base.inline_content_sizes(layout_context, constraint_space, contents)

--- a/components/layout_2020/formatting_contexts.rs
+++ b/components/layout_2020/formatting_contexts.rs
@@ -204,11 +204,18 @@ impl IndependentFormattingContext {
         auto_minimum: &LogicalVec2<Au>,
         auto_block_size_stretches_to_containing_block: bool,
     ) -> InlineContentSizesResult {
+        let is_table = matches!(
+            self.contents,
+            IndependentFormattingContextContents::NonReplaced(
+                IndependentNonReplacedContents::Table(_)
+            )
+        );
         sizing::outer_inline(
             self.style(),
             containing_block,
             auto_minimum,
             auto_block_size_stretches_to_containing_block,
+            is_table,
             |padding_border_sums| self.preferred_aspect_ratio(padding_border_sums),
             |constraint_space| self.inline_content_sizes(layout_context, constraint_space),
         )

--- a/tests/wpt/meta/css/css-tables/table-intrinsic-size-001.html.ini
+++ b/tests/wpt/meta/css/css-tables/table-intrinsic-size-001.html.ini
@@ -1,2 +1,0 @@
-[table-intrinsic-size-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-tables/table-intrinsic-size-002.html.ini
+++ b/tests/wpt/meta/css/css-tables/table-intrinsic-size-002.html.ini
@@ -1,2 +1,0 @@
-[table-intrinsic-size-002.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-tables/table-intrinsic-size-003.html.ini
+++ b/tests/wpt/meta/css/css-tables/table-intrinsic-size-003.html.ini
@@ -1,2 +1,0 @@
-[table-intrinsic-size-003.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-tables/table-intrinsic-size-004.html.ini
+++ b/tests/wpt/meta/css/css-tables/table-intrinsic-size-004.html.ini
@@ -1,2 +1,0 @@
-[table-intrinsic-size-004.html]
-  expected: FAIL


### PR DESCRIPTION
If a table element had e.g. `width: 0px`, we were assuming that this was its intrinsic min-content and max-content contributions.

However, tables are always at least as big as its min-content size, so this patch floors the intrinsic contributions by that amount.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
