### PR TITLE
layout: Lay out Shadow DOM elements

### DIFF
--- a/components/layout_2020/dom_traversal.rs
+++ b/components/layout_2020/dom_traversal.rs
@@ -10,6 +10,7 @@ use script_layout_interface::wrapper_traits::{ThreadSafeLayoutElement, ThreadSaf
 use script_layout_interface::{LayoutElementType, LayoutNodeType};
 use selectors::Element as SelectorsElement;
 use servo_arc::Arc as ServoArc;
+use style::dom::{TElement, TShadowRoot};
 use style::properties::ComputedValues;
 use style::selector_parser::PseudoElement;
 use style::values::generics::counters::{Content, ContentItem};
@@ -467,6 +468,10 @@ pub(crate) fn iter_child_nodes<'dom, Node>(parent: Node) -> impl Iterator<Item =
 where
     Node: NodeExt<'dom>,
 {
+    if let Some(shadow) = parent.as_element().and_then(|e| e.shadow_root()) {
+        return iter_child_nodes(shadow.as_node());
+    };
+
     let mut next = parent.first_child();
     std::iter::from_fn(move || {
         next.inspect(|child| {

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -558,19 +558,24 @@ impl Element {
         };
         shadow_root.bind_to_tree(&bind_context);
 
-        self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
+        let node = self.upcast::<Node>();
+        node.dirty(NodeDamage::OtherNodeDamage);
+        node.rev_version();
 
         Ok(shadow_root)
     }
 
     pub fn detach_shadow(&self) {
-        if let Some(ref shadow_root) = self.shadow_root() {
-            self.upcast::<Node>().note_dirty_descendants();
-            shadow_root.detach();
-            self.ensure_rare_data().shadow_root = None;
-        } else {
-            debug_assert!(false, "Trying to detach a non-attached shadow root");
-        }
+        let Some(ref shadow_root) = self.shadow_root() else {
+            unreachable!("Trying to detach a non-attached shadow root");
+        };
+
+        let node = self.upcast::<Node>();
+        node.note_dirty_descendants();
+        node.rev_version();
+
+        shadow_root.detach();
+        self.ensure_rare_data().shadow_root = None;
     }
 
     // https://html.spec.whatwg.org/multipage/#translation-mode

--- a/tests/wpt/meta/css/css-animations/cancel-animation-shadow-slot-invalidation.html.ini
+++ b/tests/wpt/meta/css/css-animations/cancel-animation-shadow-slot-invalidation.html.ini
@@ -1,2 +1,0 @@
-[cancel-animation-shadow-slot-invalidation.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/css/css-content/quotes-slot-scoping.html.ini
+++ b/tests/wpt/meta/css/css-content/quotes-slot-scoping.html.ini
@@ -1,2 +1,2 @@
 [quotes-slot-scoping.html]
-  expected: PASS
+  expected: FAIL

--- a/tests/wpt/meta/css/css-display/display-contents-shadow-host-whitespace.html.ini
+++ b/tests/wpt/meta/css/css-display/display-contents-shadow-host-whitespace.html.ini
@@ -1,2 +1,0 @@
-[display-contents-shadow-host-whitespace.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-display/display-contents-slot-attach-whitespace.html.ini
+++ b/tests/wpt/meta/css/css-display/display-contents-slot-attach-whitespace.html.ini
@@ -1,0 +1,2 @@
+[display-contents-slot-attach-whitespace.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-pseudo/file-selector-button-after-part.html.ini
+++ b/tests/wpt/meta/css/css-pseudo/file-selector-button-after-part.html.ini
@@ -1,0 +1,2 @@
+[file-selector-button-after-part.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text-decor/text-decoration-propagation-shadow.html.ini
+++ b/tests/wpt/meta/css/css-text-decor/text-decoration-propagation-shadow.html.ini
@@ -1,0 +1,2 @@
+[text-decoration-propagation-shadow.html]
+  expected: FAIL

--- a/tests/wpt/meta/dom/slot-recalc.html.ini
+++ b/tests/wpt/meta/dom/slot-recalc.html.ini
@@ -1,2 +1,0 @@
-[slot-recalc.html]
-  expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/2d.text-outside-of-the-flat-tree.html.ini
+++ b/tests/wpt/meta/html/canvas/element/2d.text-outside-of-the-flat-tree.html.ini
@@ -1,2 +1,2 @@
 [2d.text-outside-of-the-flat-tree.html]
-  expected: PASS
+  expected: FAIL

--- a/tests/wpt/meta/selection/shadow-dom/cross-shadow-boundary-1.html.ini
+++ b/tests/wpt/meta/selection/shadow-dom/cross-shadow-boundary-1.html.ini
@@ -1,2 +1,0 @@
-[cross-shadow-boundary-1.html]
-  expected: FAIL

--- a/tests/wpt/meta/selection/shadow-dom/cross-shadow-boundary-2.html.ini
+++ b/tests/wpt/meta/selection/shadow-dom/cross-shadow-boundary-2.html.ini
@@ -1,2 +1,0 @@
-[cross-shadow-boundary-2.html]
-  expected: FAIL

--- a/tests/wpt/meta/selection/shadow-dom/cross-shadow-boundary-3.html.ini
+++ b/tests/wpt/meta/selection/shadow-dom/cross-shadow-boundary-3.html.ini
@@ -1,2 +1,0 @@
-[cross-shadow-boundary-3.html]
-  expected: FAIL

--- a/tests/wpt/meta/selection/shadow-dom/cross-shadow-boundary-4.html.ini
+++ b/tests/wpt/meta/selection/shadow-dom/cross-shadow-boundary-4.html.ini
@@ -1,2 +1,0 @@
-[cross-shadow-boundary-4.html]
-  expected: FAIL

--- a/tests/wpt/meta/selection/shadow-dom/cross-shadow-boundary-5.html.ini
+++ b/tests/wpt/meta/selection/shadow-dom/cross-shadow-boundary-5.html.ini
@@ -1,2 +1,0 @@
-[cross-shadow-boundary-5.html]
-  expected: FAIL

--- a/tests/wpt/meta/selection/shadow-dom/cross-shadow-boundary-img.html.ini
+++ b/tests/wpt/meta/selection/shadow-dom/cross-shadow-boundary-img.html.ini
@@ -1,2 +1,0 @@
-[cross-shadow-boundary-img.html]
-  expected: FAIL

--- a/tests/wpt/meta/selection/shadow-dom/cross-shadow-boundary-select-document.html.ini
+++ b/tests/wpt/meta/selection/shadow-dom/cross-shadow-boundary-select-document.html.ini
@@ -1,2 +1,0 @@
-[cross-shadow-boundary-select-document.html]
-  expected: FAIL

--- a/tests/wpt/meta/selection/shadow-dom/cross-shadow-boundary-select-root.html.ini
+++ b/tests/wpt/meta/selection/shadow-dom/cross-shadow-boundary-select-root.html.ini
@@ -1,2 +1,0 @@
-[cross-shadow-boundary-select-root.html]
-  expected: FAIL

--- a/tests/wpt/meta/shadow-dom/focus/focus-pseudo-on-shadow-host-2.html.ini
+++ b/tests/wpt/meta/shadow-dom/focus/focus-pseudo-on-shadow-host-2.html.ini
@@ -1,2 +1,0 @@
-[focus-pseudo-on-shadow-host-2.html]
-  expected: FAIL

--- a/tests/wpt/meta/shadow-dom/layout-slot-no-longer-fallback.html.ini
+++ b/tests/wpt/meta/shadow-dom/layout-slot-no-longer-fallback.html.ini
@@ -1,0 +1,2 @@
+[layout-slot-no-longer-fallback.html]
+  expected: FAIL

--- a/tests/wpt/meta/shadow-dom/offsetParent-across-shadow-boundaries.html.ini
+++ b/tests/wpt/meta/shadow-dom/offsetParent-across-shadow-boundaries.html.ini
@@ -1,16 +1,4 @@
 [offsetParent-across-shadow-boundaries.html]
-  [offsetParent must return the offset parent in the same shadow tree of open mode]
-    expected: FAIL
-
-  [offsetParent must return the offset parent in the same shadow tree of closed mode]
-    expected: FAIL
-
-  [offsetParent must return the offset parent in the same shadow tree of open mode even when nested]
-    expected: FAIL
-
-  [offsetParent must return the offset parent in the same shadow tree of closed mode even when nested]
-    expected: FAIL
-
   [offsetParent must skip offset parents of an element when the context object is assigned to a slot in a shadow tree of open mode]
     expected: FAIL
 

--- a/tests/wpt/meta/shadow-dom/shadow-style-invalidation-vw-units.html.ini
+++ b/tests/wpt/meta/shadow-dom/shadow-style-invalidation-vw-units.html.ini
@@ -1,2 +1,0 @@
-[shadow-style-invalidation-vw-units.html]
-  expected: FAIL

--- a/tests/wpt/meta/shadow-dom/slot-fallback-content-001.html.ini
+++ b/tests/wpt/meta/shadow-dom/slot-fallback-content-001.html.ini
@@ -1,0 +1,2 @@
+[slot-fallback-content-001.html]
+  expected: FAIL

--- a/tests/wpt/meta/shadow-dom/slot-fallback-content-002.html.ini
+++ b/tests/wpt/meta/shadow-dom/slot-fallback-content-002.html.ini
@@ -1,0 +1,2 @@
+[slot-fallback-content-002.html]
+  expected: FAIL

--- a/tests/wpt/meta/shadow-dom/slot-fallback-content-003.html.ini
+++ b/tests/wpt/meta/shadow-dom/slot-fallback-content-003.html.ini
@@ -1,2 +1,0 @@
-[slot-fallback-content-003.html]
-  expected: FAIL

--- a/tests/wpt/meta/shadow-dom/slot-fallback-content-004.html.ini
+++ b/tests/wpt/meta/shadow-dom/slot-fallback-content-004.html.ini
@@ -1,2 +1,0 @@
-[slot-fallback-content-004.html]
-  expected: FAIL

--- a/tests/wpt/meta/shadow-dom/slot-fallback-content-005.html.ini
+++ b/tests/wpt/meta/shadow-dom/slot-fallback-content-005.html.ini
@@ -1,2 +1,0 @@
-[slot-fallback-content-005.html]
-  expected: FAIL

--- a/tests/wpt/meta/shadow-dom/untriaged/elements-and-dom-objects/extensions-to-element-interface/methods/test-002.html.ini
+++ b/tests/wpt/meta/shadow-dom/untriaged/elements-and-dom-objects/extensions-to-element-interface/methods/test-002.html.ini
@@ -1,3 +1,0 @@
-[test-002.html]
-  [A_10_02_02_02_T01]
-    expected: FAIL

--- a/tests/wpt/meta/shadow-dom/untriaged/shadow-trees/nested-shadow-trees/nested_tree_reftest.html.ini
+++ b/tests/wpt/meta/shadow-dom/untriaged/shadow-trees/nested-shadow-trees/nested_tree_reftest.html.ini
@@ -1,2 +1,0 @@
-[nested_tree_reftest.html]
-  expected: FAIL

--- a/tests/wpt/meta/shadow-dom/untriaged/shadow-trees/shadow-root-001.html.ini
+++ b/tests/wpt/meta/shadow-dom/untriaged/shadow-trees/shadow-root-001.html.ini
@@ -1,2 +1,0 @@
-[shadow-root-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/shadow-dom/untriaged/styles/test-001.html.ini
+++ b/tests/wpt/meta/shadow-dom/untriaged/styles/test-001.html.ini
@@ -1,6 +1,0 @@
-[test-001.html]
-  [A_06_00_01_T01]
-    expected: FAIL
-
-  [A_06_00_01_T02]
-    expected: FAIL


### PR DESCRIPTION
When an element is a shadow root, lay out the shadow root elements
instead of the non-shadow children.

This fixes some tests and introduces some failures, due to bugs in the
Shadow DOM implementation. In general, this is very low impact as the
Shadow DOM is still disabled by default. At least this gets elements
rendering when the preference is turned on though.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
