### PR TITLE
Fix the incorrect percentage calculation of width (#34665)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1737,7 +1737,7 @@ dependencies = [
 [[package]]
 name = "dom"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-03-01#a93e7efd1b4ce73d5a1b3df2337f5d16d3de121e"
+source = "git+https://github.com/servo/stylo?branch=2025-03-01#4add86f53a05ee27c13db998465e83e1ed733871"
 dependencies = [
  "bitflags 2.9.0",
  "malloc_size_of",
@@ -4566,7 +4566,7 @@ dependencies = [
 [[package]]
 name = "malloc_size_of"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-03-01#a93e7efd1b4ce73d5a1b3df2337f5d16d3de121e"
+source = "git+https://github.com/servo/stylo?branch=2025-03-01#4add86f53a05ee27c13db998465e83e1ed733871"
 dependencies = [
  "app_units",
  "cssparser",
@@ -6586,7 +6586,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.26.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-01#a93e7efd1b4ce73d5a1b3df2337f5d16d3de121e"
+source = "git+https://github.com/servo/stylo?branch=2025-03-01#4add86f53a05ee27c13db998465e83e1ed733871"
 dependencies = [
  "bitflags 2.9.0",
  "cssparser",
@@ -6871,7 +6871,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-01#a93e7efd1b4ce73d5a1b3df2337f5d16d3de121e"
+source = "git+https://github.com/servo/stylo?branch=2025-03-01#4add86f53a05ee27c13db998465e83e1ed733871"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -6880,7 +6880,7 @@ dependencies = [
 [[package]]
 name = "servo_atoms"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-03-01#a93e7efd1b4ce73d5a1b3df2337f5d16d3de121e"
+source = "git+https://github.com/servo/stylo?branch=2025-03-01#4add86f53a05ee27c13db998465e83e1ed733871"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -7237,7 +7237,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "static_prefs"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-01#a93e7efd1b4ce73d5a1b3df2337f5d16d3de121e"
+source = "git+https://github.com/servo/stylo?branch=2025-03-01#4add86f53a05ee27c13db998465e83e1ed733871"
 
 [[package]]
 name = "strck"
@@ -7317,7 +7317,7 @@ dependencies = [
 [[package]]
 name = "style"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-03-01#a93e7efd1b4ce73d5a1b3df2337f5d16d3de121e"
+source = "git+https://github.com/servo/stylo?branch=2025-03-01#4add86f53a05ee27c13db998465e83e1ed733871"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -7375,7 +7375,7 @@ dependencies = [
 [[package]]
 name = "style_config"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-03-01#a93e7efd1b4ce73d5a1b3df2337f5d16d3de121e"
+source = "git+https://github.com/servo/stylo?branch=2025-03-01#4add86f53a05ee27c13db998465e83e1ed733871"
 dependencies = [
  "lazy_static",
 ]
@@ -7383,7 +7383,7 @@ dependencies = [
 [[package]]
 name = "style_derive"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-03-01#a93e7efd1b4ce73d5a1b3df2337f5d16d3de121e"
+source = "git+https://github.com/servo/stylo?branch=2025-03-01#4add86f53a05ee27c13db998465e83e1ed733871"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -7413,7 +7413,7 @@ dependencies = [
 [[package]]
 name = "style_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-03-01#a93e7efd1b4ce73d5a1b3df2337f5d16d3de121e"
+source = "git+https://github.com/servo/stylo?branch=2025-03-01#4add86f53a05ee27c13db998465e83e1ed733871"
 dependencies = [
  "app_units",
  "bitflags 2.9.0",
@@ -7797,7 +7797,7 @@ dependencies = [
 [[package]]
 name = "to_shmem"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-01#a93e7efd1b4ce73d5a1b3df2337f5d16d3de121e"
+source = "git+https://github.com/servo/stylo?branch=2025-03-01#4add86f53a05ee27c13db998465e83e1ed733871"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -7810,7 +7810,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-01#a93e7efd1b4ce73d5a1b3df2337f5d16d3de121e"
+source = "git+https://github.com/servo/stylo?branch=2025-03-01#4add86f53a05ee27c13db998465e83e1ed733871"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/tests/wpt/meta/css/css-sizing/percentage-width-subpixels.tentative.html.ini
+++ b/tests/wpt/meta/css/css-sizing/percentage-width-subpixels.tentative.html.ini
@@ -1,2 +1,0 @@
-[percentage-width-subpixels.tentative.html]
-  expected: FAIL


### PR DESCRIPTION
The conversion from percentage * basis to Au is unreasonably. Round method is used in this process and the size of box is larger.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #34665 (GitHub issue number if applicable)
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
