### PR TITLE
Invert check for webxr when determining animation status.

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -1807,7 +1807,7 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
         let webxr_running = self.webxr_main_thread.running();
         #[cfg(not(feature = "webxr"))]
         let webxr_running = false;
-        let animation_state = if pipeline_ids.is_empty() && webxr_running {
+        let animation_state = if pipeline_ids.is_empty() && !webxr_running {
             windowing::AnimationState::Idle
         } else {
             windowing::AnimationState::Animating


### PR DESCRIPTION
The intent here is that if no pipelines are running animation callbacks, and there is no webxr session active, then the embedder should not need to run continuous window updates. Instead, we're telling embedders that Servo is constantly animating when there is no webxr session active.

This was a regression from https://github.com/servo/servo/commit/47a243614f920cb9cf4c058ee9d0584377a2a11e.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because we have no test harness that can verify this behaviour.