### PR TITLE
ci: explictly install Clang 14 on Linux nightly job runners

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -124,7 +124,14 @@ jobs:
         run: |
           git switch --detach
           git reset --hard FETCH_HEAD
-
+      - name: Install LLVM and Clang
+        # Expliclity install Clang 14 on Ubuntu 20.04 used by the nightly job (#34713).
+        if: ${{ runner.environment != 'self-hosted' && inputs.upload }}
+        uses: KyleMayes/install-llvm-action@v2
+        with:
+          version: 14
+        # FIXME: It would be better to use the above step for regular Linux jobs
+        # and remove the following step, but currenty that is failing and needs investigation.
       - name: Set LIBCLANG_PATH env # needed for bindgen in mozangle
         if: ${{ runner.environment != 'self-hosted' && !inputs.upload }} # not needed on ubuntu 20.04 used for nightly
         run: echo "LIBCLANG_PATH=/usr/lib/llvm-14/lib" >> $GITHUB_ENV


### PR DESCRIPTION
The nightly build jobs run on Ubuntu 20.04 to ensure the glibc version
is compatible with WPT.fyi runners. But this version of Ubuntu has an
older clang version (12) that is not compatible with mozjs.

This patch makes the nightly job for Linux explicity install Clang 14
using the KyleMayes/install-llvm-action@v2 action. The regular Linux job
still uses system Clang installation as there are failures when using
the github action.

Fixes #34713.

Signed-off-by: Mukilan Thiyagarajan <mukilan@igalia.com>

----

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #34713
- [ ] These changes are modify CI configuration and will be tested manually using try/UI dispatched jobs

