### PR TITLE
Update wgpu for supporting TextureView.usage

### DIFF
--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -79,6 +79,7 @@ jobs:
             ${{ inputs.wpt-args }}
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
+          RUST_LOG: wgpu_core=off,naga=off
       - name: Archive results (filtered)
         uses: actions/upload-artifact@v4
         if: ${{ always() }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -794,12 +794,6 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
-
-[[package]]
-name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
@@ -4485,12 +4479,12 @@ checksum = "956787520e75e9bd233246045d19f42fb73242759cc57fba9611d940ae96d4b0"
 [[package]]
 name = "naga"
 version = "23.0.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=4da7c263ed075e5d1ac7ee5640712542830e6330#4da7c263ed075e5d1ac7ee5640712542830e6330"
+source = "git+https://github.com/gfx-rs/wgpu?rev=53f40794f275329a48efc7d1c637c91b8e51327d#53f40794f275329a48efc7d1c637c91b8e51327d"
 dependencies = [
  "arrayvec",
  "bit-set",
  "bitflags 2.6.0",
- "cfg_aliases 0.1.1",
+ "cfg_aliases",
  "codespan-reporting",
  "hexf-parse",
  "indexmap",
@@ -4695,7 +4689,7 @@ checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",
- "cfg_aliases 0.2.1",
+ "cfg_aliases",
  "libc",
 ]
 
@@ -7033,7 +7027,7 @@ version = "0.9.8"
 source = "git+https://github.com/servo/surfman?rev=c8d6b4b65aeab739ee7651602e29c8d58ceee123#c8d6b4b65aeab739ee7651602e29c8d58ceee123"
 dependencies = [
  "bitflags 2.6.0",
- "cfg_aliases 0.2.1",
+ "cfg_aliases",
  "cgl",
  "cocoa",
  "core-foundation 0.9.4",
@@ -8317,12 +8311,12 @@ checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
 [[package]]
 name = "wgpu-core"
 version = "23.0.1"
-source = "git+https://github.com/gfx-rs/wgpu?rev=4da7c263ed075e5d1ac7ee5640712542830e6330#4da7c263ed075e5d1ac7ee5640712542830e6330"
+source = "git+https://github.com/gfx-rs/wgpu?rev=53f40794f275329a48efc7d1c637c91b8e51327d#53f40794f275329a48efc7d1c637c91b8e51327d"
 dependencies = [
  "arrayvec",
  "bit-vec",
  "bitflags 2.6.0",
- "cfg_aliases 0.1.1",
+ "cfg_aliases",
  "document-features",
  "indexmap",
  "log",
@@ -8342,7 +8336,7 @@ dependencies = [
 [[package]]
 name = "wgpu-hal"
 version = "23.0.1"
-source = "git+https://github.com/gfx-rs/wgpu?rev=4da7c263ed075e5d1ac7ee5640712542830e6330#4da7c263ed075e5d1ac7ee5640712542830e6330"
+source = "git+https://github.com/gfx-rs/wgpu?rev=53f40794f275329a48efc7d1c637c91b8e51327d#53f40794f275329a48efc7d1c637c91b8e51327d"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -8351,7 +8345,7 @@ dependencies = [
  "bitflags 2.6.0",
  "block",
  "bytemuck",
- "cfg_aliases 0.1.1",
+ "cfg_aliases",
  "core-graphics-types",
  "glow",
  "glutin_wgl_sys",
@@ -8385,7 +8379,7 @@ dependencies = [
 [[package]]
 name = "wgpu-types"
 version = "23.0.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=4da7c263ed075e5d1ac7ee5640712542830e6330#4da7c263ed075e5d1ac7ee5640712542830e6330"
+source = "git+https://github.com/gfx-rs/wgpu?rev=53f40794f275329a48efc7d1c637c91b8e51327d#53f40794f275329a48efc7d1c637c91b8e51327d"
 dependencies = [
  "bitflags 2.6.0",
  "js-sys",
@@ -8724,7 +8718,7 @@ dependencies = [
  "block2",
  "bytemuck",
  "calloop",
- "cfg_aliases 0.2.1",
+ "cfg_aliases",
  "concurrent-queue",
  "core-foundation 0.9.4",
  "core-graphics",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3621,7 +3621,6 @@ checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
 dependencies = [
  "equivalent",
  "hashbrown",
- "serde",
 ]
 
 [[package]]
@@ -4490,7 +4489,6 @@ dependencies = [
  "indexmap",
  "log",
  "rustc-hash 1.1.0",
- "serde",
  "spirv",
  "termcolor",
  "thiserror",
@@ -8324,7 +8322,6 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "profiling",
- "ron",
  "rustc-hash 1.1.0",
  "serde",
  "smallvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,8 +155,8 @@ webrender_api = { git = "https://github.com/servo/webrender", branch = "0.65" }
 webrender_traits = { path = "components/shared/webrender" }
 webxr = { git = "https://github.com/servo/webxr" }
 webxr-api = { git = "https://github.com/servo/webxr" }
-wgpu-core = { git = "https://github.com/gfx-rs/wgpu", rev = "4da7c263ed075e5d1ac7ee5640712542830e6330" }
-wgpu-types = { git = "https://github.com/gfx-rs/wgpu", rev = "4da7c263ed075e5d1ac7ee5640712542830e6330" }
+wgpu-core = { git = "https://github.com/gfx-rs/wgpu", rev = "53f40794f275329a48efc7d1c637c91b8e51327d" }
+wgpu-types = { git = "https://github.com/gfx-rs/wgpu", rev = "53f40794f275329a48efc7d1c637c91b8e51327d" }
 windows-sys = "0.59"
 wr_malloc_size_of = { git = "https://github.com/servo/webrender", branch = "0.65" }
 xi-unicode = "0.3.0"

--- a/components/script/dom/webgpu/gpucommandencoder.rs
+++ b/components/script/dom/webgpu/gpucommandencoder.rs
@@ -158,13 +158,13 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
                 depth: wgpu_com::PassChannel {
                     load_op: ds.depthLoadOp.as_ref().map(Convert::convert),
                     store_op: ds.depthStoreOp.as_ref().map(Convert::convert),
-                    clear_value: *ds.depthClearValue.unwrap_or_default(),
+                    clear_value: ds.depthClearValue.map(|v| *v),
                     read_only: ds.depthReadOnly,
                 },
                 stencil: wgpu_com::PassChannel {
                     load_op: ds.stencilLoadOp.as_ref().map(Convert::convert),
                     store_op: ds.stencilStoreOp.as_ref().map(Convert::convert),
-                    clear_value: ds.stencilClearValue,
+                    clear_value: Some(ds.stencilClearValue),
                     read_only: ds.stencilReadOnly,
                 },
                 view: ds.view.id().0,

--- a/components/script/dom/webgpu/gputexture.rs
+++ b/components/script/dom/webgpu/gputexture.rs
@@ -189,6 +189,7 @@ impl GPUTextureMethods<crate::DomTypeHolder> for GPUTexture {
                     .map(|f| self.device.validate_texture_format_required_features(&f))
                     .transpose()?,
                 dimension: descriptor.dimension.map(|dimension| dimension.convert()),
+                usage: Some(wgt::TextureUsages::from_bits_retain(descriptor.usage)),
                 range: wgt::ImageSubresourceRange {
                     aspect: match descriptor.aspect {
                         GPUTextureAspect::All => wgt::TextureAspect::All,

--- a/components/script/dom/webidls/WebGPU.webidl
+++ b/components/script/dom/webidls/WebGPU.webidl
@@ -268,6 +268,7 @@ GPUTextureView includes GPUObjectBase;
 dictionary GPUTextureViewDescriptor : GPUObjectDescriptorBase {
     GPUTextureFormat format;
     GPUTextureViewDimension dimension;
+    GPUTextureUsageFlags usage = 0;
     GPUTextureAspect aspect = "all";
     GPUIntegerCoordinate baseMipLevel = 0;
     GPUIntegerCoordinate mipLevelCount;

--- a/components/webgpu/Cargo.toml
+++ b/components/webgpu/Cargo.toml
@@ -23,7 +23,7 @@ servo_config = { path = "../config" }
 webrender = { workspace = true }
 webrender_api = { workspace = true }
 webrender_traits = { workspace = true }
-wgpu-core = { workspace = true, features = ["replay", "trace", "wgsl"] }
+wgpu-core = { workspace = true, features = ["serde", "wgsl"] }
 wgpu-types = { workspace = true }
 
 # We want the wgpu-core Metal backend on macOS and iOS.

--- a/deny.toml
+++ b/deny.toml
@@ -94,7 +94,6 @@ deny = [
 
 # List of crates to skip for the duplicate check:
 skip = [
-    "cfg_aliases",
     "bitflags",
     "cookie",
     "futures",


### PR DESCRIPTION
I also removed some unused features from wgpu-core and make CTS runs less spammy by disabling logs for wgpu, but I opened issue upstream for proper fix https://github.com/gfx-rs/wgpu/issues/6794.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes in WebGPU CTS

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
