### PR TITLE
Convert http&https to ws&wss in websocket constructor

### DIFF
--- a/tests/wpt/meta/websockets/Create-http-urls.any.js.ini
+++ b/tests/wpt/meta/websockets/Create-http-urls.any.js.ini
@@ -1,8 +1,0 @@
-[Create-http-urls.any.worker.html]
-  [WebSocket: ensure both HTTP schemes are supported]
-    expected: FAIL
-
-
-[Create-http-urls.any.html]
-  [WebSocket: ensure both HTTP schemes are supported]
-    expected: FAIL


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Add protocol conversion in websocket constructor:
- http to ws
- https to wss

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #34633  (GitHub issue number if applicable)

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
