### PR TITLE
Optimize mutex locking in fetch to use a single scoped MutexGuard

### DIFF
--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -101,17 +101,11 @@ pub type DoneChannel = Option<(TokioSender<Data>, TokioReceiver<Data>)>;
 pub async fn fetch(request: &mut Request, target: Target<'_>, context: &FetchContext) {
     // Steps 7,4 of https://w3c.github.io/resource-timing/#processing-model
     // rev order okay since spec says they're equal - https://w3c.github.io/resource-timing/#dfn-starttime
-    context
-        .timing
-        .lock()
-        .unwrap()
-        .set_attribute(ResourceAttribute::FetchStart);
-    context
-        .timing
-        .lock()
-        .unwrap()
-        .set_attribute(ResourceAttribute::StartTime(ResourceTimeValue::FetchStart));
-
+    {
+        let mut timing_guard = context.timing.lock().unwrap();
+        timing_guard.set_attribute(ResourceAttribute::FetchStart);
+        timing_guard.set_attribute(ResourceAttribute::StartTime(ResourceTimeValue::FetchStart));
+    }
     fetch_with_cors_cache(request, &mut CorsCache::default(), target, context).await;
 }
 


### PR DESCRIPTION
The fetch function in components/net/fetch/methods.rs was locking the same mutex twice sequentially. 
This change ensures that the mutex is locked only once by introducing a scoped MutexGuard. 
The guard is used to perform the necessary operations (`set_attribute`) and is dropped immediately after.
- Locks the mutex only once.
- Stores the MutexGuard in a scoped variable to minimize the lock's lifetime.
- Improves code readability and avoids redundant locking.

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #34734 
- [X] These changes do not require tests because they do not modify functionality

@sagudev , this PR is ready for review. Please let me know if there are any additional adjustments required. Thank you.