### PR TITLE
Clone node on a shadow root should always throw an error

### DIFF
--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -2946,7 +2946,7 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
 
     /// <https://dom.spec.whatwg.org/#dom-node-clonenode>
     fn CloneNode(&self, deep: bool, can_gc: CanGc) -> Fallible<DomRoot<Node>> {
-        if deep && self.is::<ShadowRoot>() {
+        if self.is::<ShadowRoot>() {
             return Err(Error::NotSupported);
         }
         Ok(Node::clone(

--- a/tests/wpt/meta-legacy-layout/shadow-dom/untriaged/elements-and-dom-objects/shadowroot-object/shadowroot-methods/test-010.html.ini
+++ b/tests/wpt/meta-legacy-layout/shadow-dom/untriaged/elements-and-dom-objects/shadowroot-object/shadowroot-methods/test-010.html.ini
@@ -1,3 +1,0 @@
-[test-010.html]
-  [A_10_01_02_09_T01]
-    expected: FAIL

--- a/tests/wpt/meta/shadow-dom/Node-prototype-cloneNode.html.ini
+++ b/tests/wpt/meta/shadow-dom/Node-prototype-cloneNode.html.ini
@@ -1,6 +1,0 @@
-[Node-prototype-cloneNode.html]
-  [cloneNode on a shadow root in open mode must throw a NotSupportedError]
-    expected: FAIL
-
-  [cloneNode on a shadow root in closed mode must throw a NotSupportedError]
-    expected: FAIL

--- a/tests/wpt/meta/shadow-dom/untriaged/elements-and-dom-objects/shadowroot-object/shadowroot-methods/test-010.html.ini
+++ b/tests/wpt/meta/shadow-dom/untriaged/elements-and-dom-objects/shadowroot-object/shadowroot-methods/test-010.html.ini
@@ -1,3 +1,0 @@
-[test-010.html]
-  [A_10_01_02_09_T01]
-    expected: FAIL

--- a/tests/wpt/tests/shadow-dom/Node-prototype-cloneNode.html
+++ b/tests/wpt/tests/shadow-dom/Node-prototype-cloneNode.html
@@ -23,7 +23,7 @@ function testCloneNode(mode) {
         assert_throws_dom('NotSupportedError', function () {
             var element = document.createElement('div');
             var shadowRoot = element.attachShadow({mode: mode});
-            shadowRoot.cloneNode(false);
+            shadowRoot.cloneNode(true);
         }, 'cloneNode(true) on a closed shadow root must throw a NotSupportedError');
 
     }, 'cloneNode on a shadow root in ' + mode + ' mode must throw a NotSupportedError');


### PR DESCRIPTION
- Corrected cloneNode method
- Corrected test
- Updated Manifest


---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #34739 


- [x] These changes do not require tests because they just exist