### PR TITLE
Spec-align resolving history handling during navigation

### DIFF
--- a/components/script/dom/domimplementation.rs
+++ b/components/script/dom/domimplementation.rs
@@ -164,6 +164,7 @@ impl DOMImplementationMethods<crate::DomTypeHolder> for DOMImplementation {
             None,
             None,
             Default::default(),
+            false,
             can_gc,
         );
 

--- a/components/script/dom/domparser.rs
+++ b/components/script/dom/domparser.rs
@@ -87,6 +87,7 @@ impl DOMParserMethods<crate::DomTypeHolder> for DOMParser {
                     None,
                     None,
                     Default::default(),
+                    false,
                     can_gc,
                 );
                 ServoParser::parse_html_document(&document, Some(s), url, can_gc);
@@ -108,6 +109,7 @@ impl DOMParserMethods<crate::DomTypeHolder> for DOMParser {
                     None,
                     None,
                     Default::default(),
+                    false,
                     can_gc,
                 );
                 ServoParser::parse_xml_document(&document, Some(s), url, can_gc);

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -2360,6 +2360,7 @@ impl Node {
                     None,
                     document.status_code(),
                     Default::default(),
+                    false,
                     can_gc,
                 );
                 DomRoot::upcast::<Node>(document)

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -216,6 +216,7 @@ impl ServoParser {
             None,
             None,
             Default::default(),
+            false,
             can_gc,
         );
 

--- a/components/script/dom/xmldocument.rs
+++ b/components/script/dom/xmldocument.rs
@@ -57,6 +57,7 @@ impl XMLDocument {
                 None,
                 None,
                 Default::default(),
+                false,
             ),
         }
     }

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -1534,6 +1534,7 @@ impl XMLHttpRequest {
             None,
             None,
             Default::default(),
+            false,
             can_gc,
         )
     }

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3134,6 +3134,8 @@ impl ScriptThread {
             .as_ref()
             .map(|referrer| referrer.clone().into_string());
 
+        let is_initial_about_blank = final_url.as_str() == "about:blank";
+
         let document = Document::new(
             &window,
             HasBrowsingContext::Yes,
@@ -3148,6 +3150,7 @@ impl ScriptThread {
             referrer,
             Some(metadata.status.raw_code()),
             incomplete.canceller,
+            is_initial_about_blank,
             can_gc,
         );
 

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/iframe-src-204.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/iframe-src-204.html.ini
@@ -1,9 +1,3 @@
 [iframe-src-204.html]
   [Navigating to a different document with window.open]
     expected: FAIL
-
-  [Navigating to a different document with link click]
-    expected: FAIL
-
-  [Navigating to a different document with form submission]
-    expected: FAIL

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/iframe-src-aboutblank-wait-for-load.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/iframe-src-aboutblank-wait-for-load.html.ini
@@ -2,17 +2,5 @@
   [Navigating to a different document with src]
     expected: FAIL
 
-  [Navigating to a different document with location.href]
-    expected: FAIL
-
-  [Navigating to a different document with location.assign]
-    expected: FAIL
-
   [Navigating to a different document with window.open]
-    expected: FAIL
-
-  [Navigating to a different document with link click]
-    expected: FAIL
-
-  [Navigating to a different document with form submission]
     expected: FAIL

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/window-open-aboutblank.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/window-open-aboutblank.html.ini
@@ -1,6 +1,0 @@
-[window-open-aboutblank.html]
-  [location.href]
-    expected: FAIL
-
-  [location.assign]
-    expected: FAIL

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/window-open-nourl.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/window-open-nourl.html.ini
@@ -1,6 +1,0 @@
-[window-open-nourl.html]
-  [location.href]
-    expected: FAIL
-
-  [location.assign]
-    expected: FAIL


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Makes use of the `is_initial_about_blank` property on `Document` in order to determine whether a navigation should create a history entry, or replace the current history entry.

This unfortunately introduces a new intermittent failure (`/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/iframe-nosrc.html`, [example](https://github.com/shanehandley/servo/actions/runs/12451361595/job/34759475861)). Initially I thought I should not push the change and open this PR, but it appears to belong in the [family of intermittents](https://github.com/servo/servo/issues?q=is%3Aissue+is%3Aopen+label%3AI-intermittent+initial-empty-document) that Gregory was looking into in https://github.com/servo/servo/issues/31973 and a little more spec alignment might be useful - but happy to close this if it's an issue.

[Try](https://github.com/shanehandley/servo/actions/runs/12451412855)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
