### PR TITLE
Add check for valid custom element name in element::attach_shadow

### DIFF
--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -1318,7 +1318,8 @@ fn is_potential_custom_element_char(c: char) -> bool {
         ('\u{37F}'..='\u{1FFF}').contains(&c) ||
         ('\u{200C}'..='\u{200D}').contains(&c) ||
         ('\u{203F}'..='\u{2040}').contains(&c) ||
-        ('\u{2070}'..='\u{2FEF}').contains(&c) ||
+        ('\u{2070}'..='\u{218F}').contains(&c) ||
+        ('\u{2C00}'..='\u{2FEF}').contains(&c) ||
         ('\u{3001}'..='\u{D7FF}').contains(&c) ||
         ('\u{F900}'..='\u{FDCF}').contains(&c) ||
         ('\u{FDF0}'..='\u{FFFD}').contains(&c) ||

--- a/tests/wpt/meta/css/selectors/invalidation/part-dir.html.ini
+++ b/tests/wpt/meta/css/selectors/invalidation/part-dir.html.ini
@@ -1,2 +1,6 @@
 [part-dir.html]
-  expected: ERROR
+  [::part():dir() invalidation]
+    expected: FAIL
+
+  [::part():dir() invalidation from setAttribute]
+    expected: FAIL

--- a/tests/wpt/meta/css/selectors/invalidation/part-lang.html.ini
+++ b/tests/wpt/meta/css/selectors/invalidation/part-lang.html.ini
@@ -1,2 +1,6 @@
 [part-lang.html]
-  expected: ERROR
+  [::part():lang() invalidation]
+    expected: FAIL
+
+  [::part():lang() invalidation from setAttribute]
+    expected: FAIL

--- a/tests/wpt/meta/custom-elements/form-associated/ElementInternals-validation.html.ini
+++ b/tests/wpt/meta/custom-elements/form-associated/ElementInternals-validation.html.ini
@@ -1,6 +1,3 @@
 [ElementInternals-validation.html]
-  ["anchor" argument of setValidity()]
-    expected: FAIL
-
   [Custom control affects :valid :invalid for FORM and FIELDSET]
     expected: FAIL

--- a/tests/wpt/meta/custom-elements/form-associated/disabled-delegatesFocus.html.ini
+++ b/tests/wpt/meta/custom-elements/form-associated/disabled-delegatesFocus.html.ini
@@ -1,2 +1,3 @@
 [disabled-delegatesFocus.html]
-  expected: ERROR
+  [Focus events fire on disabled form-associated custom elements with delegatesFocus]
+    expected: FAIL

--- a/tests/wpt/meta/dom/nodes/moveBefore/tentative/slotchange-events.html.ini
+++ b/tests/wpt/meta/dom/nodes/moveBefore/tentative/slotchange-events.html.ini
@@ -1,5 +1,4 @@
 [slotchange-events.html]
-  expected: ERROR
   [Moving default content into a slot fires 'slotchange' event]
     expected: FAIL
 

--- a/tests/wpt/meta/html/dom/elements/global-attributes/translate-inherit-no-parent-element.html.ini
+++ b/tests/wpt/meta/html/dom/elements/global-attributes/translate-inherit-no-parent-element.html.ini
@@ -1,6 +1,0 @@
-[translate-inherit-no-parent-element.html]
-  [ShadowRoot parent node whose shadow host has translate=yes]
-    expected: FAIL
-
-  [ShadowRoot parent node whose shadow host has translate=no]
-    expected: FAIL

--- a/tests/wpt/meta/shadow-dom/DocumentOrShadowRoot-prototype-elementFromPoint.html.ini
+++ b/tests/wpt/meta/shadow-dom/DocumentOrShadowRoot-prototype-elementFromPoint.html.ini
@@ -1,4 +1,5 @@
 [DocumentOrShadowRoot-prototype-elementFromPoint.html]
+  expected: CRASH
   [document.elementFromPoint and shadow.ElementFromPoint must return the shadow host of the hit-tested text node when the hit-tested text node is a direct child of the root and the host has display: inline]
     expected: FAIL
 

--- a/tests/wpt/meta/shadow-dom/Element-interface-attachShadow-custom-element.html.ini
+++ b/tests/wpt/meta/shadow-dom/Element-interface-attachShadow-custom-element.html.ini
@@ -1,15 +1,6 @@
 [Element-interface-attachShadow-custom-element.html]
-  [Element.attachShadow must create an instance of ShadowRoot for autonomous custom elements]
-    expected: FAIL
-
-  [Element.attachShadow must create an instance of ShadowRoot for undefined autonomous custom elements]
-    expected: FAIL
-
   [Element.attachShadow for an autonomous custom element with disabledFeatures=["shadow"\] should throw a NotSupportedError]
     expected: FAIL
 
   [Element.attachShadow for a customized built-in element with disabledFeatures=["shadow"\] should throw a NotSupportedError]
-    expected: FAIL
-
-  [Element.attachShadow for a custom element with disabledFeatures=["SHADOW"\] should not throw a NotSupportedError]
     expected: FAIL

--- a/tests/wpt/meta/shadow-dom/MouseEvent-prototype-offsetX-offsetY.html.ini
+++ b/tests/wpt/meta/shadow-dom/MouseEvent-prototype-offsetX-offsetY.html.ini
@@ -1,4 +1,4 @@
 [MouseEvent-prototype-offsetX-offsetY.html]
-  expected: ERROR
+  expected: CRASH
   [MouseEvent's offsetX and offsetY attributes must be relative to the target.]
     expected: FAIL

--- a/tests/wpt/meta/shadow-dom/innerHTML-setter.xhtml.ini
+++ b/tests/wpt/meta/shadow-dom/innerHTML-setter.xhtml.ini
@@ -1,2 +1,6 @@
 [innerHTML-setter.xhtml]
-  expected: ERROR
+  [InnerHTML behavior on custom element in default 'foo' namespace]
+    expected: FAIL
+
+  [InnerHTML behavior with prefixes on custom element]
+    expected: FAIL

--- a/tests/wpt/meta/shadow-dom/slotchange-customelements.html.ini
+++ b/tests/wpt/meta/shadow-dom/slotchange-customelements.html.ini
@@ -1,2 +1,3 @@
 [slotchange-customelements.html]
-  expected: ERROR
+  [slotchange must fire on initialization of custom elements with slotted children]
+    expected: FAIL


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This PR will:
- Add the check of [valid custom element name](https://html.spec.whatwg.org/#valid-custom-element-name) in the step 2 of https://dom.spec.whatwg.org/#concept-attach-a-shadow-root. 
- Update the check for valid custom name's [PCENChar](https://html.spec.whatwg.org/multipage/#prod-pcenchar) to match the notation in the specifications.

[Try (with updated WPT)](https://github.com/stevennovaryo/servo/actions/runs/12475992745)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #34743 

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
