### PR TITLE
fix(wayland): segfault because of double free surfaces

### DIFF
--- a/ports/servoshell/desktop/cli.rs
+++ b/ports/servoshell/desktop/cli.rs
@@ -107,6 +107,8 @@ pub fn main() {
         .expect("Failed to create events loop");
 
     // Implements window methods, used by compositor.
+    // FIXME: We keep the window until application exits. Otherwise, it will cause
+    // simthay-clipboard thread segfault on Wayland.
     let window = if opts::get().headless {
         if pref!(media.glvideo.enabled) {
             warn!("GL video rendering is not supported on headless windows.");

--- a/ports/servoshell/desktop/cli.rs
+++ b/ports/servoshell/desktop/cli.rs
@@ -6,7 +6,7 @@ use std::rc::Rc;
 use std::{env, panic, process};
 
 use getopts::Options;
-use log::error;
+use log::{error, warn};
 use servo::config::opts::{self, ArgumentParsingResult};
 use servo::config::set_pref;
 use servo::servo_config::pref;
@@ -108,8 +108,10 @@ pub fn main() {
 
     // Implements window methods, used by compositor.
     let window = if opts::get().headless {
-        // GL video rendering is not supported on headless windows.
-        set_pref!(media.glvideo.enabled, false);
+        if pref!(media.glvideo.enabled) {
+            warn!("GL video rendering is not supported on headless windows.");
+            set_pref!(media.glvideo.enabled, false);
+        }
         headless_window::Window::new(opts::get().initial_window_size, device_pixel_ratio_override)
     } else {
         Rc::new(headed_window::Window::new(


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
It turns out there are two problems when the window is dropped early on Wayland.
One is double free of EGL surface. The other is double free of smithay-clipboard's states.
The PR makes sure EGL surface is freed only once, and keep the winit window til end to make sure smithay's states are intact.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #34699

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
