### PR TITLE
Generate attestations for CI artifacts

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -75,6 +75,7 @@ on:
 env:
   RUST_BACKTRACE: 1
   SHELL: /bin/bash
+  MOZJS_ATTESTATION: force
 
 jobs:
   # Runs the underlying job (“workload”) on a self-hosted runner if available,

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -103,6 +103,10 @@ jobs:
       - runner-select
     name: Linux Build [${{ needs.runner-select.outputs.unique-id }}]
     runs-on: ${{ needs.runner-select.outputs.selected-runner-label }}
+    permissions:
+      id-token: write
+      contents: read
+      attestations: write
     steps:
       - uses: actions/checkout@v4
         if: ${{ runner.environment != 'self-hosted' && github.event_name != 'pull_request_target' }}
@@ -173,6 +177,11 @@ jobs:
           path: target/cargo-timings-*
       - name: Build mach package
         run: ./mach package --${{ inputs.profile }}
+      - name: Generate mach package artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: 'linux'
+          subject-path: 'target/${{ inputs.profile }}/servo-tech-demo.tar.gz'
       - name: Upload artifact for mach package
         uses: actions/upload-artifact@v4
         with:
@@ -190,6 +199,11 @@ jobs:
           NIGHTLY_REPO: ${{ github.repository_owner }}/servo-nightly-builds
       - name: Build package for target
         run: tar -czf target.tar.gz target/${{ inputs.profile }}/servo resources
+      - name: Generate package artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: '${{ inputs.profile }}-binary-linux'
+          subject-path: 'target.tar.gz'
       - name: Upload artifact for target
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -179,6 +179,7 @@ jobs:
       - name: Build mach package
         run: ./mach package --${{ inputs.profile }}
       - name: Generate mach package artifact attestation
+        if: ${{ inputs.upload }}
         uses: actions/attest-build-provenance@v1
         with:
           subject-name: 'linux'
@@ -200,11 +201,6 @@ jobs:
           NIGHTLY_REPO: ${{ github.repository_owner }}/servo-nightly-builds
       - name: Build package for target
         run: tar -czf target.tar.gz target/${{ inputs.profile }}/servo resources
-      - name: Generate package artifact attestation
-        uses: actions/attest-build-provenance@v1
-        with:
-          subject-name: '${{ inputs.profile }}-binary-linux'
-          subject-path: 'target.tar.gz'
       - name: Upload artifact for target
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -53,6 +53,7 @@ env:
   RUST_BACKTRACE: 1
   SHELL: /bin/bash
   CARGO_INCREMENTAL: 0
+  MOZJS_ATTESTATION: force
 
 jobs:
   build:

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -58,6 +58,10 @@ jobs:
   build:
     name: MacOS Build
     runs-on: macos-13
+    permissions:
+      id-token: write
+      contents: read
+      attestations: write
     steps:
       # XProtect can cause random failures if it decides that the DMG we create
       # during the packaging phase is malware.
@@ -115,6 +119,11 @@ jobs:
           name: cargo-timings-macos
           # Using a wildcard here ensures that the archive includes the path.
           path: target/cargo-timings-*
+      - name: Generate mach package artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: 'mac'
+          subject-path: 'target/${{ inputs.profile }}/servo-tech-demo.dmg'
       - name: Upload artifact for mach package
         uses: actions/upload-artifact@v4
         with:
@@ -132,6 +141,11 @@ jobs:
           NIGHTLY_REPO: ${{ github.repository_owner }}/servo-nightly-builds
       - name: Build package for target
         run: gtar -czf target.tar.gz target/${{ inputs.profile }}/servo target/${{ inputs.profile }}/lib/*.dylib resources
+      - name: Generate package artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: '${{ inputs.profile }}-binary-macos'
+          subject-path: 'target.tar.gz'
       - name: Upload package for target
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -121,6 +121,7 @@ jobs:
           # Using a wildcard here ensures that the archive includes the path.
           path: target/cargo-timings-*
       - name: Generate mach package artifact attestation
+        if: ${{ inputs.upload }}
         uses: actions/attest-build-provenance@v1
         with:
           subject-name: 'mac'
@@ -142,11 +143,6 @@ jobs:
           NIGHTLY_REPO: ${{ github.repository_owner }}/servo-nightly-builds
       - name: Build package for target
         run: gtar -czf target.tar.gz target/${{ inputs.profile }}/servo target/${{ inputs.profile }}/lib/*.dylib resources
-      - name: Generate package artifact attestation
-        uses: actions/attest-build-provenance@v1
-        with:
-          subject-name: '${{ inputs.profile }}-binary-macos'
-          subject-path: 'target.tar.gz'
       - name: Upload package for target
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -76,6 +76,10 @@ jobs:
       - runner-select
     name: Windows Build [${{ needs.runner-select.outputs.unique-id }}]
     runs-on: ${{ needs.runner-select.outputs.selected-runner-label }}
+    permissions:
+      id-token: write
+      contents: read
+      attestations: write
     steps:
       - if: ${{ runner.environment != 'self-hosted' && github.event_name != 'pull_request_target' }}
         uses: actions/checkout@v4
@@ -168,6 +172,11 @@ jobs:
           path: C:\\a\\servo\\servo\\target\\cargo-timings-*
       - name: Build mach package
         run: .\mach package --${{ inputs.profile }}
+      - name: Generate mach package artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: win
+          subject-path: C:\\a\\servo\\servo\\target\\${{ inputs.profile }}\\msi\\Servo.exe
       - name: Upload artifact for mach package
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -51,6 +51,7 @@ env:
   # https://github.com/KyleMayes/clang-sys/issues/150
   LIBCLANG_PATH: C:\Program Files\LLVM\bin
   RUSTUP_WINDOWS_PATH_ADD_BIN: 1
+  MOZJS_ATTESTATION: force
 
 jobs:
   # Runs the underlying job (“workload”) on a self-hosted runner if available,

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -174,6 +174,7 @@ jobs:
       - name: Build mach package
         run: .\mach package --${{ inputs.profile }}
       - name: Generate mach package artifact attestation
+        if: ${{ inputs.upload }}
         uses: actions/attest-build-provenance@v1
         with:
           subject-name: win


### PR DESCRIPTION
This change makes the CI generate artifact attestations for windows, linux and mac artifacts. Ohos and android seem to already be generating attestations.

Attestations are generated for both the mach packages and the binaries (but not the build timings, as those don't seem relevant for security).

With this change, it becomes possible to ensure that artifacts have not been tampered with by using the GitHub CLI tool [^1].


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix https://github.com/servo/servo/issues/33309
- [X] I do not know how to effectively test these changes, but I have manually verified that attestations are being generated correctly.

[^1]: https://github.blog/changelog/2024-06-25-artifact-attestations-is-generally-available/
