### PR TITLE
Whitelist RUSTSEC-2024-0429 to fix CI

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -14,6 +14,8 @@ feature-depth = 1
 ignore = [
     # This is for the usage of time@0.1.45 in WebRender, which should be removed soon.
     "RUSTSEC-2020-0071",
+    # This is for glib < 0.20 which is pulled in by gstreamer
+    "RUSTSEC-2024-0429",
     # This has been yanked, but upgrading to the next version breaks some WPT tests.
     # It needs investigation.
     "url@2.5.3",


### PR DESCRIPTION
Will be addressed in a follow-up issue: https://github.com/servo/servo/issues/34766

Fixes #34764.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix CI failing

