### PR TITLE
script: Handle null contexts better during JS runtime shutdown.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4447,7 +4447,7 @@ dependencies = [
 [[package]]
 name = "mozjs"
 version = "0.14.1"
-source = "git+https://github.com/servo/mozjs#1765a7c7eaf1e4a02fdfff6866c8f427c659dc91"
+source = "git+https://github.com/servo/mozjs#0081fc4a3f5fc9891d4377844a874651f7c46041"
 dependencies = [
  "bindgen",
  "cc",
@@ -4460,7 +4460,7 @@ dependencies = [
 [[package]]
 name = "mozjs_sys"
 version = "0.128.6-1"
-source = "git+https://github.com/servo/mozjs#1765a7c7eaf1e4a02fdfff6866c8f427c659dc91"
+source = "git+https://github.com/servo/mozjs#0081fc4a3f5fc9891d4377844a874651f7c46041"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,7 +429,7 @@ dependencies = [
  "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -957,7 +957,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1862,7 +1862,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5889,7 +5889,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7153,7 +7153,7 @@ dependencies = [
  "fastrand",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8423,7 +8423,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/components/script/dom/bindings/callback.rs
+++ b/components/script/dom/bindings/callback.rs
@@ -93,8 +93,9 @@ impl Drop for CallbackObject {
     #[allow(unsafe_code)]
     fn drop(&mut self) {
         unsafe {
-            let cx = Runtime::get();
-            RemoveRawValueRoot(cx, self.permanent_js_root.get_unsafe());
+            if let Some(cx) = Runtime::get() {
+                RemoveRawValueRoot(cx.as_ptr(), self.permanent_js_root.get_unsafe());
+            }
         }
     }
 }

--- a/components/script/dom/bindings/principals.rs
+++ b/components/script/dom/bindings/principals.rs
@@ -70,7 +70,9 @@ impl Clone for ServoJSPrincipals {
 impl Drop for ServoJSPrincipals {
     #[inline]
     fn drop(&mut self) {
-        unsafe { JS_DropPrincipals(Runtime::get(), self.as_raw()) };
+        if let Some(cx) = Runtime::get() {
+            unsafe { JS_DropPrincipals(cx.as_ptr(), self.as_raw()) };
+        }
     }
 }
 

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -2253,7 +2253,10 @@ impl GlobalScope {
 
     #[allow(unsafe_code)]
     pub fn get_cx() -> SafeJSContext {
-        unsafe { SafeJSContext::from_ptr(Runtime::get()) }
+        let cx = Runtime::get()
+            .expect("Can't obtain context after runtime shutdown")
+            .as_ptr();
+        unsafe { SafeJSContext::from_ptr(cx) }
     }
 
     pub fn crypto(&self) -> DomRoot<Crypto> {
@@ -3058,14 +3061,13 @@ impl GlobalScope {
     /// ["current"]: https://html.spec.whatwg.org/multipage/#current
     #[allow(unsafe_code)]
     pub fn current() -> Option<DomRoot<Self>> {
+        let cx = Runtime::get()?;
         unsafe {
-            let cx = Runtime::get();
-            assert!(!cx.is_null());
-            let global = CurrentGlobalOrNull(cx);
+            let global = CurrentGlobalOrNull(cx.as_ptr());
             if global.is_null() {
                 None
             } else {
-                Some(global_scope_from_global(global, cx))
+                Some(global_scope_from_global(global, cx.as_ptr()))
             }
         }
     }

--- a/components/script/dom/promise.rs
+++ b/components/script/dom/promise.rs
@@ -78,9 +78,9 @@ impl Drop for Promise {
         unsafe {
             let object = self.permanent_js_root.get().to_object();
             assert!(!object.is_null());
-            let cx = Runtime::get();
-            assert!(!cx.is_null());
-            RemoveRawValueRoot(cx, self.permanent_js_root.get_unsafe());
+            if let Some(cx) = Runtime::get() {
+                RemoveRawValueRoot(cx.as_ptr(), self.permanent_js_root.get_unsafe());
+            }
         }
     }
 }

--- a/tests/wpt/meta/fetch/api/basic/keepalive.any.js.ini
+++ b/tests/wpt/meta/fetch/api/basic/keepalive.any.js.ini
@@ -1,5 +1,4 @@
 [keepalive.any.html]
-  expected: CRASH
   [keepalive in onunload in nested frame in another window]
     expected: FAIL
 


### PR DESCRIPTION
These changes use the updated API from https://github.com/servo/mozjs/pull/545 to make Servo more resilient when shutting down a JS runtime. `GlobalScope::get_cx()` is an opportunity for improvement, but it has >100 call sites and can be addressed separately in an incremental way.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #32904
- [x] There are tests for these changes