### PR TITLE
chore: remove `WindowMethods::rendering_context`

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -1340,7 +1340,11 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
 
         if self.embedder_coordinates.viewport != old_coords.viewport {
             let mut transaction = Transaction::new();
-            transaction.set_document_view(self.embedder_coordinates.get_viewport());
+            let size = self.embedder_coordinates.get_viewport();
+            transaction.set_document_view(size);
+            if let Err(e) = self.rendering_context.resize(size.size().to_untyped()) {
+                warn!("Failed to resize surface: {e:?}");
+            }
             self.webrender_api
                 .send_transaction(self.webrender_document, transaction);
         }

--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -363,33 +363,13 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
         composite_target: CompositeTarget,
         exit_after_load: bool,
         convert_mouse_to_touch: bool,
-        top_level_browsing_context_id: TopLevelBrowsingContextId,
         version_string: String,
     ) -> Self {
-        let embedder_coordinates = window.get_coordinates();
-        let mut webviews = WebViewManager::default();
-        webviews
-            .add(
-                top_level_browsing_context_id,
-                WebView {
-                    pipeline_id: None,
-                    rect: embedder_coordinates.get_viewport().to_f32(),
-                },
-            )
-            .expect("Infallible with a new WebViewManager");
-        let msg = ConstellationMsg::WebViewOpened(top_level_browsing_context_id);
-        if let Err(e) = state.constellation_chan.send(msg) {
-            warn!("Sending event to constellation failed ({:?}).", e);
-        }
-        webviews
-            .show(top_level_browsing_context_id)
-            .expect("Infallible due to add");
-
         let compositor = IOCompositor {
             embedder_coordinates: window.get_coordinates(),
             window,
             port: state.receiver,
-            webviews,
+            webviews: WebViewManager::default(),
             pipeline_details: HashMap::new(),
             composition_request: CompositionRequest::NoCompositingNecessary,
             touch_handler: TouchHandler::new(),

--- a/components/compositing/windowing.rs
+++ b/components/compositing/windowing.rs
@@ -23,7 +23,6 @@ use webrender_api::units::{
     DeviceIntPoint, DeviceIntRect, DeviceIntSize, DevicePixel, DevicePoint, DeviceRect,
 };
 use webrender_api::ScrollLocation;
-use webrender_traits::RenderingContext;
 
 #[derive(Clone)]
 pub enum MouseWindowEvent {
@@ -218,8 +217,6 @@ pub trait WindowMethods {
     /// will want to avoid blocking on UI events, and just
     /// run the event loop at the vsync interval.
     fn set_animation_state(&self, _state: AnimationState);
-    /// Get the [`RenderingContext`] of this Window.
-    fn rendering_context(&self) -> RenderingContext;
 }
 
 pub trait EmbedderMethods {

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -233,6 +233,7 @@ where
     )]
     #[allow(clippy::new_ret_no_self)]
     pub fn new(
+        rendering_context: RenderingContext,
         mut embedder: Box<dyn EmbedderMethods>,
         window: Rc<Window>,
         user_agent: Option<String>,
@@ -271,9 +272,6 @@ where
                 .map(Into::into)
                 .unwrap_or(default_user_agent_string_for(DEFAULT_USER_AGENT).into()),
         };
-
-        // Initialize surfman
-        let rendering_context = window.rendering_context();
 
         // Get GL bindings
         let webrender_gl = match rendering_context.connection().gl_api() {
@@ -375,8 +373,8 @@ where
                     } else {
                         ShaderPrecacheFlags::empty()
                     },
-                    enable_subpixel_aa: pref!(gfx.subpixel_text_antialiasing.enabled) &&
-                        !opts.debug.disable_subpixel_text_antialiasing,
+                    enable_subpixel_aa: pref!(gfx.subpixel_text_antialiasing.enabled)
+                        && !opts.debug.disable_subpixel_text_antialiasing,
                     allow_texture_swizzling: pref!(gfx.texture_swizzling.enabled),
                     clear_color,
                     upload_method,

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -373,8 +373,8 @@ where
                     } else {
                         ShaderPrecacheFlags::empty()
                     },
-                    enable_subpixel_aa: pref!(gfx.subpixel_text_antialiasing.enabled)
-                        && !opts.debug.disable_subpixel_text_antialiasing,
+                    enable_subpixel_aa: pref!(gfx.subpixel_text_antialiasing.enabled) &&
+                        !opts.debug.disable_subpixel_text_antialiasing,
                     allow_texture_swizzling: pref!(gfx.texture_swizzling.enabled),
                     clear_color,
                     upload_method,

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -219,11 +219,6 @@ impl webrender_api::RenderNotifier for RenderNotifier {
     }
 }
 
-pub struct InitializedServo<Window: WindowMethods + 'static + ?Sized> {
-    pub servo: Servo<Window>,
-    pub browser_id: TopLevelBrowsingContextId,
-}
-
 impl<Window> Servo<Window>
 where
     Window: WindowMethods + 'static + ?Sized,
@@ -242,7 +237,7 @@ where
         window: Rc<Window>,
         user_agent: Option<String>,
         composite_target: CompositeTarget,
-    ) -> InitializedServo<Window> {
+    ) -> Servo<Window> {
         // Global configuration options, parsed from the command line.
         let opts = opts::get();
 
@@ -302,7 +297,6 @@ where
 
         // Reserving a namespace to create TopLevelBrowsingContextId.
         PipelineNamespace::install(PipelineNamespaceId(0));
-        let top_level_browsing_context_id = TopLevelBrowsingContextId::new();
 
         // Get both endpoints of a special channel for communication between
         // the client window and the compositor. This channel is unique because
@@ -525,21 +519,16 @@ where
             composite_target,
             opts.exit_after_load,
             opts.debug.convert_mouse_to_touch,
-            top_level_browsing_context_id,
             embedder.get_version_string().unwrap_or_default(),
         );
 
-        let servo = Servo {
+        Servo {
             compositor,
             constellation_chan,
             embedder_receiver,
             messages_for_embedder: Vec::new(),
             profiler_enabled: false,
             _js_engine_setup: js_engine_setup,
-        };
-        InitializedServo {
-            servo,
-            browser_id: top_level_browsing_context_id,
         }
     }
 

--- a/components/shared/base/id.rs
+++ b/components/shared/base/id.rs
@@ -282,6 +282,8 @@ thread_local!(pub static TOP_LEVEL_BROWSING_CONTEXT_ID: Cell<Option<TopLevelBrow
     Clone, Copy, Deserialize, Eq, Hash, MallocSizeOf, Ord, PartialEq, PartialOrd, Serialize,
 )]
 pub struct TopLevelBrowsingContextId(pub BrowsingContextId);
+/// An alias to ID of top level browsing context. A web view is usually what people would treat as
+/// a normal web page.
 pub type WebViewId = TopLevelBrowsingContextId;
 
 size_of_test!(TopLevelBrowsingContextId, 8);

--- a/components/shared/webrender/rendering_context.rs
+++ b/components/shared/webrender/rendering_context.rs
@@ -88,15 +88,15 @@ impl RenderingContext {
 
     pub fn bind_surface(&self, surface: Surface) -> Result<(), Error> {
         let device = &self.0.device.borrow();
-        let mut context = &mut self.0.context.borrow_mut();
+        let context = &mut self.0.context.borrow_mut();
         device
-            .bind_surface_to_context(&mut context, surface)
+            .bind_surface_to_context(context, surface)
             .map_err(|(err, mut surface)| {
-                let _ = device.destroy_surface(&mut context, &mut surface);
+                let _ = device.destroy_surface(context, &mut surface);
                 err
             })?;
 
-        device.make_context_current(&context)?;
+        device.make_context_current(context)?;
         Ok(())
     }
 

--- a/components/shared/webrender/rendering_context.rs
+++ b/components/shared/webrender/rendering_context.rs
@@ -46,9 +46,9 @@ impl RenderingContext {
         headless: bool,
     ) -> Result<Self, Error> {
         let mut device = connection.create_device(adapter)?;
-        let flags = ContextAttributeFlags::ALPHA
-            | ContextAttributeFlags::DEPTH
-            | ContextAttributeFlags::STENCIL;
+        let flags = ContextAttributeFlags::ALPHA |
+            ContextAttributeFlags::DEPTH |
+            ContextAttributeFlags::STENCIL;
         let version = match connection.gl_api() {
             GLApi::GLES => GLVersion { major: 3, minor: 0 },
             GLApi::GL => GLVersion { major: 3, minor: 2 },

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -53,7 +53,7 @@ pub struct App {
     t_start: Instant,
     t: Instant,
     do_not_use_native_titlebar: bool,
-    pub(crate) device_pixel_ratio_override: Option<f32>,
+    device_pixel_ratio_override: Option<f32>,
 }
 
 enum Present {
@@ -145,21 +145,18 @@ impl App {
         // Create window's context
         self.webviews = Some(WebViewManager::new(window.clone()));
         if window.winit_window().is_some() {
-            self.minibrowser = Some(
-                Minibrowser::new(
-                    &rendering_context,
-                    event_loop.unwrap(),
-                    self.initial_url.clone(),
-                )
-                .into(),
-            );
+            self.minibrowser = Some(Minibrowser::new(
+                &rendering_context,
+                event_loop.unwrap(),
+                self.initial_url.clone(),
+            ));
         }
 
         if let Some(ref mut minibrowser) = self.minibrowser {
             // Servo is not yet initialised, so there is no `servo_framebuffer_id`.
             minibrowser.update(
                 window.winit_window().unwrap(),
-                &mut self.webviews.as_mut().unwrap(),
+                self.webviews.as_mut().unwrap(),
                 None,
                 "init",
             );

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -110,8 +110,12 @@ impl App {
             let adapter = connection
                 .create_software_adapter()
                 .expect("Failed to create adapter");
-            RenderingContext::create(&connection, &adapter, true)
-                .expect("Failed to create WR surfman")
+            RenderingContext::create(
+                &connection,
+                &adapter,
+                Some(opts::get().initial_window_size.to_untyped().to_i32()),
+            )
+            .expect("Failed to create WR surfman")
         } else {
             let display_handle = event_loop
                 .unwrap()
@@ -122,13 +126,12 @@ impl App {
             let adapter = connection
                 .create_adapter()
                 .expect("Failed to create adapter");
-            RenderingContext::create(&connection, &adapter, false)
+            RenderingContext::create(&connection, &adapter, None)
                 .expect("Failed to create WR surfman")
         };
 
         let window = if opts::get().headless {
             headless_window::Window::new(
-                &rendering_context,
                 opts::get().initial_window_size,
                 self.device_pixel_ratio_override,
             )

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -12,6 +12,7 @@ use std::{env, fs};
 
 use gleam::gl;
 use log::{error, info, trace};
+use servo::base::id::WebViewId;
 use servo::compositing::windowing::EmbedderEvent;
 use servo::compositing::CompositeTarget;
 use servo::config::opts;
@@ -182,17 +183,16 @@ impl App {
         } else {
             CompositeTarget::Window
         };
-        let servo_data = Servo::new(
+        let mut servo = Servo::new(
             embedder,
             window.clone(),
             self.user_agent.clone(),
             composite_target,
         );
-        let mut servo = servo_data.servo;
 
         servo.handle_events(vec![EmbedderEvent::NewWebView(
             self.initial_url.to_owned(),
-            servo_data.browser_id,
+            WebViewId::new(),
         )]);
         servo.setup_logging();
 

--- a/ports/servoshell/desktop/egui_glue.rs
+++ b/ports/servoshell/desktop/egui_glue.rs
@@ -38,6 +38,7 @@ use egui_glow::ShaderVersion;
 pub use egui_winit;
 use egui_winit::winit;
 pub use egui_winit::EventResponse;
+use winit::event_loop::ActiveEventLoop;
 
 /// Use [`egui`] from a [`glow`] app based on [`winit`].
 pub struct EguiGlow {
@@ -52,7 +53,7 @@ pub struct EguiGlow {
 impl EguiGlow {
     /// For automatic shader version detection set `shader_version` to `None`.
     pub fn new(
-        event_loop: &winit::event_loop::EventLoop<super::events_loop::WakerEvent>,
+        event_loop: &ActiveEventLoop,
         gl: std::sync::Arc<glow::Context>,
         shader_version: Option<ShaderVersion>,
     ) -> Self {

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -124,8 +124,14 @@ impl Window {
             .expect("Failed to create native widget");
 
         let surface_type = SurfaceType::Widget { native_widget };
-        let rendering_context = RenderingContext::create(&connection, &adapter, surface_type)
+        let rendering_context = RenderingContext::create(&connection, &adapter, false)
             .expect("Failed to create WR surfman");
+        let surface = rendering_context
+            .create_surface(surface_type)
+            .expect("Failed to create surface");
+        rendering_context
+            .bind_surface(surface)
+            .expect("Failed to bind surface");
 
         debug!("Created window {:?}", winit_window.id());
         Window {

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -25,11 +25,11 @@ use servo::webrender_traits::RenderingContext;
 use surfman::{Connection, Context, Device, SurfaceType};
 use winit::dpi::{LogicalSize, PhysicalPosition, PhysicalSize};
 use winit::event::{ElementState, KeyEvent, MouseButton, MouseScrollDelta, TouchPhase};
+use winit::event_loop::ActiveEventLoop;
 use winit::keyboard::{Key as LogicalKey, ModifiersState, NamedKey};
 #[cfg(any(target_os = "linux", target_os = "windows"))]
 use winit::window::Icon;
 
-use super::events_loop::WakerEvent;
 use super::geometry::{winit_position_to_euclid_point, winit_size_to_euclid_size};
 use super::keyutils::keyboard_event_from_winit;
 use super::window_trait::{WindowPortsMethods, LINE_HEIGHT};
@@ -59,7 +59,7 @@ pub struct Window {
 impl Window {
     pub fn new(
         window_size: Size2D<u32, DeviceIndependentPixel>,
-        event_loop: &winit::event_loop::EventLoop<WakerEvent>,
+        event_loop: &ActiveEventLoop,
         no_native_titlebar: bool,
         device_pixel_ratio_override: Option<f32>,
     ) -> Window {

--- a/ports/servoshell/desktop/headless_window.rs
+++ b/ports/servoshell/desktop/headless_window.rs
@@ -16,8 +16,7 @@ use servo::compositing::windowing::{
 use servo::config::opts;
 use servo::servo_geometry::DeviceIndependentPixel;
 use servo::webrender_api::units::{DeviceIntSize, DevicePixel};
-use servo::webrender_traits::RenderingContext;
-use surfman::{Context, Device, SurfaceType};
+use surfman::{Context, Device};
 
 use crate::desktop::window_trait::WindowPortsMethods;
 
@@ -34,23 +33,9 @@ pub struct Window {
 impl Window {
     #[allow(clippy::new_ret_no_self)]
     pub fn new(
-        rendering_context: &RenderingContext,
         size: Size2D<u32, DeviceIndependentPixel>,
         device_pixel_ratio_override: Option<f32>,
     ) -> Rc<dyn WindowPortsMethods> {
-        // Initialize surfman
-        let surface_type = SurfaceType::Generic {
-            size: size.to_untyped().to_i32(),
-        };
-        let surface = rendering_context
-            .create_surface(surface_type)
-            .expect("Failed to create surface");
-        rendering_context
-            .bind_surface(surface)
-            .expect("Failed to bind surface");
-        // Make sure the gl context is made current.
-        rendering_context.make_gl_context_current().unwrap();
-
         let device_pixel_ratio_override: Option<Scale<f32, DeviceIndependentPixel, DevicePixel>> =
             device_pixel_ratio_override.map(Scale::new);
         let hidpi_factor = device_pixel_ratio_override.unwrap_or_else(Scale::identity);

--- a/ports/servoshell/desktop/headless_window.rs
+++ b/ports/servoshell/desktop/headless_window.rs
@@ -47,8 +47,14 @@ impl Window {
         let surface_type = SurfaceType::Generic {
             size: size.to_untyped().to_i32(),
         };
-        let rendering_context = RenderingContext::create(&connection, &adapter, surface_type)
+        let rendering_context = RenderingContext::create(&connection, &adapter, true)
             .expect("Failed to create WR surfman");
+        let surface = rendering_context
+            .create_surface(surface_type)
+            .expect("Failed to create surface");
+        rendering_context
+            .bind_surface(surface)
+            .expect("Failed to bind surface");
 
         let device_pixel_ratio_override: Option<Scale<f32, DeviceIndependentPixel, DevicePixel>> =
             device_pixel_ratio_override.map(Scale::new);

--- a/ports/servoshell/desktop/minibrowser.rs
+++ b/ports/servoshell/desktop/minibrowser.rs
@@ -339,8 +339,8 @@ impl Minibrowser {
                                             state.store(ui.ctx(), location_id);
                                         }
                                     }
-                                    if location_field.lost_focus()
-                                        && ui.input(|i| i.clone().key_pressed(Key::Enter))
+                                    if location_field.lost_focus() &&
+                                        ui.input(|i| i.clone().key_pressed(Key::Enter))
                                     {
                                         event_queue.borrow_mut().push(MinibrowserEvent::Go);
                                         location_dirty.set(false);
@@ -402,9 +402,10 @@ impl Minibrowser {
                         x: width,
                         y: height,
                     } = ui.available_size();
-                    let rect =
-                        Box2D::from_origin_and_size(Point2D::new(x, y), Size2D::new(width, height))
-                            * scale;
+                    let rect = Box2D::from_origin_and_size(
+                        Point2D::new(x, y),
+                        Size2D::new(width, height),
+                    ) * scale;
                     if rect != webview.rect {
                         webview.rect = rect;
                         embedder_events
@@ -584,8 +585,8 @@ impl Minibrowser {
         //       because logical OR would short-circuit if any of the functions return true.
         //       We want to ensure that all functions are called. The "bitwise OR" operator
         //       does not short-circuit.
-        self.update_location_in_toolbar(browser)
-            | self.update_spinner_in_toolbar(browser)
-            | self.update_status_text(browser)
+        self.update_location_in_toolbar(browser) |
+            self.update_spinner_in_toolbar(browser) |
+            self.update_status_text(browser)
     }
 }

--- a/ports/servoshell/desktop/minibrowser.rs
+++ b/ports/servoshell/desktop/minibrowser.rs
@@ -28,11 +28,10 @@ use servo::webrender_api::units::DevicePixel;
 use servo::webrender_traits::RenderingContext;
 use servo::TopLevelBrowsingContextId;
 use winit::event::{ElementState, MouseButton, WindowEvent};
-use winit::event_loop::EventLoop;
+use winit::event_loop::ActiveEventLoop;
 use winit::window::Window;
 
 use super::egui_glue::EguiGlow;
-use super::events_loop::WakerEvent;
 use super::geometry::winit_position_to_euclid_point;
 use super::webview::{LoadStatus, WebViewManager};
 use super::window_trait::WindowPortsMethods;
@@ -80,7 +79,7 @@ fn truncate_with_ellipsis(input: &str, max_length: usize) -> String {
 impl Minibrowser {
     pub fn new(
         rendering_context: &RenderingContext,
-        event_loop: &EventLoop<WakerEvent>,
+        event_loop: &ActiveEventLoop,
         initial_url: ServoUrl,
     ) -> Self {
         let gl = unsafe {
@@ -340,8 +339,8 @@ impl Minibrowser {
                                             state.store(ui.ctx(), location_id);
                                         }
                                     }
-                                    if location_field.lost_focus() &&
-                                        ui.input(|i| i.clone().key_pressed(Key::Enter))
+                                    if location_field.lost_focus()
+                                        && ui.input(|i| i.clone().key_pressed(Key::Enter))
                                     {
                                         event_queue.borrow_mut().push(MinibrowserEvent::Go);
                                         location_dirty.set(false);
@@ -403,10 +402,9 @@ impl Minibrowser {
                         x: width,
                         y: height,
                     } = ui.available_size();
-                    let rect = Box2D::from_origin_and_size(
-                        Point2D::new(x, y),
-                        Size2D::new(width, height),
-                    ) * scale;
+                    let rect =
+                        Box2D::from_origin_and_size(Point2D::new(x, y), Size2D::new(width, height))
+                            * scale;
                     if rect != webview.rect {
                         webview.rect = rect;
                         embedder_events
@@ -586,8 +584,8 @@ impl Minibrowser {
         //       because logical OR would short-circuit if any of the functions return true.
         //       We want to ensure that all functions are called. The "bitwise OR" operator
         //       does not short-circuit.
-        self.update_location_in_toolbar(browser) |
-            self.update_spinner_in_toolbar(browser) |
-            self.update_status_text(browser)
+        self.update_location_in_toolbar(browser)
+            | self.update_spinner_in_toolbar(browser)
+            | self.update_status_text(browser)
     }
 }

--- a/ports/servoshell/egl/android/simpleservo.rs
+++ b/ports/servoshell/egl/android/simpleservo.rs
@@ -94,7 +94,7 @@ pub fn init(
             SurfaceType::Widget { native_widget }
         },
     };
-    let rendering_context = RenderingContext::create(&connection, &adapter, false)
+    let rendering_context = RenderingContext::create(&connection, &adapter, None)
         .or(Err("Failed to create surface manager"))?;
     let surface = rendering_context
         .create_surface(surface_type)

--- a/ports/servoshell/egl/android/simpleservo.rs
+++ b/ports/servoshell/egl/android/simpleservo.rs
@@ -107,7 +107,6 @@ pub fn init(
         callbacks,
         RefCell::new(init_opts.coordinates),
         init_opts.density,
-        rendering_context.clone(),
     ));
 
     let embedder_callbacks = Box::new(ServoEmbedderCallbacks::new(

--- a/ports/servoshell/egl/ohos/simpleservo.rs
+++ b/ports/servoshell/egl/ohos/simpleservo.rs
@@ -134,7 +134,6 @@ pub fn init(
         callbacks,
         RefCell::new(Coordinates::new(0, 0, width, height, width, height)),
         options.display_density as f32,
-        rendering_context.clone(),
     ));
 
     let embedder_callbacks = Box::new(ServoEmbedderCallbacks::new(

--- a/ports/servoshell/egl/ohos/simpleservo.rs
+++ b/ports/servoshell/egl/ohos/simpleservo.rs
@@ -119,7 +119,7 @@ pub fn init(
     let surface_type = SurfaceType::Widget { native_widget };
 
     info!("Creating rendering context");
-    let rendering_context = RenderingContext::create(&connection, &adapter, false)
+    let rendering_context = RenderingContext::create(&connection, &adapter, None)
         .or(Err("Failed to create surface manager"))?;
     let surface = rendering_context
         .create_surface(surface_type)

--- a/ports/servoshell/egl/ohos/simpleservo.rs
+++ b/ports/servoshell/egl/ohos/simpleservo.rs
@@ -144,6 +144,7 @@ pub fn init(
     ));
 
     let servo = Servo::new(
+        rendering_context.clone(),
         embedder_callbacks,
         window_callbacks.clone(),
         // User agent: Mozilla/5.0 (<Phone|PC|Tablet>; HarmonyOS 5.0) bla bla

--- a/ports/servoshell/egl/servo_glue.rs
+++ b/ports/servoshell/egl/servo_glue.rs
@@ -713,8 +713,4 @@ impl WindowMethods for ServoWindowCallbacks {
         self.host_callbacks
             .on_animating_changed(state == AnimationState::Animating);
     }
-
-    fn rendering_context(&self) -> RenderingContext {
-        self.rendering_context.clone()
-    }
 }

--- a/ports/servoshell/egl/servo_glue.rs
+++ b/ports/servoshell/egl/servo_glue.rs
@@ -545,6 +545,8 @@ impl ServoGlue {
                 },
                 EmbedderMsg::WebViewFocused(webview_id) => {
                     self.focused_webview_id = Some(webview_id);
+                    self.events
+                        .push(EmbedderEvent::ShowWebView(webview_id, true));
                 },
                 EmbedderMsg::WebViewBlurred => {
                     self.focused_webview_id = None;

--- a/ports/servoshell/egl/servo_glue.rs
+++ b/ports/servoshell/egl/servo_glue.rs
@@ -58,7 +58,6 @@ pub(super) struct ServoWindowCallbacks {
     host_callbacks: Box<dyn HostTrait>,
     coordinates: RefCell<Coordinates>,
     hidpi_factor: Scale<f32, DeviceIndependentPixel, DevicePixel>,
-    rendering_context: RenderingContext,
 }
 
 impl ServoWindowCallbacks {
@@ -66,13 +65,11 @@ impl ServoWindowCallbacks {
         host_callbacks: Box<dyn HostTrait>,
         coordinates: RefCell<Coordinates>,
         hidpi_factor: f32,
-        rendering_context: RenderingContext,
     ) -> Self {
         Self {
             host_callbacks,
             coordinates,
             hidpi_factor: Scale::new(hidpi_factor),
-            rendering_context,
         }
     }
 }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Part of #34522
This PR removes `WindowMethods::rendering_context` and allows Servo to receive a single rendering_context instance upon creation.
This allows the first and more windows to be created during the event loop running. This should give future embedders more freedom to handle the lifetime of windows. 
I also noticed the segfault of smithay-clipboard is caused by egui actually. The following PR should make a feature flag to opt out of the egui dependency.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors


<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
