### PR TITLE
Add CORS safelisted range header support in request validation

### DIFF
--- a/components/shared/net/request.rs
+++ b/components/shared/net/request.rs
@@ -719,6 +719,7 @@ pub fn is_cors_safelisted_request_header<N: AsRef<str>, V: AsRef<[u8]>>(
         "accept" => is_cors_safelisted_request_accept(value),
         "accept-language" | "content-language" => is_cors_safelisted_language(value),
         "content-type" => is_cors_safelisted_request_content_type(value),
+        "range" => is_cors_safelisted_request_range(value),
         _ => false,
     }
 }
@@ -726,6 +727,40 @@ pub fn is_cors_safelisted_request_header<N: AsRef<str>, V: AsRef<[u8]>>(
 /// <https://fetch.spec.whatwg.org/#cors-safelisted-method>
 pub fn is_cors_safelisted_method(m: &Method) -> bool {
     matches!(*m, Method::GET | Method::HEAD | Method::POST)
+}
+
+/// <https://fetch.spec.whatwg.org/#cors-safelisted-request-header>
+pub fn is_cors_safelisted_request_range(value: &[u8]) -> bool {
+    if let Ok(value_str) = std::str::from_utf8(value) {
+        return validate_range_header(value_str);
+    }
+    false
+}
+
+/// Helper function to validate the syntax of the `Range` header. Ensures it follows the format "bytes=start-end".
+fn validate_range_header(value: &str) -> bool {
+    let trimmed = value.trim();
+    if !trimmed.starts_with("bytes=") {
+        return false;
+    }
+
+    if let Some(range) = trimmed.strip_prefix("bytes=") {
+        let mut parts = range.split('-');
+        let start = parts.next();
+        let end = parts.next();
+
+        if let Some(start) = start {
+            if let Ok(start_num) = start.parse::<u64>() {
+                return match end {
+                    Some(e) if !e.is_empty() => e
+                        .parse::<u64>()
+                        .map_or(false, |end_num| start_num <= end_num),
+                    _ => true,
+                };
+            }
+        }
+    }
+    false
 }
 
 /// <https://fetch.spec.whatwg.org/#cors-non-wildcard-request-header-name>

--- a/components/shared/net/tests/cors_safelisted_request_header.rs
+++ b/components/shared/net/tests/cors_safelisted_request_header.rs
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#[test]
+fn test_is_cors_safelisted_request_range() {
+    use net_traits::request::is_cors_safelisted_request_range;
+
+    assert!(is_cors_safelisted_request_range(b"bytes=100-200"));
+    assert!(is_cors_safelisted_request_range(b"bytes=200-"));
+    assert!(!is_cors_safelisted_request_range(b"bytes=abc-def"));
+    assert!(!is_cors_safelisted_request_range(b""));
+}


### PR DESCRIPTION
This PR addresses the issue where the Range header is missing from the CORS header safelist. The implementation adds the Range header as a safelisted request header according to the [Fetch Standard](https://fetch.spec.whatwg.org/#cors-safelisted-request-header).

Changes Made:
Added "range" to the is_cors_safelisted_request_header function in components/shared/net/request.rs.
Introduced the is_cors_safelisted_request_range function to validate the Range header with the following logic:
The value must start with "bytes=" as per the specification.
Any invalid or non-compliant value will not pass the safelist check.

Testing:
The functionality was tested locally to ensure the Range header is properly handled as per the requirements.

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #34767 

- [X] These changes do not require tests because the added functionality is a simple validation check which doesn't require custom test case.