### PR TITLE
Document's current script should not be updated when executing script elements inside shadow trees

### DIFF
--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -949,7 +949,7 @@ impl HTMLScriptElement {
 
         match script.type_ {
             ScriptType::Classic => {
-                if self.as_parent().as_parent().as_parent().is_in_shadow_tree() {
+                if self.upcast::<Node>().is_in_shadow_tree() {
                     document.set_current_script(None)
                 } else {
                     document.set_current_script(Some(self))

--- a/tests/wpt/meta/shadow-dom/Document-prototype-currentScript.html.ini
+++ b/tests/wpt/meta/shadow-dom/Document-prototype-currentScript.html.ini
@@ -1,7 +1,0 @@
-[Document-prototype-currentScript.html]
-  expected: ERROR
-  [document.currentScript must not be set to a script element that loads an external script in an open shadow tree]
-    expected: FAIL
-
-  [document.currentScript must not be set to a script element that loads an external script in a closed shadow tree]
-    expected: FAIL


### PR DESCRIPTION
- [x] Added check if node is in shadow tree
- [x] Added flag removing when node is removed from subtree
- [x] Removed related `ini` file 


---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #34738 

- [x] These changes do require tests, but this functionality is already tested as part of the WPT suite. 
