### PR TITLE
Consider shadow dom when dispatching events

### DIFF
--- a/components/script/dom/event.rs
+++ b/components/script/dom/event.rs
@@ -226,7 +226,7 @@ impl Event {
         // then set invocationTargetInShadowTree to true.
         if invocation_target
             .downcast::<Node>()
-            .is_some_and(Node::is_in_shadow_tree)
+            .is_some_and(Node::is_in_a_shadow_tree)
         {
             invocation_target_in_shadow_tree = true;
         }
@@ -438,12 +438,12 @@ impl Event {
                         .shadow_adjusted_target
                         .as_ref()
                         .and_then(|target| target.downcast::<Node>())
-                        .is_some_and(Node::is_in_shadow_tree) ||
+                        .is_some_and(Node::is_in_a_shadow_tree) ||
                         clear_targets
                             .related_target
                             .as_ref()
                             .and_then(|target| target.downcast::<Node>())
-                            .is_some_and(Node::is_in_shadow_tree)
+                            .is_some_and(Node::is_in_a_shadow_tree)
                 });
 
             // Step 5.12 If activationTarget is non-null and activationTarget has legacy-pre-activation behavior,

--- a/components/script/dom/event.rs
+++ b/components/script/dom/event.rs
@@ -81,6 +81,8 @@ pub struct Event {
 
     /// <https://dom.spec.whatwg.org/#initialized-flag>
     initialized: Cell<bool>,
+
+    /// <https://dom.spec.whatwg.org/#dom-event-timestamp>
     #[no_trace]
     time_stamp: CrossProcessInstant,
 
@@ -715,7 +717,7 @@ impl EventMethods<crate::DomTypeHolder> for Event {
         // Step 11. Set index to currentTargetIndex − 1.
         // Step 12. While index is greater than or equal to 0:
         // NOTE: This is just iterating the path in reverse
-        for element in path.iter().rev() {
+        for element in path.iter().take(current_target_index).rev() {
             // Step 12.1 If path[index]'s root-of-closed-tree is true, then increase currentHiddenLevel by 1.
             if element.root_of_closed_tree {
                 current_hidden_level += 1;

--- a/components/script/dom/event.rs
+++ b/components/script/dom/event.rs
@@ -352,13 +352,13 @@ impl Event {
 
                 // Step 5.9.6 If parent is a Window object, or parent is a node and target’s root is a
                 // shadow-including inclusive ancestor of parent:
-                let root_is_shadow_inclusive_ancestor =
-                    parent.downcast::<Node>().is_some_and(|parent| {
-                        target.downcast::<Node>().is_some_and(|target| {
-                            target
-                                .GetRootNode(&GetRootNodeOptions::empty())
-                                .is_shadow_including_inclusive_ancestor_of(parent)
-                        })
+                let root_is_shadow_inclusive_ancestor = parent
+                    .downcast::<Node>()
+                    .zip(target.downcast::<Node>())
+                    .is_some_and(|(parent, target)| {
+                        target
+                            .GetRootNode(&GetRootNodeOptions::empty())
+                            .is_shadow_including_inclusive_ancestor_of(parent)
                     });
                 if parent.is::<Window>() || root_is_shadow_inclusive_ancestor {
                     // Step 5.9.6.1 If isActivationEvent is true, event’s bubbles attribute is true, activationTarget

--- a/components/script/dom/event.rs
+++ b/components/script/dom/event.rs
@@ -716,7 +716,7 @@ impl EventMethods<crate::DomTypeHolder> for Event {
 
         // Step 11. Set index to currentTargetIndex − 1.
         // Step 12. While index is greater than or equal to 0:
-        // NOTE: This is just iterating the path in reverse
+        // NOTE: This is just iterating part of the path in reverse
         for element in path.iter().take(current_target_index).rev() {
             // Step 12.1 If path[index]'s root-of-closed-tree is true, then increase currentHiddenLevel by 1.
             if element.root_of_closed_tree {

--- a/components/script/dom/event.rs
+++ b/components/script/dom/event.rs
@@ -117,7 +117,7 @@ pub struct EventPathSegment {
 }
 
 impl Event {
-    pub fn new_inherited() -> Event {
+    pub(crate) fn new_inherited() -> Event {
         Event {
             reflector_: Reflector::new(),
             current_target: Default::default(),
@@ -138,11 +138,11 @@ impl Event {
         }
     }
 
-    pub fn new_uninitialized(global: &GlobalScope, can_gc: CanGc) -> DomRoot<Event> {
+    pub(crate) fn new_uninitialized(global: &GlobalScope, can_gc: CanGc) -> DomRoot<Event> {
         Self::new_uninitialized_with_proto(global, None, can_gc)
     }
 
-    pub fn new_uninitialized_with_proto(
+    pub(crate) fn new_uninitialized_with_proto(
         global: &GlobalScope,
         proto: Option<HandleObject>,
         can_gc: CanGc,
@@ -150,7 +150,7 @@ impl Event {
         reflect_dom_object_with_proto(Box::new(Event::new_inherited()), global, proto, can_gc)
     }
 
-    pub fn new(
+    pub(crate) fn new(
         global: &GlobalScope,
         type_: Atom,
         bubbles: EventBubbles,
@@ -175,7 +175,7 @@ impl Event {
 
     /// <https://dom.spec.whatwg.org/#dom-event-initevent>
     /// and <https://dom.spec.whatwg.org/#concept-event-initialize>
-    pub fn init_event(&self, type_: Atom, bubbles: bool, cancelable: bool) {
+    pub(crate) fn init_event(&self, type_: Atom, bubbles: bool, cancelable: bool) {
         // https://dom.spec.whatwg.org/#dom-event-initevent
         if self.dispatch.get() {
             return;
@@ -206,13 +206,13 @@ impl Event {
         self.cancelable.set(cancelable);
     }
 
-    pub fn set_target(&self, target_: Option<&EventTarget>) {
+    pub(crate) fn set_target(&self, target_: Option<&EventTarget>) {
         self.target.set(target_);
     }
 
     /// <https://dom.spec.whatwg.org/#concept-event-path-append>
     #[allow(crown::unrooted_must_root)]
-    pub fn append_to_path(
+    pub(crate) fn append_to_path(
         &self,
         invocation_target: &EventTarget,
         shadow_adjusted_target: Option<&EventTarget>,
@@ -258,7 +258,7 @@ impl Event {
     }
 
     /// <https://dom.spec.whatwg.org/#concept-event-dispatch>
-    pub fn dispatch(
+    pub(crate) fn dispatch(
         &self,
         target: &EventTarget,
         legacy_target_override: bool,
@@ -580,7 +580,7 @@ impl Event {
         self.status()
     }
 
-    pub fn status(&self) -> EventStatus {
+    pub(crate) fn status(&self) -> EventStatus {
         if self.DefaultPrevented() {
             EventStatus::Canceled
         } else {
@@ -589,36 +589,36 @@ impl Event {
     }
 
     #[inline]
-    pub fn dispatching(&self) -> bool {
+    pub(crate) fn dispatching(&self) -> bool {
         self.dispatch.get()
     }
 
     #[inline]
-    pub fn initialized(&self) -> bool {
+    pub(crate) fn initialized(&self) -> bool {
         self.initialized.get()
     }
 
     #[inline]
-    pub fn type_(&self) -> Atom {
+    pub(crate) fn type_(&self) -> Atom {
         self.type_.borrow().clone()
     }
 
     #[inline]
-    pub fn mark_as_handled(&self) {
+    pub(crate) fn mark_as_handled(&self) {
         self.canceled.set(EventDefault::Handled);
     }
 
     #[inline]
-    pub fn get_cancel_state(&self) -> EventDefault {
+    pub(crate) fn get_cancel_state(&self) -> EventDefault {
         self.canceled.get()
     }
 
-    pub fn set_trusted(&self, trusted: bool) {
+    pub(crate) fn set_trusted(&self, trusted: bool) {
         self.is_trusted.set(trusted);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#fire-a-simple-event>
-    pub fn fire(&self, target: &EventTarget, can_gc: CanGc) -> EventStatus {
+    pub(crate) fn fire(&self, target: &EventTarget, can_gc: CanGc) -> EventStatus {
         self.set_trusted(true);
         target.dispatch_event(self, can_gc)
     }

--- a/components/script/dom/event.rs
+++ b/components/script/dom/event.rs
@@ -211,6 +211,7 @@ impl Event {
     }
 
     /// <https://dom.spec.whatwg.org/#concept-event-path-append>
+    #[allow(crown::unrooted_must_root)]
     pub fn append_to_path(
         &self,
         invocation_target: &EventTarget,

--- a/components/script/dom/event.rs
+++ b/components/script/dom/event.rs
@@ -110,19 +110,36 @@ impl Event {
         event
     }
 
+    /// <https://dom.spec.whatwg.org/#dom-event-initevent>
+    /// and <https://dom.spec.whatwg.org/#concept-event-initialize>
     pub fn init_event(&self, type_: Atom, bubbles: bool, cancelable: bool) {
+        // https://dom.spec.whatwg.org/#dom-event-initevent
         if self.dispatching.get() {
             return;
         }
 
+        // https://dom.spec.whatwg.org/#concept-event-initialize
+        // Step 1. Set event’s initialized flag.
         self.initialized.set(true);
+
+        // Step 2. Unset event’s stop propagation flag, stop immediate propagation flag, and canceled flag.
         self.stop_propagation.set(false);
         self.stop_immediate.set(false);
         self.canceled.set(EventDefault::Allowed);
+
+        // Step 3. Set event’s isTrusted attribute to false.
         self.trusted.set(false);
+
+        // Step 4. Set event’s target to null.
         self.target.set(None);
+
+        // Step 5. Set event’s type attribute to type.
         *self.type_.borrow_mut() = type_;
+
+        // Step 6. Set event’s bubbles attribute to bubbles.
         self.bubbles.set(bubbles);
+
+        // Step 7. Set event’s cancelable attribute to cancelable.
         self.cancelable.set(cancelable);
     }
 

--- a/components/script/dom/event.rs
+++ b/components/script/dom/event.rs
@@ -431,7 +431,7 @@ impl Event {
                 .borrow()
                 .iter()
                 .rev()
-                .find(|segment| segment.shadow_adjusted_target.is_none())
+                .find(|segment| segment.shadow_adjusted_target.is_some())
                 // This is "clearTargetsStruct"
                 .is_some_and(|clear_targets| {
                     clear_targets

--- a/components/script/dom/event.rs
+++ b/components/script/dom/event.rs
@@ -222,7 +222,8 @@ impl Event {
         // Step 1. Let invocationTargetInShadowTree be false.
         let mut invocation_target_in_shadow_tree = false;
 
-        // Step 2. If invocationTarget is a node and its root is a shadow root, then set invocationTargetInShadowTree to true.
+        // Step 2. If invocationTarget is a node and its root is a shadow root,
+        // then set invocationTargetInShadowTree to true.
         if invocation_target
             .downcast::<Node>()
             .is_some_and(Node::is_in_shadow_tree)
@@ -242,9 +243,9 @@ impl Event {
         }
 
         // Step 5. Append a new struct to event’s path whose invocation target is invocationTarget,
-        // invocation-target-in-shadow-tree is invocationTargetInShadowTree, shadow-adjusted target is shadowAdjustedTarget,
-        // relatedTarget is relatedTarget, touch target list is touchTargets, root-of-closed-tree is root-of-closed-tree,
-        // and slot-in-closed-tree is slot-in-closed-tree.
+        // invocation-target-in-shadow-tree is invocationTargetInShadowTree, shadow-adjusted target is
+        // shadowAdjustedTarget, relatedTarget is relatedTarget, touch target list is touchTargets,
+        // root-of-closed-tree is root-of-closed-tree, and slot-in-closed-tree is slot-in-closed-tree.
         let event_path_segment = EventPathSegment {
             invocation_target: Dom::from_ref(invocation_target),
             shadow_adjusted_target: shadow_adjusted_target.map(Dom::from_ref),
@@ -269,7 +270,8 @@ impl Event {
         // Step 1. Set event’s dispatch flag.
         self.dispatch.set(true);
 
-        // Step 2. Let targetOverride be target, if legacy target override flag is not given, and target’s associated Document otherwise.
+        // Step 2. Let targetOverride be target, if legacy target override flag is not given,
+        // and target’s associated Document otherwise.
         let target_override_document; // upcasted EventTarget's lifetime depends on this
         let target_override = if legacy_target_override {
             target_override_document = target
@@ -302,7 +304,8 @@ impl Event {
             // TODO Step 5.2 For each touchTarget of event’s touch target list, append the result of retargeting
             // touchTarget against target to touchTargets.
 
-            // Step 5.3 Append to an event path with event, target, targetOverride, relatedTarget, touchTargets, and false.
+            // Step 5.3 Append to an event path with event, target, targetOverride, relatedTarget,
+            // touchTargets, and false.
             self.append_to_path(
                 &target,
                 Some(target_override.upcast::<EventTarget>()),
@@ -310,10 +313,12 @@ impl Event {
                 false,
             );
 
-            // Step 5.4 Let isActivationEvent be true, if event is a MouseEvent object and event’s type attribute is "click"; otherwise false.
+            // Step 5.4 Let isActivationEvent be true, if event is a MouseEvent object and
+            // event’s type attribute is "click"; otherwise false.
             let is_activation_event = self.is::<MouseEvent>() && self.type_() == atom!("click");
 
-            // Step 5.5 If isActivationEvent is true and target has activation behavior, then set activationTarget to target.
+            // Step 5.5 If isActivationEvent is true and target has activation behavior,
+            // then set activationTarget to target.
             if is_activation_event {
                 if let Some(element) = target.downcast::<Element>() {
                     if element.as_maybe_activatable().is_some() {
@@ -356,8 +361,8 @@ impl Event {
                         })
                     });
                 if parent.is::<Window>() || root_is_shadow_inclusive_ancestor {
-                    // Step 5.9.6.1 If isActivationEvent is true, event’s bubbles attribute is true, activationTarget is null,
-                    // and parent has activation behavior, then set activationTarget to parent.
+                    // Step 5.9.6.1 If isActivationEvent is true, event’s bubbles attribute is true, activationTarget
+                    // is null, and parent has activation behavior, then set activationTarget to parent.
                     if is_activation_event && activation_target.is_none() && self.bubbles.get() {
                         if let Some(element) = parent.downcast::<Element>() {
                             if element.as_maybe_activatable().is_some() {
@@ -366,7 +371,8 @@ impl Event {
                         }
                     }
 
-                    // Step 5.9.6.2 Append to an event path with event, parent, null, relatedTarget, touchTargets, and slot-in-closed-tree.
+                    // Step 5.9.6.2 Append to an event path with event, parent, null, relatedTarget, touchTargets,
+                    // and slot-in-closed-tree.
                     self.append_to_path(
                         &parent,
                         None,
@@ -385,8 +391,8 @@ impl Event {
                     // Step 5.9.8.1 Set target to parent.
                     target = parent.clone();
 
-                    // Step 5.9.8.2 If isActivationEvent is true, activationTarget is null, and target has activation behavior,
-                    // then set activationTarget to target.
+                    // Step 5.9.8.2 If isActivationEvent is true, activationTarget is null, and target has
+                    // activation behavior, then set activationTarget to target.
                     if is_activation_event && activation_target.is_none() {
                         if let Some(element) = parent.downcast::<Element>() {
                             if element.as_maybe_activatable().is_some() {
@@ -395,7 +401,8 @@ impl Event {
                         }
                     }
 
-                    // Step 5.9.8.3 Append to an event path with event, parent, target, relatedTarget, touchTargets, and slot-in-closed-tree.
+                    // Step 5.9.8.3 Append to an event path with event, parent, target, relatedTarget,
+                    // touchTargets, and slot-in-closed-tree.
                     self.append_to_path(
                         &parent,
                         Some(&target),
@@ -404,7 +411,8 @@ impl Event {
                     );
                 }
 
-                // Step 5.9.9 If parent is non-null, then set parent to the result of invoking parent’s get the parent with event
+                // Step 5.9.9 If parent is non-null, then set parent to the result of invoking parent’s
+                // get the parent with event
                 if !done {
                     parent_or_none = parent.get_the_parent(self);
                 }
@@ -412,9 +420,11 @@ impl Event {
                 // TODO Step 5.9.10 Set slot-in-closed-tree to false.
             }
 
-            // Step 5.10 Let clearTargetsStruct be the last struct in event’s path whose shadow-adjusted target is non-null.
-            // Step 5.11 Let clearTargets be true if clearTargetsStruct’s shadow-adjusted target, clearTargetsStruct’s relatedTarget,
-            // or an EventTarget object in clearTargetsStruct’s touch target list is a node and its root is a shadow root; otherwise false.
+            // Step 5.10 Let clearTargetsStruct be the last struct in event’s path whose shadow-adjusted target
+            // is non-null.
+            // Step 5.11 Let clearTargets be true if clearTargetsStruct’s shadow-adjusted target,
+            // clearTargetsStruct’s relatedTarget, or an EventTarget object in clearTargetsStruct’s
+            // touch target list is a node and its root is a shadow root; otherwise false.
             // TODO: Handle touch target list
             clear_targets = self
                 .path
@@ -453,7 +463,8 @@ impl Event {
 
             // Step 5.13 For each struct in event’s path, in reverse order:
             for (index, segment) in self.path.borrow().iter().enumerate().rev() {
-                // Step 5.13.1 If struct’s shadow-adjusted target is non-null, then set event’s eventPhase attribute to AT_TARGET.
+                // Step 5.13.1 If struct’s shadow-adjusted target is non-null, then set event’s
+                // eventPhase attribute to AT_TARGET.
                 if segment.shadow_adjusted_target.is_some() {
                     self.phase.set(EventPhase::AtTarget);
                 }
@@ -475,7 +486,8 @@ impl Event {
 
             // Step 5.14 For each struct in event’s path:
             for (index, segment) in self.path.borrow().iter().enumerate() {
-                //  Step 5.14.1 If struct’s shadow-adjusted target is non-null, then set event’s eventPhase attribute to AT_TARGET.
+                // Step 5.14.1 If struct’s shadow-adjusted target is non-null, then set event’s
+                // eventPhase attribute to AT_TARGET.
                 if segment.shadow_adjusted_target.is_some() {
                     self.phase.set(EventPhase::AtTarget);
                 }
@@ -551,7 +563,8 @@ impl Event {
         if let Some(activation_target) = activation_target {
             // NOTE: The activation target may have been disabled by an event handler
             if let Some(activatable) = activation_target.as_maybe_activatable() {
-                // Step 11.1 If event’s canceled flag is unset, then run activationTarget’s activation behavior with event.
+                // Step 11.1 If event’s canceled flag is unset, then run activationTarget’s
+                // activation behavior with event.
                 if !self.DefaultPrevented() {
                     activatable.activation_behavior(self, &target, can_gc);
                 }
@@ -689,12 +702,14 @@ impl EventMethods<crate::DomTypeHolder> for Event {
         // Step 9. While index is greater than or equal to 0:
         // NOTE: This is just iterating the path in reverse
         for (index, element) in path.iter().enumerate().rev() {
-            // Step 9.1 If path[index]'s root-of-closed-tree is true, then increase currentTargetHiddenSubtreeLevel by 1.
+            // Step 9.1 If path[index]'s root-of-closed-tree is true, then increase
+            // currentTargetHiddenSubtreeLevel by 1.
             if element.root_of_closed_tree {
                 current_target_hidden_subtree_level += 1;
             }
 
-            // Step 9.2 If path[index]'s invocation target is currentTarget, then set currentTargetIndex to index and break.
+            // Step 9.2 If path[index]'s invocation target is currentTarget, then set
+            // currentTargetIndex to index and break.
             if current_target
                 .as_ref()
                 .is_some_and(|target| target.as_traced() == element.invocation_target)
@@ -703,7 +718,8 @@ impl EventMethods<crate::DomTypeHolder> for Event {
                 break;
             }
 
-            // Step 9.3 If path[index]'s slot-in-closed-tree is true, then decrease currentTargetHiddenSubtreeLevel by 1.
+            // Step 9.3 If path[index]'s slot-in-closed-tree is true, then decrease
+            // currentTargetHiddenSubtreeLevel by 1.
             if element.slot_in_closed_tree {
                 current_target_hidden_subtree_level -= 1;
             }
@@ -735,7 +751,8 @@ impl EventMethods<crate::DomTypeHolder> for Event {
                 // Step 12.3.1 Decrease currentHiddenLevel by 1.
                 current_hidden_level -= 1;
 
-                // Step 12.3.2 If currentHiddenLevel is less than maxHiddenLevel, then set maxHiddenLevel to currentHiddenLevel.
+                // Step 12.3.2 If currentHiddenLevel is less than maxHiddenLevel, then set
+                // maxHiddenLevel to currentHiddenLevel.
                 if current_hidden_level < max_hidden_level {
                     max_hidden_level = current_hidden_level;
                 }
@@ -769,7 +786,8 @@ impl EventMethods<crate::DomTypeHolder> for Event {
                 // Step 15.3.1 Decrease currentHiddenLevel by 1.
                 current_hidden_level -= 1;
 
-                // Step 15.3.2 If currentHiddenLevel is less than maxHiddenLevel, then set maxHiddenLevel to currentHiddenLevel.
+                // Step 15.3.2 If currentHiddenLevel is less than maxHiddenLevel, then set
+                // maxHiddenLevel to currentHiddenLevel.
                 if current_hidden_level < max_hidden_level {
                     max_hidden_level = current_hidden_level;
                 }
@@ -1046,7 +1064,8 @@ fn invoke(
         };
         *event.type_.borrow_mut() = legacy_type;
 
-        // Step 9.3 Inner invoke with event, listeners, phase, invocationTargetInShadowTree, and legacyOutputDidListenersThrowFlag if given.
+        // Step 9.3 Inner invoke with event, listeners, phase, invocationTargetInShadowTree,
+        // and legacyOutputDidListenersThrowFlag if given.
         inner_invoke(
             event,
             &listeners,
@@ -1092,7 +1111,8 @@ fn inner_invoke(
         // TODO Step 2.3 If phase is "capturing" and listener’s capture is false, then continue.
         // TODO Step 2.4 If phase is "bubbling" and listener’s capture is true, then continue.
 
-        // Step 2.5 If listener’s once is true, then remove an event listener given event’s currentTarget attribute value and listener.
+        // Step 2.5 If listener’s once is true, then remove an event listener given event’s currentTarget
+        // attribute value and listener.
         if let CompiledEventListener::Listener(event_listener) = listener {
             event
                 .GetCurrentTarget()
@@ -1121,7 +1141,8 @@ fn inner_invoke(
         // Step 2.10 If global is a Window object, then record timing info for event listener given event and listener.
         // Step 2.11 Call a user object’s operation with listener’s callback, "handleEvent", « event »,
         // and event’s currentTarget attribute value. If this throws an exception exception:
-        //     Step 2.10.1 Report exception for listener’s callback’s corresponding JavaScript object’s associated realm’s global object.
+        //     Step 2.10.1 Report exception for listener’s callback’s corresponding JavaScript object’s
+        //     associated realm’s global object.
         //     TODO Step 2.10.2 Set legacyOutputDidListenersThrowFlag if given.
         let marker = TimelineMarker::start("DOMEvent".to_owned());
         listener.call_or_handle_event(

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -788,7 +788,7 @@ impl EventTarget {
     }
 
     /// <https://dom.spec.whatwg.org/#get-the-parent>
-    pub fn get_the_parent(&self, event: &Event) -> Option<DomRoot<EventTarget>> {
+    pub(crate) fn get_the_parent(&self, event: &Event) -> Option<DomRoot<EventTarget>> {
         if let Some(document) = self.downcast::<Document>() {
             if event.type_() == atom!("load") || !document.has_browsing_context() {
                 return None;
@@ -816,7 +816,7 @@ impl EventTarget {
     // FIXME: This algorithm operates on "objects", which may not be event targets.
     // All our current use-cases only work on event targets, but this might change in the future
     /// <https://dom.spec.whatwg.org/#retarget>
-    pub fn retarget(&self, b: &Self) -> DomRoot<EventTarget> {
+    pub(crate) fn retarget(&self, b: &Self) -> DomRoot<EventTarget> {
         // To retarget an object A against an object B, repeat these steps until they return an object:
         let mut a = DomRoot::from_ref(self);
         loop {

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -797,11 +797,11 @@ impl EventTarget {
             }
         }
 
-        if let Some(shadow_root) = self.downcast::<ShadowRoot>() {
+        if self.downcast::<ShadowRoot>().is_some() {
             // FIXME: Handle event composed flag here
-            return Some(DomRoot::from_ref(
-                shadow_root.Host().upcast::<EventTarget>(),
-            ));
+            // We currently assume that events are never composed (so events may never
+            // cross a shadow boundary)
+            return None;
         }
 
         if let Some(node) = self.downcast::<Node>() {

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -1280,27 +1280,6 @@ impl Node {
         }
     }
 
-    /// <https://dom.spec.whatwg.org/#retarget>
-    pub fn retarget(&self, b: &Node) -> DomRoot<Node> {
-        let mut a = DomRoot::from_ref(self);
-        loop {
-            // Step 1.
-            let a_root = a.GetRootNode(&GetRootNodeOptions::empty());
-            if !a_root.is::<ShadowRoot>() || a_root.is_shadow_including_inclusive_ancestor_of(b) {
-                return DomRoot::from_ref(&a);
-            }
-
-            // Step 2.
-            a = DomRoot::from_ref(
-                a_root
-                    .downcast::<ShadowRoot>()
-                    .unwrap()
-                    .Host()
-                    .upcast::<Node>(),
-            );
-        }
-    }
-
     pub fn is_styled(&self) -> bool {
         self.style_data.borrow().is_some()
     }

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -611,6 +611,7 @@ impl Node {
         self.flags.get().contains(NodeFlags::IS_IN_A_DOCUMENT_TREE)
     }
 
+    /// Return true iff node's root is a shadow-root.
     pub fn is_in_a_shadow_tree(&self) -> bool {
         self.flags.get().contains(NodeFlags::IS_IN_SHADOW_TREE)
     }

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -28,6 +28,7 @@ use crate::dom::node::{
     BindContext, Node, NodeDamage, NodeFlags, NodeTraits, ShadowIncluding, UnbindContext,
 };
 use crate::dom::stylesheetlist::{StyleSheetList, StyleSheetListOwner};
+use crate::dom::types::EventTarget;
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::dom::window::Window;
 use crate::script_runtime::CanGc;
@@ -218,7 +219,9 @@ impl ShadowRootMethods<crate::DomTypeHolder> for ShadowRoot {
             can_gc,
         ) {
             Some(e) => {
-                let retargeted_node = self.upcast::<Node>().retarget(e.upcast::<Node>());
+                let retargeted_node = self
+                    .upcast::<EventTarget>()
+                    .retarget(e.upcast::<EventTarget>());
                 retargeted_node.downcast::<Element>().map(DomRoot::from_ref)
             },
             None => None,
@@ -240,7 +243,9 @@ impl ShadowRootMethods<crate::DomTypeHolder> for ShadowRoot {
             .elements_from_point(x, y, None, self.document.has_browsing_context(), can_gc)
             .iter()
         {
-            let retargeted_node = self.upcast::<Node>().retarget(e.upcast::<Node>());
+            let retargeted_node = self
+                .upcast::<EventTarget>()
+                .retarget(e.upcast::<EventTarget>());
             if let Some(element) = retargeted_node.downcast::<Element>().map(DomRoot::from_ref) {
                 elements.push(element);
             }

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1604,12 +1604,15 @@ impl Window {
         window_named_properties::create(cx, proto, object)
     }
 
-    pub(crate) fn set_current_event(&self, event: Option<&Event>) -> Option<DomRoot<Event>> {
-        let current = self
-            .current_event
+    pub(crate) fn current_event(&self) -> Option<DomRoot<Event>> {
+        self.current_event
             .borrow()
             .as_ref()
-            .map(|e| DomRoot::from_ref(&**e));
+            .map(|e| DomRoot::from_ref(&**e))
+    }
+
+    pub(crate) fn set_current_event(&self, event: Option<&Event>) -> Option<DomRoot<Event>> {
+        let current = self.current_event();
         *self.current_event.borrow_mut() = event.map(Dom::from_ref);
         current
     }

--- a/tests/wpt/meta/dom/events/Event-dispatch-click.html.ini
+++ b/tests/wpt/meta/dom/events/Event-dispatch-click.html.ini
@@ -1,6 +1,0 @@
-[Event-dispatch-click.html]
-  [event state during post-click handling]
-    expected: FAIL
-
-  [submit button should not activate if the event listener disables it]
-    expected: FAIL

--- a/tests/wpt/meta/dom/events/EventTarget-constructible.any.js.ini
+++ b/tests/wpt/meta/dom/events/EventTarget-constructible.any.js.ini
@@ -1,8 +1,0 @@
-[EventTarget-constructible.any.worker.html]
-  [A constructed EventTarget implements dispatch correctly]
-    expected: FAIL
-
-
-[EventTarget-constructible.any.html]
-  [A constructed EventTarget implements dispatch correctly]
-    expected: FAIL

--- a/tests/wpt/meta/dom/events/event-global.html.ini
+++ b/tests/wpt/meta/dom/events/event-global.html.ini
@@ -1,6 +1,7 @@
 [event-global.html]
+  expected: TIMEOUT
   [window.event is undefined if the target is in a shadow tree (event dispatched inside shadow tree)]
-    expected: FAIL
+    expected: TIMEOUT
 
   [window.event is undefined inside window.onerror if the target is in a shadow tree (ErrorEvent dispatched inside shadow tree)]
     expected: FAIL

--- a/tests/wpt/meta/shadow-dom/Extensions-to-Event-Interface.html.ini
+++ b/tests/wpt/meta/shadow-dom/Extensions-to-Event-Interface.html.ini
@@ -1,7 +1,4 @@
 [Extensions-to-Event-Interface.html]
-  [composedPath() must return an empty array when the event is no longer dispatched]
-    expected: FAIL
-
   [composed on EventInit must default to false]
     expected: FAIL
 

--- a/tests/wpt/meta/shadow-dom/event-post-dispatch.html.ini
+++ b/tests/wpt/meta/shadow-dom/event-post-dispatch.html.ini
@@ -1,26 +1,11 @@
 [event-post-dispatch.html]
-  [Event properties post dispatch without ShadowRoots (composed: true).]
-    expected: FAIL
-
-  [Event properties post dispatch without ShadowRoots (composed: false).]
-    expected: FAIL
-
   [Event properties post dispatch with an open ShadowRoot (composed: true).]
-    expected: FAIL
-
-  [Event properties post dispatch with an open ShadowRoot (composed: false).]
     expected: FAIL
 
   [Event properties post dispatch with a closed ShadowRoot (composed: true).]
     expected: FAIL
 
-  [Event properties post dispatch with a closed ShadowRoot (composed: false).]
-    expected: FAIL
-
   [Event properties post dispatch with nested ShadowRoots (composed: true).]
-    expected: FAIL
-
-  [Event properties post dispatch with nested ShadowRoots (composed: false).]
     expected: FAIL
 
   [Event properties post dispatch with relatedTarget in the same shadow tree. (composed: true)]
@@ -42,7 +27,4 @@
     expected: FAIL
 
   [Event properties post dispatch when target get moved out of the shadow tree by event listener]
-    expected: FAIL
-
-  [Event properties post dispatch when target get moved into the the shadow tree by event listener]
     expected: FAIL


### PR DESCRIPTION
This essentially rewrites to event dispatching code to follow the spec more closely. The previous implementation completely ignored potential shadow roots in the DOM.

These changes  will allow us to implement the `composed` flag on events in the future.

There is a new TIMEOUT (previously FAIL) in `dom/events/event-global.html`. The test tries to bubble an event over a shadow boundary. This doesn't work anymore, as the `composed` flag is not supported yet.

[try](https://github.com/simonwuelker/servo/actions/runs/12530666693)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of https://github.com/servo/servo/issues/31149 (events do not yet pass shadow roots, but the infrastructure is in place)
- [X] There are tests for these changes (covered by WPT)

