### PR TITLE
Upgrade rustc to 1.83

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ authors = ["The Servo Project Developers"]
 license = "MPL-2.0"
 edition = "2021"
 publish = false
-rust-version = "1.82.0"
+rust-version = "1.83.0"
 
 [workspace.dependencies]
 accountable-refcell = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,6 +162,9 @@ wr_malloc_size_of = { git = "https://github.com/servo/webrender", branch = "0.65
 xi-unicode = "0.3.0"
 xml5ever = "0.20"
 
+[workspace.lints.clippy]
+needless_lifetimes = "allow"
+
 [profile.release]
 opt-level = 3
 debug-assertions = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,9 +162,6 @@ wr_malloc_size_of = { git = "https://github.com/servo/webrender", branch = "0.65
 xi-unicode = "0.3.0"
 xml5ever = "0.20"
 
-[workspace.lints.clippy]
-needless_lifetimes = "allow"
-
 [profile.release]
 opt-level = 3
 debug-assertions = true

--- a/components/bluetooth/lib.rs
+++ b/components/bluetooth/lib.rs
@@ -189,7 +189,7 @@ fn matches_filters(device: &BluetoothDevice, filters: &BluetoothScanfilterSequen
         return false;
     }
 
-    return filters.iter().any(|f| matches_filter(device, f));
+    filters.iter().any(|f| matches_filter(device, f))
 }
 
 fn is_mock_adapter(adapter: &BluetoothAdapter) -> bool {

--- a/components/canvas/lib.rs
+++ b/components/canvas/lib.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #![deny(unsafe_code)]
+#![allow(clippy::needless_lifetimes)]
 
 mod raqote_backend;
 

--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -1429,10 +1429,10 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
     }
 
     fn hit_test_at_point(&self, point: DevicePoint) -> Option<CompositorHitTestResult> {
-        return self
+        self
             .hit_test_at_point_with_flags_and_pipeline(point, HitTestFlags::empty(), None)
             .first()
-            .cloned();
+            .cloned()
     }
 
     fn hit_test_at_point_with_flags_and_pipeline(

--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -1429,8 +1429,7 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
     }
 
     fn hit_test_at_point(&self, point: DevicePoint) -> Option<CompositorHitTestResult> {
-        self
-            .hit_test_at_point_with_flags_and_pipeline(point, HitTestFlags::empty(), None)
+        self.hit_test_at_point_with_flags_and_pipeline(point, HitTestFlags::empty(), None)
             .first()
             .cloned()
     }

--- a/components/constellation/logging.rs
+++ b/components/constellation/logging.rs
@@ -14,9 +14,9 @@ use log::{Level, LevelFilter, Log, Metadata, Record};
 use parking_lot::ReentrantMutex;
 use script_traits::{LogEntry, ScriptMsg as FromScriptMsg, ScriptToConstellationChan};
 
-/// The constellation uses logging to perform crash reporting.
-/// The constellation receives all `warn!`, `error!` and `panic!` messages,
-/// and generates a crash report when it receives a panic.
+// The constellation uses logging to perform crash reporting.
+// The constellation receives all `warn!`, `error!` and `panic!` messages,
+// and generates a crash report when it receives a panic.
 
 /// A logger directed at the constellation from content processes
 /// #[derive(Clone)]

--- a/components/constellation/logging.rs
+++ b/components/constellation/logging.rs
@@ -2,6 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+//! The constellation uses logging to perform crash reporting.
+//! The constellation receives all `warn!`, `error!` and `panic!` messages,
+//! and generates a crash report when it receives a panic.
+
 use std::borrow::ToOwned;
 use std::sync::Arc;
 use std::thread;
@@ -14,20 +18,12 @@ use log::{Level, LevelFilter, Log, Metadata, Record};
 use parking_lot::ReentrantMutex;
 use script_traits::{LogEntry, ScriptMsg as FromScriptMsg, ScriptToConstellationChan};
 
-// The constellation uses logging to perform crash reporting.
-// The constellation receives all `warn!`, `error!` and `panic!` messages,
-// and generates a crash report when it receives a panic.
-
 /// A logger directed at the constellation from content processes
 /// #[derive(Clone)]
 pub struct FromScriptLogger {
     /// A channel to the constellation
     pub script_to_constellation_chan: Arc<ReentrantMutex<ScriptToConstellationChan>>,
 }
-
-// The constellation uses logging to perform crash reporting.
-// The constellation receives all `warn!`, `error!` and `panic!` messages,
-// and generates a crash report when it receives a panic.
 
 /// A logger directed at the constellation from content processes
 impl FromScriptLogger {

--- a/components/constellation/logging.rs
+++ b/components/constellation/logging.rs
@@ -25,9 +25,9 @@ pub struct FromScriptLogger {
     pub script_to_constellation_chan: Arc<ReentrantMutex<ScriptToConstellationChan>>,
 }
 
-/// The constellation uses logging to perform crash reporting.
-/// The constellation receives all `warn!`, `error!` and `panic!` messages,
-/// and generates a crash report when it receives a panic.
+// The constellation uses logging to perform crash reporting.
+// The constellation receives all `warn!`, `error!` and `panic!` messages,
+// and generates a crash report when it receives a panic.
 
 /// A logger directed at the constellation from content processes
 impl FromScriptLogger {

--- a/components/constellation/sandboxing.rs
+++ b/components/constellation/sandboxing.rs
@@ -203,7 +203,9 @@ pub fn spawn_multiprocess(content: UnprivilegedContent) -> Result<(), Error> {
         setup_common(&mut child_process, token);
         let _ = child_process
             .spawn()
-            .expect("Failed to start unsandboxed child process!");
+            .expect("Failed to start unsandboxed child process!")
+            .wait()
+            .expect("Failed to wait on unsandboxed child process!");
     }
 
     let (_receiver, sender) = server.accept().expect("Server failed to accept.");

--- a/components/constellation/sandboxing.rs
+++ b/components/constellation/sandboxing.rs
@@ -182,23 +182,6 @@ pub fn spawn_multiprocess(content: UnprivilegedContent) -> Result<(), Error> {
     use gaol::sandbox::{self, Sandbox, SandboxMethods};
     use ipc_channel::ipc::{IpcOneShotServer, IpcSender};
 
-    impl CommandMethods for sandbox::Command {
-        fn arg<T>(&mut self, arg: T)
-        where
-            T: AsRef<OsStr>,
-        {
-            self.arg(arg);
-        }
-
-        fn env<T, U>(&mut self, key: T, val: U)
-        where
-            T: AsRef<OsStr>,
-            U: AsRef<OsStr>,
-        {
-            self.env(key, val);
-        }
-    }
-
     // Note that this function can panic, due to process creation,
     // avoiding this panic would require a mechanism for dealing
     // with low-resource scenarios.
@@ -262,6 +245,31 @@ trait CommandMethods {
     where
         T: AsRef<OsStr>,
         U: AsRef<OsStr>;
+}
+
+#[cfg(all(
+    not(target_os = "windows"),
+    not(target_os = "ios"),
+    not(target_os = "android"),
+    not(target_env = "ohos"),
+    not(target_arch = "arm"),
+    not(target_arch = "aarch64")
+))]
+impl CommandMethods for gaol::sandbox::Command {
+    fn arg<T>(&mut self, arg: T)
+    where
+        T: AsRef<OsStr>,
+    {
+        self.arg(arg);
+    }
+
+    fn env<T, U>(&mut self, key: T, val: U)
+    where
+        T: AsRef<OsStr>,
+        U: AsRef<OsStr>,
+    {
+        self.env(key, val);
+    }
 }
 
 impl CommandMethods for process::Command {

--- a/components/constellation/sandboxing.rs
+++ b/components/constellation/sandboxing.rs
@@ -158,11 +158,11 @@ pub fn spawn_multiprocess(content: UnprivilegedContent) -> Result<(), Error> {
     let path_to_self = env::current_exe().expect("Failed to get current executor.");
     let mut child_process = process::Command::new(path_to_self);
     setup_common(&mut child_process, token);
+
+    #[allow(clippy::zombie_processes)]
     let _ = child_process
         .spawn()
-        .expect("Failed to start unsandboxed child process!")
-        .wait()
-        .expect("Failed to wait on unsandboxed child process!");
+        .expect("Failed to start unsandboxed child process!");
 
     let (_receiver, sender) = server.accept().expect("Server failed to accept.");
     sender.send(content)?;
@@ -221,11 +221,11 @@ pub fn spawn_multiprocess(content: UnprivilegedContent) -> Result<(), Error> {
         let path_to_self = env::current_exe().expect("Failed to get current executor.");
         let mut child_process = process::Command::new(path_to_self);
         setup_common(&mut child_process, token);
+
+        #[allow(clippy::zombie_processes)]
         let _ = child_process
             .spawn()
-            .expect("Failed to start unsandboxed child process!")
-            .wait()
-            .expect("Failed to wait on unsandboxed child process!");
+            .expect("Failed to start unsandboxed child process!");
     }
 
     let (_receiver, sender) = server.accept().expect("Server failed to accept.");

--- a/components/constellation/sandboxing.rs
+++ b/components/constellation/sandboxing.rs
@@ -182,6 +182,26 @@ pub fn spawn_multiprocess(content: UnprivilegedContent) -> Result<(), Error> {
     use gaol::sandbox::{self, Sandbox, SandboxMethods};
     use ipc_channel::ipc::{IpcOneShotServer, IpcSender};
 
+    // TODO: Move this impl out of the function. It is only currently here to avoid
+    // duplicating the feature flagging.
+    #[allow(non_local_definitions)]
+    impl CommandMethods for gaol::sandbox::Command {
+        fn arg<T>(&mut self, arg: T)
+        where
+            T: AsRef<OsStr>,
+        {
+            self.arg(arg);
+        }
+
+        fn env<T, U>(&mut self, key: T, val: U)
+        where
+            T: AsRef<OsStr>,
+            U: AsRef<OsStr>,
+        {
+            self.env(key, val);
+        }
+    }
+
     // Note that this function can panic, due to process creation,
     // avoiding this panic would require a mechanism for dealing
     // with low-resource scenarios.
@@ -247,31 +267,6 @@ trait CommandMethods {
     where
         T: AsRef<OsStr>,
         U: AsRef<OsStr>;
-}
-
-#[cfg(all(
-    not(target_os = "windows"),
-    not(target_os = "ios"),
-    not(target_os = "android"),
-    not(target_env = "ohos"),
-    not(target_arch = "arm"),
-    not(target_arch = "aarch64")
-))]
-impl CommandMethods for gaol::sandbox::Command {
-    fn arg<T>(&mut self, arg: T)
-    where
-        T: AsRef<OsStr>,
-    {
-        self.arg(arg);
-    }
-
-    fn env<T, U>(&mut self, key: T, val: U)
-    where
-        T: AsRef<OsStr>,
-        U: AsRef<OsStr>,
-    {
-        self.env(key, val);
-    }
 }
 
 impl CommandMethods for process::Command {

--- a/components/constellation/sandboxing.rs
+++ b/components/constellation/sandboxing.rs
@@ -160,7 +160,9 @@ pub fn spawn_multiprocess(content: UnprivilegedContent) -> Result<(), Error> {
     setup_common(&mut child_process, token);
     let _ = child_process
         .spawn()
-        .expect("Failed to start unsandboxed child process!");
+        .expect("Failed to start unsandboxed child process!")
+        .wait()
+        .expect("Failed to wait on unsandboxed child process!");
 
     let (_receiver, sender) = server.accept().expect("Server failed to accept.");
     sender.send(content)?;

--- a/components/domobject_derive/lib.rs
+++ b/components/domobject_derive/lib.rs
@@ -35,7 +35,7 @@ fn expand_dom_object(input: syn::DeriveInput) -> proc_macro2::TokenStream {
 
     let name = &input.ident;
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
-    let mut items = quote! {
+    let items = quote! {
         impl #impl_generics ::js::conversions::ToJSValConvertible for #name #ty_generics #where_clause {
             #[allow(unsafe_code)]
             unsafe fn to_jsval(&self,
@@ -66,6 +66,15 @@ fn expand_dom_object(input: syn::DeriveInput) -> proc_macro2::TokenStream {
                 crate::DomObject::reflector(self) == crate::DomObject::reflector(other)
             }
         }
+    };
+
+    let mut params = proc_macro2::TokenStream::new();
+    params.append_separated(
+        input.generics.type_params().map(|param| &param.ident),
+        quote! {,},
+    );
+
+    let mut dummy_items = quote! {
 
         // Generic trait with a blanket impl over `()` for all types.
         // becomes ambiguous if impl
@@ -83,13 +92,7 @@ fn expand_dom_object(input: syn::DeriveInput) -> proc_macro2::TokenStream {
         impl<T> NoDomObjectInDomObject<Invalid> for T where T: ?Sized + crate::DomObject {}
     };
 
-    let mut params = proc_macro2::TokenStream::new();
-    params.append_separated(
-        input.generics.type_params().map(|param| &param.ident),
-        quote! {,},
-    );
-
-    items.append_all(field_types.iter().enumerate().map(|(i, ty)| {
+    dummy_items.append_all(field_types.iter().enumerate().map(|(i, ty)| {
         let s = syn::Ident::new(&format!("S{i}"), proc_macro2::Span::call_site());
         quote! {
             struct #s<#params>(#params);
@@ -111,7 +114,8 @@ fn expand_dom_object(input: syn::DeriveInput) -> proc_macro2::TokenStream {
     );
     let tokens = quote! {
         #[allow(non_upper_case_globals)]
-        const #dummy_const: () = { #items };
+        const #dummy_const: () = { #dummy_items };
+        #items
     };
 
     tokens

--- a/components/domobject_derive/lib.rs
+++ b/components/domobject_derive/lib.rs
@@ -75,7 +75,6 @@ fn expand_dom_object(input: syn::DeriveInput) -> proc_macro2::TokenStream {
     );
 
     let mut dummy_items = quote! {
-
         // Generic trait with a blanket impl over `()` for all types.
         // becomes ambiguous if impl
         trait NoDomObjectInDomObject<A> {

--- a/components/fonts/glyph.rs
+++ b/components/fonts/glyph.rs
@@ -353,7 +353,7 @@ pub enum GlyphInfo<'a> {
     Detail(&'a GlyphStore, ByteIndex, u16),
 }
 
-impl<'a> GlyphInfo<'a> {
+impl GlyphInfo<'_> {
     pub fn id(self) -> GlyphId {
         match self {
             GlyphInfo::Simple(store, entry_i) => store.entry_buffer[entry_i.to_usize()].id(),

--- a/components/hyper_serde/lib.rs
+++ b/components/hyper_serde/lib.rs
@@ -62,6 +62,7 @@
 
 #![deny(missing_docs)]
 #![deny(unsafe_code)]
+#![allow(clippy::needless_lifetimes)]
 
 use std::ops::{Deref, DerefMut};
 use std::str::FromStr;

--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -1859,7 +1859,7 @@ impl<'container> PlacementState<'container> {
     fn new(
         collapsible_with_parent_start_margin: CollapsibleWithParentStartMargin,
         containing_block: &'container ContainingBlock<'container>,
-    ) -> PlacementState {
+    ) -> PlacementState<'container> {
         let is_inline_block_context =
             containing_block.style.get_box().clone_display() == Display::InlineBlock;
         PlacementState {

--- a/components/layout_2020/lib.rs
+++ b/components/layout_2020/lib.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #![deny(unsafe_code)]
+#![allow(clippy::needless_lifetimes)]
 
 mod cell;
 pub mod context;

--- a/components/layout_2020/table/layout.rs
+++ b/components/layout_2020/table/layout.rs
@@ -218,7 +218,7 @@ impl Zero for CellOrTrackMeasure {
 }
 
 impl<'a> TableLayout<'a> {
-    fn new(table: &'a Table) -> TableLayout {
+    fn new(table: &'a Table) -> TableLayout<'a> {
         Self {
             table,
             pbm: PaddingBorderMargin::zero(),

--- a/components/layout_2020/taffy/layout.rs
+++ b/components/layout_2020/taffy/layout.rs
@@ -75,7 +75,10 @@ impl Iterator for ChildIter {
 }
 
 impl taffy::TraversePartialTree for TaffyContainerContext<'_> {
-    type ChildIter<'a> = ChildIter where Self: 'a;
+    type ChildIter<'a>
+        = ChildIter
+    where
+        Self: 'a;
 
     fn child_ids(&self, _node_id: taffy::NodeId) -> Self::ChildIter<'_> {
         ChildIter(0..self.source_child_nodes.len())
@@ -91,7 +94,10 @@ impl taffy::TraversePartialTree for TaffyContainerContext<'_> {
 }
 
 impl taffy::LayoutPartialTree for TaffyContainerContext<'_> {
-    type CoreContainerStyle<'a> = TaffyStyloStyle<&'a ComputedValues> where Self: 'a;
+    type CoreContainerStyle<'a>
+        = TaffyStyloStyle<&'a ComputedValues>
+    where
+        Self: 'a;
 
     fn get_core_container_style(&self, _node_id: taffy::NodeId) -> Self::CoreContainerStyle<'_> {
         TaffyStyloStyle(self.style)
@@ -283,11 +289,13 @@ impl taffy::LayoutPartialTree for TaffyContainerContext<'_> {
 }
 
 impl taffy::LayoutGridContainer for TaffyContainerContext<'_> {
-    type GridContainerStyle<'a> = TaffyStyloStyle<&'a ComputedValues>
+    type GridContainerStyle<'a>
+        = TaffyStyloStyle<&'a ComputedValues>
     where
         Self: 'a;
 
-    type GridItemStyle<'a> = TaffyStyloStyle<AtomicRef<'a, ComputedValues>>
+    type GridItemStyle<'a>
+        = TaffyStyloStyle<AtomicRef<'a, ComputedValues>>
     where
         Self: 'a;
 

--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -160,7 +160,7 @@ impl MallocSizeOf for String {
     }
 }
 
-impl<'a, T: ?Sized> MallocSizeOf for &'a T {
+impl<T: ?Sized> MallocSizeOf for &'_ T {
     fn size_of(&self, _ops: &mut MallocSizeOfOps) -> usize {
         // Zero makes sense for a non-owning reference.
         0
@@ -249,7 +249,7 @@ impl<T: MallocSizeOf> MallocSizeOf for std::cell::RefCell<T> {
     }
 }
 
-impl<'a, B: ?Sized + ToOwned> MallocSizeOf for std::borrow::Cow<'a, B>
+impl<B: ?Sized + ToOwned> MallocSizeOf for std::borrow::Cow<'_, B>
 where
     B::Owned: MallocSizeOf,
 {

--- a/components/net/cookie.rs
+++ b/components/net/cookie.rs
@@ -206,6 +206,7 @@ impl ServoCookie {
 
             // 3. The cookie-attribute-list contains an attribute with an attribute-name of "Path",
             // and the cookie's path is /.
+            #[allow(clippy::nonminimal_bool)]
             if !has_path_specified || !cookie.path().is_some_and(|path| path == "/") {
                 return None;
             }

--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -25,15 +25,15 @@ use webrender_traits::{CrossProcessCompositorApi, SerializableImageData};
 
 use crate::resource_thread::CoreResourceThreadPool;
 
-///
-/// TODO(gw): Remaining work on image cache:
-///     * Make use of the prefetch support in various parts of the code.
-///     * Profile time in GetImageIfAvailable - might be worth caching these
-///       results per paint / layout.
-///
-/// MAYBE(Yoric):
-///     * For faster lookups, it might be useful to store the LoadKey in the
-///       DOM once we have performed a first load.
+//
+// TODO(gw): Remaining work on image cache:
+//     * Make use of the prefetch support in various parts of the code.
+//     * Profile time in GetImageIfAvailable - might be worth caching these
+//       results per paint / layout.
+//
+// MAYBE(Yoric):
+//     * For faster lookups, it might be useful to store the LoadKey in the
+//       DOM once we have performed a first load.
 
 // ======================================================================
 // Helper functions.

--- a/components/script/build.rs
+++ b/components/script/build.rs
@@ -56,7 +56,7 @@ fn main() {
 #[derive(Eq, Hash, PartialEq)]
 struct Bytes<'a>(&'a str);
 
-impl<'a> FmtConst for Bytes<'a> {
+impl FmtConst for Bytes<'_> {
     fn fmt_const(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         // https://github.com/rust-lang/rust/issues/55223
         // should technically be just `write!(formatter, "b\"{}\"", self.0)
@@ -65,7 +65,7 @@ impl<'a> FmtConst for Bytes<'a> {
     }
 }
 
-impl<'a> phf_shared::PhfHash for Bytes<'a> {
+impl phf_shared::PhfHash for Bytes<'_> {
     fn phf_hash<H: std::hash::Hasher>(&self, hasher: &mut H) {
         self.0.as_bytes().phf_hash(hasher)
     }

--- a/components/script/dom/audiobuffer.rs
+++ b/components/script/dom/audiobuffer.rs
@@ -179,7 +179,7 @@ impl AudioBuffer {
                 *self.shared_channels.borrow_mut() = channels;
             }
         }
-        return self.shared_channels.borrow();
+        self.shared_channels.borrow()
     }
 }
 

--- a/components/script/dom/bindings/finalize.rs
+++ b/components/script/dom/bindings/finalize.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+//! Generic finalizer implementations for DOM binding implementations.
+
 use std::any::type_name;
 use std::mem;
 
@@ -11,8 +13,6 @@ use js::jsval::UndefinedValue;
 
 use crate::dom::bindings::utils::finalize_global as do_finalize_global;
 use crate::dom::bindings::weakref::{WeakBox, WeakReferenceable, DOM_WEAK_SLOT};
-
-// Generic finalizer implementations for DOM binding implementations.
 
 pub unsafe fn finalize_common<T>(this: *const T) {
     if !this.is_null() {

--- a/components/script/dom/bindings/finalize.rs
+++ b/components/script/dom/bindings/finalize.rs
@@ -12,7 +12,7 @@ use js::jsval::UndefinedValue;
 use crate::dom::bindings::utils::finalize_global as do_finalize_global;
 use crate::dom::bindings::weakref::{WeakBox, WeakReferenceable, DOM_WEAK_SLOT};
 
-/// Generic finalizer implementations for DOM binding implementations.
+// Generic finalizer implementations for DOM binding implementations.
 
 pub unsafe fn finalize_common<T>(this: *const T) {
     if !this.is_null() {

--- a/components/script/dom/bindings/proxyhandler.rs
+++ b/components/script/dom/bindings/proxyhandler.rs
@@ -631,7 +631,7 @@ pub unsafe fn cross_origin_get_own_property_helper(
         holder.handle_mut().into(),
     );
 
-    return JS_GetOwnPropertyDescriptorById(*cx, holder.handle().into(), id, desc, is_none);
+    JS_GetOwnPropertyDescriptorById(*cx, holder.handle().into(), id, desc, is_none)
 }
 
 /// Implementation of [`CrossOriginPropertyFallback`].

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -483,9 +483,9 @@ impl HTMLFormElementMethods<crate::DomTypeHolder> for HTMLFormElement {
         );
 
         // Step 6
-        return Some(RadioNodeListOrElement::Element(DomRoot::from_ref(
+        Some(RadioNodeListOrElement::Element(DomRoot::from_ref(
             element_node.downcast::<Element>().unwrap(),
-        )));
+        )))
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-a-rel

--- a/components/script/dom/mediafragmentparser.rs
+++ b/components/script/dom/mediafragmentparser.rs
@@ -293,7 +293,7 @@ fn parse_npt_seconds(s: &str) -> Result<f64, ()> {
 
 fn parse_hms(s: &str) -> Result<f64, ()> {
     let mut vec: VecDeque<&str> = s.split(':').collect();
-    vec.retain(|x| !x.eq(&""));
+    vec.retain(|x| !x.is_empty());
 
     let result = match vec.len() {
         1 => {

--- a/components/script/dom/performance.rs
+++ b/components/script/dom/performance.rs
@@ -198,8 +198,8 @@ impl Performance {
         self.resource_timing_buffer_size_limit.set(0);
     }
 
-    /// Add a PerformanceObserver to the list of observers with a set of
-    /// observed entry types.
+    // Add a PerformanceObserver to the list of observers with a set of
+    // observed entry types.
 
     pub fn add_multiple_type_observer(
         &self,

--- a/components/script/dom/resizeobserver.rs
+++ b/components/script/dom/resizeobserver.rs
@@ -219,10 +219,11 @@ enum ObservationState {
 }
 
 /// <https://drafts.csswg.org/resize-observer/#resizeobservation>
+///
+/// Note: `target` is kept out of here, to avoid having to root the `ResizeObservation`.
+/// <https://drafts.csswg.org/resize-observer/#dom-resizeobservation-target>
 #[derive(JSTraceable, MallocSizeOf)]
 struct ResizeObservation {
-    // <https://drafts.csswg.org/resize-observer/#dom-resizeobservation-target>
-    // Note: `target` is kept out of here, to avoid having to root the `ResizeObservation`.
     /// <https://drafts.csswg.org/resize-observer/#dom-resizeobservation-observedbox>
     observed_box: RefCell<ResizeObserverBoxOptions>,
     /// <https://drafts.csswg.org/resize-observer/#dom-resizeobservation-lastreportedsizes>

--- a/components/script/dom/resizeobserver.rs
+++ b/components/script/dom/resizeobserver.rs
@@ -221,8 +221,8 @@ enum ObservationState {
 /// <https://drafts.csswg.org/resize-observer/#resizeobservation>
 #[derive(JSTraceable, MallocSizeOf)]
 struct ResizeObservation {
-    /// <https://drafts.csswg.org/resize-observer/#dom-resizeobservation-target>
-    /// Note: `target` is kept out of here, to avoid having to root the `ResizeObservation`.
+    // <https://drafts.csswg.org/resize-observer/#dom-resizeobservation-target>
+    // Note: `target` is kept out of here, to avoid having to root the `ResizeObservation`.
 
     /// <https://drafts.csswg.org/resize-observer/#dom-resizeobservation-observedbox>
     observed_box: RefCell<ResizeObserverBoxOptions>,

--- a/components/script/dom/resizeobserver.rs
+++ b/components/script/dom/resizeobserver.rs
@@ -223,7 +223,6 @@ enum ObservationState {
 struct ResizeObservation {
     // <https://drafts.csswg.org/resize-observer/#dom-resizeobservation-target>
     // Note: `target` is kept out of here, to avoid having to root the `ResizeObservation`.
-
     /// <https://drafts.csswg.org/resize-observer/#dom-resizeobservation-observedbox>
     observed_box: RefCell<ResizeObserverBoxOptions>,
     /// <https://drafts.csswg.org/resize-observer/#dom-resizeobservation-lastreportedsizes>

--- a/components/script/dom/servoparser/async_html.rs
+++ b/components/script/dom/servoparser/async_html.rs
@@ -701,7 +701,10 @@ impl TreeSink for Sink {
     }
 
     type Handle = ParseNode;
-    type ElemName<'a> = ExpandedName<'a> where Self: 'a;
+    type ElemName<'a>
+        = ExpandedName<'a>
+    where
+        Self: 'a;
 
     fn get_document(&self) -> Self::Handle {
         self.document_node.clone()

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -1135,7 +1135,10 @@ impl TreeSink for Sink {
     }
 
     type Handle = Dom<Node>;
-    type ElemName<'a> = ExpandedName<'a> where Self: 'a;
+    type ElemName<'a>
+        = ExpandedName<'a>
+    where
+        Self: 'a;
 
     #[allow(crown::unrooted_must_root)]
     fn get_document(&self) -> Dom<Node> {

--- a/components/script/dom/webgl_validations/tex_image_2d.rs
+++ b/components/script/dom/webgl_validations/tex_image_2d.rs
@@ -435,8 +435,8 @@ fn valid_compressed_data_len(
     let block_width = compression.block_width as u32;
     let block_height = compression.block_height as u32;
 
-    let required_blocks_hor = (width + block_width - 1) / block_width;
-    let required_blocks_ver = (height + block_height - 1) / block_height;
+    let required_blocks_hor = width.div_ceil(block_width);
+    let required_blocks_ver = height.div_ceil(block_height);
     let required_blocks = required_blocks_hor * required_blocks_ver;
 
     let required_bytes = required_blocks * compression.bytes_per_block as u32;

--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -930,7 +930,7 @@ unsafe extern "C" fn getOwnPropertyDescriptor(
     let mut slot = UndefinedValue();
     GetProxyPrivate(proxy.get(), &mut slot);
     rooted!(in(cx) let target = slot.to_object());
-    return JS_GetOwnPropertyDescriptorById(cx, target.handle().into(), id, desc, is_none);
+    JS_GetOwnPropertyDescriptorById(cx, target.handle().into(), id, desc, is_none)
 }
 
 #[allow(unsafe_code, non_snake_case)]

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -11,6 +11,7 @@
 #![register_tool(crown)]
 #![cfg_attr(any(doc, clippy), allow(unknown_lints))]
 #![deny(crown_is_not_used)]
+#![allow(clippy::needless_lifetimes)]
 
 // These are used a lot so let's keep them for now
 #[macro_use]

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -5,6 +5,7 @@
 #![crate_name = "webdriver_server"]
 #![crate_type = "rlib"]
 #![deny(unsafe_code)]
+#![allow(clippy::needless_lifetimes)]
 
 mod actions;
 mod capabilities;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 # Be sure to update shell.nix and support/crown/rust-toolchain.toml when bumping this!
-channel = "1.82.0"
+channel = "1.83.0"
 
 components = [
     "clippy",

--- a/shell.nix
+++ b/shell.nix
@@ -10,7 +10,7 @@ with import (builtins.fetchTarball {
   overlays = [
     (import (builtins.fetchTarball {
       # Bumped the channel in rust-toolchain.toml? Bump this commit too!
-      url = "https://github.com/oxalica/rust-overlay/archive/0be641045af6d8666c11c2c40e45ffc9667839b5.tar.gz";
+      url = "https://github.com/oxalica/rust-overlay/archive/10faa81b4c0135a04716cbd1649260d82b2890cd.tar.gz";
     }))
   ];
   config = {

--- a/support/crown/rust-toolchain.toml
+++ b/support/crown/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.82.0"
+channel = "1.83.0"
 
 components = [
     "clippy",

--- a/support/crown/src/common.rs
+++ b/support/crown/src/common.rs
@@ -101,12 +101,11 @@ fn find_primitive_impls<'tcx>(tcx: TyCtxt<'tcx>, name: &str) -> impl Iterator<It
         _ => {
             return Result::<_, rustc_errors::ErrorGuaranteed>::Ok(&[] as &[_])
                 .into_iter()
-                .flatten()
                 .copied();
         },
     };
 
-    tcx.incoherent_impls(ty).into_iter().flatten().copied()
+    tcx.incoherent_impls(ty).into_iter().copied()
 }
 
 fn non_local_item_children_by_name(tcx: TyCtxt<'_>, def_id: DefId, name: Symbol) -> Vec<Res> {

--- a/support/crown/src/common.rs
+++ b/support/crown/src/common.rs
@@ -99,13 +99,11 @@ fn find_primitive_impls<'tcx>(tcx: TyCtxt<'tcx>, name: &str) -> impl Iterator<It
         "f64" => SimplifiedType::Float(FloatTy::F64),
         #[allow(trivial_casts)]
         _ => {
-            return Result::<_, rustc_errors::ErrorGuaranteed>::Ok(&[] as &[_])
-                .into_iter()
-                .copied();
+            return [].iter().copied();
         },
     };
 
-    tcx.incoherent_impls(ty).into_iter().copied()
+    tcx.incoherent_impls(ty).iter().copied()
 }
 
 fn non_local_item_children_by_name(tcx: TyCtxt<'_>, def_id: DefId, name: Symbol) -> Vec<Res> {
@@ -234,7 +232,6 @@ pub fn def_path_res(cx: &LateContext<'_>, path: &[&str]) -> Vec<Res> {
                 let inherent_impl_children = tcx
                     .inherent_impls(def_id)
                     .into_iter()
-                    .flatten()
                     .flat_map(|&impl_def_id| item_children_by_name(tcx, impl_def_id, segment));
 
                 let direct_children = item_children_by_name(tcx, def_id, segment);
@@ -279,7 +276,6 @@ pub fn def_local_res(cx: &LateContext<'_>, path: &str) -> Vec<Res> {
             let inherent_impl_children = tcx
                 .inherent_impls(def_id)
                 .into_iter()
-                .flatten()
                 .flat_map(|&impl_def_id| item_children_by_name(tcx, impl_def_id, segment));
 
             let direct_children = item_children_by_name(tcx, def_id, segment);


### PR DESCRIPTION
- Upgraded rustc version to 1.83
- Fixed crown compile
- Fixed clippy lints
- Fixed formatting

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

## Notes

This is currently producing a warning similar to the following for every usage of `#[dom_struct]`. Advice on the best way to resolve this would be appreciated! 

```
warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
  --> components/script/dom/xpathexpression.rs:18:1
   |
18 | #[dom_struct]
   | ^------------
   | |
   | `ToJSValConvertible` is not local
   | move the `impl` block outside of this constant `_IMPL_DOMOBJECT_FOR_XPathExpression`
19 | pub struct XPathExpression {
   |            --------------- `XPathExpression` is not local
   |
   = note: the derive macro `domobject_derive::DomObject` defines the non-local `impl`, and may need to be changed
   = note: the derive macro `domobject_derive::DomObject` may come from an old version of the `domobject_derive` crate, try updating your dependency with `cargo update -p domobject_derive`
   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
   = note: items in an anonymous const item (`const _: () = { ... }`) are treated as in the same scope as the anonymous const's declaration for the purpose of this lint
   = note: this warning originates in the derive macro `domobject_derive::DomObject` which comes from the expansion of the attribute macro `dom_struct` (in Nightly builds, run with -Z macro-backtrace for more info)
   ```