### PR TITLE
Fix IS_IN_SHADOW_TREE flag for descendants after Node::remove call

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -3665,7 +3665,11 @@ impl VirtualMethods for Element {
         }
         if let Some(ref value) = *self.id_attribute.borrow() {
             if let Some(ref shadow_root) = self.containing_shadow_root() {
-                shadow_root.unregister_element_id(self, value.clone());
+                // Only unregister the element id if the node was disconnected from it's shadow root
+                // (as opposed to the whole shadow tree being disconnected as a whole)
+                if !self.upcast::<Node>().is_in_shadow_tree() {
+                    shadow_root.unregister_element_id(self, value.clone());
+                }
             } else {
                 doc.unregister_element_id(self, value.clone());
             }

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -608,6 +608,11 @@ impl Node {
         self.flags.get().contains(NodeFlags::IS_CONNECTED)
     }
 
+    /// Return true iff the node's root is a Document or a ShadowRoot
+    pub fn is_connected_to_tree(&self) -> bool {
+        self.is_connected() || self.is_in_shadow_tree()
+    }
+
     /// Returns the type ID of this node.
     pub fn type_id(&self) -> NodeTypeId {
         match *self.eventtarget.type_id() {
@@ -3559,6 +3564,8 @@ pub struct UnbindContext<'a> {
     /// The next sibling of the inclusive ancestor that was removed.
     pub next_sibling: Option<&'a Node>,
     /// Whether the tree is connected.
+    ///
+    /// A tree is connected iff it's root is a Document or a ShadowRoot.
     pub tree_connected: bool,
     /// Whether the tree is in doc.
     pub tree_in_doc: bool,
@@ -3577,7 +3584,7 @@ impl<'a> UnbindContext<'a> {
             parent,
             prev_sibling,
             next_sibling,
-            tree_connected: parent.is_connected(),
+            tree_connected: parent.is_connected_to_tree(),
             tree_in_doc: parent.is_in_doc(),
         }
     }

--- a/tests/wpt/meta/shadow-dom/getElementById-dynamic-001.html.ini
+++ b/tests/wpt/meta/shadow-dom/getElementById-dynamic-001.html.ini
@@ -1,3 +1,0 @@
-[getElementById-dynamic-001.html]
-  [ShadowRoot.getElementById keeps working after host has been removed]
-    expected: FAIL


### PR DESCRIPTION
Every node needs a way to keep track of whether or not it is inside a shadow tree (meaning that at least one of its inclusive ancestors is a shadow root). This is currently handled by a boolean flag. Currenty we don't do this correctly (https://github.com/servo/servo/issues/34740, https://github.com/servo/servo/pull/34787#issuecomment-2564577001)

By traversing the affected subtree of a dom-disconnect operation in two seperate stages it becomes possible to handle shadow roots correctly.

This also adds `Node::is_connected_to_tree`  (This is equivalent to webkits `Node::IsisInTreeScope`), which should be used in many places where `Node::is_connected` is currently used, to support shadow roots.

[try run](https://github.com/simonwuelker/servo/actions/runs/12550447998)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #34740
- [X] There are tests for these changes (covered by wpt)
