### PR TITLE
Support syntax highlighting of arguments in the devtools console

### DIFF
--- a/components/devtools/actors/console.rs
+++ b/components/devtools/actors/console.rs
@@ -272,40 +272,17 @@ impl ConsoleActor {
         id: UniqueId,
         registry: &ActorRegistry,
     ) {
-        let level = match console_message.log_level {
-            LogLevel::Debug => "debug",
-            LogLevel::Info => "info",
-            LogLevel::Warn => "warn",
-            LogLevel::Error => "error",
-            LogLevel::Clear => "clear",
-            LogLevel::Trace => "trace",
-            LogLevel::Log => "log",
-        }
-        .to_owned();
-
-        let console_api = ConsoleLog {
-            level,
-            filename: console_message.filename,
-            line_number: console_message.line_number as u32,
-            column_number: console_message.column_number as u32,
-            time_stamp: SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_millis() as u64,
-            arguments: vec![console_message.message],
-            stacktrace: console_message.stacktrace,
-        };
-
+        let log_message: ConsoleLog = console_message.into();
         self.cached_events
             .borrow_mut()
             .entry(id.clone())
             .or_default()
-            .push(CachedConsoleMessage::ConsoleLog(console_api.clone()));
+            .push(CachedConsoleMessage::ConsoleLog(log_message.clone()));
         if id == self.current_unique_id(registry) {
             if let Root::BrowsingContext(bc) = &self.root {
                 registry
                     .find::<BrowsingContextActor>(bc)
-                    .resource_available(console_api, "console-message".into())
+                    .resource_available(log_message, "console-message".into())
             };
         }
     }

--- a/components/devtools/actors/console.rs
+++ b/components/devtools/actors/console.rs
@@ -17,7 +17,7 @@ use devtools_traits::EvaluateJSReply::{
 };
 use devtools_traits::{
     CachedConsoleMessage, CachedConsoleMessageTypes, ConsoleLog, ConsoleMessage,
-    DevtoolScriptControlMsg, LogLevel, PageError,
+    DevtoolScriptControlMsg, PageError,
 };
 use ipc_channel::ipc::{self, IpcSender};
 use log::debug;

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -22,9 +22,9 @@ use std::thread;
 use base::id::{BrowsingContextId, PipelineId};
 use crossbeam_channel::{unbounded, Receiver, Sender};
 use devtools_traits::{
-    ChromeToDevtoolsControlMsg, ConsoleLog, ConsoleMessage, ConsoleMessageBuilder,
-    DevtoolScriptControlMsg, DevtoolsControlMsg, DevtoolsPageInfo, LogLevel, NavigationState,
-    NetworkEvent, PageError, ScriptToDevtoolsControlMsg, WorkerId,
+    ChromeToDevtoolsControlMsg, ConsoleMessage, ConsoleMessageBuilder, DevtoolScriptControlMsg,
+    DevtoolsControlMsg, DevtoolsPageInfo, LogLevel, NavigationState, NetworkEvent, PageError,
+    ScriptToDevtoolsControlMsg, WorkerId,
 };
 use embedder_traits::{EmbedderMsg, EmbedderProxy, PromptDefinition, PromptOrigin, PromptResult};
 use ipc_channel::ipc::{self, IpcSender};

--- a/components/script/dom/console.rs
+++ b/components/script/dom/console.rs
@@ -6,8 +6,8 @@ use std::convert::TryFrom;
 use std::{io, ptr};
 
 use devtools_traits::{
-    ConsoleArgument, ConsoleLog, ConsoleMessage, ConsoleMessageArgument, ConsoleMessageBuilder,
-    LogLevel, ScriptToDevtoolsControlMsg, StackFrame,
+    ConsoleMessage, ConsoleMessageArgument, ConsoleMessageBuilder, LogLevel,
+    ScriptToDevtoolsControlMsg, StackFrame,
 };
 use js::jsapi::{self, ESClass, PropertyDescriptor};
 use js::jsval::UndefinedValue;
@@ -51,7 +51,12 @@ impl Console {
         Self::send_to_devtools(global, log_message);
     }
 
-    fn method(global: &GlobalScope, level: LogLevel, messages: Vec<HandleValue>, include_stacktrace: IncludeStackTrace) {
+    fn method(
+        global: &GlobalScope,
+        level: LogLevel,
+        messages: Vec<HandleValue>,
+        include_stacktrace: IncludeStackTrace,
+    ) {
         let cx = GlobalScope::get_cx();
 
         let mut log: ConsoleMessageBuilder = Console::build_message(level);
@@ -278,7 +283,7 @@ fn console_message(global: &GlobalScope, message: DOMString) {
     })
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Eq, PartialEq)]
 enum IncludeStackTrace {
     Yes,
     No,
@@ -286,7 +291,7 @@ enum IncludeStackTrace {
 
 impl consoleMethods<crate::DomTypeHolder> for Console {
     // https://developer.mozilla.org/en-US/docs/Web/API/Console/log
-    fn Log(cx: JSContext, global: &GlobalScope, messages: Vec<HandleValue>) {
+    fn Log(_cx: JSContext, global: &GlobalScope, messages: Vec<HandleValue>) {
         Console::method(global, LogLevel::Log, messages, IncludeStackTrace::No);
     }
 

--- a/components/script/dom/console.rs
+++ b/components/script/dom/console.rs
@@ -5,7 +5,10 @@
 use std::convert::TryFrom;
 use std::{io, ptr};
 
-use devtools_traits::{ConsoleMessage, LogLevel, ScriptToDevtoolsControlMsg, StackFrame};
+use devtools_traits::{
+    ConsoleArgument, ConsoleLog, ConsoleMessage, ConsoleMessageArgument, ConsoleMessageBuilder,
+    LogLevel, ScriptToDevtoolsControlMsg, StackFrame,
+};
 use js::jsapi::{self, ESClass, PropertyDescriptor};
 use js::jsval::UndefinedValue;
 use js::rust::wrappers::{
@@ -32,34 +35,55 @@ pub struct Console;
 
 impl Console {
     #[allow(unsafe_code)]
-    fn send_to_devtools(global: &GlobalScope, level: LogLevel, message: String) {
-        if let Some(chan) = global.devtools_chan() {
-            let caller =
-                unsafe { describe_scripted_caller(*GlobalScope::get_cx()) }.unwrap_or_default();
+    fn build_message(level: LogLevel) -> ConsoleMessageBuilder {
+        let cx = GlobalScope::get_cx();
+        let caller = unsafe { describe_scripted_caller(*cx) }.unwrap_or_default();
 
-            let console_message = ConsoleMessage {
-                message,
-                log_level: level,
-                filename: caller.filename,
-                line_number: caller.line as usize,
-                column_number: caller.col as usize,
-                stacktrace: get_js_stack(*GlobalScope::get_cx()),
-            };
+        ConsoleMessageBuilder::new(level, caller.filename, caller.line, caller.col)
+    }
+
+    /// Helper to send a message that only consists of a single string to the devtools
+    fn send_string_message(global: &GlobalScope, level: LogLevel, message: String) {
+        let mut builder = Self::build_message(level);
+        builder.add_argument(message.into());
+        let log_message = builder.finish();
+
+        Self::send_to_devtools(global, log_message);
+    }
+
+    fn method(global: &GlobalScope, level: LogLevel, messages: Vec<HandleValue>, include_stacktrace: IncludeStackTrace) {
+        let cx = GlobalScope::get_cx();
+
+        let mut log: ConsoleMessageBuilder = Console::build_message(level);
+        for message in &messages {
+            log.add_argument(console_argument_from_handle_value(cx, *message));
+        }
+
+        if include_stacktrace == IncludeStackTrace::Yes {
+            log.attach_stack_trace(get_js_stack(*GlobalScope::get_cx()));
+        }
+
+        Console::send_to_devtools(global, log.finish());
+
+        // Also log messages to stdout
+        console_messages(global, messages)
+    }
+
+    fn send_to_devtools(global: &GlobalScope, message: ConsoleMessage) {
+        if let Some(chan) = global.devtools_chan() {
             let worker_id = global
                 .downcast::<WorkerGlobalScope>()
                 .map(|worker| worker.get_worker_id());
-            let devtools_message = ScriptToDevtoolsControlMsg::ConsoleAPI(
-                global.pipeline_id(),
-                console_message,
-                worker_id,
-            );
+            let devtools_message =
+                ScriptToDevtoolsControlMsg::ConsoleAPI(global.pipeline_id(), message, worker_id);
             chan.send(devtools_message).unwrap();
         }
     }
 
     // Directly logs a DOMString, without processing the message
     pub fn internal_warn(global: &GlobalScope, message: DOMString) {
-        console_message(global, message, LogLevel::Warn)
+        Console::send_string_message(global, LogLevel::Warn, String::from(message.clone()));
+        console_message(global, message);
     }
 }
 
@@ -87,6 +111,22 @@ unsafe fn handle_value_to_string(cx: *mut jsapi::JSContext, value: HandleValue) 
         },
         None => "<error converting value to string>".into(),
     }
+}
+
+#[allow(unsafe_code)]
+fn console_argument_from_handle_value(
+    cx: JSContext,
+    handle_value: HandleValue,
+) -> ConsoleMessageArgument {
+    if handle_value.is_string() {
+        let js_string = ptr::NonNull::new(handle_value.to_string()).unwrap();
+        let dom_string = unsafe { jsstring_to_str(*cx, js_string) };
+        return ConsoleMessageArgument::String(dom_string.into());
+    }
+
+    // FIXME: Handle more complex argument types here
+    let stringified_value = stringify_handle_value(handle_value);
+    ConsoleMessageArgument::String(stringified_value.into())
 }
 
 #[allow(unsafe_code)]
@@ -208,110 +248,116 @@ fn stringify_handle_value(message: HandleValue) -> DOMString {
     }
 }
 
-fn stringify_handle_values(messages: Vec<HandleValue>) -> DOMString {
+fn stringify_handle_values(messages: &[HandleValue]) -> DOMString {
     DOMString::from(itertools::join(
-        messages.into_iter().map(stringify_handle_value),
+        messages.iter().copied().map(stringify_handle_value),
         " ",
     ))
 }
 
-fn console_messages(global: &GlobalScope, messages: Vec<HandleValue>, level: LogLevel) {
-    let message = stringify_handle_values(messages);
-    console_message(global, message, level)
+fn console_messages(global: &GlobalScope, messages: Vec<HandleValue>) {
+    let message = stringify_handle_values(&messages);
+    console_message(global, message)
 }
 
-fn console_message(global: &GlobalScope, message: DOMString, level: LogLevel) {
+fn console_message(global: &GlobalScope, message: DOMString) {
     with_stderr_lock(move || {
         let prefix = global.current_group_label().unwrap_or_default();
         let message = format!("{}{}", prefix, message);
         println!("{}", message);
-        Console::send_to_devtools(global, level, message);
     })
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum IncludeStackTrace {
+    Yes,
+    No,
 }
 
 impl consoleMethods<crate::DomTypeHolder> for Console {
     // https://developer.mozilla.org/en-US/docs/Web/API/Console/log
-    fn Log(_cx: JSContext, global: &GlobalScope, messages: Vec<HandleValue>) {
-        console_messages(global, messages, LogLevel::Log)
+    fn Log(cx: JSContext, global: &GlobalScope, messages: Vec<HandleValue>) {
+        Console::method(global, LogLevel::Log, messages, IncludeStackTrace::No);
     }
 
     // https://developer.mozilla.org/en-US/docs/Web/API/Console/clear
     fn Clear(global: &GlobalScope) {
-        let message: Vec<HandleValue> = Vec::new();
-        console_messages(global, message, LogLevel::Clear)
+        let message = Console::build_message(LogLevel::Clear).finish();
+        Console::send_to_devtools(global, message);
     }
 
     // https://developer.mozilla.org/en-US/docs/Web/API/Console
-    fn Debug(_cx: JSContext, global: &GlobalScope, messages: Vec<HandleValue>) {
-        console_messages(global, messages, LogLevel::Debug)
+    fn Debug(cx: JSContext, global: &GlobalScope, messages: Vec<HandleValue>) {
+        Console::method(global, LogLevel::Debug, messages, IncludeStackTrace::No);
     }
 
     // https://developer.mozilla.org/en-US/docs/Web/API/Console/info
-    fn Info(_cx: JSContext, global: &GlobalScope, messages: Vec<HandleValue>) {
-        console_messages(global, messages, LogLevel::Info)
+    fn Info(cx: JSContext, global: &GlobalScope, messages: Vec<HandleValue>) {
+        Console::method(global, LogLevel::Info, messages, IncludeStackTrace::No);
     }
 
     // https://developer.mozilla.org/en-US/docs/Web/API/Console/warn
-    fn Warn(_cx: JSContext, global: &GlobalScope, messages: Vec<HandleValue>) {
-        console_messages(global, messages, LogLevel::Warn)
+    fn Warn(cx: JSContext, global: &GlobalScope, messages: Vec<HandleValue>) {
+        Console::method(global, LogLevel::Warn, messages, IncludeStackTrace::No);
     }
 
     // https://developer.mozilla.org/en-US/docs/Web/API/Console/error
-    fn Error(_cx: JSContext, global: &GlobalScope, messages: Vec<HandleValue>) {
-        console_messages(global, messages, LogLevel::Error)
+    fn Error(cx: JSContext, global: &GlobalScope, messages: Vec<HandleValue>) {
+        Console::method(global, LogLevel::Error, messages, IncludeStackTrace::No);
     }
 
     /// <https://console.spec.whatwg.org/#trace>
-    fn Trace(_cx: JSContext, global: &GlobalScope, messages: Vec<HandleValue>) {
-        console_messages(global, messages, LogLevel::Trace)
+    fn Trace(cx: JSContext, global: &GlobalScope, messages: Vec<HandleValue>) {
+        Console::method(global, LogLevel::Trace, messages, IncludeStackTrace::Yes);
     }
 
     // https://developer.mozilla.org/en-US/docs/Web/API/Console/assert
-    fn Assert(_cx: JSContext, global: &GlobalScope, condition: bool, messages: Vec<HandleValue>) {
+    fn Assert(cx: JSContext, global: &GlobalScope, condition: bool, messages: Vec<HandleValue>) {
         if !condition {
-            let message = DOMString::from(format!(
-                "Assertion failed: {}",
-                stringify_handle_values(messages)
-            ));
-            console_message(global, message, LogLevel::Error);
+            let message = format!("Assertion failed: {}", stringify_handle_values(&messages));
+
+            Console::send_string_message(global, LogLevel::Log, message.clone());
+            console_message(global, DOMString::from(message));
         }
     }
 
     // https://console.spec.whatwg.org/#time
     fn Time(global: &GlobalScope, label: DOMString) {
         if let Ok(()) = global.time(label.clone()) {
-            let message = DOMString::from(format!("{label}: timer started"));
-            console_message(global, message, LogLevel::Log);
+            let message = format!("{label}: timer started");
+            Console::send_string_message(global, LogLevel::Log, message.clone());
+            console_message(global, DOMString::from(message));
         }
     }
 
     // https://console.spec.whatwg.org/#timelog
     fn TimeLog(_cx: JSContext, global: &GlobalScope, label: DOMString, data: Vec<HandleValue>) {
         if let Ok(delta) = global.time_log(&label) {
-            let message = DOMString::from(format!(
-                "{label}: {delta}ms {}",
-                stringify_handle_values(data)
-            ));
-            console_message(global, message, LogLevel::Log);
+            let message = format!("{label}: {delta}ms {}", stringify_handle_values(&data));
+
+            Console::send_string_message(global, LogLevel::Log, message.clone());
+            console_message(global, DOMString::from(message));
         }
     }
 
     // https://console.spec.whatwg.org/#timeend
     fn TimeEnd(global: &GlobalScope, label: DOMString) {
         if let Ok(delta) = global.time_end(&label) {
-            let message = DOMString::from(format!("{label}: {delta}ms"));
-            console_message(global, message, LogLevel::Log);
+            let message = format!("{label}: {delta}ms");
+
+            Console::send_string_message(global, LogLevel::Log, message.clone());
+            console_message(global, DOMString::from(message));
         }
     }
 
     // https://console.spec.whatwg.org/#group
     fn Group(_cx: JSContext, global: &GlobalScope, messages: Vec<HandleValue>) {
-        global.push_console_group(stringify_handle_values(messages));
+        global.push_console_group(stringify_handle_values(&messages));
     }
 
     // https://console.spec.whatwg.org/#groupcollapsed
     fn GroupCollapsed(_cx: JSContext, global: &GlobalScope, messages: Vec<HandleValue>) {
-        global.push_console_group(stringify_handle_values(messages));
+        global.push_console_group(stringify_handle_values(&messages));
     }
 
     // https://console.spec.whatwg.org/#groupend
@@ -322,8 +368,10 @@ impl consoleMethods<crate::DomTypeHolder> for Console {
     /// <https://console.spec.whatwg.org/#count>
     fn Count(global: &GlobalScope, label: DOMString) {
         let count = global.increment_console_count(&label);
-        let message = DOMString::from(format!("{label}: {count}"));
-        console_message(global, message, LogLevel::Log);
+        let message = format!("{label}: {count}");
+
+        Console::send_string_message(global, LogLevel::Log, message.clone());
+        console_message(global, DOMString::from(message));
     }
 
     /// <https://console.spec.whatwg.org/#countreset>

--- a/components/script/dom/console.rs
+++ b/components/script/dom/console.rs
@@ -125,8 +125,13 @@ fn console_argument_from_handle_value(
     }
 
     if handle_value.is_int32() {
-        let number = handle_value.to_int32();
-        return ConsoleMessageArgument::Integer(number);
+        let integer = handle_value.to_int32();
+        return ConsoleMessageArgument::Integer(integer);
+    }
+
+    if handle_value.is_number() {
+        let number = handle_value.to_number();
+        return ConsoleMessageArgument::Number(number);
     }
 
     // FIXME: Handle more complex argument types here

--- a/components/script/dom/console.rs
+++ b/components/script/dom/console.rs
@@ -297,32 +297,32 @@ impl consoleMethods<crate::DomTypeHolder> for Console {
     }
 
     // https://developer.mozilla.org/en-US/docs/Web/API/Console
-    fn Debug(cx: JSContext, global: &GlobalScope, messages: Vec<HandleValue>) {
+    fn Debug(_cx: JSContext, global: &GlobalScope, messages: Vec<HandleValue>) {
         Console::method(global, LogLevel::Debug, messages, IncludeStackTrace::No);
     }
 
     // https://developer.mozilla.org/en-US/docs/Web/API/Console/info
-    fn Info(cx: JSContext, global: &GlobalScope, messages: Vec<HandleValue>) {
+    fn Info(_cx: JSContext, global: &GlobalScope, messages: Vec<HandleValue>) {
         Console::method(global, LogLevel::Info, messages, IncludeStackTrace::No);
     }
 
     // https://developer.mozilla.org/en-US/docs/Web/API/Console/warn
-    fn Warn(cx: JSContext, global: &GlobalScope, messages: Vec<HandleValue>) {
+    fn Warn(_cx: JSContext, global: &GlobalScope, messages: Vec<HandleValue>) {
         Console::method(global, LogLevel::Warn, messages, IncludeStackTrace::No);
     }
 
     // https://developer.mozilla.org/en-US/docs/Web/API/Console/error
-    fn Error(cx: JSContext, global: &GlobalScope, messages: Vec<HandleValue>) {
+    fn Error(_cx: JSContext, global: &GlobalScope, messages: Vec<HandleValue>) {
         Console::method(global, LogLevel::Error, messages, IncludeStackTrace::No);
     }
 
     /// <https://console.spec.whatwg.org/#trace>
-    fn Trace(cx: JSContext, global: &GlobalScope, messages: Vec<HandleValue>) {
+    fn Trace(_cx: JSContext, global: &GlobalScope, messages: Vec<HandleValue>) {
         Console::method(global, LogLevel::Trace, messages, IncludeStackTrace::Yes);
     }
 
     // https://developer.mozilla.org/en-US/docs/Web/API/Console/assert
-    fn Assert(cx: JSContext, global: &GlobalScope, condition: bool, messages: Vec<HandleValue>) {
+    fn Assert(_cx: JSContext, global: &GlobalScope, condition: bool, messages: Vec<HandleValue>) {
         if !condition {
             let message = format!("Assertion failed: {}", stringify_handle_values(&messages));
 

--- a/components/script/dom/console.rs
+++ b/components/script/dom/console.rs
@@ -124,6 +124,11 @@ fn console_argument_from_handle_value(
         return ConsoleMessageArgument::String(dom_string.into());
     }
 
+    if handle_value.is_int32() {
+        let number = handle_value.to_int32();
+        return ConsoleMessageArgument::Integer(number);
+    }
+
     // FIXME: Handle more complex argument types here
     let stringified_value = stringify_handle_value(handle_value);
     ConsoleMessageArgument::String(stringified_value.into())

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -299,6 +299,7 @@ pub struct ConsoleMessage {
 pub enum ConsoleMessageArgument {
     String(String),
     Integer(i32),
+    Number(f64),
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -457,13 +458,15 @@ pub struct CssDatabaseProperty {
 pub enum ConsoleArgument {
     String(String),
     Integer(i32),
+    Number(f64),
 }
 
 impl From<ConsoleMessageArgument> for ConsoleArgument {
     fn from(value: ConsoleMessageArgument) -> Self {
         match value {
-            ConsoleMessageArgument::String(s) => Self::String(s),
-            ConsoleMessageArgument::Integer(i) => Self::Integer(i),
+            ConsoleMessageArgument::String(string) => Self::String(string),
+            ConsoleMessageArgument::Integer(integer) => Self::Integer(integer),
+            ConsoleMessageArgument::Number(number) => Self::Number(number),
         }
     }
 }

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -12,7 +12,7 @@
 
 use std::collections::HashMap;
 use std::net::TcpStream;
-use std::time::{Duration, SystemTime};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use base::cross_process_instant::CrossProcessInstant;
 use base::id::{BrowsingContextId, PipelineId};
@@ -283,15 +283,21 @@ pub enum LogLevel {
     Trace,
 }
 
+/// A console message as it is sent from script to the constellation
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ConsoleMessage {
-    pub message: String,
     pub log_level: LogLevel,
     pub filename: String,
     pub line_number: usize,
     pub column_number: usize,
-    pub stacktrace: Vec<StackFrame>,
+    pub arguments: Vec<ConsoleMessageArgument>,
+    pub stacktrace: Option<Vec<StackFrame>>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum ConsoleMessageArgument {
+    String(String),
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -335,6 +341,7 @@ pub struct PageError {
     pub private: bool,
 }
 
+/// Represents a console message as it is sent to the devtools
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ConsoleLog {
     pub level: String,
@@ -342,8 +349,39 @@ pub struct ConsoleLog {
     pub line_number: u32,
     pub column_number: u32,
     pub time_stamp: u64,
-    pub arguments: Vec<String>,
-    pub stacktrace: Vec<StackFrame>,
+    pub arguments: Vec<ConsoleArgument>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stacktrace: Option<Vec<StackFrame>>,
+}
+
+impl From<ConsoleMessage> for ConsoleLog {
+    fn from(value: ConsoleMessage) -> Self {
+        let level = match value.log_level {
+            LogLevel::Debug => "debug",
+            LogLevel::Info => "info",
+            LogLevel::Warn => "warn",
+            LogLevel::Error => "error",
+            LogLevel::Clear => "clear",
+            LogLevel::Trace => "trace",
+            LogLevel::Log => "log",
+        }
+        .to_owned();
+
+        let time_stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64;
+
+        Self {
+            level,
+            filename: value.filename,
+            line_number: value.line_number as u32,
+            column_number: value.column_number as u32,
+            time_stamp,
+            arguments: value.arguments.into_iter().map(|arg| arg.into()).collect(),
+            stacktrace: value.stacktrace,
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -411,4 +449,67 @@ pub struct CssDatabaseProperty {
     pub values: Vec<String>,
     pub supports: Vec<String>,
     pub subproperties: Vec<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum ConsoleArgument {
+    String(String),
+}
+
+impl From<ConsoleMessageArgument> for ConsoleArgument {
+    fn from(value: ConsoleMessageArgument) -> Self {
+        match value {
+            ConsoleMessageArgument::String(s) => Self::String(s),
+        }
+    }
+}
+
+impl From<String> for ConsoleMessageArgument {
+    fn from(value: String) -> Self {
+        Self::String(value)
+    }
+}
+
+pub struct ConsoleMessageBuilder {
+    level: LogLevel,
+    filename: String,
+    line_number: u32,
+    column_number: u32,
+    arguments: Vec<ConsoleMessageArgument>,
+    stack_trace: Option<Vec<StackFrame>>,
+}
+
+impl ConsoleMessageBuilder {
+    pub fn new(level: LogLevel, filename: String, line_number: u32, column_number: u32) -> Self {
+        Self {
+            level,
+            filename,
+            line_number,
+            column_number,
+            arguments: vec![],
+            stack_trace: None,
+        }
+    }
+
+    pub fn attach_stack_trace(&mut self, stack_trace: Vec<StackFrame>) -> &mut Self {
+        self.stack_trace = Some(stack_trace);
+        self
+    }
+
+    pub fn add_argument(&mut self, argument: ConsoleMessageArgument) -> &mut Self {
+        self.arguments.push(argument);
+        self
+    }
+
+    pub fn finish(self) -> ConsoleMessage {
+        ConsoleMessage {
+            log_level: self.level,
+            filename: self.filename,
+            line_number: self.line_number as usize,
+            column_number: self.column_number as usize,
+            arguments: self.arguments,
+            stacktrace: self.stack_trace,
+        }
+    }
 }

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -298,6 +298,7 @@ pub struct ConsoleMessage {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum ConsoleMessageArgument {
     String(String),
+    Integer(i32),
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -455,12 +456,14 @@ pub struct CssDatabaseProperty {
 #[serde(untagged)]
 pub enum ConsoleArgument {
     String(String),
+    Integer(i32),
 }
 
 impl From<ConsoleMessageArgument> for ConsoleArgument {
     fn from(value: ConsoleMessageArgument) -> Self {
         match value {
             ConsoleMessageArgument::String(s) => Self::String(s),
+            ConsoleMessageArgument::Integer(i) => Self::Integer(i),
         }
     }
 }


### PR DESCRIPTION
Currently, all arguments of methods like `console.log` are concatenated into one string that's then sent to the devtools server. This is not ideal, because it means that the values are not highlighted (and complex effects like object views in the devtools cannot be supported).

With this change, the values are sent to the devtools separately. To demonstrate the benefits, I also implemented support for for integer/floating point arguments, which are now properly highlighted in the devtools console.

| code | before | after | 
| --- | --- | --- |
|`console.log(1, "i am a string", 1.5);` | ![image](https://github.com/user-attachments/assets/521361a3-8a76-46bc-acb7-773478adef8f) | ![image](https://github.com/user-attachments/assets/a55e973a-3b61-4078-b0db-0c66f1d8c6ec) |
---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because they only affect devtools.  None of this is part of any web spec and there are no docs for the devtool protocol that we could test against.
