### PR TITLE
fix click event when long time in touchstart

### DIFF
--- a/components/compositing/touch.rs
+++ b/components/compositing/touch.rs
@@ -236,7 +236,11 @@ impl TouchHandler {
             Flinging { .. } => {
                 unreachable!("On touchup received, but already flinging.")
             },
-            WaitingForScript | DefaultPrevented | MultiTouch => {
+            WaitingForScript => {
+                self.state = Nothing;
+                TouchAction::Click
+            },
+            DefaultPrevented | MultiTouch => {
                 if self.active_touch_points.is_empty() {
                     self.state = Nothing;
                 }

--- a/components/compositing/touch.rs
+++ b/components/compositing/touch.rs
@@ -237,8 +237,11 @@ impl TouchHandler {
                 unreachable!("On touchup received, but already flinging.")
             },
             WaitingForScript => {
-                self.state = Nothing;
-                TouchAction::Click
+                if self.active_touch_points.is_empty() {
+                    self.state = Nothing;
+                    return TouchAction::Click;
+                }
+                TouchAction::NoAction
             },
             DefaultPrevented | MultiTouch => {
                 if self.active_touch_points.is_empty() {


### PR DESCRIPTION
fix click event when long time in touchstart
split branch in WaitingForScript and return TouchAction::Click
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #34806 (GitHub issue number if applicable)

<!-- Either: -->
- [x] There are tests for these changes WPT

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
