### PR TITLE
webxr: create glwindow with Rc window and without rendering context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8292,13 +8292,14 @@ dependencies = [
 [[package]]
 name = "webxr"
 version = "0.0.1"
-source = "git+https://github.com/wusyong/webxr?branch=rc#6dbe84a33ba5025007ea0299abff910f39174008"
+source = "git+https://github.com/wusyong/webxr?branch=rc#cdc4d26160be509785729c07bf40c143bdb6f823"
 dependencies = [
  "crossbeam-channel",
  "euclid",
  "glow",
  "log",
  "openxr",
+ "raw-window-handle",
  "serde",
  "surfman",
  "webxr-api",
@@ -8309,7 +8310,7 @@ dependencies = [
 [[package]]
 name = "webxr-api"
 version = "0.0.1"
-source = "git+https://github.com/wusyong/webxr?branch=rc#6dbe84a33ba5025007ea0299abff910f39174008"
+source = "git+https://github.com/wusyong/webxr?branch=rc#cdc4d26160be509785729c07bf40c143bdb6f823"
 dependencies = [
  "euclid",
  "ipc-channel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8292,7 +8292,7 @@ dependencies = [
 [[package]]
 name = "webxr"
 version = "0.0.1"
-source = "git+https://github.com/servo/webxr#db11d8d3c72b88ae5e3eb59679a0b2f7dd0bce7f"
+source = "git+https://github.com/wusyong/webxr?branch=rc#6dbe84a33ba5025007ea0299abff910f39174008"
 dependencies = [
  "crossbeam-channel",
  "euclid",
@@ -8309,7 +8309,7 @@ dependencies = [
 [[package]]
 name = "webxr-api"
 version = "0.0.1"
-source = "git+https://github.com/servo/webxr#db11d8d3c72b88ae5e3eb59679a0b2f7dd0bce7f"
+source = "git+https://github.com/wusyong/webxr?branch=rc#6dbe84a33ba5025007ea0299abff910f39174008"
 dependencies = [
  "euclid",
  "ipc-channel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8292,7 +8292,7 @@ dependencies = [
 [[package]]
 name = "webxr"
 version = "0.0.1"
-source = "git+https://github.com/wusyong/webxr?branch=rc#cdc4d26160be509785729c07bf40c143bdb6f823"
+source = "git+https://github.com/servo/webxr#4fd38cf6dd29ac58bafd0be2ef5337827853dcdd"
 dependencies = [
  "crossbeam-channel",
  "euclid",
@@ -8310,7 +8310,7 @@ dependencies = [
 [[package]]
 name = "webxr-api"
 version = "0.0.1"
-source = "git+https://github.com/wusyong/webxr?branch=rc#cdc4d26160be509785729c07bf40c143bdb6f823"
+source = "git+https://github.com/servo/webxr#4fd38cf6dd29ac58bafd0be2ef5337827853dcdd"
 dependencies = [
  "euclid",
  "ipc-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,6 +222,5 @@ codegen-units = 1
 #
 # Or for another Git dependency:
 #
-[patch."https://github.com/servo/webxr"]
-webxr = { git = "https://github.com/wusyong/webxr", branch = "rc" }
-webxr-api = { git = "https://github.com/wusyong/webxr", branch = "rc" }
+# [patch."https://github.com/servo/<repository>"]
+# <crate> = { path = "/path/to/local/checkout" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,5 +222,6 @@ codegen-units = 1
 #
 # Or for another Git dependency:
 #
-# [patch."https://github.com/servo/<repository>"]
-# <crate> = { path = "/path/to/local/checkout" }
+[patch."https://github.com/servo/webxr"]
+webxr = { git = "https://github.com/wusyong/webxr", branch = "rc" }
+webxr-api = { git = "https://github.com/wusyong/webxr", branch = "rc" }

--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -404,6 +404,8 @@ mod gen {
                     test: bool,
                     first_person_observer_view: bool,
                     glwindow: {
+                        /// Enable servo/webxr's glwindow port. This is enabled only if openxr is
+                        /// disabled.
                         #[serde(default)]
                         enabled: bool,
                         #[serde(rename = "dom.webxr.glwindow.left-right")]
@@ -421,6 +423,7 @@ mod gen {
                         enabled: bool,
                     },
                     openxr: {
+                        /// Enable servo/webxr's openxr port
                         enabled: bool,
                     },
                     sessionavailable: bool,

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -171,7 +171,7 @@ impl App {
         self.event_queue.push(EmbedderEvent::Idle);
         let (_, window) = self.windows.iter().next().unwrap();
 
-        let openxr_discovery = if pref!(dom.webxr.openxr.enabled) && !opts::get().headless {
+        let xr_discovery = if pref!(dom.webxr.openxr.enabled) && !opts::get().headless {
             #[cfg(target_os = "windows")]
             let openxr = {
                 let app_info = AppInfo::new("Servoshell", 0, "Servo", 0);
@@ -181,18 +181,12 @@ impl App {
             let openxr = None;
 
             openxr
-        } else {
-            None
-        };
-
-        let glwindow_discovery = if pref!(dom.webxr.glwindow.enabled) && !opts::get().headless {
+        } else if pref!(dom.webxr.glwindow.enabled) && !opts::get().headless {
             let window = window.new_glwindow(event_loop.unwrap());
             Some(XrDiscovery::GlWindow(GlWindowDiscovery::new(window)))
         } else {
             None
         };
-
-        let xr_discovery = openxr_discovery.or(glwindow_discovery);
 
         let window = window.clone();
         // Implements embedder methods, used by libservo and constellation.

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -35,7 +35,6 @@ use super::minibrowser::Minibrowser;
 use super::webview::WebViewManager;
 use super::{headed_window, headless_window};
 use crate::desktop::embedder::{EmbedderCallbacks, XrDiscovery};
-use crate::desktop::events_loop::with_current_event_loop;
 use crate::desktop::tracing::trace_winit_event;
 use crate::desktop::window_trait::WindowPortsMethods;
 use crate::parser::get_default_url;
@@ -187,17 +186,8 @@ impl App {
         };
 
         let glwindow_discovery = if pref!(dom.webxr.glwindow.enabled) && !opts::get().headless {
-            let window = window.clone();
-            let factory = Box::new(move || {
-                with_current_event_loop(|w| Ok(window.new_glwindow(w)))
-                    .expect("An event loop should always be active in headed mode")
-            });
-            Some(XrDiscovery::GlWindow(GlWindowDiscovery::new(
-                rendering_context.connection(),
-                rendering_context.adapter(),
-                rendering_context.context_attributes(),
-                factory,
-            )))
+            let window = window.new_glwindow(event_loop.unwrap());
+            Some(XrDiscovery::GlWindow(GlWindowDiscovery::new(window)))
         } else {
             None
         };

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -30,7 +30,7 @@ use winit::event::WindowEvent;
 use winit::event_loop::{ActiveEventLoop, ControlFlow};
 use winit::window::WindowId;
 
-use super::events_loop::{EventLoopGuard, EventsLoop, WakerEvent};
+use super::events_loop::{EventsLoop, WakerEvent};
 use super::minibrowser::Minibrowser;
 use super::webview::WebViewManager;
 use super::{headed_window, headless_window};
@@ -413,7 +413,6 @@ impl App {
 
 impl ApplicationHandler<WakerEvent> for App {
     fn resumed(&mut self, event_loop: &ActiveEventLoop) {
-        let _guard = EventLoopGuard::new(event_loop);
         self.init(Some(event_loop));
     }
 

--- a/ports/servoshell/desktop/events_loop.rs
+++ b/ports/servoshell/desktop/events_loop.rs
@@ -4,7 +4,6 @@
 
 //! An event loop implementation that works in headless mode.
 
-use std::cell::Cell;
 use std::sync::{Arc, Condvar, Mutex};
 use std::time;
 
@@ -12,7 +11,7 @@ use log::warn;
 use servo::config::{pref, set_pref};
 use servo::embedder_traits::EventLoopWaker;
 use winit::error::EventLoopError;
-use winit::event_loop::{ActiveEventLoop, EventLoop as WinitEventLoop};
+use winit::event_loop::EventLoop as WinitEventLoop;
 #[cfg(target_os = "macos")]
 use winit::platform::macos::{ActivationPolicy, EventLoopBuilderExtMacOS};
 
@@ -162,30 +161,5 @@ impl EventLoopWaker for HeadlessEventLoopWaker {
     }
     fn clone_box(&self) -> Box<dyn EventLoopWaker> {
         Box::new(HeadlessEventLoopWaker(self.0.clone()))
-    }
-}
-
-thread_local! {
-    static CURRENT_EVENT_LOOP: Cell<Option<*const ActiveEventLoop>> = const { Cell::new(None) };
-}
-
-pub struct EventLoopGuard;
-
-impl EventLoopGuard {
-    pub fn new(event_loop: &ActiveEventLoop) -> Self {
-        CURRENT_EVENT_LOOP.with(|cell| {
-            assert!(
-                cell.get().is_none(),
-                "Attempted to set a new event loop while one is already set"
-            );
-            cell.set(Some(event_loop as *const ActiveEventLoop));
-        });
-        Self
-    }
-}
-
-impl Drop for EventLoopGuard {
-    fn drop(&mut self) {
-        CURRENT_EVENT_LOOP.with(|cell| cell.set(None));
     }
 }

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -10,7 +10,7 @@ use std::rc::Rc;
 
 use euclid::{Angle, Length, Point2D, Rotation3D, Scale, Size2D, UnknownUnit, Vector2D, Vector3D};
 use log::{debug, info, trace};
-use raw_window_handle::HasWindowHandle;
+use raw_window_handle::{HasDisplayHandle, HasWindowHandle};
 use servo::compositing::windowing::{
     AnimationState, EmbedderCoordinates, EmbedderEvent, MouseWindowEvent, WindowMethods,
 };
@@ -504,7 +504,7 @@ impl WindowPortsMethods for Window {
         let window_attr = winit::window::Window::default_attributes()
             .with_title("Servo XR".to_string())
             .with_inner_size(size)
-            .with_visible(true);
+            .with_visible(false);
 
         let winit_window = event_loop
             .create_window(window_attr)
@@ -602,6 +602,7 @@ impl webxr::glwindow::GlWindow for XRWindow {
         device: &mut Device,
         _context: &mut Context,
     ) -> webxr::glwindow::GlWindowRenderTarget {
+        self.winit_window.set_visible(true);
         let window_handle = self
             .winit_window
             .window_handle()
@@ -635,6 +636,10 @@ impl webxr::glwindow::GlWindow for XRWindow {
         } else {
             webxr::glwindow::GlWindowMode::Blit
         }
+    }
+
+    fn display_handle(&self) -> raw_window_handle::DisplayHandle {
+        self.winit_window.display_handle().unwrap()
     }
 }
 

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -498,7 +498,7 @@ impl WindowPortsMethods for Window {
     fn new_glwindow(
         &self,
         event_loop: &winit::event_loop::ActiveEventLoop,
-    ) -> Box<dyn webxr::glwindow::GlWindow> {
+    ) -> Rc<dyn webxr::glwindow::GlWindow> {
         let size = self.winit_window.outer_size();
 
         let window_attr = winit::window::Window::default_attributes()
@@ -515,7 +515,7 @@ impl WindowPortsMethods for Window {
             xr_translation: Cell::new(Vector3D::zero()),
         });
         self.xr_window_poses.borrow_mut().push(pose.clone());
-        Box::new(XRWindow { winit_window, pose })
+        Rc::new(XRWindow { winit_window, pose })
     }
 
     fn winit_window(&self) -> Option<&winit::window::Window> {

--- a/ports/servoshell/desktop/headless_window.rs
+++ b/ports/servoshell/desktop/headless_window.rs
@@ -9,14 +9,13 @@ use std::rc::Rc;
 use std::sync::RwLock;
 
 use euclid::num::Zero;
-use euclid::{Box2D, Length, Point2D, Rotation3D, Scale, Size2D, UnknownUnit, Vector3D};
+use euclid::{Box2D, Length, Point2D, Scale, Size2D};
 use servo::compositing::windowing::{
     AnimationState, EmbedderCoordinates, EmbedderEvent, WindowMethods,
 };
 use servo::config::opts;
 use servo::servo_geometry::DeviceIndependentPixel;
 use servo::webrender_api::units::{DeviceIntSize, DevicePixel};
-use surfman::{Context, Device};
 
 use crate::desktop::window_trait::WindowPortsMethods;
 
@@ -124,7 +123,7 @@ impl WindowPortsMethods for Window {
     fn new_glwindow(
         &self,
         _events_loop: &winit::event_loop::ActiveEventLoop,
-    ) -> Box<dyn webxr::glwindow::GlWindow> {
+    ) -> Rc<dyn webxr::glwindow::GlWindow> {
         unimplemented!()
     }
 
@@ -156,23 +155,5 @@ impl WindowMethods for Window {
 
     fn set_animation_state(&self, state: AnimationState) {
         self.animation_state.set(state);
-    }
-}
-
-impl webxr::glwindow::GlWindow for Window {
-    fn get_render_target(
-        &self,
-        _device: &mut Device,
-        _context: &mut Context,
-    ) -> webxr::glwindow::GlWindowRenderTarget {
-        unimplemented!()
-    }
-
-    fn get_rotation(&self) -> Rotation3D<f32, UnknownUnit, UnknownUnit> {
-        Rotation3D::identity()
-    }
-
-    fn get_translation(&self) -> Vector3D<f32, UnknownUnit> {
-        Vector3D::zero()
     }
 }

--- a/ports/servoshell/desktop/window_trait.rs
+++ b/ports/servoshell/desktop/window_trait.rs
@@ -5,6 +5,8 @@
 //! Definition of Window.
 //! Implemented by headless and headed windows.
 
+use std::rc::Rc;
+
 use euclid::{Length, Scale};
 use servo::compositing::windowing::{EmbedderEvent, WindowMethods};
 use servo::config::opts;
@@ -41,7 +43,7 @@ pub trait WindowPortsMethods: WindowMethods {
     fn new_glwindow(
         &self,
         event_loop: &winit::event_loop::ActiveEventLoop,
-    ) -> Box<dyn webxr::glwindow::GlWindow>;
+    ) -> Rc<dyn webxr::glwindow::GlWindow>;
     fn winit_window(&self) -> Option<&winit::window::Window>;
     fn toolbar_height(&self) -> Length<f32, DeviceIndependentPixel>;
     fn set_toolbar_height(&self, height: Length<f32, DeviceIndependentPixel>);


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Companion PR of https://github.com/servo/webxr/pull/257
Part of https://github.com/servo/servo/issues/34522

This PR clarifies rendering context usage in Weber. WebXR's window creates its own Surfman context, so it doesn't really need to pass the rendering context's information. This should simplify the usage for rendering context.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [x] These changes do not require tests because but servoshell should be built successfully.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
