### PR TITLE
Elide lifetimes where possible after rustup

### DIFF
--- a/components/canvas/canvas_data.rs
+++ b/components/canvas/canvas_data.rs
@@ -136,7 +136,7 @@ struct PathBuilderRef<'a> {
     transform: Transform2D<f32>,
 }
 
-impl<'a> PathBuilderRef<'a> {
+impl PathBuilderRef<'_> {
     fn line_to(&mut self, pt: &Point2D<f32>) {
         let pt = self.transform.transform_point(*pt);
         self.builder.line_to(pt);
@@ -238,7 +238,7 @@ struct UnshapedTextRun<'a> {
     string: &'a str,
 }
 
-impl<'a> UnshapedTextRun<'a> {
+impl UnshapedTextRun<'_> {
     fn script_and_font_compatible(&self, script: Script, other_font: &Option<FontRef>) -> bool {
         if self.script != script {
             return false;
@@ -1417,7 +1417,7 @@ impl<'a> CanvasData<'a> {
     }
 }
 
-impl<'a> Drop for CanvasData<'a> {
+impl Drop for CanvasData<'_> {
     fn drop(&mut self) {
         let mut updates = vec![];
         if let Some(image_key) = self.old_image_key.take() {

--- a/components/canvas/lib.rs
+++ b/components/canvas/lib.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #![deny(unsafe_code)]
-#![allow(clippy::needless_lifetimes)]
 
 mod raqote_backend;
 

--- a/components/canvas/raqote_backend.rs
+++ b/components/canvas/raqote_backend.rs
@@ -118,7 +118,7 @@ pub enum Pattern<'a> {
     Surface(SurfacePattern<'a>),
 }
 
-impl<'a> Pattern<'a> {
+impl Pattern<'_> {
     fn set_transform(&mut self, transform: Transform2D<f32>) {
         match self {
             Pattern::Surface(pattern) => pattern.set_transform(transform),

--- a/components/canvas/webgl_limits.rs
+++ b/components/canvas/webgl_limits.rs
@@ -233,7 +233,7 @@ macro_rules! create_fun {
     };
 }
 
-impl<'a> GLExt for &'a Gl {
+impl GLExt for &Gl {
     create_fun!(
         try_get_integer,
         get_integer,

--- a/components/canvas/webxr.rs
+++ b/components/canvas/webxr.rs
@@ -310,7 +310,7 @@ pub(crate) struct WebXRBridgeContexts<'a> {
     pub(crate) bound_context_id: &'a mut Option<WebGLContextId>,
 }
 
-impl<'a> WebXRContexts<WebXRSurfman> for WebXRBridgeContexts<'a> {
+impl WebXRContexts<WebXRSurfman> for WebXRBridgeContexts<'_> {
     fn context(&mut self, device: &Device, context_id: WebXRContextId) -> Option<&mut Context> {
         let data = WebGLThread::make_current_if_needed_mut(
             device,

--- a/components/hyper_serde/lib.rs
+++ b/components/hyper_serde/lib.rs
@@ -62,7 +62,6 @@
 
 #![deny(missing_docs)]
 #![deny(unsafe_code)]
-#![allow(clippy::needless_lifetimes)]
 
 use std::ops::{Deref, DerefMut};
 use std::str::FromStr;
@@ -288,7 +287,7 @@ impl<'de> Deserialize<'de> for De<ContentType> {
     }
 }
 
-impl<'a> Serialize for Ser<'a, ContentType> {
+impl Serialize for Ser<'_, ContentType> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -304,7 +303,7 @@ impl<'de> Deserialize<'de> for De<Cookie<'static>> {
     {
         struct CookieVisitor;
 
-        impl<'de> Visitor<'de> for CookieVisitor {
+        impl Visitor<'_> for CookieVisitor {
             type Value = De<Cookie<'static>>;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
@@ -326,7 +325,7 @@ impl<'de> Deserialize<'de> for De<Cookie<'static>> {
     }
 }
 
-impl<'a, 'cookie> Serialize for Ser<'a, Cookie<'cookie>> {
+impl Serialize for Ser<'_, Cookie<'_>> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -418,14 +417,14 @@ impl<'de> Deserialize<'de> for De<HeaderMap> {
     }
 }
 
-impl<'a> Serialize for Ser<'a, HeaderMap> {
+impl Serialize for Ser<'_, HeaderMap> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
         struct Value<'headers>(&'headers [Vec<u8>], bool);
 
-        impl<'headers> Serialize for Value<'headers> {
+        impl Serialize for Value<'_> {
             fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
             where
                 S: Serializer,
@@ -469,7 +468,7 @@ impl<'de> Deserialize<'de> for De<Method> {
     {
         struct MethodVisitor;
 
-        impl<'de> Visitor<'de> for MethodVisitor {
+        impl Visitor<'_> for MethodVisitor {
             type Value = De<Method>;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
@@ -488,7 +487,7 @@ impl<'de> Deserialize<'de> for De<Method> {
     }
 }
 
-impl<'a> Serialize for Ser<'a, Method> {
+impl Serialize for Ser<'_, Method> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -504,7 +503,7 @@ impl<'de> Deserialize<'de> for De<Mime> {
     {
         struct MimeVisitor;
 
-        impl<'de> Visitor<'de> for MimeVisitor {
+        impl Visitor<'_> for MimeVisitor {
             type Value = De<Mime>;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
@@ -525,7 +524,7 @@ impl<'de> Deserialize<'de> for De<Mime> {
     }
 }
 
-impl<'a> Serialize for Ser<'a, Mime> {
+impl Serialize for Ser<'_, Mime> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -546,7 +545,7 @@ impl<'de> Deserialize<'de> for De<StatusCode> {
     }
 }
 
-impl<'a> Serialize for Ser<'a, StatusCode> {
+impl Serialize for Ser<'_, StatusCode> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -555,7 +554,7 @@ impl<'a> Serialize for Ser<'a, StatusCode> {
     }
 }
 
-impl<'a> Serialize for Ser<'a, (StatusCode, String)> {
+impl Serialize for Ser<'_, (StatusCode, String)> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -610,7 +609,7 @@ impl<'de> Deserialize<'de> for De<Uri> {
     {
         struct UriVisitor;
 
-        impl<'de> Visitor<'de> for UriVisitor {
+        impl Visitor<'_> for UriVisitor {
             type Value = De<Uri>;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
@@ -631,7 +630,7 @@ impl<'de> Deserialize<'de> for De<Uri> {
     }
 }
 
-impl<'a> Serialize for Ser<'a, Uri> {
+impl Serialize for Ser<'_, Uri> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,

--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -529,7 +529,7 @@ fn translate_including_floats(cur_b: &mut Au, delta: Au, floats: &mut Floats) {
 /// have the Root flow as their CB.
 pub struct AbsoluteAssignBSizesTraversal<'a>(pub &'a SharedStyleContext<'a>);
 
-impl<'a> PreorderFlowTraversal for AbsoluteAssignBSizesTraversal<'a> {
+impl PreorderFlowTraversal for AbsoluteAssignBSizesTraversal<'_> {
     #[inline]
     fn process(&self, flow: &mut dyn Flow) {
         if !flow.is_block_like() {

--- a/components/layout/construct.rs
+++ b/components/layout/construct.rs
@@ -1802,9 +1802,9 @@ where
     }
 }
 
-impl<'a, 'dom, ConcreteThreadSafeLayoutNode>
+impl<'dom, ConcreteThreadSafeLayoutNode>
     PostorderNodeMutTraversal<'dom, ConcreteThreadSafeLayoutNode>
-    for FlowConstructor<'a, ConcreteThreadSafeLayoutNode>
+    for FlowConstructor<'_, ConcreteThreadSafeLayoutNode>
 where
     ConcreteThreadSafeLayoutNode: ThreadSafeLayoutNode<'dom>,
 {

--- a/components/layout/context.rs
+++ b/components/layout/context.rs
@@ -54,7 +54,7 @@ pub struct LayoutContext<'a> {
     pub pending_images: Mutex<Vec<PendingImage>>,
 }
 
-impl<'a> Drop for LayoutContext<'a> {
+impl Drop for LayoutContext<'_> {
     fn drop(&mut self) {
         if !thread::panicking() {
             assert!(self.pending_images.lock().unwrap().is_empty());
@@ -62,7 +62,7 @@ impl<'a> Drop for LayoutContext<'a> {
     }
 }
 
-impl<'a> LayoutContext<'a> {
+impl LayoutContext<'_> {
     #[inline(always)]
     pub fn shared_context(&self) -> &SharedStyleContext {
         &self.style_context

--- a/components/layout/flow.rs
+++ b/components/layout/flow.rs
@@ -1231,7 +1231,7 @@ impl BaseFlow {
     }
 }
 
-impl<'a> ImmutableFlowUtils for &'a dyn Flow {
+impl ImmutableFlowUtils for &dyn Flow {
     /// Returns true if this flow is a block flow or subclass thereof.
     fn is_block_like(self) -> bool {
         self.class().is_block_like()
@@ -1332,7 +1332,7 @@ impl<'a> ImmutableFlowUtils for &'a dyn Flow {
     }
 }
 
-impl<'a> MutableFlowUtils for &'a mut dyn Flow {
+impl MutableFlowUtils for &mut dyn Flow {
     /// Calls `repair_style` and `bubble_inline_sizes`. You should use this method instead of
     /// calling them individually, since there is no reason not to perform both operations.
     fn repair_style_and_bubble_inline_sizes(self, style: &crate::ServoArc<ComputedValues>) {

--- a/components/layout/flow_list.rs
+++ b/components/layout/flow_list.rs
@@ -192,7 +192,7 @@ pub struct FlowListRandomAccessMut<'a> {
     cache: Vec<FlowRef>,
 }
 
-impl<'a> FlowListRandomAccessMut<'a> {
+impl FlowListRandomAccessMut<'_> {
     pub fn get(&mut self, index: usize) -> &mut dyn Flow {
         while index >= self.cache.len() {
             match self.iterator.next() {

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -3353,7 +3353,7 @@ impl<'a> Iterator for InlineStyleIterator<'a> {
     }
 }
 
-impl<'a> InlineStyleIterator<'a> {
+impl InlineStyleIterator<'_> {
     fn new(fragment: &Fragment) -> InlineStyleIterator {
         InlineStyleIterator {
             fragment,

--- a/components/layout/generated_content.rs
+++ b/components/layout/generated_content.rs
@@ -133,7 +133,7 @@ impl<'a> ResolveGeneratedContent<'a> {
     }
 }
 
-impl<'a> InorderFlowTraversal for ResolveGeneratedContent<'a> {
+impl InorderFlowTraversal for ResolveGeneratedContent<'_> {
     #[inline]
     fn process(&mut self, flow: &mut dyn Flow, level: u32) {
         let mut mutator = ResolveGeneratedContentFragmentMutator {
@@ -168,7 +168,7 @@ struct ResolveGeneratedContentFragmentMutator<'a, 'b: 'a> {
     incremented: bool,
 }
 
-impl<'a, 'b> ResolveGeneratedContentFragmentMutator<'a, 'b> {
+impl ResolveGeneratedContentFragmentMutator<'_, '_> {
     fn mutate_fragment(&mut self, fragment: &mut Fragment) {
         // We only reset and/or increment counters once per flow. This avoids double-incrementing
         // counters on list items (once for the main fragment and once for the marker).

--- a/components/layout/table.rs
+++ b/components/layout/table.rs
@@ -1317,7 +1317,7 @@ impl<'table> Iterator for TableCellStyleIterator<'table> {
     }
 }
 
-impl<'table> TableCellStyleInfo<'table> {
+impl TableCellStyleInfo<'_> {
     fn build_display_list(&self, mut state: &mut DisplayListBuildState) {
         use style::computed_values::visibility::T as Visibility;
 

--- a/components/layout/table_wrapper.rs
+++ b/components/layout/table_wrapper.rs
@@ -669,7 +669,7 @@ impl AutoLayoutCandidateGuess {
     }
 }
 
-impl<'a> Add for &'a AutoLayoutCandidateGuess {
+impl Add for &AutoLayoutCandidateGuess {
     type Output = AutoLayoutCandidateGuess;
     #[inline]
     fn add(self, other: &AutoLayoutCandidateGuess) -> AutoLayoutCandidateGuess {

--- a/components/layout/text_run.rs
+++ b/components/layout/text_run.rs
@@ -69,7 +69,7 @@ pub struct TextRunSlice<'a> {
     pub range: Range<ByteIndex>,
 }
 
-impl<'a> TextRunSlice<'a> {
+impl TextRunSlice<'_> {
     /// Returns the range that these glyphs encompass, relative to the start of the *text run*.
     #[inline]
     pub fn text_run_range(&self) -> Range<ByteIndex> {

--- a/components/layout/traversal.rs
+++ b/components/layout/traversal.rs
@@ -43,7 +43,7 @@ impl<'a> RecalcStyleAndConstructFlows<'a> {
 }
 
 #[allow(unsafe_code)]
-impl<'a, 'dom, E> DomTraversal<E> for RecalcStyleAndConstructFlows<'a>
+impl<'dom, E> DomTraversal<E> for RecalcStyleAndConstructFlows<'_>
 where
     E: TElement,
     E::ConcreteNode: LayoutNode<'dom>,
@@ -252,7 +252,7 @@ pub struct BubbleISizes<'a> {
     pub layout_context: &'a LayoutContext<'a>,
 }
 
-impl<'a> PostorderFlowTraversal for BubbleISizes<'a> {
+impl PostorderFlowTraversal for BubbleISizes<'_> {
     #[inline]
     fn process(&self, flow: &mut dyn Flow) {
         flow.bubble_inline_sizes();
@@ -275,7 +275,7 @@ pub struct AssignISizes<'a> {
     pub layout_context: &'a LayoutContext<'a>,
 }
 
-impl<'a> PreorderFlowTraversal for AssignISizes<'a> {
+impl PreorderFlowTraversal for AssignISizes<'_> {
     #[inline]
     fn process(&self, flow: &mut dyn Flow) {
         flow.assign_inline_sizes(self.layout_context);
@@ -297,7 +297,7 @@ pub struct AssignBSizes<'a> {
     pub layout_context: &'a LayoutContext<'a>,
 }
 
-impl<'a> PostorderFlowTraversal for AssignBSizes<'a> {
+impl PostorderFlowTraversal for AssignBSizes<'_> {
     #[inline]
     fn process(&self, flow: &mut dyn Flow) {
         // Can't do anything with anything that floats might flow through until we reach their
@@ -326,7 +326,7 @@ pub struct ComputeStackingRelativePositions<'a> {
     pub layout_context: &'a LayoutContext<'a>,
 }
 
-impl<'a> PreorderFlowTraversal for ComputeStackingRelativePositions<'a> {
+impl PreorderFlowTraversal for ComputeStackingRelativePositions<'_> {
     #[inline]
     fn should_process_subtree(&self, flow: &mut dyn Flow) -> bool {
         flow.base()
@@ -347,7 +347,7 @@ pub struct BuildDisplayList<'a> {
     pub state: DisplayListBuildState<'a>,
 }
 
-impl<'a> BuildDisplayList<'a> {
+impl BuildDisplayList<'_> {
     #[inline]
     pub fn traverse(&mut self, flow: &mut dyn Flow) {
         if flow.has_non_invertible_transform_or_zero_scale() {

--- a/components/layout_2020/construct_modern.rs
+++ b/components/layout_2020/construct_modern.rs
@@ -71,7 +71,7 @@ pub(crate) struct ModernItem<'dom> {
     pub formatting_context: IndependentFormattingContext,
 }
 
-impl<'a, 'dom, Node: 'dom> TraversalHandler<'dom, Node> for ModernContainerBuilder<'a, 'dom, Node>
+impl<'dom, Node: 'dom> TraversalHandler<'dom, Node> for ModernContainerBuilder<'_, 'dom, Node>
 where
     Node: NodeExt<'dom>,
 {

--- a/components/layout_2020/context.rs
+++ b/components/layout_2020/context.rs
@@ -42,7 +42,7 @@ pub struct LayoutContext<'a> {
         Arc<RwLock<FnvHashMap<(ServoUrl, UsePlaceholder), WebRenderImageInfo>>>,
 }
 
-impl<'a> Drop for LayoutContext<'a> {
+impl Drop for LayoutContext<'_> {
     fn drop(&mut self) {
         if !std::thread::panicking() {
             assert!(self.pending_images.lock().is_empty());
@@ -50,7 +50,7 @@ impl<'a> Drop for LayoutContext<'a> {
     }
 }
 
-impl<'a> LayoutContext<'a> {
+impl LayoutContext<'_> {
     #[inline(always)]
     pub fn shared_context(&self) -> &SharedStyleContext {
         &self.style_context

--- a/components/layout_2020/display_list/mod.rs
+++ b/components/layout_2020/display_list/mod.rs
@@ -189,7 +189,7 @@ impl DisplayList {
     }
 }
 
-impl<'a> DisplayListBuilder<'a> {
+impl DisplayListBuilder<'_> {
     fn wr(&mut self) -> &mut wr::DisplayListBuilder {
         &mut self.display_list.wr
     }

--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -176,7 +176,7 @@ struct FlexLineItem<'a> {
     used_main_size: Au,
 }
 
-impl<'a> FlexLineItem<'a> {
+impl FlexLineItem<'_> {
     fn get_or_synthesize_baseline_with_cross_size(&self, cross_size: Au) -> Au {
         self.layout_result
             .baseline_relative_to_margin_box

--- a/components/layout_2020/flow/inline/line.rs
+++ b/components/layout_2020/flow/inline/line.rs
@@ -152,7 +152,7 @@ pub(super) struct LineItemLayout<'layout_data, 'layout> {
     pub justification_adjustment: Au,
 }
 
-impl<'layout_data, 'layout> LineItemLayout<'layout_data, 'layout> {
+impl LineItemLayout<'_, '_> {
     pub(super) fn layout_line_items(
         layout: &mut InlineFormattingContextLayout,
         line_items: Vec<LineItem>,

--- a/components/layout_2020/flow/inline/mod.rs
+++ b/components/layout_2020/flow/inline/mod.rs
@@ -649,7 +649,7 @@ pub(super) struct InlineFormattingContextLayout<'layout_data> {
     baselines: Baselines,
 }
 
-impl<'layout_dta> InlineFormattingContextLayout<'layout_dta> {
+impl InlineFormattingContextLayout<'_> {
     fn current_inline_container_state(&self) -> &InlineContainerState {
         match self.inline_box_state_stack.last() {
             Some(inline_box_state) => &inline_box_state.base,

--- a/components/layout_2020/lib.rs
+++ b/components/layout_2020/lib.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #![deny(unsafe_code)]
-#![allow(clippy::needless_lifetimes)]
 
 mod cell;
 pub mod context;

--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -749,7 +749,7 @@ struct AbsoluteAxisSolver<'a> {
     flip_anchor: bool,
 }
 
-impl<'a> AbsoluteAxisSolver<'a> {
+impl AbsoluteAxisSolver<'_> {
     /// Returns the amount that we need to subtract from the containing block size in order to
     /// obtain the inset-modified containing block that we will use for sizing purposes.
     /// (Note that for alignment purposes, we may re-resolve auto insets to a different value.)

--- a/components/layout_2020/table/construct.rs
+++ b/components/layout_2020/table/construct.rs
@@ -39,7 +39,7 @@ pub(super) struct ResolvedSlotAndLocation<'a> {
     pub coords: TableSlotCoordinates,
 }
 
-impl<'a> ResolvedSlotAndLocation<'a> {
+impl ResolvedSlotAndLocation<'_> {
     fn covers_cell_at(&self, coords: TableSlotCoordinates) -> bool {
         let covered_in_x =
             coords.x >= self.coords.x && coords.x < self.coords.x + self.cell.colspan;
@@ -59,7 +59,7 @@ pub(crate) enum AnonymousTableContent<'dom, Node> {
     },
 }
 
-impl<'dom, Node> AnonymousTableContent<'dom, Node> {
+impl<Node> AnonymousTableContent<'_, Node> {
     fn is_whitespace_only(&self) -> bool {
         match self {
             Self::Element { .. } => false,
@@ -725,8 +725,7 @@ where
     }
 }
 
-impl<'style, 'dom, Node: 'dom> TraversalHandler<'dom, Node>
-    for TableBuilderTraversal<'style, 'dom, Node>
+impl<'dom, Node: 'dom> TraversalHandler<'dom, Node> for TableBuilderTraversal<'_, 'dom, Node>
 where
     Node: NodeExt<'dom>,
 {
@@ -987,8 +986,7 @@ where
     }
 }
 
-impl<'style, 'builder, 'dom, 'a, Node: 'dom> TraversalHandler<'dom, Node>
-    for TableRowBuilder<'style, 'builder, 'dom, 'a, Node>
+impl<'dom, Node: 'dom> TraversalHandler<'dom, Node> for TableRowBuilder<'_, '_, 'dom, '_, Node>
 where
     Node: NodeExt<'dom>,
 {

--- a/components/layout_2020/table/layout.rs
+++ b/components/layout_2020/table/layout.rs
@@ -2922,7 +2922,7 @@ struct RowspanToDistribute<'a> {
     measure: &'a CellOrTrackMeasure,
 }
 
-impl<'a> RowspanToDistribute<'a> {
+impl RowspanToDistribute<'_> {
     fn range(&self) -> Range<usize> {
         self.coordinates.y..self.coordinates.y + self.cell.rowspan
     }

--- a/components/layout_2020/traversal.rs
+++ b/components/layout_2020/traversal.rs
@@ -30,7 +30,7 @@ impl<'a> RecalcStyle<'a> {
 }
 
 #[allow(unsafe_code)]
-impl<'a, 'dom, E> DomTraversal<E> for RecalcStyle<'a>
+impl<'dom, E> DomTraversal<E> for RecalcStyle<'_>
 where
     E: TElement,
     E::ConcreteNode: 'dom + LayoutNode<'dom>,

--- a/components/script/document_collection.rs
+++ b/components/script/document_collection.rs
@@ -105,7 +105,7 @@ pub struct DocumentsIter<'a> {
     iter: hash_map::Iter<'a, PipelineId, Dom<Document>>,
 }
 
-impl<'a> Iterator for DocumentsIter<'a> {
+impl Iterator for DocumentsIter<'_> {
     type Item = (PipelineId, DomRoot<Document>);
 
     fn next(&mut self) -> Option<(PipelineId, DomRoot<Document>)> {

--- a/components/script/dom/audiocontext.rs
+++ b/components/script/dom/audiocontext.rs
@@ -315,7 +315,7 @@ impl Convert<LatencyCategory> for AudioContextLatencyCategory {
     }
 }
 
-impl<'a> Convert<RealTimeAudioContextOptions> for &'a AudioContextOptions {
+impl Convert<RealTimeAudioContextOptions> for &AudioContextOptions {
     fn convert(self) -> RealTimeAudioContextOptions {
         RealTimeAudioContextOptions {
             sample_rate: *self.sampleRate.unwrap_or(Finite::wrap(44100.)),

--- a/components/script/dom/bindings/callback.rs
+++ b/components/script/dom/bindings/callback.rs
@@ -216,7 +216,7 @@ impl<T: DomObject> ThisReflector for T {
     }
 }
 
-impl<'a> ThisReflector for HandleObject<'a> {
+impl ThisReflector for HandleObject<'_> {
     fn jsobject(&self) -> *mut JSObject {
         self.get()
     }

--- a/components/script/dom/bindings/root.rs
+++ b/components/script/dom/bindings/root.rs
@@ -260,7 +260,7 @@ impl<'a> ThreadLocalStackRoots<'a> {
     }
 }
 
-impl<'a> Drop for ThreadLocalStackRoots<'a> {
+impl Drop for ThreadLocalStackRoots<'_> {
     fn drop(&mut self) {
         STACK_ROOTS.with(|r| r.set(None));
     }
@@ -698,7 +698,7 @@ impl<T: DomObject> PartialEq for MutNullableDom<T> {
     }
 }
 
-impl<'a, T: DomObject> PartialEq<Option<&'a T>> for MutNullableDom<T> {
+impl<T: DomObject> PartialEq<Option<&T>> for MutNullableDom<T> {
     fn eq(&self, other: &Option<&T>) -> bool {
         unsafe { *self.ptr.get() == other.map(Dom::from_ref) }
     }

--- a/components/script/dom/bindings/str.rs
+++ b/components/script/dom/bindings/str.rs
@@ -356,7 +356,7 @@ impl From<String> for DOMString {
     }
 }
 
-impl<'a> From<&'a str> for DOMString {
+impl From<&str> for DOMString {
     fn from(contents: &str) -> DOMString {
         DOMString::from(String::from(contents))
     }

--- a/components/script/dom/biquadfilternode.rs
+++ b/components/script/dom/biquadfilternode.rs
@@ -187,7 +187,7 @@ impl BiquadFilterNodeMethods<crate::DomTypeHolder> for BiquadFilterNode {
     }
 }
 
-impl<'a> Convert<BiquadFilterNodeOptions> for &'a BiquadFilterOptions {
+impl Convert<BiquadFilterNodeOptions> for &BiquadFilterOptions {
     fn convert(self) -> BiquadFilterNodeOptions {
         BiquadFilterNodeOptions {
             gain: *self.gain,

--- a/components/script/dom/canvasgradient.rs
+++ b/components/script/dom/canvasgradient.rs
@@ -75,7 +75,7 @@ pub trait ToFillOrStrokeStyle {
     fn to_fill_or_stroke_style(self) -> FillOrStrokeStyle;
 }
 
-impl<'a> ToFillOrStrokeStyle for &'a CanvasGradient {
+impl ToFillOrStrokeStyle for &CanvasGradient {
     fn to_fill_or_stroke_style(self) -> FillOrStrokeStyle {
         let gradient_stops = self.stops.borrow().clone();
         match self.style {

--- a/components/script/dom/canvaspattern.rs
+++ b/components/script/dom/canvaspattern.rs
@@ -70,7 +70,7 @@ impl CanvasPattern {
     }
 }
 
-impl<'a> ToFillOrStrokeStyle for &'a CanvasPattern {
+impl ToFillOrStrokeStyle for &CanvasPattern {
     fn to_fill_or_stroke_style(self) -> FillOrStrokeStyle {
         FillOrStrokeStyle::Surface(SurfaceStyle::new(
             self.surface_data.clone(),

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -83,7 +83,7 @@ impl<'a> AutoWorkerReset<'a> {
     }
 }
 
-impl<'a> Drop for AutoWorkerReset<'a> {
+impl Drop for AutoWorkerReset<'_> {
     fn drop(&mut self) {
         self.workerscope
             .worker

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -681,7 +681,7 @@ pub trait LayoutElementHelpers<'dom> {
     fn get_attr_vals_for_layout(self, name: &LocalName) -> Vec<&'dom AttrValue>;
 }
 
-impl<'dom> LayoutDom<'dom, Element> {
+impl LayoutDom<'_, Element> {
     pub(super) fn focus_state(self) -> bool {
         self.unsafe_get().state.get().contains(ElementState::FOCUS)
     }
@@ -4361,7 +4361,7 @@ pub enum AttributeMutation<'a> {
     Removed,
 }
 
-impl<'a> AttributeMutation<'a> {
+impl AttributeMutation<'_> {
     pub fn is_removal(&self) -> bool {
         match *self {
             AttributeMutation::Removed => true,

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -1383,7 +1383,7 @@ pub enum FormSubmitterElement<'a> {
     // (including custom elements) that can be passed as submitter.
 }
 
-impl<'a> FormSubmitterElement<'a> {
+impl FormSubmitterElement<'_> {
     fn action(&self) -> DOMString {
         match *self {
             FormSubmitterElement::Form(form) => form.Action(),

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -195,7 +195,7 @@ impl InputType {
     }
 }
 
-impl<'a> From<&'a Atom> for InputType {
+impl From<&Atom> for InputType {
     fn from(value: &Atom) -> InputType {
         match value.to_ascii_lowercase() {
             atom!("button") => InputType::Button,

--- a/components/script/dom/htmlobjectelement.rs
+++ b/components/script/dom/htmlobjectelement.rs
@@ -73,7 +73,7 @@ trait ProcessDataURL {
     fn process_data_url(&self);
 }
 
-impl<'a> ProcessDataURL for &'a HTMLObjectElement {
+impl ProcessDataURL for &HTMLObjectElement {
     // Makes the local `data` member match the status of the `data` attribute and starts
     /// prefetching the image. This method must be called after `data` is changed.
     fn process_data_url(&self) {

--- a/components/script/dom/oscillatornode.rs
+++ b/components/script/dom/oscillatornode.rs
@@ -157,7 +157,7 @@ impl OscillatorNodeMethods<crate::DomTypeHolder> for OscillatorNode {
     }
 }
 
-impl<'a> Convert<ServoMediaOscillatorOptions> for &'a OscillatorOptions {
+impl Convert<ServoMediaOscillatorOptions> for &OscillatorOptions {
     fn convert(self) -> ServoMediaOscillatorOptions {
         ServoMediaOscillatorOptions {
             oscillator_type: self.type_.convert(),

--- a/components/script/dom/pannernode.rs
+++ b/components/script/dom/pannernode.rs
@@ -373,7 +373,7 @@ impl PannerNodeMethods<crate::DomTypeHolder> for PannerNode {
     }
 }
 
-impl<'a> Convert<PannerNodeOptions> for &'a PannerOptions {
+impl Convert<PannerNodeOptions> for &PannerOptions {
     fn convert(self) -> PannerNodeOptions {
         PannerNodeOptions {
             panning_model: self.panningModel.convert(),

--- a/components/script/dom/rtcpeerconnection.rs
+++ b/components/script/dom/rtcpeerconnection.rs
@@ -837,7 +837,7 @@ impl Convert<RTCSessionDescriptionInit> for SessionDescription {
     }
 }
 
-impl<'a> Convert<SessionDescription> for &'a RTCSessionDescriptionInit {
+impl Convert<SessionDescription> for &RTCSessionDescriptionInit {
     fn convert(self) -> SessionDescription {
         let type_ = match self.type_ {
             RTCSdpType::Answer => SdpType::Answer,

--- a/components/script/dom/servoparser/html.rs
+++ b/components/script/dom/servoparser/html.rs
@@ -212,7 +212,7 @@ impl Iterator for SerializationIterator {
     }
 }
 
-impl<'a> Serialize for &'a Node {
+impl Serialize for &Node {
     fn serialize<S: Serializer>(
         &self,
         serializer: &mut S,

--- a/components/script/dom/treewalker.rs
+++ b/components/script/dom/treewalker.rs
@@ -456,7 +456,7 @@ impl TreeWalker {
     }
 }
 
-impl<'a> Iterator for &'a TreeWalker {
+impl Iterator for &TreeWalker {
     type Item = DomRoot<Node>;
 
     fn next(&mut self) -> Option<DomRoot<Node>> {

--- a/components/script/dom/webgl_validations/tex_image_2d.rs
+++ b/components/script/dom/webgl_validations/tex_image_2d.rs
@@ -107,7 +107,7 @@ pub struct CommonTexImage2DValidatorResult {
     pub border: u32,
 }
 
-impl<'a> WebGLValidator for CommonTexImage2DValidator<'a> {
+impl WebGLValidator for CommonTexImage2DValidator<'_> {
     type Error = TexImageValidationError;
     type ValidatedOutput = CommonTexImage2DValidatorResult;
     fn validate(self) -> Result<Self::ValidatedOutput, TexImageValidationError> {
@@ -299,7 +299,7 @@ pub struct TexImage2DValidatorResult {
 
 /// TexImage2d validator as per
 /// <https://www.khronos.org/opengles/sdk/docs/man/xhtml/glTexImage2D.xml>
-impl<'a> WebGLValidator for TexImage2DValidator<'a> {
+impl WebGLValidator for TexImage2DValidator<'_> {
     type ValidatedOutput = TexImage2DValidatorResult;
     type Error = TexImageValidationError;
 
@@ -459,7 +459,7 @@ fn is_subimage_blockaligned(
         (height % block_height == 0 || yoffset + height == tex_info.height())
 }
 
-impl<'a> WebGLValidator for CommonCompressedTexImage2DValidator<'a> {
+impl WebGLValidator for CommonCompressedTexImage2DValidator<'_> {
     type Error = TexImageValidationError;
     type ValidatedOutput = CommonCompressedTexImage2DValidatorResult;
 
@@ -537,7 +537,7 @@ impl<'a> CompressedTexImage2DValidator<'a> {
     }
 }
 
-impl<'a> WebGLValidator for CompressedTexImage2DValidator<'a> {
+impl WebGLValidator for CompressedTexImage2DValidator<'_> {
     type Error = TexImageValidationError;
     type ValidatedOutput = CommonCompressedTexImage2DValidatorResult;
 
@@ -617,7 +617,7 @@ impl<'a> CompressedTexSubImage2DValidator<'a> {
     }
 }
 
-impl<'a> WebGLValidator for CompressedTexSubImage2DValidator<'a> {
+impl WebGLValidator for CompressedTexSubImage2DValidator<'_> {
     type Error = TexImageValidationError;
     type ValidatedOutput = CommonCompressedTexImage2DValidatorResult;
 
@@ -728,7 +728,7 @@ impl<'a> TexStorageValidator<'a> {
     }
 }
 
-impl<'a> WebGLValidator for TexStorageValidator<'a> {
+impl WebGLValidator for TexStorageValidator<'_> {
     type Error = TexImageValidationError;
     type ValidatedOutput = TexStorageValidatorResult;
 

--- a/components/script/layout_dom/element.rs
+++ b/components/script/layout_dom/element.rs
@@ -56,7 +56,7 @@ pub struct ServoLayoutElement<'dom> {
     element: LayoutDom<'dom, Element>,
 }
 
-impl<'dom> fmt::Debug for ServoLayoutElement<'dom> {
+impl fmt::Debug for ServoLayoutElement<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "<{}", self.element.local_name())?;
         if let Some(id) = self.id() {
@@ -800,7 +800,7 @@ impl<'dom> ThreadSafeLayoutElement<'dom> for ServoThreadSafeLayoutElement<'dom> 
 ///
 /// Note that the element implementation is needed only for selector matching,
 /// not for inheritance (styles are inherited appropriately).
-impl<'dom> ::selectors::Element for ServoThreadSafeLayoutElement<'dom> {
+impl ::selectors::Element for ServoThreadSafeLayoutElement<'_> {
     type Impl = SelectorImpl;
 
     fn opaque(&self) -> ::selectors::OpaqueElement {

--- a/components/script/layout_dom/node.rs
+++ b/components/script/layout_dom/node.rs
@@ -59,7 +59,7 @@ pub struct ServoLayoutNode<'dom> {
 unsafe impl Send for ServoLayoutNode<'_> {}
 unsafe impl Sync for ServoLayoutNode<'_> {}
 
-impl<'dom> fmt::Debug for ServoLayoutNode<'dom> {
+impl fmt::Debug for ServoLayoutNode<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if let Some(el) = self.as_element() {
             el.fmt(f)
@@ -95,7 +95,7 @@ impl<'dom> ServoLayoutNode<'dom> {
     }
 }
 
-impl<'dom> style::dom::NodeInfo for ServoLayoutNode<'dom> {
+impl style::dom::NodeInfo for ServoLayoutNode<'_> {
     fn is_element(&self) -> bool {
         self.node.is_element_for_layout()
     }
@@ -262,7 +262,7 @@ impl<'dom> ServoThreadSafeLayoutNode<'dom> {
     }
 }
 
-impl<'dom> style::dom::NodeInfo for ServoThreadSafeLayoutNode<'dom> {
+impl style::dom::NodeInfo for ServoThreadSafeLayoutNode<'_> {
     fn is_element(&self) -> bool {
         self.node.is_element()
     }

--- a/components/script/layout_dom/shadow_root.rs
+++ b/components/script/layout_dom/shadow_root.rs
@@ -18,7 +18,7 @@ pub struct ServoShadowRoot<'dom> {
     shadow_root: LayoutDom<'dom, ShadowRoot>,
 }
 
-impl<'dom> fmt::Debug for ServoShadowRoot<'dom> {
+impl fmt::Debug for ServoShadowRoot<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.as_node().fmt(f)
     }

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -11,7 +11,6 @@
 #![register_tool(crown)]
 #![cfg_attr(any(doc, clippy), allow(unknown_lints))]
 #![deny(crown_is_not_used)]
-#![allow(clippy::needless_lifetimes)]
 
 // These are used a lot so let's keep them for now
 #[macro_use]

--- a/components/script/realms.rs
+++ b/components/script/realms.rs
@@ -33,7 +33,7 @@ pub enum InRealm<'a> {
     Entered(&'a JSAutoRealm),
 }
 
-impl<'a> InRealm<'a> {
+impl InRealm<'_> {
     pub fn already(token: &AlreadyInRealm) -> InRealm {
         InRealm::Already(token)
     }

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -463,7 +463,7 @@ impl<'a> ScriptMemoryFailsafe<'a> {
     }
 }
 
-impl<'a> Drop for ScriptMemoryFailsafe<'a> {
+impl Drop for ScriptMemoryFailsafe<'_> {
     #[allow(crown::unrooted_must_root)]
     fn drop(&mut self) {
         if let Some(owner) = self.owner {

--- a/components/script/stylesheet_loader.rs
+++ b/components/script/stylesheet_loader.rs
@@ -302,7 +302,7 @@ impl<'a> StylesheetLoader<'a> {
     }
 }
 
-impl<'a> StylesheetLoader<'a> {
+impl StylesheetLoader<'_> {
     pub fn load(
         &self,
         source: StylesheetContextSource,
@@ -373,7 +373,7 @@ pub(crate) fn stylesheet_fetch_request(
         .integrity_metadata(integrity_metadata)
 }
 
-impl<'a> StyleStylesheetLoader for StylesheetLoader<'a> {
+impl StyleStylesheetLoader for StylesheetLoader<'_> {
     /// Request a stylesheet after parsing a given `@import` rule, and return
     /// the constructed `@import` rule.
     fn request_stylesheet(

--- a/components/script/stylesheet_set.rs
+++ b/components/script/stylesheet_set.rs
@@ -18,7 +18,7 @@ where
     Document(&'a mut DocumentStylesheetSet<S>),
 }
 
-impl<'a, S> StylesheetSetRef<'a, S>
+impl<S> StylesheetSetRef<'_, S>
 where
     S: StylesheetInDocument + PartialEq + 'static,
 {

--- a/components/script/xpath/context.rs
+++ b/components/script/xpath/context.rs
@@ -78,7 +78,7 @@ pub struct EvalNodesetIter<'a> {
     size: usize,
 }
 
-impl<'a> Iterator for EvalNodesetIter<'a> {
+impl Iterator for EvalNodesetIter<'_> {
     type Item = EvaluationCtx;
 
     fn next(&mut self) -> Option<EvaluationCtx> {

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -5,7 +5,6 @@
 #![crate_name = "webdriver_server"]
 #![crate_type = "rlib"]
 #![deny(unsafe_code)]
-#![allow(clippy::needless_lifetimes)]
 
 mod actions;
 mod capabilities;
@@ -313,7 +312,7 @@ impl<'de> Deserialize<'de> for WebDriverPrefValue {
     {
         struct Visitor;
 
-        impl<'de> ::serde::de::Visitor<'de> for Visitor {
+        impl ::serde::de::Visitor<'_> for Visitor {
             type Value = WebDriverPrefValue;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {


### PR DESCRIPTION
The new version of rust allows us to elide some lifetimes and clippy is
now complaining about this. This change elides them where possible and
removes the clippy exceptions.

Fixes #34804.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because these are just syntax changes.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
