### PR TITLE
script: Move `TaskManager` to `GlobalScope`

### DIFF
--- a/components/script/dom/audiocontext.rs
+++ b/components/script/dom/audiocontext.rs
@@ -157,8 +157,7 @@ impl AudioContextMethods<crate::DomTypeHolder> for AudioContext {
         }
 
         // Steps 4 and 5.
-        let window = DomRoot::downcast::<Window>(self.global()).unwrap();
-        let task_source = window.task_manager().dom_manipulation_task_source();
+        let task_source = self.global().task_manager().dom_manipulation_task_source();
         let trusted_promise = TrustedPromise::new(promise.clone());
         match self.context.audio_context_impl().lock().unwrap().suspend() {
             Ok(_) => {
@@ -172,27 +171,21 @@ impl AudioContextMethods<crate::DomTypeHolder> for AudioContext {
                         promise.resolve_native(&());
                         if base_context.State() != AudioContextState::Suspended {
                             base_context.set_state_attribute(AudioContextState::Suspended);
-                            let window = DomRoot::downcast::<Window>(context.global()).unwrap();
-                            window.task_manager().dom_manipulation_task_source().queue_simple_event(
+                            context.global().task_manager().dom_manipulation_task_source().queue_simple_event(
                                 context.upcast(),
                                 atom!("statechange"),
-                                &window
-                                );
+                            );
                         }
-                    }),
-                    window.upcast(),
+                    })
                 );
             },
             Err(_) => {
                 // The spec does not define the error case and `suspend` should
                 // never fail, but we handle the case here for completion.
-                let _ = task_source.queue(
-                    task!(suspend_error: move || {
-                        let promise = trusted_promise.root();
-                        promise.reject_error(Error::Type("Something went wrong".to_owned()));
-                    }),
-                    window.upcast(),
-                );
+                let _ = task_source.queue(task!(suspend_error: move || {
+                    let promise = trusted_promise.root();
+                    promise.reject_error(Error::Type("Something went wrong".to_owned()));
+                }));
             },
         };
 
@@ -218,8 +211,7 @@ impl AudioContextMethods<crate::DomTypeHolder> for AudioContext {
         }
 
         // Steps 4 and 5.
-        let window = DomRoot::downcast::<Window>(self.global()).unwrap();
-        let task_source = window.task_manager().dom_manipulation_task_source();
+        let task_source = self.global().task_manager().dom_manipulation_task_source();
         let trusted_promise = TrustedPromise::new(promise.clone());
         match self.context.audio_context_impl().lock().unwrap().close() {
             Ok(_) => {
@@ -233,27 +225,21 @@ impl AudioContextMethods<crate::DomTypeHolder> for AudioContext {
                         promise.resolve_native(&());
                         if base_context.State() != AudioContextState::Closed {
                             base_context.set_state_attribute(AudioContextState::Closed);
-                            let window = DomRoot::downcast::<Window>(context.global()).unwrap();
-                            window.task_manager().dom_manipulation_task_source().queue_simple_event(
+                            context.global().task_manager().dom_manipulation_task_source().queue_simple_event(
                                 context.upcast(),
                                 atom!("statechange"),
-                                &window
-                                );
+                            );
                         }
-                    }),
-                    window.upcast(),
+                    })
                 );
             },
             Err(_) => {
                 // The spec does not define the error case and `suspend` should
                 // never fail, but we handle the case here for completion.
-                let _ = task_source.queue(
-                    task!(suspend_error: move || {
-                        let promise = trusted_promise.root();
-                        promise.reject_error(Error::Type("Something went wrong".to_owned()));
-                    }),
-                    window.upcast(),
-                );
+                let _ = task_source.queue(task!(suspend_error: move || {
+                    let promise = trusted_promise.root();
+                    promise.reject_error(Error::Type("Something went wrong".to_owned()));
+                }));
             },
         };
 

--- a/components/script/dom/audiotracklist.rs
+++ b/components/script/dom/audiotracklist.rs
@@ -89,18 +89,11 @@ impl AudioTrackList {
         // Queue a task to fire an event named change.
         let global = &self.global();
         let this = Trusted::new(self);
-        let (source, canceller) = global
-            .as_window()
-            .task_manager()
-            .media_element_task_source_with_canceller();
-
-        let _ = source.queue_with_canceller(
-            task!(media_track_change: move || {
-                let this = this.root();
-                this.upcast::<EventTarget>().fire_event(atom!("change"), CanGc::note());
-            }),
-            &canceller,
-        );
+        let task_source = global.task_manager().media_element_task_source();
+        let _ = task_source.queue(task!(media_track_change: move || {
+            let this = this.root();
+            this.upcast::<EventTarget>().fire_event(atom!("change"), CanGc::note());
+        }));
     }
 
     pub fn add(&self, track: &AudioTrack) {

--- a/components/script/dom/eventsource.rs
+++ b/components/script/dom/eventsource.rs
@@ -45,7 +45,6 @@ use crate::fetch::{create_a_potential_cors_request, FetchCanceller};
 use crate::network_listener::{self, NetworkListener, PreInvoke, ResourceTimingListener};
 use crate::realms::enter_realm;
 use crate::script_runtime::CanGc;
-use crate::task_source::TaskSourceName;
 use crate::timers::OneshotTimerCallback;
 
 const DEFAULT_RECONNECTION_TIME: Duration = Duration::from_millis(5000);
@@ -121,7 +120,6 @@ impl EventSourceContext {
                     event_source.upcast::<EventTarget>().fire_event(atom!("open"), CanGc::note());
                 }
             }),
-            &global,
         );
     }
 
@@ -177,7 +175,6 @@ impl EventSourceContext {
                 // FIXME(nox): Why are errors silenced here?
                 let _ = event_source.global().schedule_callback(callback, duration);
             }),
-            &global,
         );
     }
 
@@ -266,7 +263,6 @@ impl EventSourceContext {
                     event.root().upcast::<Event>().fire(event_source.upcast(), CanGc::note());
                 }
             }),
-            &global,
         );
     }
 
@@ -508,7 +504,6 @@ impl EventSource {
                     event_source.upcast::<EventTarget>().fire_event(atom!("error"), CanGc::note());
                 }
             }),
-            &global,
         );
     }
 
@@ -606,7 +601,6 @@ impl EventSourceMethods<crate::DomTypeHolder> for EventSource {
         let listener = NetworkListener {
             context: Arc::new(Mutex::new(context)),
             task_source: global.task_manager().networking_task_source(),
-            canceller: Some(global.task_canceller(TaskSourceName::Networking)),
         };
         ROUTER.add_typed_route(
             action_receiver,

--- a/components/script/dom/htmldetailselement.rs
+++ b/components/script/dom/htmldetailselement.rs
@@ -92,7 +92,6 @@ impl VirtualMethods for HTMLDetailsElement {
                         this.upcast::<EventTarget>().fire_event(atom!("toggle"), CanGc::note());
                     }
                 }),
-                window.upcast(),
             );
             self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage)
         }

--- a/components/script/dom/htmldialogelement.rs
+++ b/components/script/dom/htmldialogelement.rs
@@ -122,6 +122,6 @@ impl HTMLDialogElementMethods<crate::DomTypeHolder> for HTMLDialogElement {
         // Step 5
         win.task_manager()
             .dom_manipulation_task_source()
-            .queue_simple_event(target, atom!("close"), &win);
+            .queue_simple_event(target, atom!("close"));
     }
 }

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -1039,7 +1039,7 @@ impl HTMLFormElement {
         target
             .task_manager()
             .dom_manipulation_task_source()
-            .queue(task, target.upcast())
+            .queue(task)
             .unwrap();
     }
 

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -2576,8 +2576,7 @@ impl VirtualMethods for HTMLInputElement {
             self.input_type().is_textual_or_password()
         {
             if event.IsTrusted() {
-                let window = self.owner_window();
-                window
+                self.owner_window()
                     .task_manager()
                     .user_interaction_task_source()
                     .queue_event(
@@ -2585,7 +2584,6 @@ impl VirtualMethods for HTMLInputElement {
                         atom!("input"),
                         EventBubbles::Bubbles,
                         EventCancelable::NotCancelable,
-                        &window,
                     );
             }
         } else if (event.type_() == atom!("compositionstart") ||

--- a/components/script/dom/htmlstyleelement.rs
+++ b/components/script/dom/htmlstyleelement.rs
@@ -133,11 +133,10 @@ impl HTMLStyleElement {
 
         // No subresource loads were triggered, queue load event
         if self.pending_loads.get() == 0 {
-            let window = self.owner_window();
-            window
+            self.owner_window()
                 .task_manager()
                 .dom_manipulation_task_source()
-                .queue_simple_event(self.upcast(), atom!("load"), &window);
+                .queue_simple_event(self.upcast(), atom!("load"));
         }
 
         self.set_stylesheet(sheet);

--- a/components/script/dom/htmltextareaelement.rs
+++ b/components/script/dom/htmltextareaelement.rs
@@ -650,8 +650,7 @@ impl VirtualMethods for HTMLTextAreaElement {
             }
         } else if event.type_() == atom!("keypress") && !event.DefaultPrevented() {
             if event.IsTrusted() {
-                let window = self.owner_window();
-                window
+                self.owner_window()
                     .task_manager()
                     .user_interaction_task_source()
                     .queue_event(
@@ -659,7 +658,6 @@ impl VirtualMethods for HTMLTextAreaElement {
                         atom!("input"),
                         EventBubbles::Bubbles,
                         EventCancelable::NotCancelable,
-                        &window,
                     );
             }
         } else if event.type_() == atom!("compositionstart") ||

--- a/components/script/dom/htmlvideoelement.rs
+++ b/components/script/dom/htmlvideoelement.rs
@@ -125,9 +125,10 @@ impl HTMLVideoElement {
         let sent_resize = if self.htmlmediaelement.get_ready_state() == ReadyState::HaveNothing {
             None
         } else {
-            let window = self.owner_window();
-            let task_source = window.task_manager().media_element_task_source();
-            task_source.queue_simple_event(self.upcast(), atom!("resize"), &window);
+            self.owner_window()
+                .task_manager()
+                .media_element_task_source()
+                .queue_simple_event(self.upcast(), atom!("resize"));
             Some((width, height))
         };
 

--- a/components/script/dom/performance.rs
+++ b/components/script/dom/performance.rs
@@ -247,7 +247,7 @@ impl Performance {
                 let task = task!(notify_performance_observers: move || {
                     owner.root().notify_observers();
                 });
-                let _ = task_source.queue(task, global);
+                let _ = task_source.queue(task);
             }
         }
         let mut observers = self.observers.borrow_mut();
@@ -334,7 +334,7 @@ impl Performance {
         let task = task!(notify_performance_observers: move || {
             owner.root().notify_observers();
         });
-        let _ = task_source.queue(task, global);
+        let _ = task_source.queue(task);
 
         Some(entry_last_index)
     }

--- a/components/script/dom/selection.rs
+++ b/components/script/dom/selection.rs
@@ -88,8 +88,8 @@ impl Selection {
             return;
         }
         let this = Trusted::new(self);
-        let window = self.document.window();
-        window
+        self.document
+            .window()
             .task_manager()
             .user_interaction_task_source() // w3c/selection-api#117
             .queue(
@@ -97,8 +97,7 @@ impl Selection {
                     let this = this.root();
                     this.task_queued.set(false);
                     this.document.upcast::<EventTarget>().fire_event(atom!("selectionchange"), CanGc::note());
-                }),
-                window.upcast(),
+                })
             )
             .expect("Couldn't queue selectionchange task!");
         self.task_queued.set(true);

--- a/components/script/dom/serviceworkerglobalscope.rs
+++ b/components/script/dom/serviceworkerglobalscope.rs
@@ -412,7 +412,7 @@ impl ServiceWorkerGlobalScope {
                             }
                         },
                         reporter_name,
-                        scope.script_chan(),
+                        global.event_loop_sender(),
                         CommonScriptMsg::CollectReports,
                     );
 
@@ -485,7 +485,7 @@ impl ServiceWorkerGlobalScope {
         }
     }
 
-    pub fn script_chan(&self) -> Box<dyn ScriptChan + Send> {
+    pub(crate) fn event_loop_sender(&self) -> Box<dyn ScriptChan + Send> {
         Box::new(ServiceWorkerChan {
             sender: self.own_sender.clone(),
         })

--- a/components/script/dom/storage.rs
+++ b/components/script/dom/storage.rs
@@ -209,29 +209,25 @@ impl Storage {
         let global = self.global();
         let this = Trusted::new(self);
         global
-            .as_window()
             .task_manager()
             .dom_manipulation_task_source()
-            .queue(
-                task!(send_storage_notification: move || {
-                    let this = this.root();
-                    let global = this.global();
-                    let event = StorageEvent::new(
-                        global.as_window(),
-                        atom!("storage"),
-                        EventBubbles::DoesNotBubble,
-                        EventCancelable::NotCancelable,
-                        key.map(DOMString::from),
-                        old_value.map(DOMString::from),
-                        new_value.map(DOMString::from),
-                        DOMString::from(url.into_string()),
-                        Some(&this),
-                        CanGc::note()
-                    );
-                    event.upcast::<Event>().fire(global.upcast(), CanGc::note());
-                }),
-                global.upcast(),
-            )
+            .queue(task!(send_storage_notification: move || {
+                let this = this.root();
+                let global = this.global();
+                let event = StorageEvent::new(
+                    global.as_window(),
+                    atom!("storage"),
+                    EventBubbles::DoesNotBubble,
+                    EventCancelable::NotCancelable,
+                    key.map(DOMString::from),
+                    old_value.map(DOMString::from),
+                    new_value.map(DOMString::from),
+                    DOMString::from(url.into_string()),
+                    Some(&this),
+                    CanGc::note()
+                );
+                event.upcast::<Event>().fire(global.upcast(), CanGc::note());
+            }))
             .unwrap();
     }
 }

--- a/components/script/dom/textcontrol.rs
+++ b/components/script/dom/textcontrol.rs
@@ -300,8 +300,8 @@ impl<'a, E: TextControlElement> TextControlSelection<'a, E> {
 
         // Step 6
         if textinput.selection_state() != original_selection_state {
-            let window = self.element.owner_window();
-            window
+            self.element
+                .owner_window()
                 .task_manager()
                 .user_interaction_task_source()
                 .queue_event(
@@ -309,7 +309,6 @@ impl<'a, E: TextControlElement> TextControlSelection<'a, E> {
                     atom!("select"),
                     EventBubbles::Bubbles,
                     EventCancelable::NotCancelable,
-                    &window,
                 );
         }
 

--- a/components/script/dom/videotracklist.rs
+++ b/components/script/dom/videotracklist.rs
@@ -81,12 +81,8 @@ impl VideoTrackList {
             return;
         }
 
-        let global = &self.global();
         let this = Trusted::new(self);
-        let (source, canceller) = global
-            .as_window()
-            .task_manager()
-            .media_element_task_source_with_canceller();
+        let task_source = self.global().task_manager().media_element_task_source();
 
         if let Some(current) = self.selected_index() {
             self.tracks.borrow()[current].set_selected(false);
@@ -97,13 +93,10 @@ impl VideoTrackList {
             media_element.set_video_track(idx, value);
         }
 
-        let _ = source.queue_with_canceller(
-            task!(media_track_change: move || {
-                let this = this.root();
-                this.upcast::<EventTarget>().fire_event(atom!("change"), CanGc::note());
-            }),
-            &canceller,
-        );
+        let _ = task_source.queue(task!(media_track_change: move || {
+            let this = this.root();
+            this.upcast::<EventTarget>().fire_event(atom!("change"), CanGc::note());
+        }));
     }
 
     pub fn add(&self, track: &VideoTrack) {

--- a/components/script/dom/webglquery.rs
+++ b/components/script/dom/webglquery.rs
@@ -171,12 +171,10 @@ impl WebGLQuery {
                 this.update_results(&context);
             });
 
-            let global = self.global();
-            global
-                .as_window()
+            self.global()
                 .task_manager()
                 .dom_manipulation_task_source()
-                .queue(task, global.upcast())
+                .queue(task)
                 .unwrap();
         }
 

--- a/components/script/dom/webglsync.rs
+++ b/components/script/dom/webglsync.rs
@@ -59,7 +59,6 @@ impl WebGLSync {
     ) -> Option<u32> {
         match self.client_wait_status.get() {
             Some(constants::TIMEOUT_EXPIRED) | Some(constants::WAIT_FAILED) | None => {
-                let global = self.global();
                 let this = Trusted::new(self);
                 let context = Trusted::new(context);
                 let task = task!(request_client_wait_status: move || {
@@ -74,11 +73,10 @@ impl WebGLSync {
                     ));
                     this.client_wait_status.set(Some(receiver.recv().unwrap()));
                 });
-                global
-                    .as_window()
+                self.global()
                     .task_manager()
                     .dom_manipulation_task_source()
-                    .queue(task, global.upcast())
+                    .queue(task)
                     .unwrap();
             },
             _ => {},
@@ -101,7 +99,6 @@ impl WebGLSync {
     pub fn get_sync_status(&self, pname: u32, context: &WebGLRenderingContext) -> Option<u32> {
         match self.sync_status.get() {
             Some(constants::UNSIGNALED) | None => {
-                let global = self.global();
                 let this = Trusted::new(self);
                 let context = Trusted::new(context);
                 let task = task!(request_sync_status: move || {
@@ -111,11 +108,10 @@ impl WebGLSync {
                     context.send_command(WebGLCommand::GetSyncParameter(this.sync_id, pname, sender));
                     this.sync_status.set(Some(receiver.recv().unwrap()));
                 });
-                global
-                    .as_window()
+                self.global()
                     .task_manager()
                     .dom_manipulation_task_source()
-                    .queue(task, global.upcast())
+                    .queue(task)
                     .unwrap();
             },
             _ => {},

--- a/components/script/dom/webgpu/gpu.rs
+++ b/components/script/dom/webgpu/gpu.rs
@@ -25,7 +25,6 @@ use crate::dom::promise::Promise;
 use crate::dom::webgpu::gpuadapter::GPUAdapter;
 use crate::realms::InRealm;
 use crate::script_runtime::CanGc;
-use crate::task_source::TaskSourceName;
 
 #[dom_struct]
 #[allow(clippy::upper_case_acronyms)]
@@ -73,9 +72,6 @@ pub fn response_async<T: AsyncWGPUListener + DomObject + 'static>(
         .global()
         .task_manager()
         .dom_manipulation_task_source();
-    let canceller = receiver
-        .global()
-        .task_canceller(TaskSourceName::DOMManipulation);
     let mut trusted: Option<TrustedPromise> = Some(TrustedPromise::new(promise.clone()));
     let trusted_receiver = Trusted::new(receiver);
     ROUTER.add_typed_route(
@@ -92,12 +88,9 @@ pub fn response_async<T: AsyncWGPUListener + DomObject + 'static>(
                 trusted,
                 receiver: trusted_receiver.clone(),
             };
-            let result = task_source.queue_with_canceller(
-                task!(process_webgpu_task: move|| {
-                    context.response(message.unwrap(), CanGc::note());
-                }),
-                &canceller,
-            );
+            let result = task_source.queue(task!(process_webgpu_task: move|| {
+                context.response(message.unwrap(), CanGc::note());
+            }));
             if let Err(err) = result {
                 error!("Failed to queue GPU listener-task: {:?}", err);
             }

--- a/components/script/dom/webxr/fakexrdevice.rs
+++ b/components/script/dom/webxr/fakexrdevice.rs
@@ -306,10 +306,7 @@ impl FakeXRDeviceMethods<crate::DomTypeHolder> for FakeXRDevice {
         let global = self.global();
         let p = Promise::new(&global, can_gc);
         let mut trusted = Some(TrustedPromise::new(p.clone()));
-        let (task_source, canceller) = global
-            .as_window()
-            .task_manager()
-            .dom_manipulation_task_source_with_canceller();
+        let task_source = global.task_manager().dom_manipulation_task_source();
         let (sender, receiver) = ipc::channel(global.time_profiler_chan().clone()).unwrap();
 
         ROUTER.add_typed_route(
@@ -318,7 +315,7 @@ impl FakeXRDeviceMethods<crate::DomTypeHolder> for FakeXRDevice {
                 let trusted = trusted
                     .take()
                     .expect("disconnect callback called multiple times");
-                let _ = task_source.queue_with_canceller(trusted.resolve_task(()), &canceller);
+                let _ = task_source.queue(trusted.resolve_task(()));
             }),
         );
         self.disconnect(sender);

--- a/components/script/dom/worker.rs
+++ b/components/script/dom/worker.rs
@@ -220,12 +220,15 @@ impl WorkerMethods<crate::DomTypeHolder> for Worker {
         let (control_sender, control_receiver) = unbounded();
         let (context_sender, context_receiver) = unbounded();
 
+        let event_loop_sender = global
+            .event_loop_sender()
+            .expect("Tried to create a worker in a worker while not handling a message?");
         let join_handle = DedicatedWorkerGlobalScope::run_worker_scope(
             init,
             worker_url,
             devtools_receiver,
             worker_ref,
-            global.script_chan(),
+            event_loop_sender,
             sender,
             receiver,
             worker_load_origin,

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -1566,6 +1566,7 @@ impl XMLHttpRequest {
                     sender,
                     pipeline_id: global.pipeline_id(),
                     name: TaskSourceName::Networking,
+                    canceller: Default::default(),
                 },
                 Some(receiver),
             )

--- a/components/script/links.rs
+++ b/components/script/links.rs
@@ -434,7 +434,7 @@ pub fn follow_hyperlink(
         target_window
             .task_manager()
             .dom_manipulation_task_source()
-            .queue(task, target_window.upcast())
+            .queue(task)
             .unwrap();
     };
 }

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -75,7 +75,6 @@ use crate::network_listener::{self, NetworkListener, PreInvoke, ResourceTimingLi
 use crate::realms::{enter_realm, AlreadyInRealm, InRealm};
 use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
 use crate::task::TaskBox;
-use crate::task_source::TaskSourceName;
 
 #[allow(unsafe_code)]
 unsafe fn gen_type_error(global: &GlobalScope, string: String) -> RethrowError {
@@ -1768,13 +1767,9 @@ fn fetch_single_module_script(
         resource_timing: ResourceFetchTiming::new(ResourceTimingType::Resource),
     }));
 
-    let task_source = global.task_manager().networking_task_source();
-    let canceller = global.task_canceller(TaskSourceName::Networking);
-
     let network_listener = NetworkListener {
         context,
-        task_source,
-        canceller: Some(canceller),
+        task_source: global.task_manager().networking_task_source(),
     };
     match document {
         Some(document) => {

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -399,8 +399,7 @@ unsafe extern "C" fn promise_rejection_tracker(
                     );
 
                     event.upcast::<Event>().fire(&target, CanGc::note());
-                }),
-                global.upcast(),
+                })
             ).unwrap();
             },
         };
@@ -455,7 +454,7 @@ unsafe extern "C" fn content_security_policy_allows(
                 global
                     .task_manager()
                     .dom_manipulation_task_source()
-                    .queue(task, &global)
+                    .queue(task)
                     .unwrap();
             }
         }
@@ -529,8 +528,7 @@ pub fn notify_about_rejected_promises(global: &GlobalScope) {
                             target.global().add_consumed_rejection(promise.reflector().get_jsobject().into_handle());
                         }
                     }
-                }),
-                global.upcast(),
+                })
             ).unwrap();
         }
     }

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -152,7 +152,6 @@ use crate::script_runtime::{
     CanGc, CommonScriptMsg, JSContext, Runtime, ScriptChan, ScriptThreadEventCategory,
     ThreadSafeJSContext,
 };
-use crate::task_manager::TaskManager;
 use crate::task_queue::TaskQueue;
 use crate::task_source::{TaskSource, TaskSourceName};
 use crate::{devtools, webdriver_handlers};
@@ -693,7 +692,7 @@ impl ScriptThread {
                 global
                     .task_manager()
                     .dom_manipulation_task_source()
-                    .queue(task, global.upcast())
+                    .queue(task)
                     .expect("Enqueing navigate js task on the DOM manipulation task source failed");
             } else {
                 if let Some(ref sender) = script_thread.senders.devtools_server_sender {
@@ -907,6 +906,7 @@ impl ScriptThread {
             sender: self_sender.as_boxed(),
             pipeline_id: state.id,
             name: TaskSourceName::Networking,
+            canceller: Default::default(),
         }));
         let cx = runtime.cx();
 
@@ -1033,8 +1033,10 @@ impl ScriptThread {
     fn prepare_for_shutdown_inner(&self) {
         let docs = self.documents.borrow();
         for (_, document) in docs.iter() {
-            let window = document.window();
-            window.ignore_all_tasks();
+            document
+                .window()
+                .task_manager()
+                .cancel_all_tasks_and_ignore_future_tasks();
         }
     }
 
@@ -1407,6 +1409,7 @@ impl ScriptThread {
         //
         // This task is empty because any new IPC messages in the ScriptThread trigger a
         // rendering update when animations are not running.
+        let _realm = enter_realm(&*document);
         let rendering_task_source = document.window().task_manager().rendering_task_source();
         let _ =
             rendering_task_source.queue_unconditionally(task!(update_the_rendering: move || { }));
@@ -3129,10 +3132,6 @@ impl ScriptThread {
             pipeline_id: incomplete.pipeline_id,
         };
 
-        let task_manager = TaskManager::new(
-            Box::new(self.senders.self_sender.clone()),
-            incomplete.pipeline_id,
-        );
         let paint_time_metrics = PaintTimeMetrics::new(
             incomplete.pipeline_id,
             self.senders.time_profiler_sender.clone(),
@@ -3161,7 +3160,6 @@ impl ScriptThread {
         let window = Window::new(
             self.js_runtime.clone(),
             self.senders.self_sender.clone(),
-            task_manager,
             self.layout_factory.create(layout_config),
             self.senders.image_cache_sender.clone(),
             self.image_cache.clone(),

--- a/components/script/task.rs
+++ b/components/script/task.rs
@@ -67,15 +67,15 @@ impl fmt::Debug for dyn TaskBox {
 }
 
 /// Encapsulated state required to create cancellable tasks from non-script threads.
-#[derive(Clone)]
+#[derive(Clone, Default, JSTraceable, MallocSizeOf)]
 pub struct TaskCanceller {
+    #[ignore_malloc_size_of = "This is difficult, because only one of them should be measured"]
     pub cancelled: Arc<AtomicBool>,
 }
 
 impl TaskCanceller {
-    /// Returns a wrapped `task` that will be cancelled if the `TaskCanceller`
-    /// says so.
-    pub fn wrap_task<T>(&self, task: T) -> impl TaskOnce
+    /// Returns a wrapped `task` that will be cancelled if the `TaskCanceller` says so.
+    pub(crate) fn wrap_task<T>(&self, task: T) -> impl TaskOnce
     where
         T: TaskOnce,
     {

--- a/components/script/task_manager.rs
+++ b/components/script/task_manager.rs
@@ -2,110 +2,148 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use core::cell::RefCell;
+use core::sync::atomic::Ordering;
 use std::collections::HashMap;
-use std::sync::atomic::AtomicBool;
-use std::sync::Arc;
 
 use base::id::PipelineId;
 
-use crate::dom::bindings::cell::DomRefCell;
 use crate::script_runtime::ScriptChan;
 use crate::task::TaskCanceller;
 use crate::task_source::{TaskSource, TaskSourceName};
 
-macro_rules! task_source_functions {
-    ($self:ident, $task_source:ident) => {
-        pub(crate) fn $task_source(&$self) -> TaskSource {
-            $self.$task_source.clone()
-        }
-    };
-    ($self:ident, $with_canceller:ident, $task_source:ident) => {
-        pub(crate) fn $with_canceller(&$self) -> (TaskSource, TaskCanceller) {
-            ($self.$task_source.clone(), $self.task_canceller($self.$task_source.name))
-        }
+#[derive(JSTraceable, MallocSizeOf)]
+enum TaskCancellers {
+    /// A shared canceller that is used for workers, which can create multiple TaskManagers, but all
+    /// of them need to have the same canceller flag for all task sources.
+    Shared(TaskCanceller),
+    /// For `Window` each `TaskSource` has its own canceller.
+    OnePerTaskSource(RefCell<HashMap<TaskSourceName, TaskCanceller>>),
+}
 
+impl TaskCancellers {
+    fn get(&self, name: TaskSourceName) -> TaskCanceller {
+        match self {
+            Self::Shared(canceller) => canceller.clone(),
+            Self::OnePerTaskSource(map) => map.borrow_mut().entry(name).or_default().clone(),
+        }
+    }
+
+    fn cancel_all_tasks_and_ignore_future_tasks(&self) {
+        match self {
+            Self::Shared(canceller) => canceller.cancelled.store(true, Ordering::SeqCst),
+            Self::OnePerTaskSource(..) => {
+                // We must create the canceller if they aren't created because we want future
+                // tasks to be ignored completely.
+                for task_source_name in TaskSourceName::all() {
+                    self.get(*task_source_name)
+                        .cancelled
+                        .store(true, Ordering::SeqCst)
+                }
+            },
+        }
+    }
+
+    fn cancel_pending_tasks_for_source(&self, task_source_name: TaskSourceName) {
+        let Self::OnePerTaskSource(map) = self else {
+            unreachable!(
+                "It isn't possible to cancel pending tasks for Worker \
+                 TaskManager's without ignoring future tasks."
+            )
+        };
+
+        // Remove the canceller from the map so that the next time a task like this is
+        // queued, it has a fresh, uncancelled canceller.
+        if let Some(canceller) = map.borrow_mut().remove(&task_source_name) {
+            // Cancel any tasks that use the current canceller.
+            canceller.cancelled.store(true, Ordering::SeqCst);
+        }
+    }
+}
+
+macro_rules! task_source_functions {
+    ($self:ident, $task_source:ident, $task_source_name:ident) => {
         pub(crate) fn $task_source(&$self) -> TaskSource {
-            $self.$task_source.clone()
+            $self.task_source_for_task_source_name(TaskSourceName::$task_source_name)
         }
     };
 }
 
 #[derive(JSTraceable, MallocSizeOf)]
 pub struct TaskManager {
-    #[ignore_malloc_size_of = "task sources are hard"]
-    pub task_cancellers: DomRefCell<HashMap<TaskSourceName, Arc<AtomicBool>>>,
-    dom_manipulation_task_source: TaskSource,
-    file_reading_task_source: TaskSource,
-    gamepad_task_source: TaskSource,
-    history_traversal_task_source: TaskSource,
-    media_element_task_source: TaskSource,
-    networking_task_source: TaskSource,
-    performance_timeline_task_source: TaskSource,
-    port_message_queue: TaskSource,
-    user_interaction_task_source: TaskSource,
-    remote_event_task_source: TaskSource,
-    rendering_task_source: TaskSource,
-    timer_task_source: TaskSource,
-    websocket_task_source: TaskSource,
+    #[ignore_malloc_size_of = "We need to push the measurement of this down into the ScriptChan trait"]
+    sender: RefCell<Option<Box<dyn ScriptChan + Send>>>,
+    #[no_trace]
+    pipeline_id: PipelineId,
+    cancellers: TaskCancellers,
 }
 
 impl TaskManager {
-    #[allow(clippy::too_many_arguments)]
-    pub(crate) fn new(sender: Box<dyn ScriptChan + Send>, pipeline_id: PipelineId) -> Self {
-        let task_source = |name| TaskSource {
-            sender: sender.as_boxed(),
-            pipeline_id,
-            name,
+    pub(crate) fn new(
+        sender: Option<Box<dyn ScriptChan + Send>>,
+        pipeline_id: PipelineId,
+        shared_canceller: Option<TaskCanceller>,
+    ) -> Self {
+        let cancellers = match shared_canceller {
+            Some(shared_canceller) => TaskCancellers::Shared(shared_canceller),
+            None => TaskCancellers::OnePerTaskSource(Default::default()),
         };
+        let sender = RefCell::new(sender);
 
         TaskManager {
-            dom_manipulation_task_source: task_source(TaskSourceName::DOMManipulation),
-            file_reading_task_source: task_source(TaskSourceName::FileReading),
-            gamepad_task_source: task_source(TaskSourceName::Gamepad),
-            history_traversal_task_source: task_source(TaskSourceName::HistoryTraversal),
-            media_element_task_source: task_source(TaskSourceName::MediaElement),
-            networking_task_source: task_source(TaskSourceName::Networking),
-            performance_timeline_task_source: task_source(TaskSourceName::PerformanceTimeline),
-            port_message_queue: task_source(TaskSourceName::PortMessage),
-            user_interaction_task_source: task_source(TaskSourceName::UserInteraction),
-            remote_event_task_source: task_source(TaskSourceName::RemoteEvent),
-            rendering_task_source: task_source(TaskSourceName::Rendering),
-            timer_task_source: task_source(TaskSourceName::Timer),
-            websocket_task_source: task_source(TaskSourceName::WebSocket),
-            task_cancellers: Default::default(),
+            sender,
+            pipeline_id,
+            cancellers,
         }
     }
 
-    task_source_functions!(
-        self,
-        dom_manipulation_task_source_with_canceller,
-        dom_manipulation_task_source
-    );
-    task_source_functions!(self, gamepad_task_source);
-    task_source_functions!(
-        self,
-        media_element_task_source_with_canceller,
-        media_element_task_source
-    );
-    task_source_functions!(self, user_interaction_task_source);
-    task_source_functions!(
-        self,
-        networking_task_source_with_canceller,
-        networking_task_source
-    );
-    task_source_functions!(self, file_reading_task_source);
-    task_source_functions!(self, performance_timeline_task_source);
-    task_source_functions!(self, port_message_queue);
-    task_source_functions!(self, remote_event_task_source);
-    task_source_functions!(self, rendering_task_source);
-    task_source_functions!(self, timer_task_source);
-    task_source_functions!(self, websocket_task_source);
+    fn task_source_for_task_source_name(&self, name: TaskSourceName) -> TaskSource {
+        let Some(sender) = self
+            .sender
+            .borrow()
+            .as_ref()
+            .map(|sender| sender.as_boxed())
+        else {
+            unreachable!("Tried to enqueue task for DedicatedWorker while not handling a message.")
+        };
 
-    pub fn task_canceller(&self, name: TaskSourceName) -> TaskCanceller {
-        let mut flags = self.task_cancellers.borrow_mut();
-        let cancel_flag = flags.entry(name).or_default();
-        TaskCanceller {
-            cancelled: cancel_flag.clone(),
+        TaskSource {
+            sender,
+            pipeline_id: self.pipeline_id,
+            name,
+            canceller: self.cancellers.get(name),
         }
     }
+
+    /// Update the sender for this [`TaskSource`]. This is used by dedicated workers, which only have a
+    /// sender while handling messages (as their sender prevents the main thread Worker object from being
+    /// garbage collected).
+    pub(crate) fn set_sender(&self, sender: Option<Box<dyn ScriptChan + Send>>) {
+        *self.sender.borrow_mut() = sender;
+    }
+
+    /// Cancel all queued but unexecuted tasks and ignore all subsequently queued tasks.
+    pub(crate) fn cancel_all_tasks_and_ignore_future_tasks(&self) {
+        self.cancellers.cancel_all_tasks_and_ignore_future_tasks();
+    }
+
+    /// Cancel all queued but unexecuted tasks for the given task source, but subsequently queued
+    /// tasks will not be ignored.
+    pub(crate) fn cancel_pending_tasks_for_source(&self, task_source_name: TaskSourceName) {
+        self.cancellers
+            .cancel_pending_tasks_for_source(task_source_name);
+    }
+
+    task_source_functions!(self, dom_manipulation_task_source, DOMManipulation);
+    task_source_functions!(self, file_reading_task_source, FileReading);
+    task_source_functions!(self, gamepad_task_source, Gamepad);
+    task_source_functions!(self, media_element_task_source, MediaElement);
+    task_source_functions!(self, networking_task_source, Networking);
+    task_source_functions!(self, performance_timeline_task_source, PerformanceTimeline);
+    task_source_functions!(self, port_message_queue, PortMessage);
+    task_source_functions!(self, remote_event_task_source, RemoteEvent);
+    task_source_functions!(self, rendering_task_source, Rendering);
+    task_source_functions!(self, timer_task_source, Timer);
+    task_source_functions!(self, user_interaction_task_source, UserInteraction);
+    task_source_functions!(self, websocket_task_source, WebSocket);
 }


### PR DESCRIPTION
This is a simplification of the internal `TaskQueue` API that moves the
`TaskManager` to the `GlobalScope` itself. In addition, the handling of
cancellers is moved to the `TaskManager` as well. This means that no
arguments other than the `task` are necessary for queueing tasks, which
makes the API a lot easier to use and cleaner.

`TaskSource` now also keeps a copy of the canceller with it, so that
they always know the proper way to cancel any tasks queued on them.

There is one complication here. The event loop `sender` for dedicated
workers is constantly changing as it is set to `None` when not handling
messages. This is because this sender keeps a handle to the main
thread's `Worker` object, preventing garbage collection while any
messages are still in flight or being handled. This change allows
setting the `sender` on the `TaskManager` to `None` to allow proper
garbabge collection.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes they are covered by existing tests which should continue passing.


<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
