### PR TITLE
script: Expose node helpers as `NodeTraits` and give more descriptive names

### DIFF
--- a/components/script/animations.rs
+++ b/components/script/animations.rs
@@ -30,7 +30,7 @@ use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::bindings::trace::NoTrace;
 use crate::dom::event::Event;
-use crate::dom::node::{from_untrusted_node_address, window_from_node, Node, NodeDamage};
+use crate::dom::node::{from_untrusted_node_address, Node, NodeDamage, NodeTraits};
 use crate::dom::transitionevent::TransitionEvent;
 use crate::dom::window::Window;
 use crate::script_runtime::CanGc;
@@ -516,7 +516,7 @@ impl Animations {
                     DOMString::from(pseudo_element.to_css_string())
                 });
             let elapsed_time = Finite::new(event.elapsed_time as f32).unwrap();
-            let window = window_from_node(&*node);
+            let window = node.owner_window();
 
             if event.event_type.is_transition_event() {
                 let event_init = TransitionEventInit {

--- a/components/script/canvas_state.rs
+++ b/components/script/canvas_state.rs
@@ -53,7 +53,7 @@ use crate::dom::element::{cors_setting_for_element, Element};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::htmlcanvaselement::{CanvasContext, HTMLCanvasElement};
 use crate::dom::imagedata::ImageData;
-use crate::dom::node::{window_from_node, Node, NodeDamage};
+use crate::dom::node::{Node, NodeDamage, NodeTraits};
 use crate::dom::offscreencanvas::{OffscreenCanvas, OffscreenCanvasContext};
 use crate::dom::paintworkletglobalscope::PaintWorkletGlobalScope;
 use crate::dom::textmetrics::TextMetrics;
@@ -1086,7 +1086,7 @@ impl CanvasState {
             None => return, // offscreen canvas doesn't have a placeholder canvas
         };
         let node = canvas.upcast::<Node>();
-        let window = window_from_node(canvas);
+        let window = canvas.owner_window();
         let resolved_font_style =
             match window.resolved_font_style_query(node, value.to_string(), can_gc) {
                 Some(value) => value,

--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -37,7 +37,7 @@ use crate::dom::document::AnimationFrameCallback;
 use crate::dom::element::Element;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::htmlscriptelement::SourceCode;
-use crate::dom::node::{stylesheets_owner_from_node, window_from_node, Node, ShadowIncluding};
+use crate::dom::node::{Node, NodeTraits, ShadowIncluding};
 use crate::dom::types::HTMLElement;
 use crate::realms::enter_realm;
 use crate::script_module::ScriptFetchOptions;
@@ -152,7 +152,7 @@ pub fn handle_get_children(
             let inline: Vec<_> = parent
                 .children()
                 .map(|child| {
-                    let window = window_from_node(&*child);
+                    let window = child.owner_window();
                     let Some(elem) = child.downcast::<Element>() else {
                         return false;
                     };
@@ -231,7 +231,7 @@ pub fn handle_get_stylesheet_style(
 
         let document = documents.find_document(pipeline)?;
         let _realm = enter_realm(document.window());
-        let owner = stylesheets_owner_from_node(&*node);
+        let owner = node.stylesheet_list_owner();
 
         let stylesheet = owner.stylesheet_at(stylesheet)?;
         let list = stylesheet.GetCssRules().ok()?;
@@ -275,7 +275,7 @@ pub fn handle_get_selectors(
 
         let document = documents.find_document(pipeline)?;
         let _realm = enter_realm(document.window());
-        let owner = stylesheets_owner_from_node(&*node);
+        let owner = node.stylesheet_list_owner();
 
         let rules = (0..owner.stylesheet_count())
             .filter_map(|i| {
@@ -312,7 +312,7 @@ pub fn handle_get_computed_style(
         Some(found_node) => found_node,
     };
 
-    let window = window_from_node(&*node);
+    let window = node.owner_window();
     let elem = node
         .downcast::<Element>()
         .expect("This should be an element");
@@ -353,7 +353,7 @@ pub fn handle_get_layout(
     let width = rect.Width() as f32;
     let height = rect.Height() as f32;
 
-    let window = window_from_node(&*node);
+    let window = node.owner_window();
     let elem = node
         .downcast::<Element>()
         .expect("should be getting layout of element");

--- a/components/script/dom/cssstylerule.rs
+++ b/components/script/dom/cssstylerule.rs
@@ -20,7 +20,7 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::cssrule::{CSSRule, SpecificCSSRule};
 use crate::dom::cssstyledeclaration::{CSSModificationAccess, CSSStyleDeclaration, CSSStyleOwner};
 use crate::dom::cssstylesheet::CSSStyleSheet;
-use crate::dom::node::{stylesheets_owner_from_node, Node};
+use crate::dom::node::NodeTraits;
 use crate::dom::window::Window;
 use crate::script_runtime::CanGc;
 
@@ -120,7 +120,7 @@ impl CSSStyleRuleMethods<crate::DomTypeHolder> for CSSStyleRule {
             let stylerule = self.stylerule.write_with(&mut guard);
             mem::swap(&mut stylerule.selectors, &mut s);
             if let Some(owner) = self.cssrule.parent_stylesheet().get_owner() {
-                stylesheets_owner_from_node(owner.upcast::<Node>()).invalidate_stylesheets();
+                owner.stylesheet_list_owner().invalidate_stylesheets();
             }
         }
     }

--- a/components/script/dom/cssstylesheet.rs
+++ b/components/script/dom/cssstylesheet.rs
@@ -11,14 +11,13 @@ use style::stylesheets::{CssRuleTypes, Stylesheet as StyleStyleSheet};
 
 use crate::dom::bindings::codegen::Bindings::CSSStyleSheetBinding::CSSStyleSheetMethods;
 use crate::dom::bindings::error::{Error, ErrorResult, Fallible};
-use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::{reflect_dom_object, DomObject};
 use crate::dom::bindings::root::{DomRoot, MutNullableDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::cssrulelist::{CSSRuleList, RulesSource};
 use crate::dom::element::Element;
 use crate::dom::medialist::MediaList;
-use crate::dom::node::{stylesheets_owner_from_node, Node};
+use crate::dom::node::NodeTraits;
 use crate::dom::stylesheet::StyleSheet;
 use crate::dom::window::Window;
 use crate::script_runtime::CanGc;
@@ -86,7 +85,9 @@ impl CSSStyleSheet {
 
     pub fn set_disabled(&self, disabled: bool) {
         if self.style_stylesheet.set_disabled(disabled) && self.get_owner().is_some() {
-            stylesheets_owner_from_node(self.get_owner().unwrap().upcast::<Node>())
+            self.get_owner()
+                .unwrap()
+                .stylesheet_list_owner()
                 .invalidate_stylesheets();
         }
     }

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -43,7 +43,7 @@ use crate::dom::element::Element;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::htmlformelement::{FormControl, HTMLFormElement};
-use crate::dom::node::{document_from_node, window_from_node, Node, ShadowIncluding};
+use crate::dom::node::{Node, NodeTraits, ShadowIncluding};
 use crate::dom::promise::Promise;
 use crate::dom::window::Window;
 use crate::microtask::Microtask;
@@ -895,7 +895,7 @@ fn run_upgrade_constructor(
     element: &Element,
     can_gc: CanGc,
 ) -> ErrorResult {
-    let window = window_from_node(element);
+    let window = element.owner_window();
     let cx = GlobalScope::get_cx();
     rooted!(in(*cx) let constructor_val = ObjectValue(constructor.callback()));
     rooted!(in(*cx) let mut element_val = UndefinedValue());
@@ -954,7 +954,7 @@ fn run_upgrade_constructor(
 /// <https://html.spec.whatwg.org/multipage/#concept-try-upgrade>
 pub fn try_upgrade_element(element: &Element) {
     // Step 1
-    let document = document_from_node(element);
+    let document = element.owner_document();
     let namespace = element.namespace();
     let local_name = element.local_name();
     let is = element.get_is();

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -152,8 +152,7 @@ use crate::dom::location::Location;
 use crate::dom::messageevent::MessageEvent;
 use crate::dom::mouseevent::MouseEvent;
 use crate::dom::node::{
-    self, document_from_node, window_from_node, CloneChildrenFlag, Node, NodeDamage, NodeFlags,
-    ShadowIncluding,
+    self, CloneChildrenFlag, Node, NodeDamage, NodeFlags, NodeTraits, ShadowIncluding,
 };
 use crate::dom::nodeiterator::NodeIterator;
 use crate::dom::nodelist::NodeList;
@@ -2261,7 +2260,7 @@ impl Document {
             let iframes: Vec<_> = self.iframes().iter().collect();
             for iframe in &iframes {
                 // TODO: handle the case of cross origin iframes.
-                let document = document_from_node(&**iframe);
+                let document = iframe.owner_document();
                 can_unload = document.prompt_to_unload(true, can_gc);
                 if !document.salvageable() {
                     self.salvageable.set(false);
@@ -2333,7 +2332,7 @@ impl Document {
             let iframes: Vec<_> = self.iframes().iter().collect();
             for iframe in &iframes {
                 // TODO: handle the case of cross origin iframes.
-                let document = document_from_node(&**iframe);
+                let document = iframe.owner_document();
                 document.unload(true, can_gc);
                 if !document.salvageable() {
                     self.salvageable.set(false);
@@ -2501,7 +2500,7 @@ impl Document {
                             // https://html.spec.whatwg.org/multipage/#shared-declarative-refresh-steps
                             document.window.upcast::<GlobalScope>().schedule_callback(
                                 OneshotTimerCallback::RefreshRedirectDue(RefreshRedirectDue {
-                                    window: window_from_node(&*document),
+                                    window: DomRoot::from_ref(document.window()),
                                     url: url.clone(),
                                 }),
                                 Duration::from_secs(*time),
@@ -5314,7 +5313,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
         // TODO: prompt to unload.
         // TODO: set unload_event_start and unload_event_end
 
-        window_from_node(self).set_navigation_start();
+        self.window().set_navigation_start();
 
         // Step 8
         // TODO: https://github.com/servo/servo/issues/21937

--- a/components/script/dom/documentfragment.rs
+++ b/components/script/dom/documentfragment.rs
@@ -18,7 +18,7 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
 use crate::dom::element::Element;
 use crate::dom::htmlcollection::HTMLCollection;
-use crate::dom::node::{window_from_node, Node};
+use crate::dom::node::{Node, NodeTraits};
 use crate::dom::nodelist::NodeList;
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::dom::window::Window;
@@ -77,7 +77,7 @@ impl DocumentFragmentMethods<crate::DomTypeHolder> for DocumentFragment {
 
     // https://dom.spec.whatwg.org/#dom-parentnode-children
     fn Children(&self) -> DomRoot<HTMLCollection> {
-        let window = window_from_node(self);
+        let window = self.owner_window();
         HTMLCollection::children(&window, self.upcast())
     }
 

--- a/components/script/dom/domstringmap.rs
+++ b/components/script/dom/domstringmap.rs
@@ -10,7 +10,7 @@ use crate::dom::bindings::reflector::{reflect_dom_object, Reflector};
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::htmlelement::HTMLElement;
-use crate::dom::node::window_from_node;
+use crate::dom::node::NodeTraits;
 use crate::script_runtime::CanGc;
 
 #[dom_struct]
@@ -28,10 +28,9 @@ impl DOMStringMap {
     }
 
     pub fn new(element: &HTMLElement) -> DomRoot<DOMStringMap> {
-        let window = window_from_node(element);
         reflect_dom_object(
             Box::new(DOMStringMap::new_inherited(element)),
-            &*window,
+            &*element.owner_window(),
             CanGc::note(),
         )
     }

--- a/components/script/dom/domtokenlist.rs
+++ b/components/script/dom/domtokenlist.rs
@@ -14,7 +14,7 @@ use crate::dom::bindings::reflector::{reflect_dom_object, Reflector};
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::element::Element;
-use crate::dom::node::window_from_node;
+use crate::dom::node::NodeTraits;
 use crate::script_runtime::CanGc;
 
 #[dom_struct]
@@ -46,14 +46,13 @@ impl DOMTokenList {
         local_name: &LocalName,
         supported_tokens: Option<Vec<Atom>>,
     ) -> DomRoot<DOMTokenList> {
-        let window = window_from_node(element);
         reflect_dom_object(
             Box::new(DOMTokenList::new_inherited(
                 element,
                 local_name.clone(),
                 supported_tokens,
             )),
-            &*window,
+            &*element.owner_window(),
             CanGc::note(),
         )
     }

--- a/components/script/dom/elementinternals.rs
+++ b/components/script/dom/elementinternals.rs
@@ -21,7 +21,7 @@ use crate::dom::element::Element;
 use crate::dom::file::File;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::htmlformelement::{FormDatum, FormDatumValue, HTMLFormElement};
-use crate::dom::node::{window_from_node, Node};
+use crate::dom::node::{Node, NodeTraits};
 use crate::dom::nodelist::NodeList;
 use crate::dom::validation::{is_barred_by_datalist_ancestor, Validatable};
 use crate::dom::validitystate::{ValidationFlags, ValidityState};
@@ -88,7 +88,7 @@ impl ElementInternals {
     }
 
     pub fn new(element: &HTMLElement) -> DomRoot<ElementInternals> {
-        let global = window_from_node(element);
+        let global = element.owner_window();
         reflect_dom_object(
             Box::new(ElementInternals::new_inherited(element)),
             &*global,
@@ -348,7 +348,7 @@ impl Validatable for ElementInternals {
         debug_assert!(self.is_target_form_associated());
         self.validity_state.or_init(|| {
             ValidityState::new(
-                &window_from_node(self.target_element.upcast::<Node>()),
+                &self.target_element.owner_window(),
                 self.target_element.upcast(),
             )
         })

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -52,7 +52,7 @@ use crate::dom::errorevent::ErrorEvent;
 use crate::dom::event::{Event, EventBubbles, EventCancelable, EventStatus};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::htmlformelement::FormControlElementHelpers;
-use crate::dom::node::document_from_node;
+use crate::dom::node::NodeTraits;
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::dom::window::Window;
 use crate::dom::workerglobalscope::WorkerGlobalScope;
@@ -501,7 +501,7 @@ impl EventTarget {
         // Step 3.1
         let element = self.downcast::<Element>();
         let document = match element {
-            Some(element) => document_from_node(element),
+            Some(element) => element.owner_document(),
             None => self.downcast::<Window>().unwrap().Document(),
         };
 

--- a/components/script/dom/htmlanchorelement.rs
+++ b/components/script/dom/htmlanchorelement.rs
@@ -30,7 +30,7 @@ use crate::dom::eventtarget::EventTarget;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::htmlimageelement::HTMLImageElement;
 use crate::dom::mouseevent::MouseEvent;
-use crate::dom::node::{document_from_node, BindContext, Node};
+use crate::dom::node::{BindContext, Node, NodeTraits};
 use crate::dom::urlhelper::UrlHelper;
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::links::{follow_hyperlink, LinkRelations};
@@ -95,7 +95,7 @@ impl HTMLAnchorElement {
 
         // Step 3. Let url be the result of encoding-parsing a URL given this element's
         // href content attribute's value, relative to this element's node document.
-        let document = document_from_node(self);
+        let document = self.owner_document();
         let url = document.encoding_parse_a_url(&attribute.value());
 
         // Step 4. If url is not failure, then set this element's url to url.

--- a/components/script/dom/htmlbaseelement.rs
+++ b/components/script/dom/htmlbaseelement.rs
@@ -15,7 +15,7 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
 use crate::dom::element::{AttributeMutation, Element};
 use crate::dom::htmlelement::HTMLElement;
-use crate::dom::node::{document_from_node, BindContext, Node, UnbindContext};
+use crate::dom::node::{BindContext, Node, NodeTraits, UnbindContext};
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::script_runtime::CanGc;
 
@@ -60,7 +60,7 @@ impl HTMLBaseElement {
                 "The frozen base url is only defined for base elements \
                  that have a base url.",
             );
-        let document = document_from_node(self);
+        let document = self.owner_document();
         let base = document.fallback_base_url();
         let parsed = base.join(&href.value());
         parsed.unwrap_or(base)
@@ -74,7 +74,7 @@ impl HTMLBaseElement {
         }
 
         if self.upcast::<Element>().has_attribute(&local_name!("href")) {
-            let document = document_from_node(self);
+            let document = self.owner_document();
             document.refresh_base_element();
         }
     }
@@ -84,7 +84,7 @@ impl HTMLBaseElementMethods<crate::DomTypeHolder> for HTMLBaseElement {
     // https://html.spec.whatwg.org/multipage/#dom-base-href
     fn Href(&self) -> DOMString {
         // Step 1.
-        let document = document_from_node(self);
+        let document = self.owner_document();
 
         // Step 2.
         let attr = self
@@ -120,7 +120,7 @@ impl VirtualMethods for HTMLBaseElement {
     fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation) {
         self.super_type().unwrap().attribute_mutated(attr, mutation);
         if *attr.local_name() == local_name!("href") {
-            document_from_node(self).refresh_base_element();
+            self.owner_document().refresh_base_element();
         }
     }
 

--- a/components/script/dom/htmlbuttonelement.rs
+++ b/components/script/dom/htmlbuttonelement.rs
@@ -26,7 +26,7 @@ use crate::dom::htmlformelement::{
     FormControl, FormDatum, FormDatumValue, FormSubmitterElement, HTMLFormElement, ResetFrom,
     SubmittedFrom,
 };
-use crate::dom::node::{window_from_node, BindContext, Node, UnbindContext};
+use crate::dom::node::{BindContext, Node, NodeTraits, UnbindContext};
 use crate::dom::nodelist::NodeList;
 use crate::dom::validation::{is_barred_by_datalist_ancestor, Validatable};
 use crate::dom::validitystate::{ValidationFlags, ValidityState};
@@ -333,7 +333,7 @@ impl Validatable for HTMLButtonElement {
 
     fn validity_state(&self) -> DomRoot<ValidityState> {
         self.validity_state
-            .or_init(|| ValidityState::new(&window_from_node(self), self.upcast()))
+            .or_init(|| ValidityState::new(&self.owner_window(), self.upcast()))
     }
 
     fn is_instance_validatable(&self) -> bool {

--- a/components/script/dom/htmlcanvaselement.rs
+++ b/components/script/dom/htmlcanvaselement.rs
@@ -48,7 +48,7 @@ use crate::dom::gpucanvascontext::GPUCanvasContext;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::mediastream::MediaStream;
 use crate::dom::mediastreamtrack::MediaStreamTrack;
-use crate::dom::node::{window_from_node, Node};
+use crate::dom::node::{Node, NodeTraits};
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::dom::webgl2renderingcontext::WebGL2RenderingContext;
 use crate::dom::webglrenderingcontext::WebGLRenderingContext;
@@ -197,7 +197,7 @@ impl HTMLCanvasElement {
                 _ => None,
             };
         }
-        let window = window_from_node(self);
+        let window = self.owner_window();
         let size = self.get_size();
         let context = CanvasRenderingContext2D::new(window.upcast::<GlobalScope>(), self, size);
         *self.context.borrow_mut() = Some(CanvasContext::Context2d(Dom::from_ref(&*context)));
@@ -216,7 +216,7 @@ impl HTMLCanvasElement {
                 _ => None,
             };
         }
-        let window = window_from_node(self);
+        let window = self.owner_window();
         let size = self.get_size();
         let attrs = Self::get_gl_attributes(cx, options)?;
         let canvas = HTMLCanvasElementOrOffscreenCanvas::HTMLCanvasElement(DomRoot::from_ref(self));
@@ -248,7 +248,7 @@ impl HTMLCanvasElement {
                 _ => None,
             };
         }
-        let window = window_from_node(self);
+        let window = self.owner_window();
         let size = self.get_size();
         let attrs = Self::get_gl_attributes(cx, options)?;
         let canvas = HTMLCanvasElementOrOffscreenCanvas::HTMLCanvasElement(DomRoot::from_ref(self));
@@ -279,7 +279,7 @@ impl HTMLCanvasElement {
             .recv()
             .expect("Failed to get WebGPU channel")
             .map(|channel| {
-                let window = window_from_node(self);
+                let window = self.owner_window();
                 let context = GPUCanvasContext::new(window.upcast::<GlobalScope>(), self, channel);
                 *self.context.borrow_mut() = Some(CanvasContext::WebGPU(Dom::from_ref(&*context)));
                 context

--- a/components/script/dom/htmlcollection.rs
+++ b/components/script/dom/htmlcollection.rs
@@ -18,7 +18,7 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::bindings::trace::JSTraceable;
 use crate::dom::bindings::xmlname::namespace_from_domstring;
 use crate::dom::element::Element;
-use crate::dom::node::{document_from_node, Node};
+use crate::dom::node::{Node, NodeTraits};
 use crate::dom::window::Window;
 use crate::script_runtime::CanGc;
 
@@ -282,7 +282,8 @@ impl HTMLCollection {
         }
         impl CollectionFilter for ClassNameFilter {
             fn filter(&self, elem: &Element, _root: &Node) -> bool {
-                let case_sensitivity = document_from_node(elem)
+                let case_sensitivity = elem
+                    .owner_document()
                     .quirks_mode()
                     .classes_and_ids_case_sensitivity();
 

--- a/components/script/dom/htmldatalistelement.rs
+++ b/components/script/dom/htmldatalistelement.rs
@@ -13,7 +13,7 @@ use crate::dom::document::Document;
 use crate::dom::htmlcollection::HTMLCollection;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::htmloptionelement::HTMLOptionElement;
-use crate::dom::node::{window_from_node, Node};
+use crate::dom::node::{Node, NodeTraits};
 use crate::script_runtime::CanGc;
 
 #[dom_struct]
@@ -54,7 +54,7 @@ impl HTMLDataListElement {
 impl HTMLDataListElementMethods<crate::DomTypeHolder> for HTMLDataListElement {
     // https://html.spec.whatwg.org/multipage/#dom-datalist-options
     fn Options(&self) -> DomRoot<HTMLCollection> {
-        HTMLCollection::new_with_filter_fn(&window_from_node(self), self.upcast(), |element, _| {
+        HTMLCollection::new_with_filter_fn(&self.owner_window(), self.upcast(), |element, _| {
             element.is::<HTMLOptionElement>()
         })
     }

--- a/components/script/dom/htmldetailselement.rs
+++ b/components/script/dom/htmldetailselement.rs
@@ -17,7 +17,7 @@ use crate::dom::document::Document;
 use crate::dom::element::AttributeMutation;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::htmlelement::HTMLElement;
-use crate::dom::node::{window_from_node, Node, NodeDamage};
+use crate::dom::node::{Node, NodeDamage, NodeTraits};
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::script_runtime::CanGc;
 
@@ -82,7 +82,7 @@ impl VirtualMethods for HTMLDetailsElement {
             let counter = self.toggle_counter.get() + 1;
             self.toggle_counter.set(counter);
 
-            let window = window_from_node(self);
+            let window = self.owner_window();
             let this = Trusted::new(self);
             // FIXME(nox): Why are errors silenced here?
             let _ = window.task_manager().dom_manipulation_task_source().queue(

--- a/components/script/dom/htmldialogelement.rs
+++ b/components/script/dom/htmldialogelement.rs
@@ -15,7 +15,7 @@ use crate::dom::document::Document;
 use crate::dom::element::Element;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::htmlelement::HTMLElement;
-use crate::dom::node::{window_from_node, Node};
+use crate::dom::node::{Node, NodeTraits};
 use crate::script_runtime::CanGc;
 
 #[dom_struct]
@@ -102,7 +102,7 @@ impl HTMLDialogElementMethods<crate::DomTypeHolder> for HTMLDialogElement {
     fn Close(&self, return_value: Option<DOMString>) {
         let element = self.upcast::<Element>();
         let target = self.upcast::<EventTarget>();
-        let win = window_from_node(self);
+        let win = self.owner_window();
 
         // Step 1 & 2
         if element

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -46,9 +46,7 @@ use crate::dom::htmlhtmlelement::HTMLHtmlElement;
 use crate::dom::htmlinputelement::{HTMLInputElement, InputType};
 use crate::dom::htmllabelelement::HTMLLabelElement;
 use crate::dom::htmltextareaelement::HTMLTextAreaElement;
-use crate::dom::node::{
-    document_from_node, window_from_node, BindContext, Node, ShadowIncluding, UnbindContext,
-};
+use crate::dom::node::{BindContext, Node, NodeTraits, ShadowIncluding, UnbindContext};
 use crate::dom::text::Text;
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::script_runtime::CanGc;
@@ -117,7 +115,7 @@ impl HTMLElement {
     /// <https://html.spec.whatwg.org/multipage/#get-the-text-steps>
     fn get_inner_outer_text(&self, can_gc: CanGc) -> DOMString {
         let node = self.upcast::<Node>();
-        let window = window_from_node(node);
+        let window = node.owner_window();
         let element = self.as_element();
 
         // Step 1.
@@ -139,7 +137,7 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
     // https://html.spec.whatwg.org/multipage/#the-style-attribute
     fn Style(&self) -> DomRoot<CSSStyleDeclaration> {
         self.style_decl.or_init(|| {
-            let global = window_from_node(self);
+            let global = self.owner_window();
             CSSStyleDeclaration::new(
                 &global,
                 CSSStyleOwner::Element(Dom::from_ref(self.upcast())),
@@ -190,7 +188,7 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
     // https://html.spec.whatwg.org/multipage/#handler-onerror
     fn GetOnerror(&self, can_gc: CanGc) -> Option<Rc<OnErrorEventHandlerNonNull>> {
         if self.is_body_or_frameset() {
-            let document = document_from_node(self);
+            let document = self.owner_document();
             if document.has_browsing_context() {
                 document.window().GetOnerror()
             } else {
@@ -205,7 +203,7 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
     // https://html.spec.whatwg.org/multipage/#handler-onerror
     fn SetOnerror(&self, listener: Option<Rc<OnErrorEventHandlerNonNull>>) {
         if self.is_body_or_frameset() {
-            let document = document_from_node(self);
+            let document = self.owner_document();
             if document.has_browsing_context() {
                 document.window().SetOnerror(listener)
             }
@@ -219,7 +217,7 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
     // https://html.spec.whatwg.org/multipage/#handler-onload
     fn GetOnload(&self, can_gc: CanGc) -> Option<Rc<EventHandlerNonNull>> {
         if self.is_body_or_frameset() {
-            let document = document_from_node(self);
+            let document = self.owner_document();
             if document.has_browsing_context() {
                 document.window().GetOnload()
             } else {
@@ -234,7 +232,7 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
     // https://html.spec.whatwg.org/multipage/#handler-onload
     fn SetOnload(&self, listener: Option<Rc<EventHandlerNonNull>>) {
         if self.is_body_or_frameset() {
-            let document = document_from_node(self);
+            let document = self.owner_document();
             if document.has_browsing_context() {
                 document.window().SetOnload(listener)
             }
@@ -247,7 +245,7 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
     // https://html.spec.whatwg.org/multipage/#handler-onblur
     fn GetOnblur(&self, can_gc: CanGc) -> Option<Rc<EventHandlerNonNull>> {
         if self.is_body_or_frameset() {
-            let document = document_from_node(self);
+            let document = self.owner_document();
             if document.has_browsing_context() {
                 document.window().GetOnblur()
             } else {
@@ -262,7 +260,7 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
     // https://html.spec.whatwg.org/multipage/#handler-onblur
     fn SetOnblur(&self, listener: Option<Rc<EventHandlerNonNull>>) {
         if self.is_body_or_frameset() {
-            let document = document_from_node(self);
+            let document = self.owner_document();
             if document.has_browsing_context() {
                 document.window().SetOnblur(listener)
             }
@@ -275,7 +273,7 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
     // https://html.spec.whatwg.org/multipage/#handler-onfocus
     fn GetOnfocus(&self, can_gc: CanGc) -> Option<Rc<EventHandlerNonNull>> {
         if self.is_body_or_frameset() {
-            let document = document_from_node(self);
+            let document = self.owner_document();
             if document.has_browsing_context() {
                 document.window().GetOnfocus()
             } else {
@@ -290,7 +288,7 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
     // https://html.spec.whatwg.org/multipage/#handler-onfocus
     fn SetOnfocus(&self, listener: Option<Rc<EventHandlerNonNull>>) {
         if self.is_body_or_frameset() {
-            let document = document_from_node(self);
+            let document = self.owner_document();
             if document.has_browsing_context() {
                 document.window().SetOnfocus(listener)
             }
@@ -303,7 +301,7 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
     // https://html.spec.whatwg.org/multipage/#handler-onresize
     fn GetOnresize(&self, can_gc: CanGc) -> Option<Rc<EventHandlerNonNull>> {
         if self.is_body_or_frameset() {
-            let document = document_from_node(self);
+            let document = self.owner_document();
             if document.has_browsing_context() {
                 document.window().GetOnresize()
             } else {
@@ -318,7 +316,7 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
     // https://html.spec.whatwg.org/multipage/#handler-onresize
     fn SetOnresize(&self, listener: Option<Rc<EventHandlerNonNull>>) {
         if self.is_body_or_frameset() {
-            let document = document_from_node(self);
+            let document = self.owner_document();
             if document.has_browsing_context() {
                 document.window().SetOnresize(listener)
             }
@@ -331,7 +329,7 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
     // https://html.spec.whatwg.org/multipage/#handler-onscroll
     fn GetOnscroll(&self, can_gc: CanGc) -> Option<Rc<EventHandlerNonNull>> {
         if self.is_body_or_frameset() {
-            let document = document_from_node(self);
+            let document = self.owner_document();
             if document.has_browsing_context() {
                 document.window().GetOnscroll()
             } else {
@@ -346,7 +344,7 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
     // https://html.spec.whatwg.org/multipage/#handler-onscroll
     fn SetOnscroll(&self, listener: Option<Rc<EventHandlerNonNull>>) {
         if self.is_body_or_frameset() {
-            let document = document_from_node(self);
+            let document = self.owner_document();
             if document.has_browsing_context() {
                 document.window().SetOnscroll(listener)
             }
@@ -412,7 +410,7 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
     fn Focus(&self, can_gc: CanGc) {
         // TODO: Mark the element as locked for focus and run the focusing steps.
         // https://html.spec.whatwg.org/multipage/#focusing-steps
-        let document = document_from_node(self);
+        let document = self.owner_document();
         document.request_focus(Some(self.upcast()), FocusType::Element, can_gc);
     }
 
@@ -423,7 +421,7 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
             return;
         }
         // https://html.spec.whatwg.org/multipage/#unfocusing-steps
-        let document = document_from_node(self);
+        let document = self.owner_document();
         document.request_focus(None, FocusType::Element, can_gc);
     }
 
@@ -434,7 +432,7 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
         }
 
         let node = self.upcast::<Node>();
-        let window = window_from_node(self);
+        let window = self.owner_window();
         let (element, _) = window.offset_parent_query(node, can_gc);
 
         element
@@ -447,7 +445,7 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
         }
 
         let node = self.upcast::<Node>();
-        let window = window_from_node(self);
+        let window = self.owner_window();
         let (_, rect) = window.offset_parent_query(node, can_gc);
 
         rect.origin.y.to_nearest_px()
@@ -460,7 +458,7 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
         }
 
         let node = self.upcast::<Node>();
-        let window = window_from_node(self);
+        let window = self.owner_window();
         let (_, rect) = window.offset_parent_query(node, can_gc);
 
         rect.origin.x.to_nearest_px()
@@ -469,7 +467,7 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
     // https://drafts.csswg.org/cssom-view/#dom-htmlelement-offsetwidth
     fn OffsetWidth(&self, can_gc: CanGc) -> i32 {
         let node = self.upcast::<Node>();
-        let window = window_from_node(self);
+        let window = self.owner_window();
         let (_, rect) = window.offset_parent_query(node, can_gc);
 
         rect.size.width.to_nearest_px()
@@ -478,7 +476,7 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
     // https://drafts.csswg.org/cssom-view/#dom-htmlelement-offsetheight
     fn OffsetHeight(&self, can_gc: CanGc) -> i32 {
         let node = self.upcast::<Node>();
-        let window = window_from_node(self);
+        let window = self.owner_window();
         let (_, rect) = window.offset_parent_query(node, can_gc);
 
         rect.size.height.to_nearest_px()
@@ -512,7 +510,7 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
         };
 
         let node = self.upcast::<Node>();
-        let document = document_from_node(self);
+        let document = self.owner_document();
 
         // Step 2: Let next be this's next sibling.
         let next = node.GetNextSibling();
@@ -600,7 +598,7 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
         // Note: the element can pass this check without yet being a custom
         // element, as long as there is a registered definition
         // that could upgrade it to one later.
-        let registry = document_from_node(self).window().CustomElements();
+        let registry = self.owner_document().window().CustomElements();
         let definition = registry.lookup_definition(self.as_element().local_name(), None);
 
         // Step 3: If definition is null, then throw an "NotSupportedError" DOMException
@@ -943,7 +941,7 @@ impl HTMLElement {
     /// <https://html.spec.whatwg.org/multipage/#rendered-text-fragment>
     fn rendered_text_fragment(&self, input: DOMString, can_gc: CanGc) -> DomRoot<DocumentFragment> {
         // Step 1: Let fragment be a new DocumentFragment whose node document is document.
-        let document = document_from_node(self);
+        let document = self.owner_document();
         let fragment = DocumentFragment::new(&document, can_gc);
 
         // Step 2: Let position be a position variable for input, initially pointing at the start
@@ -1036,7 +1034,7 @@ impl VirtualMethods for HTMLElement {
                 let evtarget = self.upcast::<EventTarget>();
                 let source_line = 1; //TODO(#9604) get current JS execution line
                 evtarget.set_event_handler_uncompiled(
-                    window_from_node(self).get_url(),
+                    self.owner_window().get_url(),
                     source_line,
                     &name[2..],
                     // FIXME(ajeffrey): Convert directly from AttrValue to DOMString

--- a/components/script/dom/htmlfieldsetelement.rs
+++ b/components/script/dom/htmlfieldsetelement.rs
@@ -21,7 +21,7 @@ use crate::dom::htmlcollection::HTMLCollection;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::htmlformelement::{FormControl, HTMLFormElement};
 use crate::dom::htmllegendelement::HTMLLegendElement;
-use crate::dom::node::{window_from_node, Node, ShadowIncluding};
+use crate::dom::node::{Node, NodeTraits, ShadowIncluding};
 use crate::dom::validation::Validatable;
 use crate::dom::validitystate::ValidityState;
 use crate::dom::virtualmethods::VirtualMethods;
@@ -88,7 +88,7 @@ impl HTMLFieldSetElement {
 impl HTMLFieldSetElementMethods<crate::DomTypeHolder> for HTMLFieldSetElement {
     // https://html.spec.whatwg.org/multipage/#dom-fieldset-elements
     fn Elements(&self) -> DomRoot<HTMLCollection> {
-        HTMLCollection::new_with_filter_fn(&window_from_node(self), self.upcast(), |element, _| {
+        HTMLCollection::new_with_filter_fn(&self.owner_window(), self.upcast(), |element, _| {
             element
                 .downcast::<HTMLElement>()
                 .is_some_and(HTMLElement::is_listed_element)
@@ -271,7 +271,7 @@ impl Validatable for HTMLFieldSetElement {
 
     fn validity_state(&self) -> DomRoot<ValidityState> {
         self.validity_state
-            .or_init(|| ValidityState::new(&window_from_node(self), self.upcast()))
+            .or_init(|| ValidityState::new(&self.owner_window(), self.upcast()))
     }
 
     fn is_instance_validatable(&self) -> bool {

--- a/components/script/dom/htmlframesetelement.rs
+++ b/components/script/dom/htmlframesetelement.rs
@@ -12,7 +12,7 @@ use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::document::Document;
 use crate::dom::htmlelement::HTMLElement;
-use crate::dom::node::{document_from_node, Node};
+use crate::dom::node::{Node, NodeTraits};
 use crate::script_runtime::CanGc;
 
 #[dom_struct]

--- a/components/script/dom/htmlheadelement.rs
+++ b/components/script/dom/htmlheadelement.rs
@@ -14,7 +14,7 @@ use crate::dom::document::{determine_policy_for_token, Document};
 use crate::dom::element::Element;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::htmlmetaelement::HTMLMetaElement;
-use crate::dom::node::{document_from_node, BindContext, Node, ShadowIncluding};
+use crate::dom::node::{BindContext, Node, NodeTraits, ShadowIncluding};
 use crate::dom::userscripts::load_script;
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::script_runtime::CanGc;
@@ -56,7 +56,7 @@ impl HTMLHeadElement {
 
     /// <https://html.spec.whatwg.org/multipage/#meta-referrer>
     pub fn set_document_referrer(&self) {
-        let doc = document_from_node(self);
+        let doc = self.owner_document();
 
         if doc.GetHead().as_deref() != Some(self) {
             return;
@@ -87,7 +87,7 @@ impl HTMLHeadElement {
 
     /// <https://html.spec.whatwg.org/multipage/#attr-meta-http-equiv-content-security-policy>
     pub fn set_content_security_policy(&self) {
-        let doc = document_from_node(self);
+        let doc = self.owner_document();
 
         if doc.GetHead().as_deref() != Some(self) {
             return;

--- a/components/script/dom/htmlmetaelement.rs
+++ b/components/script/dom/htmlmetaelement.rs
@@ -27,7 +27,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::htmlheadelement::HTMLHeadElement;
 use crate::dom::location::NavigationType;
-use crate::dom::node::{document_from_node, window_from_node, BindContext, Node, UnbindContext};
+use crate::dom::node::{BindContext, Node, NodeTraits, UnbindContext};
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::dom::window::Window;
 use crate::script_runtime::CanGc;
@@ -146,7 +146,7 @@ impl HTMLMetaElement {
     /// <https://html.spec.whatwg.org/multipage/#shared-declarative-refresh-steps>
     fn shared_declarative_refresh_steps(&self, content: DOMString) {
         // 1
-        let document = document_from_node(self);
+        let document = self.owner_document();
         if document.will_declaratively_refresh() {
             return;
         }
@@ -206,7 +206,7 @@ impl HTMLMetaElement {
         // 12-13
         if document.completely_loaded() {
             // TODO: handle active sandboxing flag
-            let window = window_from_node(self);
+            let window = self.owner_window();
             window.upcast::<GlobalScope>().schedule_callback(
                 OneshotTimerCallback::RefreshRedirectDue(RefreshRedirectDue {
                     window: window.clone(),

--- a/components/script/dom/htmlobjectelement.rs
+++ b/components/script/dom/htmlobjectelement.rs
@@ -20,7 +20,7 @@ use crate::dom::document::Document;
 use crate::dom::element::{AttributeMutation, Element};
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::htmlformelement::{FormControl, HTMLFormElement};
-use crate::dom::node::{window_from_node, Node};
+use crate::dom::node::{Node, NodeTraits};
 use crate::dom::validation::Validatable;
 use crate::dom::validitystate::ValidityState;
 use crate::dom::virtualmethods::VirtualMethods;
@@ -139,7 +139,7 @@ impl Validatable for HTMLObjectElement {
 
     fn validity_state(&self) -> DomRoot<ValidityState> {
         self.validity_state
-            .or_init(|| ValidityState::new(&window_from_node(self), self.upcast()))
+            .or_init(|| ValidityState::new(&self.owner_window(), self.upcast()))
     }
 
     fn is_instance_validatable(&self) -> bool {

--- a/components/script/dom/htmloptionscollection.rs
+++ b/components/script/dom/htmloptionscollection.rs
@@ -24,7 +24,7 @@ use crate::dom::element::Element;
 use crate::dom::htmlcollection::{CollectionFilter, HTMLCollection};
 use crate::dom::htmloptionelement::HTMLOptionElement;
 use crate::dom::htmlselectelement::HTMLSelectElement;
-use crate::dom::node::{document_from_node, Node};
+use crate::dom::node::{Node, NodeTraits};
 use crate::dom::window::Window;
 use crate::script_runtime::CanGc;
 
@@ -57,7 +57,7 @@ impl HTMLOptionsCollection {
 
     fn add_new_elements(&self, count: u32, can_gc: CanGc) -> ErrorResult {
         let root = self.upcast().root_node();
-        let document = document_from_node(&*root);
+        let document = root.owner_document();
 
         for _ in 0..count {
             let element =

--- a/components/script/dom/htmloutputelement.rs
+++ b/components/script/dom/htmloutputelement.rs
@@ -16,7 +16,7 @@ use crate::dom::document::Document;
 use crate::dom::element::{AttributeMutation, Element};
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::htmlformelement::{FormControl, HTMLFormElement};
-use crate::dom::node::{window_from_node, Node};
+use crate::dom::node::{Node, NodeTraits};
 use crate::dom::nodelist::NodeList;
 use crate::dom::validation::Validatable;
 use crate::dom::validitystate::ValidityState;
@@ -188,7 +188,7 @@ impl Validatable for HTMLOutputElement {
 
     fn validity_state(&self) -> DomRoot<ValidityState> {
         self.validity_state
-            .or_init(|| ValidityState::new(&window_from_node(self), self.upcast()))
+            .or_init(|| ValidityState::new(&self.owner_window(), self.upcast()))
     }
 
     fn is_instance_validatable(&self) -> bool {

--- a/components/script/dom/htmlselectelement.rs
+++ b/components/script/dom/htmlselectelement.rs
@@ -34,7 +34,7 @@ use crate::dom::htmlformelement::{FormControl, FormDatum, FormDatumValue, HTMLFo
 use crate::dom::htmloptgroupelement::HTMLOptGroupElement;
 use crate::dom::htmloptionelement::HTMLOptionElement;
 use crate::dom::htmloptionscollection::HTMLOptionsCollection;
-use crate::dom::node::{window_from_node, BindContext, Node, UnbindContext};
+use crate::dom::node::{BindContext, Node, NodeTraits, UnbindContext};
 use crate::dom::nodelist::NodeList;
 use crate::dom::validation::{is_barred_by_datalist_ancestor, Validatable};
 use crate::dom::validitystate::{ValidationFlags, ValidityState};
@@ -279,7 +279,7 @@ impl HTMLSelectElementMethods<crate::DomTypeHolder> for HTMLSelectElement {
     // https://html.spec.whatwg.org/multipage/#dom-select-options
     fn Options(&self) -> DomRoot<HTMLOptionsCollection> {
         self.options.or_init(|| {
-            let window = window_from_node(self);
+            let window = self.owner_window();
             HTMLOptionsCollection::new(&window, self, Box::new(OptionsFilter))
         })
     }
@@ -510,7 +510,7 @@ impl Validatable for HTMLSelectElement {
 
     fn validity_state(&self) -> DomRoot<ValidityState> {
         self.validity_state
-            .or_init(|| ValidityState::new(&window_from_node(self), self.upcast()))
+            .or_init(|| ValidityState::new(&self.owner_window(), self.upcast()))
     }
 
     fn is_instance_validatable(&self) -> bool {

--- a/components/script/dom/htmltableelement.rs
+++ b/components/script/dom/htmltableelement.rs
@@ -26,7 +26,7 @@ use crate::dom::htmltablecaptionelement::HTMLTableCaptionElement;
 use crate::dom::htmltablecolelement::HTMLTableColElement;
 use crate::dom::htmltablerowelement::HTMLTableRowElement;
 use crate::dom::htmltablesectionelement::HTMLTableSectionElement;
-use crate::dom::node::{document_from_node, window_from_node, Node};
+use crate::dom::node::{Node, NodeTraits};
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::script_runtime::CanGc;
 
@@ -149,13 +149,8 @@ impl HTMLTableElement {
             return section;
         }
 
-        let section = HTMLTableSectionElement::new(
-            atom.clone(),
-            None,
-            &document_from_node(self),
-            None,
-            can_gc,
-        );
+        let section =
+            HTMLTableSectionElement::new(atom.clone(), None, &self.owner_document(), None, can_gc);
         match *atom {
             local_name!("thead") => self.SetTHead(Some(&section)),
             local_name!("tfoot") => self.SetTFoot(Some(&section)),
@@ -192,7 +187,7 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
     // https://html.spec.whatwg.org/multipage/#dom-table-rows
     fn Rows(&self) -> DomRoot<HTMLCollection> {
         let filter = self.get_rows();
-        HTMLCollection::new(&window_from_node(self), self.upcast(), Box::new(filter))
+        HTMLCollection::new(&self.owner_window(), self.upcast(), Box::new(filter))
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-table-caption
@@ -225,7 +220,7 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
                 let caption = HTMLTableCaptionElement::new(
                     local_name!("caption"),
                     None,
-                    &document_from_node(self),
+                    &self.owner_document(),
                     None,
                     can_gc,
                 );
@@ -302,7 +297,7 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
     fn TBodies(&self) -> DomRoot<HTMLCollection> {
         self.tbodies.or_init(|| {
             HTMLCollection::new_with_filter_fn(
-                &window_from_node(self),
+                &self.owner_window(),
                 self.upcast(),
                 |element, root| {
                     element.is::<HTMLTableSectionElement>() &&
@@ -318,7 +313,7 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
         let tbody = HTMLTableSectionElement::new(
             local_name!("tbody"),
             None,
-            &document_from_node(self),
+            &self.owner_document(),
             None,
             can_gc,
         );
@@ -346,7 +341,7 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
         let new_row = HTMLTableRowElement::new(
             local_name!("tr"),
             None,
-            &document_from_node(self),
+            &self.owner_document(),
             None,
             can_gc,
         );

--- a/components/script/dom/htmltablerowelement.rs
+++ b/components/script/dom/htmltablerowelement.rs
@@ -23,7 +23,7 @@ use crate::dom::htmlelement::HTMLElement;
 use crate::dom::htmltablecellelement::HTMLTableCellElement;
 use crate::dom::htmltableelement::HTMLTableElement;
 use crate::dom::htmltablesectionelement::HTMLTableSectionElement;
-use crate::dom::node::{window_from_node, Node};
+use crate::dom::node::{Node, NodeTraits};
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::script_runtime::CanGc;
 
@@ -87,7 +87,7 @@ impl HTMLTableRowElementMethods<crate::DomTypeHolder> for HTMLTableRowElement {
     fn Cells(&self) -> DomRoot<HTMLCollection> {
         self.cells.or_init(|| {
             HTMLCollection::new_with_filter_fn(
-                &window_from_node(self),
+                &self.owner_window(),
                 self.upcast(),
                 |element, root| {
                     (element.is::<HTMLTableCellElement>()) &&

--- a/components/script/dom/htmltablesectionelement.rs
+++ b/components/script/dom/htmltablesectionelement.rs
@@ -19,7 +19,7 @@ use crate::dom::element::{Element, LayoutElementHelpers};
 use crate::dom::htmlcollection::HTMLCollection;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::htmltablerowelement::HTMLTableRowElement;
-use crate::dom::node::{window_from_node, Node};
+use crate::dom::node::{Node, NodeTraits};
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::script_runtime::CanGc;
 
@@ -64,14 +64,10 @@ impl HTMLTableSectionElement {
 impl HTMLTableSectionElementMethods<crate::DomTypeHolder> for HTMLTableSectionElement {
     // https://html.spec.whatwg.org/multipage/#dom-tbody-rows
     fn Rows(&self) -> DomRoot<HTMLCollection> {
-        HTMLCollection::new_with_filter_fn(
-            &window_from_node(self),
-            self.upcast(),
-            |element, root| {
-                element.is::<HTMLTableRowElement>() &&
-                    element.upcast::<Node>().GetParentNode().as_deref() == Some(root)
-            },
-        )
+        HTMLCollection::new_with_filter_fn(&self.owner_window(), self.upcast(), |element, root| {
+            element.is::<HTMLTableRowElement>() &&
+                element.upcast::<Node>().GetParentNode().as_deref() == Some(root)
+        })
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-tbody-insertrow

--- a/components/script/dom/htmltemplateelement.rs
+++ b/components/script/dom/htmltemplateelement.rs
@@ -14,7 +14,7 @@ use crate::dom::bindings::root::{DomRoot, MutNullableDom};
 use crate::dom::document::Document;
 use crate::dom::documentfragment::DocumentFragment;
 use crate::dom::htmlelement::HTMLElement;
-use crate::dom::node::{document_from_node, CloneChildrenFlag, Node};
+use crate::dom::node::{CloneChildrenFlag, Node, NodeTraits};
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::script_runtime::CanGc;
 
@@ -64,7 +64,7 @@ impl HTMLTemplateElementMethods<crate::DomTypeHolder> for HTMLTemplateElement {
     /// <https://html.spec.whatwg.org/multipage/#dom-template-content>
     fn Content(&self, can_gc: CanGc) -> DomRoot<DocumentFragment> {
         self.contents.or_init(|| {
-            let doc = document_from_node(self);
+            let doc = self.owner_document();
             doc.appropriate_template_contents_owner_document(can_gc)
                 .CreateDocumentFragment(can_gc)
         })
@@ -80,8 +80,9 @@ impl VirtualMethods for HTMLTemplateElement {
     fn adopting_steps(&self, old_doc: &Document) {
         self.super_type().unwrap().adopting_steps(old_doc);
         // Step 1.
-        let doc =
-            document_from_node(self).appropriate_template_contents_owner_document(CanGc::note());
+        let doc = self
+            .owner_document()
+            .appropriate_template_contents_owner_document(CanGc::note());
         // Step 2.
         Node::adopt(self.Content(CanGc::note()).upcast(), &doc);
     }

--- a/components/script/dom/htmltextareaelement.rs
+++ b/components/script/dom/htmltextareaelement.rs
@@ -34,8 +34,7 @@ use crate::dom::htmlformelement::{FormControl, HTMLFormElement};
 use crate::dom::htmlinputelement::HTMLInputElement;
 use crate::dom::keyboardevent::KeyboardEvent;
 use crate::dom::node::{
-    window_from_node, BindContext, ChildrenMutation, CloneChildrenFlag, Node, NodeDamage,
-    UnbindContext,
+    BindContext, ChildrenMutation, CloneChildrenFlag, Node, NodeDamage, NodeTraits, UnbindContext,
 };
 use crate::dom::nodelist::NodeList;
 use crate::dom::textcontrol::{TextControlElement, TextControlSelection};
@@ -651,7 +650,7 @@ impl VirtualMethods for HTMLTextAreaElement {
             }
         } else if event.type_() == atom!("keypress") && !event.DefaultPrevented() {
             if event.IsTrusted() {
-                let window = window_from_node(self);
+                let window = self.owner_window();
                 window
                     .task_manager()
                     .user_interaction_task_source()
@@ -714,7 +713,7 @@ impl Validatable for HTMLTextAreaElement {
 
     fn validity_state(&self) -> DomRoot<ValidityState> {
         self.validity_state
-            .or_init(|| ValidityState::new(&window_from_node(self), self.upcast()))
+            .or_init(|| ValidityState::new(&self.owner_window(), self.upcast()))
     }
 
     fn is_instance_validatable(&self) -> bool {

--- a/components/script/dom/macros.rs
+++ b/components/script/dom/macros.rs
@@ -128,7 +128,7 @@ macro_rules! make_form_action_getter(
             use $crate::dom::bindings::inheritance::Castable;
             use $crate::dom::element::Element;
             let element = self.upcast::<Element>();
-            let doc = $crate::dom::node::document_from_node(self);
+            let doc = $crate::dom::node::NodeTraits::owner_document(self);
             let attr = element.get_attribute(&html5ever::ns!(), &html5ever::local_name!($htmlname));
             let value = attr.as_ref().map(|attr| attr.value());
             let value = match value {
@@ -410,7 +410,7 @@ macro_rules! define_event_handler(
 macro_rules! define_window_owned_event_handler(
     ($handler: ty, $event_type: ident, $getter: ident, $setter: ident) => (
         fn $getter(&self) -> Option<::std::rc::Rc<$handler>> {
-            let document = document_from_node(self);
+            let document = self.owner_document();
             if document.has_browsing_context() {
                 document.window().$getter()
             } else {
@@ -419,7 +419,7 @@ macro_rules! define_window_owned_event_handler(
         }
 
         fn $setter(&self, listener: Option<::std::rc::Rc<$handler>>) {
-            let document = document_from_node(self);
+            let document = self.owner_document();
             if document.has_browsing_context() {
                 document.window().$setter(listener)
             }

--- a/components/script/dom/resizeobserver.rs
+++ b/components/script/dom/resizeobserver.rs
@@ -21,7 +21,7 @@ use crate::dom::bindings::reflector::{reflect_dom_object_with_proto, Reflector};
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::domrectreadonly::DOMRectReadOnly;
 use crate::dom::element::Element;
-use crate::dom::node::{window_from_node, Node};
+use crate::dom::node::{Node, NodeTraits};
 use crate::dom::resizeobserverentry::ResizeObserverEntry;
 use crate::dom::resizeobserversize::{ResizeObserverSize, ResizeObserverSizeImpl};
 use crate::dom::window::Window;
@@ -111,7 +111,7 @@ impl ResizeObserver {
             let width = box_size.width().to_f64_px();
             let height = box_size.height().to_f64_px();
             let size_impl = ResizeObserverSizeImpl::new(width, height);
-            let window = window_from_node(&**target);
+            let window = target.owner_window();
             let observer_size = ResizeObserverSize::new(&window, size_impl, can_gc);
 
             // Note: content rect is built from content box size.

--- a/components/script/dom/selection.rs
+++ b/components/script/dom/selection.rs
@@ -17,7 +17,7 @@ use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
 use crate::dom::eventtarget::EventTarget;
-use crate::dom::node::{window_from_node, Node};
+use crate::dom::node::Node;
 use crate::dom::range::Range;
 use crate::script_runtime::CanGc;
 
@@ -88,7 +88,7 @@ impl Selection {
             return;
         }
         let this = Trusted::new(self);
-        let window = window_from_node(&*self.document);
+        let window = self.document.window();
         window
             .task_manager()
             .user_interaction_task_source() // w3c/selection-api#117

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -25,7 +25,7 @@ use crate::dom::documentfragment::DocumentFragment;
 use crate::dom::documentorshadowroot::{DocumentOrShadowRoot, StyleSheetInDocument};
 use crate::dom::element::Element;
 use crate::dom::node::{
-    document_from_node, BindContext, Node, NodeDamage, NodeFlags, ShadowIncluding, UnbindContext,
+    BindContext, Node, NodeDamage, NodeFlags, NodeTraits, ShadowIncluding, UnbindContext,
 };
 use crate::dom::stylesheetlist::{StyleSheetList, StyleSheetListOwner};
 use crate::dom::virtualmethods::VirtualMethods;
@@ -314,7 +314,7 @@ impl VirtualMethods for ShadowRoot {
         }
 
         if context.tree_connected {
-            let document = document_from_node(self);
+            let document = self.owner_document();
             document.register_shadow_root(self);
         }
 
@@ -332,7 +332,7 @@ impl VirtualMethods for ShadowRoot {
         }
 
         if context.tree_connected {
-            let document = document_from_node(self);
+            let document = self.owner_document();
             document.unregister_shadow_root(self);
         }
     }

--- a/components/script/dom/svgelement.rs
+++ b/components/script/dom/svgelement.rs
@@ -13,7 +13,7 @@ use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
 use crate::dom::cssstyledeclaration::{CSSModificationAccess, CSSStyleDeclaration, CSSStyleOwner};
 use crate::dom::document::Document;
 use crate::dom::element::Element;
-use crate::dom::node::{window_from_node, Node};
+use crate::dom::node::{Node, NodeTraits};
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::script_runtime::CanGc;
 
@@ -70,7 +70,7 @@ impl SVGElementMethods<crate::DomTypeHolder> for SVGElement {
     // https://html.spec.whatwg.org/multipage/#the-style-attribute
     fn Style(&self) -> DomRoot<CSSStyleDeclaration> {
         self.style_decl.or_init(|| {
-            let global = window_from_node(self);
+            let global = self.owner_window();
             CSSStyleDeclaration::new(
                 &global,
                 CSSStyleOwner::Element(Dom::from_ref(self.upcast())),

--- a/components/script/dom/textcontrol.rs
+++ b/components/script/dom/textcontrol.rs
@@ -16,7 +16,7 @@ use crate::dom::bindings::error::{Error, ErrorResult};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::event::{EventBubbles, EventCancelable};
 use crate::dom::eventtarget::EventTarget;
-use crate::dom::node::{window_from_node, Node, NodeDamage};
+use crate::dom::node::{Node, NodeDamage, NodeTraits};
 use crate::textinput::{SelectionDirection, SelectionState, TextInput, UTF8Bytes};
 
 pub trait TextControlElement: DerivedFrom<EventTarget> + DerivedFrom<Node> {
@@ -300,7 +300,7 @@ impl<'a, E: TextControlElement> TextControlSelection<'a, E> {
 
         // Step 6
         if textinput.selection_state() != original_selection_state {
-            let window = window_from_node(self.element);
+            let window = self.element.owner_window();
             window
                 .task_manager()
                 .user_interaction_task_source()

--- a/components/script/dom/uievent.rs
+++ b/components/script/dom/uievent.rs
@@ -9,7 +9,7 @@ use dom_struct::dom_struct;
 use js::rust::HandleObject;
 use servo_atoms::Atom;
 
-use super::node::document_from_node;
+use super::node::NodeTraits;
 use crate::dom::bindings::codegen::Bindings::EventBinding::EventMethods;
 use crate::dom::bindings::codegen::Bindings::UIEventBinding;
 use crate::dom::bindings::codegen::Bindings::UIEventBinding::UIEventMethods;
@@ -106,7 +106,7 @@ impl UIEvent {
         if let Some(target_) = target_ {
             let element = target_.downcast::<Element>();
             let document = match element {
-                Some(element) => document_from_node(element),
+                Some(element) => element.owner_document(),
                 None => target_.downcast::<Window>().unwrap().Document(),
             };
             self.view.set(Some(document.window()));

--- a/components/script/dom/userscripts.rs
+++ b/components/script/dom/userscripts.rs
@@ -15,12 +15,12 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::htmlheadelement::HTMLHeadElement;
 use crate::dom::htmlscriptelement::SourceCode;
-use crate::dom::node::document_from_node;
+use crate::dom::node::NodeTraits;
 use crate::script_module::ScriptFetchOptions;
 use crate::script_runtime::CanGc;
 
 pub fn load_script(head: &HTMLHeadElement) {
-    let doc = document_from_node(head);
+    let doc = head.owner_document();
     let path_str = match doc.window().get_userscripts_path() {
         Some(p) => p,
         None => return,

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -57,7 +57,7 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::element::cors_setting_for_element;
 use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::htmlcanvaselement::{utils as canvas_utils, LayoutCanvasRenderingContextHelpers};
-use crate::dom::node::{document_from_node, window_from_node, Node, NodeDamage};
+use crate::dom::node::{Node, NodeDamage, NodeTraits};
 use crate::dom::promise::Promise;
 use crate::dom::vertexarrayobject::VertexAttribData;
 use crate::dom::webgl_extensions::WebGLExtensions;
@@ -551,8 +551,7 @@ impl WebGLRenderingContext {
         match self.canvas {
             HTMLCanvasElementOrOffscreenCanvas::HTMLCanvasElement(ref canvas) => {
                 canvas.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
-                let document = document_from_node(&**canvas);
-                document.add_dirty_webgl_canvas(self);
+                canvas.owner_document().add_dirty_webgl_canvas(self);
             },
             HTMLCanvasElementOrOffscreenCanvas::OffscreenCanvas(_) => {},
         }
@@ -665,7 +664,7 @@ impl WebGLRenderingContext {
             TexImageSource::HTMLImageElement(image) => {
                 let document = match self.canvas {
                     HTMLCanvasElementOrOffscreenCanvas::HTMLCanvasElement(ref canvas) => {
-                        document_from_node(&**canvas)
+                        canvas.owner_document()
                     },
                     HTMLCanvasElementOrOffscreenCanvas::OffscreenCanvas(ref _canvas) => {
                         // TODO: Support retrieving image pixels here for OffscreenCanvas
@@ -683,7 +682,7 @@ impl WebGLRenderingContext {
 
                 let window = match self.canvas {
                     HTMLCanvasElementOrOffscreenCanvas::HTMLCanvasElement(ref canvas) => {
-                        window_from_node(&**canvas)
+                        canvas.owner_window()
                     },
                     // This is marked as unreachable as we should have returned already
                     HTMLCanvasElementOrOffscreenCanvas::OffscreenCanvas(_) => unreachable!(),

--- a/components/script/dom/webgpu/gpucanvascontext.rs
+++ b/components/script/dom/webgpu/gpucanvascontext.rs
@@ -38,7 +38,7 @@ use crate::dom::bindings::weakref::WeakRef;
 use crate::dom::document::WebGPUContextsMap;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::htmlcanvaselement::{HTMLCanvasElement, LayoutCanvasRenderingContextHelpers};
-use crate::dom::node::{document_from_node, Node, NodeDamage};
+use crate::dom::node::{Node, NodeDamage, NodeTraits};
 use crate::script_runtime::CanGc;
 
 impl HTMLCanvasElementOrOffscreenCanvas {
@@ -141,7 +141,7 @@ impl GPUCanvasContext {
     }
 
     pub fn new(global: &GlobalScope, canvas: &HTMLCanvasElement, channel: WebGPU) -> DomRoot<Self> {
-        let document = document_from_node(canvas);
+        let document = canvas.owner_document();
         let this = reflect_dom_object(
             Box::new(GPUCanvasContext::new_inherited(
                 global,

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -133,7 +133,7 @@ use crate::dom::mediaquerylist::{MediaQueryList, MediaQueryListMatchState};
 use crate::dom::mediaquerylistevent::MediaQueryListEvent;
 use crate::dom::messageevent::MessageEvent;
 use crate::dom::navigator::Navigator;
-use crate::dom::node::{document_from_node, from_untrusted_node_address, Node, NodeDamage};
+use crate::dom::node::{from_untrusted_node_address, Node, NodeDamage, NodeTraits};
 use crate::dom::performance::Performance;
 use crate::dom::promise::Promise;
 use crate::dom::screen::Screen;
@@ -882,7 +882,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
         let container = window_proxy.frame_element()?;
 
         // Step 6.
-        let container_doc = document_from_node(container);
+        let container_doc = container.owner_document();
         let current_doc = GlobalScope::current()
             .expect("No current global object")
             .as_window()

--- a/components/script/image_listener.rs
+++ b/components/script/image_listener.rs
@@ -10,7 +10,7 @@ use net_traits::image_cache::{ImageResponse, PendingImageResponse};
 use crate::dom::bindings::conversions::DerivedFrom;
 use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::DomObject;
-use crate::dom::node::{window_from_node, Node};
+use crate::dom::node::{Node, NodeTraits};
 use crate::script_runtime::CanGc;
 
 pub trait ImageCacheListener {
@@ -26,7 +26,7 @@ pub fn generate_cache_listener_for_element<
     let trusted_node = Trusted::new(elem);
     let (responder_sender, responder_receiver) = ipc::channel().unwrap();
 
-    let window = window_from_node(elem);
+    let window = elem.owner_window();
     let (task_source, canceller) = window
         .task_manager()
         .networking_task_source_with_canceller();

--- a/components/script/layout_image.rs
+++ b/components/script/layout_image.rs
@@ -21,7 +21,7 @@ use crate::dom::bindings::reflector::DomObject;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::document::Document;
 use crate::dom::globalscope::GlobalScope;
-use crate::dom::node::{document_from_node, Node};
+use crate::dom::node::{Node, NodeTraits};
 use crate::dom::performanceresourcetiming::InitiatorType;
 use crate::network_listener::{self, PreInvoke, ResourceTimingListener};
 use crate::script_runtime::CanGc;
@@ -97,7 +97,7 @@ pub fn fetch_image_for_layout(
     id: PendingImageId,
     cache: Arc<dyn ImageCache>,
 ) {
-    let document = document_from_node(node);
+    let document = node.owner_document();
     let context = LayoutImageContext {
         id,
         cache,

--- a/components/script/links.rs
+++ b/components/script/links.rs
@@ -19,7 +19,7 @@ use crate::dom::htmlanchorelement::HTMLAnchorElement;
 use crate::dom::htmlareaelement::HTMLAreaElement;
 use crate::dom::htmlformelement::HTMLFormElement;
 use crate::dom::htmllinkelement::HTMLLinkElement;
-use crate::dom::node::document_from_node;
+use crate::dom::node::NodeTraits;
 use crate::dom::types::{Element, GlobalScope};
 use crate::script_runtime::CanGc;
 
@@ -322,7 +322,7 @@ pub fn get_element_target(subject: &Element) -> Option<DOMString> {
         return Some(subject.get_string_attribute(&local_name!("target")));
     }
 
-    let doc = document_from_node(subject).base_element();
+    let doc = subject.owner_document().base_element();
     match doc {
         Some(doc) => {
             let element = doc.upcast::<Element>();
@@ -348,7 +348,7 @@ pub fn follow_hyperlink(
     }
     // Step 2, done in Step 7.
 
-    let document = document_from_node(subject);
+    let document = subject.owner_document();
     let window = document.window();
 
     // Step 3: source browsing context.

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -65,7 +65,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::htmlscriptelement::{
     HTMLScriptElement, ScriptId, ScriptOrigin, ScriptType, SCRIPT_JS_MIMES,
 };
-use crate::dom::node::document_from_node;
+use crate::dom::node::NodeTraits;
 use crate::dom::performanceresourcetiming::InitiatorType;
 use crate::dom::promise::Promise;
 use crate::dom::promisenativehandler::{Callback, PromiseNativeHandler};
@@ -962,8 +962,7 @@ impl ModuleOwner {
             ModuleOwner::Window(script) => {
                 let global = self.global();
 
-                let document = document_from_node(&*script.root());
-
+                let document = script.root().owner_document();
                 let load = {
                     let module_tree = module_identity.get_module_tree(&global);
 
@@ -1745,7 +1744,7 @@ fn fetch_single_module_script(
 
     let document: Option<DomRoot<Document>> = match &owner {
         ModuleOwner::Worker(_) | ModuleOwner::DynamicModule(_) => None,
-        ModuleOwner::Window(script) => Some(document_from_node(&*script.root())),
+        ModuleOwner::Window(script) => Some(script.root().owner_document()),
     };
 
     // Step 7-8.

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -130,7 +130,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::htmlanchorelement::HTMLAnchorElement;
 use crate::dom::htmliframeelement::HTMLIFrameElement;
 use crate::dom::mutationobserver::MutationObserver;
-use crate::dom::node::{window_from_node, Node, ShadowIncluding};
+use crate::dom::node::{Node, NodeTraits, ShadowIncluding};
 use crate::dom::performanceentry::PerformanceEntry;
 use crate::dom::performancepainttiming::PerformancePaintTiming;
 use crate::dom::servoparser::{ParserContext, ServoParser};
@@ -3062,7 +3062,7 @@ impl ScriptThread {
                 .find_iframe(parent_id, browsing_context_id)
         });
         let parent_browsing_context = match (parent_info, iframe.as_ref()) {
-            (_, Some(iframe)) => Some(window_from_node(&**iframe).window_proxy()),
+            (_, Some(iframe)) => Some(iframe.owner_window().window_proxy()),
             (Some(parent_id), _) => self.remote_window_proxy(
                 window.upcast(),
                 top_level_browsing_context_id,

--- a/components/script/stylesheet_loader.rs
+++ b/components/script/stylesheet_loader.rs
@@ -37,7 +37,7 @@ use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::htmllinkelement::{HTMLLinkElement, RequestGenerationId};
-use crate::dom::node::{containing_shadow_root, document_from_node, window_from_node};
+use crate::dom::node::NodeTraits;
 use crate::dom::performanceresourcetiming::InitiatorType;
 use crate::dom::shadowroot::ShadowRoot;
 use crate::fetch::create_a_potential_cors_request;
@@ -179,7 +179,7 @@ impl FetchResponseListener for StylesheetContext {
             let protocol_encoding_label = metadata.charset.as_deref();
             let final_url = metadata.final_url;
 
-            let win = window_from_node(&*elem);
+            let win = elem.owner_window();
 
             let loader = StylesheetLoader::for_element(&elem);
             match self.source {
@@ -288,7 +288,7 @@ impl ResourceTimingListener for StylesheetContext {
     }
 
     fn resource_timing_global(&self) -> DomRoot<GlobalScope> {
-        document_from_node(&*self.elem.root()).global()
+        self.elem.root().owner_document().global()
     }
 }
 
@@ -310,8 +310,11 @@ impl<'a> StylesheetLoader<'a> {
         cors_setting: Option<CorsSettings>,
         integrity_metadata: String,
     ) {
-        let document = document_from_node(self.elem);
-        let shadow_root = containing_shadow_root(self.elem).map(|sr| Trusted::new(&*sr));
+        let document = self.elem.owner_document();
+        let shadow_root = self
+            .elem
+            .containing_shadow_root()
+            .map(|sr| Trusted::new(&*sr));
         let gen = self
             .elem
             .downcast::<HTMLLinkElement>()

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -58,7 +58,7 @@ use crate::dom::htmliframeelement::HTMLIFrameElement;
 use crate::dom::htmlinputelement::{HTMLInputElement, InputType};
 use crate::dom::htmloptionelement::HTMLOptionElement;
 use crate::dom::htmlselectelement::HTMLSelectElement;
-use crate::dom::node::{window_from_node, Node, ShadowIncluding};
+use crate::dom::node::{Node, NodeTraits, ShadowIncluding};
 use crate::dom::nodelist::NodeList;
 use crate::dom::window::Window;
 use crate::dom::xmlserializer::XMLSerializer;
@@ -414,8 +414,8 @@ pub fn handle_get_browsing_context_id(
 
 // https://w3c.github.io/webdriver/#dfn-center-point
 fn get_element_in_view_center_point(element: &Element, can_gc: CanGc) -> Option<Point2D<i64>> {
-    window_from_node(element.upcast::<Node>())
-        .Document()
+    element
+        .owner_document()
         .GetBody()
         .map(DomRoot::upcast::<Element>)
         .and_then(|body| {
@@ -1088,7 +1088,7 @@ pub fn handle_get_css(
     reply
         .send(
             find_node_by_unique_id(documents, pipeline, node_id).map(|node| {
-                let window = window_from_node(&*node);
+                let window = node.owner_window();
                 let element = node.downcast::<Element>().unwrap();
                 String::from(
                     window


### PR DESCRIPTION
This puts a few commonly used `Node` helpers into a trait (`NodeTraits`)
and gives them more descriptive names and documentation. The renames:

- `document_from_node` -> `NodeTraits::owner_document`
- `window_from_node` -> `NodeTraits::owner_window`
- `stylesheets_owner_from_node` -> `NodeTraits::stylesheet_list_owner`
- `containing_shadow_root` -> `NodeTraits::containing_shadow_root`

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes: covered by existing tests.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
