### PR TITLE
add minimal implementation of FetchParams

### DIFF
--- a/components/net/fetch/fetch_params.rs
+++ b/components/net/fetch/fetch_params.rs
@@ -6,9 +6,12 @@ use std::sync::{Arc, Mutex};
 
 use net_traits::request::Request;
 
+/// https://fetch.spec.whatwg.org/#fetch-params
 #[derive(Clone)]
 pub struct FetchParams {
+    /// https://fetch.spec.whatwg.org/#concept-request
     pub request: Request,
+    /// https://fetch.spec.whatwg.org/#fetch-controller
     pub controller: Arc<Mutex<FetchController>>,
 }
 
@@ -21,11 +24,14 @@ impl FetchParams {
     }
 }
 
+/// https://fetch.spec.whatwg.org/#fetch-controller
 #[derive(Clone, Debug, Default)]
 pub struct FetchController {
+    /// https://fetch.spec.whatwg.org/#fetch-controller-state
     pub state: FetchControllerState,
 }
 
+/// https://fetch.spec.whatwg.org/#fetch-controller-state
 #[derive(Clone, Copy, Debug, Default)]
 pub enum FetchControllerState {
     #[default]

--- a/components/net/fetch/fetch_params.rs
+++ b/components/net/fetch/fetch_params.rs
@@ -2,40 +2,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::sync::{Arc, Mutex};
-
 use net_traits::request::Request;
 
-/// https://fetch.spec.whatwg.org/#fetch-params
+/// <https://fetch.spec.whatwg.org/#fetch-params>
 #[derive(Clone)]
 pub struct FetchParams {
-    /// https://fetch.spec.whatwg.org/#concept-request
+    /// <https://fetch.spec.whatwg.org/#concept-request>
     pub request: Request,
-    /// https://fetch.spec.whatwg.org/#fetch-controller
-    pub controller: Arc<Mutex<FetchController>>,
 }
 
 impl FetchParams {
     pub fn new(request: Request) -> FetchParams {
         FetchParams {
             request,
-            controller: Arc::new(Mutex::new(FetchController::default())),
         }
     }
-}
-
-/// https://fetch.spec.whatwg.org/#fetch-controller
-#[derive(Clone, Debug, Default)]
-pub struct FetchController {
-    /// https://fetch.spec.whatwg.org/#fetch-controller-state
-    pub state: FetchControllerState,
-}
-
-/// https://fetch.spec.whatwg.org/#fetch-controller-state
-#[derive(Clone, Copy, Debug, Default)]
-pub enum FetchControllerState {
-    #[default]
-    Ongoing,
-    Terminated,
-    Aborted,
 }

--- a/components/net/fetch/fetch_params.rs
+++ b/components/net/fetch/fetch_params.rs
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::sync::{Arc, Mutex};
+
+use net_traits::request::Request;
+
+#[derive(Clone)]
+pub struct FetchParams {
+    pub request: Request,
+    pub controller: Arc<Mutex<FetchController>>,
+}
+
+impl FetchParams {
+    pub fn new(request: Request) -> FetchParams {
+        FetchParams {
+            request,
+            controller: Arc::new(Mutex::new(FetchController::default())),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct FetchController {
+    pub state: FetchControllerState,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub enum FetchControllerState {
+    #[default]
+    Ongoing,
+    Terminated,
+    Aborted,
+}

--- a/components/net/fetch/fetch_params.rs
+++ b/components/net/fetch/fetch_params.rs
@@ -13,8 +13,6 @@ pub struct FetchParams {
 
 impl FetchParams {
     pub fn new(request: Request) -> FetchParams {
-        FetchParams {
-            request,
-        }
+        FetchParams { request }
     }
 }

--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -409,7 +409,7 @@ pub async fn main_fetch(
         return response;
     }
 
-    // shadow the mutable request because without this I get an error related to double mutable borrow
+    // reborrow request to avoid double mutable borrow
     let request = &mut fetch_params.request;
 
     // Step 14.

--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -237,7 +237,7 @@ pub async fn main_fetch(
     // Step 3: If request’s local-URLs-only flag is set and request’s current URL is not local, then set response to a network error.
     if request.local_urls_only &&
         !matches!(
-            fetch_params.request.current_url().scheme(),
+            request.current_url().scheme(),
             "about" | "blob" | "data" | "filesystem"
         )
     {
@@ -251,13 +251,13 @@ pub async fn main_fetch(
 
     // The request should have a valid policy_container associated with it.
     // TODO: This should not be `Client` here
-    let policy_container = match &fetch_params.request.policy_container {
+    let policy_container = match &request.policy_container {
         RequestPolicyContainer::Client => PolicyContainer::default(),
         RequestPolicyContainer::PolicyContainer(container) => container.to_owned(),
     };
 
     // Step 2.4.
-    if should_request_be_blocked_by_csp(&fetch_params.request, &policy_container) ==
+    if should_request_be_blocked_by_csp(request, &policy_container) ==
         csp::CheckResult::Blocked
     {
         warn!("Request blocked by CSP");
@@ -273,7 +273,7 @@ pub async fn main_fetch(
     // TODO: handle upgrade to a potentially secure URL.
 
     // Step 5.
-    if should_be_blocked_due_to_bad_port(&fetch_params.request.current_url()) {
+    if should_be_blocked_due_to_bad_port(&request.current_url()) {
         response = Some(Response::network_error(NetworkError::Internal(
             "Request attempted on bad port".into(),
         )));
@@ -283,23 +283,23 @@ pub async fn main_fetch(
 
     // Step 8: If request’s referrer policy is the empty string, then set request’s referrer policy
     // to request’s policy container’s referrer policy.
-    if fetch_params.request.referrer_policy == ReferrerPolicy::EmptyString {
-        fetch_params.request.referrer_policy = policy_container.get_referrer_policy();
+    if request.referrer_policy == ReferrerPolicy::EmptyString {
+        request.referrer_policy = policy_container.get_referrer_policy();
     }
 
-    let referrer_url = match mem::replace(&mut fetch_params.request.referrer, Referrer::NoReferrer)
+    let referrer_url = match mem::replace(&mut request.referrer, Referrer::NoReferrer)
     {
         Referrer::NoReferrer => None,
         Referrer::ReferrerUrl(referrer_source) | Referrer::Client(referrer_source) => {
-            fetch_params.request.headers.remove(header::REFERER);
+            request.headers.remove(header::REFERER);
             determine_requests_referrer(
-                fetch_params.request.referrer_policy,
+                request.referrer_policy,
                 referrer_source,
-                fetch_params.request.current_url(),
+                request.current_url(),
             )
         },
     };
-    fetch_params.request.referrer =
+    request.referrer =
         referrer_url.map_or(Referrer::NoReferrer, Referrer::ReferrerUrl);
 
     // Step 9.
@@ -311,20 +311,20 @@ pub async fn main_fetch(
         .hsts_list
         .read()
         .unwrap()
-        .apply_hsts_rules(fetch_params.request.current_url_mut());
+        .apply_hsts_rules(request.current_url_mut());
 
     // Step 11.
     // Not applicable: see fetch_async.
 
     // Step 12.
 
-    let current_url = fetch_params.request.current_url();
+    let current_url = request.current_url();
     let current_scheme = current_url.scheme();
 
     let mut response = match response {
         Some(res) => res,
         None => {
-            let same_origin = if let Origin::Origin(ref origin) = fetch_params.request.origin {
+            let same_origin = if let Origin::Origin(ref origin) = request.origin {
                 *origin == current_url.origin()
             } else {
                 false
@@ -332,46 +332,46 @@ pub async fn main_fetch(
 
             // request's current URL's origin is same origin with request's origin, and request's
             // response tainting is "basic"
-            if (same_origin && fetch_params.request.response_tainting == ResponseTainting::Basic) ||
+            if (same_origin && request.response_tainting == ResponseTainting::Basic) ||
                 // request's current URL's scheme is "data"
                 current_scheme == "data" ||
                 // request's mode is "navigate" or "websocket"
                 matches!(
-                    fetch_params.request.mode,
+                    request.mode,
                     RequestMode::Navigate | RequestMode::WebSocket { .. }
                 )
             {
                 // Substep 1. Set request’s response tainting to "basic".
-                fetch_params.request.response_tainting = ResponseTainting::Basic;
+                request.response_tainting = ResponseTainting::Basic;
 
                 // Substep 2. Return the result of running scheme fetch given fetchParams.
                 scheme_fetch(fetch_params, cache, target, done_chan, context).await
-            } else if fetch_params.request.mode == RequestMode::SameOrigin {
+            } else if request.mode == RequestMode::SameOrigin {
                 Response::network_error(NetworkError::Internal("Cross-origin response".into()))
-            } else if fetch_params.request.mode == RequestMode::NoCors {
+            } else if request.mode == RequestMode::NoCors {
                 // Substep 1. If request’s redirect mode is not "follow", then return a network error.
-                if fetch_params.request.redirect_mode != RedirectMode::Follow {
+                if request.redirect_mode != RedirectMode::Follow {
                     Response::network_error(NetworkError::Internal(
                         "NoCors requests must follow redirects".into(),
                     ))
                 } else {
                     // Substep 2. Set request’s response tainting to "opaque".
-                    fetch_params.request.response_tainting = ResponseTainting::Opaque;
+                    request.response_tainting = ResponseTainting::Opaque;
 
                     // Substep 3. Return the result of running scheme fetch given fetchParams.
                     scheme_fetch(fetch_params, cache, target, done_chan, context).await
                 }
             } else if !matches!(current_scheme, "http" | "https") {
                 Response::network_error(NetworkError::Internal("Non-http scheme".into()))
-            } else if fetch_params.request.use_cors_preflight ||
-                (fetch_params.request.unsafe_request &&
-                    (!is_cors_safelisted_method(&fetch_params.request.method) ||
-                        fetch_params.request.headers.iter().any(|(name, value)| {
+            } else if request.use_cors_preflight ||
+                (request.unsafe_request &&
+                    (!is_cors_safelisted_method(&request.method) ||
+                        request.headers.iter().any(|(name, value)| {
                             !is_cors_safelisted_request_header(&name, &value)
                         })))
             {
                 // Substep 1.
-                fetch_params.request.response_tainting = ResponseTainting::CorsTainting;
+                request.response_tainting = ResponseTainting::CorsTainting;
                 // Substep 2.
                 let response = http_fetch(
                     fetch_params,
@@ -392,7 +392,7 @@ pub async fn main_fetch(
                 response
             } else {
                 // Substep 1.
-                fetch_params.request.response_tainting = ResponseTainting::CorsTainting;
+                request.response_tainting = ResponseTainting::CorsTainting;
                 // Substep 2.
                 http_fetch(
                     fetch_params,
@@ -414,10 +414,13 @@ pub async fn main_fetch(
         return response;
     }
 
+    // shadow the mutable request because without this I get an error related to double mutable borrow
+    let request = &mut fetch_params.request;
+
     // Step 14.
     let mut response = if !response.is_network_error() && response.internal_response.is_none() {
         // Substep 1.
-        if fetch_params.request.response_tainting == ResponseTainting::CorsTainting {
+        if request.response_tainting == ResponseTainting::CorsTainting {
             // Subsubstep 1.
             let header_names: Option<Vec<HeaderName>> = response
                 .headers
@@ -426,7 +429,7 @@ pub async fn main_fetch(
             match header_names {
                 // Subsubstep 2.
                 Some(ref list)
-                    if fetch_params.request.credentials_mode != CredentialsMode::Include &&
+                    if request.credentials_mode != CredentialsMode::Include &&
                         list.iter().any(|header| header == "*") =>
                 {
                     response.cors_exposed_header_name_list = response
@@ -445,7 +448,7 @@ pub async fn main_fetch(
         }
 
         // Substep 2.
-        let response_type = match fetch_params.request.response_tainting {
+        let response_type = match request.response_tainting {
             ResponseTainting::Basic => ResponseType::Basic,
             ResponseTainting::CorsTainting => ResponseType::Cors,
             ResponseTainting::Opaque => ResponseType::Opaque,
@@ -460,12 +463,12 @@ pub async fn main_fetch(
         let response_is_network_error = response.is_network_error();
         let should_replace_with_nosniff_error = !response_is_network_error &&
             should_be_blocked_due_to_nosniff(
-                fetch_params.request.destination,
+                request.destination,
                 &response.headers,
             );
         let should_replace_with_mime_type_error = !response_is_network_error &&
             should_be_blocked_due_to_mime_type(
-                fetch_params.request.destination,
+                request.destination,
                 &response.headers,
             );
 
@@ -484,7 +487,7 @@ pub async fn main_fetch(
         if internal_response.url_list.is_empty() {
             internal_response
                 .url_list
-                .clone_from(&fetch_params.request.url_list)
+                .clone_from(&request.url_list)
         }
 
         // Step 17.
@@ -511,7 +514,7 @@ pub async fn main_fetch(
         let not_network_error = !response_is_network_error && !internal_response.is_network_error();
         if not_network_error &&
             (is_null_body_status(&internal_response.status) ||
-                matches!(fetch_params.request.method, Method::HEAD | Method::CONNECT))
+                matches!(request.method, Method::HEAD | Method::CONNECT))
         {
             // when Fetch is used only asynchronously, we will need to make sure
             // that nothing tries to write to the body at this point
@@ -532,13 +535,13 @@ pub async fn main_fetch(
     // Step 19.
     let mut response_loaded = false;
     let mut response =
-        if !response.is_network_error() && !fetch_params.request.integrity_metadata.is_empty() {
+        if !response.is_network_error() && !request.integrity_metadata.is_empty() {
             // Step 19.1.
-            wait_for_response(&fetch_params.request, &mut response, target, done_chan).await;
+            wait_for_response(request, &mut response, target, done_chan).await;
             response_loaded = true;
 
             // Step 19.2.
-            let integrity_metadata = &fetch_params.request.integrity_metadata;
+            let integrity_metadata = &request.integrity_metadata;
             if response.termination_reason.is_none() &&
                 !is_response_integrity_valid(integrity_metadata, &response)
             {
@@ -553,41 +556,41 @@ pub async fn main_fetch(
         };
 
     // Step 20.
-    if fetch_params.request.synchronous {
+    if request.synchronous {
         // process_response is not supposed to be used
         // by sync fetch, but we overload it here for simplicity
-        target.process_response(&fetch_params.request, &response);
+        target.process_response(request, &response);
         if !response_loaded {
-            wait_for_response(&fetch_params.request, &mut response, target, done_chan).await;
+            wait_for_response(request, &mut response, target, done_chan).await;
         }
         // overloaded similarly to process_response
-        target.process_response_eof(&fetch_params.request, &response);
+        target.process_response_eof(request, &response);
         return response;
     }
 
     // Step 21.
-    if fetch_params.request.body.is_some() && matches!(current_scheme, "http" | "https") {
+    if request.body.is_some() && matches!(current_scheme, "http" | "https") {
         // XXXManishearth: We actually should be calling process_request
         // in http_network_fetch. However, we can't yet follow the request
         // upload progress, so I'm keeping it here for now and pretending
         // the body got sent in one chunk
-        target.process_request_body(&fetch_params.request);
-        target.process_request_eof(&fetch_params.request);
+        target.process_request_body(request);
+        target.process_request_eof(request);
     }
 
     // Step 22.
-    target.process_response(&fetch_params.request, &response);
+    target.process_response(request, &response);
 
     // Step 23.
     if !response_loaded {
-        wait_for_response(&fetch_params.request, &mut response, target, done_chan).await;
+        wait_for_response(request, &mut response, target, done_chan).await;
     }
 
     // Step 24.
-    target.process_response_eof(&fetch_params.request, &response);
+    target.process_response_eof(request, &response);
 
     if let Ok(http_cache) = context.state.http_cache.write() {
-        http_cache.update_awaiting_consumers(&fetch_params.request, &response);
+        http_cache.update_awaiting_consumers(request, &response);
     }
 
     // Steps 25-27.

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -754,12 +754,10 @@ pub async fn http_fetch(
             // nothing to do, since actual_response is a function on response
 
             // Subsubstep 3
-            if (res.response_type == ResponseType::Opaque &&
-                request.mode != RequestMode::NoCors) ||
+            if (res.response_type == ResponseType::Opaque && request.mode != RequestMode::NoCors) ||
                 (res.response_type == ResponseType::OpaqueRedirect &&
                     request.redirect_mode != RedirectMode::Manual) ||
-                (res.url_list.len() > 1 &&
-                    request.redirect_mode != RedirectMode::Follow) ||
+                (res.url_list.len() > 1 && request.redirect_mode != RedirectMode::Follow) ||
                 res.is_network_error()
             {
                 return Response::network_error(NetworkError::Internal("Request failed".into()));
@@ -774,12 +772,10 @@ pub async fn http_fetch(
     if response.is_none() {
         // Substep 1
         if cors_preflight_flag {
-            let method_cache_match =
-                cache.match_method(request, request.method.clone());
+            let method_cache_match = cache.match_method(request, request.method.clone());
 
             let method_mismatch = !method_cache_match &&
-                (!is_cors_safelisted_method(&request.method) ||
-                    request.use_cors_preflight);
+                (!is_cors_safelisted_method(&request.method) || request.use_cors_preflight);
             let header_mismatch = request.headers.iter().any(|(name, value)| {
                 !cache.match_header(request, name) &&
                     !is_cors_safelisted_request_header(&name, &value)
@@ -787,8 +783,7 @@ pub async fn http_fetch(
 
             // Sub-substep 1
             if method_mismatch || header_mismatch {
-                let preflight_result =
-                    cors_preflight_fetch(request, cache, context).await;
+                let preflight_result = cors_preflight_fetch(request, cache, context).await;
                 // Sub-substep 2
                 if let Some(e) = preflight_result.get_network_error() {
                     return Response::network_error(e.clone());

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -733,11 +733,12 @@ pub async fn http_fetch(
 ) -> Response {
     // This is a new async fetch, reset the channel we are waiting on
     *done_chan = None;
-    // Step 1
-    let mut response: Option<Response> = None;
+    // Step 1 Let request be fetchParams’s request.
+    // couldn't assign request to a variable due to mutable borrowing issues when calling
 
     // Step 2
     // nothing to do, since actual_response is a function on response
+    let mut response: Option<Response> = None;
 
     // Step 3
     if fetch_params.request.service_workers_mode == ServiceWorkersMode::All {
@@ -940,7 +941,9 @@ pub async fn http_redirect_fetch(
 ) -> Response {
     let mut redirect_end_timer = RedirectEndTimer(Some(context.timing.clone()));
 
-    // Step 1
+    // Step 1: Let request be fetchParams’s request.
+    let request = &mut fetch_params.request;
+
     assert!(response.return_internal);
 
     let location_url = response.actual_response().location_url.clone();
@@ -993,7 +996,6 @@ pub async fn http_redirect_fetch(
             ResourceTimeValue::RedirectStart,
         )); // updates start_time only if redirect_start is nonzero (implying TAO)
 
-    let request = &mut fetch_params.request;
     // Step 7: If request’s redirect count is 20, then return a network error.
     if request.redirect_count >= 20 {
         return Response::network_error(NetworkError::Internal("Too many redirects".into()));

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -2159,7 +2159,8 @@ async fn cors_preflight_fetch(
     // Step 6
     let mut fetch_params = FetchParams::new(preflight);
     let response =
-        http_network_or_cache_fetch(&mut fetch_params.request, false, false, &mut None, context).await;
+        http_network_or_cache_fetch(&mut fetch_params.request, false, false, &mut None, context)
+            .await;
     // Step 7
     if cors_check(request, &response).is_ok() && response.status.code().is_success() {
         // Substep 1

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -737,7 +737,7 @@ pub async fn http_fetch(
     let request = &mut fetch_params.request;
 
     // Step 2
-    // nothing to do, since actual_response is a function on response
+    // Let response and internalResponse be null.
     let mut response: Option<Response> = None;
 
     // Step 3

--- a/components/net/lib.rs
+++ b/components/net/lib.rs
@@ -26,6 +26,7 @@ mod websocket_loader;
 /// An implementation of the [Fetch specification](https://fetch.spec.whatwg.org/)
 pub mod fetch {
     pub mod cors_cache;
+    pub mod fetch_params;
     pub mod headers;
     pub mod methods;
 }

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -47,6 +47,7 @@ use crate::connector::{
 use crate::cookie::ServoCookie;
 use crate::cookie_storage::CookieStorage;
 use crate::fetch::cors_cache::CorsCache;
+use crate::fetch::fetch_params::FetchParams;
 use crate::fetch::methods::{fetch, CancellationListener, FetchContext};
 use crate::filemanager_thread::FileManager;
 use crate::hsts::HstsList;
@@ -755,7 +756,7 @@ impl CoreResourceManager {
                 Some(res_init) => {
                     let response = Response::from_init(res_init, timing_type);
 
-                    let mut fetch_params = crate::fetch::fetch_params::FetchParams::new(request);
+                    let mut fetch_params = FetchParams::new(request);
                     http_redirect_fetch(
                         &mut fetch_params,
                         &mut CorsCache::default(),

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -712,8 +712,7 @@ impl CoreResourceManager {
         };
 
         let request = request_builder.build();
-        let mut fetch_params = crate::fetch::fetch_params::FetchParams::new(request);
-        let url = fetch_params.request.current_url();
+        let url = request.current_url();
 
         // In the case of a valid blob URL, acquiring a token granting access to a file,
         // regardless if the URL is revoked after token acquisition.
@@ -748,15 +747,15 @@ impl CoreResourceManager {
                 filemanager: Arc::new(Mutex::new(filemanager)),
                 file_token,
                 cancellation_listener: Arc::new(Mutex::new(CancellationListener::new(cancel_chan))),
-                timing: ServoArc::new(Mutex::new(ResourceFetchTiming::new(
-                    fetch_params.request.timing_type(),
-                ))),
+                timing: ServoArc::new(Mutex::new(ResourceFetchTiming::new(request.timing_type()))),
                 protocols,
             };
 
             match res_init_ {
                 Some(res_init) => {
                     let response = Response::from_init(res_init, timing_type);
+
+                    let mut fetch_params = crate::fetch::fetch_params::FetchParams::new(request);
                     http_redirect_fetch(
                         &mut fetch_params,
                         &mut CorsCache::default(),
@@ -769,7 +768,7 @@ impl CoreResourceManager {
                     .await;
                 },
                 None => {
-                    fetch(&mut fetch_params, &mut sender, &context).await;
+                    fetch(request, &mut sender, &context).await;
                 },
             };
 

--- a/components/net/tests/data_loader.rs
+++ b/components/net/tests/data_loader.rs
@@ -21,6 +21,7 @@ fn assert_parse(
     charset: Option<&str>,
     data: Option<&[u8]>,
 ) {
+    use net::fetch::fetch_params::FetchParams;
     use net_traits::request::RequestBuilder;
 
     let url = ServoUrl::parse(url).unwrap();
@@ -29,7 +30,8 @@ fn assert_parse(
         .pipeline_id(None)
         .build();
 
-    let response = fetch(&mut request, None);
+    let mut fetch_params = FetchParams::new(request);
+    let response = fetch(&mut fetch_params, None);
 
     match data {
         Some(data) => {

--- a/components/net/tests/data_loader.rs
+++ b/components/net/tests/data_loader.rs
@@ -30,8 +30,7 @@ fn assert_parse(
         .pipeline_id(None)
         .build();
 
-    let mut fetch_params = FetchParams::new(request);
-    let response = fetch(&mut fetch_params, None);
+    let response = fetch(&mut request, None);
 
     match data {
         Some(data) => {

--- a/components/net/tests/data_loader.rs
+++ b/components/net/tests/data_loader.rs
@@ -21,16 +21,15 @@ fn assert_parse(
     charset: Option<&str>,
     data: Option<&[u8]>,
 ) {
-    use net::fetch::fetch_params::FetchParams;
     use net_traits::request::RequestBuilder;
 
     let url = ServoUrl::parse(url).unwrap();
-    let mut request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
+    let request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
         .origin(url.origin())
         .pipeline_id(None)
         .build();
 
-    let response = fetch(&mut request, None);
+    let response = fetch(request, None);
 
     match data {
         Some(data) => {

--- a/components/net/tests/http_loader.rs
+++ b/components/net/tests/http_loader.rs
@@ -175,14 +175,14 @@ fn test_check_default_headers_loaded_in_every_request() {
     *expected_headers.lock().unwrap() = Some(headers.clone());
 
     // Testing for method.GET
-    let mut request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
+    let request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
         .method(Method::GET)
         .destination(Destination::Document)
         .origin(url.clone().origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
         .build();
 
-    let response = dbg!(fetch(&mut request, None));
+    let response = dbg!(fetch(request, None));
     assert!(response
         .internal_response
         .unwrap()
@@ -201,14 +201,14 @@ fn test_check_default_headers_loaded_in_every_request() {
         HeaderValue::from_str(&url_str[..url_str.len() - 1]).unwrap(),
     );
     *expected_headers.lock().unwrap() = Some(post_headers);
-    let mut request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
+    let request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
         .method(Method::POST)
         .destination(Destination::Document)
         .origin(url.clone().origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
         .build();
 
-    let response = fetch(&mut request, None);
+    let response = fetch(request, None);
     assert!(response
         .internal_response
         .unwrap()
@@ -231,7 +231,7 @@ fn test_load_when_request_is_not_get_or_head_and_there_is_no_body_content_length
     };
     let (server, url) = make_server(handler);
 
-    let mut request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
+    let request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
         .method(Method::POST)
         .body(None)
         .destination(Destination::Document)
@@ -239,7 +239,7 @@ fn test_load_when_request_is_not_get_or_head_and_there_is_no_body_content_length
         .pipeline_id(Some(TEST_PIPELINE_ID))
         .build();
 
-    let response = fetch(&mut request, None);
+    let response = fetch(request, None);
     assert!(response
         .internal_response
         .unwrap()
@@ -264,7 +264,7 @@ fn test_request_and_response_data_with_network_messages() {
 
     let mut request_headers = HeaderMap::new();
     request_headers.typed_insert(Host::from("bar.foo".parse::<Authority>().unwrap()));
-    let mut request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
+    let request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
         .method(Method::GET)
         .headers(request_headers)
         .body(None)
@@ -274,7 +274,7 @@ fn test_request_and_response_data_with_network_messages() {
         .build();
 
     let (devtools_chan, devtools_port) = unbounded();
-    let response = fetch(&mut request, Some(devtools_chan));
+    let response = fetch(request, Some(devtools_chan));
     assert!(response
         .internal_response
         .unwrap()
@@ -377,7 +377,7 @@ fn test_request_and_response_message_from_devtool_without_pipeline_id() {
         };
     let (server, url) = make_server(handler);
 
-    let mut request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
+    let request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
         .method(Method::GET)
         .destination(Destination::Document)
         .origin(mock_origin())
@@ -385,7 +385,7 @@ fn test_request_and_response_message_from_devtool_without_pipeline_id() {
         .build();
 
     let (devtools_chan, devtools_port) = unbounded();
-    let response = fetch(&mut request, Some(devtools_chan));
+    let response = fetch(request, Some(devtools_chan));
     assert!(response.actual_response().status.code().is_success());
 
     let _ = server.close();
@@ -417,14 +417,14 @@ fn test_redirected_request_to_devtools() {
         };
     let (pre_server, pre_url) = make_server(pre_handler);
 
-    let mut request = RequestBuilder::new(pre_url.clone(), Referrer::NoReferrer)
+    let request = RequestBuilder::new(pre_url.clone(), Referrer::NoReferrer)
         .method(Method::POST)
         .destination(Destination::Document)
         .pipeline_id(Some(TEST_PIPELINE_ID))
         .build();
 
     let (devtools_chan, devtools_port) = unbounded();
-    fetch(&mut request, Some(devtools_chan));
+    fetch(request, Some(devtools_chan));
 
     let _ = pre_server.close();
     let _ = post_server.close();
@@ -470,14 +470,14 @@ fn test_load_when_redirecting_from_a_post_should_rewrite_next_request_as_get() {
         };
     let (pre_server, pre_url) = make_server(pre_handler);
 
-    let mut request = RequestBuilder::new(pre_url.clone(), Referrer::NoReferrer)
+    let request = RequestBuilder::new(pre_url.clone(), Referrer::NoReferrer)
         .method(Method::POST)
         .destination(Destination::Document)
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
         .build();
 
-    let response = fetch(&mut request, None);
+    let response = fetch(request, None);
 
     let _ = pre_server.close();
     let _ = post_server.close();
@@ -502,7 +502,7 @@ fn test_load_should_decode_the_response_as_deflate_when_response_headers_have_co
         };
     let (server, url) = make_server(handler);
 
-    let mut request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
+    let request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
         .method(Method::GET)
         .body(None)
         .destination(Destination::Document)
@@ -510,7 +510,7 @@ fn test_load_should_decode_the_response_as_deflate_when_response_headers_have_co
         .pipeline_id(Some(TEST_PIPELINE_ID))
         .build();
 
-    let response = fetch(&mut request, None);
+    let response = fetch(request, None);
 
     let _ = server.close();
 
@@ -537,7 +537,7 @@ fn test_load_should_decode_the_response_as_gzip_when_response_headers_have_conte
         };
     let (server, url) = make_server(handler);
 
-    let mut request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
+    let request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
         .method(Method::GET)
         .body(None)
         .destination(Destination::Document)
@@ -545,7 +545,7 @@ fn test_load_should_decode_the_response_as_gzip_when_response_headers_have_conte
         .pipeline_id(Some(TEST_PIPELINE_ID))
         .build();
 
-    let response = fetch(&mut request, None);
+    let response = fetch(request, None);
 
     let _ = server.close();
 
@@ -584,7 +584,7 @@ fn test_load_doesnt_send_request_body_on_any_redirect() {
     let content = b"Body on POST!";
     let request_body = create_request_body_with_content(content.to_vec());
 
-    let mut request = RequestBuilder::new(pre_url.clone(), Referrer::NoReferrer)
+    let request = RequestBuilder::new(pre_url.clone(), Referrer::NoReferrer)
         .body(Some(request_body))
         .method(Method::POST)
         .destination(Destination::Document)
@@ -592,7 +592,7 @@ fn test_load_doesnt_send_request_body_on_any_redirect() {
         .pipeline_id(Some(TEST_PIPELINE_ID))
         .build();
 
-    let response = fetch(&mut request, None);
+    let response = fetch(request, None);
 
     let _ = pre_server.close();
     let _ = post_server.close();
@@ -614,7 +614,7 @@ fn test_load_doesnt_add_host_to_hsts_list_when_url_is_http_even_if_hsts_headers_
         };
     let (server, url) = make_server(handler);
 
-    let mut request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
+    let request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
         .method(Method::GET)
         .body(None)
         .destination(Destination::Document)
@@ -623,7 +623,7 @@ fn test_load_doesnt_add_host_to_hsts_list_when_url_is_http_even_if_hsts_headers_
         .build();
 
     let mut context = new_fetch_context(None, None, None);
-    let response = fetch_with_context(&mut request, &mut context);
+    let response = fetch_with_context(request, &mut context);
 
     let _ = server.close();
 
@@ -661,7 +661,7 @@ fn test_load_sets_cookies_in_the_resource_manager_when_it_get_set_cookie_header_
 
     assert_cookie_for_domain(&context.state.cookie_jar, url.as_str(), None);
 
-    let mut request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
+    let request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
         .method(Method::GET)
         .body(None)
         .destination(Destination::Document)
@@ -670,7 +670,7 @@ fn test_load_sets_cookies_in_the_resource_manager_when_it_get_set_cookie_header_
         .credentials_mode(CredentialsMode::Include)
         .build();
 
-    let response = fetch_with_context(&mut request, &mut context);
+    let response = fetch_with_context(request, &mut context);
 
     let _ = server.close();
 
@@ -714,7 +714,7 @@ fn test_load_sets_requests_cookies_header_for_url_by_getting_cookies_from_the_re
         cookie_jar.push(cookie, &url, CookieSource::HTTP);
     }
 
-    let mut request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
+    let request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
         .method(Method::GET)
         .body(None)
         .destination(Destination::Document)
@@ -723,7 +723,7 @@ fn test_load_sets_requests_cookies_header_for_url_by_getting_cookies_from_the_re
         .credentials_mode(CredentialsMode::Include)
         .build();
 
-    let response = fetch_with_context(&mut request, &mut context);
+    let response = fetch_with_context(request, &mut context);
 
     let _ = server.close();
 
@@ -761,7 +761,7 @@ fn test_load_sends_cookie_if_nonhttp() {
         cookie_jar.push(cookie, &url, CookieSource::HTTP);
     }
 
-    let mut request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
+    let request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
         .method(Method::GET)
         .body(None)
         .destination(Destination::Document)
@@ -770,7 +770,7 @@ fn test_load_sends_cookie_if_nonhttp() {
         .credentials_mode(CredentialsMode::Include)
         .build();
 
-    let response = fetch_with_context(&mut request, &mut context);
+    let response = fetch_with_context(request, &mut context);
 
     let _ = server.close();
 
@@ -800,7 +800,7 @@ fn test_cookie_set_with_httponly_should_not_be_available_using_getcookiesforurl(
 
     assert_cookie_for_domain(&context.state.cookie_jar, url.as_str(), None);
 
-    let mut request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
+    let request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
         .method(Method::GET)
         .body(None)
         .destination(Destination::Document)
@@ -809,7 +809,7 @@ fn test_cookie_set_with_httponly_should_not_be_available_using_getcookiesforurl(
         .credentials_mode(CredentialsMode::Include)
         .build();
 
-    let response = fetch_with_context(&mut request, &mut context);
+    let response = fetch_with_context(request, &mut context);
 
     let _ = server.close();
 
@@ -849,7 +849,7 @@ fn test_when_cookie_received_marked_secure_is_ignored_for_http() {
 
     assert_cookie_for_domain(&context.state.cookie_jar, url.as_str(), None);
 
-    let mut request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
+    let request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
         .method(Method::GET)
         .body(None)
         .destination(Destination::Document)
@@ -858,7 +858,7 @@ fn test_when_cookie_received_marked_secure_is_ignored_for_http() {
         .credentials_mode(CredentialsMode::Include)
         .build();
 
-    let response = fetch_with_context(&mut request, &mut context);
+    let response = fetch_with_context(request, &mut context);
 
     let _ = server.close();
 
@@ -884,7 +884,7 @@ fn test_load_sets_content_length_to_length_of_request_body() {
 
     let request_body = create_request_body_with_content(content.to_vec());
 
-    let mut request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
+    let request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
         .method(Method::POST)
         .body(Some(request_body))
         .destination(Destination::Document)
@@ -892,7 +892,7 @@ fn test_load_sets_content_length_to_length_of_request_body() {
         .pipeline_id(Some(TEST_PIPELINE_ID))
         .build();
 
-    let response = fetch(&mut request, None);
+    let response = fetch(request, None);
 
     let _ = server.close();
 
@@ -924,7 +924,7 @@ fn test_load_uses_explicit_accept_from_headers_in_load_data() {
 
     let mut accept_headers = HeaderMap::new();
     accept_headers.insert(header::ACCEPT, HeaderValue::from_static("text/html"));
-    let mut request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
+    let request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
         .method(Method::GET)
         .headers(accept_headers)
         .destination(Destination::Document)
@@ -932,7 +932,7 @@ fn test_load_uses_explicit_accept_from_headers_in_load_data() {
         .pipeline_id(Some(TEST_PIPELINE_ID))
         .build();
 
-    let response = fetch(&mut request, None);
+    let response = fetch(request, None);
 
     let _ = server.close();
 
@@ -962,14 +962,14 @@ fn test_load_sets_default_accept_to_html_xhtml_xml_and_then_anything_else() {
         };
     let (server, url) = make_server(handler);
 
-    let mut request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
+    let request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
         .method(Method::GET)
         .destination(Destination::Document)
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
         .build();
 
-    let response = fetch(&mut request, None);
+    let response = fetch(request, None);
 
     let _ = server.close();
 
@@ -1001,7 +1001,7 @@ fn test_load_uses_explicit_accept_encoding_from_load_data_headers() {
 
     let mut accept_encoding_headers = HeaderMap::new();
     accept_encoding_headers.insert(header::ACCEPT_ENCODING, HeaderValue::from_static("chunked"));
-    let mut request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
+    let request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
         .method(Method::GET)
         .headers(accept_encoding_headers)
         .destination(Destination::Document)
@@ -1009,7 +1009,7 @@ fn test_load_uses_explicit_accept_encoding_from_load_data_headers() {
         .pipeline_id(Some(TEST_PIPELINE_ID))
         .build();
 
-    let response = fetch(&mut request, None);
+    let response = fetch(request, None);
 
     let _ = server.close();
 
@@ -1039,14 +1039,14 @@ fn test_load_sets_default_accept_encoding_to_gzip_and_deflate() {
         };
     let (server, url) = make_server(handler);
 
-    let mut request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
+    let request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
         .method(Method::GET)
         .destination(Destination::Document)
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
         .build();
 
-    let response = fetch(&mut request, None);
+    let response = fetch(request, None);
 
     let _ = server.close();
 
@@ -1095,14 +1095,14 @@ fn test_load_errors_when_there_a_redirect_loop() {
 
     *url_b_for_a.lock().unwrap() = Some(url_b.clone());
 
-    let mut request = RequestBuilder::new(url_a.clone(), Referrer::NoReferrer)
+    let request = RequestBuilder::new(url_a.clone(), Referrer::NoReferrer)
         .method(Method::GET)
         .destination(Destination::Document)
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
         .build();
 
-    let response = fetch(&mut request, None);
+    let response = fetch(request, None);
 
     let _ = server_a.close();
     let _ = server_b.close();
@@ -1155,14 +1155,14 @@ fn test_load_succeeds_with_a_redirect_loop() {
 
     *url_b_for_a.lock().unwrap() = Some(url_b.clone());
 
-    let mut request = RequestBuilder::new(url_a.clone(), Referrer::NoReferrer)
+    let request = RequestBuilder::new(url_a.clone(), Referrer::NoReferrer)
         .method(Method::GET)
         .destination(Destination::Document)
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
         .build();
 
-    let response = fetch(&mut request, None);
+    let response = fetch(request, None);
 
     let _ = server_a.close();
     let _ = server_b.close();
@@ -1198,14 +1198,14 @@ fn test_load_follows_a_redirect() {
         };
     let (pre_server, pre_url) = make_server(pre_handler);
 
-    let mut request = RequestBuilder::new(pre_url.clone(), Referrer::NoReferrer)
+    let request = RequestBuilder::new(pre_url.clone(), Referrer::NoReferrer)
         .method(Method::GET)
         .destination(Destination::Document)
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
         .build();
 
-    let response = fetch(&mut request, None);
+    let response = fetch(request, None);
 
     let _ = pre_server.close();
     let _ = post_server.close();
@@ -1283,7 +1283,7 @@ fn test_redirect_from_x_to_y_provides_y_cookies_from_y() {
         cookie_jar.push(cookie_y, &url_y, CookieSource::HTTP);
     }
 
-    let mut request = RequestBuilder::new(url_x.clone(), Referrer::NoReferrer)
+    let request = RequestBuilder::new(url_x.clone(), Referrer::NoReferrer)
         .method(Method::GET)
         .destination(Destination::Document)
         .origin(mock_origin())
@@ -1291,7 +1291,7 @@ fn test_redirect_from_x_to_y_provides_y_cookies_from_y() {
         .credentials_mode(CredentialsMode::Include)
         .build();
 
-    let response = fetch_with_context(&mut request, &mut context);
+    let response = fetch_with_context(request, &mut context);
 
     let _ = server.close();
 
@@ -1334,7 +1334,7 @@ fn test_redirect_from_x_to_x_provides_x_with_cookie_from_first_response() {
 
     let url = url.join("/initial/").unwrap();
 
-    let mut request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
+    let request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
         .method(Method::GET)
         .destination(Destination::Document)
         .origin(mock_origin())
@@ -1342,7 +1342,7 @@ fn test_redirect_from_x_to_x_provides_x_with_cookie_from_first_response() {
         .credentials_mode(CredentialsMode::Include)
         .build();
 
-    let response = fetch(&mut request, None);
+    let response = fetch(request, None);
 
     let _ = server.close();
 
@@ -1367,7 +1367,7 @@ fn test_if_auth_creds_not_in_url_but_in_cache_it_sets_it() {
         };
     let (server, url) = make_server(handler);
 
-    let mut request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
+    let request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
         .method(Method::GET)
         .body(None)
         .destination(Destination::Document)
@@ -1391,7 +1391,7 @@ fn test_if_auth_creds_not_in_url_but_in_cache_it_sets_it() {
         .entries
         .insert(url.origin().clone().ascii_serialization(), auth_entry);
 
-    let response = fetch_with_context(&mut request, &mut context);
+    let response = fetch_with_context(request, &mut context);
 
     let _ = server.close();
 
@@ -1412,7 +1412,7 @@ fn test_auth_ui_needs_www_auth() {
         };
     let (server, url) = make_server(handler);
 
-    let mut request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
+    let request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
         .method(Method::GET)
         .body(None)
         .destination(Destination::Document)
@@ -1421,7 +1421,7 @@ fn test_auth_ui_needs_www_auth() {
         .credentials_mode(CredentialsMode::Include)
         .build();
 
-    let response = fetch(&mut request, None);
+    let response = fetch(request, None);
 
     let _ = server.close();
 
@@ -1479,7 +1479,7 @@ fn test_fetch_compressed_response_update_count() {
         };
     let (server, url) = make_server(handler);
 
-    let mut request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
+    let request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
         .method(Method::GET)
         .body(None)
         .destination(Destination::Document)
@@ -1511,7 +1511,7 @@ fn test_fetch_compressed_response_update_count() {
     };
     let response_update_count = crate::HANDLE.block_on(async move {
         methods::fetch(
-            &mut request,
+            request,
             &mut target,
             &mut new_fetch_context(None, None, None),
         )
@@ -1565,7 +1565,7 @@ fn test_user_credentials_prompt_when_proxy_authentication_is_required() {
         };
     let (server, url) = make_server(handler);
 
-    let mut request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
+    let request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
         .method(Method::GET)
         .body(None)
         .destination(Destination::Document)
@@ -1583,7 +1583,7 @@ fn test_user_credentials_prompt_when_proxy_authentication_is_required() {
 
     let mut context = new_fetch_context(None, Some(embedder_proxy), None);
 
-    let response = fetch_with_context(&mut request, &mut context);
+    let response = fetch_with_context(request, &mut context);
 
     let _ = server.close();
 
@@ -1613,7 +1613,7 @@ fn test_prompt_credentials_when_client_receives_unauthorized_response() {
         };
     let (server, url) = make_server(handler);
 
-    let mut request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
+    let request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
         .method(Method::GET)
         .body(None)
         .destination(Destination::Document)
@@ -1630,7 +1630,7 @@ fn test_prompt_credentials_when_client_receives_unauthorized_response() {
     );
     let mut context = new_fetch_context(None, Some(embedder_proxy), None);
 
-    let response = fetch_with_context(&mut request, &mut context);
+    let response = fetch_with_context(request, &mut context);
 
     server.close();
 
@@ -1660,7 +1660,7 @@ fn test_prompt_credentials_user_cancels_dialog_input() {
         };
     let (server, url) = make_server(handler);
 
-    let mut request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
+    let request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
         .method(Method::GET)
         .body(None)
         .destination(Destination::Document)
@@ -1673,7 +1673,7 @@ fn test_prompt_credentials_user_cancels_dialog_input() {
     let _ = receive_credential_prompt_msgs(embedder_receiver, None, None);
     let mut context = new_fetch_context(None, Some(embedder_proxy), None);
 
-    let response = fetch_with_context(&mut request, &mut context);
+    let response = fetch_with_context(request, &mut context);
 
     server.close();
 
@@ -1703,7 +1703,7 @@ fn test_prompt_credentials_user_input_incorrect_credentials() {
         };
     let (server, url) = make_server(handler);
 
-    let mut request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
+    let request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
         .method(Method::GET)
         .body(None)
         .destination(Destination::Document)
@@ -1720,7 +1720,7 @@ fn test_prompt_credentials_user_input_incorrect_credentials() {
     );
     let mut context = new_fetch_context(None, Some(embedder_proxy), None);
 
-    let response = fetch_with_context(&mut request, &mut context);
+    let response = fetch_with_context(request, &mut context);
 
     server.close();
 

--- a/components/net/tests/main.rs
+++ b/components/net/tests/main.rs
@@ -202,7 +202,7 @@ impl FetchTaskTarget for FetchResponseCollector {
     }
 }
 
-fn fetch(request: &mut FetchParams, dc: Option<Sender<DevtoolsControlMsg>>) -> Response {
+fn fetch(request: &mut Request, dc: Option<Sender<DevtoolsControlMsg>>) -> Response {
     fetch_with_context(request, &mut new_fetch_context(dc, None, None))
 }
 

--- a/components/net/tests/main.rs
+++ b/components/net/tests/main.rs
@@ -39,6 +39,7 @@ use hyper::{Request as HyperRequest, Response as HyperResponse};
 use hyper_util::rt::tokio::TokioIo;
 use net::connector::{create_http_client, create_tls_config};
 use net::fetch::cors_cache::CorsCache;
+use net::fetch::fetch_params::FetchParams;
 use net::fetch::methods::{self, CancellationListener, FetchContext};
 use net::filemanager_thread::FileManager;
 use net::protocols::ProtocolRegistry;
@@ -201,7 +202,7 @@ impl FetchTaskTarget for FetchResponseCollector {
     }
 }
 
-fn fetch(request: &mut Request, dc: Option<Sender<DevtoolsControlMsg>>) -> Response {
+fn fetch(request: &mut FetchParams, dc: Option<Sender<DevtoolsControlMsg>>) -> Response {
     fetch_with_context(request, &mut new_fetch_context(dc, None, None))
 }
 

--- a/components/net/tests/main.rs
+++ b/components/net/tests/main.rs
@@ -39,7 +39,6 @@ use hyper::{Request as HyperRequest, Response as HyperResponse};
 use hyper_util::rt::tokio::TokioIo;
 use net::connector::{create_http_client, create_tls_config};
 use net::fetch::cors_cache::CorsCache;
-use net::fetch::fetch_params::FetchParams;
 use net::fetch::methods::{self, CancellationListener, FetchContext};
 use net::filemanager_thread::FileManager;
 use net::protocols::ProtocolRegistry;
@@ -202,11 +201,11 @@ impl FetchTaskTarget for FetchResponseCollector {
     }
 }
 
-fn fetch(request: &mut Request, dc: Option<Sender<DevtoolsControlMsg>>) -> Response {
+fn fetch(request: Request, dc: Option<Sender<DevtoolsControlMsg>>) -> Response {
     fetch_with_context(request, &mut new_fetch_context(dc, None, None))
 }
 
-fn fetch_with_context(request: &mut Request, mut context: &mut FetchContext) -> Response {
+fn fetch_with_context(request: Request, mut context: &mut FetchContext) -> Response {
     let (sender, receiver) = tokio::sync::oneshot::channel();
     let mut target = FetchResponseCollector {
         sender: Some(sender),
@@ -217,7 +216,7 @@ fn fetch_with_context(request: &mut Request, mut context: &mut FetchContext) -> 
     })
 }
 
-fn fetch_with_cors_cache(request: &mut Request, cache: &mut CorsCache) -> Response {
+fn fetch_with_cors_cache(request: Request, cache: &mut CorsCache) -> Response {
     let (sender, receiver) = tokio::sync::oneshot::channel();
     let mut target = FetchResponseCollector {
         sender: Some(sender),


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Refactor some of the `fetch` functions to take a `FetchParams` object as input instead of `Request`. This would bring it closer to the spec. Please look at #34741 for some more details. I plan to start with a minimal implementation of `FetchParams` and try to add more to it in future PRs as I implement and understand it more.

I had some trouble changing `http_network_or_cache_fetch` which might need a bigger refactor.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix some of #34741

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because this is a refactor of some fetch methods to take fetch params as input. The change in input doesn't change functionality

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
