### PR TITLE
Ensure Element ID modifications inside disconnected shadow roots are registered

### DIFF
--- a/components/script/dom/documentorshadowroot.rs
+++ b/components/script/dom/documentorshadowroot.rs
@@ -303,7 +303,7 @@ impl DocumentOrShadowRoot {
         root: DomRoot<Node>,
     ) {
         debug!("Adding named element {:p}: {:p} id={}", self, element, id);
-        assert!(element.upcast::<Node>().is_connected());
+        assert!(element.upcast::<Node>().is_connected_to_tree());
         assert!(!id.is_empty());
         let mut id_map = id_map.borrow_mut();
         let elements = id_map.entry(id.clone()).or_default();

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -3510,8 +3510,9 @@ impl VirtualMethods for Element {
                         None
                     }
                 });
+
                 let containing_shadow_root = self.containing_shadow_root();
-                if node.is_connected() {
+                if node.is_connected_to_tree() {
                     let value = attr.value().as_atom().clone();
                     match mutation {
                         AttributeMutation::Set(old_value) => {

--- a/tests/wpt/tests/shadow-dom/getElementById-dynamic-002.html
+++ b/tests/wpt/tests/shadow-dom/getElementById-dynamic-002.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<title>Shadow DOM: ShadowRoot.getElementById in shadow trees keeps working after host is removed from tree</title>
+<link rel="help" href="https://dom.spec.whatwg.org/#dom-nonelementparentnode-getelementbyid">
+<link rel="author" name="Simon Wülker">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="host"></div>
+<script>
+test(function() {
+  let host = document.getElementById("host");
+  host.attachShadow({ mode: "open" }).innerHTML = `<div id="test-id"></div>`;
+  let element = host.shadowRoot.getElementById("test-id");
+  assert_true(!!element);
+
+  host.remove();
+  host.shadowRoot.getElementById("test-id").id = "new-id";
+
+  assert_equals(host.shadowRoot.getElementById("new-id"), element);
+}, "ShadowRoot.getElementById works on elements whose id was modified after the root was disconnected");
+</script>

--- a/tests/wpt/tests/shadow-dom/getElementById-dynamic-002.html
+++ b/tests/wpt/tests/shadow-dom/getElementById-dynamic-002.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<title>Shadow DOM: ShadowRoot.getElementById in shadow trees keeps working after host is removed from tree</title>
+<title>Shadow DOM: Modifying an element ID inside a disconnected shadow root does not break getElementById</title>
 <link rel="help" href="https://dom.spec.whatwg.org/#dom-nonelementparentnode-getelementbyid">
 <link rel="author" name="Simon Wülker">
 <script src="/resources/testharness.js"></script>


### PR DESCRIPTION
The previous code used `Node::is_connected` instead of `Node::is_connected_to_tree`, meaning that modifications to an element id inside a shadow root that is not connected to a document would not be registered.

Also fixes a crash with registering named elements caused by the same problem. Both of these changes are covered by the new web platform test.

We'll likely run into more of these issues as we integrate the shadow dom into the codebase.

[try](https://github.com/simonwuelker/servo/actions/runs/12605903112)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes (one new wpt test)

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
