### PR TITLE
ReadableStream: remove the use of get_js_stream and use DomRoot<ReadableStream>

### DIFF
--- a/components/script/dom/blob.rs
+++ b/components/script/dom/blob.rs
@@ -4,13 +4,11 @@
 
 use std::collections::HashMap;
 use std::num::NonZeroU32;
-use std::ptr::NonNull;
 use std::rc::Rc;
 
 use base::id::{BlobId, BlobIndex, PipelineNamespaceId};
 use dom_struct::dom_struct;
 use encoding_rs::UTF_8;
-use js::jsapi::JSObject;
 use js::rust::HandleObject;
 use net_traits::filemanager_thread::RelativePos;
 use script_traits::serializable::BlobImpl;
@@ -30,7 +28,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
 use crate::dom::readablestream::ReadableStream;
 use crate::realms::{AlreadyInRealm, InRealm};
-use crate::script_runtime::{CanGc, JSContext};
+use crate::script_runtime::CanGc;
 
 // https://w3c.github.io/FileAPI/#blob
 #[dom_struct]
@@ -86,7 +84,7 @@ impl Blob {
     }
 
     /// <https://w3c.github.io/FileAPI/#blob-get-stream>
-    pub fn get_stream(&self, can_gc: CanGc) -> DomRoot<ReadableStream> {
+    pub fn get_stream(&self, can_gc: CanGc) -> Fallible<DomRoot<ReadableStream>> {
         self.global().get_blob_stream(&self.blob_id, can_gc)
     }
 }
@@ -226,8 +224,8 @@ impl BlobMethods<crate::DomTypeHolder> for Blob {
     }
 
     // <https://w3c.github.io/FileAPI/#blob-get-stream>
-    fn Stream(&self, _cx: JSContext, can_gc: CanGc) -> NonNull<JSObject> {
-        self.get_stream(can_gc).get_js_stream()
+    fn Stream(&self, can_gc: CanGc) -> Fallible<DomRoot<ReadableStream>> {
+        self.get_stream(can_gc)
     }
 
     // https://w3c.github.io/FileAPI/#slice-method-algo

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -1955,12 +1955,15 @@ impl GlobalScope {
     }
 
     /// <https://w3c.github.io/FileAPI/#blob-get-stream>
-    pub fn get_blob_stream(&self, blob_id: &BlobId, can_gc: CanGc) -> DomRoot<ReadableStream> {
+    pub fn get_blob_stream(
+        &self,
+        blob_id: &BlobId,
+        can_gc: CanGc,
+    ) -> Fallible<DomRoot<ReadableStream>> {
         let (file_id, size) = match self.get_blob_bytes_or_file_id(blob_id) {
             BlobResult::Bytes(bytes) => {
                 // If we have all the bytes in memory, queue them and close the stream.
-                let stream = ReadableStream::new_from_bytes(self, bytes, can_gc);
-                return stream;
+                return ReadableStream::new_from_bytes(self, bytes, can_gc);
             },
             BlobResult::File(id, size) => (id, size),
         };
@@ -1969,7 +1972,7 @@ impl GlobalScope {
             self,
             UnderlyingSourceType::Blob(size),
             can_gc,
-        );
+        )?;
 
         let recv = self.send_msg(file_id);
 
@@ -1988,7 +1991,7 @@ impl GlobalScope {
             }),
         );
 
-        stream
+        Ok(stream)
     }
 
     pub fn read_file_async(&self, id: Uuid, promise: Rc<Promise>, callback: FileListenerCallback) {

--- a/components/script/dom/request.rs
+++ b/components/script/dom/request.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::ptr::NonNull;
 use std::rc::Rc;
 use std::str::FromStr;
 
@@ -11,7 +10,6 @@ use dom_struct::dom_struct;
 use http::header::{HeaderName, HeaderValue};
 use http::method::InvalidMethod;
 use http::Method as HttpMethod;
-use js::jsapi::JSObject;
 use js::rust::HandleObject;
 use net_traits::fetch::headers::is_forbidden_method;
 use net_traits::request::{
@@ -40,7 +38,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::headers::{Guard, Headers};
 use crate::dom::promise::Promise;
 use crate::dom::readablestream::ReadableStream;
-use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct Request {
@@ -598,8 +596,8 @@ impl RequestMethods<crate::DomTypeHolder> for Request {
     }
 
     /// <https://fetch.spec.whatwg.org/#dom-body-body>
-    fn GetBody(&self, _cx: SafeJSContext) -> Option<NonNull<JSObject>> {
-        self.body().map(|stream| stream.get_js_stream())
+    fn GetBody(&self) -> Option<DomRoot<ReadableStream>> {
+        self.body()
     }
 
     // https://fetch.spec.whatwg.org/#dom-body-bodyused

--- a/components/script/dom/webidls/Blob.webidl
+++ b/components/script/dom/webidls/Blob.webidl
@@ -17,7 +17,7 @@ interface Blob {
              optional [Clamp] long long end,
              optional DOMString contentType);
 
-  [NewObject] object stream();
+  [NewObject, Throws] ReadableStream stream();
   [NewObject] Promise<DOMString> text();
   [NewObject] Promise<ArrayBuffer> arrayBuffer();
 };

--- a/components/script/dom/webidls/Body.webidl
+++ b/components/script/dom/webidls/Body.webidl
@@ -7,7 +7,7 @@
 [Exposed=(Window,Worker)]
 interface mixin Body {
   readonly attribute boolean bodyUsed;
-  readonly attribute object? body;
+  readonly attribute ReadableStream? body;
 
   [NewObject] Promise<ArrayBuffer> arrayBuffer();
   [NewObject] Promise<Blob> blob();

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -564,14 +564,13 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
                 };
                 let total_bytes = bytes.len();
                 let global = self.global();
-                ReadableStream::new_from_bytes(&global, bytes, can_gc)
-                    .ok()
-                    .map(|stream| ExtractedBody {
-                        stream,
-                        total_bytes: Some(total_bytes),
-                        content_type: Some(DOMString::from(content_type)),
-                        source: BodySource::Object,
-                    })
+                let stream = ReadableStream::new_from_bytes(&global, bytes, can_gc)?;
+                Some(ExtractedBody {
+                    stream,
+                    total_bytes: Some(total_bytes),
+                    content_type: Some(DOMString::from(content_type)),
+                    source: BodySource::Object,
+                })
             },
             Some(DocumentOrXMLHttpRequestBodyInit::Blob(ref b)) => {
                 let extracted_body = b
@@ -602,27 +601,25 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
                 let bytes = typedarray.to_vec();
                 let total_bytes = bytes.len();
                 let global = self.global();
-                ReadableStream::new_from_bytes(&global, bytes, can_gc)
-                    .ok()
-                    .map(|stream| ExtractedBody {
-                        stream,
-                        total_bytes: Some(total_bytes),
-                        content_type: None,
-                        source: BodySource::Object,
-                    })
+                let stream = ReadableStream::new_from_bytes(&global, bytes, can_gc)?;
+                Some(ExtractedBody {
+                    stream,
+                    total_bytes: Some(total_bytes),
+                    content_type: None,
+                    source: BodySource::Object,
+                })
             },
             Some(DocumentOrXMLHttpRequestBodyInit::ArrayBufferView(ref typedarray)) => {
                 let bytes = typedarray.to_vec();
                 let total_bytes = bytes.len();
                 let global = self.global();
-                ReadableStream::new_from_bytes(&global, bytes, can_gc)
-                    .ok()
-                    .map(|stream| ExtractedBody {
-                        stream,
-                        total_bytes: Some(total_bytes),
-                        content_type: None,
-                        source: BodySource::Object,
-                    })
+                let stream = ReadableStream::new_from_bytes(&global, bytes, can_gc)?;
+                Some(ExtractedBody {
+                    stream,
+                    total_bytes: Some(total_bytes),
+                    content_type: None,
+                    source: BodySource::Object,
+                })
             },
             None => None,
         };

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -564,13 +564,14 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
                 };
                 let total_bytes = bytes.len();
                 let global = self.global();
-                let stream = ReadableStream::new_from_bytes(&global, bytes, can_gc);
-                Some(ExtractedBody {
-                    stream,
-                    total_bytes: Some(total_bytes),
-                    content_type: Some(DOMString::from(content_type)),
-                    source: BodySource::Object,
-                })
+                ReadableStream::new_from_bytes(&global, bytes, can_gc)
+                    .ok()
+                    .map(|stream| ExtractedBody {
+                        stream,
+                        total_bytes: Some(total_bytes),
+                        content_type: Some(DOMString::from(content_type)),
+                        source: BodySource::Object,
+                    })
             },
             Some(DocumentOrXMLHttpRequestBodyInit::Blob(ref b)) => {
                 let extracted_body = b
@@ -601,25 +602,27 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
                 let bytes = typedarray.to_vec();
                 let total_bytes = bytes.len();
                 let global = self.global();
-                let stream = ReadableStream::new_from_bytes(&global, bytes, can_gc);
-                Some(ExtractedBody {
-                    stream,
-                    total_bytes: Some(total_bytes),
-                    content_type: None,
-                    source: BodySource::Object,
-                })
+                ReadableStream::new_from_bytes(&global, bytes, can_gc)
+                    .ok()
+                    .map(|stream| ExtractedBody {
+                        stream,
+                        total_bytes: Some(total_bytes),
+                        content_type: None,
+                        source: BodySource::Object,
+                    })
             },
             Some(DocumentOrXMLHttpRequestBodyInit::ArrayBufferView(ref typedarray)) => {
                 let bytes = typedarray.to_vec();
                 let total_bytes = bytes.len();
                 let global = self.global();
-                let stream = ReadableStream::new_from_bytes(&global, bytes, can_gc);
-                Some(ExtractedBody {
-                    stream,
-                    total_bytes: Some(total_bytes),
-                    content_type: None,
-                    source: BodySource::Object,
-                })
+                ReadableStream::new_from_bytes(&global, bytes, can_gc)
+                    .ok()
+                    .map(|stream| ExtractedBody {
+                        stream,
+                        total_bytes: Some(total_bytes),
+                        content_type: None,
+                        source: BodySource::Object,
+                    })
             },
             None => None,
         };


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
part of #34676

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
