### PR TITLE
feat: Decouple `egui` as optional feature for `servoshell`

### DIFF
--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -37,7 +37,7 @@ ProductName = "Servo"
 
 [features]
 debugmozjs = ["libservo/debugmozjs"]
-default = ["max_log_level", "webdriver", "webxr", "webgpu"]
+default = ["egui", "max_log_level", "webdriver", "webxr", "webgpu"]
 egui = ["dep:egui", "dep:egui_glow", "dep:egui-winit"]
 jitspew = ["libservo/jitspew"]
 js_backtrace = ["libservo/js_backtrace"]

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -38,6 +38,7 @@ ProductName = "Servo"
 [features]
 debugmozjs = ["libservo/debugmozjs"]
 default = ["max_log_level", "webdriver", "webxr", "webgpu"]
+egui = ["dep:egui", "dep:egui_glow", "dep:egui-winit"]
 jitspew = ["libservo/jitspew"]
 js_backtrace = ["libservo/js_backtrace"]
 layout_2013 = ["libservo/layout_2013"]
@@ -104,9 +105,9 @@ webxr = { workspace = true, optional = true }
 # For optional feature servo_allocator/use-system-allocator
 servo_allocator = { path = "../../components/allocator" }
 arboard = { version = "3" }
-egui = { version = "0.30.0" }
-egui_glow = { version = "0.30.0", features = ["winit"] }
-egui-winit = { version = "0.30.0", default-features = false, features = ["clipboard", "wayland"] }
+egui = { version = "0.30.0", optional = true }
+egui_glow = { version = "0.30.0", features = ["winit"], optional = true }
+egui-winit = { version = "0.30.0", default-features = false, features = ["clipboard", "wayland"], optional = true }
 euclid = { workspace = true }
 gilrs = "0.11.0"
 gleam = { workspace = true }

--- a/ports/servoshell/desktop/mod.rs
+++ b/ports/servoshell/desktop/mod.rs
@@ -6,6 +6,7 @@
 
 pub(crate) mod app;
 pub(crate) mod cli;
+#[cfg(feature = "egui")]
 mod egui_glue;
 mod embedder;
 pub(crate) mod events_loop;
@@ -13,6 +14,7 @@ pub mod geometry;
 mod headed_window;
 mod headless_window;
 mod keyutils;
+#[cfg(feature = "egui")]
 mod minibrowser;
 mod protocols;
 mod tracing;

--- a/ports/servoshell/desktop/webview.rs
+++ b/ports/servoshell/desktop/webview.rs
@@ -161,6 +161,7 @@ where
         self.focused_webview_id
     }
 
+    #[cfg(feature = "egui")]
     pub fn current_url_string(&self) -> Option<String> {
         match self.focused_webview() {
             Some(webview) => webview.url.as_ref().map(|url| url.to_string()),
@@ -182,6 +183,7 @@ where
         }
     }
 
+    #[cfg(feature = "egui")]
     pub fn status_text(&self) -> Option<String> {
         self.status_text.clone()
     }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Decoupled `egui` as optional feature for `servoshell`, so `servoshell` may be used as a webview library.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix part of #34522 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because this is just a feature refactor without function change

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
