### PR TITLE
script: Expose `NodeTraits::owner_global` / `Window::as_global_scope`

### DIFF
--- a/components/script/dom/analysernode.rs
+++ b/components/script/dom/analysernode.rs
@@ -111,6 +111,7 @@ impl AnalyserNode {
         let (node, recv) = AnalyserNode::new_inherited(window, context, options)?;
         let object = reflect_dom_object_with_proto(Box::new(node), window, proto, can_gc);
         let task_source = window
+            .as_global_scope()
             .task_manager()
             .dom_manipulation_task_source()
             .to_sendable();

--- a/components/script/dom/bindings/reflector.rs
+++ b/components/script/dom/bindings/reflector.rs
@@ -100,7 +100,9 @@ pub trait DomObject: JSTraceable + 'static {
     /// Returns the receiver's reflector.
     fn reflector(&self) -> &Reflector;
 
-    /// Returns the global scope of the realm that the DomObject was created in.
+    /// Returns the [`GlobalScope`] of the realm that the [`DomObject`] was created in.  If this
+    /// object is a `Node`, this will be different from it's owning `Document` if adopted by. For
+    /// `Node`s it's almost always better to use `NodeTraits::owning_global`.
     fn global(&self) -> DomRoot<GlobalScope>
     where
         Self: Sized,

--- a/components/script/dom/bluetoothadvertisingevent.rs
+++ b/components/script/dom/bluetoothadvertisingevent.rs
@@ -91,7 +91,6 @@ impl BluetoothAdvertisingEventMethods<crate::DomTypeHolder> for BluetoothAdverti
         type_: DOMString,
         init: &BluetoothAdvertisingEventInit,
     ) -> Fallible<DomRoot<BluetoothAdvertisingEvent>> {
-        let global = window.upcast::<GlobalScope>();
         let name = init.name.clone();
         let appearance = init.appearance;
         let txPower = init.txPower;
@@ -99,7 +98,7 @@ impl BluetoothAdvertisingEventMethods<crate::DomTypeHolder> for BluetoothAdverti
         let bubbles = EventBubbles::from(init.parent.bubbles);
         let cancelable = EventCancelable::from(init.parent.cancelable);
         Ok(BluetoothAdvertisingEvent::new(
-            global,
+            window.as_global_scope(),
             proto,
             Atom::from(type_),
             bubbles,

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -571,13 +571,15 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
     /// <https://html.spec.whatwg.org/multipage/#dom-customelementregistry-whendefined>
     #[allow(unsafe_code)]
     fn WhenDefined(&self, name: DOMString, comp: InRealm, can_gc: CanGc) -> Rc<Promise> {
-        let global_scope = self.window.upcast::<GlobalScope>();
         let name = LocalName::from(&*name);
 
         // Step 1
         if !is_valid_custom_element_name(&name) {
             let promise = Promise::new_in_current_realm(comp, can_gc);
-            promise.reject_native(&DOMException::new(global_scope, DOMErrorName::SyntaxError));
+            promise.reject_native(&DOMException::new(
+                self.window.as_global_scope(),
+                DOMErrorName::SyntaxError,
+            ));
             return promise;
         }
 
@@ -733,7 +735,7 @@ impl CustomElementDefinition {
         // https://html.spec.whatwg.org/multipage/#clean-up-after-running-script
         if is_execution_stack_empty() {
             window
-                .upcast::<GlobalScope>()
+                .as_global_scope()
                 .perform_a_microtask_checkpoint(can_gc);
         }
 
@@ -925,7 +927,7 @@ fn run_upgrade_constructor(
         // https://html.spec.whatwg.org/multipage/#clean-up-after-running-script
         if is_execution_stack_empty() {
             window
-                .upcast::<GlobalScope>()
+                .as_global_scope()
                 .perform_a_microtask_checkpoint(can_gc);
         }
 

--- a/components/script/dom/history.rs
+++ b/components/script/dom/history.rs
@@ -78,7 +78,7 @@ impl History {
         let msg = ScriptMsg::TraverseHistory(direction);
         let _ = self
             .window
-            .upcast::<GlobalScope>()
+            .as_global_scope()
             .script_to_constellation_chan()
             .send(msg);
         Ok(())
@@ -109,7 +109,7 @@ impl History {
                 let (tx, rx) = ipc::channel(self.global().time_profiler_chan().clone()).unwrap();
                 let _ = self
                     .window
-                    .upcast::<GlobalScope>()
+                    .as_global_scope()
                     .resource_threads()
                     .send(CoreResourceMsg::GetHistoryState(state_id, tx));
                 rx.recv().unwrap()
@@ -124,9 +124,10 @@ impl History {
                     ports: None,
                     blobs: None,
                 };
-                let global_scope = self.window.upcast::<GlobalScope>();
                 rooted!(in(*GlobalScope::get_cx()) let mut state = UndefinedValue());
-                if structuredclone::read(global_scope, data, state.handle_mut()).is_err() {
+                if structuredclone::read(self.window.as_global_scope(), data, state.handle_mut())
+                    .is_err()
+                {
                     warn!("Error reading structuredclone data");
                 }
                 self.state.set(state.get());
@@ -167,7 +168,7 @@ impl History {
     pub fn remove_states(&self, states: Vec<HistoryStateId>) {
         let _ = self
             .window
-            .upcast::<GlobalScope>()
+            .as_global_scope()
             .resource_threads()
             .send(CoreResourceMsg::RemoveHistoryStates(states));
     }
@@ -240,7 +241,7 @@ impl History {
                 let msg = ScriptMsg::PushHistoryState(state_id, new_url.clone());
                 let _ = self
                     .window
-                    .upcast::<GlobalScope>()
+                    .as_global_scope()
                     .script_to_constellation_chan()
                     .send(msg);
                 state_id
@@ -257,14 +258,14 @@ impl History {
                 let msg = ScriptMsg::ReplaceHistoryState(state_id, new_url.clone());
                 let _ = self
                     .window
-                    .upcast::<GlobalScope>()
+                    .as_global_scope()
                     .script_to_constellation_chan()
                     .send(msg);
                 state_id
             },
         };
 
-        let _ = self.window.upcast::<GlobalScope>().resource_threads().send(
+        let _ = self.window.as_global_scope().resource_threads().send(
             CoreResourceMsg::SetHistoryState(state_id, serialized_data.serialized.clone()),
         );
 
@@ -275,9 +276,14 @@ impl History {
         document.set_url(new_url);
 
         // Step 11
-        let global_scope = self.window.upcast::<GlobalScope>();
         rooted!(in(*cx) let mut state = UndefinedValue());
-        if structuredclone::read(global_scope, serialized_data, state.handle_mut()).is_err() {
+        if structuredclone::read(
+            self.window.as_global_scope(),
+            serialized_data,
+            state.handle_mut(),
+        )
+        .is_err()
+        {
             warn!("Error reading structuredclone data");
         }
 
@@ -311,7 +317,7 @@ impl HistoryMethods<crate::DomTypeHolder> for History {
         let msg = ScriptMsg::JointSessionHistoryLength(sender);
         let _ = self
             .window
-            .upcast::<GlobalScope>()
+            .as_global_scope()
             .script_to_constellation_chan()
             .send(msg);
         Ok(recv.recv().unwrap())

--- a/components/script/dom/htmldetailselement.rs
+++ b/components/script/dom/htmldetailselement.rs
@@ -82,16 +82,16 @@ impl VirtualMethods for HTMLDetailsElement {
             let counter = self.toggle_counter.get() + 1;
             self.toggle_counter.set(counter);
 
-            let window = self.owner_window();
             let this = Trusted::new(self);
-            window.task_manager().dom_manipulation_task_source().queue(
-                task!(details_notification_task_steps: move || {
+            self.owner_global()
+                .task_manager()
+                .dom_manipulation_task_source()
+                .queue(task!(details_notification_task_steps: move || {
                     let this = this.root();
                     if counter == this.toggle_counter.get() {
                         this.upcast::<EventTarget>().fire_event(atom!("toggle"), CanGc::note());
                     }
-                }),
-            );
+                }));
             self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage)
         }
     }

--- a/components/script/dom/htmldialogelement.rs
+++ b/components/script/dom/htmldialogelement.rs
@@ -102,7 +102,6 @@ impl HTMLDialogElementMethods<crate::DomTypeHolder> for HTMLDialogElement {
     fn Close(&self, return_value: Option<DOMString>) {
         let element = self.upcast::<Element>();
         let target = self.upcast::<EventTarget>();
-        let win = self.owner_window();
 
         // Step 1 & 2
         if element
@@ -120,7 +119,8 @@ impl HTMLDialogElementMethods<crate::DomTypeHolder> for HTMLDialogElement {
         // TODO: Step 4 implement pending dialog stack removal
 
         // Step 5
-        win.task_manager()
+        self.owner_global()
+            .task_manager()
             .dom_manipulation_task_source()
             .queue_simple_event(target, atom!("close"));
     }

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -57,7 +57,6 @@ use crate::dom::eventtarget::EventTarget;
 use crate::dom::file::File;
 use crate::dom::formdata::FormData;
 use crate::dom::formdataevent::FormDataEvent;
-use crate::dom::globalscope::GlobalScope;
 use crate::dom::htmlbuttonelement::HTMLButtonElement;
 use crate::dom::htmlcollection::CollectionFilter;
 use crate::dom::htmldatalistelement::HTMLDataListElement;
@@ -856,9 +855,9 @@ impl HTMLFormElement {
             LoadOrigin::Script(doc.origin().immutable().clone()),
             action_components,
             None,
-            target_window.upcast::<GlobalScope>().get_referrer(),
+            target_window.as_global_scope().get_referrer(),
             target_document.get_referrer_policy(),
-            Some(target_window.upcast::<GlobalScope>().is_secure_context()),
+            Some(target_window.as_global_scope().is_secure_context()),
         );
 
         // Step 22
@@ -1009,12 +1008,11 @@ impl HTMLFormElement {
             Some(ref link_types) if link_types.Value().contains("noreferrer") => {
                 Referrer::NoReferrer
             },
-            _ => target.upcast::<GlobalScope>().get_referrer(),
+            _ => target.as_global_scope().get_referrer(),
         };
 
         let referrer_policy = target.Document().get_referrer_policy();
-        let pipeline_id = target.upcast::<GlobalScope>().pipeline_id();
-        load_data.creator_pipeline_id = Some(pipeline_id);
+        load_data.creator_pipeline_id = Some(target.pipeline_id());
         load_data.referrer = referrer;
         load_data.referrer_policy = referrer_policy;
 
@@ -1037,6 +1035,7 @@ impl HTMLFormElement {
 
         // Step 3.
         target
+            .global()
             .task_manager()
             .dom_manipulation_task_source()
             .queue(task)

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -185,9 +185,8 @@ impl HTMLIFrameElement {
         let new_pipeline_id = PipelineId::new();
         self.pending_pipeline_id.set(Some(new_pipeline_id));
 
-        let global_scope = window.upcast::<GlobalScope>();
         let load_info = IFrameLoadInfo {
-            parent_pipeline_id: global_scope.pipeline_id(),
+            parent_pipeline_id: window.pipeline_id(),
             browsing_context_id,
             top_level_browsing_context_id,
             new_pipeline_id,
@@ -214,13 +213,14 @@ impl HTMLIFrameElement {
                     sandbox: sandboxed,
                     window_size,
                 };
-                global_scope
+                window
+                    .as_global_scope()
                     .script_to_constellation_chan()
                     .send(ScriptMsg::ScriptNewIFrame(load_info))
                     .unwrap();
 
                 let new_layout_info = NewLayoutInfo {
-                    parent_info: Some(global_scope.pipeline_id()),
+                    parent_info: Some(window.pipeline_id()),
                     new_pipeline_id,
                     browsing_context_id,
                     top_level_browsing_context_id,
@@ -240,7 +240,8 @@ impl HTMLIFrameElement {
                     sandbox: sandboxed,
                     window_size,
                 };
-                global_scope
+                window
+                    .as_global_scope()
                     .script_to_constellation_chan()
                     .send(ScriptMsg::ScriptLoadedURLInIFrame(load_info))
                     .unwrap();
@@ -258,14 +259,14 @@ impl HTMLIFrameElement {
             let url = ServoUrl::parse("about:srcdoc").unwrap();
             let document = self.owner_document();
             let window = self.owner_window();
-            let pipeline_id = Some(window.upcast::<GlobalScope>().pipeline_id());
+            let pipeline_id = Some(window.pipeline_id());
             let mut load_data = LoadData::new(
                 LoadOrigin::Script(document.origin().immutable().clone()),
                 url,
                 pipeline_id,
-                window.upcast::<GlobalScope>().get_referrer(),
+                window.as_global_scope().get_referrer(),
                 document.get_referrer_policy(),
-                Some(window.upcast::<GlobalScope>().is_secure_context()),
+                Some(window.as_global_scope().is_secure_context()),
             );
             let element = self.upcast::<Element>();
             load_data.srcdoc = String::from(element.get_string_attribute(&local_name!("srcdoc")));
@@ -344,7 +345,7 @@ impl HTMLIFrameElement {
         }
 
         let creator_pipeline_id = if url.as_str() == "about:blank" {
-            Some(window.upcast::<GlobalScope>().pipeline_id())
+            Some(window.pipeline_id())
         } else {
             None
         };
@@ -353,9 +354,9 @@ impl HTMLIFrameElement {
             LoadOrigin::Script(document.origin().immutable().clone()),
             url,
             creator_pipeline_id,
-            window.upcast::<GlobalScope>().get_referrer(),
+            window.as_global_scope().get_referrer(),
             referrer_policy,
-            Some(window.upcast::<GlobalScope>().is_secure_context()),
+            Some(window.as_global_scope().is_secure_context()),
         );
 
         let pipeline_id = self.pipeline_id();
@@ -392,14 +393,14 @@ impl HTMLIFrameElement {
         let url = ServoUrl::parse("about:blank").unwrap();
         let document = self.owner_document();
         let window = self.owner_window();
-        let pipeline_id = Some(window.upcast::<GlobalScope>().pipeline_id());
+        let pipeline_id = Some(window.pipeline_id());
         let load_data = LoadData::new(
             LoadOrigin::Script(document.origin().immutable().clone()),
             url,
             pipeline_id,
-            window.upcast::<GlobalScope>().get_referrer(),
+            window.as_global_scope().get_referrer(),
             document.get_referrer_policy(),
-            Some(window.upcast::<GlobalScope>().is_secure_context()),
+            Some(window.as_global_scope().is_secure_context()),
         );
         let browsing_context_id = BrowsingContextId::new();
         let top_level_browsing_context_id = window.window_proxy().top_level_browsing_context_id();
@@ -777,7 +778,7 @@ impl VirtualMethods for HTMLIFrameElement {
 
         let msg = ScriptMsg::RemoveIFrame(browsing_context_id, sender);
         window
-            .upcast::<GlobalScope>()
+            .as_global_scope()
             .script_to_constellation_chan()
             .send(msg)
             .unwrap();

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -286,7 +286,7 @@ impl HTMLInputElement {
     ) -> HTMLInputElement {
         let chan = document
             .window()
-            .upcast::<GlobalScope>()
+            .as_global_scope()
             .script_to_constellation_chan()
             .clone();
         HTMLInputElement {
@@ -1843,7 +1843,7 @@ impl HTMLInputElement {
     fn select_files(&self, opt_test_paths: Option<Vec<DOMString>>, can_gc: CanGc) {
         let window = self.owner_window();
         let origin = get_blob_origin(&window.get_url());
-        let resource_threads = window.upcast::<GlobalScope>().resource_threads();
+        let resource_threads = window.as_global_scope().resource_threads();
 
         let mut files: Vec<DomRoot<File>> = vec![];
         let mut error = None;
@@ -2576,7 +2576,7 @@ impl VirtualMethods for HTMLInputElement {
             self.input_type().is_textual_or_password()
         {
             if event.IsTrusted() {
-                self.owner_window()
+                self.owner_global()
                     .task_manager()
                     .user_interaction_task_source()
                     .queue_event(

--- a/components/script/dom/htmlmetaelement.rs
+++ b/components/script/dom/htmlmetaelement.rs
@@ -23,7 +23,6 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::document::{DeclarativeRefresh, Document};
 use crate::dom::element::{AttributeMutation, Element};
-use crate::dom::globalscope::GlobalScope;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::htmlheadelement::HTMLHeadElement;
 use crate::dom::location::NavigationType;
@@ -207,7 +206,7 @@ impl HTMLMetaElement {
         if document.completely_loaded() {
             // TODO: handle active sandboxing flag
             let window = self.owner_window();
-            window.upcast::<GlobalScope>().schedule_callback(
+            window.as_global_scope().schedule_callback(
                 OneshotTimerCallback::RefreshRedirectDue(RefreshRedirectDue {
                     window: window.clone(),
                     url: url_record,

--- a/components/script/dom/htmlstyleelement.rs
+++ b/components/script/dom/htmlstyleelement.rs
@@ -133,7 +133,7 @@ impl HTMLStyleElement {
 
         // No subresource loads were triggered, queue load event
         if self.pending_loads.get() == 0 {
-            self.owner_window()
+            self.owner_global()
                 .task_manager()
                 .dom_manipulation_task_source()
                 .queue_simple_event(self.upcast(), atom!("load"));

--- a/components/script/dom/htmltextareaelement.rs
+++ b/components/script/dom/htmltextareaelement.rs
@@ -27,7 +27,6 @@ use crate::dom::compositionevent::CompositionEvent;
 use crate::dom::document::Document;
 use crate::dom::element::{AttributeMutation, Element, LayoutElementHelpers};
 use crate::dom::event::{Event, EventBubbles, EventCancelable};
-use crate::dom::globalscope::GlobalScope;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::htmlfieldsetelement::HTMLFieldSetElement;
 use crate::dom::htmlformelement::{FormControl, HTMLFormElement};
@@ -143,7 +142,7 @@ impl HTMLTextAreaElement {
     ) -> HTMLTextAreaElement {
         let chan = document
             .window()
-            .upcast::<GlobalScope>()
+            .as_global_scope()
             .script_to_constellation_chan()
             .clone();
         HTMLTextAreaElement {
@@ -650,7 +649,7 @@ impl VirtualMethods for HTMLTextAreaElement {
             }
         } else if event.type_() == atom!("keypress") && !event.DefaultPrevented() {
             if event.IsTrusted() {
-                self.owner_window()
+                self.owner_global()
                     .task_manager()
                     .user_interaction_task_source()
                     .queue_event(

--- a/components/script/dom/htmlvideoelement.rs
+++ b/components/script/dom/htmlvideoelement.rs
@@ -125,7 +125,7 @@ impl HTMLVideoElement {
         let sent_resize = if self.htmlmediaelement.get_ready_state() == ReadyState::HaveNothing {
             None
         } else {
-            self.owner_window()
+            self.owner_global()
                 .task_manager()
                 .media_element_task_source()
                 .queue_simple_event(self.upcast(), atom!("resize"));

--- a/components/script/dom/mediaquerylistevent.rs
+++ b/components/script/dom/mediaquerylistevent.rs
@@ -89,9 +89,8 @@ impl MediaQueryListEventMethods<crate::DomTypeHolder> for MediaQueryListEvent {
         type_: DOMString,
         init: &MediaQueryListEventInit,
     ) -> Fallible<DomRoot<MediaQueryListEvent>> {
-        let global = window.upcast::<GlobalScope>();
         Ok(MediaQueryListEvent::new_with_proto(
-            global,
+            window.as_global_scope(),
             proto,
             Atom::from(type_),
             init.parent.bubbles,

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -45,6 +45,7 @@ use style::stylesheets::{Stylesheet, UrlExtraData};
 use uuid::Uuid;
 use xml5ever::serialize as xml_serialize;
 
+use super::globalscope::GlobalScope;
 use crate::document_loader::DocumentLoader;
 use crate::dom::attr::Attr;
 use crate::dom::bindings::cell::{DomRefCell, Ref, RefMut};
@@ -3346,6 +3347,10 @@ pub(crate) trait NodeTraits {
     /// differ from the [`Document`] that the node was created in if it was adopted by a
     /// different [`Document`] (the owner).
     fn owner_window(&self) -> DomRoot<Window>;
+    /// Get the [`GlobalScope`] of the [`Document`] that owns this node. Note that this may
+    /// differ from the [`GlobalScope`] that the node was created in if it was adopted by a
+    /// different [`Document`] (the owner).
+    fn owner_global(&self) -> DomRoot<GlobalScope>;
     /// If this [`Node`] is contained in a [`ShadowRoot`] return it, otherwise `None`.
     fn containing_shadow_root(&self) -> Option<DomRoot<ShadowRoot>>;
     /// Get the stylesheet owner for this node: either the [`Document`] or the [`ShadowRoot`]
@@ -3361,6 +3366,10 @@ impl<T: DerivedFrom<Node> + DomObject> NodeTraits for T {
 
     fn owner_window(&self) -> DomRoot<Window> {
         DomRoot::from_ref(self.owner_document().window())
+    }
+
+    fn owner_global(&self) -> DomRoot<GlobalScope> {
+        DomRoot::from_ref(self.owner_window().upcast())
     }
 
     fn containing_shadow_root(&self) -> Option<DomRoot<ShadowRoot>> {

--- a/components/script/dom/selection.rs
+++ b/components/script/dom/selection.rs
@@ -17,7 +17,7 @@ use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
 use crate::dom::eventtarget::EventTarget;
-use crate::dom::node::Node;
+use crate::dom::node::{Node, NodeTraits};
 use crate::dom::range::Range;
 use crate::script_runtime::CanGc;
 
@@ -89,7 +89,7 @@ impl Selection {
         }
         let this = Trusted::new(self);
         self.document
-            .window()
+            .owner_global()
             .task_manager()
             .user_interaction_task_source() // w3c/selection-api#117
             .queue(

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -55,7 +55,6 @@ use crate::dom::comment::Comment;
 use crate::dom::document::{Document, DocumentSource, HasBrowsingContext, IsHTMLDocument};
 use crate::dom::documenttype::DocumentType;
 use crate::dom::element::{CustomElementCreationMode, Element, ElementCreator};
-use crate::dom::globalscope::GlobalScope;
 use crate::dom::htmlformelement::{FormControlElementHelpers, HTMLFormElement};
 use crate::dom::htmlimageelement::HTMLImageElement;
 use crate::dom::htmlinputelement::HTMLInputElement;
@@ -366,7 +365,7 @@ impl ServoParser {
         let profiler_chan = self
             .document
             .window()
-            .upcast::<GlobalScope>()
+            .as_global_scope()
             .time_profiler_chan()
             .clone();
         let profiler_metadata = TimerMetadata {
@@ -564,7 +563,7 @@ impl ServoParser {
         let profiler_chan = self
             .document
             .window()
-            .upcast::<GlobalScope>()
+            .as_global_scope()
             .time_profiler_chan()
             .clone();
         let profiler_metadata = TimerMetadata {
@@ -637,7 +636,7 @@ impl ServoParser {
             if is_execution_stack_empty() {
                 self.document
                     .window()
-                    .upcast::<GlobalScope>()
+                    .as_global_scope()
                     .perform_a_microtask_checkpoint(can_gc);
             }
 
@@ -1401,7 +1400,7 @@ fn create_element_for_token(
         if is_execution_stack_empty() {
             document
                 .window()
-                .upcast::<GlobalScope>()
+                .as_global_scope()
                 .perform_a_microtask_checkpoint(can_gc);
         }
         // Step 6.3

--- a/components/script/dom/textcontrol.rs
+++ b/components/script/dom/textcontrol.rs
@@ -301,7 +301,7 @@ impl<'a, E: TextControlElement> TextControlSelection<'a, E> {
         // Step 6
         if textinput.selection_state() != original_selection_state {
             self.element
-                .owner_window()
+                .owner_global()
                 .task_manager()
                 .user_interaction_task_source()
                 .queue_event(

--- a/components/script/dom/worklet.rs
+++ b/components/script/dom/worklet.rs
@@ -145,17 +145,16 @@ impl WorkletMethods<crate::DomTypeHolder> for Worklet {
 
         // Steps 6-12 in parallel.
         let pending_tasks_struct = PendingTasksStruct::new();
-        let global = self.window.upcast::<GlobalScope>();
 
         self.droppable_field
             .thread_pool
             .get_or_init(ScriptThread::worklet_thread_pool)
             .fetch_and_invoke_a_worklet_script(
-                global.pipeline_id(),
+                self.window.pipeline_id(),
                 self.droppable_field.worklet_id,
                 self.global_type,
                 self.window.origin().immutable().clone(),
-                global.api_base_url(),
+                self.window.as_global_scope().api_base_url(),
                 module_url_record,
                 options.credentials,
                 pending_tasks_struct,

--- a/components/script/image_listener.rs
+++ b/components/script/image_listener.rs
@@ -27,7 +27,7 @@ pub fn generate_cache_listener_for_element<
     let (responder_sender, responder_receiver) = ipc::channel().unwrap();
 
     let task_source = elem
-        .owner_window()
+        .owner_global()
         .task_manager()
         .networking_task_source()
         .to_sendable();

--- a/components/script/links.rs
+++ b/components/script/links.rs
@@ -20,7 +20,7 @@ use crate::dom::htmlareaelement::HTMLAreaElement;
 use crate::dom::htmlformelement::HTMLFormElement;
 use crate::dom::htmllinkelement::HTMLLinkElement;
 use crate::dom::node::NodeTraits;
-use crate::dom::types::{Element, GlobalScope};
+use crate::dom::types::Element;
 use crate::script_runtime::CanGc;
 
 bitflags::bitflags! {
@@ -412,12 +412,12 @@ pub fn follow_hyperlink(
         let referrer = if relations.contains(LinkRelations::NO_REFERRER) {
             Referrer::NoReferrer
         } else {
-            target_window.upcast::<GlobalScope>().get_referrer()
+            target_window.as_global_scope().get_referrer()
         };
 
         // Step 14
-        let pipeline_id = target_window.upcast::<GlobalScope>().pipeline_id();
-        let secure = target_window.upcast::<GlobalScope>().is_secure_context();
+        let pipeline_id = target_window.as_global_scope().pipeline_id();
+        let secure = target_window.as_global_scope().is_secure_context();
         let load_data = LoadData::new(
             LoadOrigin::Script(document.origin().immutable().clone()),
             url,
@@ -431,7 +431,8 @@ pub fn follow_hyperlink(
             debug!("following hyperlink to {}", load_data.url);
             target.root().load_url(history_handling, false, load_data, CanGc::note());
         });
-        target_window
+        target_document
+            .owner_global()
             .task_manager()
             .dom_manipulation_task_source()
             .queue(task);

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -942,7 +942,7 @@ pub(crate) enum ModuleOwner {
 }
 
 impl ModuleOwner {
-    pub fn global(&self) -> DomRoot<GlobalScope> {
+    pub(crate) fn global(&self) -> DomRoot<GlobalScope> {
         match &self {
             ModuleOwner::Worker(worker) => (*worker.root().clone()).global(),
             ModuleOwner::Window(script) => (*script.root()).global(),


### PR DESCRIPTION
Expose two new helpers and start using them as much as possible.

- `NodeTraits::owner_global`: which gets the `GlobalScope` that currenty
 owns a `Node`. This may be different than `.global()` in the case that
 the `Node` was adopted by a different `Document`.
- `Window::as_global_scope`: A helper to avoid having to cast so much
  when treating a `Window` like a `GlobalScope`.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they just expose two new helpers that don't change the way code works.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
