### PR TITLE
script: Unsilence all main thread `TaskQueue` errors

### DIFF
--- a/components/script/dom/audiocontext.rs
+++ b/components/script/dom/audiocontext.rs
@@ -157,13 +157,12 @@ impl AudioContextMethods<crate::DomTypeHolder> for AudioContext {
         }
 
         // Steps 4 and 5.
-        let task_source = self.global().task_manager().dom_manipulation_task_source();
         let trusted_promise = TrustedPromise::new(promise.clone());
         match self.context.audio_context_impl().lock().unwrap().suspend() {
             Ok(_) => {
                 let base_context = Trusted::new(&self.context);
                 let context = Trusted::new(self);
-                let _ = task_source.queue(
+                self.global().task_manager().dom_manipulation_task_source().queue(
                     task!(suspend_ok: move || {
                         let base_context = base_context.root();
                         let context = context.root();
@@ -182,10 +181,13 @@ impl AudioContextMethods<crate::DomTypeHolder> for AudioContext {
             Err(_) => {
                 // The spec does not define the error case and `suspend` should
                 // never fail, but we handle the case here for completion.
-                let _ = task_source.queue(task!(suspend_error: move || {
-                    let promise = trusted_promise.root();
-                    promise.reject_error(Error::Type("Something went wrong".to_owned()));
-                }));
+                self.global()
+                    .task_manager()
+                    .dom_manipulation_task_source()
+                    .queue(task!(suspend_error: move || {
+                        let promise = trusted_promise.root();
+                        promise.reject_error(Error::Type("Something went wrong".to_owned()));
+                    }));
             },
         };
 
@@ -211,13 +213,12 @@ impl AudioContextMethods<crate::DomTypeHolder> for AudioContext {
         }
 
         // Steps 4 and 5.
-        let task_source = self.global().task_manager().dom_manipulation_task_source();
         let trusted_promise = TrustedPromise::new(promise.clone());
         match self.context.audio_context_impl().lock().unwrap().close() {
             Ok(_) => {
                 let base_context = Trusted::new(&self.context);
                 let context = Trusted::new(self);
-                let _ = task_source.queue(
+                self.global().task_manager().dom_manipulation_task_source().queue(
                     task!(suspend_ok: move || {
                         let base_context = base_context.root();
                         let context = context.root();
@@ -236,10 +237,13 @@ impl AudioContextMethods<crate::DomTypeHolder> for AudioContext {
             Err(_) => {
                 // The spec does not define the error case and `suspend` should
                 // never fail, but we handle the case here for completion.
-                let _ = task_source.queue(task!(suspend_error: move || {
-                    let promise = trusted_promise.root();
-                    promise.reject_error(Error::Type("Something went wrong".to_owned()));
-                }));
+                self.global()
+                    .task_manager()
+                    .dom_manipulation_task_source()
+                    .queue(task!(suspend_error: move || {
+                        let promise = trusted_promise.root();
+                        promise.reject_error(Error::Type("Something went wrong".to_owned()));
+                    }));
             },
         };
 

--- a/components/script/dom/audioscheduledsourcenode.rs
+++ b/components/script/dom/audioscheduledsourcenode.rs
@@ -71,9 +71,13 @@ impl AudioScheduledSourceNodeMethods<crate::DomTypeHolder> for AudioScheduledSou
         }
 
         let this = Trusted::new(self);
-        let task_source = self.global().task_manager().dom_manipulation_task_source();
+        let task_source = self
+            .global()
+            .task_manager()
+            .dom_manipulation_task_source()
+            .to_sendable();
         let callback = OnEndedCallback::new(move || {
-            let _ = task_source.queue(task!(ended: move || {
+            task_source.queue(task!(ended: move || {
                 let this = this.root();
                 this.global().task_manager().dom_manipulation_task_source().queue_simple_event(
                     this.upcast(),

--- a/components/script/dom/audiotracklist.rs
+++ b/components/script/dom/audiotracklist.rs
@@ -90,7 +90,7 @@ impl AudioTrackList {
         let global = &self.global();
         let this = Trusted::new(self);
         let task_source = global.task_manager().media_element_task_source();
-        let _ = task_source.queue(task!(media_track_change: move || {
+        task_source.queue(task!(media_track_change: move || {
             let this = this.root();
             this.upcast::<EventTarget>().fire_event(atom!("change"), CanGc::note());
         }));

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -59,7 +59,7 @@ use crate::script_runtime::{
     ThreadSafeJSContext,
 };
 use crate::task_queue::{QueuedTask, QueuedTaskConversion, TaskQueue};
-use crate::task_source::{TaskSource, TaskSourceName};
+use crate::task_source::{SendableTaskSource, TaskSourceName};
 
 /// Set the `worker` field of a related DedicatedWorkerGlobalScope object to a particular
 /// value for the duration of this object's lifetime. This ensures that the related Worker
@@ -378,7 +378,7 @@ impl DedicatedWorkerGlobalScope {
                     .origin(origin);
 
                 let runtime = unsafe {
-                    let task_source = TaskSource {
+                    let task_source = SendableTaskSource {
                         sender: Box::new(WorkerThreadWorkerChan {
                             sender: own_sender.clone(),
                             worker: worker.clone(),

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -724,7 +724,6 @@ impl Document {
                 event.set_trusted(true);
                 window.dispatch_event_with_target_override(event, CanGc::note());
             }))
-            .unwrap();
     }
 
     pub fn origin(&self) -> &MutableOrigin {
@@ -2128,7 +2127,7 @@ impl Document {
     ) {
         let callback = NetworkListener {
             context: std::sync::Arc::new(Mutex::new(listener)),
-            task_source: self.window().task_manager().networking_task_source(),
+            task_source: self.window().task_manager().networking_task_source().into(),
         }
         .into_callback();
         self.loader_mut()
@@ -2143,7 +2142,7 @@ impl Document {
     ) {
         let callback = NetworkListener {
             context: std::sync::Arc::new(Mutex::new(listener)),
-            task_source: self.window().task_manager().networking_task_source(),
+            task_source: self.window().task_manager().networking_task_source().into(),
         }
         .into_callback();
         self.loader_mut()
@@ -2409,8 +2408,7 @@ impl Document {
                 if let Some(fragment) = document.url().fragment() {
                     document.check_and_scroll_fragment(fragment, CanGc::note());
                 }
-            }))
-            .unwrap();
+            }));
 
         // Step 8.
         let document = Trusted::new(self);
@@ -2439,8 +2437,7 @@ impl Document {
                     event.set_trusted(true);
 
                     window.dispatch_event_with_target_override(event, CanGc::note());
-                }))
-                .unwrap();
+                }));
         }
 
         // Step 9.
@@ -2489,8 +2486,7 @@ impl Document {
                     // Note: this will, among others, result in the "iframe-load-event-steps" being run.
                     // https://html.spec.whatwg.org/multipage/#iframe-load-event-steps
                     document.notify_constellation_load();
-                }))
-                .unwrap();
+                }));
         }
     }
 
@@ -2645,8 +2641,7 @@ impl Document {
                 document.upcast::<EventTarget>().fire_bubbling_event(atom!("DOMContentLoaded"), CanGc::note());
                 update_with_current_instant(&document.dom_content_loaded_event_end);
                 })
-            )
-            .unwrap();
+            );
 
         // html parsing has finished - set dom content loaded
         self.interactive_time

--- a/components/script/dom/eventsource.rs
+++ b/components/script/dom/eventsource.rs
@@ -111,8 +111,7 @@ impl EventSourceContext {
         }
         let global = event_source.global();
         let event_source = self.event_source.clone();
-        // FIXME(nox): Why are errors silenced here?
-        let _ = global.task_manager().remote_event_task_source().queue(
+        global.task_manager().remote_event_task_source().queue(
             task!(announce_the_event_source_connection: move || {
                 let event_source = event_source.root();
                 if event_source.ready_state.get() != ReadyState::Closed {
@@ -143,8 +142,7 @@ impl EventSourceContext {
         let trusted_event_source = self.event_source.clone();
         let action_sender = self.action_sender.clone();
         let global = event_source.global();
-        // FIXME(nox): Why are errors silenced here?
-        let _ = global.task_manager().remote_event_task_source().queue(
+        global.task_manager().remote_event_task_source().queue(
             task!(reestablish_the_event_source_onnection: move || {
                 let event_source = trusted_event_source.root();
 
@@ -172,8 +170,7 @@ impl EventSourceContext {
                         action_sender,
                     }
                 );
-                // FIXME(nox): Why are errors silenced here?
-                let _ = event_source.global().schedule_callback(callback, duration);
+                event_source.global().schedule_callback(callback, duration);
             }),
         );
     }
@@ -255,8 +252,7 @@ impl EventSourceContext {
         let global = event_source.global();
         let event_source = self.event_source.clone();
         let event = Trusted::new(&*event);
-        // FIXME(nox): Why are errors silenced here?
-        let _ = global.task_manager().remote_event_task_source().queue(
+        global.task_manager().remote_event_task_source().queue(
             task!(dispatch_the_event_source_event: move || {
                 let event_source = event_source.root();
                 if event_source.ready_state.get() != ReadyState::Closed {
@@ -495,8 +491,7 @@ impl EventSource {
     pub fn fail_the_connection(&self) {
         let global = self.global();
         let event_source = Trusted::new(self);
-        // FIXME(nox): Why are errors silenced here?
-        let _ = global.task_manager().remote_event_task_source().queue(
+        global.task_manager().remote_event_task_source().queue(
             task!(fail_the_event_source_connection: move || {
                 let event_source = event_source.root();
                 if event_source.ready_state.get() != ReadyState::Closed {
@@ -600,7 +595,7 @@ impl EventSourceMethods<crate::DomTypeHolder> for EventSource {
         };
         let listener = NetworkListener {
             context: Arc::new(Mutex::new(context)),
-            task_source: global.task_manager().networking_task_source(),
+            task_source: global.task_manager().networking_task_source().into(),
         };
         ROUTER.add_typed_route(
             action_receiver,

--- a/components/script/dom/filereader.rs
+++ b/components/script/dom/filereader.rs
@@ -502,27 +502,22 @@ impl FileReader {
 
         let filereader = Trusted::new(self);
         let global = self.global();
-        let task_source = global.task_manager().file_reading_task_source();
+        let task_manager = global.task_manager();
+        let task_source = task_manager.file_reading_task_source();
 
         // Queue tasks as appropriate.
-        task_source
-            .queue(FileReadingTask::ProcessRead(filereader.clone(), gen_id))
-            .unwrap();
+        task_source.queue(FileReadingTask::ProcessRead(filereader.clone(), gen_id));
 
         if !blob_contents.is_empty() {
-            task_source
-                .queue(FileReadingTask::ProcessReadData(filereader.clone(), gen_id))
-                .unwrap();
+            task_source.queue(FileReadingTask::ProcessReadData(filereader.clone(), gen_id));
         }
 
-        task_source
-            .queue(FileReadingTask::ProcessReadEOF(
-                filereader,
-                gen_id,
-                load_data,
-                blob_contents,
-            ))
-            .unwrap();
+        task_source.queue(FileReadingTask::ProcessReadEOF(
+            filereader,
+            gen_id,
+            load_data,
+            blob_contents,
+        ));
 
         Ok(())
     }

--- a/components/script/dom/gamepadhapticactuator.rs
+++ b/components/script/dom/gamepadhapticactuator.rs
@@ -27,18 +27,17 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
 use crate::realms::InRealm;
 use crate::script_runtime::{CanGc, JSContext};
-use crate::task_source::TaskSource;
+use crate::task_source::SendableTaskSource;
 
 struct HapticEffectListener {
-    task_source: TaskSource,
+    task_source: SendableTaskSource,
     context: Trusted<GamepadHapticActuator>,
 }
 
 impl HapticEffectListener {
     fn handle_stopped(&self, stopped_successfully: bool) {
         let context = self.context.clone();
-        let _ = self
-            .task_source
+        self.task_source
             .queue(task!(handle_haptic_effect_stopped: move || {
                 let actuator = context.root();
                 actuator.handle_haptic_effect_stopped(stopped_successfully);
@@ -47,8 +46,7 @@ impl HapticEffectListener {
 
     fn handle_completed(&self, completed_successfully: bool) {
         let context = self.context.clone();
-        let _ = self
-            .task_source
+        self.task_source
             .queue(task!(handle_haptic_effect_completed: move || {
                 let actuator = context.root();
                 actuator.handle_haptic_effect_completed(completed_successfully);
@@ -194,7 +192,7 @@ impl GamepadHapticActuatorMethods<crate::DomTypeHolder> for GamepadHapticActuato
 
         if let Some(promise) = self.playing_effect_promise.borrow_mut().take() {
             let trusted_promise = TrustedPromise::new(promise);
-            let _ = self.global().task_manager().gamepad_task_source().queue(
+            self.global().task_manager().gamepad_task_source().queue(
                 task!(preempt_promise: move || {
                     let promise = trusted_promise.root();
                     let message = DOMString::from("preempted");
@@ -215,7 +213,7 @@ impl GamepadHapticActuatorMethods<crate::DomTypeHolder> for GamepadHapticActuato
         let (effect_complete_sender, effect_complete_receiver) =
             ipc::channel().expect("ipc channel failure");
         let listener = HapticEffectListener {
-            task_source: self.global().task_manager().gamepad_task_source(),
+            task_source: self.global().task_manager().gamepad_task_source().into(),
             context,
         };
 
@@ -261,7 +259,7 @@ impl GamepadHapticActuatorMethods<crate::DomTypeHolder> for GamepadHapticActuato
 
         if let Some(promise) = self.playing_effect_promise.borrow_mut().take() {
             let trusted_promise = TrustedPromise::new(promise);
-            let _ = self.global().task_manager().gamepad_task_source().queue(
+            self.global().task_manager().gamepad_task_source().queue(
                 task!(preempt_promise: move || {
                     let promise = trusted_promise.root();
                     let message = DOMString::from("preempted");
@@ -278,7 +276,7 @@ impl GamepadHapticActuatorMethods<crate::DomTypeHolder> for GamepadHapticActuato
         let (effect_stop_sender, effect_stop_receiver) =
             ipc::channel().expect("ipc channel failure");
         let listener = HapticEffectListener {
-            task_source: self.global().task_manager().gamepad_task_source(),
+            task_source: self.global().task_manager().gamepad_task_source().into(),
             context,
         };
 
@@ -325,7 +323,7 @@ impl GamepadHapticActuator {
             let trusted_promise = TrustedPromise::new(promise);
             let sequence_id = self.sequence_id.get();
             let reset_sequence_id = self.reset_sequence_id.get();
-            let _ = self.global().task_manager().gamepad_task_source().queue(
+            self.global().task_manager().gamepad_task_source().queue(
                 task!(complete_promise: move || {
                     if sequence_id != reset_sequence_id {
                         warn!("Mismatched sequence/reset sequence ids: {} != {}", sequence_id, reset_sequence_id);
@@ -346,7 +344,7 @@ impl GamepadHapticActuator {
         }
 
         let this = Trusted::new(self);
-        let _ = self.global().task_manager().gamepad_task_source().queue(
+        self.global().task_manager().gamepad_task_source().queue(
             task!(stop_playing_effect: move || {
                 let actuator = this.root();
                 let Some(promise) = actuator.playing_effect_promise.borrow_mut().take() else {

--- a/components/script/dom/htmldetailselement.rs
+++ b/components/script/dom/htmldetailselement.rs
@@ -84,8 +84,7 @@ impl VirtualMethods for HTMLDetailsElement {
 
             let window = self.owner_window();
             let this = Trusted::new(self);
-            // FIXME(nox): Why are errors silenced here?
-            let _ = window.task_manager().dom_manipulation_task_source().queue(
+            window.task_manager().dom_manipulation_task_source().queue(
                 task!(details_notification_task_steps: move || {
                     let this = this.root();
                     if counter == this.toggle_counter.get() {

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -1040,7 +1040,6 @@ impl HTMLFormElement {
             .task_manager()
             .dom_manipulation_task_source()
             .queue(task)
-            .unwrap();
     }
 
     /// Interactively validate the constraints of form elements

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -65,7 +65,7 @@ use crate::script_module::{
     fetch_external_module_script, fetch_inline_module_script, ModuleOwner, ScriptFetchOptions,
 };
 use crate::script_runtime::CanGc;
-use crate::task_source::{TaskSource, TaskSourceName};
+use crate::task_source::{SendableTaskSource, TaskSourceName};
 use crate::unminify::{unminify_js, ScriptSource};
 use crate::HasParent;
 

--- a/components/script/dom/offlineaudiocontext.rs
+++ b/components/script/dom/offlineaudiocontext.rs
@@ -170,12 +170,16 @@ impl OfflineAudioContextMethods<crate::DomTypeHolder> for OfflineAudioContext {
             }));
 
         let this = Trusted::new(self);
-        let task_source = self.global().task_manager().dom_manipulation_task_source();
+        let task_source = self
+            .global()
+            .task_manager()
+            .dom_manipulation_task_source()
+            .to_sendable();
         Builder::new()
             .name("OfflineACResolver".to_owned())
             .spawn(move || {
                 let _ = receiver.recv();
-                let _ = task_source.queue(
+                task_source.queue(
                     task!(resolve: move || {
                         let this = this.root();
                         let processed_audio = processed_audio.lock().unwrap();

--- a/components/script/dom/performance.rs
+++ b/components/script/dom/performance.rs
@@ -238,16 +238,14 @@ impl Performance {
 
             if !self.pending_notification_observers_task.get() {
                 self.pending_notification_observers_task.set(true);
-                let task_source = self
-                    .global()
-                    .task_manager()
-                    .performance_timeline_task_source();
                 let global = &self.global();
                 let owner = Trusted::new(&*global.performance());
-                let task = task!(notify_performance_observers: move || {
-                    owner.root().notify_observers();
-                });
-                let _ = task_source.queue(task);
+                self.global()
+                    .task_manager()
+                    .performance_timeline_task_source()
+                    .queue(task!(notify_performance_observers: move || {
+                        owner.root().notify_observers();
+                    }));
             }
         }
         let mut observers = self.observers.borrow_mut();
@@ -324,17 +322,15 @@ impl Performance {
         // Step 6.
         // Queue a new notification task.
         self.pending_notification_observers_task.set(true);
-        let task_source = self
-            .global()
-            .task_manager()
-            .performance_timeline_task_source();
 
         let global = &self.global();
         let owner = Trusted::new(&*global.performance());
-        let task = task!(notify_performance_observers: move || {
-            owner.root().notify_observers();
-        });
-        let _ = task_source.queue(task);
+        self.global()
+            .task_manager()
+            .performance_timeline_task_source()
+            .queue(task!(notify_performance_observers: move || {
+                owner.root().notify_observers();
+            }));
 
         Some(entry_last_index)
     }

--- a/components/script/dom/rtcpeerconnection.rs
+++ b/components/script/dom/rtcpeerconnection.rs
@@ -52,7 +52,7 @@ use crate::dom::rtctrackevent::RTCTrackEvent;
 use crate::dom::window::Window;
 use crate::realms::{enter_realm, InRealm};
 use crate::script_runtime::CanGc;
-use crate::task_source::TaskSource;
+use crate::task_source::SendableTaskSource;
 
 #[dom_struct]
 pub struct RTCPeerConnection {
@@ -79,13 +79,13 @@ pub struct RTCPeerConnection {
 
 struct RTCSignaller {
     trusted: Trusted<RTCPeerConnection>,
-    task_source: TaskSource,
+    task_source: SendableTaskSource,
 }
 
 impl WebRtcSignaller for RTCSignaller {
     fn on_ice_candidate(&self, _: &WebRtcController, candidate: IceCandidate) {
         let this = self.trusted.clone();
-        let _ = self.task_source.queue(task!(on_ice_candidate: move || {
+        self.task_source.queue(task!(on_ice_candidate: move || {
             let this = this.root();
             this.on_ice_candidate(candidate, CanGc::note());
         }));
@@ -93,8 +93,7 @@ impl WebRtcSignaller for RTCSignaller {
 
     fn on_negotiation_needed(&self, _: &WebRtcController) {
         let this = self.trusted.clone();
-        let _ = self
-            .task_source
+        self.task_source
             .queue(task!(on_negotiation_needed: move || {
                 let this = this.root();
                 this.on_negotiation_needed(CanGc::note());
@@ -103,8 +102,7 @@ impl WebRtcSignaller for RTCSignaller {
 
     fn update_gathering_state(&self, state: GatheringState) {
         let this = self.trusted.clone();
-        let _ = self
-            .task_source
+        self.task_source
             .queue(task!(update_gathering_state: move || {
                 let this = this.root();
                 this.update_gathering_state(state, CanGc::note());
@@ -113,8 +111,7 @@ impl WebRtcSignaller for RTCSignaller {
 
     fn update_ice_connection_state(&self, state: IceConnectionState) {
         let this = self.trusted.clone();
-        let _ = self
-            .task_source
+        self.task_source
             .queue(task!(update_ice_connection_state: move || {
                 let this = this.root();
                 this.update_ice_connection_state(state, CanGc::note());
@@ -123,8 +120,7 @@ impl WebRtcSignaller for RTCSignaller {
 
     fn update_signaling_state(&self, state: SignalingState) {
         let this = self.trusted.clone();
-        let _ = self
-            .task_source
+        self.task_source
             .queue(task!(update_signaling_state: move || {
                 let this = this.root();
                 this.update_signaling_state(state, CanGc::note());
@@ -134,7 +130,7 @@ impl WebRtcSignaller for RTCSignaller {
     fn on_add_stream(&self, id: &MediaStreamId, ty: MediaStreamType) {
         let this = self.trusted.clone();
         let id = *id;
-        let _ = self.task_source.queue(task!(on_add_stream: move || {
+        self.task_source.queue(task!(on_add_stream: move || {
             let this = this.root();
             this.on_add_stream(id, ty, CanGc::note());
         }));
@@ -148,8 +144,7 @@ impl WebRtcSignaller for RTCSignaller {
     ) {
         // XXX(ferjm) get label and options from channel properties.
         let this = self.trusted.clone();
-        let _ = self
-            .task_source
+        self.task_source
             .queue(task!(on_data_channel_event: move || {
                 let this = this.root();
                 let global = this.global();
@@ -224,10 +219,9 @@ impl RTCPeerConnection {
 
     fn make_signaller(&self) -> Box<dyn WebRtcSignaller> {
         let trusted = Trusted::new(self);
-        let task_source = self.global().task_manager().networking_task_source();
         Box::new(RTCSignaller {
             trusted,
-            task_source,
+            task_source: self.global().task_manager().networking_task_source().into(),
         })
     }
 
@@ -442,14 +436,18 @@ impl RTCPeerConnection {
 
     fn create_offer(&self) {
         let generation = self.offer_answer_generation.get();
-        let task_source = self.global().task_manager().networking_task_source();
+        let task_source = self
+            .global()
+            .task_manager()
+            .networking_task_source()
+            .to_sendable();
         let this = Trusted::new(self);
         self.controller
             .borrow_mut()
             .as_ref()
             .unwrap()
             .create_offer(Box::new(move |desc: SessionDescription| {
-                let _ = task_source.queue(task!(offer_created: move || {
+                task_source.queue(task!(offer_created: move || {
                     let this = this.root();
                     if this.offer_answer_generation.get() != generation {
                         // the state has changed since we last created the offer,
@@ -467,14 +465,18 @@ impl RTCPeerConnection {
 
     fn create_answer(&self) {
         let generation = self.offer_answer_generation.get();
-        let task_source = self.global().task_manager().networking_task_source();
+        let task_source = self
+            .global()
+            .task_manager()
+            .networking_task_source()
+            .to_sendable();
         let this = Trusted::new(self);
         self.controller
             .borrow_mut()
             .as_ref()
             .unwrap()
             .create_answer(Box::new(move |desc: SessionDescription| {
-                let _ = task_source.queue(task!(answer_created: move || {
+                task_source.queue(task!(answer_created: move || {
                     let this = this.root();
                     if this.offer_answer_generation.get() != generation {
                         // the state has changed since we last created the offer,
@@ -635,7 +637,11 @@ impl RTCPeerConnectionMethods<crate::DomTypeHolder> for RTCPeerConnection {
         let this = Trusted::new(self);
         let desc: SessionDescription = desc.convert();
         let trusted_promise = TrustedPromise::new(p.clone());
-        let task_source = self.global().task_manager().networking_task_source();
+        let task_source = self
+            .global()
+            .task_manager()
+            .networking_task_source()
+            .to_sendable();
         self.controller
             .borrow_mut()
             .as_ref()
@@ -643,7 +649,7 @@ impl RTCPeerConnectionMethods<crate::DomTypeHolder> for RTCPeerConnection {
             .set_local_description(
                 desc.clone(),
                 Box::new(move || {
-                    let _ = task_source.queue(task!(local_description_set: move || {
+                    task_source.queue(task!(local_description_set: move || {
                         // XXXManishearth spec actually asks for an intricate
                         // dance between pending/current local/remote descriptions
                         let this = this.root();
@@ -674,7 +680,11 @@ impl RTCPeerConnectionMethods<crate::DomTypeHolder> for RTCPeerConnection {
         let this = Trusted::new(self);
         let desc: SessionDescription = desc.convert();
         let trusted_promise = TrustedPromise::new(p.clone());
-        let task_source = self.global().task_manager().networking_task_source();
+        let task_source = self
+            .global()
+            .task_manager()
+            .networking_task_source()
+            .to_sendable();
         self.controller
             .borrow_mut()
             .as_ref()
@@ -682,7 +692,7 @@ impl RTCPeerConnectionMethods<crate::DomTypeHolder> for RTCPeerConnection {
             .set_remote_description(
                 desc.clone(),
                 Box::new(move || {
-                    let _ = task_source.queue(task!(remote_description_set: move || {
+                    task_source.queue(task!(remote_description_set: move || {
                         // XXXManishearth spec actually asks for an intricate
                         // dance between pending/current local/remote descriptions
                         let this = this.root();

--- a/components/script/dom/selection.rs
+++ b/components/script/dom/selection.rs
@@ -98,8 +98,7 @@ impl Selection {
                     this.task_queued.set(false);
                     this.document.upcast::<EventTarget>().fire_event(atom!("selectionchange"), CanGc::note());
                 })
-            )
-            .expect("Couldn't queue selectionchange task!");
+            );
         self.task_queued.set(true);
     }
 

--- a/components/script/dom/storage.rs
+++ b/components/script/dom/storage.rs
@@ -208,10 +208,8 @@ impl Storage {
     ) {
         let global = self.global();
         let this = Trusted::new(self);
-        global
-            .task_manager()
-            .dom_manipulation_task_source()
-            .queue(task!(send_storage_notification: move || {
+        global.task_manager().dom_manipulation_task_source().queue(
+            task!(send_storage_notification: move || {
                 let this = this.root();
                 let global = this.global();
                 let event = StorageEvent::new(
@@ -227,7 +225,7 @@ impl Storage {
                     CanGc::note()
                 );
                 event.upcast::<Event>().fire(global.upcast(), CanGc::note());
-            }))
-            .unwrap();
+            }),
+        );
     }
 }

--- a/components/script/dom/subtlecrypto.rs
+++ b/components/script/dom/subtlecrypto.rs
@@ -162,13 +162,12 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
             ArrayBufferViewOrArrayBuffer::ArrayBuffer(buffer) => buffer.to_vec(),
         };
 
-        let task_source = self.global().task_manager().dom_manipulation_task_source();
         let this = Trusted::new(self);
         let trusted_promise = TrustedPromise::new(promise.clone());
         let trusted_key = Trusted::new(key);
         let key_alg = key.algorithm();
         let valid_usage = key.usages().contains(&KeyUsage::Encrypt);
-        let _ = task_source.queue(
+        self.global().task_manager().dom_manipulation_task_source().queue(
             task!(encrypt: move || {
                 let subtle = this.root();
                 let promise = trusted_promise.root();
@@ -217,13 +216,12 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
             ArrayBufferViewOrArrayBuffer::ArrayBuffer(buffer) => buffer.to_vec(),
         };
 
-        let task_source = self.global().task_manager().dom_manipulation_task_source();
         let this = Trusted::new(self);
         let trusted_promise = TrustedPromise::new(promise.clone());
         let trusted_key = Trusted::new(key);
         let key_alg = key.algorithm();
         let valid_usage = key.usages().contains(&KeyUsage::Decrypt);
-        let _ = task_source.queue(
+        self.global().task_manager().dom_manipulation_task_source().queue(
             task!(decrypt: move || {
                 let subtle = this.root();
                 let promise = trusted_promise.root();
@@ -283,48 +281,50 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
         // NOTE: We did that in preparation of Step 4.
 
         // Step 6. Return promise and perform the remaining steps in parallel.
-        let task_source = self.global().task_manager().dom_manipulation_task_source();
         let trusted_promise = TrustedPromise::new(promise.clone());
         let trusted_key = Trusted::new(key);
 
-        let _ = task_source.queue(task!(sign: move || {
-            // Step 7. If the following steps or referenced procedures say to throw an error, reject promise
-            // with the returned error and then terminate the algorithm.
-            let promise = trusted_promise.root();
-            let key = trusted_key.root();
+        self.global()
+            .task_manager()
+            .dom_manipulation_task_source()
+            .queue(task!(sign: move || {
+                // Step 7. If the following steps or referenced procedures say to throw an error, reject promise
+                // with the returned error and then terminate the algorithm.
+                let promise = trusted_promise.root();
+                let key = trusted_key.root();
 
-            // Step 8. If the name member of normalizedAlgorithm is not equal to the name attribute of the
-            // [[algorithm]] internal slot of key then throw an InvalidAccessError.
-            if normalized_algorithm.name() != key.algorithm() {
-                promise.reject_error(Error::InvalidAccess);
-                return;
-            }
-
-            // Step 9. If the [[usages]] internal slot of key does not contain an entry that is "sign",
-            // then throw an InvalidAccessError.
-            if !key.usages().contains(&KeyUsage::Sign) {
-                promise.reject_error(Error::InvalidAccess);
-                return;
-            }
-
-            // Step 10.  Let result be the result of performing the sign operation specified by normalizedAlgorithm
-            // using key and algorithm and with data as message.
-            let cx = GlobalScope::get_cx();
-            let result = match normalized_algorithm.sign(cx, &key, &data) {
-                Ok(signature) => signature,
-                Err(e) => {
-                    promise.reject_error(e);
+                // Step 8. If the name member of normalizedAlgorithm is not equal to the name attribute of the
+                // [[algorithm]] internal slot of key then throw an InvalidAccessError.
+                if normalized_algorithm.name() != key.algorithm() {
+                    promise.reject_error(Error::InvalidAccess);
                     return;
                 }
-            };
 
-            rooted!(in(*cx) let mut array_buffer_ptr = ptr::null_mut::<JSObject>());
-            create_buffer_source::<ArrayBufferU8>(cx, &result, array_buffer_ptr.handle_mut())
-                .expect("failed to create buffer source for exported key.");
+                // Step 9. If the [[usages]] internal slot of key does not contain an entry that is "sign",
+                // then throw an InvalidAccessError.
+                if !key.usages().contains(&KeyUsage::Sign) {
+                    promise.reject_error(Error::InvalidAccess);
+                    return;
+                }
 
-            // Step 9. Resolve promise with result.
-            promise.resolve_native(&*array_buffer_ptr);
-        }));
+                // Step 10.  Let result be the result of performing the sign operation specified by normalizedAlgorithm
+                // using key and algorithm and with data as message.
+                let cx = GlobalScope::get_cx();
+                let result = match normalized_algorithm.sign(cx, &key, &data) {
+                    Ok(signature) => signature,
+                    Err(e) => {
+                        promise.reject_error(e);
+                        return;
+                    }
+                };
+
+                rooted!(in(*cx) let mut array_buffer_ptr = ptr::null_mut::<JSObject>());
+                create_buffer_source::<ArrayBufferU8>(cx, &result, array_buffer_ptr.handle_mut())
+                    .expect("failed to create buffer source for exported key.");
+
+                // Step 9. Resolve promise with result.
+                promise.resolve_native(&*array_buffer_ptr);
+            }));
 
         promise
     }
@@ -373,44 +373,46 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
         // NOTE: We did that in preparation of Step 6.
 
         // Step 7. Return promise and perform the remaining steps in parallel.
-        let task_source = self.global().task_manager().dom_manipulation_task_source();
         let trusted_promise = TrustedPromise::new(promise.clone());
         let trusted_key = Trusted::new(key);
 
-        let _ = task_source.queue(task!(sign: move || {
-            // Step 8. If the following steps or referenced procedures say to throw an error, reject promise
-            // with the returned error and then terminate the algorithm.
-            let promise = trusted_promise.root();
-            let key = trusted_key.root();
+        self.global()
+            .task_manager()
+            .dom_manipulation_task_source()
+            .queue(task!(sign: move || {
+                // Step 8. If the following steps or referenced procedures say to throw an error, reject promise
+                // with the returned error and then terminate the algorithm.
+                let promise = trusted_promise.root();
+                let key = trusted_key.root();
 
-            // Step 9. If the name member of normalizedAlgorithm is not equal to the name attribute of the
-            // [[algorithm]] internal slot of key then throw an InvalidAccessError.
-            if normalized_algorithm.name() != key.algorithm() {
-                promise.reject_error(Error::InvalidAccess);
-                return;
-            }
-
-            // Step 10. If the [[usages]] internal slot of key does not contain an entry that is "verify",
-            // then throw an InvalidAccessError.
-            if !key.usages().contains(&KeyUsage::Verify) {
-                promise.reject_error(Error::InvalidAccess);
-                return;
-            }
-
-            // Step 1. Let result be the result of performing the verify operation specified by normalizedAlgorithm
-            // using key, algorithm and signature and with data as message.
-            let cx = GlobalScope::get_cx();
-            let result = match normalized_algorithm.verify(cx, &key, &data, &signature) {
-                Ok(result) => result,
-                Err(e) => {
-                    promise.reject_error(e);
+                // Step 9. If the name member of normalizedAlgorithm is not equal to the name attribute of the
+                // [[algorithm]] internal slot of key then throw an InvalidAccessError.
+                if normalized_algorithm.name() != key.algorithm() {
+                    promise.reject_error(Error::InvalidAccess);
                     return;
                 }
-            };
 
-            // Step 9. Resolve promise with result.
-            promise.resolve_native(&result);
-        }));
+                // Step 10. If the [[usages]] internal slot of key does not contain an entry that is "verify",
+                // then throw an InvalidAccessError.
+                if !key.usages().contains(&KeyUsage::Verify) {
+                    promise.reject_error(Error::InvalidAccess);
+                    return;
+                }
+
+                // Step 1. Let result be the result of performing the verify operation specified by normalizedAlgorithm
+                // using key, algorithm and signature and with data as message.
+                let cx = GlobalScope::get_cx();
+                let result = match normalized_algorithm.verify(cx, &key, &data, &signature) {
+                    Ok(result) => result,
+                    Err(e) => {
+                        promise.reject_error(e);
+                        return;
+                    }
+                };
+
+                // Step 9. Resolve promise with result.
+                promise.resolve_native(&result);
+            }));
 
         promise
     }
@@ -449,10 +451,9 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
         // NOTE: We did that in preparation of Step 4.
 
         // Step 6. Return promise and perform the remaining steps in parallel.
-        let task_source = self.global().task_manager().dom_manipulation_task_source();
         let trusted_promise = TrustedPromise::new(promise.clone());
 
-        let _ = task_source.queue(
+        self.global().task_manager().dom_manipulation_task_source().queue(
             task!(generate_key: move || {
                 // Step 7. If the following steps or referenced procedures say to throw an error, reject promise
                 // with the returned error and then terminate the algorithm.
@@ -501,19 +502,21 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
             },
         };
 
-        let task_source = self.global().task_manager().dom_manipulation_task_source();
         let this = Trusted::new(self);
         let trusted_promise = TrustedPromise::new(promise.clone());
-        let _ = task_source.queue(task!(generate_key: move || {
-            let subtle = this.root();
-            let promise = trusted_promise.root();
-            let key = normalized_algorithm.generate_key(&subtle, key_usages, extractable);
+        self.global()
+            .task_manager()
+            .dom_manipulation_task_source()
+            .queue(task!(generate_key: move || {
+                let subtle = this.root();
+                let promise = trusted_promise.root();
+                let key = normalized_algorithm.generate_key(&subtle, key_usages, extractable);
 
-            match key {
-                Ok(key) => promise.resolve_native(&key),
-                Err(e) => promise.reject_error(e),
-            }
-        }));
+                match key {
+                    Ok(key) => promise.resolve_native(&key),
+                    Err(e) => promise.reject_error(e),
+                }
+            }));
 
         promise
     }
@@ -573,11 +576,10 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
         // NOTE: We created the promise earlier, after Step 1.
 
         // Step 9. Return promise and perform the remaining steps in parallel.
-        let task_source = self.global().task_manager().dom_manipulation_task_source();
         let trusted_promise = TrustedPromise::new(promise.clone());
         let trusted_base_key = Trusted::new(base_key);
         let this = Trusted::new(self);
-        let _ = task_source.queue(
+        self.global().task_manager().dom_manipulation_task_source().queue(
             task!(derive_key: move || {
                 // Step 10. If the following steps or referenced procedures say to throw an error, reject promise
                 // with the returned error and then terminate the algorithm.
@@ -677,44 +679,46 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
         // NOTE: We did that in preparation of Step 3.
 
         // Step 5. Return promise and perform the remaining steps in parallel.
-        let task_source = self.global().task_manager().dom_manipulation_task_source();
         let trusted_promise = TrustedPromise::new(promise.clone());
         let trusted_base_key = Trusted::new(base_key);
 
-        let _ = task_source.queue(task!(import_key: move || {
-            // Step 6. If the following steps or referenced procedures say to throw an error,
-            // reject promise with the returned error and then terminate the algorithm.
+        self.global()
+            .task_manager()
+            .dom_manipulation_task_source()
+            .queue(task!(import_key: move || {
+                // Step 6. If the following steps or referenced procedures say to throw an error,
+                // reject promise with the returned error and then terminate the algorithm.
 
-            // TODO Step 7. If the name member of normalizedAlgorithm is not equal to the name attribute
-            // of the [[algorithm]] internal slot of baseKey then throw an InvalidAccessError.
-            let promise = trusted_promise.root();
-            let base_key = trusted_base_key.root();
+                // TODO Step 7. If the name member of normalizedAlgorithm is not equal to the name attribute
+                // of the [[algorithm]] internal slot of baseKey then throw an InvalidAccessError.
+                let promise = trusted_promise.root();
+                let base_key = trusted_base_key.root();
 
-            // Step 8. If the [[usages]] internal slot of baseKey does not contain an entry that
-            // is "deriveBits", then throw an InvalidAccessError.
-            if !base_key.usages().contains(&KeyUsage::DeriveBits) {
-                promise.reject_error(Error::InvalidAccess);
-                return;
-            }
-
-            // Step 9. Let result be the result of creating an ArrayBuffer containing the result of performing the
-            // derive bits operation specified by normalizedAlgorithm using baseKey, algorithm and length.
-            let cx = GlobalScope::get_cx();
-            rooted!(in(*cx) let mut array_buffer_ptr = ptr::null_mut::<JSObject>());
-            let result = match normalized_algorithm.derive_bits(&base_key, length) {
-                Ok(derived_bits) => derived_bits,
-                Err(e) => {
-                    promise.reject_error(e);
+                // Step 8. If the [[usages]] internal slot of baseKey does not contain an entry that
+                // is "deriveBits", then throw an InvalidAccessError.
+                if !base_key.usages().contains(&KeyUsage::DeriveBits) {
+                    promise.reject_error(Error::InvalidAccess);
                     return;
                 }
-            };
 
-            create_buffer_source::<ArrayBufferU8>(cx, &result, array_buffer_ptr.handle_mut())
-                .expect("failed to create buffer source for derived bits.");
+                // Step 9. Let result be the result of creating an ArrayBuffer containing the result of performing the
+                // derive bits operation specified by normalizedAlgorithm using baseKey, algorithm and length.
+                let cx = GlobalScope::get_cx();
+                rooted!(in(*cx) let mut array_buffer_ptr = ptr::null_mut::<JSObject>());
+                let result = match normalized_algorithm.derive_bits(&base_key, length) {
+                    Ok(derived_bits) => derived_bits,
+                    Err(e) => {
+                        promise.reject_error(e);
+                        return;
+                    }
+                };
 
-            // Step 10. Resolve promise with result.
-            promise.resolve_native(&*array_buffer_ptr);
-        }));
+                create_buffer_source::<ArrayBufferU8>(cx, &result, array_buffer_ptr.handle_mut())
+                    .expect("failed to create buffer source for derived bits.");
+
+                // Step 10. Resolve promise with result.
+                promise.resolve_native(&*array_buffer_ptr);
+            }));
 
         promise
     }
@@ -766,10 +770,9 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
             },
         };
 
-        let task_source = self.global().task_manager().dom_manipulation_task_source();
         let this = Trusted::new(self);
         let trusted_promise = TrustedPromise::new(promise.clone());
-        let _ = task_source.queue(
+        self.global().task_manager().dom_manipulation_task_source().queue(
             task!(import_key: move || {
                 let subtle = this.root();
                 let promise = trusted_promise.root();
@@ -794,11 +797,10 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
     ) -> Rc<Promise> {
         let promise = Promise::new_in_current_realm(comp, can_gc);
 
-        let task_source = self.global().task_manager().dom_manipulation_task_source();
         let this = Trusted::new(self);
         let trusted_key = Trusted::new(key);
         let trusted_promise = TrustedPromise::new(promise.clone());
-        let _ = task_source.queue(
+        self.global().task_manager().dom_manipulation_task_source().queue(
             task!(export_key: move || {
                 let subtle = this.root();
                 let promise = trusted_promise.root();
@@ -861,12 +863,11 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
             },
         };
 
-        let task_source = self.global().task_manager().dom_manipulation_task_source();
         let this = Trusted::new(self);
         let trusted_key = Trusted::new(key);
         let trusted_wrapping_key = Trusted::new(wrapping_key);
         let trusted_promise = TrustedPromise::new(promise.clone());
-        let _ = task_source.queue(
+        self.global().task_manager().dom_manipulation_task_source().queue(
             task!(wrap_key: move || {
                 let subtle = this.root();
                 let promise = trusted_promise.root();
@@ -999,11 +1000,10 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                 },
             };
 
-        let task_source = self.global().task_manager().dom_manipulation_task_source();
         let this = Trusted::new(self);
         let trusted_key = Trusted::new(unwrapping_key);
         let trusted_promise = TrustedPromise::new(promise.clone());
-        let _ = task_source.queue(
+        self.global().task_manager().dom_manipulation_task_source().queue(
             task!(unwrap_key: move || {
                 let subtle = this.root();
                 let promise = trusted_promise.root();

--- a/components/script/dom/texttracklist.rs
+++ b/components/script/dom/texttracklist.rs
@@ -62,31 +62,32 @@ impl TextTrackList {
         if self.find(track).is_none() {
             self.dom_tracks.borrow_mut().push(Dom::from_ref(track));
 
-            let this = Trusted::new(self);
-            let task_source = self.global().task_manager().media_element_task_source();
-
             let Some(idx) = self.find(track) else {
                 return;
             };
 
-            let _ = task_source.queue(task!(track_event_queue: move || {
-                let this = this.root();
+            let this = Trusted::new(self);
+            self.global()
+                .task_manager()
+                .media_element_task_source()
+                .queue(task!(track_event_queue: move || {
+                    let this = this.root();
 
-                if let Some(track) = this.item(idx) {
-                    let event = TrackEvent::new(
-                        &this.global(),
-                        atom!("addtrack"),
-                        false,
-                        false,
-                        &Some(VideoTrackOrAudioTrackOrTextTrack::TextTrack(
-                            DomRoot::from_ref(&track)
-                        )),
-                        CanGc::note()
-                    );
+                    if let Some(track) = this.item(idx) {
+                        let event = TrackEvent::new(
+                            &this.global(),
+                            atom!("addtrack"),
+                            false,
+                            false,
+                            &Some(VideoTrackOrAudioTrackOrTextTrack::TextTrack(
+                                DomRoot::from_ref(&track)
+                            )),
+                            CanGc::note()
+                        );
 
-                    event.upcast::<Event>().fire(this.upcast::<EventTarget>(), CanGc::note());
-                }
-            }));
+                        event.upcast::<Event>().fire(this.upcast::<EventTarget>(), CanGc::note());
+                    }
+                }));
             track.add_track_list(self);
         }
     }

--- a/components/script/dom/videotracklist.rs
+++ b/components/script/dom/videotracklist.rs
@@ -81,9 +81,6 @@ impl VideoTrackList {
             return;
         }
 
-        let this = Trusted::new(self);
-        let task_source = self.global().task_manager().media_element_task_source();
-
         if let Some(current) = self.selected_index() {
             self.tracks.borrow()[current].set_selected(false);
         }
@@ -93,10 +90,14 @@ impl VideoTrackList {
             media_element.set_video_track(idx, value);
         }
 
-        let _ = task_source.queue(task!(media_track_change: move || {
-            let this = this.root();
-            this.upcast::<EventTarget>().fire_event(atom!("change"), CanGc::note());
-        }));
+        let this = Trusted::new(self);
+        self.global()
+            .task_manager()
+            .media_element_task_source()
+            .queue(task!(media_track_change: move || {
+                let this = this.root();
+                this.upcast::<EventTarget>().fire_event(atom!("change"), CanGc::note());
+            }));
     }
 
     pub fn add(&self, track: &VideoTrack) {

--- a/components/script/dom/webglquery.rs
+++ b/components/script/dom/webglquery.rs
@@ -174,8 +174,7 @@ impl WebGLQuery {
             self.global()
                 .task_manager()
                 .dom_manipulation_task_source()
-                .queue(task)
-                .unwrap();
+                .queue(task);
         }
 
         match pname {

--- a/components/script/dom/webglsync.rs
+++ b/components/script/dom/webglsync.rs
@@ -76,8 +76,7 @@ impl WebGLSync {
                 self.global()
                     .task_manager()
                     .dom_manipulation_task_source()
-                    .queue(task)
-                    .unwrap();
+                    .queue(task);
             },
             _ => {},
         }
@@ -111,8 +110,7 @@ impl WebGLSync {
                 self.global()
                     .task_manager()
                     .dom_manipulation_task_source()
-                    .queue(task)
-                    .unwrap();
+                    .queue(task);
             },
             _ => {},
         }

--- a/components/script/dom/webgpu/gpu.rs
+++ b/components/script/dom/webgpu/gpu.rs
@@ -71,7 +71,8 @@ pub fn response_async<T: AsyncWGPUListener + DomObject + 'static>(
     let task_source = receiver
         .global()
         .task_manager()
-        .dom_manipulation_task_source();
+        .dom_manipulation_task_source()
+        .to_sendable();
     let mut trusted: Option<TrustedPromise> = Some(TrustedPromise::new(promise.clone()));
     let trusted_receiver = Trusted::new(receiver);
     ROUTER.add_typed_route(
@@ -88,12 +89,9 @@ pub fn response_async<T: AsyncWGPUListener + DomObject + 'static>(
                 trusted,
                 receiver: trusted_receiver.clone(),
             };
-            let result = task_source.queue(task!(process_webgpu_task: move|| {
+            task_source.queue(task!(process_webgpu_task: move|| {
                 context.response(message.unwrap(), CanGc::note());
             }));
-            if let Err(err) = result {
-                error!("Failed to queue GPU listener-task: {:?}", err);
-            }
         }),
     );
     action_sender

--- a/components/script/dom/websocket.rs
+++ b/components/script/dom/websocket.rs
@@ -40,7 +40,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::messageevent::MessageEvent;
 use crate::script_runtime::CanGc;
 use crate::task::TaskOnce;
-use crate::task_source::TaskSource;
+use crate::task_source::SendableTaskSource;
 
 #[derive(Clone, Copy, Debug, JSTraceable, MallocSizeOf, PartialEq)]
 enum WebSocketRequestState {
@@ -70,27 +70,25 @@ mod close_code {
 
 fn close_the_websocket_connection(
     address: Trusted<WebSocket>,
-    task_source: &TaskSource,
+    task_source: &SendableTaskSource,
     code: Option<u16>,
     reason: String,
 ) {
-    let close_task = CloseTask {
+    task_source.queue(CloseTask {
         address,
         failed: false,
         code,
         reason: Some(reason),
-    };
-    let _ = task_source.queue(close_task);
+    });
 }
 
-fn fail_the_websocket_connection(address: Trusted<WebSocket>, task_source: &TaskSource) {
-    let close_task = CloseTask {
+fn fail_the_websocket_connection(address: Trusted<WebSocket>, task_source: &SendableTaskSource) {
+    task_source.queue(CloseTask {
         address,
         failed: true,
         code: Some(close_code::ABNORMAL),
         reason: None,
-    };
-    let _ = task_source.queue(close_task);
+    });
 }
 
 #[dom_struct]
@@ -162,8 +160,7 @@ impl WebSocket {
             self.clearing_buffer.set(true);
 
             // TODO(mrobinson): Should this task be cancellable?
-            let _ = self
-                .global()
+            self.global()
                 .task_manager()
                 .websocket_task_source()
                 .queue_unconditionally(BufferedAmountTask { address });
@@ -270,7 +267,7 @@ impl WebSocketMethods<crate::DomTypeHolder> for WebSocket {
             .core_resource_thread()
             .send(CoreResourceMsg::Fetch(request, channels));
 
-        let task_source = global.task_manager().websocket_task_source();
+        let task_source = global.task_manager().websocket_task_source().to_sendable();
         ROUTER.add_typed_route(
             dom_event_receiver.to_ipc_receiver(),
             Box::new(move |message| match message.unwrap() {
@@ -279,14 +276,14 @@ impl WebSocketMethods<crate::DomTypeHolder> for WebSocket {
                         address: address.clone(),
                         protocol_in_use,
                     };
-                    let _ = task_source.queue(open_thread);
+                    task_source.queue(open_thread);
                 },
                 WebSocketNetworkEvent::MessageReceived(message) => {
                     let message_thread = MessageReceivedTask {
                         address: address.clone(),
                         message,
                     };
-                    let _ = task_source.queue(message_thread);
+                    task_source.queue(message_thread);
                 },
                 WebSocketNetworkEvent::Fail => {
                     fail_the_websocket_connection(address.clone(), &task_source);
@@ -426,9 +423,14 @@ impl WebSocketMethods<crate::DomTypeHolder> for WebSocket {
                 will abort connecting the websocket*/
                 self.ready_state.set(WebSocketRequestState::Closing);
 
-                let address = Trusted::new(self);
-                let task_source = self.global().task_manager().websocket_task_source();
-                fail_the_websocket_connection(address, &task_source);
+                fail_the_websocket_connection(
+                    Trusted::new(self),
+                    &self
+                        .global()
+                        .task_manager()
+                        .websocket_task_source()
+                        .to_sendable(),
+                );
             },
             WebSocketRequestState::Open => {
                 self.ready_state.set(WebSocketRequestState::Closing);

--- a/components/script/dom/webxr/fakexrdevice.rs
+++ b/components/script/dom/webxr/fakexrdevice.rs
@@ -306,7 +306,10 @@ impl FakeXRDeviceMethods<crate::DomTypeHolder> for FakeXRDevice {
         let global = self.global();
         let p = Promise::new(&global, can_gc);
         let mut trusted = Some(TrustedPromise::new(p.clone()));
-        let task_source = global.task_manager().dom_manipulation_task_source();
+        let task_source = global
+            .task_manager()
+            .dom_manipulation_task_source()
+            .to_sendable();
         let (sender, receiver) = ipc::channel(global.time_profiler_chan().clone()).unwrap();
 
         ROUTER.add_typed_route(
@@ -315,7 +318,7 @@ impl FakeXRDeviceMethods<crate::DomTypeHolder> for FakeXRDevice {
                 let trusted = trusted
                     .take()
                     .expect("disconnect callback called multiple times");
-                let _ = task_source.queue(trusted.resolve_task(()));
+                task_source.queue(trusted.resolve_task(()));
             }),
         );
         self.disconnect(sender);

--- a/components/script/dom/webxr/xrsession.rs
+++ b/components/script/dom/webxr/xrsession.rs
@@ -201,14 +201,17 @@ impl XRSession {
     fn setup_raf_loop(&self, frame_receiver: IpcReceiver<Frame>) {
         let this = Trusted::new(self);
         let global = self.global();
-        let task_source = global.task_manager().dom_manipulation_task_source();
+        let task_source = global
+            .task_manager()
+            .dom_manipulation_task_source()
+            .to_sendable();
         ROUTER.add_typed_route(
             frame_receiver,
             Box::new(move |message| {
                 let frame: Frame = message.unwrap();
                 let time = CrossProcessInstant::now();
                 let this = this.clone();
-                let _ = task_source.queue(task!(xr_raf_callback: move || {
+                task_source.queue(task!(xr_raf_callback: move || {
                     this.root().raf_callback(frame, time);
                 }));
             }),
@@ -224,14 +227,17 @@ impl XRSession {
     fn attach_event_handler(&self) {
         let this = Trusted::new(self);
         let global = self.global();
-        let task_source = global.task_manager().dom_manipulation_task_source();
+        let task_source = global
+            .task_manager()
+            .dom_manipulation_task_source()
+            .to_sendable();
         let (sender, receiver) = ipc::channel(global.time_profiler_chan().clone()).unwrap();
 
         ROUTER.add_typed_route(
             receiver.to_ipc_receiver(),
             Box::new(move |message| {
                 let this = this.clone();
-                let _ = task_source.queue(task!(xr_event_callback: move || {
+                task_source.queue(task!(xr_event_callback: move || {
                     this.root().event_callback(message.unwrap(), CanGc::note());
                 }));
             }),
@@ -254,14 +260,16 @@ impl XRSession {
             return;
         }
 
-        let task_source = self.global().task_manager().dom_manipulation_task_source();
         let this = Trusted::new(self);
         // Queue a task so that it runs after resolve()'s microtasks complete
         // so that content has a chance to attach a listener for inputsourceschange
-        let _ = task_source.queue(task!(session_initial_inputs: move || {
-            let this = this.root();
-            this.input_sources.add_input_sources(&this, &initial_inputs, CanGc::note());
-        }));
+        self.global()
+            .task_manager()
+            .dom_manipulation_task_source()
+            .queue(task!(session_initial_inputs: move || {
+                let this = this.root();
+                this.input_sources.add_input_sources(&this, &initial_inputs, CanGc::note());
+            }));
     }
 
     fn event_callback(&self, event: XREvent, can_gc: CanGc) {
@@ -1036,14 +1044,17 @@ impl XRSessionMethods<crate::DomTypeHolder> for XRSession {
 
         let this = Trusted::new(self);
         let global = self.global();
-        let task_source = global.task_manager().dom_manipulation_task_source();
+        let task_source = global
+            .task_manager()
+            .dom_manipulation_task_source()
+            .to_sendable();
         let (sender, receiver) = ipc::channel(global.time_profiler_chan().clone()).unwrap();
 
         ROUTER.add_typed_route(
             receiver.to_ipc_receiver(),
             Box::new(move |message| {
                 let this = this.clone();
-                let _ = task_source.queue(task!(update_session_framerate: move || {
+                task_source.queue(task!(update_session_framerate: move || {
                     let session = this.root();
                     session.apply_nominal_framerate(message.unwrap(), CanGc::note());
                     if let Some(promise) = session.update_framerate_promise.borrow_mut().take() {

--- a/components/script/dom/webxr/xrsystem.rs
+++ b/components/script/dom/webxr/xrsystem.rs
@@ -118,7 +118,10 @@ impl XRSystemMethods<crate::DomTypeHolder> for XRSystem {
         let promise = Promise::new(&self.global(), can_gc);
         let mut trusted = Some(TrustedPromise::new(promise.clone()));
         let global = self.global();
-        let task_source = global.task_manager().dom_manipulation_task_source();
+        let task_source = global
+            .task_manager()
+            .dom_manipulation_task_source()
+            .to_sendable();
         let (sender, receiver) = ipc::channel(global.time_profiler_chan().clone()).unwrap();
         ROUTER.add_typed_route(
             receiver.to_ipc_receiver(),
@@ -137,9 +140,9 @@ impl XRSystemMethods<crate::DomTypeHolder> for XRSystem {
                     return;
                 };
                 if let Ok(()) = message {
-                    let _ = task_source.queue(trusted.resolve_task(true));
+                    task_source.queue(trusted.resolve_task(true));
                 } else {
-                    let _ = task_source.queue(trusted.resolve_task(false));
+                    task_source.queue(trusted.resolve_task(false));
                 };
             }),
         );
@@ -234,7 +237,10 @@ impl XRSystemMethods<crate::DomTypeHolder> for XRSystem {
 
         let mut trusted = Some(TrustedPromise::new(promise.clone()));
         let this = Trusted::new(self);
-        let task_source = global.task_manager().dom_manipulation_task_source();
+        let task_source = global
+            .task_manager()
+            .dom_manipulation_task_source()
+            .to_sendable();
         let (sender, receiver) = ipc::channel(global.time_profiler_chan().clone()).unwrap();
         let (frame_sender, frame_receiver) = ipc_crate::channel().unwrap();
         let mut frame_receiver = Some(frame_receiver);
@@ -251,7 +257,7 @@ impl XRSystemMethods<crate::DomTypeHolder> for XRSystem {
                     error!("requestSession callback given incorrect payload");
                     return;
                 };
-                let _ = task_source.queue(task!(request_session: move || {
+                task_source.queue(task!(request_session: move || {
                     this.root().session_obtained(message, trusted.root(), mode, frame_receiver);
                 }));
             }),
@@ -316,7 +322,6 @@ impl XRSystem {
                     xr.upcast::<EventTarget>().fire_bubbling_event(atom!("sessionavailable"), CanGc::note());
                     ScriptThread::set_user_interacting(interacting);
                 })
-            )
-            .unwrap();
+            );
     }
 }

--- a/components/script/dom/webxr/xrtest.rs
+++ b/components/script/dom/webxr/xrtest.rs
@@ -150,7 +150,10 @@ impl XRTestMethods<crate::DomTypeHolder> for XRTest {
         let this = Trusted::new(self);
         let mut trusted = Some(TrustedPromise::new(p.clone()));
 
-        let task_source = global.task_manager().dom_manipulation_task_source();
+        let task_source = global
+            .task_manager()
+            .dom_manipulation_task_source()
+            .to_sendable();
         let (sender, receiver) = ipc::channel(global.time_profiler_chan().clone()).unwrap();
 
         ROUTER.add_typed_route(
@@ -163,7 +166,7 @@ impl XRTestMethods<crate::DomTypeHolder> for XRTest {
                 let message =
                     message.expect("SimulateDeviceConnection callback given incorrect payload");
 
-                let _ = task_source.queue(task!(request_session: move || {
+                task_source.queue(task!(request_session: move || {
                     this.root().device_obtained(message, trusted);
                 }));
             }),
@@ -200,7 +203,10 @@ impl XRTestMethods<crate::DomTypeHolder> for XRTest {
             devices.clear();
 
             let mut trusted = Some(TrustedPromise::new(p.clone()));
-            let task_source = global.task_manager().dom_manipulation_task_source();
+            let task_source = global
+                .task_manager()
+                .dom_manipulation_task_source()
+                .to_sendable();
 
             ROUTER.add_typed_route(
                 receiver.to_ipc_receiver(),
@@ -210,7 +216,7 @@ impl XRTestMethods<crate::DomTypeHolder> for XRTest {
                         let trusted = trusted
                             .take()
                             .expect("DisconnectAllDevices disconnected more devices than expected");
-                        let _ = task_source.queue(trusted.resolve_task(()));
+                        task_source.queue(trusted.resolve_task(()));
                     }
                 }),
             );

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -816,8 +816,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
                 self.global()
                     .task_manager()
                     .dom_manipulation_task_source()
-                    .queue(task)
-                    .expect("Queuing window_close_browsing_context task to work");
+                    .queue(task);
             }
         }
     }
@@ -2335,8 +2334,7 @@ impl Window {
                         CanGc::note());
                     event.upcast::<Event>().fire(this.upcast::<EventTarget>(), CanGc::note());
                 });
-                let _ = self
-                    .task_manager()
+                self.task_manager()
                     .dom_manipulation_task_source()
                     .queue(task);
                 doc.set_url(load_data.url.clone());
@@ -2946,8 +2944,7 @@ impl Window {
             }
         });
         // TODO(#12718): Use the "posted message task source".
-        let _ = self
-            .task_manager()
+        self.task_manager()
             .dom_manipulation_task_source()
             .queue(task);
     }

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -196,7 +196,7 @@ pub fn Fetch(
     global.fetch(
         request_init,
         fetch_context,
-        global.task_manager().networking_task_source(),
+        global.task_manager().networking_task_source().to_sendable(),
         None,
     );
 

--- a/components/script/image_listener.rs
+++ b/components/script/image_listener.rs
@@ -26,7 +26,11 @@ pub fn generate_cache_listener_for_element<
     let trusted_node = Trusted::new(elem);
     let (responder_sender, responder_receiver) = ipc::channel().unwrap();
 
-    let task_source = elem.owner_window().task_manager().networking_task_source();
+    let task_source = elem
+        .owner_window()
+        .task_manager()
+        .networking_task_source()
+        .to_sendable();
     let generation = elem.generation_id();
 
     ROUTER.add_typed_route(
@@ -35,7 +39,7 @@ pub fn generate_cache_listener_for_element<
             let element = trusted_node.clone();
             let image: PendingImageResponse = message.unwrap();
             debug!("Got image {:?}", image);
-            let _ = task_source.queue(task!(process_image_response: move || {
+            task_source.queue(task!(process_image_response: move || {
                 let element = element.root();
                 // Ignore any image response for a previous request that has been discarded.
                 if generation == element.generation_id() {

--- a/components/script/links.rs
+++ b/components/script/links.rs
@@ -434,7 +434,6 @@ pub fn follow_hyperlink(
         target_window
             .task_manager()
             .dom_manipulation_task_source()
-            .queue(task)
-            .unwrap();
+            .queue(task);
     };
 }

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -1769,7 +1769,7 @@ fn fetch_single_module_script(
 
     let network_listener = NetworkListener {
         context,
-        task_source: global.task_manager().networking_task_source(),
+        task_source: global.task_manager().networking_task_source().to_sendable(),
     };
     match document {
         Some(document) => {


### PR DESCRIPTION
No longer hide errors while queueing tasks on the main thread. This
requires creating two types of `TaskSource`s: one for the main thread
and one that can be sent to other threads. This makes queueing a bit
more efficient on the main thread and more importantly, no longer hides
task queue errors.

Fixes #25688.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>
Co-authored-by: Mukilan Thiyagarajan <mukilan@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #25688.
- [x] These changes are covered by existing tests. Tests should start to crash if it uncovers issues.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
