### PR TITLE
Add jpeg and webp support to canvas.toDataURL()

### DIFF
--- a/tests/wpt/meta/html/semantics/embedded-content/the-canvas-element/toDataURL.jpeg.alpha.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/the-canvas-element/toDataURL.jpeg.alpha.html.ini
@@ -1,0 +1,3 @@
+[toDataURL.jpeg.alpha.html]
+  [toDataURL with JPEG composites onto black]
+    expected: FAIL

--- a/tests/wpt/webgl/meta/conformance/context/premultiplyalpha-test.html.ini
+++ b/tests/wpt/webgl/meta/conformance/context/premultiplyalpha-test.html.ini
@@ -90,3 +90,8 @@
   [WebGL test #55: should draw with 255,192,128,1\nat (0, 0) expected: 255,192,128,1 was 0,0,0,255]
     expected: FAIL
 
+  [WebGL test #62: should draw with 128,128,128,255\nat (0, 0) expected: 128,128,128,255 was 255,255,255,255]
+    expected: FAIL
+
+  [WebGL test #69: should draw with 128,128,128,255\nat (0, 0) expected: 128,128,128,255 was 255,255,255,255]
+    expected: FAIL


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This adds support for the following types to `canvas.toDataURL()`:
- `image/jpeg` with quality.
- `image/webp` in lossless mode.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [X] There are tests for these changes in wpt. Unfortunately adding jpeg support cause a few new failures that were hidden by the fallback to PNG before.
