### PR TITLE
Fix a leak in MacOS thread count function

### DIFF
--- a/ports/servoshell/build.rs
+++ b/ports/servoshell/build.rs
@@ -56,6 +56,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         #[cfg(not(windows))]
         panic!("Cross-compiling to windows is currently not supported");
     } else if target_os == "macos" {
+        println!("cargo:rerun-if-changed=platform/macos/count_threads.c");
         cc::Build::new()
             .file("platform/macos/count_threads.c")
             .compile("count_threads");

--- a/ports/servoshell/platform/macos/count_threads.c
+++ b/ports/servoshell/platform/macos/count_threads.c
@@ -8,6 +8,13 @@ int macos_count_running_threads() {
   task_t task = current_task();
   thread_act_array_t threads;
   mach_msg_type_number_t tcnt;
-  task_threads(task, &threads, &tcnt);
+  const kern_return_t status = task_threads(task, &threads, &tcnt);
+  if (status == KERN_SUCCESS) {
+    // Free data structures attached to the thread list.
+    for (uint32_t t = 0; t < tcnt; t++) {
+      mach_port_deallocate(task, threads[t]);
+    }
+    vm_deallocate(task, (vm_address_t)threads, sizeof(thread_t) * tcnt);
+  }
   return tcnt;
 }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Minor leak since we run that only once during shutdown. This is also updating `build.rs` to rebuild the C shim when it changes.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
