### PR TITLE
Add shadow tree flags to Bind/UnbindContext

### DIFF
--- a/components/script/dom/documentorshadowroot.rs
+++ b/components/script/dom/documentorshadowroot.rs
@@ -303,7 +303,7 @@ impl DocumentOrShadowRoot {
         root: DomRoot<Node>,
     ) {
         debug!("Adding named element {:p}: {:p} id={}", self, element, id);
-        assert!(element.upcast::<Node>().is_connected_to_tree());
+        assert!(element.upcast::<Node>().is_in_a_document_tree() || element.upcast::<Node>().is_in_a_shadow_tree());
         assert!(!id.is_empty());
         let mut id_map = id_map.borrow_mut();
         let elements = id_map.entry(id.clone()).or_default();

--- a/components/script/dom/documentorshadowroot.rs
+++ b/components/script/dom/documentorshadowroot.rs
@@ -303,7 +303,10 @@ impl DocumentOrShadowRoot {
         root: DomRoot<Node>,
     ) {
         debug!("Adding named element {:p}: {:p} id={}", self, element, id);
-        assert!(element.upcast::<Node>().is_in_a_document_tree() || element.upcast::<Node>().is_in_a_shadow_tree());
+        assert!(
+            element.upcast::<Node>().is_in_a_document_tree() ||
+                element.upcast::<Node>().is_in_a_shadow_tree()
+        );
         assert!(!id.is_empty());
         let mut id_map = id_map.borrow_mut();
         let elements = id_map.entry(id.clone()).or_default();

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -544,7 +544,7 @@ impl Element {
 
         let bind_context = BindContext {
             tree_connected: self.upcast::<Node>().is_connected(),
-            tree_in_doc: self.upcast::<Node>().is_in_doc(),
+            tree_is_in_a_document_tree: self.upcast::<Node>().is_in_a_document_tree(),
         };
         shadow_root.bind_to_tree(&bind_context);
 
@@ -1355,7 +1355,7 @@ impl Element {
     }
 
     pub fn root_element(&self) -> DomRoot<Element> {
-        if self.node.is_in_doc() {
+        if self.node.is_in_a_document_tree() {
             self.upcast::<Node>()
                 .owner_doc()
                 .GetDocumentElement()
@@ -3512,7 +3512,7 @@ impl VirtualMethods for Element {
                 });
 
                 let containing_shadow_root = self.containing_shadow_root();
-                if node.is_connected_to_tree() {
+                if node.is_connected() {
                     let value = attr.value().as_atom().clone();
                     match mutation {
                         AttributeMutation::Set(old_value) => {

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -545,6 +545,7 @@ impl Element {
         let bind_context = BindContext {
             tree_connected: self.upcast::<Node>().is_connected(),
             tree_is_in_a_document_tree: self.upcast::<Node>().is_in_a_document_tree(),
+            tree_is_in_a_shadow_tree: self.upcast::<Node>().is_in_a_shadow_tree(),
         };
         shadow_root.bind_to_tree(&bind_context);
 
@@ -3619,7 +3620,7 @@ impl VirtualMethods for Element {
             shadow_root.bind_to_tree(context);
         }
 
-        if !context.tree_connected {
+        if !context.is_in_tree() {
             return;
         }
 
@@ -3668,7 +3669,7 @@ impl VirtualMethods for Element {
             if let Some(ref shadow_root) = self.containing_shadow_root() {
                 // Only unregister the element id if the node was disconnected from it's shadow root
                 // (as opposed to the whole shadow tree being disconnected as a whole)
-                if !self.upcast::<Node>().is_in_shadow_tree() {
+                if !self.upcast::<Node>().is_in_a_shadow_tree() {
                     shadow_root.unregister_element_id(self, value.clone());
                 }
             } else {

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -545,7 +545,7 @@ impl Element {
         let bind_context = BindContext {
             tree_connected: self.upcast::<Node>().is_connected(),
             tree_is_in_a_document_tree: self.upcast::<Node>().is_in_a_document_tree(),
-            tree_is_in_a_shadow_tree: self.upcast::<Node>().is_in_a_shadow_tree(),
+            tree_is_in_a_shadow_tree: true,
         };
         shadow_root.bind_to_tree(&bind_context);
 
@@ -3513,7 +3513,7 @@ impl VirtualMethods for Element {
                 });
 
                 let containing_shadow_root = self.containing_shadow_root();
-                if node.is_connected() {
+                if node.is_in_a_document_tree() || node.is_in_a_shadow_tree() {
                     let value = attr.value().as_atom().clone();
                     match mutation {
                         AttributeMutation::Set(old_value) => {
@@ -3653,7 +3653,7 @@ impl VirtualMethods for Element {
             f.unbind_form_control_from_tree();
         }
 
-        if !context.tree_connected {
+        if !context.tree_is_in_a_document_tree && !context.tree_is_in_a_shadow_tree {
             return;
         }
 

--- a/components/script/dom/htmlbaseelement.rs
+++ b/components/script/dom/htmlbaseelement.rs
@@ -126,11 +126,11 @@ impl VirtualMethods for HTMLBaseElement {
 
     fn bind_to_tree(&self, context: &BindContext) {
         self.super_type().unwrap().bind_to_tree(context);
-        self.bind_unbind(context.tree_in_doc);
+        self.bind_unbind(context.tree_is_in_a_document_tree);
     }
 
     fn unbind_from_tree(&self, context: &UnbindContext) {
         self.super_type().unwrap().unbind_from_tree(context);
-        self.bind_unbind(context.tree_in_doc);
+        self.bind_unbind(context.tree_is_in_a_document_tree);
     }
 }

--- a/components/script/dom/htmlbodyelement.rs
+++ b/components/script/dom/htmlbodyelement.rs
@@ -146,7 +146,7 @@ impl VirtualMethods for HTMLBodyElement {
             s.bind_to_tree(context);
         }
 
-        if !context.tree_in_doc {
+        if !context.tree_is_in_a_document_tree {
             return;
         }
 

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -949,7 +949,7 @@ impl HTMLScriptElement {
 
         match script.type_ {
             ScriptType::Classic => {
-                if self.upcast::<Node>().is_in_shadow_tree() {
+                if self.upcast::<Node>().is_in_a_shadow_tree() {
                     document.set_current_script(None)
                 } else {
                     document.set_current_script(Some(self))

--- a/components/script/dom/htmlstyleelement.rs
+++ b/components/script/dom/htmlstyleelement.rs
@@ -194,7 +194,7 @@ impl VirtualMethods for HTMLStyleElement {
         // "The element is not on the stack of open elements of an HTML parser or XML parser,
         // and one of its child nodes is modified by a script."
         // TODO: Handle Text child contents being mutated.
-        if self.upcast::<Node>().is_in_doc() && !self.in_stack_of_open_elements.get() {
+        if self.upcast::<Node>().is_in_a_document_tree() && !self.in_stack_of_open_elements.get() {
             self.parse_own_css();
         }
     }
@@ -218,7 +218,7 @@ impl VirtualMethods for HTMLStyleElement {
         // Handles the case when:
         // "The element is popped off the stack of open elements of an HTML parser or XML parser."
         self.in_stack_of_open_elements.set(false);
-        if self.upcast::<Node>().is_in_doc() {
+        if self.upcast::<Node>().is_in_a_document_tree() {
             self.parse_own_css();
         }
     }

--- a/components/script/dom/htmltitleelement.rs
+++ b/components/script/dom/htmltitleelement.rs
@@ -57,7 +57,7 @@ impl HTMLTitleElement {
 
     fn notify_title_changed(&self) {
         let node = self.upcast::<Node>();
-        if node.is_in_doc() {
+        if node.is_in_a_document_tree() {
             node.owner_doc().title_changed();
         }
     }
@@ -97,7 +97,7 @@ impl VirtualMethods for HTMLTitleElement {
             s.bind_to_tree(context);
         }
         let node = self.upcast::<Node>();
-        if context.tree_in_doc {
+        if context.tree_is_in_a_document_tree {
             node.owner_doc().title_changed();
         }
     }

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -300,7 +300,10 @@ impl Node {
                 }
                 debug_assert!(node.containing_shadow_root().is_some());
             }
-            node.set_flag(NodeFlags::IS_IN_A_DOCUMENT_TREE, parent_is_in_a_document_tree);
+            node.set_flag(
+                NodeFlags::IS_IN_A_DOCUMENT_TREE,
+                parent_is_in_a_document_tree,
+            );
             node.set_flag(NodeFlags::IS_IN_SHADOW_TREE, parent_in_shadow_tree);
             node.set_flag(NodeFlags::IS_CONNECTED, parent_is_connected);
 
@@ -1845,7 +1848,10 @@ impl Node {
 
     #[allow(crown::unrooted_must_root)]
     pub fn new_document_node() -> Node {
-        Node::new_(NodeFlags::IS_IN_A_DOCUMENT_TREE | NodeFlags::IS_CONNECTED, None)
+        Node::new_(
+            NodeFlags::IS_IN_A_DOCUMENT_TREE | NodeFlags::IS_CONNECTED,
+            None,
+        )
     }
 
     #[allow(crown::unrooted_must_root)]
@@ -3604,7 +3610,7 @@ pub struct UnbindContext<'a> {
     pub tree_is_in_a_document_tree: bool,
 
     /// Whether the tree's root is a shadow root
-    pub tree_is_in_a_shadow_tree: bool
+    pub tree_is_in_a_shadow_tree: bool,
 }
 
 impl<'a> UnbindContext<'a> {

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -193,7 +193,9 @@ pub struct NodeFlags(u16);
 bitflags! {
     impl NodeFlags: u16 {
         /// Specifies whether this node is in a document.
-        const IS_IN_DOC = 1 << 0;
+        ///
+        /// <https://dom.spec.whatwg.org/#in-a-document-tree>
+        const IS_IN_A_DOCUMENT_TREE = 1 << 0;
 
         /// Specifies whether this node needs style recalc on next reflow.
         const HAS_DIRTY_DESCENDANTS = 1 << 1;
@@ -225,6 +227,8 @@ bitflags! {
         const IS_IN_SHADOW_TREE = 1 << 9;
 
         /// Specifies whether this node's shadow-including root is a document.
+        ///
+        /// <https://dom.spec.whatwg.org/#connected>
         const IS_CONNECTED = 1 << 10;
 
         /// Whether this node has a weird parser insertion mode. i.e whether setting innerHTML
@@ -285,7 +289,7 @@ impl Node {
         new_child.parent_node.set(Some(self));
         self.children_count.set(self.children_count.get() + 1);
 
-        let parent_in_doc = self.is_in_doc();
+        let parent_is_in_a_document_tree = self.is_in_a_document_tree();
         let parent_in_shadow_tree = self.is_in_shadow_tree();
         let parent_is_connected = self.is_connected();
 
@@ -296,14 +300,15 @@ impl Node {
                 }
                 debug_assert!(node.containing_shadow_root().is_some());
             }
-            node.set_flag(NodeFlags::IS_IN_DOC, parent_in_doc);
+            node.set_flag(NodeFlags::IS_IN_A_DOCUMENT_TREE, parent_is_in_a_document_tree);
             node.set_flag(NodeFlags::IS_IN_SHADOW_TREE, parent_in_shadow_tree);
             node.set_flag(NodeFlags::IS_CONNECTED, parent_is_connected);
+
             // Out-of-document elements never have the descendants flag set.
             debug_assert!(!node.get_flag(NodeFlags::HAS_DIRTY_DESCENDANTS));
             vtable_for(&node).bind_to_tree(&BindContext {
                 tree_connected: parent_is_connected,
-                tree_in_doc: parent_in_doc,
+                tree_is_in_a_document_tree: parent_is_in_a_document_tree,
             });
         }
     }
@@ -317,7 +322,7 @@ impl Node {
     /// Clean up flags and unbind from tree.
     pub fn complete_remove_subtree(root: &Node, context: &UnbindContext) {
         // Flags that reset when a node is disconnected
-        const RESET_FLAGS: NodeFlags = NodeFlags::IS_IN_DOC
+        const RESET_FLAGS: NodeFlags = NodeFlags::IS_IN_A_DOCUMENT_TREE
             .union(NodeFlags::IS_CONNECTED)
             .union(NodeFlags::HAS_DIRTY_DESCENDANTS)
             .union(NodeFlags::HAS_SNAPSHOT)
@@ -597,8 +602,9 @@ impl Node {
         format!("{:?}", self.type_id())
     }
 
-    pub fn is_in_doc(&self) -> bool {
-        self.flags.get().contains(NodeFlags::IS_IN_DOC)
+    /// <https://dom.spec.whatwg.org/#in-a-document-tree>
+    pub fn is_in_a_document_tree(&self) -> bool {
+        self.flags.get().contains(NodeFlags::IS_IN_A_DOCUMENT_TREE)
     }
 
     pub fn is_in_shadow_tree(&self) -> bool {
@@ -615,13 +621,9 @@ impl Node {
         self.set_flag(NodeFlags::HAS_WEIRD_PARSER_INSERTION_MODE, true)
     }
 
+    /// <https://dom.spec.whatwg.org/#connected>
     pub fn is_connected(&self) -> bool {
         self.flags.get().contains(NodeFlags::IS_CONNECTED)
-    }
-
-    /// Return true iff the node's root is a Document or a ShadowRoot
-    pub fn is_connected_to_tree(&self) -> bool {
-        self.is_connected() || self.is_in_shadow_tree()
     }
 
     /// Returns the type ID of this node.
@@ -1842,7 +1844,7 @@ impl Node {
 
     #[allow(crown::unrooted_must_root)]
     pub fn new_document_node() -> Node {
-        Node::new_(NodeFlags::IS_IN_DOC | NodeFlags::IS_CONNECTED, None)
+        Node::new_(NodeFlags::IS_IN_A_DOCUMENT_TREE | NodeFlags::IS_CONNECTED, None)
     }
 
     #[allow(crown::unrooted_must_root)]
@@ -2679,7 +2681,7 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
             };
         }
 
-        if self.is_in_doc() {
+        if self.is_in_a_document_tree() {
             DomRoot::from_ref(self.owner_doc().upcast::<Node>())
         } else {
             self.inclusive_ancestors(ShadowIncluding::No)
@@ -3558,9 +3560,14 @@ impl<'a> ChildrenMutation<'a> {
 /// The context of the binding to tree of a node.
 pub struct BindContext {
     /// Whether the tree is connected.
+    ///
+    /// <https://dom.spec.whatwg.org/#connected>
     pub tree_connected: bool,
-    /// Whether the tree is in the document.
-    pub tree_in_doc: bool,
+
+    /// Whether the tree's root is a document.
+    ///
+    /// <https://dom.spec.whatwg.org/#in-a-document-tree>
+    pub tree_is_in_a_document_tree: bool,
 }
 
 /// The context of the unbinding from a tree of a node when one of its
@@ -3574,12 +3581,16 @@ pub struct UnbindContext<'a> {
     prev_sibling: Option<&'a Node>,
     /// The next sibling of the inclusive ancestor that was removed.
     pub next_sibling: Option<&'a Node>,
+
     /// Whether the tree is connected.
     ///
-    /// A tree is connected iff it's root is a Document or a ShadowRoot.
+    /// <https://dom.spec.whatwg.org/#connected>
     pub tree_connected: bool,
-    /// Whether the tree is in doc.
-    pub tree_in_doc: bool,
+
+    /// Whether the tree's root is a document.
+    ///
+    /// <https://dom.spec.whatwg.org/#in-a-document-tree>
+    pub tree_is_in_a_document_tree: bool,
 }
 
 impl<'a> UnbindContext<'a> {
@@ -3595,8 +3606,8 @@ impl<'a> UnbindContext<'a> {
             parent,
             prev_sibling,
             next_sibling,
-            tree_connected: parent.is_connected_to_tree(),
-            tree_in_doc: parent.is_in_doc(),
+            tree_connected: parent.is_connected(),
+            tree_is_in_a_document_tree: parent.is_in_a_document_tree(),
         }
     }
 

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -3602,6 +3602,9 @@ pub struct UnbindContext<'a> {
     ///
     /// <https://dom.spec.whatwg.org/#in-a-document-tree>
     pub tree_is_in_a_document_tree: bool,
+
+    /// Whether the tree's root is a shadow root
+    pub tree_is_in_a_shadow_tree: bool
 }
 
 impl<'a> UnbindContext<'a> {
@@ -3619,6 +3622,7 @@ impl<'a> UnbindContext<'a> {
             next_sibling,
             tree_connected: parent.is_connected(),
             tree_is_in_a_document_tree: parent.is_in_a_document_tree(),
+            tree_is_in_a_shadow_tree: parent.is_in_a_shadow_tree(),
         }
     }
 

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -290,7 +290,7 @@ impl Node {
         self.children_count.set(self.children_count.get() + 1);
 
         let parent_is_in_a_document_tree = self.is_in_a_document_tree();
-        let parent_in_shadow_tree = self.is_in_shadow_tree();
+        let parent_in_shadow_tree = self.is_in_a_shadow_tree();
         let parent_is_connected = self.is_connected();
 
         for node in new_child.traverse_preorder(ShadowIncluding::No) {
@@ -309,6 +309,7 @@ impl Node {
             vtable_for(&node).bind_to_tree(&BindContext {
                 tree_connected: parent_is_connected,
                 tree_is_in_a_document_tree: parent_is_in_a_document_tree,
+                tree_is_in_a_shadow_tree: parent_in_shadow_tree,
             });
         }
     }
@@ -607,7 +608,7 @@ impl Node {
         self.flags.get().contains(NodeFlags::IS_IN_A_DOCUMENT_TREE)
     }
 
-    pub fn is_in_shadow_tree(&self) -> bool {
+    pub fn is_in_a_shadow_tree(&self) -> bool {
         self.flags.get().contains(NodeFlags::IS_IN_SHADOW_TREE)
     }
 
@@ -3568,6 +3569,16 @@ pub struct BindContext {
     ///
     /// <https://dom.spec.whatwg.org/#in-a-document-tree>
     pub tree_is_in_a_document_tree: bool,
+
+    /// Whether the tree's root is a shadow root
+    pub tree_is_in_a_shadow_tree: bool,
+}
+
+impl BindContext {
+    /// Return true iff the tree is inside either a document- or a shadow tree.
+    pub fn is_in_tree(&self) -> bool {
+        self.tree_is_in_a_document_tree || self.tree_is_in_a_shadow_tree
+    }
 }
 
 /// The context of the unbinding from a tree of a node when one of its

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -319,6 +319,8 @@ impl VirtualMethods for ShadowRoot {
         }
 
         let shadow_root = self.upcast::<Node>();
+
+
         shadow_root.set_flag(NodeFlags::IS_CONNECTED, context.tree_connected);
         for node in shadow_root.children() {
             node.set_flag(NodeFlags::IS_CONNECTED, context.tree_connected);

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -320,7 +320,6 @@ impl VirtualMethods for ShadowRoot {
 
         let shadow_root = self.upcast::<Node>();
 
-
         shadow_root.set_flag(NodeFlags::IS_CONNECTED, context.tree_connected);
         for node in shadow_root.children() {
             node.set_flag(NodeFlags::IS_CONNECTED, context.tree_connected);

--- a/components/script/layout_dom/node.rs
+++ b/components/script/layout_dom/node.rs
@@ -168,7 +168,7 @@ impl<'dom> style::dom::TNode for ServoLayoutNode<'dom> {
     }
 
     fn is_in_document(&self) -> bool {
-        unsafe { self.node.get_flag(NodeFlags::IS_IN_DOC) }
+        unsafe { self.node.get_flag(NodeFlags::IS_IN_A_DOCUMENT_TREE) }
     }
 }
 

--- a/tests/wpt/meta/shadow-dom/form-control-form-attribute.html.ini
+++ b/tests/wpt/meta/shadow-dom/form-control-form-attribute.html.ini
@@ -1,6 +1,3 @@
 [form-control-form-attribute.html]
   [Shadow form control's form attribute should work also in shadow DOM.]
     expected: FAIL
-
-  [Form element as form control's ancestor should work also in shadow DOM.]
-    expected: FAIL


### PR DESCRIPTION
There are four different situations that the flags in a Bind/UnbindContext need to cover:

* Tree's root is neither a document nor a shadow root
* Tree's root is a document
* Tree's root is a shadow root, Tree's shadow-inclusive root is not a document
* Tree's root is a shadow root, Tree's shadow-inclusive root is a document

This change adds `tree_is_in_a_shadow_tree` flags to both Bind/UnbindContextand renames the existing `tree_in_doc` to better match the specification.

With these changes, the turnstile captcha succeeds in finding the widget iframe (and proceeds to immediately crash, but that's a separate issue).

[try run](https://github.com/simonwuelker/servo/actions/runs/12636609517/job/35210090535)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are a part of #34320 (fix some errors from https://github.com/servo/servo/issues/34320#issuecomment-2567836870)
- [X] There are tests for these changes  (covered by wpt)
