### PR TITLE
CI: use self-hosted runners for macOS build jobs

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -25,6 +25,10 @@ on:
       github-release-id:
         required: false
         type: string
+      force-github-hosted-runner:
+        required: false
+        type: boolean
+        default: false
   workflow_dispatch:
     inputs:
       profile:
@@ -48,6 +52,10 @@ on:
         required: false
         default: false
         type: boolean
+      force-github-hosted-runner:
+        required: false
+        type: boolean
+        default: false
 
 env:
   RUST_BACKTRACE: 1
@@ -55,9 +63,29 @@ env:
   CARGO_INCREMENTAL: 0
 
 jobs:
+  # Runs the underlying job (“workload”) on a self-hosted runner if available,
+  # with the help of a `runner-select` job and a `runner-timeout` job.
+  runner-select:
+    uses: ./.github/workflows/self-hosted-runner-select.yml
+    secrets: inherit
+    with:
+      github-hosted-runner-label: macos-13
+      self-hosted-image-name: servo-macos13
+      force-github-hosted-runner: ${{ inputs.force-github-hosted-runner }}
+  runner-timeout:
+    needs:
+      - runner-select
+    uses: ./.github/workflows/self-hosted-runner-timeout.yml
+    secrets: inherit
+    with:
+      unique-id: ${{ needs.runner-select.outputs.unique-id }}
+      is-self-hosted: ${{ fromJSON(needs.runner-select.outputs.is-self-hosted) }}
+
   build:
-    name: MacOS Build
-    runs-on: macos-13
+    needs:
+      - runner-select
+    name: MacOS Build [${{ needs.runner-select.outputs.unique-id }}]
+    runs-on: ${{ needs.runner-select.outputs.selected-runner-label }}
     steps:
       # XProtect can cause random failures if it decides that the DMG we create
       # during the packaging phase is malware.
@@ -67,18 +95,33 @@ jobs:
         run: |
           echo Killing XProtect.; sudo pkill -9 XProtect >/dev/null || true;
       - uses: actions/checkout@v4
-        if: github.event_name != 'pull_request_target'
+        if: runner.environment != 'self-hosted' && github.event_name != 'pull_request_target'
       # This is necessary to checkout the pull request if this run was triggered via a
       # `pull_request_target` event.
       - uses: actions/checkout@v4
-        if: github.event_name == 'pull_request_target'
+        if: runner.environment != 'self-hosted' && github.event_name == 'pull_request_target'
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - name: Setup Python
+      # Faster checkout for self-hosted runner that uses prebaked repo.
+      - if: ${{ runner.environment == 'self-hosted' && github.event_name != 'pull_request_target' }}
+        run: git fetch --depth=1 origin $GITHUB_SHA
+      - if: ${{ runner.environment == 'self-hosted' && github.event_name == 'pull_request_target' }}
+        run: git fetch --depth=1 origin ${{ github.event.pull_request.head.sha }}
+      - if: ${{ runner.environment == 'self-hosted' }}
+        # Same as `git switch --detach FETCH_HEAD`, but fixes up dirty working
+        # trees, in case the runner image was baked with a dirty working tree.
+        run: |
+          git switch --detach
+          git reset --hard FETCH_HEAD
+
+      - if: runner.environment != 'self-hosted'
+        name: Setup Python
         uses: ./.github/actions/setup-python
-      - name: Install crown
+      - if: runner.environment != 'self-hosted'
+        name: Install crown
         run: cargo install --path support/crown
-      - name: Bootstrap
+      - if: runner.environment != 'self-hosted'
+        name: Bootstrap
         run: |
           ./mach bootstrap --skip-lints
           brew install gnu-tar


### PR DESCRIPTION
This patch makes our macOS builds use [our self-hosted runners](https://github.com/servo/ci-runners) where possible, falling back to the slower GitHub-hosted runners only when none are available, cutting macOS build jobs from [over an hour](https://github.com/servo/servo/actions/runs/12645352026/job/35234357948) to [under 9 minutes](https://github.com/servo/servo/actions/runs/12647598839/job/35240334670).

**If self-hosted runners break the build after landing, please disable them by [creating a repository variable](https://github.com/servo/servo/settings/variables/actions) named NO_SELF_HOSTED_RUNNERS with any non-empty value, then let me know on Zulip or mention me in a GitHub issue, either in this repo or on [servo/ci-runners](https://github.com/servo/ci-runners).**

(see also #33321, #33081)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] ~~These changes fix #___ (GitHub issue number if applicable)~~

<!-- Either: -->
- [x] Self-hosted runner test plan
  - [x] try job (has monitor access): <https://github.com/servo/servo/actions/runs/12647598839/job/35240334670>
  - [x] try-label job (no token): <https://github.com/servo/servo/actions/runs/12648164655/job/35241966000>