### PR TITLE
Various servodriver fixes

### DIFF
--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2108,7 +2108,7 @@ impl Window {
         let (sender, receiver) = ipc::channel().expect("Failed to create IPC channel!");
         let event = ScriptMsg::SetLayoutEpoch(epoch, sender);
         self.send_to_constellation(event);
-        receiver.recv().unwrap();
+        let _ = receiver.recv();
     }
 
     pub fn layout_reflow(&self, query_msg: QueryMsg, can_gc: CanGc) -> bool {

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -426,9 +426,6 @@ impl Handler {
     }
 
     fn focus_top_level_browsing_context_id(&self) -> WebDriverResult<TopLevelBrowsingContextId> {
-        // FIXME(#34550): This is a hack for unexpected behaviour in the constellation.
-        thread::sleep(Duration::from_millis(1000));
-
         debug!("Getting focused context.");
         let interval = 20;
         let iterations = 30_000 / interval;

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -10521,6 +10521,10 @@
      "e2c2de8556c7fa88f54a76a3c18e06be14722de9",
      []
     ],
+    "max-session-history-frame.html": [
+     "192c7235d061b439ef2b57d4b01b170b7412dcdc",
+     []
+    ],
     "nested_asap_script.js": [
      "59562a8c9c39130cad411815059513c4ce0a7c04",
      []
@@ -14004,7 +14008,7 @@
      ]
     },
     "servo-max-session-history.html": [
-     "e49616b326009da98f35bd0384d1715c38a40998",
+     "79fe4073601d7cbe9620132b281065aa6903af47",
      [
       null,
       {}

--- a/tests/wpt/mozilla/tests/mozilla/max-session-history-frame.html
+++ b/tests/wpt/mozilla/tests/mozilla/max-session-history-frame.html
@@ -1,0 +1,30 @@
+<script>
+  onload = () => {
+      // This test goes forward by X pages, then back by Y pages,
+      // then checks to see if that triggered a reload.
+      // If it did, the document must have been discarded,
+
+      // The current page number (stored in the URL search string)
+      var page_number = location.search.substring(1) | 0;
+
+      // The number of pages to go forward by.
+      // This should be more than go_back_by, to ensure that
+      // we actually do more than one back traversal.
+      var go_forward_by = 24;
+
+      // The number of pages to go back by.
+      // This should be more than the default session-history.max-length pref,
+      // to ensure that going back reloads the page.
+      var go_back_by = Math.min(page_number, 21);
+
+      if (history.length < go_forward_by) {
+          // Keep loading new pages until we have loaded enough of them.
+          location.assign("?" + (page_number + 1));
+      } else if (page_number === 0) {
+          parent.postMessage("done");
+      } else {
+          // Otherwise, go back.
+          history.go(-go_back_by);
+      }
+  }
+</script>

--- a/tests/wpt/mozilla/tests/mozilla/servo-max-session-history.html
+++ b/tests/wpt/mozilla/tests/mozilla/servo-max-session-history.html
@@ -4,33 +4,11 @@
 <script src="/resources/testharnessreport.js"></script>
 </head>
 <body></body>
+<iframe src="max-session-history-frame.html"></iframe>
 <script>
-  // This test goes forward by X pages, then back by Y pages,
-  // then checks to see if that triggered a reload.
-  // If it did, the document must have been discarded,
-
-  // The current page number (stored in the URL search string)
-  var page_number = location.search.substring(1) | 0;
-
-  // The number of pages to go forward by.
-  // This should be more than go_back_by, to ensure that
-  // we actually do more than one back traversal.
-  var go_forward_by = 24;
-
-  // The number of pages to go back by.
-  // This should be more than the default session-history.max-length pref,
-  // to ensure that going back reloads the page.
-  var go_back_by = Math.min(page_number, 21);
-
-  if (history.length < go_forward_by) {
-    // Keep loading new pages until we have loaded enough of them.
-    location.assign("?" + (page_number + 1));
-  } else if (page_number === 0) {
-    // If we got back to the beginning, we must have triggered reloads.
-    test(function() {}, "Forward then back triggered a reload.");
-  } else {
-    // Otherwise, go back.
-    history.go(-go_back_by);
-  }
+  let t = async_test("Forward then back triggered a reload.");
+  onmessage = t.step_func(() => {
+      t.done();
+  });
 </script>
 </html>

--- a/tests/wpt/tests/tools/wptrunner/wptrunner/browsers/servodriver.py
+++ b/tests/wpt/tests/tools/wptrunner/wptrunner/browsers/servodriver.py
@@ -87,7 +87,7 @@ class ServoWebDriverBrowser(WebDriverBrowser):
         args = [
             "--hard-fail",
             "--webdriver=%s" % port,
-            "about:blank",
+            "data:,",
         ]
 
         ca_cert_path = server_config.ssl_config["ca_cert_path"]


### PR DESCRIPTION
This is a grab-bag of fixes for failures that occur when running `./mach test-wpt tests/wpt/mozilla/tests/mozilla/ --product=servodriver --processes=1`. They get us incrementally closer to being able to use servodriver as the primary test harness.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #34869 and work around #34551
- [x] These changes do not require tests because they are part of the test harness and not executed in CI