### PR TITLE
net: Use `RequestId` to cancel fetches instead of creating an IPC channel

### DIFF
--- a/components/fonts/font_context.rs
+++ b/components/fonts/font_context.rs
@@ -661,7 +661,6 @@ impl RemoteWebFontDownloader {
             &core_resource_thread_clone,
             request,
             None,
-            None,
             Box::new(move |response_message| {
                 match downloader.handle_web_font_fetch_message(response_message) {
                     DownloaderResponseResult::InProcess => {},

--- a/components/net/filemanager_thread.rs
+++ b/components/net/filemanager_thread.rs
@@ -128,7 +128,7 @@ impl FileManager {
     pub fn fetch_file(
         &self,
         done_sender: &mut TokioSender<Data>,
-        cancellation_listener: Arc<Mutex<CancellationListener>>,
+        cancellation_listener: Arc<CancellationListener>,
         id: Uuid,
         file_token: &FileTokenCheck,
         origin: FileOrigin,
@@ -211,7 +211,7 @@ impl FileManager {
         done_sender: &mut TokioSender<Data>,
         mut reader: BufReader<File>,
         res_body: ServoArc<Mutex<ResponseBody>>,
-        cancellation_listener: Arc<Mutex<CancellationListener>>,
+        cancellation_listener: Arc<CancellationListener>,
         range: RelativePos,
     ) {
         let done_sender = done_sender.clone();
@@ -220,7 +220,7 @@ impl FileManager {
             .map(|pool| {
                 pool.spawn(move || {
                     loop {
-                        if cancellation_listener.lock().unwrap().cancelled() {
+                        if cancellation_listener.cancelled() {
                             *res_body.lock().unwrap() = ResponseBody::Done(vec![]);
                             let _ = done_sender.send(Data::Cancelled);
                             return;
@@ -282,7 +282,7 @@ impl FileManager {
     fn fetch_blob_buf(
         &self,
         done_sender: &mut TokioSender<Data>,
-        cancellation_listener: Arc<Mutex<CancellationListener>>,
+        cancellation_listener: Arc<CancellationListener>,
         id: &Uuid,
         file_token: &FileTokenCheck,
         origin_in: &FileOrigin,

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -1944,7 +1944,7 @@ async fn http_network_fetch(
     let meta_status = meta.status;
     let meta_headers = meta.headers;
     let cancellation_listener = context.cancellation_listener.clone();
-    if cancellation_listener.lock().unwrap().cancelled() {
+    if cancellation_listener.cancelled() {
         return Response::network_error(NetworkError::Internal("Fetch aborted".into()));
     }
 
@@ -1983,7 +1983,7 @@ async fn http_network_fetch(
                 warn!("Error streaming response body: {:?}", e);
             })
             .try_fold(res_body, move |res_body, chunk| {
-                if cancellation_listener.lock().unwrap().cancelled() {
+                if cancellation_listener.cancelled() {
                     *res_body.lock().unwrap() = ResponseBody::Done(vec![]);
                     let _ = done_sender.send(Data::Cancelled);
                     return future::ready(Err(()));

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -10,7 +10,7 @@ use std::fs::File;
 use std::io::prelude::*;
 use std::io::{self, BufReader};
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, Mutex, RwLock, Weak};
 use std::thread;
 use std::time::Duration;
 
@@ -24,7 +24,7 @@ use log::{debug, warn};
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 use net_traits::blob_url_store::parse_blob_url;
 use net_traits::filemanager_thread::FileTokenCheck;
-use net_traits::request::{Destination, RequestBuilder};
+use net_traits::request::{Destination, RequestBuilder, RequestId};
 use net_traits::response::{Response, ResponseInit};
 use net_traits::storage_thread::StorageThreadMsg;
 use net_traits::{
@@ -142,6 +142,7 @@ pub fn new_core_resource_thread(
                 config_dir,
                 ca_certificates,
                 ignore_certificate_errors,
+                cancellation_listeners: Default::default(),
             };
 
             mem_profiler_chan.run_with_memory_reporting(
@@ -168,6 +169,7 @@ struct ResourceChannelManager {
     config_dir: Option<PathBuf>,
     ca_certificates: CACertificates,
     ignore_certificate_errors: bool,
+    cancellation_listeners: HashMap<RequestId, Weak<CancellationListener>>,
 }
 
 fn create_http_states(
@@ -300,6 +302,30 @@ impl ResourceChannelManager {
         msg.send(vec![public_report, private_report]);
     }
 
+    fn cancellation_listener(&self, request_id: RequestId) -> Option<Arc<CancellationListener>> {
+        self.cancellation_listeners
+            .get(&request_id)
+            .and_then(Weak::upgrade)
+    }
+
+    fn get_or_create_cancellation_listener(
+        &mut self,
+        request_id: RequestId,
+    ) -> Arc<CancellationListener> {
+        if let Some(listener) = self.cancellation_listener(request_id) {
+            return listener;
+        }
+
+        // Clear away any cancellation listeners that are no longer valid.
+        self.cancellation_listeners
+            .retain(|_, listener| listener.strong_count() > 0);
+
+        let cancellation_listener = Arc::new(Default::default());
+        self.cancellation_listeners
+            .insert(request_id, Arc::downgrade(&cancellation_listener));
+        cancellation_listener
+    }
+
     /// Returns false if the thread should exit.
     fn process_msg(
         &mut self,
@@ -308,32 +334,44 @@ impl ResourceChannelManager {
         protocols: Arc<ProtocolRegistry>,
     ) -> bool {
         match msg {
-            CoreResourceMsg::Fetch(req_init, channels) => match channels {
-                FetchChannels::ResponseMsg(sender, cancel_chan) => self.resource_manager.fetch(
-                    req_init,
-                    None,
-                    sender,
-                    http_state,
-                    cancel_chan,
-                    protocols,
-                ),
+            CoreResourceMsg::Fetch(request_builder, channels) => match channels {
+                FetchChannels::ResponseMsg(sender) => {
+                    let cancellation_listener =
+                        self.get_or_create_cancellation_listener(request_builder.id);
+                    self.resource_manager.fetch(
+                        request_builder,
+                        None,
+                        sender,
+                        http_state,
+                        cancellation_listener,
+                        protocols,
+                    );
+                },
                 FetchChannels::WebSocket {
                     event_sender,
                     action_receiver,
                 } => self.resource_manager.websocket_connect(
-                    req_init,
+                    request_builder,
                     event_sender,
                     action_receiver,
                     http_state,
                 ),
                 FetchChannels::Prefetch => self.resource_manager.fetch(
-                    req_init,
+                    request_builder,
                     None,
                     DiscardFetch,
                     http_state,
-                    None,
+                    Arc::new(Default::default()),
                     protocols,
                 ),
+            },
+            CoreResourceMsg::Cancel(request_ids) => {
+                for cancellation_listener in request_ids
+                    .into_iter()
+                    .filter_map(|request_id| self.cancellation_listener(request_id))
+                {
+                    cancellation_listener.cancel();
+                }
             },
             CoreResourceMsg::DeleteCookies(request) => {
                 http_state
@@ -343,13 +381,15 @@ impl ResourceChannelManager {
                     .clear_storage(&request);
                 return true;
             },
-            CoreResourceMsg::FetchRedirect(req_init, res_init, sender, cancel_chan) => {
+            CoreResourceMsg::FetchRedirect(request_builder, res_init, sender) => {
+                let cancellation_listener =
+                    self.get_or_create_cancellation_listener(request_builder.id);
                 self.resource_manager.fetch(
-                    req_init,
+                    request_builder,
                     Some(res_init),
                     sender,
                     http_state,
-                    cancel_chan,
+                    cancellation_listener,
                     protocols,
                 )
             },
@@ -698,7 +738,7 @@ impl CoreResourceManager {
         res_init_: Option<ResponseInit>,
         mut sender: Target,
         http_state: &Arc<HttpState>,
-        cancel_chan: Option<IpcReceiver<()>>,
+        cancellation_listener: Arc<CancellationListener>,
         protocols: Arc<ProtocolRegistry>,
     ) {
         let http_state = http_state.clone();
@@ -746,7 +786,7 @@ impl CoreResourceManager {
                 devtools_chan: dc.map(|dc| Arc::new(Mutex::new(dc))),
                 filemanager: Arc::new(Mutex::new(filemanager)),
                 file_token,
-                cancellation_listener: Arc::new(Mutex::new(CancellationListener::new(cancel_chan))),
+                cancellation_listener,
                 timing: ServoArc::new(Mutex::new(ResourceFetchTiming::new(request.timing_type()))),
                 protocols,
             };

--- a/components/net/tests/fetch.rs
+++ b/components/net/tests/fetch.rs
@@ -26,7 +26,7 @@ use hyper::body::{Bytes, Incoming};
 use hyper::{Request as HyperRequest, Response as HyperResponse};
 use mime::{self, Mime};
 use net::fetch::cors_cache::CorsCache;
-use net::fetch::methods::{self, CancellationListener, FetchContext};
+use net::fetch::methods::{self, FetchContext};
 use net::filemanager_thread::FileManager;
 use net::hsts::HstsEntry;
 use net::protocols::ProtocolRegistry;
@@ -702,7 +702,7 @@ fn test_fetch_with_hsts() {
             Weak::new(),
         ))),
         file_token: FileTokenCheck::NotRequired,
-        cancellation_listener: Arc::new(Mutex::new(CancellationListener::new(None))),
+        cancellation_listener: Arc::new(Default::default()),
         timing: ServoArc::new(Mutex::new(ResourceFetchTiming::new(
             ResourceTimingType::Navigation,
         ))),
@@ -759,7 +759,7 @@ fn test_load_adds_host_to_hsts_list_when_url_is_https() {
             Weak::new(),
         ))),
         file_token: FileTokenCheck::NotRequired,
-        cancellation_listener: Arc::new(Mutex::new(CancellationListener::new(None))),
+        cancellation_listener: Arc::new(Default::default()),
         timing: ServoArc::new(Mutex::new(ResourceFetchTiming::new(
             ResourceTimingType::Navigation,
         ))),
@@ -818,7 +818,7 @@ fn test_fetch_self_signed() {
             Weak::new(),
         ))),
         file_token: FileTokenCheck::NotRequired,
-        cancellation_listener: Arc::new(Mutex::new(CancellationListener::new(None))),
+        cancellation_listener: Arc::new(Default::default()),
         timing: ServoArc::new(Mutex::new(ResourceFetchTiming::new(
             ResourceTimingType::Navigation,
         ))),

--- a/components/net/tests/main.rs
+++ b/components/net/tests/main.rs
@@ -39,7 +39,7 @@ use hyper::{Request as HyperRequest, Response as HyperResponse};
 use hyper_util::rt::tokio::TokioIo;
 use net::connector::{create_http_client, create_tls_config};
 use net::fetch::cors_cache::CorsCache;
-use net::fetch::methods::{self, CancellationListener, FetchContext};
+use net::fetch::methods::{self, FetchContext};
 use net::filemanager_thread::FileManager;
 use net::protocols::ProtocolRegistry;
 use net::resource_thread::CoreResourceThreadPool;
@@ -183,7 +183,7 @@ fn new_fetch_context(
             pool_handle.unwrap_or_else(|| Weak::new()),
         ))),
         file_token: FileTokenCheck::NotRequired,
-        cancellation_listener: Arc::new(Mutex::new(CancellationListener::new(None))),
+        cancellation_listener: Arc::new(Default::default()),
         timing: ServoArc::new(Mutex::new(ResourceFetchTiming::new(
             ResourceTimingType::Navigation,
         ))),

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -2150,7 +2150,6 @@ impl Document {
         &self,
         request: RequestBuilder,
         listener: Listener,
-        cancel_override: Option<ipc::IpcReceiver<()>>,
     ) {
         let callback = NetworkListener {
             context: std::sync::Arc::new(Mutex::new(listener)),
@@ -2161,8 +2160,7 @@ impl Document {
                 .into(),
         }
         .into_callback();
-        self.loader_mut()
-            .fetch_async_background(request, callback, cancel_override);
+        self.loader_mut().fetch_async_background(request, callback);
     }
 
     // https://html.spec.whatwg.org/multipage/#the-end

--- a/components/script/dom/eventsource.rs
+++ b/components/script/dom/eventsource.rs
@@ -602,12 +602,12 @@ impl EventSourceMethods<crate::DomTypeHolder> for EventSource {
                 listener.notify_fetch(message.unwrap());
             }),
         );
-        let cancel_receiver = ev.canceller.borrow_mut().initialize();
+        *ev.canceller.borrow_mut() = FetchCanceller::new(request.id);
         global
             .core_resource_thread()
             .send(CoreResourceMsg::Fetch(
                 request,
-                FetchChannels::ResponseMsg(action_sender, Some(cancel_receiver)),
+                FetchChannels::ResponseMsg(action_sender),
             ))
             .unwrap();
         // Step 13
@@ -681,7 +681,7 @@ impl EventSourceTimeoutCallback {
             .core_resource_thread()
             .send(CoreResourceMsg::Fetch(
                 request,
-                FetchChannels::ResponseMsg(self.action_sender, None),
+                FetchChannels::ResponseMsg(self.action_sender),
             ))
             .unwrap();
     }

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -3242,13 +3242,12 @@ impl GlobalScope {
         request_builder: RequestBuilder,
         context: Arc<Mutex<Listener>>,
         task_source: SendableTaskSource,
-        cancellation_sender: Option<ipc::IpcReceiver<()>>,
     ) {
         let network_listener = NetworkListener {
             context,
             task_source,
         };
-        self.fetch_with_network_listener(request_builder, network_listener, cancellation_sender);
+        self.fetch_with_network_listener(request_builder, network_listener);
     }
 
     pub(crate) fn fetch_with_network_listener<
@@ -3257,13 +3256,11 @@ impl GlobalScope {
         &self,
         request_builder: RequestBuilder,
         network_listener: NetworkListener<Listener>,
-        cancellation_receiver: Option<ipc::IpcReceiver<()>>,
     ) {
         fetch_async(
             &self.core_resource_thread(),
             request_builder,
             None,
-            cancellation_receiver,
             network_listener.into_callback(),
         );
     }

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -419,7 +419,7 @@ impl HTMLImageElement {
 
         // This is a background load because the load blocker already fulfills the
         // purpose of delaying the document's load event.
-        document.fetch_background(request, context, None);
+        document.fetch_background(request, context);
     }
 
     // Steps common to when an image has been loaded.

--- a/components/script/dom/htmllinkelement.rs
+++ b/components/script/dom/htmllinkelement.rs
@@ -384,7 +384,7 @@ impl HTMLLinkElement {
             resource_timing: ResourceFetchTiming::new(ResourceTimingType::Resource),
         };
 
-        document.fetch_background(request, fetch_context, None);
+        document.fetch_background(request, fetch_context);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#concept-link-obtain>

--- a/components/script/layout_image.rs
+++ b/components/script/layout_image.rs
@@ -112,5 +112,5 @@ pub(crate) fn fetch_image_for_layout(
         .pipeline_id(Some(document.global().pipeline_id()));
 
     // Layout image loads do not delay the document load event.
-    document.fetch_background(request, context, None);
+    document.fetch_background(request, context);
 }

--- a/components/script/navigation.rs
+++ b/components/script/navigation.rs
@@ -13,7 +13,6 @@ use base::id::{BrowsingContextId, PipelineId, TopLevelBrowsingContextId};
 use content_security_policy::Destination;
 use crossbeam_channel::Sender;
 use http::header;
-use ipc_channel::ipc;
 use net_traits::request::{CredentialsMode, RedirectMode, RequestBuilder, RequestMode};
 use net_traits::response::ResponseInit;
 use net_traits::{
@@ -55,13 +54,11 @@ impl NavigationListener {
         self,
         core_resource_thread: &CoreResourceThread,
         response_init: Option<ResponseInit>,
-        cancellation_receiver: Option<ipc::IpcReceiver<()>>,
     ) {
         fetch_async(
             core_resource_thread,
             self.request_builder.clone(),
             response_init,
-            cancellation_receiver,
             self.into_callback(),
         );
     }

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -1780,7 +1780,7 @@ fn fetch_single_module_script(
                 network_listener.into_callback(),
             );
         },
-        None => global.fetch_with_network_listener(request, network_listener, None),
+        None => global.fetch_with_network_listener(request, network_listener),
     }
 }
 


### PR DESCRIPTION
Instead of creating an IPC channel for every fetch, allow cancelling
fetches based on the `RequestId` of the original request. This requires
that `RequestId`s be UUIDs so that they are unique between processes
that might communicating with the resource process.

In addition, the resource process loop now keeps a `HashMap` or `Weak`
handles to cancellers and cleans them up.

This allows for creating mutiple `FetchCanceller`s in `script` for a
single fetch request, allowing integration of the media and video
elements to integrate with the `Document` canceller list -- meaning
these fetches also get cancelled when the `Document` unloads.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are covered by existing WPT tests. They should have no observable behavior on pages.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
