### PR TITLE
Make webgl test preferences more consistent.

### DIFF
--- a/tests/wpt/webgl/meta/__dir__.ini
+++ b/tests/wpt/webgl/meta/__dir__.ini
@@ -1,0 +1,1 @@
+prefs: ["dom.offscreen_canvas.enabled:true", "dom.imagebitmap.enabled:true", "dom.webgl2.enabled:true"]

--- a/tests/wpt/webgl/meta/conformance/__dir__.ini
+++ b/tests/wpt/webgl/meta/conformance/__dir__.ini
@@ -1,1 +1,0 @@
-prefs: ["dom.offscreen_canvas.enabled:true","dom.imagebitmap.enabled:true"]

--- a/tests/wpt/webgl/meta/conformance2/__dir__.ini
+++ b/tests/wpt/webgl/meta/conformance2/__dir__.ini
@@ -1,2 +1,0 @@
-prefs: ["dom.webgl2.enabled:true","dom.offscreen_canvas.enabled:true","dom.imagebitmap.enabled:true"]
-


### PR DESCRIPTION
This has no functional change; it only reduces the risk of drift over time.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes