### PR TITLE
layout: Defer some table sizing logic to the parent formatting context

### DIFF
--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -843,6 +843,7 @@ fn layout_in_flow_non_replaced_block_level_same_formatting_context(
         containing_block,
         style,
         get_inline_content_sizes,
+        false, /* is_table */
     );
     let ResolvedMargins {
         margin,
@@ -1084,6 +1085,7 @@ impl IndependentNonReplacedContents {
             containing_block,
             &base.style,
             get_inline_content_sizes,
+            self.is_table(),
         );
 
         let layout = self.layout(
@@ -1220,9 +1222,15 @@ impl IndependentNonReplacedContents {
                 .sizes
         };
 
+        // TODO: the automatic inline size should take `justify-self` into account.
+        let automatic_inline_size = if self.is_table() {
+            Size::FitContent
+        } else {
+            Size::Stretch
+        };
         let compute_inline_size = |stretch_size| {
             content_box_sizes.inline.resolve(
-                Size::Stretch,
+                automatic_inline_size,
                 Au::zero(),
                 stretch_size,
                 get_inline_content_sizes,
@@ -1607,6 +1615,7 @@ fn solve_containing_block_padding_and_border_for_in_flow_box<'a>(
     containing_block: &ContainingBlock<'_>,
     style: &'a Arc<ComputedValues>,
     get_inline_content_sizes: impl FnOnce(&ConstraintSpace) -> ContentSizes,
+    is_table: bool,
 ) -> ContainingBlockPaddingAndBorder<'a> {
     if matches!(style.pseudo(), Some(PseudoElement::ServoAnonymousBox)) {
         // <https://drafts.csswg.org/css2/#anonymous-block-level>
@@ -1666,8 +1675,14 @@ fn solve_containing_block_padding_and_border_for_in_flow_box<'a>(
             None, /* TODO: support preferred aspect ratios on non-replaced boxes */
         ))
     };
+    // TODO: the automatic inline size should take `justify-self` into account.
+    let automatic_inline_size = if is_table {
+        Size::FitContent
+    } else {
+        Size::Stretch
+    };
     let inline_size = content_box_sizes.inline.resolve(
-        Size::Stretch,
+        automatic_inline_size,
         Au::zero(),
         available_inline_size,
         get_inline_content_sizes,

--- a/tests/wpt/meta/css/css-align/abspos/table-justify-self-stretch.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/table-justify-self-stretch.html.ini
@@ -1,10 +1,4 @@
 [table-justify-self-stretch.html]
-  [.item 1]
-    expected: FAIL
-
-  [.item 3]
-    expected: FAIL
-
   [.item 5]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-flexbox/table-as-item-inflexible-in-row-1.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/table-as-item-inflexible-in-row-1.html.ini
@@ -1,2 +1,0 @@
-[table-as-item-inflexible-in-row-1.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/table-as-item-inflexible-in-row-2.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/table-as-item-inflexible-in-row-2.html.ini
@@ -1,2 +1,0 @@
-[table-as-item-inflexible-in-row-2.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/table-as-item-narrow-content.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/table-as-item-narrow-content.html.ini
@@ -1,2 +1,0 @@
-[table-as-item-narrow-content.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/table-as-item-stretch-cross-size-3.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/table-as-item-stretch-cross-size-3.html.ini
@@ -1,2 +1,0 @@
-[table-as-item-stretch-cross-size-3.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/table-item-flex-percentage-min-width.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/table-item-flex-percentage-min-width.html.ini
@@ -1,2 +1,0 @@
-[table-item-flex-percentage-min-width.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-grid/grid-items/explicitly-sized-grid-item-as-table.html.ini
+++ b/tests/wpt/meta/css/css-grid/grid-items/explicitly-sized-grid-item-as-table.html.ini
@@ -1,2 +1,0 @@
-[explicitly-sized-grid-item-as-table.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-tables/tentative/td-box-sizing-003.html.ini
+++ b/tests/wpt/meta/css/css-tables/tentative/td-box-sizing-003.html.ini
@@ -1,6 +1,3 @@
 [td-box-sizing-003.html]
-  [table 9]
-    expected: FAIL
-
   [table 10]
     expected: FAIL


### PR DESCRIPTION
A box is usually sized by the formatting context in which it participates. However, tables have some special sizing behaviors, and these were in conflict.

Instead of letting tables attempt to re-resolve their inline table, which failed to e.g. take flex properties into account or resolve sizing keywords correctly, now tables will trust the inline size determined by the parent. They will only floor it by the min-content size, and maybe shrink the final size due to collapsed columns.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
