### PR TITLE
layout: Don't use `content_inline_size_for_table` in taffy

### DIFF
--- a/components/layout_2020/taffy/layout.rs
+++ b/components/layout_2020/taffy/layout.rs
@@ -596,9 +596,7 @@ impl TaffyContainer {
         IndependentLayout {
             fragments,
             content_block_size: Au::from_f32_px(output.size.height) - pbm.padding_border_sums.block,
-            content_inline_size_for_table: Some(
-                Au::from_f32_px(output.size.width) - pbm.padding_border_sums.inline,
-            ),
+            content_inline_size_for_table: None,
             baselines: Baselines::default(),
 
             // TODO: determine this accurately


### PR DESCRIPTION
`content_inline_size_for_table` is an override for table layout. We only use taffy for grid layout, not for table layout.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because at the moment there doesn't seem to be a difference in behavior

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
