### PR TITLE
layout: Assert that GRIDMIN <= GRIDMAX

### DIFF
--- a/components/layout_2020/table/layout.rs
+++ b/components/layout_2020/table/layout.rs
@@ -753,11 +753,11 @@ impl<'a> TableLayout<'a> {
             .fold(ContentSizes::zero(), |result, measure| {
                 result + measure.content_sizes
             });
-
-        // TODO: GRIDMAX should never be smaller than GRIDMIN!
-        grid_min_max
-            .max_content
-            .max_assign(grid_min_max.min_content);
+        assert!(
+            grid_min_max.min_content <= grid_min_max.max_content,
+            "GRIDMAX should never be smaller than GRIDMIN {:?}",
+            grid_min_max
+        );
 
         let inline_border_spacing = self.table.total_border_spacing().inline;
         grid_min_max.min_content += inline_border_spacing;


### PR DESCRIPTION
In the past this didn't hold, so we had to floor GRIDMAX by GRIDMIN. We must have fixed some bugs because now it's fine to just assert it.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because there is no behavior change

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
