### PR TITLE
Update xcomponent-sys to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,6 +230,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arkui-sys"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "283c4ba7ec4317108737fadc5ed469ef1084e54607b74504ea71fb9516b4ca00"
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5203,9 +5209,6 @@ name = "ohos-sys"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a786868a20866e5682c6666ebd84435563d7ff2d6088576d958c1bb7475e460"
-dependencies = [
- "xcomponent-sys",
-]
 
 [[package]]
 name = "ohos-vsync"
@@ -6716,7 +6719,6 @@ dependencies = [
  "nix",
  "ohos-ime",
  "ohos-ime-sys",
- "ohos-sys",
  "ohos-vsync",
  "raw-window-handle",
  "rustls",
@@ -9018,10 +9020,11 @@ dependencies = [
 
 [[package]]
 name = "xcomponent-sys"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "663e26cce4f574daf506a01f4e5cfedd5355c60afebc30daeeeea95f38f6b600"
+checksum = "5614071fe8188485b9e9494da95a579331de83faa528095cd3182867116f5d58"
 dependencies = [
+ "arkui-sys",
  "keyboard-types",
 ]
 

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -89,11 +89,10 @@ ipc-channel = { workspace = true, features = ["force-inprocess"] }
 hilog = "0.1.1"
 napi-derive-ohos = "1.0.3"
 napi-ohos = "1.0.3"
-ohos-sys = { version = "0.4.0", features = ["xcomponent"] }
 ohos-vsync = "0.1.2"
 ohos-ime = { version = "0.2" }
 ohos-ime-sys = "0.1.2"
-xcomponent-sys = { version = "0.1.1", features = ["api-12", "keyboard-types"] }
+xcomponent-sys = { version = "0.2.0", features = ["api-12", "keyboard-types"] }
 
 [target.'cfg(any(target_os = "android", target_env = "ohos"))'.dependencies]
 nix = { workspace = true, features = ["fs"] }

--- a/ports/servoshell/egl/ohos.rs
+++ b/ports/servoshell/egl/ohos.rs
@@ -20,20 +20,18 @@ use napi_ohos::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallM
 use napi_ohos::{Env, JsObject, JsString, NapiRaw};
 use ohos_ime::{AttachOptions, Ime, ImeProxy, RawTextEditorProxy};
 use ohos_ime_sys::types::InputMethod_EnterKeyType;
-use ohos_sys::xcomponent::{
-    OH_NativeXComponent, OH_NativeXComponent_Callback, OH_NativeXComponent_GetKeyEvent,
-    OH_NativeXComponent_GetKeyEventAction, OH_NativeXComponent_GetTouchEvent,
-    OH_NativeXComponent_KeyEvent, OH_NativeXComponent_RegisterCallback,
-    OH_NativeXComponent_RegisterKeyEventCallback, OH_NativeXComponent_TouchEvent,
-    OH_NativeXComponent_TouchEventType,
-};
 use servo::compositing::windowing::EmbedderEvent;
 use servo::embedder_traits;
 use servo::embedder_traits::{InputMethodType, PromptResult};
 use servo::style::Zero;
 use simpleservo::EventLoopWaker;
 use xcomponent_sys::{
-    OH_NativeXComponent_GetKeyEventCode, OH_NativeXComponent_KeyAction, OH_NativeXComponent_KeyCode,
+    OH_NativeXComponent, OH_NativeXComponent_Callback, OH_NativeXComponent_GetKeyEvent,
+    OH_NativeXComponent_GetKeyEventAction, OH_NativeXComponent_GetKeyEventCode,
+    OH_NativeXComponent_GetTouchEvent, OH_NativeXComponent_KeyAction, OH_NativeXComponent_KeyCode,
+    OH_NativeXComponent_KeyEvent, OH_NativeXComponent_RegisterCallback,
+    OH_NativeXComponent_RegisterKeyEventCallback, OH_NativeXComponent_TouchEvent,
+    OH_NativeXComponent_TouchEventType,
 };
 
 use super::host_trait::HostTrait;

--- a/ports/servoshell/egl/ohos/simpleservo.rs
+++ b/ports/servoshell/egl/ohos/simpleservo.rs
@@ -8,7 +8,6 @@ use std::path::PathBuf;
 use std::rc::Rc;
 
 use log::{debug, error, info};
-use ohos_sys::xcomponent::{OH_NativeXComponent, OH_NativeXComponent_GetXComponentSize};
 use servo::base::id::WebViewId;
 use servo::compositing::windowing::EmbedderEvent;
 use servo::compositing::CompositeTarget;
@@ -24,6 +23,7 @@ use servo::servo_url::ServoUrl;
 use servo::webrender_traits::RenderingContext;
 use servo::{self, Servo};
 use surfman::{Connection, SurfaceType};
+use xcomponent_sys::{OH_NativeXComponent, OH_NativeXComponent_GetXComponentSize};
 
 use crate::egl::host_trait::HostTrait;
 use crate::egl::ohos::resources::ResourceReaderInstance;


### PR DESCRIPTION
Use xcomponent exclusively via `xcomponent_sys` instead of using some of the APIs from ohos-sys.
ohos-sys simply re-exports xcomponent-sys,
so using both makes updating either difficult.


---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

