### PR TITLE
layout: Set padding to zero on tables in collapsed-borders mode

### DIFF
--- a/components/layout_2020/geom.rs
+++ b/components/layout_2020/geom.rs
@@ -343,7 +343,7 @@ impl<T: Copy> LogicalSides<T> {
     }
 }
 
-impl LogicalSides<&'_ LengthPercentage> {
+impl LogicalSides<LengthPercentage> {
     pub fn percentages_relative_to(&self, basis: Au) -> LogicalSides<Au> {
         self.map(|value| value.to_used_value(basis))
     }

--- a/tests/wpt/tests/css/CSS2/tables/collapsing-border-model-011.html
+++ b/tests/wpt/tests/css/CSS2/tables/collapsing-border-model-011.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<title>CSS Test: Tables under the collapsing borders model don't have padding</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#collapsing-borders">
+<link rel="match" href="../../reference/ref-filled-green-100px-square-only.html">
+<style>
+table {
+  border-collapse: collapse;
+  box-sizing: content-box;
+  width: 100px;
+  height: 100px;
+  padding: 100px;
+  background: green;
+}
+</style>
+<p>Test passes if there is a filled green square.</p>
+<table></table>

--- a/tests/wpt/tests/css/CSS2/tables/collapsing-border-model-012.html
+++ b/tests/wpt/tests/css/CSS2/tables/collapsing-border-model-012.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<title>CSS Test: Tables under the collapsing borders model don't have padding</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#collapsing-borders">
+<link rel="match" href="../../reference/ref-filled-green-100px-square-only.html">
+<style>
+table {
+  border-collapse: collapse;
+  box-sizing: border-box;
+  width: 100px;
+  height: 100px;
+  padding: 100px;
+  background: green;
+}
+</style>
+<p>Test passes if there is a filled green square.</p>
+<table></table>

--- a/tests/wpt/tests/css/CSS2/tables/collapsing-border-model-013.html
+++ b/tests/wpt/tests/css/CSS2/tables/collapsing-border-model-013.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<title>CSS Test: Tables under the collapsing borders model don't have padding</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#collapsing-borders">
+<link rel="match" href="../../reference/ref-filled-green-100px-square-only.html">
+<style>
+div {
+  float: left;
+  background: green;
+}
+table {
+  border-collapse: collapse;
+  box-sizing: content-box;
+  width: 100px;
+  height: 100px;
+  padding: 100px;
+}
+</style>
+<p>Test passes if there is a filled green square.</p>
+<div>
+  <table></table>
+</div>

--- a/tests/wpt/tests/css/CSS2/tables/collapsing-border-model-014.html
+++ b/tests/wpt/tests/css/CSS2/tables/collapsing-border-model-014.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<title>CSS Test: Tables under the collapsing borders model don't have padding</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#collapsing-borders">
+<link rel="match" href="../../reference/ref-filled-green-100px-square-only.html">
+<style>
+div {
+  float: left;
+  background: green;
+}
+table {
+  border-collapse: collapse;
+  box-sizing: border-box;
+  width: 100px;
+  height: 100px;
+  padding: 100px;
+}
+</style>
+<p>Test passes if there is a filled green square.</p>
+<div>
+  <table></table>
+</div>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
https://drafts.csswg.org/css2/#collapsing-borders
> in this model, a table does not have padding

https://drafts.csswg.org/css-tables/#collapsed-style-overrides
> The padding of the table-root is ignored (as if it was set to 0px).

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
