### PR TITLE
script: Downgrade noisy debug logs.

### DIFF
--- a/components/script/dom/bindings/refcounted.rs
+++ b/components/script/dom/bindings/refcounted.rs
@@ -265,7 +265,7 @@ impl LiveDOMReferences {
         let capacity = table.capacity();
         let len = table.len();
         if (0 < capacity) && (capacity <= len) {
-            info!("growing refcounted references by {}", len);
+            trace!("growing refcounted references by {}", len);
             remove_nulls(&mut table);
             table.reserve(len);
         }
@@ -294,7 +294,7 @@ fn remove_nulls<K: Eq + Hash + Clone, V>(table: &mut HashMap<K, Weak<V>>) {
         .filter(|&(_, value)| Weak::upgrade(value).is_none())
         .map(|(key, _)| key.clone())
         .collect();
-    info!("removing {} refcounted references", to_remove.len());
+    trace!("removing {} refcounted references", to_remove.len());
     for key in to_remove {
         table.remove(&key);
     }
@@ -303,7 +303,7 @@ fn remove_nulls<K: Eq + Hash + Clone, V>(table: &mut HashMap<K, Weak<V>>) {
 /// A JSTraceDataOp for tracing reflectors held in LIVE_REFERENCES
 #[allow(crown::unrooted_must_root)]
 pub unsafe fn trace_refcounted_objects(tracer: *mut JSTracer) {
-    info!("tracing live refcounted references");
+    trace!("tracing live refcounted references");
     LIVE_REFERENCES.with(|r| {
         let r = r.borrow();
         let live_references = r.as_ref().unwrap();

--- a/components/script/dom/bindings/root.rs
+++ b/components/script/dom/bindings/root.rs
@@ -299,7 +299,7 @@ impl RootCollection {
 
 /// SM Callback that traces the rooted reflectors
 pub unsafe fn trace_roots(tracer: *mut JSTracer) {
-    debug!("tracing stack roots");
+    trace!("tracing stack roots");
     STACK_ROOTS.with(|collection| {
         let collection = &*(*collection.get().unwrap()).roots.get();
         for root in collection {

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -892,12 +892,12 @@ unsafe extern "C" fn trace_rust_roots(tr: *mut JSTracer, _data: *mut os::raw::c_
     if !THREAD_ACTIVE.with(|t| t.get()) {
         return;
     }
-    debug!("starting custom root handler");
+    trace!("starting custom root handler");
     trace_thread(tr);
     trace_roots(tr);
     trace_refcounted_objects(tr);
     settings_stack::trace(tr);
-    debug!("done custom root handler");
+    trace!("done custom root handler");
 }
 
 #[allow(unsafe_code)]

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -176,7 +176,7 @@ pub(crate) fn with_script_thread<R: Default>(f: impl FnOnce(&ScriptThread) -> R)
 /// or else the garbage collector may end up collecting objects that are still reachable.
 pub unsafe fn trace_thread(tr: *mut JSTracer) {
     with_script_thread(|script_thread| {
-        debug!("tracing fields of ScriptThread");
+        trace!("tracing fields of ScriptThread");
         script_thread.trace(tr);
     })
 }


### PR DESCRIPTION
Every time I use `RUST_LOG=script=debug` I regret it. These particular log messages are low signal and high noise.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they are debug logs.