### PR TITLE
Add http2 feature for hyper-util

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ http-body-util = "0.1"
 hyper = "1.0"
 hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "logging", "tls12", "webpki-tokio"] }
 hyper_serde = { path = "components/hyper_serde" }
-hyper-util = "0.1"
+hyper-util = { version = "0.1", features = ["client", "client-legacy", "http2", "tokio"] }
 icu_segmenter = "1.5.0"
 image = "0.24"
 imsz = "0.2"

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -37,7 +37,7 @@ http-body-util = { workspace = true }
 hyper = { workspace = true, features = ["client", "http1", "http2"] }
 hyper-rustls = { workspace = true }
 hyper_serde = { workspace = true }
-hyper-util = { workspace = true, features = ["client", "client-legacy", "tokio"] }
+hyper-util = { workspace = true }
 imsz = { workspace = true }
 ipc-channel = { workspace = true }
 log = { workspace = true }

--- a/components/shared/net/Cargo.toml
+++ b/components/shared/net/Cargo.toml
@@ -23,7 +23,7 @@ headers = { workspace = true }
 http = { workspace = true }
 hyper = { workspace = true }
 hyper_serde = { workspace = true }
-hyper-util = { workspace = true, features = ["client-legacy"] }
+hyper-util = { workspace = true }
 ipc-channel = { workspace = true }
 log = { workspace = true }
 malloc_size_of = { workspace = true }


### PR DESCRIPTION
This fixes an error when running `./mach clippy -r -p layout_2020`.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #34890
- [X] These changes do not require tests because it's just a compile error fix

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
