### PR TITLE
layout: Minor tweaks for table layout

### DIFF
--- a/components/layout_2020/table/layout.rs
+++ b/components/layout_2020/table/layout.rs
@@ -2101,14 +2101,14 @@ impl<'a> TableLayout<'a> {
         //
         // This rectangle is an offset between the row fragment and the other table
         // part rectangle (row group, column, column group). Everything between them
-        // is laid out in a left-to-right fashion, but respecting the veritcality of
+        // is laid out in a left-to-right fashion, but respecting the verticality of
         // the writing mode. This is why below, only the axes are flipped, but the
         // rectangle is not flipped for RTL.
         let make_relative_to_row_start = |mut rect: LogicalRect<Au>| {
             rect.start_corner -= row_fragment_layout.rect.start_corner;
-            let writing_mode = row_fragment_layout.containing_block.style.writing_mode;
+            let writing_mode = self.table.style.writing_mode;
             PhysicalRect::new(
-                if !writing_mode.is_vertical() {
+                if writing_mode.is_horizontal() {
                     PhysicalPoint::new(rect.start_corner.inline, rect.start_corner.block)
                 } else {
                     PhysicalPoint::new(rect.start_corner.block, rect.start_corner.inline)


### PR DESCRIPTION
 - Fix a typo in a comment.
 - Get the writing mode of the table in a less convoluted way.
 - Check `is_horizontal()` instead of `!is_vertical()`

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because there is no change in behavior

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
