### PR TITLE
layout: grid-template getComputedStyle cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -945,7 +945,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1850,7 +1850,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2371,7 +2371,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4156,7 +4156,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5997,7 +5997,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7217,9 +7217,9 @@ dependencies = [
 
 [[package]]
 name = "taffy"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdc8cd64a014acc7597f470ba70be81639d6d310ff0dcaadd2327e32e0c00258"
+checksum = "348c37cb6f9d9f757152332fa9a6c024bcf3c1346925a033246ac47c6ca2e238"
 dependencies = [
  "arrayvec",
  "grid",
@@ -7262,7 +7262,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8544,7 +8544,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,7 +132,7 @@ style_malloc_size_of = { package = "malloc_size_of", git = "https://github.com/s
 surfman = { git = "https://github.com/servo/surfman", rev = "300789ddbda45c89e9165c31118bf1c4c07f89f6", features = ["chains"] }
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"
-taffy = { version = "0.7.2", default-features = false, features = ["std", "serde", "grid", "detailed_layout_info"] }
+taffy = { version = "0.7.4", default-features = false, features = ["std", "serde", "grid", "detailed_layout_info"] }
 thin-vec = "0.2.13"
 tikv-jemalloc-sys = "0.6.0"
 tikv-jemallocator = "0.6.0"

--- a/components/layout_2020/formatting_contexts.rs
+++ b/components/layout_2020/formatting_contexts.rs
@@ -15,7 +15,7 @@ use crate::dom_traversal::{Contents, NodeAndStyleInfo};
 use crate::flexbox::FlexContainer;
 use crate::flow::BlockFormattingContext;
 use crate::fragment_tree::{
-    BaseFragmentInfo, BoxFragment, SpecificLayoutInfo, Fragment, FragmentFlags,
+    BaseFragmentInfo, BoxFragment, Fragment, FragmentFlags, SpecificLayoutInfo,
 };
 use crate::geom::LogicalSides;
 use crate::layout_box_base::LayoutBoxBase;

--- a/components/layout_2020/formatting_contexts.rs
+++ b/components/layout_2020/formatting_contexts.rs
@@ -15,7 +15,7 @@ use crate::dom_traversal::{Contents, NodeAndStyleInfo};
 use crate::flexbox::FlexContainer;
 use crate::flow::BlockFormattingContext;
 use crate::fragment_tree::{
-    BaseFragmentInfo, BoxFragment, DetailedLayoutInfo, Fragment, FragmentFlags,
+    BaseFragmentInfo, BoxFragment, SpecificLayoutInfo, Fragment, FragmentFlags,
 };
 use crate::geom::LogicalSides;
 use crate::layout_box_base::LayoutBoxBase;
@@ -88,7 +88,7 @@ pub(crate) struct IndependentLayout {
     pub depends_on_block_constraints: bool,
 
     /// Additional information of this layout that could be used by Javascripts and devtools.
-    pub detailed_layout_info: Option<DetailedLayoutInfo>,
+    pub detailed_layout_info: Option<SpecificLayoutInfo>,
 }
 
 pub(crate) struct IndependentLayoutResult {

--- a/components/layout_2020/fragment_tree/box_fragment.rs
+++ b/components/layout_2020/fragment_tree/box_fragment.rs
@@ -20,7 +20,7 @@ use crate::geom::{
     AuOrAuto, LengthPercentageOrAuto, PhysicalPoint, PhysicalRect, PhysicalSides, ToLogical,
 };
 use crate::style_ext::ComputedValuesExt;
-use crate::taffy::DetailedTaffyGridInfo;
+use crate::taffy::SpecificTaffyGridInfo;
 
 /// Describes how a [`BoxFragment`] paints its background.
 pub(crate) enum BackgroundMode {
@@ -41,8 +41,8 @@ pub(crate) struct ExtraBackground {
 }
 
 #[derive(Clone, Debug)]
-pub(crate) enum DetailedLayoutInfo {
-    Grid(Box<DetailedTaffyGridInfo>),
+pub(crate) enum SpecificLayoutInfo {
+    Grid(Box<SpecificTaffyGridInfo>),
 }
 
 #[derive(Serialize)]
@@ -89,7 +89,7 @@ pub(crate) struct BoxFragment {
 
     /// Additional information of from layout that could be used by Javascripts and devtools.
     #[serde(skip_serializing)]
-    pub detailed_layout_info: Option<DetailedLayoutInfo>,
+    pub detailed_layout_info: Option<SpecificLayoutInfo>,
 }
 
 impl BoxFragment {
@@ -177,7 +177,7 @@ impl BoxFragment {
         self.background_mode = BackgroundMode::None;
     }
 
-    pub fn with_detailed_layout_info(mut self, info: Option<DetailedLayoutInfo>) -> Self {
+    pub fn with_detailed_layout_info(mut self, info: Option<SpecificLayoutInfo>) -> Self {
         self.detailed_layout_info = info;
         self
     }

--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -23,7 +23,7 @@ use crate::formatting_contexts::{
     IndependentFormattingContext, IndependentFormattingContextContents,
 };
 use crate::fragment_tree::{
-    BoxFragment, CollapsedBlockMargins, DetailedLayoutInfo, Fragment, FragmentFlags,
+    BoxFragment, CollapsedBlockMargins, SpecificLayoutInfo, Fragment, FragmentFlags,
     HoistedSharedFragment,
 };
 use crate::geom::{
@@ -562,7 +562,7 @@ impl HoistedAbsolutelyPositionedBox {
         let mut new_fragment = {
             let content_size: LogicalVec2<Au>;
             let fragments;
-            let mut detailed_layout_info: Option<DetailedLayoutInfo> = None;
+            let mut detailed_layout_info: Option<SpecificLayoutInfo> = None;
             match &context.contents {
                 IndependentFormattingContextContents::Replaced(replaced) => {
                     // https://drafts.csswg.org/css2/visudet.html#abs-replaced-width

--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -23,8 +23,8 @@ use crate::formatting_contexts::{
     IndependentFormattingContext, IndependentFormattingContextContents,
 };
 use crate::fragment_tree::{
-    BoxFragment, CollapsedBlockMargins, SpecificLayoutInfo, Fragment, FragmentFlags,
-    HoistedSharedFragment,
+    BoxFragment, CollapsedBlockMargins, Fragment, FragmentFlags, HoistedSharedFragment,
+    SpecificLayoutInfo,
 };
 use crate::geom::{
     AuOrAuto, LengthPercentageOrAuto, LogicalRect, LogicalSides, LogicalVec2, PhysicalPoint,

--- a/components/layout_2020/query.rs
+++ b/components/layout_2020/query.rs
@@ -40,7 +40,7 @@ use style_traits::{ParsingMode, ToCss};
 
 use crate::flow::inline::construct::{TextTransformation, WhitespaceCollapse};
 use crate::fragment_tree::{
-    BoxFragment, SpecificLayoutInfo, Fragment, FragmentFlags, FragmentTree, Tag,
+    BoxFragment, Fragment, FragmentFlags, FragmentTree, SpecificLayoutInfo, Tag,
 };
 use crate::geom::{PhysicalRect, PhysicalVec};
 use crate::taffy::SpecificTaffyGridInfo;

--- a/components/layout_2020/query.rs
+++ b/components/layout_2020/query.rs
@@ -40,10 +40,10 @@ use style_traits::{ParsingMode, ToCss};
 
 use crate::flow::inline::construct::{TextTransformation, WhitespaceCollapse};
 use crate::fragment_tree::{
-    BoxFragment, DetailedLayoutInfo, Fragment, FragmentFlags, FragmentTree, Tag,
+    BoxFragment, SpecificLayoutInfo, Fragment, FragmentFlags, FragmentTree, Tag,
 };
 use crate::geom::{PhysicalRect, PhysicalVec};
-use crate::taffy::DetailedTaffyGridInfo;
+use crate::taffy::SpecificTaffyGridInfo;
 
 pub fn process_content_box_request(
     requested_node: OpaqueNode,
@@ -234,7 +234,7 @@ pub fn process_resolved_style_request<'dom>(
             //
             // > When an element generates a grid container box...
             if display.inside() == DisplayInside::Grid {
-                if let Some(DetailedLayoutInfo::Grid(info)) = detailed_layout_info {
+                if let Some(SpecificLayoutInfo::Grid(info)) = detailed_layout_info {
                     if let Some(value) = resolve_grid_template(info, style, longhand_id) {
                         return Some(value);
                     }
@@ -285,7 +285,7 @@ fn resolved_size_should_be_used_value(fragment: &Fragment) -> bool {
 }
 
 fn resolve_grid_template(
-    grid_info: &DetailedTaffyGridInfo,
+    grid_info: &SpecificTaffyGridInfo,
     style: &ComputedValues,
     longhand_id: LonghandId,
 ) -> Option<String> {

--- a/components/layout_2020/taffy/layout.rs
+++ b/components/layout_2020/taffy/layout.rs
@@ -21,7 +21,7 @@ use crate::formatting_contexts::{
     Baselines, IndependentFormattingContext, IndependentFormattingContextContents,
     IndependentLayout,
 };
-use crate::fragment_tree::{BoxFragment, CollapsedBlockMargins, SpecificLayoutInfo, Fragment};
+use crate::fragment_tree::{BoxFragment, CollapsedBlockMargins, Fragment, SpecificLayoutInfo};
 use crate::geom::{
     LogicalSides, LogicalVec2, PhysicalPoint, PhysicalRect, PhysicalSides, PhysicalSize, Size,
     SizeConstraint, Sizes,

--- a/components/layout_2020/taffy/layout.rs
+++ b/components/layout_2020/taffy/layout.rs
@@ -13,7 +13,7 @@ use taffy::style_helpers::{TaffyMaxContent, TaffyMinContent};
 use taffy::{AvailableSpace, MaybeMath, RequestedAxis, RunMode};
 
 use super::{
-    DetailedTaffyGridInfo, TaffyContainer, TaffyItemBox, TaffyItemBoxInner, TaffyStyloStyle,
+    SpecificTaffyGridInfo, TaffyContainer, TaffyItemBox, TaffyItemBoxInner, TaffyStyloStyle,
 };
 use crate::cell::ArcRefCell;
 use crate::context::LayoutContext;
@@ -21,7 +21,7 @@ use crate::formatting_contexts::{
     Baselines, IndependentFormattingContext, IndependentFormattingContextContents,
     IndependentLayout,
 };
-use crate::fragment_tree::{BoxFragment, CollapsedBlockMargins, DetailedLayoutInfo, Fragment};
+use crate::fragment_tree::{BoxFragment, CollapsedBlockMargins, SpecificLayoutInfo, Fragment};
 use crate::geom::{
     LogicalSides, LogicalVec2, PhysicalPoint, PhysicalRect, PhysicalSides, PhysicalSize, Size,
     SizeConstraint, Sizes,
@@ -66,10 +66,10 @@ struct TaffyContainerContext<'a> {
     positioning_context: &'a mut PositioningContext,
     content_box_size_override: &'a ContainingBlock<'a>,
     style: &'a ComputedValues,
-    detailed_layout_info: Option<DetailedLayoutInfo>,
+    detailed_layout_info: Option<SpecificLayoutInfo>,
 
     /// Temporary location for children detailed info, which will be moved into child fragments
-    child_detailed_layout_infos: Vec<Option<DetailedLayoutInfo>>,
+    child_detailed_layout_infos: Vec<Option<SpecificLayoutInfo>>,
 }
 
 struct ChildIter(std::ops::Range<usize>);
@@ -328,8 +328,8 @@ impl taffy::LayoutGridContainer for TaffyContainerContext<'_> {
         _node_id: taffy::NodeId,
         detailed_layout_info: taffy::DetailedGridInfo,
     ) {
-        self.detailed_layout_info = Some(DetailedLayoutInfo::Grid(Box::new(
-            DetailedTaffyGridInfo::from_detailed_grid_layout(detailed_layout_info),
+        self.detailed_layout_info = Some(SpecificLayoutInfo::Grid(Box::new(
+            SpecificTaffyGridInfo::from_detailed_grid_layout(detailed_layout_info),
         )));
     }
 }
@@ -546,7 +546,7 @@ impl TaffyContainer {
                     .map(Au::from_f32_px),
                 );
 
-                let child_detailed_layout_info: Option<DetailedLayoutInfo> =
+                let child_detailed_layout_info: Option<SpecificLayoutInfo> =
                     std::mem::take(&mut container_ctx.child_detailed_layout_infos[child_id]);
 
                 match &mut child.taffy_level_box {

--- a/components/layout_2020/taffy/mod.rs
+++ b/components/layout_2020/taffy/mod.rs
@@ -121,15 +121,15 @@ impl TaffyItemBox {
 
 /// Details from Taffy grid layout that will be stored
 #[derive(Clone, Debug)]
-pub(crate) struct DetailedTaffyGridInfo {
-    pub rows: DetailedTaffyGridTrackInfo,
-    pub columns: DetailedTaffyGridTrackInfo,
+pub(crate) struct SpecificTaffyGridInfo {
+    pub rows: SpecificTaffyGridTrackInfo,
+    pub columns: SpecificTaffyGridTrackInfo,
 }
 
-impl DetailedTaffyGridInfo {
+impl SpecificTaffyGridInfo {
     fn from_detailed_grid_layout(grid_info: taffy::DetailedGridInfo) -> Self {
         Self {
-            rows: DetailedTaffyGridTrackInfo {
+            rows: SpecificTaffyGridTrackInfo {
                 sizes: grid_info
                     .rows
                     .sizes
@@ -137,7 +137,7 @@ impl DetailedTaffyGridInfo {
                     .map(|size| Au::from_f32_px(*size))
                     .collect(),
             },
-            columns: DetailedTaffyGridTrackInfo {
+            columns: SpecificTaffyGridTrackInfo {
                 sizes: grid_info
                     .columns
                     .sizes
@@ -150,6 +150,6 @@ impl DetailedTaffyGridInfo {
 }
 
 #[derive(Clone, Debug)]
-pub(crate) struct DetailedTaffyGridTrackInfo {
+pub(crate) struct SpecificTaffyGridTrackInfo {
     pub sizes: Box<[Au]>,
 }

--- a/tests/wpt/meta/css/css-grid/grid-definition/grid-support-flexible-lengths-001.html.ini
+++ b/tests/wpt/meta/css/css-grid/grid-definition/grid-support-flexible-lengths-001.html.ini
@@ -1,71 +1,8 @@
 [grid-support-flexible-lengths-001.html]
-  ['emptyGrid' with: grid-template-columns: 1fr; and grid-template-rows: 1fr;]
-    expected: FAIL
-
-  ['emptyGrid' with: grid-template-columns: 2fr; and grid-template-rows: 2fr;]
-    expected: FAIL
-
-  ['emptyGrid' with: grid-template-columns: 10fr; and grid-template-rows: 10fr;]
-    expected: FAIL
-
-  ['emptyGrid' with: grid-template-columns: 0.5fr; and grid-template-rows: 0.5fr;]
-    expected: FAIL
-
-  ['emptyGrid' with: grid-template-columns: .5fr; and grid-template-rows: .5fr;]
-    expected: FAIL
-
-  ['emptyGrid' with: grid-template-columns: minmax(100px, 1fr); and grid-template-rows: minmax(100px, 1fr);]
-    expected: FAIL
-
-  ['emptyGrid' with: grid-template-columns: minmax(1fr, 1fr); and grid-template-rows: minmax(1fr, 1fr);]
-    expected: FAIL
-
-  ['emptyGrid' with: grid-template-columns: 1fr 1fr; and grid-template-rows: 1fr 1fr;]
-    expected: FAIL
-
-  ['emptyGrid' with: grid-template-columns: 0.25fr 0.75fr; and grid-template-rows: 0.25fr 0.75fr;]
-    expected: FAIL
-
-  ['emptyGrid' with: grid-template-columns: 1fr 2fr 1fr; and grid-template-rows: 1fr 2fr 1fr;]
-    expected: FAIL
-
-  ['emptyGrid' with: grid-template-columns: auto 1fr 4fr 3fr 2fr; and grid-template-rows: auto 1fr 4fr 3fr 2fr;]
-    expected: FAIL
-
-  ['emptyGrid' with: grid-template-columns: 1fr 4fr 100px 3fr 2fr; and grid-template-rows: 1fr 4fr 100px 3fr 2fr;]
-    expected: FAIL
-
-  ['emptyGrid' with: grid-template-columns: auto 1fr; and grid-template-rows: auto 1fr;]
-    expected: FAIL
-
-  ['emptyGrid' with: grid-template-columns: max-content 1fr; and grid-template-rows: max-content 1fr;]
-    expected: FAIL
-
-  ['emptyGrid' with: grid-template-columns: min-content 1fr; and grid-template-rows: min-content 1fr;]
-    expected: FAIL
-
-  ['emptyGrid' with: grid-template-columns: 1fr auto; and grid-template-rows: 1fr auto;]
-    expected: FAIL
-
-  ['emptyGrid' with: grid-template-columns: 300px 1fr; and grid-template-rows: 200px 1fr;]
-    expected: FAIL
-
-  ['emptyGrid' with: grid-template-columns: 800px 1fr; and grid-template-rows: 600px 1fr;]
-    expected: FAIL
-
-  ['emptyGrid' with: grid-template-columns: 1000px 1fr; and grid-template-rows: 700px 1fr;]
-    expected: FAIL
-
   ['emptyGrid' with: grid-template-columns: calc(50px + 50%) 1fr; and grid-template-rows: calc(50px + 50%) 1fr;]
     expected: FAIL
 
   ['grid' with: grid-template-columns: calc(50px + 50%) 1fr; and grid-template-rows: calc(50px + 50%) 1fr;]
-    expected: FAIL
-
-  ['emptyGrid' with: grid-template-columns: minmax(100px, 300px) 1fr; and grid-template-rows: minmax(100px, 200px) 1fr;]
-    expected: FAIL
-
-  ['emptyGrid' with: grid-template-columns: repeat(4, 1fr); and grid-template-rows: repeat(4, 1fr);]
     expected: FAIL
 
   ['emptyGrid' with: grid-template-columns: [a\] repeat(4, [b\] 1fr [c\]) [d\]; and grid-template-rows: [z\] repeat(4, [y\] 1fr) [x\];]

--- a/tests/wpt/meta/css/css-grid/grid-definition/grid-support-grid-template-columns-rows-001.html.ini
+++ b/tests/wpt/meta/css/css-grid/grid-definition/grid-support-grid-template-columns-rows-001.html.ini
@@ -8,46 +8,16 @@
   ['grid' with: grid-template-columns: auto; and grid-template-rows: auto;]
     expected: FAIL
 
-  ['emptyGrid' with: grid-template-columns: 25%; and grid-template-rows: 50%;]
-    expected: FAIL
-
   ['emptyGrid' with: grid-template-columns: calc(200px + 10%); and grid-template-rows: calc(25% + 50px);]
     expected: FAIL
 
   ['grid' with: grid-template-columns: calc(200px + 10%); and grid-template-rows: calc(25% + 50px);]
     expected: FAIL
 
-  ['emptyGrid' with: grid-template-columns: 1fr; and grid-template-rows: 1fr;]
-    expected: FAIL
-
-  ['emptyGrid' with: grid-template-columns: max-content; and grid-template-rows: max-content;]
-    expected: FAIL
-
-  ['emptyGrid' with: grid-template-columns: min-content; and grid-template-rows: min-content;]
-    expected: FAIL
-
-  ['emptyGrid' with: grid-template-columns: minmax(200px, 400px); and grid-template-rows: minmax(50px, 100px);]
-    expected: FAIL
-
   ['emptyGrid' with: grid-template-columns: minmax(calc(10% + 200px), calc(800px - 20%)); and grid-template-rows: minmax(calc(20% + 50px), calc(600px - 10%));]
     expected: FAIL
 
   ['grid' with: grid-template-columns: minmax(calc(10% + 200px), calc(800px - 20%)); and grid-template-rows: minmax(calc(20% + 50px), calc(600px - 10%));]
-    expected: FAIL
-
-  ['emptyGrid' with: grid-template-columns: 40em 100px 15%; and grid-template-rows: 50px 20em 10%;]
-    expected: FAIL
-
-  ['emptyGrid' with: grid-template-columns: 200px 1fr; and grid-template-rows: 1fr 100px;]
-    expected: FAIL
-
-  ['emptyGrid' with: grid-template-columns: auto 1fr; and grid-template-rows: auto 1fr;]
-    expected: FAIL
-
-  ['emptyGrid' with: grid-template-columns: 1fr 3fr; and grid-template-rows: 2fr 1fr;]
-    expected: FAIL
-
-  ['emptyGrid' with: grid-template-columns: minmax(25px, 75px) 750px; and grid-template-rows: minmax(50px, 150px) 500px;]
     expected: FAIL
 
   ['emptyGrid' with: grid-template-columns: min-content 1fr calc(20px + 10%) minmax(30em, 50em); and grid-template-rows: min-content 1fr calc(10% + 40px) minmax(3em, 5em);]

--- a/tests/wpt/meta/css/css-grid/grid-definition/grid-support-repeat-001.html.ini
+++ b/tests/wpt/meta/css/css-grid/grid-definition/grid-support-repeat-001.html.ini
@@ -17,15 +17,6 @@
   ['grid' with: grid-template-columns: repeat(2, minmax(50px, calc(50px + 50%))); and grid-template-rows: repeat(2, minmax(50px, calc(50px + 50%)));]
     expected: FAIL
 
-  ['emptyGrid' with: grid-template-columns: repeat(5, 10%); and grid-template-rows: repeat(5, 10%);]
-    expected: FAIL
-
-  ['emptyGrid' with: grid-template-columns: max-content repeat(2, 25%) 1fr; and grid-template-rows: 100px repeat(2, 25%) 1fr;]
-    expected: FAIL
-
-  ['emptyGrid' with: grid-template-columns: repeat(2, min-content 50px); and grid-template-rows: repeat(2, min-content 50px);]
-    expected: FAIL
-
   ['emptyGrid' with: grid-template-columns: repeat(2, [a\] minmax(50px, 100px) [b\] 25em [c\]); and grid-template-rows: repeat(2, [a\] minmax(50px, 100px) [b\] 25em [c\]);]
     expected: FAIL
 
@@ -84,4 +75,7 @@
     expected: FAIL
 
   ['grid' with: grid-template-columns: [a\] repeat(2, [b\] 100px); and grid-template-rows: [a\] repeat(2, [b\] 100px);]
+    expected: FAIL
+
+  ['emptyGrid' with: grid-template-columns: [a\] repeat(2, [b\] 100px); and grid-template-rows: [a\] repeat(2, [b\] 100px);]
     expected: FAIL

--- a/tests/wpt/meta/css/css-grid/parsing/grid-columns-rows-get-set-multiple.html.ini
+++ b/tests/wpt/meta/css/css-grid/parsing/grid-columns-rows-get-set-multiple.html.ini
@@ -1,29 +1,8 @@
 [grid-columns-rows-get-set-multiple.html]
-  [Test getting grid-template-columns and grid-template-rows set through CSS for element 'gridWithPercentElement' : grid-template-columns = '400px 800px', grid-template-rows = '150px 450px']
-    expected: FAIL
-
   [Test getting grid-template-columns and grid-template-rows set through CSS for element 'gridWithAutoElement' : grid-template-columns = '0px 17px', grid-template-rows = '0px 3px']
     expected: FAIL
 
   [Test getting grid-template-columns and grid-template-rows set through CSS for element 'gridWithThreeItems' : grid-template-columns = '15px 0px 100px', grid-template-rows = '120px 18px 0px']
-    expected: FAIL
-
-  [Test getting grid-template-columns and grid-template-rows set through CSS for element 'gridWithMinMaxContent' : grid-template-columns = '0px 0px', grid-template-rows = '0px 0px']
-    expected: FAIL
-
-  [Test getting grid-template-columns and grid-template-rows set through CSS for element 'gridWithMinMaxAndFixed' : grid-template-columns = '240px 15px', grid-template-rows = '120px 210px']
-    expected: FAIL
-
-  [Test getting grid-template-columns and grid-template-rows set through CSS for element 'gridWithMinMaxAndMinMaxContent' : grid-template-columns = '240px 15px', grid-template-rows = '120px 210px']
-    expected: FAIL
-
-  [Test getting grid-template-columns and grid-template-rows set through CSS for element 'gridWithFractionFraction' : grid-template-columns = '320px 480px', grid-template-rows = '225px 375px']
-    expected: FAIL
-
-  [Test getting grid-template-columns and grid-template-rows set through CSS for element 'gridWithFractionMinMax' : grid-template-columns = '45px 755px', grid-template-rows = '586px 14px']
-    expected: FAIL
-
-  [Test getting grid-template-columns and grid-template-rows set through CSS for element 'gridWithCalcAndFixed' : grid-template-columns = '400px 80px', grid-template-rows = '88px 150px']
     expected: FAIL
 
   [Test getting grid-template-columns and grid-template-rows set through CSS for element 'gridWithCalcAndMinMax' : grid-template-columns = '190px 80px', grid-template-rows = '150px 53px']
@@ -35,9 +14,6 @@
   [Test getting grid-template-columns and grid-template-rows set through CSS for element 'gridWithAutoInsideMinMax' : grid-template-columns = '0px 30px', grid-template-rows = '132px 60px']
     expected: FAIL
 
-  [Test getting and setting grid-template-rows and grid-template-columns through JS: grid-template-columns = '440px 640px', element.style.gridTemplateColumns = '55% 80%', grid-template-rows = '240px 378px', element.style.gridTemplateRows = '40% 63%']
-    expected: FAIL
-
   [Test getting and setting grid-template-rows and grid-template-columns through JS: grid-template-columns = '0px 0px', element.style.gridTemplateColumns = 'auto auto', grid-template-rows = '0px 0px', element.style.gridTemplateRows = 'auto auto']
     expected: FAIL
 
@@ -45,9 +21,6 @@
     expected: FAIL
 
   [Test getting and setting grid-template-rows and grid-template-columns through JS: grid-template-columns = '160px 20px', element.style.gridTemplateColumns = '16em minmax(16px, 20px)', grid-template-rows = '90px 0px', element.style.gridTemplateRows = 'minmax(10%, 15%) auto']
-    expected: FAIL
-
-  [Test getting and setting grid-template-rows and grid-template-columns through JS: grid-template-columns = '160px 640px', element.style.gridTemplateColumns = '16em 2fr', grid-template-rows = '600px 0px', element.style.gridTemplateRows = '14fr auto']
     expected: FAIL
 
   [Test getting and setting grid-template-rows and grid-template-columns through JS: grid-template-columns = '25px 20px', element.style.gridTemplateColumns = 'calc(25px) calc(2em)', grid-template-rows = '0px 60px', element.style.gridTemplateRows = 'auto calc(10%)']


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

#### Changes

- Update Taffy version to `0.7.4`, which will fix the my bug of exposing the info of grid without any items.
- Enhancing code qualities. 
  - https://github.com/servo/servo/pull/34885#discussion_r1908546025

#### WPT Result &mdash; [Try Run](https://github.com/stevennovaryo/servo/actions/runs/12705267937)

Most the pass tests is WPT tests that uses grid without any items. Leftover subtests from the same tests are mostly related to the upcoming features and more passes are expected soon. 

WPT tests with track list that contains only `auto`(s) computed the sizes of the track incorrectly. #34925 

This also includes tests that uses keyword `none` in grid with grid items (and undefined auto-placement) and the one with incorrect value, because all of them should resolved to `auto`.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are the follow-up of #34885
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
