### PR TITLE
Implement HTMLCanvasElement.toBlob

### DIFF
--- a/components/script/dom/webidls/HTMLCanvasElement.webidl
+++ b/components/script/dom/webidls/HTMLCanvasElement.webidl
@@ -18,8 +18,10 @@ interface HTMLCanvasElement : HTMLElement {
   RenderingContext? getContext(DOMString contextId, optional any options = null);
 
   [Throws]
-  USVString toDataURL(optional DOMString type, optional any quality);
-  //void toBlob(BlobCallback _callback, optional DOMString type, optional any quality);
+  USVString toDataURL(optional DOMString type = "image/png", optional any quality);
+
+  [Throws]
+  undefined toBlob(BlobCallback callback, optional DOMString type = "image/png", optional any quality);
   //OffscreenCanvas transferControlToOffscreen();
 };
 
@@ -28,4 +30,4 @@ partial interface HTMLCanvasElement {
     MediaStream captureStream (optional double frameRequestRate);
 };
 
-//callback BlobCallback = void (Blob? blob);
+callback BlobCallback = undefined(Blob? blob);

--- a/components/script/task_manager.rs
+++ b/components/script/task_manager.rs
@@ -131,6 +131,7 @@ impl TaskManager {
             .cancel_pending_tasks_for_source(task_source_name);
     }
 
+    task_source_functions!(self, canvas_blob_task_source, Canvas);
     task_source_functions!(self, dom_manipulation_task_source, DOMManipulation);
     task_source_functions!(self, file_reading_task_source, FileReading);
     task_source_functions!(self, gamepad_task_source, Gamepad);

--- a/components/script/task_source.rs
+++ b/components/script/task_source.rs
@@ -24,6 +24,7 @@ use crate::task_manager::TaskManager;
 /// [`TaskSourceName::all`].
 #[derive(Clone, Copy, Debug, Eq, Hash, JSTraceable, MallocSizeOf, PartialEq)]
 pub(crate) enum TaskSourceName {
+    Canvas,
     DOMManipulation,
     FileReading,
     HistoryTraversal,
@@ -44,6 +45,7 @@ pub(crate) enum TaskSourceName {
 impl From<TaskSourceName> for ScriptThreadEventCategory {
     fn from(value: TaskSourceName) -> Self {
         match value {
+            TaskSourceName::Canvas => ScriptThreadEventCategory::ScriptEvent,
             TaskSourceName::DOMManipulation => ScriptThreadEventCategory::ScriptEvent,
             TaskSourceName::FileReading => ScriptThreadEventCategory::FileRead,
             TaskSourceName::HistoryTraversal => ScriptThreadEventCategory::HistoryEvent,
@@ -66,6 +68,7 @@ impl From<TaskSourceName> for ScriptThreadEventCategory {
 impl TaskSourceName {
     pub(crate) fn all() -> &'static [TaskSourceName] {
         &[
+            TaskSourceName::Canvas,
             TaskSourceName::DOMManipulation,
             TaskSourceName::FileReading,
             TaskSourceName::HistoryTraversal,

--- a/tests/wpt/meta/html/canvas/element/wide-gamut-canvas/2d.color.space.p3.toBlob.p3.canvas.html.ini
+++ b/tests/wpt/meta/html/canvas/element/wide-gamut-canvas/2d.color.space.p3.toBlob.p3.canvas.html.ini
@@ -1,3 +1,0 @@
-[2d.color.space.p3.toBlob.p3.canvas.html]
-  [test if toblob returns p3 data from p3 color space canvas]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/wide-gamut-canvas/2d.color.space.p3.toBlob.with.putImageData.html.ini
+++ b/tests/wpt/meta/html/canvas/element/wide-gamut-canvas/2d.color.space.p3.toBlob.with.putImageData.html.ini
@@ -1,3 +1,0 @@
-[2d.color.space.p3.toBlob.with.putImageData.html]
-  [Use putImageData to put some p3 data in canvas and test if toBlob returns the same data]
-    expected: FAIL

--- a/tests/wpt/meta/html/dom/idlharness.https.html.ini
+++ b/tests/wpt/meta/html/dom/idlharness.https.html.ini
@@ -7915,16 +7915,7 @@
   [HTMLSlotElement interface: calling assign((Element or Text)...) on document.createElement("slot") with too few arguments must throw TypeError]
     expected: FAIL
 
-  [HTMLCanvasElement interface: operation toBlob(BlobCallback, optional DOMString, optional any)]
-    expected: FAIL
-
   [HTMLCanvasElement interface: operation transferControlToOffscreen()]
-    expected: FAIL
-
-  [HTMLCanvasElement interface: document.createElement("canvas") must inherit property "toBlob(BlobCallback, optional DOMString, optional any)" with the proper type]
-    expected: FAIL
-
-  [HTMLCanvasElement interface: calling toBlob(BlobCallback, optional DOMString, optional any) on document.createElement("canvas") with too few arguments must throw TypeError]
     expected: FAIL
 
   [HTMLCanvasElement interface: document.createElement("canvas") must inherit property "transferControlToOffscreen()" with the proper type]

--- a/tests/wpt/meta/html/semantics/embedded-content/the-canvas-element/toBlob-cross-realm-callback-report-exception.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/the-canvas-element/toBlob-cross-realm-callback-report-exception.html.ini
@@ -1,3 +1,0 @@
-[toBlob-cross-realm-callback-report-exception.html]
-  [toBlob() reports the exception from its callback in the callback's global object]
-    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/the-canvas-element/toBlob.jpeg.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/the-canvas-element/toBlob.jpeg.html.ini
@@ -1,3 +1,0 @@
-[toBlob.jpeg.html]
-  [toBlob with image/jpeg returns a JPEG Blob]
-    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/the-canvas-element/toBlob.null.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/the-canvas-element/toBlob.null.html.ini
@@ -1,3 +1,0 @@
-[toBlob.null.html]
-  [toBlob with zero dimension returns a null Blob]
-    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/the-canvas-element/toBlob.png.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/the-canvas-element/toBlob.png.html.ini
@@ -1,3 +1,0 @@
-[toBlob.png.html]
-  [toBlob with image/png returns a PNG Blob]
-    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/the-img-element/currentSrc-blob-cache.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/the-img-element/currentSrc-blob-cache.html.ini
@@ -1,4 +1,0 @@
-[currentSrc-blob-cache.html]
-  [currentSrc is right even if underlying image is a shared blob]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/tasks.window.js.ini
+++ b/tests/wpt/meta/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/tasks.window.js.ini
@@ -1,7 +1,0 @@
-[tasks.window.html]
-  [document.open() and tasks (canvas.toBlob())]
-    expected: FAIL
-
-  [tasks without document.open() (canvas.toBlob())]
-    expected: FAIL
-


### PR DESCRIPTION
This refactors some of the code that is shared with toDataURL, and update the webidl definition to match the current spec (using a default value for the mime type).

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [X] There are tests for these changes: wpt expectations are updated.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
