### PR TITLE
layout: Improve logic for block size of table

### DIFF
--- a/components/layout_2020/geom.rs
+++ b/components/layout_2020/geom.rs
@@ -733,22 +733,6 @@ impl From<StyleMaxSize> for Size<LengthPercentage> {
 }
 
 impl LogicalVec2<Size<LengthPercentage>> {
-    pub(crate) fn percentages_relative_to(
-        &self,
-        containing_block: &ContainingBlock,
-    ) -> LogicalVec2<Size<Au>> {
-        self.map_inline_and_block_axes(
-            |inline_size| inline_size.map(|lp| lp.to_used_value(containing_block.size.inline)),
-            |block_size| {
-                block_size
-                    .maybe_map(|lp| {
-                        lp.maybe_to_used_value(containing_block.size.block.to_definite())
-                    })
-                    .unwrap_or_default()
-            },
-        )
-    }
-
     pub(crate) fn maybe_percentages_relative_to_basis(
         &self,
         basis: &LogicalVec2<Option<Au>>,

--- a/components/layout_2020/style_ext.rs
+++ b/components/layout_2020/style_ext.rs
@@ -263,31 +263,11 @@ pub(crate) trait ComputedValuesExt {
         &self,
         containing_block_writing_mode: WritingMode,
     ) -> LogicalVec2<Size<LengthPercentage>>;
-    fn content_box_size(
-        &self,
-        containing_block: &ContainingBlock,
-        pbm: &PaddingBorderMargin,
-    ) -> LogicalVec2<Size<Au>>;
-    fn content_box_size_deprecated(
-        &self,
-        containing_block: &ContainingBlock,
-        pbm: &PaddingBorderMargin,
-    ) -> LogicalVec2<AuOrAuto>;
     fn content_box_size_for_box_size(
         &self,
         box_size: LogicalVec2<Size<Au>>,
         pbm: &PaddingBorderMargin,
     ) -> LogicalVec2<Size<Au>>;
-    fn content_min_box_size(
-        &self,
-        containing_block: &ContainingBlock,
-        pbm: &PaddingBorderMargin,
-    ) -> LogicalVec2<Size<Au>>;
-    fn content_min_box_size_deprecated(
-        &self,
-        containing_block: &ContainingBlock,
-        pbm: &PaddingBorderMargin,
-    ) -> LogicalVec2<AuOrAuto>;
     fn content_min_box_size_for_min_size(
         &self,
         box_size: LogicalVec2<Size<Au>>,
@@ -418,26 +398,6 @@ impl ComputedValuesExt for ComputedValues {
         )
     }
 
-    fn content_box_size(
-        &self,
-        containing_block: &ContainingBlock,
-        pbm: &PaddingBorderMargin,
-    ) -> LogicalVec2<Size<Au>> {
-        let box_size = self
-            .box_size(containing_block.style.writing_mode)
-            .percentages_relative_to(containing_block);
-        self.content_box_size_for_box_size(box_size, pbm)
-    }
-
-    fn content_box_size_deprecated(
-        &self,
-        containing_block: &ContainingBlock,
-        pbm: &PaddingBorderMargin,
-    ) -> LogicalVec2<AuOrAuto> {
-        self.content_box_size(containing_block, pbm)
-            .map(Size::to_auto_or)
-    }
-
     fn content_box_size_for_box_size(
         &self,
         box_size: LogicalVec2<Size<Au>>,
@@ -452,32 +412,6 @@ impl ComputedValuesExt for ComputedValues {
                 |value| value - pbm.padding_border_sums.block,
             ),
         }
-    }
-
-    fn content_min_box_size(
-        &self,
-        containing_block: &ContainingBlock,
-        pbm: &PaddingBorderMargin,
-    ) -> LogicalVec2<Size<Au>> {
-        let min_size = self
-            .min_box_size(containing_block.style.writing_mode)
-            .map_inline_and_block_sizes(
-                |lp| lp.to_used_value(containing_block.size.inline),
-                |lp| {
-                    let cbbs = containing_block.size.block.to_definite();
-                    lp.to_used_value(cbbs.unwrap_or_else(Au::zero))
-                },
-            );
-        self.content_min_box_size_for_min_size(min_size, pbm)
-    }
-
-    fn content_min_box_size_deprecated(
-        &self,
-        containing_block: &ContainingBlock,
-        pbm: &PaddingBorderMargin,
-    ) -> LogicalVec2<AuOrAuto> {
-        self.content_min_box_size(containing_block, pbm)
-            .map(Size::to_auto_or)
     }
 
     fn content_min_box_size_for_min_size(

--- a/tests/wpt/meta/css/css-align/abspos/table-align-self-stretch.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/table-align-self-stretch.html.ini
@@ -1,10 +1,4 @@
 [table-align-self-stretch.html]
-  [.item 1]
-    expected: FAIL
-
-  [.item 3]
-    expected: FAIL
-
   [.item 5]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-flexbox/flexbox-align-self-horiz-001-table.xhtml.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-align-self-horiz-001-table.xhtml.ini
@@ -1,2 +1,0 @@
-[flexbox-align-self-horiz-001-table.xhtml]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/table-as-item-inflexible-in-column-1.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/table-as-item-inflexible-in-column-1.html.ini
@@ -1,2 +1,0 @@
-[table-as-item-inflexible-in-column-1.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/table-as-item-inflexible-in-column-2.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/table-as-item-inflexible-in-column-2.html.ini
@@ -1,2 +1,0 @@
-[table-as-item-inflexible-in-column-2.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/table-as-item-min-height-1.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/table-as-item-min-height-1.html.ini
@@ -1,2 +1,0 @@
-[table-as-item-min-height-1.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/table-as-item-narrow-content-2.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/table-as-item-narrow-content-2.html.ini
@@ -1,2 +1,0 @@
-[table-as-item-narrow-content-2.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/table-as-item-specified-width-vertical.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/table-as-item-specified-width-vertical.html.ini
@@ -1,2 +1,0 @@
-[table-as-item-specified-width-vertical.html]
-  expected: FAIL


### PR DESCRIPTION
The containing block for children already has the size coming from the style and the rules of the parent formatting context, so no need to try to recompute it.

This allows removing a bunch of functions, and fixes some problems when the table is a flex item.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
