### PR TITLE
CSS Grid: percentage sizing fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2754,9 +2754,9 @@ dependencies = [
 
 [[package]]
 name = "grid"
-version = "0.15.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36119f3a540b086b4e436bb2b588cf98a68863470e0e880f4d0842f112a3183a"
+checksum = "71b01d27060ad58be4663b9e4ac9e2d4806918e8876af8912afbddd1a91d5eaa"
 
 [[package]]
 name = "gstreamer"
@@ -7607,9 +7607,9 @@ dependencies = [
 
 [[package]]
 name = "taffy"
-version = "0.7.7"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab4f4d046dd956a47a7e1a2947083d7ac3e6aa3cfaaead36173ceaa5ab11878c"
+checksum = "7aaef0ac998e6527d6d0d5582f7e43953bb17221ac75bb8eb2fcc2db3396db1c"
 dependencies = [
  "arrayvec",
  "grid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,7 +145,7 @@ stylo_traits = { git = "https://github.com/servo/stylo", branch = "2025-05-01" }
 surfman = { git = "https://github.com/servo/surfman", rev = "f7688b4585f9e0b5d4bf8ee8e4a91e82349610b1", features = ["chains"] }
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"
-taffy = { version = "0.7.7", default-features = false, features = ["detailed_layout_info", "grid", "serde", "std"] }
+taffy = { version = "0.8.3", default-features = false, features = ["detailed_layout_info", "grid", "serde", "std"] }
 thin-vec = "0.2.14"
 tikv-jemalloc-sys = "0.6.0"
 tikv-jemallocator = "0.6.0"

--- a/components/layout/taffy/layout.rs
+++ b/components/layout/taffy/layout.rs
@@ -107,7 +107,7 @@ impl taffy::LayoutPartialTree for TaffyContainerContext<'_> {
         Self: 'a;
 
     fn get_core_container_style(&self, _node_id: taffy::NodeId) -> Self::CoreContainerStyle<'_> {
-        TaffyStyloStyle(self.style)
+        TaffyStyloStyle::new(self.style, false /* is_replaced */)
     }
 
     fn set_unrounded_layout(&mut self, node_id: taffy::NodeId, layout: &taffy::Layout) {
@@ -311,7 +311,7 @@ impl taffy::LayoutGridContainer for TaffyContainerContext<'_> {
         &self,
         _node_id: taffy::prelude::NodeId,
     ) -> Self::GridContainerStyle<'_> {
-        TaffyStyloStyle(self.style)
+        TaffyStyloStyle::new(self.style, false /* is_replaced */)
     }
 
     fn get_grid_child_style(
@@ -320,7 +320,9 @@ impl taffy::LayoutGridContainer for TaffyContainerContext<'_> {
     ) -> Self::GridItemStyle<'_> {
         let id = usize::from(child_node_id);
         let child = (*self.source_child_nodes[id]).borrow();
-        TaffyStyloStyle(AtomicRef::map(child, |c| &*c.style))
+        let is_replaced = child.is_in_flow_replaced();
+        let stylo_style = AtomicRef::map(child, |c| &*c.style);
+        TaffyStyloStyle::new(stylo_style, is_replaced)
     }
 
     fn set_detailed_grid_info(

--- a/components/layout/taffy/layout.rs
+++ b/components/layout/taffy/layout.rs
@@ -320,6 +320,7 @@ impl taffy::LayoutGridContainer for TaffyContainerContext<'_> {
     ) -> Self::GridItemStyle<'_> {
         let id = usize::from(child_node_id);
         let child = (*self.source_child_nodes[id]).borrow();
+        // TODO: account for non-replaced elements that are "compressible replaced"
         let is_replaced = child.is_in_flow_replaced();
         let stylo_style = AtomicRef::map(child, |c| &*c.style);
         TaffyStyloStyle::new(stylo_style, is_replaced)

--- a/components/layout/taffy/mod.rs
+++ b/components/layout/taffy/mod.rs
@@ -19,7 +19,9 @@ use crate::construct_modern::{ModernContainerBuilder, ModernItemKind};
 use crate::context::LayoutContext;
 use crate::dom::LayoutBox;
 use crate::dom_traversal::{NodeAndStyleInfo, NonReplacedContents};
-use crate::formatting_contexts::IndependentFormattingContext;
+use crate::formatting_contexts::{
+    IndependentFormattingContext, IndependentFormattingContextContents,
+};
 use crate::fragment_tree::Fragment;
 use crate::positioned::{AbsolutelyPositionedBox, PositioningContext};
 
@@ -164,6 +166,16 @@ impl TaffyItemBox {
                 .borrow_mut()
                 .context
                 .repair_style(context, node, new_style),
+        }
+    }
+
+    fn is_in_flow_replaced(&self) -> bool {
+        match &self.taffy_level_box {
+            TaffyItemBoxInner::InFlowBox(fc) => match fc.contents {
+                IndependentFormattingContextContents::NonReplaced(_) => false,
+                IndependentFormattingContextContents::Replaced(_) => true,
+            },
+            TaffyItemBoxInner::OutOfFlowAbsolutelyPositionedBox(_) => false,
         }
     }
 }

--- a/components/layout/taffy/stylo_taffy/convert.rs
+++ b/components/layout/taffy/stylo_taffy/convert.rs
@@ -41,6 +41,7 @@ pub fn length_percentage(val: &stylo::LengthPercentage) -> taffy::LengthPercenta
     match val.unpack() {
         stylo::UnpackedLengthPercentage::Length(len) => length(len.px()),
         stylo::UnpackedLengthPercentage::Percentage(percentage) => percent(percentage.0),
+        // TODO: Support calc
         stylo::UnpackedLengthPercentage::Calc(_) => percent(0.0),
     }
 }

--- a/components/layout/taffy/stylo_taffy/convert.rs
+++ b/components/layout/taffy/stylo_taffy/convert.rs
@@ -41,7 +41,7 @@ pub fn length_percentage(val: &stylo::LengthPercentage) -> taffy::LengthPercenta
     match val.unpack() {
         stylo::UnpackedLengthPercentage::Length(len) => length(len.px()),
         stylo::UnpackedLengthPercentage::Percentage(percentage) => percent(percentage.0),
-        stylo::UnpackedLengthPercentage::Calc(_) => length(0.0),
+        stylo::UnpackedLengthPercentage::Calc(_) => percent(0.0),
     }
 }
 

--- a/components/layout/taffy/stylo_taffy/convert.rs
+++ b/components/layout/taffy/stylo_taffy/convert.rs
@@ -7,6 +7,7 @@ mod stylo {
     pub(crate) use style::properties::generated::longhands::box_sizing::computed_value::T as BoxSizing;
     pub(crate) use style::properties::longhands::aspect_ratio::computed_value::T as AspectRatio;
     pub(crate) use style::properties::longhands::position::computed_value::T as Position;
+    pub(crate) use style::values::computed::length_percentage::Unpacked as UnpackedLengthPercentage;
     pub(crate) use style::values::computed::{LengthPercentage, Percentage};
     pub(crate) use style::values::generics::NonNegative;
     pub(crate) use style::values::generics::length::{
@@ -32,15 +33,15 @@ mod stylo {
     pub(crate) use style::values::specified::GenericGridTemplateComponent;
 }
 
+use taffy::MaxTrackSizingFunction;
+use taffy::style_helpers::*;
+
 #[inline]
 pub fn length_percentage(val: &stylo::LengthPercentage) -> taffy::LengthPercentage {
-    if let Some(length) = val.to_length() {
-        taffy::LengthPercentage::Length(length.px())
-    } else if let Some(val) = val.to_percentage() {
-        taffy::LengthPercentage::Percent(val.0)
-    } else {
-        // TODO: Support calc
-        taffy::LengthPercentage::Percent(0.0)
+    match val.unpack() {
+        stylo::UnpackedLengthPercentage::Length(len) => length(len.px()),
+        stylo::UnpackedLengthPercentage::Percentage(percentage) => percent(percentage.0),
+        stylo::UnpackedLengthPercentage::Calc(_) => length(0.0),
     }
 }
 
@@ -48,14 +49,14 @@ pub fn length_percentage(val: &stylo::LengthPercentage) -> taffy::LengthPercenta
 pub fn dimension(val: &stylo::Size) -> taffy::Dimension {
     match val {
         stylo::Size::LengthPercentage(val) => length_percentage(&val.0).into(),
-        stylo::Size::Auto => taffy::Dimension::Auto,
+        stylo::Size::Auto => taffy::Dimension::AUTO,
 
         // TODO: implement other values in Taffy
-        stylo::Size::MaxContent => taffy::Dimension::Auto,
-        stylo::Size::MinContent => taffy::Dimension::Auto,
-        stylo::Size::FitContent => taffy::Dimension::Auto,
-        stylo::Size::FitContentFunction(_) => taffy::Dimension::Auto,
-        stylo::Size::Stretch => taffy::Dimension::Auto,
+        stylo::Size::MaxContent => taffy::Dimension::AUTO,
+        stylo::Size::MinContent => taffy::Dimension::AUTO,
+        stylo::Size::FitContent => taffy::Dimension::AUTO,
+        stylo::Size::FitContentFunction(_) => taffy::Dimension::AUTO,
+        stylo::Size::Stretch => taffy::Dimension::AUTO,
 
         // Anchor positioning will be flagged off for time being
         stylo::Size::AnchorSizeFunction(_) => unreachable!(),
@@ -67,14 +68,14 @@ pub fn dimension(val: &stylo::Size) -> taffy::Dimension {
 pub fn max_size_dimension(val: &stylo::MaxSize) -> taffy::Dimension {
     match val {
         stylo::MaxSize::LengthPercentage(val) => length_percentage(&val.0).into(),
-        stylo::MaxSize::None => taffy::Dimension::Auto,
+        stylo::MaxSize::None => taffy::Dimension::AUTO,
 
         // TODO: implement other values in Taffy
-        stylo::MaxSize::MaxContent => taffy::Dimension::Auto,
-        stylo::MaxSize::MinContent => taffy::Dimension::Auto,
-        stylo::MaxSize::FitContent => taffy::Dimension::Auto,
-        stylo::MaxSize::FitContentFunction(_) => taffy::Dimension::Auto,
-        stylo::MaxSize::Stretch => taffy::Dimension::Auto,
+        stylo::MaxSize::MaxContent => taffy::Dimension::AUTO,
+        stylo::MaxSize::MinContent => taffy::Dimension::AUTO,
+        stylo::MaxSize::FitContent => taffy::Dimension::AUTO,
+        stylo::MaxSize::FitContentFunction(_) => taffy::Dimension::AUTO,
+        stylo::MaxSize::Stretch => taffy::Dimension::AUTO,
 
         // Anchor positioning will be flagged off for time being
         stylo::MaxSize::AnchorSizeFunction(_) => unreachable!(),
@@ -85,7 +86,7 @@ pub fn max_size_dimension(val: &stylo::MaxSize) -> taffy::Dimension {
 #[inline]
 pub fn margin(val: &stylo::MarginVal) -> taffy::LengthPercentageAuto {
     match val {
-        stylo::MarginVal::Auto => taffy::LengthPercentageAuto::Auto,
+        stylo::MarginVal::Auto => taffy::LengthPercentageAuto::AUTO,
         stylo::MarginVal::LengthPercentage(val) => length_percentage(val).into(),
 
         // Anchor positioning will be flagged off for time being
@@ -97,7 +98,7 @@ pub fn margin(val: &stylo::MarginVal) -> taffy::LengthPercentageAuto {
 #[inline]
 pub fn inset(val: &stylo::InsetVal) -> taffy::LengthPercentageAuto {
     match val {
-        stylo::InsetVal::Auto => taffy::LengthPercentageAuto::Auto,
+        stylo::InsetVal::Auto => taffy::LengthPercentageAuto::AUTO,
         stylo::InsetVal::LengthPercentage(val) => length_percentage(val).into(),
 
         // Anchor positioning will be flagged off for time being
@@ -214,7 +215,7 @@ pub fn gap(input: &stylo::Gap) -> taffy::LengthPercentage {
     match input {
         // For Flexbox and CSS Grid the "normal" value is 0px. This may need to be updated
         // if we ever implement multi-column layout.
-        stylo::Gap::Normal => taffy::LengthPercentage::Length(0.0),
+        stylo::Gap::Normal => taffy::LengthPercentage::ZERO,
         stylo::Gap::LengthPercentage(val) => length_percentage(&val.0),
     }
 }
@@ -306,16 +307,18 @@ pub fn track_size(
             max: max_track(max),
         },
         stylo::TrackSize::FitContent(limit) => taffy::MinMax {
-            min: taffy::MinTrackSizingFunction::Auto,
-            max: taffy::MaxTrackSizingFunction::FitContent(match limit {
-                stylo::TrackBreadth::Breadth(lp) => length_percentage(lp),
+            min: taffy::MinTrackSizingFunction::AUTO,
+            max: match limit {
+                stylo::TrackBreadth::Breadth(lp) => {
+                    MaxTrackSizingFunction::fit_content(length_percentage(lp))
+                },
 
                 // Are these valid? Taffy doesn't support this in any case
                 stylo::TrackBreadth::Fr(_) => unreachable!(),
                 stylo::TrackBreadth::Auto => unreachable!(),
                 stylo::TrackBreadth::MinContent => unreachable!(),
                 stylo::TrackBreadth::MaxContent => unreachable!(),
-            }),
+            },
         },
     }
 }
@@ -325,13 +328,11 @@ pub fn min_track(
     input: &stylo::TrackBreadth<stylo::LengthPercentage>,
 ) -> taffy::MinTrackSizingFunction {
     match input {
-        stylo::TrackBreadth::Breadth(lp) => {
-            taffy::MinTrackSizingFunction::Fixed(length_percentage(lp))
-        },
-        stylo::TrackBreadth::Fr(_) => taffy::MinTrackSizingFunction::Auto,
-        stylo::TrackBreadth::Auto => taffy::MinTrackSizingFunction::Auto,
-        stylo::TrackBreadth::MinContent => taffy::MinTrackSizingFunction::MinContent,
-        stylo::TrackBreadth::MaxContent => taffy::MinTrackSizingFunction::MaxContent,
+        stylo::TrackBreadth::Breadth(lp) => length_percentage(lp).into(),
+        stylo::TrackBreadth::Fr(_) => taffy::MinTrackSizingFunction::AUTO,
+        stylo::TrackBreadth::Auto => taffy::MinTrackSizingFunction::AUTO,
+        stylo::TrackBreadth::MinContent => taffy::MinTrackSizingFunction::MIN_CONTENT,
+        stylo::TrackBreadth::MaxContent => taffy::MinTrackSizingFunction::MAX_CONTENT,
     }
 }
 
@@ -340,12 +341,10 @@ pub fn max_track(
     input: &stylo::TrackBreadth<stylo::LengthPercentage>,
 ) -> taffy::MaxTrackSizingFunction {
     match input {
-        stylo::TrackBreadth::Breadth(lp) => {
-            taffy::MaxTrackSizingFunction::Fixed(length_percentage(lp))
-        },
-        stylo::TrackBreadth::Fr(val) => taffy::MaxTrackSizingFunction::Fraction(*val),
-        stylo::TrackBreadth::Auto => taffy::MaxTrackSizingFunction::Auto,
-        stylo::TrackBreadth::MinContent => taffy::MaxTrackSizingFunction::MinContent,
-        stylo::TrackBreadth::MaxContent => taffy::MaxTrackSizingFunction::MaxContent,
+        stylo::TrackBreadth::Breadth(lp) => length_percentage(lp).into(),
+        stylo::TrackBreadth::Fr(val) => fr(*val),
+        stylo::TrackBreadth::Auto => taffy::MaxTrackSizingFunction::AUTO,
+        stylo::TrackBreadth::MinContent => taffy::MaxTrackSizingFunction::MIN_CONTENT,
+        stylo::TrackBreadth::MaxContent => taffy::MaxTrackSizingFunction::MAX_CONTENT,
     }
 }

--- a/components/layout/taffy/stylo_taffy/wrapper.rs
+++ b/components/layout/taffy/stylo_taffy/wrapper.rs
@@ -10,33 +10,41 @@ use super::convert;
 
 /// A wrapper struct for anything that Deref's to a [`ComputedValues`], which
 /// implements Taffy's layout traits and can used with Taffy's layout algorithms.
-pub struct TaffyStyloStyle<T: Deref<Target = ComputedValues>>(pub T);
+pub struct TaffyStyloStyle<T: Deref<Target = ComputedValues>> {
+    pub style: T,
+    pub is_replaced: bool,
+}
 
-impl<T: Deref<Target = ComputedValues>> From<T> for TaffyStyloStyle<T> {
-    fn from(value: T) -> Self {
-        Self(value)
+impl<T: Deref<Target = ComputedValues>> TaffyStyloStyle<T> {
+    pub fn new(style: T, is_replaced: bool) -> Self {
+        Self { style, is_replaced }
     }
 }
 
 impl<T: Deref<Target = ComputedValues>> taffy::CoreStyle for TaffyStyloStyle<T> {
     #[inline]
     fn box_generation_mode(&self) -> taffy::BoxGenerationMode {
-        convert::box_generation_mode(self.0.get_box().display)
+        convert::box_generation_mode(self.style.get_box().display)
     }
 
     #[inline]
     fn is_block(&self) -> bool {
-        convert::is_block(self.0.get_box().display)
+        convert::is_block(self.style.get_box().display)
+    }
+
+    #[inline]
+    fn is_compressible_replaced(&self) -> bool {
+        self.is_replaced
     }
 
     #[inline]
     fn box_sizing(&self) -> taffy::BoxSizing {
-        convert::box_sizing(self.0.get_position().box_sizing)
+        convert::box_sizing(self.style.get_position().box_sizing)
     }
 
     #[inline]
     fn overflow(&self) -> taffy::Point<taffy::Overflow> {
-        let box_styles = self.0.get_box();
+        let box_styles = self.style.get_box();
         taffy::Point {
             x: convert::overflow(box_styles.overflow_x),
             y: convert::overflow(box_styles.overflow_y),
@@ -50,12 +58,12 @@ impl<T: Deref<Target = ComputedValues>> taffy::CoreStyle for TaffyStyloStyle<T> 
 
     #[inline]
     fn position(&self) -> taffy::Position {
-        convert::position(self.0.get_box().position)
+        convert::position(self.style.get_box().position)
     }
 
     #[inline]
     fn inset(&self) -> taffy::Rect<taffy::LengthPercentageAuto> {
-        let position_styles = self.0.get_position();
+        let position_styles = self.style.get_position();
         taffy::Rect {
             left: convert::inset(&position_styles.left),
             right: convert::inset(&position_styles.right),
@@ -66,7 +74,7 @@ impl<T: Deref<Target = ComputedValues>> taffy::CoreStyle for TaffyStyloStyle<T> 
 
     #[inline]
     fn size(&self) -> taffy::Size<taffy::Dimension> {
-        let position_styles = self.0.get_position();
+        let position_styles = self.style.get_position();
         taffy::Size {
             width: convert::dimension(&position_styles.width),
             height: convert::dimension(&position_styles.height),
@@ -75,7 +83,7 @@ impl<T: Deref<Target = ComputedValues>> taffy::CoreStyle for TaffyStyloStyle<T> 
 
     #[inline]
     fn min_size(&self) -> taffy::Size<taffy::Dimension> {
-        let position_styles = self.0.get_position();
+        let position_styles = self.style.get_position();
         taffy::Size {
             width: convert::dimension(&position_styles.min_width),
             height: convert::dimension(&position_styles.min_height),
@@ -84,7 +92,7 @@ impl<T: Deref<Target = ComputedValues>> taffy::CoreStyle for TaffyStyloStyle<T> 
 
     #[inline]
     fn max_size(&self) -> taffy::Size<taffy::Dimension> {
-        let position_styles = self.0.get_position();
+        let position_styles = self.style.get_position();
         taffy::Size {
             width: convert::max_size_dimension(&position_styles.max_width),
             height: convert::max_size_dimension(&position_styles.max_height),
@@ -93,12 +101,12 @@ impl<T: Deref<Target = ComputedValues>> taffy::CoreStyle for TaffyStyloStyle<T> 
 
     #[inline]
     fn aspect_ratio(&self) -> Option<f32> {
-        convert::aspect_ratio(self.0.get_position().aspect_ratio)
+        convert::aspect_ratio(self.style.get_position().aspect_ratio)
     }
 
     #[inline]
     fn margin(&self) -> taffy::Rect<taffy::LengthPercentageAuto> {
-        let margin_styles = self.0.get_margin();
+        let margin_styles = self.style.get_margin();
         taffy::Rect {
             left: convert::margin(&margin_styles.margin_left),
             right: convert::margin(&margin_styles.margin_right),
@@ -109,7 +117,7 @@ impl<T: Deref<Target = ComputedValues>> taffy::CoreStyle for TaffyStyloStyle<T> 
 
     #[inline]
     fn padding(&self) -> taffy::Rect<taffy::LengthPercentage> {
-        let padding_styles = self.0.get_padding();
+        let padding_styles = self.style.get_padding();
         taffy::Rect {
             left: convert::length_percentage(&padding_styles.padding_left.0),
             right: convert::length_percentage(&padding_styles.padding_right.0),
@@ -120,7 +128,7 @@ impl<T: Deref<Target = ComputedValues>> taffy::CoreStyle for TaffyStyloStyle<T> 
 
     #[inline]
     fn border(&self) -> taffy::Rect<taffy::LengthPercentage> {
-        let border_styles = self.0.get_border();
+        let border_styles = self.style.get_border();
         taffy::Rect {
             left: taffy::LengthPercentage::length(border_styles.border_left_width.to_f32_px()),
             right: taffy::LengthPercentage::length(border_styles.border_right_width.to_f32_px()),
@@ -142,32 +150,32 @@ impl<T: Deref<Target = ComputedValues>> taffy::GridContainerStyle for TaffyStylo
 
     #[inline]
     fn grid_template_rows(&self) -> Self::TemplateTrackList<'_> {
-        convert::grid_template_tracks(&self.0.get_position().grid_template_rows)
+        convert::grid_template_tracks(&self.style.get_position().grid_template_rows)
     }
 
     #[inline]
     fn grid_template_columns(&self) -> Self::TemplateTrackList<'_> {
-        convert::grid_template_tracks(&self.0.get_position().grid_template_columns)
+        convert::grid_template_tracks(&self.style.get_position().grid_template_columns)
     }
 
     #[inline]
     fn grid_auto_rows(&self) -> Self::AutoTrackList<'_> {
-        convert::grid_auto_tracks(&self.0.get_position().grid_auto_rows)
+        convert::grid_auto_tracks(&self.style.get_position().grid_auto_rows)
     }
 
     #[inline]
     fn grid_auto_columns(&self) -> Self::AutoTrackList<'_> {
-        convert::grid_auto_tracks(&self.0.get_position().grid_auto_columns)
+        convert::grid_auto_tracks(&self.style.get_position().grid_auto_columns)
     }
 
     #[inline]
     fn grid_auto_flow(&self) -> taffy::GridAutoFlow {
-        convert::grid_auto_flow(self.0.get_position().grid_auto_flow)
+        convert::grid_auto_flow(self.style.get_position().grid_auto_flow)
     }
 
     #[inline]
     fn gap(&self) -> taffy::Size<taffy::LengthPercentage> {
-        let position_styles = self.0.get_position();
+        let position_styles = self.style.get_position();
         taffy::Size {
             width: convert::gap(&position_styles.column_gap),
             height: convert::gap(&position_styles.row_gap),
@@ -176,29 +184,29 @@ impl<T: Deref<Target = ComputedValues>> taffy::GridContainerStyle for TaffyStylo
 
     #[inline]
     fn align_content(&self) -> Option<taffy::AlignContent> {
-        convert::content_alignment(self.0.get_position().align_content.0)
+        convert::content_alignment(self.style.get_position().align_content.0)
     }
 
     #[inline]
     fn justify_content(&self) -> Option<taffy::JustifyContent> {
-        convert::content_alignment(self.0.get_position().justify_content.0)
+        convert::content_alignment(self.style.get_position().justify_content.0)
     }
 
     #[inline]
     fn align_items(&self) -> Option<taffy::AlignItems> {
-        convert::item_alignment(self.0.get_position().align_items.0)
+        convert::item_alignment(self.style.get_position().align_items.0)
     }
 
     #[inline]
     fn justify_items(&self) -> Option<taffy::AlignItems> {
-        convert::item_alignment(self.0.get_position().justify_items.computed.0)
+        convert::item_alignment(self.style.get_position().justify_items.computed.0)
     }
 }
 
 impl<T: Deref<Target = ComputedValues>> taffy::GridItemStyle for TaffyStyloStyle<T> {
     #[inline]
     fn grid_row(&self) -> taffy::Line<taffy::GridPlacement> {
-        let position_styles = self.0.get_position();
+        let position_styles = self.style.get_position();
         taffy::Line {
             start: convert::grid_line(&position_styles.grid_row_start),
             end: convert::grid_line(&position_styles.grid_row_end),
@@ -207,7 +215,7 @@ impl<T: Deref<Target = ComputedValues>> taffy::GridItemStyle for TaffyStyloStyle
 
     #[inline]
     fn grid_column(&self) -> taffy::Line<taffy::GridPlacement> {
-        let position_styles = self.0.get_position();
+        let position_styles = self.style.get_position();
         taffy::Line {
             start: convert::grid_line(&position_styles.grid_column_start),
             end: convert::grid_line(&position_styles.grid_column_end),
@@ -216,11 +224,11 @@ impl<T: Deref<Target = ComputedValues>> taffy::GridItemStyle for TaffyStyloStyle
 
     #[inline]
     fn align_self(&self) -> Option<taffy::AlignSelf> {
-        convert::item_alignment(self.0.get_position().align_self.0.0)
+        convert::item_alignment(self.style.get_position().align_self.0.0)
     }
 
     #[inline]
     fn justify_self(&self) -> Option<taffy::AlignSelf> {
-        convert::item_alignment(self.0.get_position().justify_self.0.0)
+        convert::item_alignment(self.style.get_position().justify_self.0.0)
     }
 }

--- a/components/layout/taffy/stylo_taffy/wrapper.rs
+++ b/components/layout/taffy/stylo_taffy/wrapper.rs
@@ -12,12 +12,15 @@ use super::convert;
 /// implements Taffy's layout traits and can used with Taffy's layout algorithms.
 pub struct TaffyStyloStyle<T: Deref<Target = ComputedValues>> {
     pub style: T,
-    pub is_replaced: bool,
+    pub is_compressible_replaced: bool,
 }
 
 impl<T: Deref<Target = ComputedValues>> TaffyStyloStyle<T> {
-    pub fn new(style: T, is_replaced: bool) -> Self {
-        Self { style, is_replaced }
+    pub fn new(style: T, is_compressible_replaced: bool) -> Self {
+        Self {
+            style,
+            is_compressible_replaced,
+        }
     }
 }
 
@@ -34,7 +37,7 @@ impl<T: Deref<Target = ComputedValues>> taffy::CoreStyle for TaffyStyloStyle<T> 
 
     #[inline]
     fn is_compressible_replaced(&self) -> bool {
-        self.is_replaced
+        self.is_compressible_replaced
     }
 
     #[inline]

--- a/components/layout/taffy/stylo_taffy/wrapper.rs
+++ b/components/layout/taffy/stylo_taffy/wrapper.rs
@@ -122,10 +122,10 @@ impl<T: Deref<Target = ComputedValues>> taffy::CoreStyle for TaffyStyloStyle<T> 
     fn border(&self) -> taffy::Rect<taffy::LengthPercentage> {
         let border_styles = self.0.get_border();
         taffy::Rect {
-            left: taffy::LengthPercentage::Length(border_styles.border_left_width.to_f32_px()),
-            right: taffy::LengthPercentage::Length(border_styles.border_right_width.to_f32_px()),
-            top: taffy::LengthPercentage::Length(border_styles.border_top_width.to_f32_px()),
-            bottom: taffy::LengthPercentage::Length(border_styles.border_bottom_width.to_f32_px()),
+            left: taffy::LengthPercentage::length(border_styles.border_left_width.to_f32_px()),
+            right: taffy::LengthPercentage::length(border_styles.border_right_width.to_f32_px()),
+            top: taffy::LengthPercentage::length(border_styles.border_top_width.to_f32_px()),
+            bottom: taffy::LengthPercentage::length(border_styles.border_bottom_width.to_f32_px()),
         }
     }
 }

--- a/tests/wpt/meta/css/css-grid/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-002.html.ini
+++ b/tests/wpt/meta/css/css-grid/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-002.html.ini
@@ -1,2 +1,3 @@
 [grid-self-baseline-changes-grid-area-size-002.html]
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/meta/css/css-grid/implicit-grids/grid-support-grid-auto-columns-rows-003.html.ini
+++ b/tests/wpt/meta/css/css-grid/implicit-grids/grid-support-grid-auto-columns-rows-003.html.ini
@@ -1,2 +1,0 @@
-[grid-support-grid-auto-columns-rows-003.html]
-  expected: CRASH

--- a/tests/wpt/meta/css/css-grid/parsing/grid-template-columns-computed-implicit-track.html.ini
+++ b/tests/wpt/meta/css/css-grid/parsing/grid-template-columns-computed-implicit-track.html.ini
@@ -1,9 +1,5 @@
 [grid-template-columns-computed-implicit-track.html]
-  expected: CRASH
   [Property grid-template-columns value 'none' computes to '10px']
-    expected: FAIL
-
-  [Property grid-template-columns value '1px' computes to '10px 1px']
     expected: FAIL
 
   [Property grid-template-columns value '1px [a\]' computes to '10px 1px [a\]']
@@ -16,15 +12,6 @@
     expected: FAIL
 
   [Property grid-template-columns value '[a\] 1px [b\]' computes to '10px [a\] 1px [b\]']
-    expected: FAIL
-
-  [Property grid-template-columns value '1px repeat(1, 2px) 3px' computes to '10px 1px 2px 3px']
-    expected: FAIL
-
-  [Property grid-template-columns value '1px repeat(auto-fill, 2px) 3px' computes to '10px 1px 2px 3px']
-    expected: FAIL
-
-  [Property grid-template-columns value '1px repeat(auto-fit, 2px) 3px' computes to '10px 1px 0px 3px']
     expected: FAIL
 
   [Property grid-template-columns value '1px [a\] repeat(1, 2px 3px) [b\] 4px' computes to '10px 1px [a\] 2px 3px [b\] 4px']

--- a/tests/wpt/meta/css/css-grid/placement/grid-auto-flow-sparse-001.html.ini
+++ b/tests/wpt/meta/css/css-grid/placement/grid-auto-flow-sparse-001.html.ini
@@ -1,6 +1,0 @@
-[grid-auto-flow-sparse-001.html]
-  [.grid 2]
-    expected: FAIL
-
-  [.grid 6]
-    expected: FAIL


### PR DESCRIPTION
This applies some fixes for CSS Grid percentage sizing. These fixes are mostly within Taffy, but there are some changes in Servo to allow it to communicate whether an item is replaced to Taffy.

It also updates Taffy to v0.8.0. Taffy has switched to a tagged pointer representation of length/size styles. Much of the diff here is updating Servo's type conversion code to use the new representation.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes OR