### PR TITLE
introduce ReadableStreamGenericReader to share functionality between ReadableStreamDefaultReader and ReadableStreamBYOBReader

### DIFF
--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -500,6 +500,7 @@ pub(crate) mod readablestreambyobreader;
 pub(crate) mod readablestreambyobrequest;
 pub(crate) mod readablestreamdefaultcontroller;
 pub(crate) mod readablestreamdefaultreader;
+pub(crate) mod readablestreamgenericreader;
 pub(crate) mod request;
 pub(crate) mod resizeobserver;
 pub(crate) mod resizeobserverentry;

--- a/components/script/dom/readablestreambyobreader.rs
+++ b/components/script/dom/readablestreambyobreader.rs
@@ -11,6 +11,8 @@ use js::gc::CustomAutoRooterGuard;
 use js::rust::{HandleObject as SafeHandleObject, HandleValue as SafeHandleValue};
 use js::typedarray::ArrayBufferView;
 
+use super::bindings::cell::DomRefCell;
+use super::bindings::root::MutNullableDom;
 use crate::dom::bindings::codegen::Bindings::ReadableStreamBYOBReaderBinding::ReadableStreamBYOBReaderMethods;
 use crate::dom::bindings::error::Error;
 use crate::dom::bindings::import::module::Fallible;
@@ -19,24 +21,34 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
 use crate::dom::readablestream::ReadableStream;
+use crate::dom::readablestreamgenericreader::ReadableStreamGenericReader;
 use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
 
 /// <https://streams.spec.whatwg.org/#readablestreambyobreader>
 #[dom_struct]
 pub(crate) struct ReadableStreamBYOBReader {
     reflector_: Reflector,
+
+    /// <https://streams.spec.whatwg.org/#readablestreamgenericreader-stream>
+    stream: MutNullableDom<ReadableStream>,
+
+    /// <https://streams.spec.whatwg.org/#readablestreamgenericreader-closedpromise>
+    #[ignore_malloc_size_of = "Rc is hard"]
+    closed_promise: DomRefCell<Rc<Promise>>,
 }
 
 impl ReadableStreamBYOBReader {
-    fn new_inherited() -> ReadableStreamBYOBReader {
+    pub(crate) fn new_inherited(global: &GlobalScope, can_gc: CanGc) -> ReadableStreamBYOBReader {
         ReadableStreamBYOBReader {
             reflector_: Reflector::new(),
+            stream: MutNullableDom::new(None),
+            closed_promise: DomRefCell::new(Promise::new(global, can_gc)),
         }
     }
 
     fn new(global: &GlobalScope, can_gc: CanGc) -> DomRoot<ReadableStreamBYOBReader> {
         reflect_dom_object(
-            Box::new(ReadableStreamBYOBReader::new_inherited()),
+            Box::new(ReadableStreamBYOBReader::new_inherited(global, can_gc)),
             global,
             can_gc,
         )
@@ -77,5 +89,27 @@ impl ReadableStreamBYOBReaderMethods<crate::DomTypeHolder> for ReadableStreamBYO
     fn Cancel(&self, _cx: SafeJSContext, _reason: SafeHandleValue, can_gc: CanGc) -> Rc<Promise> {
         // TODO
         Promise::new(&self.reflector_.global(), can_gc)
+    }
+}
+
+impl ReadableStreamGenericReader for ReadableStreamBYOBReader {
+    fn get_closed_promise(&self) -> Rc<Promise> {
+        self.closed_promise.borrow().clone()
+    }
+
+    fn set_closed_promise(&self, promise: Rc<Promise>) {
+        *self.closed_promise.borrow_mut() = promise;
+    }
+
+    fn set_stream(&self, stream: Option<&ReadableStream>) {
+        self.stream.set(stream);
+    }
+
+    fn get_stream(&self) -> Option<DomRoot<ReadableStream>> {
+        self.stream.get()
+    }
+
+    fn as_byob_reader(&self) -> Option<&ReadableStreamBYOBReader> {
+        Some(self)
     }
 }

--- a/components/script/dom/readablestreamgenericreader.rs
+++ b/components/script/dom/readablestreamgenericreader.rs
@@ -1,0 +1,145 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::rc::Rc;
+
+use js::jsval::UndefinedValue;
+use js::rust::HandleValue as SafeHandleValue;
+
+use super::readablestream::ReaderType;
+use super::types::ReadableStream;
+use crate::dom::bindings::error::Error;
+use crate::dom::bindings::import::module::Fallible;
+use crate::dom::bindings::reflector::DomObject;
+use crate::dom::bindings::root::{DomRoot, MutNullableDom};
+use crate::dom::globalscope::GlobalScope;
+use crate::dom::promise::Promise;
+use crate::dom::readablestreambyobreader::ReadableStreamBYOBReader;
+use crate::dom::readablestreamdefaultreader::ReadableStreamDefaultReader;
+use crate::script_runtime::CanGc;
+
+/// <https://streams.spec.whatwg.org/#readablestreamgenericreader>
+pub(crate) trait ReadableStreamGenericReader {
+    /// <https://streams.spec.whatwg.org/#readable-stream-reader-generic-initialize>
+    #[allow(crown::unrooted_must_root)]
+    fn generic_initialize(
+        &self,
+        global: &GlobalScope,
+        stream: &ReadableStream,
+        can_gc: CanGc,
+    ) -> Fallible<()> {
+        // Set reader.[[stream]] to stream.
+        self.set_stream(Some(stream));
+
+        // Set stream.[[reader]] to reader.
+        let reader_type = if let Some(default_reader) = self.as_default_reader() {
+            ReaderType::Default(MutNullableDom::new(Some(default_reader)))
+        } else if let Some(byob_reader) = self.as_byob_reader() {
+            ReaderType::BYOB(MutNullableDom::new(Some(byob_reader)))
+        } else {
+            unreachable!("Reader must be either Default or BYOB.");
+        };
+        stream.set_reader(Some(reader_type));
+
+        if stream.is_readable() {
+            // If stream.[[state]] is "readable
+            // Set reader.[[closedPromise]] to a new promise.
+            self.set_closed_promise(Promise::new(global, can_gc));
+        } else if stream.is_closed() {
+            // Otherwise, if stream.[[state]] is "closed",
+            // Set reader.[[closedPromise]] to a promise resolved with undefined.
+            let cx = GlobalScope::get_cx();
+            rooted!(in(*cx) let mut rval = UndefinedValue());
+            self.set_closed_promise(Promise::new_resolved(global, cx, rval.handle())?);
+        } else {
+            // Assert: stream.[[state]] is "errored"
+            assert!(stream.is_errored());
+
+            // Set reader.[[closedPromise]] to a promise rejected with stream.[[storedError]].
+            let cx = GlobalScope::get_cx();
+            rooted!(in(*cx) let mut error = UndefinedValue());
+            stream.get_stored_error(error.handle_mut());
+            self.set_closed_promise(Promise::new_rejected(global, cx, error.handle())?);
+
+            // Set reader.[[closedPromise]].[[PromiseIsHandled]] to true
+            self.get_closed_promise().set_promise_is_handled();
+        }
+
+        Ok(())
+    }
+
+    /// <https://streams.spec.whatwg.org/#readable-stream-reader-generic-cancel>
+    fn generic_cancel(&self, reason: SafeHandleValue, can_gc: CanGc) -> Rc<Promise> {
+        // Let stream be reader.[[stream]].
+        let stream = self.get_stream();
+
+        // Assert: stream is not undefined.
+        let stream =
+            stream.expect("Reader should have a stream when generic cancel is called into.");
+
+        // Return ! ReadableStreamCancel(stream, reason).
+        stream.cancel(reason, can_gc)
+    }
+
+    /// <https://streams.spec.whatwg.org/#readable-stream-reader-generic-release>
+    #[allow(unsafe_code)]
+    fn generic_release(&self) {
+        // Let stream be reader.[[stream]].
+
+        // Assert: stream is not undefined.
+        assert!(self.get_stream().is_some());
+
+        if let Some(stream) = self.get_stream() {
+            // Assert: stream.[[reader]] is reader.
+            assert!(stream.has_default_reader());
+
+            if stream.is_readable() {
+                // If stream.[[state]] is "readable", reject reader.[[closedPromise]] with a TypeError exception.
+                self.get_closed_promise()
+                    .reject_error(Error::Type("stream state is not readable".to_owned()));
+            } else {
+                // Otherwise, set reader.[[closedPromise]] to a promise rejected with a TypeError exception.
+                let cx = GlobalScope::get_cx();
+                rooted!(in(*cx) let mut error = UndefinedValue());
+                unsafe {
+                    Error::Type("Cannot release lock due to stream state.".to_owned()).to_jsval(
+                        *cx,
+                        &stream.global(),
+                        error.handle_mut(),
+                    )
+                };
+
+                self.set_closed_promise(
+                    Promise::new_rejected(&stream.global(), cx, error.handle()).unwrap(),
+                );
+            }
+            // Set reader.[[closedPromise]].[[PromiseIsHandled]] to true.
+            self.get_closed_promise().set_promise_is_handled();
+
+            // Perform ! stream.[[controller]].[[ReleaseSteps]]().
+            stream.perform_release_steps();
+
+            // Set stream.[[reader]] to undefined.
+            stream.set_reader(None);
+            // Set reader.[[stream]] to undefined.
+            self.set_stream(None);
+        }
+    }
+
+    fn set_stream(&self, stream: Option<&ReadableStream>);
+
+    fn get_stream(&self) -> Option<DomRoot<ReadableStream>>;
+
+    fn set_closed_promise(&self, promise: Rc<Promise>);
+
+    fn get_closed_promise(&self) -> Rc<Promise>;
+
+    fn as_default_reader(&self) -> Option<&ReadableStreamDefaultReader> {
+        None
+    }
+
+    fn as_byob_reader(&self) -> Option<&ReadableStreamBYOBReader> {
+        None
+    }
+}


### PR DESCRIPTION
part of #34676  I am working on ReadableStreamBYOBReader, and as the first step, I introduced ReadableStreamGenericReader to encapsulate common functionality

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [x] There are tests for these changes OR

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
