### PR TITLE
Read RippyPNG resource once at startup.

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -115,6 +115,7 @@ use devtools_traits::{
     ChromeToDevtoolsControlMsg, DevtoolsControlMsg, DevtoolsPageInfo, NavigationState,
     ScriptToDevtoolsControlMsg,
 };
+use embedder_traits::resources::{self, Resource};
 use embedder_traits::{
     Cursor, EmbedderMsg, EmbedderProxy, MediaSessionEvent, MediaSessionPlaybackState,
 };
@@ -479,6 +480,11 @@ pub struct Constellation<STF, SWF> {
 
     /// User agent string to report in network requests.
     user_agent: Cow<'static, str>,
+
+    /// The image bytes associated with the RippyPNG embedder resource.
+    /// Read during startup and provided to image caches that are created
+    /// on an as-needed basis, rather than retrieving it every time.
+    rippy_data: Vec<u8>,
 }
 
 /// State needed to construct a constellation.
@@ -693,6 +699,8 @@ where
                     wgpu_image_map: state.wgpu_image_map,
                 };
 
+                let rippy_data = resources::read_bytes(Resource::RippyPNG);
+
                 let mut constellation: Constellation<STF, SWF> = Constellation {
                     namespace_receiver,
                     namespace_ipc_sender,
@@ -759,6 +767,7 @@ where
                     player_context: state.player_context,
                     active_media_session: None,
                     user_agent: state.user_agent,
+                    rippy_data,
                 };
 
                 constellation.run();
@@ -1007,6 +1016,7 @@ where
             webxr_registry: self.webxr_registry.clone(),
             player_context: self.player_context.clone(),
             user_agent: self.user_agent.clone(),
+            rippy_data: self.rippy_data.clone(),
         });
 
         let pipeline = match result {

--- a/components/constellation/pipeline.rs
+++ b/components/constellation/pipeline.rs
@@ -195,6 +195,9 @@ pub struct InitialPipelineState {
 
     /// User agent string to report in network requests.
     pub user_agent: Cow<'static, str>,
+
+    /// The image bytes associated with the RippyPNG embedder resource.
+    pub rippy_data: Vec<u8>,
 }
 
 pub struct NewPipeline {
@@ -291,6 +294,7 @@ impl Pipeline {
                     webxr_registry: state.webxr_registry,
                     player_context: state.player_context,
                     user_agent: state.user_agent,
+                    rippy_data: state.rippy_data,
                 };
 
                 // Spawn the child process.
@@ -494,6 +498,7 @@ pub struct UnprivilegedPipelineContent {
     webxr_registry: Option<webxr_api::Registry>,
     player_context: WindowGLContext,
     user_agent: Cow<'static, str>,
+    rippy_data: Vec<u8>,
 }
 
 impl UnprivilegedPipelineContent {
@@ -509,6 +514,7 @@ impl UnprivilegedPipelineContent {
 
         let image_cache = Arc::new(ImageCacheImpl::new(
             self.cross_process_compositor_api.clone(),
+            self.rippy_data,
         ));
         let (content_process_shutdown_chan, content_process_shutdown_port) = unbounded();
         STF::create(

--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -7,7 +7,6 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::{mem, thread};
 
-use embedder_traits::resources::{self, Resource};
 use imsz::imsz_from_reader;
 use ipc_channel::ipc::{IpcSender, IpcSharedMemory};
 use log::{debug, warn};
@@ -415,10 +414,9 @@ pub struct ImageCacheImpl {
 }
 
 impl ImageCache for ImageCacheImpl {
-    fn new(compositor_api: CrossProcessCompositorApi) -> ImageCacheImpl {
+    fn new(compositor_api: CrossProcessCompositorApi, rippy_data: Vec<u8>) -> ImageCacheImpl {
         debug!("New image cache");
 
-        let rippy_data = resources::read_bytes(Resource::RippyPNG);
         // Uses an estimate of the system cpus to decode images
         // See https://doc.rust-lang.org/stable/std/thread/fn.available_parallelism.html
         // If no information can be obtained about the system, uses 4 threads as a default

--- a/components/shared/net/image_cache.rs
+++ b/components/shared/net/image_cache.rs
@@ -99,7 +99,7 @@ pub enum ImageCacheResult {
 }
 
 pub trait ImageCache: Sync + Send {
-    fn new(compositor_api: CrossProcessCompositorApi) -> Self
+    fn new(compositor_api: CrossProcessCompositorApi, rippy_data: Vec<u8>) -> Self
     where
         Self: Sized;
 


### PR DESCRIPTION
Per the investigation in https://github.com/servo/servo/issues/34683#issuecomment-2585396644, the servodriver test harness creates a very large number of script threads. Since each script thread creates an image cache, this means we end up reading the RippyPNG resource a very large number of times and it's easy to trigger the "Too many open files" OS error. By changing to a model where the constellation reads the data once and provides it to each image cache that is created, we avoid this problem. This change allows me to run all of the /mozilla WPT tests under servodriver without running into the "Too many open files" error.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because the tests that are affected can't run in CI yet.