### PR TITLE
CI: disable self-hosted runners for nightly.yml

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -100,6 +100,7 @@ jobs:
       profile: "production"
       upload: true
       github-release-id: ${{ needs.create-draft-release.outputs.release-id }}
+      force-github-hosted-runner: true  # <https://github.com/servo/servo/issues/33296>
     secrets: inherit
 
   upload-linux:


### PR DESCRIPTION
Like other nightly builds, macOS nightly builds seem to suffer from #33296.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are a workaround for #33296