### PR TITLE
CI: use new API for taking a runner

### DIFF
--- a/.github/workflows/self-hosted-runner-select.yml
+++ b/.github/workflows/self-hosted-runner-select.yml
@@ -79,7 +79,7 @@ jobs:
 
           # Use the monitor API to reserve a runner. If we get an object with
           # runner details, we succeeded. If we get null, we failed.
-          take_runner_url=$monitor_api_base_url/$self_hosted_image_name/$unique_id/${{ github.repository }}/${{ github.run_id }}
+          take_runner_url=$monitor_api_base_url/profile/$self_hosted_image_name/take\?unique_id=$unique_id\&qualified_repo=${{ github.repository }}\&run_id=${{ github.run_id }}
           result=$(mktemp)
           echo
           echo POST "$take_runner_url"


### PR DESCRIPTION
This patch migrates our runner select workflow to the new monitor API ([3d64eaa3224a4](https://github.com/servo/ci-runners/commit/3d64eaa3224a4be213c4ad7bd8e9d19f08e26ab7)). This is designed to be a bit more extensible than the old API, which just used path components for all of its parameters.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [x] Self-hosted runner test plan
  - [x] [`mach try windows linux mac`](https://github.com/servo/servo/actions/runs/12761012494)