### PR TITLE
layout: Make non-`normal` `align-content` establish a block formatting context

### DIFF
--- a/components/layout_2020/style_ext.rs
+++ b/components/layout_2020/style_ext.rs
@@ -721,6 +721,13 @@ impl ComputedValuesExt for ComputedValues {
             return true;
         }
 
+        // Per <https://drafts.csswg.org/css-align/#distribution-block>
+        // Block container with attribute align_content of value other
+        // than Normal, should form Independent Block formatting context
+        if self.get_position().align_content.0.primary() != AlignFlags::NORMAL {
+            return true;
+        }
+
         // TODO: We need to handle CSS Contain here.
         false
     }

--- a/components/layout_2020/style_ext.rs
+++ b/components/layout_2020/style_ext.rs
@@ -721,9 +721,11 @@ impl ComputedValuesExt for ComputedValues {
             return true;
         }
 
-        // Per <https://drafts.csswg.org/css-align/#distribution-block>
-        // Block container with attribute align_content of value other
-        // than Normal, should form Independent Block formatting context
+        // Per <https://drafts.csswg.org/css-align/#distribution-block>:
+        // Block containers with an `align-content` value that is not `normal` should
+        // form an independent block formatting context. This should really only happen
+        // for block containers, but we do not support subgrid containers yet which is the
+        // only other case.
         if self.get_position().align_content.0.primary() != AlignFlags::NORMAL {
             return true;
         }

--- a/tests/wpt/meta/css/css-align/blocks/align-content-block-001.html.ini
+++ b/tests/wpt/meta/css/css-align/blocks/align-content-block-001.html.ini
@@ -1,2 +1,0 @@
-[align-content-block-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-align/blocks/align-content-block-002.html.ini
+++ b/tests/wpt/meta/css/css-align/blocks/align-content-block-002.html.ini
@@ -28,21 +28,4 @@
 
   [.test 16: space-around]
     expected: FAIL
-
-  [.test 1: start]
-    expected: FAIL
-
-  [.test 4: baseline]
-    expected: FAIL
-
-  [.test 6: flex-start]
-    expected: FAIL
-
-  [.test 8: unsafe start]
-    expected: FAIL
-
-  [.test 11: safe start]
-    expected: FAIL
-
-  [.test 15: space-between]
-    expected: FAIL
+    

--- a/tests/wpt/meta/css/css-align/blocks/align-content-block-004.html.ini
+++ b/tests/wpt/meta/css/css-align/blocks/align-content-block-004.html.ini
@@ -1,35 +1,20 @@
 [align-content-block-004.html]
-  [.test 1: start]
-    expected: FAIL
-
   [.test 2: center]
     expected: FAIL
 
   [.test 3: end]
     expected: FAIL
 
-  [.test 4: baseline]
-    expected: FAIL
-
   [.test 5: last baseline]
     expected: FAIL
 
-  [.test 6: flex-start]
-    expected: FAIL
-
   [.test 7: flex-end]
-    expected: FAIL
-
-  [.test 8: unsafe start]
     expected: FAIL
 
   [.test 9: unsafe center]
     expected: FAIL
 
   [.test 10: unsafe end]
-    expected: FAIL
-
-  [.test 11: safe start]
     expected: FAIL
 
   [.test 12: safe center]
@@ -39,9 +24,6 @@
     expected: FAIL
 
   [.test 14: space-evenly]
-    expected: FAIL
-
-  [.test 15: space-between]
     expected: FAIL
 
   [.test 16: space-around]

--- a/tests/wpt/meta/css/css-align/blocks/align-content-block-005.html.ini
+++ b/tests/wpt/meta/css/css-align/blocks/align-content-block-005.html.ini
@@ -1,48 +1,6 @@
 [align-content-block-005.html]
-  [.test 1: start]
-    expected: FAIL
-
-  [.test 2: center]
-    expected: FAIL
-
-  [.test 3: end]
-    expected: FAIL
-
-  [.test 4: baseline]
-    expected: FAIL
-
-  [.test 5: last baseline]
-    expected: FAIL
-
-  [.test 6: flex-start]
-    expected: FAIL
-
-  [.test 7: flex-end]
-    expected: FAIL
-
-  [.test 8: unsafe start]
-    expected: FAIL
-
   [.test 9: unsafe center]
     expected: FAIL
 
   [.test 10: unsafe end]
-    expected: FAIL
-
-  [.test 11: safe start]
-    expected: FAIL
-
-  [.test 12: safe center]
-    expected: FAIL
-
-  [.test 13: safe end]
-    expected: FAIL
-
-  [.test 14: space-evenly]
-    expected: FAIL
-
-  [.test 15: space-between]
-    expected: FAIL
-
-  [.test 16: space-around]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/blocks/align-content-block-006.html.ini
+++ b/tests/wpt/meta/css/css-align/blocks/align-content-block-006.html.ini
@@ -1,35 +1,20 @@
 [align-content-block-006.html]
-  [.test 1: start]
-    expected: FAIL
-
   [.test 2: center]
     expected: FAIL
 
   [.test 3: end]
     expected: FAIL
 
-  [.test 4: baseline]
-    expected: FAIL
-
   [.test 5: last baseline]
     expected: FAIL
 
-  [.test 6: flex-start]
-    expected: FAIL
-
   [.test 7: flex-end]
-    expected: FAIL
-
-  [.test 8: unsafe start]
     expected: FAIL
 
   [.test 9: unsafe center]
     expected: FAIL
 
   [.test 10: unsafe end]
-    expected: FAIL
-
-  [.test 11: safe start]
     expected: FAIL
 
   [.test 12: safe center]
@@ -39,9 +24,6 @@
     expected: FAIL
 
   [.test 14: space-evenly]
-    expected: FAIL
-
-  [.test 15: space-between]
     expected: FAIL
 
   [.test 16: space-around]

--- a/tests/wpt/meta/css/css-align/blocks/align-content-block-007.html.ini
+++ b/tests/wpt/meta/css/css-align/blocks/align-content-block-007.html.ini
@@ -1,48 +1,6 @@
 [align-content-block-007.html]
-  [.test 1: start]
-    expected: FAIL
-
-  [.test 2: center]
-    expected: FAIL
-
-  [.test 3: end]
-    expected: FAIL
-
-  [.test 4: baseline]
-    expected: FAIL
-
-  [.test 5: last baseline]
-    expected: FAIL
-
-  [.test 6: flex-start]
-    expected: FAIL
-
-  [.test 7: flex-end]
-    expected: FAIL
-
-  [.test 8: unsafe start]
-    expected: FAIL
-
   [.test 9: unsafe center]
     expected: FAIL
 
   [.test 10: unsafe end]
-    expected: FAIL
-
-  [.test 11: safe start]
-    expected: FAIL
-
-  [.test 12: safe center]
-    expected: FAIL
-
-  [.test 13: safe end]
-    expected: FAIL
-
-  [.test 14: space-evenly]
-    expected: FAIL
-
-  [.test 15: space-between]
-    expected: FAIL
-
-  [.test 16: space-around]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/blocks/align-content-block-008.html.ini
+++ b/tests/wpt/meta/css/css-align/blocks/align-content-block-008.html.ini
@@ -1,35 +1,20 @@
 [align-content-block-008.html]
-  [.test 1: start]
-    expected: FAIL
-
   [.test 2: center]
     expected: FAIL
 
   [.test 3: end]
     expected: FAIL
 
-  [.test 4: baseline]
-    expected: FAIL
-
   [.test 5: last baseline]
     expected: FAIL
 
-  [.test 6: flex-start]
-    expected: FAIL
-
   [.test 7: flex-end]
-    expected: FAIL
-
-  [.test 8: unsafe start]
     expected: FAIL
 
   [.test 9: unsafe center]
     expected: FAIL
 
   [.test 10: unsafe end]
-    expected: FAIL
-
-  [.test 11: safe start]
     expected: FAIL
 
   [.test 12: safe center]
@@ -39,9 +24,6 @@
     expected: FAIL
 
   [.test 14: space-evenly]
-    expected: FAIL
-
-  [.test 15: space-between]
     expected: FAIL
 
   [.test 16: space-around]

--- a/tests/wpt/meta/css/css-align/blocks/align-content-block-009.html.ini
+++ b/tests/wpt/meta/css/css-align/blocks/align-content-block-009.html.ini
@@ -1,27 +1,4 @@
 [align-content-block-009.html]
-  [.test 1: start]
-    expected: FAIL
-
-  [.test 2: center]
-    expected: FAIL
-
-  [.test 3: end]
-    expected: FAIL
-
-  [.test 4: baseline]
-    expected: FAIL
-
-  [.test 5: last baseline]
-    expected: FAIL
-
-  [.test 6: flex-start]
-    expected: FAIL
-
-  [.test 7: flex-end]
-    expected: FAIL
-
-  [.test 8: unsafe start]
-    expected: FAIL
 
   [.test 9: unsafe center]
     expected: FAIL
@@ -29,20 +6,3 @@
   [.test 10: unsafe end]
     expected: FAIL
 
-  [.test 11: safe start]
-    expected: FAIL
-
-  [.test 12: safe center]
-    expected: FAIL
-
-  [.test 13: safe end]
-    expected: FAIL
-
-  [.test 14: space-evenly]
-    expected: FAIL
-
-  [.test 15: space-between]
-    expected: FAIL
-
-  [.test 16: space-around]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-align/blocks/align-content-block-010.html.ini
+++ b/tests/wpt/meta/css/css-align/blocks/align-content-block-010.html.ini
@@ -1,35 +1,20 @@
 [align-content-block-010.html]
-  [.test 1: start]
-    expected: FAIL
-
   [.test 2: center]
     expected: FAIL
 
   [.test 3: end]
     expected: FAIL
 
-  [.test 4: baseline]
-    expected: FAIL
-
   [.test 5: last baseline]
     expected: FAIL
 
-  [.test 6: flex-start]
-    expected: FAIL
-
   [.test 7: flex-end]
-    expected: FAIL
-
-  [.test 8: unsafe start]
     expected: FAIL
 
   [.test 9: unsafe center]
     expected: FAIL
 
   [.test 10: unsafe end]
-    expected: FAIL
-
-  [.test 11: safe start]
     expected: FAIL
 
   [.test 12: safe center]
@@ -39,9 +24,6 @@
     expected: FAIL
 
   [.test 14: space-evenly]
-    expected: FAIL
-
-  [.test 15: space-between]
     expected: FAIL
 
   [.test 16: space-around]

--- a/tests/wpt/meta/css/css-align/blocks/align-content-block-011.html.ini
+++ b/tests/wpt/meta/css/css-align/blocks/align-content-block-011.html.ini
@@ -1,48 +1,7 @@
 [align-content-block-011.html]
-  [.test 1: start]
-    expected: FAIL
-
-  [.test 2: center]
-    expected: FAIL
-
-  [.test 3: end]
-    expected: FAIL
-
-  [.test 4: baseline]
-    expected: FAIL
-
-  [.test 5: last baseline]
-    expected: FAIL
-
-  [.test 6: flex-start]
-    expected: FAIL
-
-  [.test 7: flex-end]
-    expected: FAIL
-
-  [.test 8: unsafe start]
-    expected: FAIL
-
   [.test 9: unsafe center]
     expected: FAIL
 
   [.test 10: unsafe end]
     expected: FAIL
-
-  [.test 11: safe start]
-    expected: FAIL
-
-  [.test 12: safe center]
-    expected: FAIL
-
-  [.test 13: safe end]
-    expected: FAIL
-
-  [.test 14: space-evenly]
-    expected: FAIL
-
-  [.test 15: space-between]
-    expected: FAIL
-
-  [.test 16: space-around]
-    expected: FAIL
+    

--- a/tests/wpt/tests/css/css-align/blocks/align-content-block-006.html
+++ b/tests/wpt/tests/css/css-align/blocks/align-content-block-006.html
@@ -21,7 +21,7 @@
   function doTest()
   {
     document.body.offsetHeight; // trigger layout
-    document.getElementById('initial').type = 'text/plain'; // invalidate stylesheet
+    document.getElementById('initial').disabled = true;
     checkLayout('.test');
   }
   window.onload = () => {

--- a/tests/wpt/tests/css/css-align/blocks/align-content-block-007.html
+++ b/tests/wpt/tests/css/css-align/blocks/align-content-block-007.html
@@ -21,7 +21,7 @@
   function doTest()
   {
     document.body.offsetHeight; // trigger layout
-    document.getElementById('initial').type = 'text/plain'; // invalidate stylesheet
+    document.getElementById('initial').disabled = true;
     checkLayout('.test');
   }
   window.onload = () => {

--- a/tests/wpt/tests/css/css-align/blocks/align-content-block-008.html
+++ b/tests/wpt/tests/css/css-align/blocks/align-content-block-008.html
@@ -38,7 +38,7 @@
   function doTest()
   {
     document.body.offsetHeight; // trigger layout
-    document.getElementById('initial').type = 'text/plain'; // invalidate stylesheet
+    document.getElementById('initial').disabled = true;
     checkLayout('.test');
   }
   window.onload = () => {

--- a/tests/wpt/tests/css/css-align/blocks/align-content-block-009.html
+++ b/tests/wpt/tests/css/css-align/blocks/align-content-block-009.html
@@ -38,7 +38,7 @@
   function doTest()
   {
     document.body.offsetHeight; // trigger layout
-    document.getElementById('initial').type = 'text/plain'; // invalidate stylesheet
+    document.getElementById('initial').disabled = true;
     checkLayout('.test');
   }
   window.onload = () => {

--- a/tests/wpt/tests/css/css-align/blocks/align-content-block-010.html
+++ b/tests/wpt/tests/css/css-align/blocks/align-content-block-010.html
@@ -21,7 +21,7 @@
   function doTest()
   {
     document.body.offsetHeight; // trigger layout
-    document.getElementById('initial').type = 'text/plain'; // invalidate stylesheet
+    document.getElementById('initial').disabled = true;
     checkLayout('.test');
   }
   window.onload = () => {

--- a/tests/wpt/tests/css/css-align/blocks/align-content-block-011.html
+++ b/tests/wpt/tests/css/css-align/blocks/align-content-block-011.html
@@ -21,7 +21,7 @@
   function doTest()
   {
     document.body.offsetHeight; // trigger layout
-    document.getElementById('initial').type = 'text/plain'; // invalidate stylesheet
+    document.getElementById('initial').disabled = true;
     checkLayout('.test');
   }
   window.onload = () => {


### PR DESCRIPTION
Following the [spec of align-content](https://drafts.csswg.org/css-align/#distribution-block), when a element have style attribute: align-content with value other than normal, this element should have an independent block formatting context. So here i add code along side  the detection of [overflow:hidden] and other css style that can cause an element to have independent block formatting context. 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes


