### PR TITLE
config: Remove legacy-layout and unused `Preferences` and `Opts`

### DIFF
--- a/components/config/opts.rs
+++ b/components/config/opts.rs
@@ -20,9 +20,6 @@ pub struct Opts {
     /// Whether or not the legacy layout system is enabled.
     pub legacy_layout: bool,
 
-    /// The maximum size of each tile in pixels (`-s`).
-    pub tile_size: usize,
-
     /// `None` to disable the time profiler or `Some` to enable it with:
     ///
     ///  - an interval in seconds to cause it to produce output on that interval.
@@ -124,12 +121,6 @@ pub struct DebugOptions {
     /// List all the debug options.
     pub help: bool,
 
-    /// True if we should bubble intrinsic widths sequentially. If this is true,
-    /// then intrinsic widths are computed as a separate pass instead of during
-    /// flow construction. You may wish to turn this flag on in order to
-    /// benchmark style recalculation against other browser engines.
-    pub bubble_inline_sizes_separately: bool,
-
     /// If set with `disable-text-aa`, disable antialiasing on fonts. This is
     /// primarily useful for reftests where pixel perfect results are required
     /// when using fonts such as the Ahem font for layout tests.
@@ -159,20 +150,11 @@ pub struct DebugOptions {
     /// Print the display list after each layout.
     pub dump_display_list: bool,
 
-    /// Print the display list in JSON form.
-    pub dump_display_list_json: bool,
-
     /// Print notifications when there is a relayout.
     pub relayout_event: bool,
 
     /// Periodically print out on which events script threads spend their processing time.
     pub profile_script_events: bool,
-
-    /// Paint borders along fragment boundaries.
-    pub show_fragment_borders: bool,
-
-    /// Mark which thread laid each flow out with colors.
-    pub show_parallel_layout: bool,
 
     /// True if each step of layout is traced to an external JSON file
     /// for debugging purposes. Setting this implies sequential layout
@@ -216,14 +198,12 @@ impl DebugOptions {
         for option in debug_string.split(',') {
             match option {
                 "help" => self.help = true,
-                "bubble-inline-sizes-separately" => self.bubble_inline_sizes_separately = true,
                 "convert-mouse-to-touch" => self.convert_mouse_to_touch = true,
                 "disable-canvas-aa" => self.disable_canvas_antialiasing = true,
                 "disable-share-style-cache" => self.disable_share_style_cache = true,
                 "disable-subpixel-aa" => self.disable_subpixel_text_antialiasing = true,
                 "disable-text-aa" => self.disable_text_antialiasing = true,
                 "dump-display-list" => self.dump_display_list = true,
-                "dump-display-list-json" => self.dump_display_list_json = true,
                 "dump-stacking-context-tree" => self.dump_stacking_context_tree = true,
                 "dump-flow-tree" => self.dump_flow_tree = true,
                 "dump-rule-tree" => self.dump_rule_tree = true,
@@ -234,8 +214,6 @@ impl DebugOptions {
                 "profile-script-events" => self.profile_script_events = true,
                 "relayout-event" => self.relayout_event = true,
                 "replace-surrogates" => self.replace_surrogates = true,
-                "show-fragment-borders" => self.show_fragment_borders = true,
-                "show-parallel-layout" => self.show_parallel_layout = true,
                 "signpost" => self.signpost = true,
                 "dump-style-stats" => self.dump_style_statistics = true,
                 "trace-layout" => self.trace_layout = true,
@@ -243,10 +221,6 @@ impl DebugOptions {
                 "" => {},
                 _ => return Err(String::from(option)),
             };
-        }
-
-        if self.trace_layout {
-            self.bubble_inline_sizes_separately = true;
         }
 
         Ok(())
@@ -263,7 +237,6 @@ pub enum OutputOptions {
 pub fn default_opts() -> Opts {
     Opts {
         legacy_layout: false,
-        tile_size: 512,
         time_profiling: None,
         time_profiler_trace_path: None,
         mem_profiler_period: None,

--- a/components/layout/construct.rs
+++ b/components/layout/construct.rs
@@ -23,7 +23,6 @@ use script_layout_interface::wrapper_traits::{
     PseudoElementType, ThreadSafeLayoutElement, ThreadSafeLayoutNode,
 };
 use script_layout_interface::{LayoutElementType, LayoutNodeType};
-use servo_config::opts;
 use servo_url::ServoUrl;
 use style::computed_values::caption_side::T as CaptionSide;
 use style::computed_values::display::T as Display;
@@ -2075,13 +2074,11 @@ impl FlowRef {
     /// All flows must be finished at some point, or they will not have their intrinsic inline-sizes
     /// properly computed. (This is not, however, a memory safety problem.)
     fn finish(&mut self) {
-        if !opts::get().debug.bubble_inline_sizes_separately {
-            FlowRef::deref_mut(self).bubble_inline_sizes();
-            FlowRef::deref_mut(self)
-                .mut_base()
-                .restyle_damage
-                .remove(ServoRestyleDamage::BUBBLE_ISIZES);
-        }
+        FlowRef::deref_mut(self).bubble_inline_sizes();
+        FlowRef::deref_mut(self)
+            .mut_base()
+            .restyle_damage
+            .remove(ServoRestyleDamage::BUBBLE_ISIZES);
     }
 }
 

--- a/components/layout/inline.rs
+++ b/components/layout/inline.rs
@@ -1948,11 +1948,6 @@ impl Flow for InlineFlow {
                 state.current_stacking_context_id = parent_stacking_context_id
             }
         }
-
-        if !self.fragments.fragments.is_empty() {
-            self.base
-                .build_display_items_for_debugging_tint(state, self.fragments.fragments[0].node);
-        }
     }
 
     fn repair_style(&mut self, _: &ServoArc<ComputedValues>) {}

--- a/components/layout/parallel.rs
+++ b/components/layout/parallel.rs
@@ -13,16 +13,13 @@ use std::{mem, ptr};
 
 use profile_traits::time::{self, TimerMetadata};
 use profile_traits::time_profile;
-use servo_config::opts;
 use smallvec::SmallVec;
 
 use crate::block::BlockFlow;
 use crate::context::LayoutContext;
 use crate::flow::{Flow, GetBaseFlow};
 use crate::flow_ref::FlowRef;
-use crate::traversal::{
-    AssignBSizes, AssignISizes, BubbleISizes, PostorderFlowTraversal, PreorderFlowTraversal,
-};
+use crate::traversal::{AssignBSizes, AssignISizes, PostorderFlowTraversal, PreorderFlowTraversal};
 
 /// Traversal chunk size.
 const CHUNK_SIZE: usize = 16;
@@ -213,13 +210,6 @@ pub fn reflow(
     context: &LayoutContext,
     queue: &rayon::ThreadPool,
 ) {
-    if opts::get().debug.bubble_inline_sizes_separately {
-        let bubble_inline_sizes = BubbleISizes {
-            layout_context: context,
-        };
-        bubble_inline_sizes.traverse(root);
-    }
-
     let assign_isize_traversal = &AssignISizes {
         layout_context: context,
     };

--- a/components/layout/sequential.rs
+++ b/components/layout/sequential.rs
@@ -6,7 +6,6 @@
 
 use app_units::Au;
 use euclid::default::{Point2D, Rect, Size2D, Vector2D};
-use servo_config::opts;
 use style::servo::restyle_damage::ServoRestyleDamage;
 use webrender_api::units::LayoutPoint;
 use webrender_api::{ColorF, PropertyBinding, RectangleDisplayItem};
@@ -21,8 +20,8 @@ use crate::fragment::{CoordinateSystem, FragmentBorderBoxIterator};
 use crate::generated_content::ResolveGeneratedContent;
 use crate::incremental::RelayoutMode;
 use crate::traversal::{
-    AssignBSizes, AssignISizes, BubbleISizes, BuildDisplayList, InorderFlowTraversal,
-    PostorderFlowTraversal, PreorderFlowTraversal,
+    AssignBSizes, AssignISizes, BuildDisplayList, InorderFlowTraversal, PostorderFlowTraversal,
+    PreorderFlowTraversal,
 };
 
 pub fn resolve_generated_content(root: &mut dyn Flow, layout_context: &LayoutContext) {
@@ -56,11 +55,6 @@ pub fn reflow(root: &mut dyn Flow, layout_context: &LayoutContext, relayout_mode
         if assign_block_sizes.should_process(flow) {
             assign_block_sizes.process(flow);
         }
-    }
-
-    if opts::get().debug.bubble_inline_sizes_separately {
-        let bubble_inline_sizes = BubbleISizes { layout_context };
-        bubble_inline_sizes.traverse(root);
     }
 
     let assign_inline_sizes = AssignISizes { layout_context };

--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -796,9 +796,6 @@ impl LayoutThread {
                 if self.debug.dump_display_list {
                     display_list.print();
                 }
-                if self.debug.dump_display_list_json {
-                    println!("{}", serde_json::to_string_pretty(&display_list).unwrap());
-                }
 
                 debug!("Layout done!");
 

--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -359,13 +359,6 @@ pub(crate) fn parse_command_line_arguments(args: Vec<String>) -> ArgumentParsing
         print_debug_options_usage(app_name);
     }
 
-    let tile_size: usize = match opt_match.opt_str("s") {
-        Some(tile_size_str) => tile_size_str
-            .parse()
-            .unwrap_or_else(|err| args_fail(&format!("Error parsing option: -s ({})", err))),
-        None => 512,
-    };
-
     // If only the flag is present, default to a 5 second period for both profilers
     let time_profiling = if opt_match.opt_present("p") {
         match opt_match.opt_str("p") {
@@ -560,7 +553,6 @@ pub(crate) fn parse_command_line_arguments(args: Vec<String>) -> ArgumentParsing
     let opts = Opts {
         debug: debug_options.clone(),
         legacy_layout,
-        tile_size,
         time_profiling,
         time_profiler_trace_path: opt_match.opt_str("profiler-trace-path"),
         mem_profiler_period,


### PR DESCRIPTION
There are some preferences and options that are only used by legacy
layout or not used at all. This PR removes them.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they just remove legacy code and features.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
