### PR TITLE
Fix ./mach test-speedometer runs

### DIFF
--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -540,7 +540,7 @@ class MachCommands(CommandBase):
         speedometer = json.loads(subprocess.check_output([
             binary,
             "https://servospeedometer.netlify.app?headless=1",
-            "--pref", "dom.allow_scripts_to_close_windows",
+            "--pref", "dom_allow_scripts_to_close_windows",
             "--window-size=1100x900",
             "--headless"], timeout=120).decode())
 


### PR DESCRIPTION
The python code set a preference that was renamed
as part of https://github.com/servo/servo/pull/34966.

This fixes MQ runs which currently all fail
(https://github.com/servo/servo/actions/runs/12779051326/job/35623343302)

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
