### PR TITLE
webdriver: Serialize JS int values as i32.

### DIFF
--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -171,7 +171,14 @@ pub(crate) unsafe fn jsval_to_webdriver(
         Ok(WebDriverJSValue::Null)
     } else if val.get().is_boolean() {
         Ok(WebDriverJSValue::Boolean(val.get().to_boolean()))
-    } else if val.get().is_double() || val.get().is_int32() {
+    } else if val.get().is_int32() {
+        Ok(WebDriverJSValue::Int(
+            match FromJSValConvertible::from_jsval(cx, val, ConversionBehavior::Default).unwrap() {
+                ConversionResult::Success(c) => c,
+                _ => unreachable!(),
+            },
+        ))
+    } else if val.get().is_double() {
         Ok(WebDriverJSValue::Number(
             match FromJSValConvertible::from_jsval(cx, val, ()).unwrap() {
                 ConversionResult::Success(c) => c,

--- a/components/shared/script/webdriver_msg.rs
+++ b/components/shared/script/webdriver_msg.rs
@@ -102,6 +102,7 @@ pub enum WebDriverJSValue {
     Undefined,
     Null,
     Boolean(bool),
+    Int(i32),
     Number(f64),
     String(String),
     Element(WebElement),

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -262,6 +262,7 @@ impl Serialize for SendableWebDriverJSValue {
             WebDriverJSValue::Undefined => serializer.serialize_unit(),
             WebDriverJSValue::Null => serializer.serialize_unit(),
             WebDriverJSValue::Boolean(x) => serializer.serialize_bool(x),
+            WebDriverJSValue::Int(x) => serializer.serialize_i32(x),
             WebDriverJSValue::Number(x) => serializer.serialize_f64(x),
             WebDriverJSValue::String(ref x) => serializer.serialize_str(x),
             WebDriverJSValue::Element(ref x) => x.serialize(serializer),


### PR DESCRIPTION
This fixes errors like `error: Action action_sequence failed: invalid argument (400): data did not match any variant of untagged enum NullActionItem at line 1 column 90` in testdriver.js tests that use action sequences.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they are only testable in a testharness that does not yet run in CI.