### PR TITLE
prefs: Move some `DebugOptions` to `Preferences` and clean up

### DIFF
--- a/components/canvas/canvas_data.rs
+++ b/components/canvas/canvas_data.rs
@@ -25,7 +25,6 @@ use webrender_api::units::{DeviceIntSize, RectExt as RectExt_};
 use webrender_api::{ImageDescriptor, ImageDescriptorFlags, ImageFormat, ImageKey};
 use webrender_traits::{CrossProcessCompositorApi, ImageUpdate, SerializableImageData};
 
-use crate::canvas_paint_thread::AntialiasMode;
 use crate::raqote_backend::Repetition;
 
 /// The canvas data stores a state machine for the current status of
@@ -445,7 +444,6 @@ impl<'a> CanvasData<'a> {
     pub fn new(
         size: Size2D<u64>,
         compositor_api: CrossProcessCompositorApi,
-        antialias: AntialiasMode,
         font_context: Arc<FontContext>,
     ) -> CanvasData<'a> {
         let backend = create_backend();
@@ -454,7 +452,7 @@ impl<'a> CanvasData<'a> {
             backend,
             drawtarget: draw_target,
             path_state: None,
-            state: CanvasPaintState::new(antialias),
+            state: CanvasPaintState::default(),
             saved_states: vec![],
             compositor_api,
             image_key: None,

--- a/components/canvas/raqote_backend.rs
+++ b/components/canvas/raqote_backend.rs
@@ -21,7 +21,6 @@ use crate::canvas_data::{
     self, Backend, CanvasPaintState, Color, CompositionOp, DrawOptions, Filter, GenericDrawTarget,
     GenericPathBuilder, GradientStop, GradientStops, Path, SourceSurface, StrokeOptions, TextRun,
 };
-use crate::canvas_paint_thread::AntialiasMode;
 
 thread_local! {
     /// The shared font cache used by all canvases that render on a thread. It would be nicer
@@ -85,12 +84,12 @@ impl Backend for RaqoteBackend {
     }
 
     fn recreate_paint_state<'a>(&self, _state: &CanvasPaintState<'a>) -> CanvasPaintState<'a> {
-        CanvasPaintState::new(AntialiasMode::Default)
+        CanvasPaintState::default()
     }
 }
 
-impl<'a> CanvasPaintState<'a> {
-    pub fn new(_antialias: AntialiasMode) -> CanvasPaintState<'a> {
+impl Default for CanvasPaintState<'_> {
+    fn default() -> Self {
         let pattern = Pattern::Color(255, 0, 0, 0);
         CanvasPaintState {
             draw_options: DrawOptions::Raqote(raqote::DrawOptions::new()),

--- a/components/config/opts.rs
+++ b/components/config/opts.rs
@@ -121,20 +121,6 @@ pub struct DebugOptions {
     /// List all the debug options.
     pub help: bool,
 
-    /// If set with `disable-text-aa`, disable antialiasing on fonts. This is
-    /// primarily useful for reftests where pixel perfect results are required
-    /// when using fonts such as the Ahem font for layout tests.
-    pub disable_text_antialiasing: bool,
-
-    /// Disable subpixel antialiasing of rendered text.
-    pub disable_subpixel_text_antialiasing: bool,
-
-    /// Disable antialiasing of rendered text on the HTML canvas element.
-    /// If set with `disable-canvas-aa`, disable antialiasing on the HTML canvas
-    /// element.  Like `disable-text-aa`, this is useful for reftests where
-    /// pixel perfect results are required.
-    pub disable_canvas_antialiasing: bool,
-
     /// Print the DOM after each restyle.
     pub dump_style_tree: bool,
 
@@ -180,11 +166,6 @@ pub struct DebugOptions {
     /// Show webrender profiling stats on screen.
     pub webrender_stats: bool,
 
-    /// True to compile all webrender shaders at init time. This is mostly
-    /// useful when modifying the shaders, to ensure they all compile
-    /// after each change is made.
-    pub precache_shaders: bool,
-
     /// True to use OS native signposting facilities. This makes profiling events (script activity,
     /// reflow, compositing, etc.) appear in Instruments.app on macOS.
     pub signpost: bool,
@@ -196,17 +177,13 @@ impl DebugOptions {
             match option {
                 "help" => self.help = true,
                 "convert-mouse-to-touch" => self.convert_mouse_to_touch = true,
-                "disable-canvas-aa" => self.disable_canvas_antialiasing = true,
                 "disable-share-style-cache" => self.disable_share_style_cache = true,
-                "disable-subpixel-aa" => self.disable_subpixel_text_antialiasing = true,
-                "disable-text-aa" => self.disable_text_antialiasing = true,
                 "dump-display-list" => self.dump_display_list = true,
                 "dump-stacking-context-tree" => self.dump_stacking_context_tree = true,
                 "dump-flow-tree" => self.dump_flow_tree = true,
                 "dump-rule-tree" => self.dump_rule_tree = true,
                 "dump-style-tree" => self.dump_style_tree = true,
                 "gc-profile" => self.gc_profile = true,
-                "precache-shaders" => self.precache_shaders = true,
                 "profile-script-events" => self.profile_script_events = true,
                 "relayout-event" => self.relayout_event = true,
                 "replace-surrogates" => self.replace_surrogates = true,

--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -135,6 +135,13 @@ pub struct Preferences {
     pub dom_worklet_blockingsleep: bool,
     pub dom_worklet_testing_enabled: bool,
     pub dom_worklet_timeout_ms: i64,
+    /// True to compile all WebRender shaders when Servo initializes. This is mostly
+    /// useful when modifying the shaders, to ensure they all compile after each change is
+    /// made.
+    pub gfx_precache_shaders: bool,
+    /// Whether or not antialiasing is enabled for text rendering.
+    pub gfx_text_antialiasing_enabled: bool,
+    /// Whether or not subpixel antialiasing is enabled for text rendering.
     pub gfx_subpixel_text_antialiasing_enabled: bool,
     pub gfx_texture_swizzling_enabled: bool,
     pub js_asmjs_enabled: bool,
@@ -303,6 +310,8 @@ impl Preferences {
             fonts_monospace: String::new(),
             fonts_sans_serif: String::new(),
             fonts_serif: String::new(),
+            gfx_precache_shaders: true,
+            gfx_text_antialiasing_enabled: true,
             gfx_subpixel_text_antialiasing_enabled: true,
             gfx_texture_swizzling_enabled: true,
             js_asmjs_enabled: true,

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -463,12 +463,6 @@ pub struct Constellation<STF, SWF> {
     /// If True, exits on thread failure instead of displaying about:failure
     hard_fail: bool,
 
-    /// If set with --disable-canvas-aa, disable antialiasing on the HTML
-    /// canvas element.
-    /// Like --disable-text-aa, this is useful for reftests where pixel perfect
-    /// results are required.
-    enable_canvas_antialiasing: bool,
-
     /// Entry point to create and get channels to a GLPlayerThread.
     glplayer_threads: Option<GLPlayerThreads>,
 
@@ -622,7 +616,6 @@ where
         random_pipeline_closure_probability: Option<f32>,
         random_pipeline_closure_seed: Option<usize>,
         hard_fail: bool,
-        enable_canvas_antialiasing: bool,
         canvas_create_sender: Sender<ConstellationCanvasMsg>,
         canvas_ipc_sender: IpcSender<CanvasMsg>,
     ) -> Sender<FromCompositorMsg> {
@@ -762,7 +755,6 @@ where
                     pending_approval_navigations: HashMap::new(),
                     pressed_mouse_buttons: 0,
                     hard_fail,
-                    enable_canvas_antialiasing,
                     glplayer_threads: state.glplayer_threads,
                     player_context: state.player_context,
                     active_media_session: None,
@@ -4514,7 +4506,6 @@ where
         if let Err(e) = self.canvas_sender.send(ConstellationCanvasMsg::Create {
             id_sender: canvas_id_sender,
             size,
-            antialias: self.enable_canvas_antialiasing,
         }) {
             return warn!("Create canvas paint thread failed ({})", e);
         }

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -374,15 +374,14 @@ where
                     // See: https://github.com/servo/servo/issues/31726
                     use_optimized_shaders: true,
                     resource_override_path: opts.shaders_dir.clone(),
-                    enable_aa: !opts.debug.disable_text_antialiasing,
                     debug_flags,
-                    precache_flags: if opts.debug.precache_shaders {
+                    precache_flags: if pref!(gfx_precache_shaders) {
                         ShaderPrecacheFlags::FULL_COMPILE
                     } else {
                         ShaderPrecacheFlags::empty()
                     },
-                    enable_subpixel_aa: pref!(gfx_subpixel_text_antialiasing_enabled) &&
-                        !opts.debug.disable_subpixel_text_antialiasing,
+                    enable_aa: pref!(gfx_text_antialiasing_enabled),
+                    enable_subpixel_aa: pref!(gfx_subpixel_text_antialiasing_enabled),
                     allow_texture_swizzling: pref!(gfx_texture_swizzling_enabled),
                     clear_color,
                     upload_method,
@@ -1147,7 +1146,6 @@ fn create_constellation(
         opts.random_pipeline_closure_probability,
         opts.random_pipeline_closure_seed,
         opts.hard_fail,
-        !opts.debug.disable_canvas_antialiasing,
         canvas_create_sender,
         canvas_ipc_sender,
     )

--- a/components/shared/canvas/lib.rs
+++ b/components/shared/canvas/lib.rs
@@ -19,7 +19,6 @@ pub enum ConstellationCanvasMsg {
     Create {
         id_sender: Sender<CanvasId>,
         size: Size2D<u64>,
-        antialias: bool,
     },
     Exit,
 }

--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -616,18 +616,9 @@ fn print_debug_options_usage(app: &str) {
         "Send touch events instead of mouse events",
     );
     print_option(
-        "disable-canvas-aa",
-        "Disable antialiasing on the HTML canvas element.",
-    );
-    print_option(
         "disable-share-style-cache",
         "Disable the style sharing cache.",
     );
-    print_option(
-        "disable-subpixel-aa",
-        "Disable subpixel text antialiasing overriding preference.",
-    );
-    print_option("disable-text-aa", "Disable antialiasing of rendered text.");
     print_option(
         "dump-stacking-context-tree",
         "Print the stacking context tree after each layout.",
@@ -662,7 +653,6 @@ fn print_debug_options_usage(app: &str) {
         "parallel-display-list-building",
         "Build display lists in parallel.",
     );
-    print_option("precache-shaders", "Compile all shaders during init.");
     print_option(
         "profile-script-events",
         "Enable profiling of script-related events.",

--- a/resources/wpt-prefs.json
+++ b/resources/wpt-prefs.json
@@ -1,4 +1,5 @@
 {
   "dom_webxr_test": true,
+  "gfx_text_antialiasing_enabled": false,
   "network_tls_ignore_unexpected_eof": true
 }

--- a/tests/wpt/tests/tools/wptrunner/wptrunner/executors/executorservo.py
+++ b/tests/wpt/tests/tools/wptrunner/wptrunner/executors/executorservo.py
@@ -231,7 +231,7 @@ class ServoRefTestExecutor(ServoExecutor):
             extra_args = ["--exit",
                           "--output=%s" % output_path,
                           "--window-size", viewport_size or "800x600"]
-            debug_opts = "disable-text-aa,replace-surrogates"
+            debug_opts = "replace-surrogates"
 
             if dpi:
                 extra_args += ["--device-pixel-ratio", dpi]


### PR DESCRIPTION
- Move options configuring antialiasing and WebRender shader precache to
  the `Preferences` to group them with other related WebRender and DOM
  settings.
- Remove the option to disable antialiasing for canvases. This was
 unused.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are covered by existing tests. They just adjust how some settings are set.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
