### PR TITLE
fonts: Remove synchronous web font loading functionality

### DIFF
--- a/components/config/opts.rs
+++ b/components/config/opts.rs
@@ -177,9 +177,6 @@ pub struct DebugOptions {
     /// Log GC passes and their durations.
     pub gc_profile: bool,
 
-    /// Load web fonts synchronously to avoid non-deterministic network-driven reflows.
-    pub load_webfonts_synchronously: bool,
-
     /// Show webrender profiling stats on screen.
     pub webrender_stats: bool,
 
@@ -209,7 +206,6 @@ impl DebugOptions {
                 "dump-rule-tree" => self.dump_rule_tree = true,
                 "dump-style-tree" => self.dump_style_tree = true,
                 "gc-profile" => self.gc_profile = true,
-                "load-webfonts-synchronously" => self.load_webfonts_synchronously = true,
                 "precache-shaders" => self.precache_shaders = true,
                 "profile-script-events" => self.profile_script_events = true,
                 "relayout-event" => self.relayout_event = true,

--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -639,22 +639,12 @@ impl LayoutThread {
                 );
             };
 
-        // Find all font-face rules and notify the FontContext of them.
-        // GWTODO: Need to handle unloading web fonts.
-        let newly_loading_font_count = self.font_context.add_all_web_fonts_from_stylesheet(
+        self.font_context.add_all_web_fonts_from_stylesheet(
             stylesheet,
             guard,
             self.stylist.device(),
             Arc::new(web_font_finished_loading_callback) as WebFontLoadFinishedCallback,
-            self.debug.load_webfonts_synchronously,
         );
-
-        if self.debug.load_webfonts_synchronously && newly_loading_font_count > 0 {
-            // TODO: Handle failure in web font loading
-            let _ = self
-                .script_chan
-                .send(ConstellationControlMsg::WebFontLoaded(self.id, true));
-        }
     }
 
     fn try_get_layout_root<'dom>(&self, node: impl LayoutNode<'dom>) -> Option<FlowRef> {

--- a/components/layout_thread_2020/lib.rs
+++ b/components/layout_thread_2020/lib.rs
@@ -618,22 +618,12 @@ impl LayoutThread {
                 ));
         };
 
-        // Find all font-face rules and notify the font cache of them.
-        // GWTODO: Need to handle unloading web fonts.
-        let newly_loading_font_count = self.font_context.add_all_web_fonts_from_stylesheet(
+        self.font_context.add_all_web_fonts_from_stylesheet(
             stylesheet,
             guard,
             self.stylist.device(),
             Arc::new(web_font_finished_loading_callback) as WebFontLoadFinishedCallback,
-            self.debug.load_webfonts_synchronously,
         );
-
-        if self.debug.load_webfonts_synchronously && newly_loading_font_count > 0 {
-            // TODO: Handle failure in web font loading
-            let _ = self
-                .script_chan
-                .send(ConstellationControlMsg::WebFontLoaded(self.id, true));
-        }
     }
 
     /// The high-level routine that performs layout.

--- a/tests/wpt/tests/tools/wptrunner/wptrunner/executors/executorservo.py
+++ b/tests/wpt/tests/tools/wptrunner/wptrunner/executors/executorservo.py
@@ -231,7 +231,7 @@ class ServoRefTestExecutor(ServoExecutor):
             extra_args = ["--exit",
                           "--output=%s" % output_path,
                           "--window-size", viewport_size or "800x600"]
-            debug_opts = "disable-text-aa,load-webfonts-synchronously,replace-surrogates"
+            debug_opts = "disable-text-aa,replace-surrogates"
 
             if dpi:
                 extra_args += ["--device-pixel-ratio", dpi]


### PR DESCRIPTION
Synchronous web font loading is not specification compliant and was
added in #8341 to work around issues that do not exist any longer. This
change removes the functionality and ensures that WPT tests are run with
the spec compliant loader.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are covered by the many WPT tests that test web font loading.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
