### PR TITLE
layout: Allow different collapsed border style/color within a row/column

### DIFF
--- a/components/layout_2020/geom.rs
+++ b/components/layout_2020/geom.rs
@@ -40,7 +40,7 @@ pub struct LogicalRect<T> {
     pub size: LogicalVec2<T>,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct LogicalSides<T> {
     pub inline_start: T,
     pub inline_end: T,

--- a/tests/wpt/meta/css/CSS2/borders/border-bottom-applies-to-006.xht.ini
+++ b/tests/wpt/meta/css/CSS2/borders/border-bottom-applies-to-006.xht.ini
@@ -1,2 +1,0 @@
-[border-bottom-applies-to-006.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/borders/border-bottom-color-applies-to-006.xht.ini
+++ b/tests/wpt/meta/css/CSS2/borders/border-bottom-color-applies-to-006.xht.ini
@@ -1,2 +1,0 @@
-[border-bottom-color-applies-to-006.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/borders/border-bottom-width-applies-to-006.xht.ini
+++ b/tests/wpt/meta/css/CSS2/borders/border-bottom-width-applies-to-006.xht.ini
@@ -1,2 +1,0 @@
-[border-bottom-width-applies-to-006.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/borders/border-top-applies-to-006.xht.ini
+++ b/tests/wpt/meta/css/CSS2/borders/border-top-applies-to-006.xht.ini
@@ -1,2 +1,0 @@
-[border-top-applies-to-006.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/borders/border-top-color-applies-to-006.xht.ini
+++ b/tests/wpt/meta/css/CSS2/borders/border-top-color-applies-to-006.xht.ini
@@ -1,2 +1,0 @@
-[border-top-color-applies-to-006.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/borders/border-top-width-applies-to-006.xht.ini
+++ b/tests/wpt/meta/css/CSS2/borders/border-top-width-applies-to-006.xht.ini
@@ -1,2 +1,0 @@
-[border-top-width-applies-to-006.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/border-collapse-dynamic-cell-002.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/border-collapse-dynamic-cell-002.xht.ini
@@ -1,2 +1,0 @@
-[border-collapse-dynamic-cell-002.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-tables/collapsed-border-remove-cell.html.ini
+++ b/tests/wpt/meta/css/css-tables/collapsed-border-remove-cell.html.ini
@@ -1,2 +1,0 @@
-[collapsed-border-remove-cell.html]
-  expected: FAIL


### PR DESCRIPTION
We were previously using the same style and color for two collapsed borders sharing a coordinate. Now such a line of collapsed borders can be piecewise and have different colors and styles.

This still doesn't add support for piecewise border widths.

Also, since we are currently painting borders as part of the table and cell boxes, and a box side can't have a piecewise border, this patch only really works when:
 - There aren't spanning cells
 - The table has no assigned border (only the cells and tracks have it)

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #34950
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
