### PR TITLE
CI: Test ohos on HarmonyOS device

### DIFF
--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -149,3 +149,93 @@ jobs:
       speedometer: false
       dromaeo: false
     secrets: inherit
+
+  # Note: We could potentially also merge this build job with the above one,
+  # if we figure out how to make hvigor build for harmonyos without the HOS commandline-tools installed.
+  build-harmonyos-aarch64:
+    name: HarmonyOS Build (aarch64)
+    continue-on-error: true
+    runs-on: hos-builder
+    if: github.repository == 'servo/servo'
+    steps:
+      - if: ${{ github.event_name != 'pull_request_target' }}
+        run: git fetch --depth=1 origin $GITHUB_SHA
+      - if: ${{ github.event_name == 'pull_request_target' }}
+        run: git fetch --depth=1 origin ${{ github.event.pull_request.head.sha }}
+      - run: |
+          git switch --detach
+          git reset --hard FETCH_HEAD
+      - name: Build for aarch64 HarmonyOS
+        run: |
+          ./mach build --locked --target aarch64-unknown-linux-ohos --profile=${{ inputs.profile }} --flavor=harmonyos --no-default-features --features tracing,tracing-hitrace
+      - uses: actions/upload-artifact@v4
+        with:
+          # Upload the **unsigned** artifact - We don't have the signing materials in pull request workflows
+          path: target/openharmony/aarch64-unknown-linux-ohos/${{ inputs.profile }}/entry/build/harmonyos/outputs/default/servoshell-default-unsigned.hap
+          name: servoshell-hos-${{ inputs.profile }}.hap
+
+
+  test-harmonyos-aarch64:
+    name: Test HarmonyOS aarch64
+    # Don't block servos Merge queue on this job failing.
+    # Since we just added this, there might be some hidden issues,
+    # so in the beginning we will just do a best effort approach but ignore errors.
+    continue-on-error: true
+    runs-on: hos-runner
+    if: github.repository == 'servo/servo'
+    needs: build-harmonyos-aarch64
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          # Name of the artifact to download.
+          # If unspecified, all artifacts for the run are downloaded.
+          name: servoshell-hos-${{ inputs.profile }}.hap
+      - name: Test hdc device
+        # First we ensure a device is actually connected and working.
+        run: hdc list targets && hdc shell echo hello world
+      - name: Sign the hap
+        run: |
+          ls -la
+          /usr/bin/sign-hos.sh servoshell-default-unsigned.hap servoshell-hos-signed.hap
+      - name: Install
+        run: |
+          # Uninstall first. hdc is not very reliable in terms of exiting with an error, so we uninstall first
+          # to make sure we don't use a previous version if installation failed for some reason.
+          hdc uninstall org.servo.servoshell
+          hdc install -r servoshell-hos-signed.hap
+      - name: Test loading servo.org
+        env:
+          TRACE_BUFFER_SZ_KB: "524288" # 512 MB
+        run:  |
+          mkdir test_output
+          hdc shell aa force-stop org.servo.servoshell
+          # Hitrace allows us to save application and system traces, which is useful to analyze performance.
+          # The main reason however, is that we can use the application traces to determine if servo
+          # successfully reaches certain locations in the code, in particular if a a page is successfully loaded.
+          hdc shell hitrace -b "${TRACE_BUFFER_SZ_KB}" app graphic ohos freq idle memory --trace_begin
+          # We start servo, tell it to load a website (servo.org). JIT is not allowed on HarmonyOS 5.
+          hdc shell aa start -a EntryAbility -b org.servo.servoshell -U https://servo.org --ps=--pref js_disable_jit=true
+          servo_pid=$(hdc shell pidof org.servo.servoshell)
+          # We don't really know how long servo needs to load a webpage, so we just wait 10s.
+          sleep 10
+          # We dump the trace in ftrace format to disk
+          hdc shell hitrace -b "${TRACE_BUFFER_SZ_KB}" --trace_finish -o /data/local/tmp/ohtrace.txt
+          hdc shell snapshot_display -f /data/local/tmp/servo.jpeg
+          hdc file recv /data/local/tmp/servo.jpeg  test_output/servo_hos_screenshot.jpeg
+          hdc file recv /data/local/tmp/ohtrace.txt  test_output/servo.ftrace
+          # To limit the logsize we only save logs from servo. 
+          # Todo:  investigate giving servo a custom domain tag, so we can also log appspawn etc, 
+          # since another common error might be the dynamic loader failing to relocate libservoshell.so
+          hdc shell hilog --exit --pid=${servo_pid} > test_output/servo.log
+      # todo: Also benchmark some other websites....
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          path: test_output
+      - name: Check success
+        run: |
+          # would be empty if servo crashed.
+          servo_pid=$(hdc shell pidof org.servo.servoshell)
+          [[ $servo_pid =~ ^[0-9]+$ ]] || { echo "It looks like servo crashed!" ; exit 1; }
+          # If the grep fails, then the trace output for the "page loaded" prompt is missing
+          grep 'servoshell.* tracing_mark_write.*PageLoadEndedPrompt' test_output/servo.ftrace

--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -211,7 +211,7 @@ jobs:
           hdc shell aa force-stop org.servo.servoshell
           # Hitrace allows us to save application and system traces, which is useful to analyze performance.
           # The main reason however, is that we can use the application traces to determine if servo
-          # successfully reaches certain locations in the code, in particular if a a page is successfully loaded.
+          # successfully reaches certain locations in the code, in particular if a page is successfully loaded.
           hdc shell hitrace -b "${TRACE_BUFFER_SZ_KB}" app graphic ohos freq idle memory --trace_begin
           # We start servo, tell it to load a website (servo.org). JIT is not allowed on HarmonyOS 5.
           hdc shell aa start -a EntryAbility -b org.servo.servoshell -U https://servo.org --ps=--pref js_disable_jit=true

--- a/ports/servoshell/egl/ohos.rs
+++ b/ports/servoshell/egl/ohos.rs
@@ -695,6 +695,13 @@ impl HostTrait for HostCallbacks {
     }
 
     fn on_load_ended(&self) {
+        // Note: It seems that we don't necessarily get 1 `on_load_ended` for each
+        // each time `on_loaded_started` is called. Presumably this requires some API changes,
+        // e.g. including webview id, perhaps URL and some additional investigation effort.
+        // For now we just add a trace event here, so that we can see in the trace if we
+        // successfully loaded **a** page.
+        #[cfg(feature = "tracing-hitrace")]
+        let _scope = hitrace::ScopedTrace::start_trace(&c"PageLoadEndedPrompt");
         self.prompt_alert("Page finished loading!".to_string(), true);
     }
 


### PR DESCRIPTION
This PR adds runtime test / benchmark for ohos.
It uses a self-hosted physical machine with an attached harmonyos device in standard configuration.
The github runners are JIT runners (destroyed after one job) using rootless docker (see companion PR https://github.com/servo/ci-runners/pull/22 ).
The machine / monitor supports multiple (exact amount TBD) concurrent build jobs + 1 concurrent test job. 
The current testing workflow is quite fast, since it is decoupled from building, so the single device should not be a bottleneck for now.

Since there might still be issues with the workflow, `continue-on-error` is set to true, so the merge queue shouldn't be blocked if the new ci job fails.

Try run: https://github.com/servo/servo/actions/runs/12899852950/job/35969365027


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)
- [x] There are tests for these changes: This is a test

