### PR TITLE
Fix build failure with tracing feature

### DIFF
--- a/components/script/dom/bindings/settings_stack.rs
+++ b/components/script/dom/bindings/settings_stack.rs
@@ -43,6 +43,7 @@ pub(crate) fn is_execution_stack_empty() -> bool {
 pub(crate) struct AutoEntryScript {
     global: DomRoot<GlobalScope>,
     #[cfg(feature = "tracing")]
+    #[allow(dead_code)]
     span: tracing::span::EnteredSpan,
 }
 

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -227,7 +227,7 @@ where
     #[cfg_attr(
         feature = "tracing",
         tracing::instrument(
-            skip(rendering_context, embedder, window),
+            skip(preferences, rendering_context, embedder, window),
             fields(servo_profiling = true),
             level = "trace",
         )


### PR DESCRIPTION
Preferences doesn't implement `Debug`, so we can't trace it. Since the struct is large, it makes sense to skip it.
Also fixes a false-positive warning about an unused tracing span (the intended usage is that the trace end event is fired when the span guard is eventually dropped)


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix a build failure with `./mach build --features tracing`

