### PR TITLE
layout: Allow layouts to customize their used style

### DIFF
--- a/components/layout_2020/flow/inline/inline_box.rs
+++ b/components/layout_2020/flow/inline/inline_box.rs
@@ -15,7 +15,7 @@ use crate::context::LayoutContext;
 use crate::dom::NodeExt;
 use crate::dom_traversal::NodeAndStyleInfo;
 use crate::fragment_tree::BaseFragmentInfo;
-use crate::style_ext::{ComputedValuesExt, PaddingBorderMargin};
+use crate::style_ext::{LayoutStyle, PaddingBorderMargin};
 use crate::ContainingBlock;
 
 #[derive(Debug)]
@@ -51,6 +51,11 @@ impl InlineBox {
             is_last_fragment: false,
             ..*self
         }
+    }
+
+    #[inline]
+    pub(crate) fn layout_style(&self) -> LayoutStyle {
+        LayoutStyle::Default(&self.style)
     }
 }
 
@@ -214,7 +219,9 @@ impl InlineBoxContainerState {
         font_metrics: Option<&FontMetrics>,
     ) -> Self {
         let style = inline_box.style.clone();
-        let pbm = style.padding_border_margin(containing_block);
+        let pbm = inline_box
+            .layout_style()
+            .padding_border_margin(containing_block);
 
         let mut flags = InlineContainerStateFlags::empty();
         if inline_container_needs_strut(&style, layout_context, Some(&pbm)) {

--- a/components/layout_2020/flow/inline/mod.rs
+++ b/components/layout_2020/flow/inline/mod.rs
@@ -2244,11 +2244,11 @@ impl<'layout_data> ContentSizesComputation<'layout_data> {
                 let inline_box = inline_box.borrow();
                 let zero = Au::zero();
                 let writing_mode = self.constraint_space.writing_mode;
-                let padding = inline_box
-                    .style
+                let layout_style = inline_box.layout_style();
+                let padding = layout_style
                     .padding(writing_mode)
                     .percentages_relative_to(zero);
-                let border = inline_box.style.border_width(writing_mode);
+                let border = layout_style.border_width(writing_mode);
                 let margin = inline_box
                     .style
                     .margin(writing_mode)

--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -467,7 +467,9 @@ impl HoistedAbsolutelyPositionedBox {
             content_box_sizes,
             pbm,
             ..
-        } = style.content_box_sizes_and_padding_border_margin(&containing_block.into());
+        } = context
+            .layout_style()
+            .content_box_sizes_and_padding_border_margin(&containing_block.into());
         let containing_block = &containing_block.into();
         let is_table = context.is_table();
 

--- a/components/layout_2020/replaced.rs
+++ b/components/layout_2020/replaced.rs
@@ -31,8 +31,9 @@ use crate::context::LayoutContext;
 use crate::dom::NodeExt;
 use crate::fragment_tree::{BaseFragmentInfo, Fragment, IFrameFragment, ImageFragment};
 use crate::geom::{LogicalVec2, PhysicalPoint, PhysicalRect, PhysicalSize, Size, Sizes};
+use crate::layout_box_base::LayoutBoxBase;
 use crate::sizing::{ComputeInlineContentSizes, ContentSizes, InlineContentSizesResult};
-use crate::style_ext::{AspectRatio, Clamp, ComputedValuesExt, ContentBoxSizesAndPBM};
+use crate::style_ext::{AspectRatio, Clamp, ComputedValuesExt, ContentBoxSizesAndPBM, LayoutStyle};
 use crate::{ConstraintSpace, ContainingBlock, SizeConstraint};
 
 #[derive(Debug)]
@@ -566,6 +567,11 @@ impl ReplacedContents {
             inline: inline_size,
             block: block_size,
         }
+    }
+
+    #[inline]
+    pub(crate) fn layout_style<'a>(&self, base: &'a LayoutBoxBase) -> LayoutStyle<'a> {
+        LayoutStyle::Default(&base.style)
     }
 }
 

--- a/components/layout_2020/sizing.rs
+++ b/components/layout_2020/sizing.rs
@@ -8,13 +8,12 @@ use std::cell::LazyCell;
 use std::ops::{Add, AddAssign};
 
 use app_units::Au;
-use style::properties::ComputedValues;
 use style::values::computed::LengthPercentage;
 use style::Zero;
 
 use crate::context::LayoutContext;
 use crate::geom::Size;
-use crate::style_ext::{AspectRatio, Clamp, ComputedValuesExt, ContentBoxSizesAndPBM};
+use crate::style_ext::{AspectRatio, Clamp, ComputedValuesExt, ContentBoxSizesAndPBM, LayoutStyle};
 use crate::{ConstraintSpace, IndefiniteContainingBlock, LogicalVec2};
 
 #[derive(PartialEq)]
@@ -111,7 +110,7 @@ impl From<Au> for ContentSizes {
 
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn outer_inline(
-    style: &ComputedValues,
+    layout_style: &LayoutStyle,
     containing_block: &IndefiniteContainingBlock,
     auto_minimum: &LogicalVec2<Au>,
     auto_block_size_stretches_to_containing_block: bool,
@@ -125,12 +124,13 @@ pub(crate) fn outer_inline(
         content_box_sizes,
         pbm,
         mut depends_on_block_constraints,
-    } = style.content_box_sizes_and_padding_border_margin(containing_block);
+    } = layout_style.content_box_sizes_and_padding_border_margin(containing_block);
     let margin = pbm.margin.map(|v| v.auto_is(Au::zero));
     let pbm_sums = LogicalVec2 {
         block: pbm.padding_border_sums.block + margin.block_sum(),
         inline: pbm.padding_border_sums.inline + margin.inline_sum(),
     };
+    let style = layout_style.style();
     let content_size = LazyCell::new(|| {
         let constraint_space = if establishes_containing_block {
             let available_block_size = containing_block


### PR DESCRIPTION
Some layouts like table need some style overrides. We were handling this in `ComputedValuesExt`, but it was messy, unreliable and too limited.

For example, we were assuming that a style with `display: table` would belong to a table wrapper box or table grid box. However, certain HTML elements can ignore their `display` value and generate a different kind of box. I think we aren't doing that yet, but we will need this.

Also, resolving the used border of a table needs layout information, which we don't have in `ComputedValuesExt`. This patch will allow to improve border collapsing in a follow-up.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because there is no behavior change

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
