### PR TITLE
Allow embedders to open links in a new tab

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -131,6 +131,7 @@ use ipc_channel::Error as IpcError;
 use ipc_channel::ipc::{self, IpcReceiver, IpcSender};
 use ipc_channel::router::ROUTER;
 use keyboard_types::webdriver::Event as WebDriverInputEvent;
+use keyboard_types::{Key, KeyState, KeyboardEvent, Modifiers};
 use log::{debug, error, info, trace, warn};
 use media::WindowGLContext;
 use net_traits::pub_domains::reg_host;
@@ -454,6 +455,9 @@ pub struct Constellation<STF, SWF> {
     /// currently being pressed.
     pressed_mouse_buttons: u16,
 
+    /// The currently activated keyboard modifiers.
+    active_keyboard_modifiers: Modifiers,
+
     /// If True, exits on thread failure instead of displaying about:failure
     hard_fail: bool,
 
@@ -730,6 +734,7 @@ where
                     canvas_ipc_sender,
                     pending_approval_navigations: HashMap::new(),
                     pressed_mouse_buttons: 0,
+                    active_keyboard_modifiers: Modifiers::empty(),
                     hard_fail,
                     active_media_session: None,
                     user_agent: state.user_agent,
@@ -2830,6 +2835,38 @@ where
         }
     }
 
+    fn update_active_keybord_modifiers(&mut self, event: &KeyboardEvent) {
+        self.active_keyboard_modifiers = event.modifiers;
+
+        // `KeyboardEvent::modifiers` contains the pre-existing modifiers before this key was
+        // either pressed or released, but `active_keyboard_modifiers` should track the subsequent
+        // state. If this event will update that state, we need to ensure that we are tracking what
+        // the event changes.
+        let modified_modifier = match event.key {
+            Key::Alt => Modifiers::ALT,
+            Key::AltGraph => Modifiers::ALT_GRAPH,
+            Key::CapsLock => Modifiers::CAPS_LOCK,
+            Key::Control => Modifiers::CONTROL,
+            Key::Fn => Modifiers::FN,
+            Key::FnLock => Modifiers::FN_LOCK,
+            Key::Meta => Modifiers::META,
+            Key::NumLock => Modifiers::NUM_LOCK,
+            Key::ScrollLock => Modifiers::SCROLL_LOCK,
+            Key::Shift => Modifiers::SHIFT,
+            Key::Symbol => Modifiers::SYMBOL,
+            Key::SymbolLock => Modifiers::SYMBOL_LOCK,
+            Key::Hyper => Modifiers::HYPER,
+            // The web doesn't make a distinction between these keys (there is only
+            // "meta") so map "super" to "meta".
+            Key::Super => Modifiers::META,
+            _ => return,
+        };
+        match event.state {
+            KeyState::Down => self.active_keyboard_modifiers.insert(modified_modifier),
+            KeyState::Up => self.active_keyboard_modifiers.remove(modified_modifier),
+        }
+    }
+
     fn forward_input_event(
         &mut self,
         webview_id: WebViewId,
@@ -2840,9 +2877,14 @@ where
             self.update_pressed_mouse_buttons(event);
         }
 
-        // The constellation tracks the state of pressed mouse buttons and updates the event
-        // here to reflect the current state.
+        if let InputEvent::Keyboard(event) = &event {
+            self.update_active_keybord_modifiers(event);
+        }
+
+        // The constellation tracks the state of pressed mouse buttons and keyboard
+        // modifiers and updates the event here to reflect the current state.
         let pressed_mouse_buttons = self.pressed_mouse_buttons;
+        let active_keyboard_modifiers = self.active_keyboard_modifiers;
 
         // TODO: Click should be handled internally in the `Document`.
         if let InputEvent::MouseButton(event) = &event {
@@ -2885,6 +2927,7 @@ where
         let event = ConstellationInputEvent {
             hit_test_result,
             pressed_mouse_buttons,
+            active_keyboard_modifiers,
             event,
         };
 
@@ -4392,11 +4435,13 @@ where
                     let event = match event {
                         WebDriverInputEvent::Keyboard(event) => ConstellationInputEvent {
                             pressed_mouse_buttons: self.pressed_mouse_buttons,
+                            active_keyboard_modifiers: event.modifiers,
                             hit_test_result: None,
                             event: InputEvent::Keyboard(event),
                         },
                         WebDriverInputEvent::Composition(event) => ConstellationInputEvent {
                             pressed_mouse_buttons: self.pressed_mouse_buttons,
+                            active_keyboard_modifiers: self.active_keyboard_modifiers,
                             hit_test_result: None,
                             event: InputEvent::Ime(ImeEvent::Composition(event)),
                         },
@@ -4422,6 +4467,7 @@ where
                     pipeline_id,
                     ConstellationInputEvent {
                         pressed_mouse_buttons: self.pressed_mouse_buttons,
+                        active_keyboard_modifiers: event.modifiers,
                         hit_test_result: None,
                         event: InputEvent::Keyboard(event),
                     },

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1069,6 +1069,8 @@ impl ScriptThread {
         let window = document.window();
         let _realm = enter_realm(document.window());
         for event in document.take_pending_input_events().into_iter() {
+            document.update_active_keyboard_modifiers(event.active_keyboard_modifiers);
+
             match event.event {
                 InputEvent::MouseButton(mouse_button_event) => {
                     document.handle_mouse_button_event(

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -38,6 +38,7 @@ use euclid::{Rect, Scale, Size2D, UnknownUnit};
 use http::{HeaderMap, Method};
 use ipc_channel::Error as IpcError;
 use ipc_channel::ipc::{IpcReceiver, IpcSender};
+use keyboard_types::Modifiers;
 use log::warn;
 use malloc_size_of_derive::MallocSizeOf;
 use media::WindowGLContext;
@@ -401,6 +402,8 @@ pub struct ConstellationInputEvent {
     /// The pressed mouse button state of the constellation when this input
     /// event was triggered.
     pub pressed_mouse_buttons: u16,
+    /// The currently active keyboard modifiers.
+    pub active_keyboard_modifiers: Modifiers,
     /// The [`InputEvent`] itself.
     pub event: InputEvent,
 }


### PR DESCRIPTION
   This changes starts tracking the keyboard modifier state in the
`Constellation` and forwards it with every input event. The state
is used to modify the target of link click so when the
platform-dependent alternate action key is enabled, the target is
overriden to "_blank".

In addition, specification step numbers and text is updated.

Co-authored-by: Martin Robinson <mrobinson@igalia.com>
Signed-off-by: webbeef <me@webbeef.org>
Signed-off-by: Martin Robinson <mrobinson@igalia.com>

---

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are no tests for this change. This requires tests of the `WebView` interface which we don't support yet.

