### PR TITLE
Remove unneeded allow annotation.

### DIFF
--- a/components/script/dom/bindings/root.rs
+++ b/components/script/dom/bindings/root.rs
@@ -43,7 +43,6 @@ use crate::dom::bindings::trace::{trace_reflector, JSTraceable};
 use crate::dom::node::Node;
 
 /// A rooted value.
-#[cfg_attr(crown, allow(crown::unrooted_must_root))]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::allow_unrooted_interior)]
 pub(crate) struct Root<T: StableTraceObject> {
     /// The value to root.

--- a/components/script/dom/bindings/weakref.rs
+++ b/components/script/dom/bindings/weakref.rs
@@ -33,7 +33,6 @@ use crate::dom::bindings::trace::JSTraceable;
 pub(crate) const DOM_WEAK_SLOT: u32 = 1;
 
 /// A weak reference to a JS-managed DOM object.
-#[cfg_attr(crown, allow(crown::unrooted_must_root))]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::allow_unrooted_interior)]
 pub(crate) struct WeakRef<T: WeakReferenceable> {
     ptr: ptr::NonNull<WeakBox<T>>,


### PR DESCRIPTION
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #35016
- [x] These changes do not require tests because they are compile-time only changes.