### PR TITLE
Fix check for unused subdir in wpt import script

### DIFF
--- a/python/wpt/update.py
+++ b/python/wpt/update.py
@@ -60,9 +60,7 @@ def remove_unused_metadata():
     for meta_root in META_ROOTS:
         for base_dir, dir_names, files in os.walk(meta_root):
             # Skip recursing into any directories that were previously found to be missing.
-            if base_dir in unused_dirs:
-                # Skip processing any subdirectories of known missing directories.
-                unused_dirs += [os.path.join(base_dir, x) for x in dir_names]
+            if any([os.path.commonpath([base_dir, unused_dir]) == unused_dir for unused_dir in unused_dirs]):
                 continue
 
             for dir_name in dir_names:


### PR DESCRIPTION
Before we appended all subdirs of unused_dir to unused_dirs, which caused errors on removing because root dir was already removed.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #35026
- [x] These changes do not require tests because they are supporting infra, but they were tested locally.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
