### PR TITLE
For compat with servo-media 1e28d1d997, don't unwrap ServoMedia::get()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,7 +421,7 @@ dependencies = [
  "bitflags 2.8.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "regex",
@@ -949,7 +949,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4162,7 +4162,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -6425,7 +6425,7 @@ dependencies = [
 [[package]]
 name = "servo-media"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#5f4c4066cb4793179adcfd678be63328de8ccbda"
+source = "git+https://github.com/servo/media#1ff67581bceada8680396cff5520587c669eac83"
 dependencies = [
  "once_cell",
  "servo-media-audio",
@@ -6438,7 +6438,7 @@ dependencies = [
 [[package]]
 name = "servo-media-audio"
 version = "0.2.0"
-source = "git+https://github.com/servo/media#5f4c4066cb4793179adcfd678be63328de8ccbda"
+source = "git+https://github.com/servo/media#1ff67581bceada8680396cff5520587c669eac83"
 dependencies = [
  "byte-slice-cast",
  "euclid",
@@ -6459,7 +6459,7 @@ dependencies = [
 [[package]]
 name = "servo-media-derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#5f4c4066cb4793179adcfd678be63328de8ccbda"
+source = "git+https://github.com/servo/media#1ff67581bceada8680396cff5520587c669eac83"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6469,7 +6469,7 @@ dependencies = [
 [[package]]
 name = "servo-media-dummy"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#5f4c4066cb4793179adcfd678be63328de8ccbda"
+source = "git+https://github.com/servo/media#1ff67581bceada8680396cff5520587c669eac83"
 dependencies = [
  "ipc-channel",
  "servo-media",
@@ -6483,7 +6483,7 @@ dependencies = [
 [[package]]
 name = "servo-media-gstreamer"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#5f4c4066cb4793179adcfd678be63328de8ccbda"
+source = "git+https://github.com/servo/media#1ff67581bceada8680396cff5520587c669eac83"
 dependencies = [
  "byte-slice-cast",
  "glib",
@@ -6517,7 +6517,7 @@ dependencies = [
 [[package]]
 name = "servo-media-gstreamer-render"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#5f4c4066cb4793179adcfd678be63328de8ccbda"
+source = "git+https://github.com/servo/media#1ff67581bceada8680396cff5520587c669eac83"
 dependencies = [
  "gstreamer",
  "gstreamer-video",
@@ -6527,7 +6527,7 @@ dependencies = [
 [[package]]
 name = "servo-media-gstreamer-render-android"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#5f4c4066cb4793179adcfd678be63328de8ccbda"
+source = "git+https://github.com/servo/media#1ff67581bceada8680396cff5520587c669eac83"
 dependencies = [
  "glib",
  "gstreamer",
@@ -6541,7 +6541,7 @@ dependencies = [
 [[package]]
 name = "servo-media-gstreamer-render-unix"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#5f4c4066cb4793179adcfd678be63328de8ccbda"
+source = "git+https://github.com/servo/media#1ff67581bceada8680396cff5520587c669eac83"
 dependencies = [
  "glib",
  "gstreamer",
@@ -6556,7 +6556,7 @@ dependencies = [
 [[package]]
 name = "servo-media-player"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#5f4c4066cb4793179adcfd678be63328de8ccbda"
+source = "git+https://github.com/servo/media#1ff67581bceada8680396cff5520587c669eac83"
 dependencies = [
  "ipc-channel",
  "serde",
@@ -6568,7 +6568,7 @@ dependencies = [
 [[package]]
 name = "servo-media-streams"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#5f4c4066cb4793179adcfd678be63328de8ccbda"
+source = "git+https://github.com/servo/media#1ff67581bceada8680396cff5520587c669eac83"
 dependencies = [
  "lazy_static",
  "uuid",
@@ -6577,12 +6577,12 @@ dependencies = [
 [[package]]
 name = "servo-media-traits"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#5f4c4066cb4793179adcfd678be63328de8ccbda"
+source = "git+https://github.com/servo/media#1ff67581bceada8680396cff5520587c669eac83"
 
 [[package]]
 name = "servo-media-webrtc"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#5f4c4066cb4793179adcfd678be63328de8ccbda"
+source = "git+https://github.com/servo/media#1ff67581bceada8680396cff5520587c669eac83"
 dependencies = [
  "lazy_static",
  "log",
@@ -8595,7 +8595,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/components/script/dom/baseaudiocontext.rs
+++ b/components/script/dom/baseaudiocontext.rs
@@ -127,7 +127,6 @@ impl BaseAudioContext {
         let client_context_id =
             ClientContextId::build(pipeline_id.namespace_id.0, pipeline_id.index.0.get());
         let audio_context_impl = ServoMedia::get()
-            .unwrap()
             .create_audio_context(&client_context_id, options.convert())
             .map_err(|_| Error::NotSupported)?;
 

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -676,7 +676,7 @@ impl Document {
 
         // Set the document's activity level, reflow if necessary, and suspend or resume timers.
         self.activity.set(activity);
-        let media = ServoMedia::get().unwrap();
+        let media = ServoMedia::get();
         let pipeline_id = self.window().pipeline_id();
         let client_context_id =
             ClientContextId::build(pipeline_id.namespace_id.0, pipeline_id.index.0.get());

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -1361,7 +1361,7 @@ impl HTMLMediaElement {
         let pipeline_id = window.pipeline_id();
         let client_context_id =
             ClientContextId::build(pipeline_id.namespace_id.0, pipeline_id.index.0.get());
-        let player = ServoMedia::get().unwrap().create_player(
+        let player = ServoMedia::get().create_player(
             &client_context_id,
             stream_type,
             action_sender,
@@ -2165,7 +2165,7 @@ impl HTMLMediaElementMethods<crate::DomTypeHolder> for HTMLMediaElement {
 
     // https://html.spec.whatwg.org/multipage/#dom-navigator-canplaytype
     fn CanPlayType(&self, type_: DOMString) -> CanPlayTypeResult {
-        match ServoMedia::get().unwrap().can_play_type(&type_) {
+        match ServoMedia::get().can_play_type(&type_) {
             SupportsMediaType::No => CanPlayTypeResult::_empty,
             SupportsMediaType::Maybe => CanPlayTypeResult::Maybe,
             SupportsMediaType::Probably => CanPlayTypeResult::Probably,

--- a/components/script/dom/mediadevices.rs
+++ b/components/script/dom/mediadevices.rs
@@ -59,7 +59,7 @@ impl MediaDevicesMethods<crate::DomTypeHolder> for MediaDevices {
         can_gc: CanGc,
     ) -> Rc<Promise> {
         let p = Promise::new_in_current_realm(comp, can_gc);
-        let media = ServoMedia::get().unwrap();
+        let media = ServoMedia::get();
         let stream = MediaStream::new(&self.global(), can_gc);
         if let Some(constraints) = convert_constraints(&constraints.audio) {
             if let Some(audio) = media.create_audioinput_stream(constraints) {
@@ -89,7 +89,7 @@ impl MediaDevicesMethods<crate::DomTypeHolder> for MediaDevices {
         // XXX Steps 2.1 - 2.4
 
         // Step 2.5
-        let media = ServoMedia::get().unwrap();
+        let media = ServoMedia::get();
         let device_monitor = media.get_device_monitor();
         let result_list = match device_monitor.enumerate_devices() {
             Ok(devices) => devices

--- a/components/script/dom/mediastreamaudiodestinationnode.rs
+++ b/components/script/dom/mediastreamaudiodestinationnode.rs
@@ -35,7 +35,7 @@ impl MediaStreamAudioDestinationNode {
         options: &AudioNodeOptions,
         can_gc: CanGc,
     ) -> Fallible<MediaStreamAudioDestinationNode> {
-        let media = ServoMedia::get().unwrap();
+        let media = ServoMedia::get();
         let (socket, id) = media.create_stream_and_socket(MediaStreamType::Audio);
         let stream = MediaStream::new_single(&context.global(), id, MediaStreamType::Audio, can_gc);
         let node_options = options.unwrap_or(

--- a/components/script/dom/rtcpeerconnection.rs
+++ b/components/script/dom/rtcpeerconnection.rs
@@ -189,7 +189,7 @@ impl RTCPeerConnection {
             can_gc,
         );
         let signaller = this.make_signaller();
-        *this.controller.borrow_mut() = Some(ServoMedia::get().unwrap().create_webrtc(signaller));
+        *this.controller.borrow_mut() = Some(ServoMedia::get().create_webrtc(signaller));
         if let Some(ref servers) = config.iceServers {
             if let Some(server) = servers.first() {
                 let server = match server.urls {


### PR DESCRIPTION
See #35047. This fixes Servo [built as a cargo dependency](https://github.com/mcclure/cuervo) for me.

- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

mach build *is* reporting errors, because I don't know how to bump mach dependencies and so servo-media is using the old pre - 1e28d1d997 build. So…

Apologies if this is the wrong way to ask, but

- How/in what file do I update the dependencies (such as servo-media) which mach inserts into the Servo build?
- Would you consider adding this information to (or linking it from) https://book.servo.org/hacking/mach.html , so the next person does not need to ask?