### PR TITLE
Don't generate gstreamer data when dummy media backend enabled.

### DIFF
--- a/components/servo/build.rs
+++ b/components/servo/build.rs
@@ -7,20 +7,22 @@ use std::process::Command;
 use std::{env, fs};
 
 fn main() {
-    println!("cargo:rerun-if-changed=../../python/servo/gstreamer.py");
+    if cfg!(feature = "media-gstreamer") {
+        println!("cargo:rerun-if-changed=../../python/servo/gstreamer.py");
 
-    let output = Command::new(find_python())
-        .arg("../../python/servo/gstreamer.py")
-        .arg(std::env::var_os("TARGET").unwrap())
-        .output()
-        .unwrap();
-    if !output.status.success() {
-        eprintln!("{}", String::from_utf8_lossy(&output.stdout));
-        eprintln!("{}", String::from_utf8_lossy(&output.stderr));
-        std::process::exit(1)
+        let output = Command::new(find_python())
+            .arg("../../python/servo/gstreamer.py")
+            .arg(std::env::var_os("TARGET").unwrap())
+            .output()
+            .unwrap();
+        if !output.status.success() {
+            eprintln!("{}", String::from_utf8_lossy(&output.stdout));
+            eprintln!("{}", String::from_utf8_lossy(&output.stderr));
+            std::process::exit(1)
+        }
+        let path = Path::new(&env::var_os("OUT_DIR").unwrap()).join("gstreamer_plugins.rs");
+        fs::write(path, output.stdout).unwrap();
     }
-    let path = Path::new(&env::var_os("OUT_DIR").unwrap()).join("gstreamer_plugins.rs");
-    fs::write(path, output.stdout).unwrap();
 }
 
 /// Tries to find a suitable python


### PR DESCRIPTION
The gstreamer python script transitively requires a certain python package that's set up by mach's venv. This requirement isn't documented anywhere and makes Servo harder to use as a dependency. We can work around it by avoiding that codepath in Servo's default feature configuration.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #35051
- [x] These changes do not require tests because we don't test embedding configurations outside of mach right now.