### PR TITLE
config: Derive defaults for Opts.

### DIFF
--- a/components/config/opts.rs
+++ b/components/config/opts.rs
@@ -15,7 +15,7 @@ use servo_geometry::DeviceIndependentPixel;
 use servo_url::ServoUrl;
 
 /// Global flags for Servo, currently set on the command line.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct Opts {
     /// Whether or not the legacy layout system is enabled.
     pub legacy_layout: bool,


### PR DESCRIPTION
The runtime options in Opts are largely interesting to the Servo developers, rather than developers trying to embed Servo. We can provide sensible defaults and remove one source of friction.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #35053
- [x] These changes do not require tests because it's compile-time only.