### PR TITLE
dom: replace `CanGc::note()` with arguments in `DataTransfer` interfaces

### DIFF
--- a/components/script/dom/bindings/codegen/Bindings.conf
+++ b/components/script/dom/bindings/codegen/Bindings.conf
@@ -83,6 +83,18 @@ DOMInterfaces = {
     'canGc': ['WhenDefined'],
 },
 
+'DataTransfer': {
+    'canGc': ['Files']
+},
+
+'DataTransferItem': {
+    'canGc': ['GetAsFile']
+},
+
+'DataTransferItemList': {
+    'canGc': ['IndexedGetter', 'Add', 'Add_']
+},
+
 'Document': {
     'canGc': ['Close', 'CreateElement', 'CreateElementNS', 'ImportNode', 'SetTitle', 'Write', 'Writeln', 'CreateEvent', 'CreateRange', 'Open', 'Open_', 'CreateComment', 'CreateAttribute', 'CreateAttributeNS', 'CreateDocumentFragment', 'CreateTextNode', 'CreateCDATASection', 'CreateProcessingInstruction', 'Prepend', 'Append', 'ReplaceChildren', 'SetBgColor', 'SetFgColor', 'Fonts', 'ElementFromPoint', 'ElementsFromPoint', 'ExitFullscreen', 'CreateExpression', 'CreateNSResolver', 'Evaluate'],
 },

--- a/components/script/dom/datatransfer.rs
+++ b/components/script/dom/datatransfer.rs
@@ -66,7 +66,7 @@ impl DataTransfer {
         can_gc: CanGc,
         data_store: Rc<RefCell<Option<DragDataStore>>>,
     ) -> DomRoot<DataTransfer> {
-        let item_list = DataTransferItemList::new(window, Rc::clone(&data_store));
+        let item_list = DataTransferItemList::new(window, Rc::clone(&data_store), can_gc);
 
         reflect_dom_object_with_proto(
             Box::new(DataTransfer::new_inherited(data_store, &item_list)),
@@ -251,13 +251,13 @@ impl DataTransferMethods<crate::DomTypeHolder> for DataTransfer {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-datatransfer-files>
-    fn Files(&self) -> DomRoot<FileList> {
+    fn Files(&self, can_gc: CanGc) -> DomRoot<FileList> {
         // Step 1 Start with an empty list.
         let mut files = Vec::new();
 
         // Step 2 If the DataTransfer is not associated with a data store return the empty list.
         if let Some(data_store) = self.data_store.borrow().as_ref() {
-            data_store.files(&self.global(), &mut files);
+            data_store.files(&self.global(), can_gc, &mut files);
         }
 
         // Step 5

--- a/components/script/dom/datatransferitem.rs
+++ b/components/script/dom/datatransferitem.rs
@@ -34,11 +34,15 @@ impl DataTransferItem {
         }
     }
 
-    pub(crate) fn new(global: &GlobalScope, item: Kind) -> DomRoot<DataTransferItem> {
+    pub(crate) fn new(
+        global: &GlobalScope,
+        can_gc: CanGc,
+        item: Kind,
+    ) -> DomRoot<DataTransferItem> {
         reflect_dom_object(
             Box::new(DataTransferItem::new_inherited(item)),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 }
@@ -65,7 +69,7 @@ impl DataTransferItemMethods<crate::DomTypeHolder> for DataTransferItem {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-datatransferitem-getasfile>
-    fn GetAsFile(&self) -> Option<DomRoot<File>> {
-        self.item.as_file(&self.global())
+    fn GetAsFile(&self, can_gc: CanGc) -> Option<DomRoot<File>> {
+        self.item.as_file(&self.global(), can_gc)
     }
 }

--- a/components/script/dom/datatransferitemlist.rs
+++ b/components/script/dom/datatransferitemlist.rs
@@ -42,11 +42,12 @@ impl DataTransferItemList {
     pub(crate) fn new(
         window: &Window,
         data_store: Rc<RefCell<Option<DragDataStore>>>,
+        can_gc: CanGc,
     ) -> DomRoot<DataTransferItemList> {
         reflect_dom_object(
             Box::new(DataTransferItemList::new_inherited(data_store)),
             window,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -80,7 +81,7 @@ impl DataTransferItemListMethods<crate::DomTypeHolder> for DataTransferItemList 
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-datatransferitemlist-item>
-    fn IndexedGetter(&self, index: u32) -> Option<DomRoot<DataTransferItem>> {
+    fn IndexedGetter(&self, index: u32, can_gc: CanGc) -> Option<DomRoot<DataTransferItem>> {
         // Step 1 Return null if it isn't associated with a data store
         let option = self.data_store.borrow();
         let data_store = match option.as_ref() {
@@ -91,7 +92,7 @@ impl DataTransferItemListMethods<crate::DomTypeHolder> for DataTransferItemList 
         // Step 2
         data_store
             .get_item(index as usize)
-            .map(|item| DataTransferItem::new(&self.global(), item))
+            .map(|item| DataTransferItem::new(&self.global(), can_gc, item))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-datatransferitemlist-add>
@@ -99,6 +100,7 @@ impl DataTransferItemListMethods<crate::DomTypeHolder> for DataTransferItemList 
         &self,
         data: DOMString,
         mut type_: DOMString,
+        can_gc: CanGc,
     ) -> Fallible<Option<DomRoot<DataTransferItem>>> {
         // Step 1 If the DataTransferItemList object is not in the read/write mode, return null.
         let mut option = self.data_store.borrow_mut();
@@ -120,13 +122,13 @@ impl DataTransferItemListMethods<crate::DomTypeHolder> for DataTransferItemList 
         let index = data_store.list_len() - 1;
         let item = data_store
             .get_item(index)
-            .map(|item| DataTransferItem::new(&self.global(), item));
+            .map(|item| DataTransferItem::new(&self.global(), can_gc, item));
 
         Ok(item)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-datatransferitemlist-add>
-    fn Add_(&self, data: &File) -> Fallible<Option<DomRoot<DataTransferItem>>> {
+    fn Add_(&self, data: &File, can_gc: CanGc) -> Fallible<Option<DomRoot<DataTransferItem>>> {
         // Step 1 If the DataTransferItemList object is not in the read/write mode, return null.
         let mut option = self.data_store.borrow_mut();
         let data_store = match option.as_mut() {
@@ -154,7 +156,7 @@ impl DataTransferItemListMethods<crate::DomTypeHolder> for DataTransferItemList 
         let index = data_store.list_len() - 1;
         let item = data_store
             .get_item(index)
-            .map(|item| DataTransferItem::new(&self.global(), item));
+            .map(|item| DataTransferItem::new(&self.global(), can_gc, item));
 
         Ok(item)
     }

--- a/components/script/drag_data_store.rs
+++ b/components/script/drag_data_store.rs
@@ -67,7 +67,7 @@ impl Kind {
 
     // TODO for now we create a new BlobImpl
     // since File constructor requires moving it.
-    pub(crate) fn as_file(&self, global: &GlobalScope) -> Option<DomRoot<File>> {
+    pub(crate) fn as_file(&self, global: &GlobalScope, can_gc: CanGc) -> Option<DomRoot<File>> {
         match self {
             Kind::Text(_) => None,
             Kind::File(binary) => Some(File::new(
@@ -75,7 +75,7 @@ impl Kind {
                 BlobImpl::new_from_bytes(binary.bytes.clone(), binary.type_.clone()),
                 binary.name.clone(),
                 None,
-                CanGc::note(),
+                can_gc,
             )),
         }
     }
@@ -243,7 +243,12 @@ impl DragDataStore {
         was_modified
     }
 
-    pub(crate) fn files(&self, global: &GlobalScope, file_list: &mut Vec<DomRoot<File>>) {
+    pub(crate) fn files(
+        &self,
+        global: &GlobalScope,
+        can_gc: CanGc,
+        file_list: &mut Vec<DomRoot<File>>,
+    ) {
         // Step 3 If the data store is in the protected mode return the empty list.
         if self.mode == Mode::Protected {
             return;
@@ -252,7 +257,7 @@ impl DragDataStore {
         // Step 4 For each item in the drag data store item list whose kind is File, add the item's data to the list L.
         self.item_list
             .iter()
-            .filter_map(|item| item.as_file(global))
+            .filter_map(|item| item.as_file(global, can_gc))
             .for_each(|file| file_list.push(file));
     }
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [X] These changes do not require tests because no new functionality

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
