### PR TITLE
layout: Remove some unneeded `is_table` parameters

### DIFF
--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -440,7 +440,6 @@ fn compute_inline_content_sizes_for_block_level_boxes(
                     &LogicalVec2::zero(),
                     false, /* auto_block_size_stretches_to_containing_block */
                     false, /* is_replaced */
-                    false, /* is_table */
                     !matches!(base.style.pseudo(), Some(PseudoElement::ServoAnonymousBox)),
                     |_| None, /* TODO: support preferred aspect ratios on non-replaced boxes */
                     |constraint_space| {
@@ -855,7 +854,6 @@ fn layout_in_flow_non_replaced_block_level_same_formatting_context(
         containing_block,
         &layout_style,
         get_inline_content_sizes,
-        false, /* is_table */
     );
     let ResolvedMargins {
         margin,
@@ -1098,7 +1096,6 @@ impl IndependentNonReplacedContents {
             containing_block,
             &layout_style,
             get_inline_content_sizes,
-            self.is_table(),
         );
 
         let layout = self.layout(
@@ -1639,7 +1636,6 @@ fn solve_containing_block_padding_and_border_for_in_flow_box<'a>(
     containing_block: &ContainingBlock<'_>,
     layout_style: &'a LayoutStyle,
     get_inline_content_sizes: impl FnOnce(&ConstraintSpace) -> ContentSizes,
-    is_table: bool,
 ) -> ContainingBlockPaddingAndBorder<'a> {
     let style = layout_style.style();
     if matches!(style.pseudo(), Some(PseudoElement::ServoAnonymousBox)) {
@@ -1701,7 +1697,7 @@ fn solve_containing_block_padding_and_border_for_in_flow_box<'a>(
         ))
     };
     // TODO: the automatic inline size should take `justify-self` into account.
-    let automatic_inline_size = if is_table {
+    let automatic_inline_size = if layout_style.is_table() {
         Size::FitContent
     } else {
         Size::Stretch

--- a/components/layout_2020/formatting_contexts.rs
+++ b/components/layout_2020/formatting_contexts.rs
@@ -186,14 +186,6 @@ impl IndependentFormattingContext {
         self.base.base_fragment_info
     }
 
-    #[inline]
-    pub(crate) fn is_table(&self) -> bool {
-        match &self.contents {
-            IndependentFormattingContextContents::NonReplaced(content) => content.is_table(),
-            IndependentFormattingContextContents::Replaced(_) => false,
-        }
-    }
-
     pub(crate) fn inline_content_sizes(
         &self,
         layout_context: &LayoutContext,
@@ -222,7 +214,6 @@ impl IndependentFormattingContext {
             auto_minimum,
             auto_block_size_stretches_to_containing_block,
             self.is_replaced(),
-            self.is_table(),
             true, /* establishes_containing_block */
             |padding_border_sums| self.preferred_aspect_ratio(padding_border_sums),
             |constraint_space| self.inline_content_sizes(layout_context, constraint_space),

--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -463,15 +463,14 @@ impl HoistedAbsolutelyPositionedBox {
         let absolutely_positioned_box = self.absolutely_positioned_box.borrow();
         let context = &absolutely_positioned_box.context;
         let style = context.style().clone();
+        let layout_style = context.layout_style();
         let ContentBoxSizesAndPBM {
             content_box_sizes,
             pbm,
             ..
-        } = context
-            .layout_style()
-            .content_box_sizes_and_padding_border_margin(&containing_block.into());
+        } = layout_style.content_box_sizes_and_padding_border_margin(&containing_block.into());
         let containing_block = &containing_block.into();
-        let is_table = context.is_table();
+        let is_table = layout_style.is_table();
 
         let shared_fragment = self.fragment.borrow();
         let static_position_rect = shared_fragment

--- a/components/layout_2020/sizing.rs
+++ b/components/layout_2020/sizing.rs
@@ -115,7 +115,6 @@ pub(crate) fn outer_inline(
     auto_minimum: &LogicalVec2<Au>,
     auto_block_size_stretches_to_containing_block: bool,
     is_replaced: bool,
-    is_table: bool,
     establishes_containing_block: bool,
     get_preferred_aspect_ratio: impl FnOnce(&LogicalVec2<Au>) -> Option<AspectRatio>,
     get_content_size: impl FnOnce(&ConstraintSpace) -> InlineContentSizesResult,
@@ -234,7 +233,7 @@ pub(crate) fn outer_inline(
 
     // Regardless of their sizing properties, tables are always forced to be at least
     // as big as their min-content size, so floor the minimums.
-    if is_table {
+    if layout_style.is_table() {
         min_min_content.max_assign(content_size.sizes.min_content);
         min_max_content.max_assign(content_size.sizes.min_content);
         min_depends_on_block_constraints |= content_size.depends_on_block_constraints;

--- a/components/layout_2020/style_ext.rs
+++ b/components/layout_2020/style_ext.rs
@@ -817,6 +817,11 @@ impl LayoutStyle<'_> {
         }
     }
 
+    #[inline]
+    pub(crate) fn is_table(&self) -> bool {
+        matches!(self, Self::Table(_))
+    }
+
     pub(crate) fn content_box_sizes_and_padding_border_margin(
         &self,
         containing_block: &IndefiniteContainingBlock,


### PR DESCRIPTION
We can just check the `LayoutStyle` instead.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because they don't change behavior

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
