### PR TITLE
Update the FormData constructor

### DIFF
--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -1475,7 +1475,7 @@ impl FormSubmitterElement<'_> {
     }
 
     // https://html.spec.whatwg.org/multipage/#concept-submit-button
-    fn is_submit_button(&self) -> bool {
+    pub(crate) fn is_submit_button(&self) -> bool {
         match *self {
             // https://html.spec.whatwg.org/multipage/#image-button-state-(type=image)
             // https://html.spec.whatwg.org/multipage/#submit-button-state-(type=submit)
@@ -1487,7 +1487,7 @@ impl FormSubmitterElement<'_> {
     }
 
     // https://html.spec.whatwg.org/multipage/#form-owner
-    fn form_owner(&self) -> Option<DomRoot<HTMLFormElement>> {
+    pub(crate) fn form_owner(&self) -> Option<DomRoot<HTMLFormElement>> {
         match *self {
             FormSubmitterElement::Button(button_el) => button_el.form_owner(),
             FormSubmitterElement::Input(input_el) => input_el.form_owner(),

--- a/components/script/dom/webidls/FormData.webidl
+++ b/components/script/dom/webidls/FormData.webidl
@@ -10,7 +10,7 @@ typedef (File or USVString) FormDataEntryValue;
 
 [Exposed=(Window,Worker)]
 interface FormData {
-  [Throws] constructor(optional HTMLFormElement form);
+  [Throws] constructor(optional HTMLFormElement form, optional HTMLElement? submitter = null);
   undefined append(USVString name, USVString value);
   undefined append(USVString name, Blob value, optional USVString filename);
   undefined delete(USVString name);

--- a/tests/wpt/meta/xhr/formdata/constructor-submitter.html.ini
+++ b/tests/wpt/meta/xhr/formdata/constructor-submitter.html.ini
@@ -1,13 +1,4 @@
 [constructor-submitter.html]
-  [FormData construction should throw a TypeError if a non-null submitter is not a submit button]
-    expected: FAIL
-
-  [FormData construction should throw a 'NotFoundError' DOMException if a non-null submitter is not owned by the form]
-    expected: FAIL
-
-  [The constructed FormData object should contain an in-tree-order entry for a named submit button submitter]
-    expected: FAIL
-
   [The constructed FormData object should contain in-tree-order entries for an activated Image Button submitter]
     expected: FAIL
 


### PR DESCRIPTION
Updates the constructor for `FormData` to allow providing a submitter.

https://xhr.spec.whatwg.org/#interface-formdata

[Try](https://github.com/shanehandley/servo/actions/runs/12850278805)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
