### PR TITLE
Correctly report number of expected test results from ./mach test-wpt

### DIFF
--- a/python/wpt/grouping_formatter.py
+++ b/python/wpt/grouping_formatter.py
@@ -327,7 +327,10 @@ class ServoFormatter(mozlog.formatters.base.BaseFormatter, ServoHandler):
 
         output += u"Ran %i tests finished in %.1f seconds.\n" % (
             self.completed_tests, (data["time"] - self.suite_start_time) / 1000)
-        output += f"  \u2022 {len(self.expected.values())} ran as expected.\n"
+
+        # Sum the number of expected test results from each category
+        expected_test_results = sum(self.expected.values())
+        output += f"  \u2022 {expected_test_results} ran as expected.\n"
         if self.number_skipped:
             output += f"    \u2022 {self.number_skipped} skipped.\n"
 


### PR DESCRIPTION
The previous code was simply reporting the number of categories,
instead of the sum of the number of expected tests in each category.

Fixes #35032