### PR TITLE
Remove workaround for fixed ICE in rust compiler

### DIFF
--- a/components/script/build.rs
+++ b/components/script/build.rs
@@ -58,10 +58,7 @@ struct Bytes<'a>(&'a str);
 
 impl FmtConst for Bytes<'_> {
     fn fmt_const(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        // https://github.com/rust-lang/rust/issues/55223
-        // should technically be just `write!(formatter, "b\"{}\"", self.0)
-        // but the referenced issue breaks promotion in the surrounding code
-        write!(formatter, "{{ const FOO: &[u8] = b\"{}\"; FOO }}", self.0)
+        write!(formatter, "b\"{}\"", self.0)
     }
 }
 


### PR DESCRIPTION
https://github.com/rust-lang/rust/issues/55223 has been fixed for a while (:


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because they are compile-time only


