### PR TITLE
crown: Pass `--cfg crown` to rustc from crown

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -808,11 +808,9 @@ class CommandBase(object):
                           'These options conflict, please specify only one of them.')
                     sys.exit(1)
             env['CARGO_BUILD_RUSTC'] = 'crown'
-            # Changing `RUSTC` or `CARGO_BUILD_RUSTC` does not cause `cargo check` to
-            # recheck files with the new compiler. `cargo build` is not affected and
-            # triggers a rebuild as expected. To also make `check` work as expected,
-            # we add a dummy `cfg` to RUSTFLAGS when using crown, so as to have different
-            # RUSTFLAGS when using `crown`, to reliably trigger re-checking.
+            # Modifying`RUSTC` or `CARGO_BUILD_RUSTC` does not cause `cargo check`
+            # to recheck with the new lints. To bypass this we uses `crown` feature
+            # to invalidate caches: https://github.com/servo/servo/issues/35072#issuecomment-2600749483
             features += ["crown"]
 
         if "-p" not in cargo_args:  # We're building specific package, that may not have features

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -807,14 +807,13 @@ class CommandBase(object):
                           f'already set to `{current_rustc}` in the parent environment.\n'
                           'These options conflict, please specify only one of them.')
                     sys.exit(1)
-            features += ["crown"]
             env['CARGO_BUILD_RUSTC'] = 'crown'
             # Changing `RUSTC` or `CARGO_BUILD_RUSTC` does not cause `cargo check` to
             # recheck files with the new compiler. `cargo build` is not affected and
             # triggers a rebuild as expected. To also make `check` work as expected,
             # we add a dummy `cfg` to RUSTFLAGS when using crown, so as to have different
             # RUSTFLAGS when using `crown`, to reliably trigger re-checking.
-            env['RUSTFLAGS'] = env.get('RUSTFLAGS', "") + " --cfg=crown"
+            features += ["crown"]
 
         if "-p" not in cargo_args:  # We're building specific package, that may not have features
             features += list(self.features)

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -808,9 +808,10 @@ class CommandBase(object):
                           'These options conflict, please specify only one of them.')
                     sys.exit(1)
             env['CARGO_BUILD_RUSTC'] = 'crown'
-            # Modifying`RUSTC` or `CARGO_BUILD_RUSTC` does not cause `cargo check`
-            # to recheck with the new lints. To bypass this we uses `crown` feature
-            # to invalidate caches: https://github.com/servo/servo/issues/35072#issuecomment-2600749483
+            # Modyfing `RUSTC` or `CARGO_BUILD_RUSTC` to use a linter does not cause
+            # `cargo check` to rebuild. To work around this bug use a `crown` feature
+            # to invalidate caches and force a rebuild / relint.
+            # See https://github.com/servo/servo/issues/35072#issuecomment-2600749483
             features += ["crown"]
 
         if "-p" not in cargo_args:  # We're building specific package, that may not have features

--- a/support/crown/tests/run-pass/cfg_crown.rs
+++ b/support/crown/tests/run-pass/cfg_crown.rs
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+//@rustc-env:RUSTC_BOOTSTRAP=1
+
+#![allow(dead_code)]
+
+const _: () = assert!(cfg!(crown), "cfg(crown) not set!");
+
+fn main() {}


### PR DESCRIPTION
also includes minor fix in crown for wrapper running based on clippy code


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes partially fix #35072
- [x] There are tests for these changes in crown

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
