### PR TITLE
layout: Paint collapsed table borders on their own

### DIFF
--- a/components/layout_2020/display_list/stacking_context.rs
+++ b/components/layout_2020/display_list/stacking_context.rs
@@ -34,7 +34,8 @@ use super::DisplayList;
 use crate::display_list::conversions::{FilterToWebRender, ToWebRender};
 use crate::display_list::{BuilderForBoxFragment, DisplayListBuilder};
 use crate::fragment_tree::{
-    BoxFragment, ContainingBlockManager, Fragment, FragmentFlags, FragmentTree, PositioningFragment,
+    BoxFragment, ContainingBlockManager, Fragment, FragmentFlags, FragmentTree,
+    PositioningFragment, SpecificLayoutInfo,
 };
 use crate::geom::{AuOrAuto, PhysicalRect, PhysicalSides};
 use crate::style_ext::ComputedValuesExt;
@@ -87,6 +88,7 @@ pub(crate) type ContainingBlockInfo<'a> = ContainingBlockManager<'a, ContainingB
 pub(crate) enum StackingContextSection {
     OwnBackgroundsAndBorders,
     DescendantBackgroundsAndBorders,
+    CollapsedTableBorders,
     Foreground,
     Outline,
 }
@@ -726,6 +728,16 @@ impl StackingContext {
             child.build_display_list(builder, &self.atomic_inline_stacking_containers);
         }
 
+        // Additional step 4.5: Collapsed table borders
+        // This step isn't in the spec, but other browsers seem to paint them at this point.
+        while contents.peek().is_some_and(|(_, child)| {
+            child.section() == StackingContextSection::CollapsedTableBorders
+        }) {
+            let (i, child) = contents.next().unwrap();
+            self.debug_push_print_item(DebugPrintField::Contents, i);
+            child.build_display_list(builder, &self.atomic_inline_stacking_containers);
+        }
+
         // Step 5: Float stacking containers
         for (i, child) in self.float_stacking_containers.iter().enumerate() {
             self.debug_push_print_item(DebugPrintField::FloatStackingContainers, i);
@@ -1181,30 +1193,34 @@ impl BoxFragment {
                     .for_absolute_and_fixed_descendants
                     .scroll_node_id
             };
-        stacking_context
-            .contents
-            .push(StackingContextContent::Fragment {
-                scroll_node_id: new_scroll_node_id,
-                reference_frame_scroll_node_id: reference_frame_scroll_node_id_for_fragments,
-                clip_chain_id: new_clip_chain_id,
-                section: self.get_stacking_context_section(),
-                containing_block: containing_block.rect,
-                fragment: fragment.clone(),
-                is_hit_test_for_scrollable_overflow: false,
-            });
 
-        if !self.style.get_outline().outline_width.is_zero() {
+        let mut add_fragment = |section| {
             stacking_context
                 .contents
                 .push(StackingContextContent::Fragment {
                     scroll_node_id: new_scroll_node_id,
                     reference_frame_scroll_node_id: reference_frame_scroll_node_id_for_fragments,
                     clip_chain_id: new_clip_chain_id,
-                    section: StackingContextSection::Outline,
+                    section,
                     containing_block: containing_block.rect,
                     fragment: fragment.clone(),
                     is_hit_test_for_scrollable_overflow: false,
                 });
+        };
+
+        add_fragment(self.get_stacking_context_section());
+
+        if let Fragment::Box(box_fragment) = &fragment {
+            if matches!(
+                box_fragment.borrow().detailed_layout_info,
+                Some(SpecificLayoutInfo::TableGridWithCollapsedBorders(_))
+            ) {
+                add_fragment(StackingContextSection::CollapsedTableBorders);
+            }
+        }
+
+        if !self.style.get_outline().outline_width.is_zero() {
+            add_fragment(StackingContextSection::Outline);
         }
 
         // We want to build the scroll frame after the background and border, because

--- a/components/layout_2020/table/mod.rs
+++ b/components/layout_2020/table/mod.rs
@@ -70,6 +70,7 @@ mod layout;
 
 use std::ops::Range;
 
+use app_units::Au;
 pub(crate) use construct::AnonymousTableContent;
 pub use construct::TableBuilder;
 use euclid::{Point2D, Size2D, UnknownUnit, Vector2D};
@@ -83,7 +84,7 @@ use crate::cell::ArcRefCell;
 use crate::flow::BlockContainer;
 use crate::formatting_contexts::IndependentFormattingContext;
 use crate::fragment_tree::BaseFragmentInfo;
-use crate::geom::PhysicalSides;
+use crate::geom::{PhysicalSides, PhysicalVec};
 use crate::layout_box_base::LayoutBoxBase;
 use crate::style_ext::BorderStyleColor;
 
@@ -317,9 +318,23 @@ pub struct TableCaption {
     context: ArcRefCell<IndependentFormattingContext>,
 }
 
+/// A calculated collapsed border.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub(crate) struct CollapsedBorder {
+    pub style_color: BorderStyleColor,
+    pub width: Au,
+}
+
+/// Represents a piecewise sequence of collapsed borders along a line.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct CollapsedBorderLine {
+    max_width: Au,
+    pub list: Vec<CollapsedBorder>,
+}
+
 #[derive(Clone, Debug)]
-pub(crate) struct SpecificTableGridOrTableCellInfo {
-    /// For tables is in collapsed-borders mode, this is used as an override for the
-    /// style and color of the border of the table and table cells.
-    pub border_style_color: PhysicalSides<BorderStyleColor>,
+pub(crate) struct SpecificTableGridInfo {
+    pub collapsed_borders: PhysicalVec<Vec<CollapsedBorderLine>>,
+    pub track_sizes: PhysicalVec<Vec<Au>>,
+    pub wrapper_border: PhysicalSides<Au>,
 }

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-formatting-contexts-003.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-formatting-contexts-003.xht.ini
@@ -1,2 +1,0 @@
-[block-formatting-contexts-003.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/border-conflict-element-001d.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/border-conflict-element-001d.xht.ini
@@ -1,2 +1,0 @@
-[border-conflict-element-001d.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/collapsing-border-model-001.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/collapsing-border-model-001.xht.ini
@@ -1,2 +1,0 @@
-[collapsing-border-model-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/collapsing-border-model-004.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/collapsing-border-model-004.xht.ini
@@ -1,2 +1,0 @@
-[collapsing-border-model-004.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-backgrounds/box-shadow-table-border-collapse-001.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/box-shadow-table-border-collapse-001.html.ini
@@ -1,2 +1,0 @@
-[box-shadow-table-border-collapse-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-backgrounds/ttwf-reftest-borderRadius.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/ttwf-reftest-borderRadius.html.ini
@@ -1,2 +1,0 @@
-[ttwf-reftest-borderRadius.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-tables/border-collapse-double-border.html.ini
+++ b/tests/wpt/meta/css/css-tables/border-collapse-double-border.html.ini
@@ -1,2 +1,0 @@
-[border-collapse-double-border.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-tables/collapsed-border-paint-phase-002.html.ini
+++ b/tests/wpt/meta/css/css-tables/collapsed-border-paint-phase-002.html.ini
@@ -1,2 +1,0 @@
-[collapsed-border-paint-phase-002.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-tables/collapsed-border-positioned-tr-td.html.ini
+++ b/tests/wpt/meta/css/css-tables/collapsed-border-positioned-tr-td.html.ini
@@ -1,0 +1,2 @@
+[collapsed-border-positioned-tr-td.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta/gfx-rs-gecko/356774-1.html.ini
+++ b/tests/wpt/mozilla/meta/gfx-rs-gecko/356774-1.html.ini
@@ -1,2 +1,0 @@
-[356774-1.html]
-  expected: FAIL


### PR DESCRIPTION
We were previously splitting collapsed borders into two halves, and then paint each one as part of the corresponding cell. This looked wrong when the border style wasn't solid, or when a cell spanned multiple tracks and the border wasn't the same for all of them.

Now the borders of a table wrapper, table grid or table cell aren't painted in collapsed borders mode. Instead, the resulting collapsed borders are painted on their own.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

`collapsed-border-positioned-tr-td.html` is now failing because it somehow expects `position: relative` to shrink the background area. This isn't currently specified (see https://github.com/w3c/csswg-drafts/issues/11515), and Firefox also fails this test.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
