### PR TITLE
Set descendant's attribute's owner document in Node::adopt

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -160,6 +160,7 @@ use crate::task::TaskOnce;
 // and when the element enters or leaves a browsing context container.
 // https://html.spec.whatwg.org/multipage/#selector-focus
 
+/// <https://dom.spec.whatwg.org/#element>
 #[dom_struct]
 pub(crate) struct Element {
     node: Node,

--- a/tests/wpt/tests/dom/nodes/Node-mutation-adoptNode.html
+++ b/tests/wpt/tests/dom/nodes/Node-mutation-adoptNode.html
@@ -20,4 +20,18 @@ test(() => {
   assert_equals(div.firstChild.ownerDocument, document);
 }, "simple append of foreign div with text");
 
+test(function() {
+  var div = document.createElement("div");
+  div.id = "foobar";
+
+  assert_equals(div.ownerDocument, document);
+  assert_equals(div.attributes[0].ownerDocument, document);
+
+  var other_doc = document.implementation.createHTMLDocument();
+  other_doc.body.appendChild(div);
+
+  assert_equals(div.ownerDocument, other_doc);
+  assert_equals(div.attributes[0].ownerDocument, other_doc);
+}, "Adopting an element into a different document update's the element's owner doc as well as the owner docs of it's attributes")
+
 </script>


### PR DESCRIPTION
Draft because I still need to write a web platform test for this.

[try run](https://github.com/simonwuelker/servo/actions/runs/12855864288)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
