### PR TITLE
Remove `Preferences::network_tls_ignore_unexpected_eof`

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -209,12 +209,6 @@ pub struct Preferences {
     pub network_http_cache_disabled: bool,
     pub network_local_directory_listing_enabled: bool,
     pub network_mime_sniff: bool,
-    /// Ignore `std::io::Error` with `ErrorKind::UnexpectedEof` received when a TLS connection
-    /// is closed without a close_notify.
-    ///
-    /// Used for tests because WPT server doesn't properly close the TLS connection.
-    // TODO: remove this when WPT server is updated to use a proper TLS implementation.
-    pub network_tls_ignore_unexpected_eof: bool,
     pub session_history_max_length: i64,
     /// The background color of shell's viewport. This will be used by OpenGL's `glClearColor`.
     pub shell_background_color_rgba: [f64; 4],
@@ -378,7 +372,6 @@ impl Preferences {
             network_http_cache_disabled: false,
             network_local_directory_listing_enabled: false,
             network_mime_sniff: false,
-            network_tls_ignore_unexpected_eof: false,
             session_history_max_length: 20,
             shell_background_color_rgba: [1.0, 1.0, 1.0, 1.0],
             threadpools_async_runtime_workers_max: 6,

--- a/components/net/decoder.rs
+++ b/components/net/decoder.rs
@@ -32,7 +32,6 @@ use http_body_util::BodyExt;
 use hyper::body::Body;
 use hyper::header::{HeaderValue, CONTENT_ENCODING, TRANSFER_ENCODING};
 use hyper::Response;
-use servo_config::pref;
 use tokio_util::codec::{BytesCodec, FramedRead};
 use tokio_util::io::StreamReader;
 
@@ -279,9 +278,7 @@ impl Stream for BodyStream {
                 let all_content_read = self
                     .content_length
                     .map_or(false, |c| c.0 == self.total_read);
-                if self.is_secure_scheme &&
-                    (all_content_read || pref!(network_tls_ignore_unexpected_eof))
-                {
+                if self.is_secure_scheme && all_content_read {
                     let source = err.source();
                     let is_unexpected_eof = source
                         .and_then(|e| e.downcast_ref::<io::Error>())

--- a/resources/wpt-prefs.json
+++ b/resources/wpt-prefs.json
@@ -1,5 +1,4 @@
 {
   "dom_webxr_test": true,
-  "gfx_text_antialiasing_enabled": false,
-  "network_tls_ignore_unexpected_eof": true
+  "gfx_text_antialiasing_enabled": false
 }


### PR DESCRIPTION
This workaround was introduced to handle an issue with the WPT server,
but it seems that it is no longer needed. This change removes the
preference and the workarond code.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes


<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
