### PR TITLE
layout: Respect alignment when sizing replaced abspos

### DIFF
--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -1972,18 +1972,21 @@ impl FlexItem<'_> {
                     containing_block,
                     item_style,
                     self.preferred_aspect_ratio,
-                    &Sizes::new(
-                        block_size
-                            .to_definite()
-                            .map_or(Size::Initial, Size::Numeric),
-                        Size::Numeric(min_size.block),
-                        max_size.block.map_or(Size::Initial, Size::Numeric),
-                    ),
-                    &Sizes::new(
-                        Size::Numeric(inline_size),
-                        Size::Numeric(min_size.inline),
-                        max_size.inline.map_or(Size::Initial, Size::Numeric),
-                    ),
+                    LogicalVec2 {
+                        block: &Sizes::new(
+                            block_size
+                                .to_definite()
+                                .map_or(Size::Initial, Size::Numeric),
+                            Size::Numeric(min_size.block),
+                            max_size.block.map_or(Size::Initial, Size::Numeric),
+                        ),
+                        inline: &Sizes::new(
+                            Size::Numeric(inline_size),
+                            Size::Numeric(min_size.inline),
+                            max_size.inline.map_or(Size::Initial, Size::Numeric),
+                        ),
+                    },
+                    Size::FitContent.into(),
                     flex_axis.vec2_to_flow_relative(self.pbm_auto_is_zero),
                 );
                 let hypothetical_cross_size = flex_axis.vec2_to_flex_relative(size).cross;
@@ -2792,22 +2795,25 @@ impl FlexItemBox {
                         flex_context.containing_block,
                         style,
                         preferred_aspect_ratio,
-                        &Sizes::new(
-                            content_box_size
-                                .block
-                                .non_auto()
-                                .map_or(Size::Initial, Size::Numeric),
-                            Size::Numeric(min_size.block),
-                            max_size.block.map_or(Size::Initial, Size::Numeric),
-                        ),
-                        &Sizes::new(
-                            content_box_size
-                                .inline
-                                .non_auto()
-                                .map_or(Size::Initial, Size::Numeric),
-                            Size::Numeric(min_size.inline),
-                            max_size.inline.map_or(Size::Initial, Size::Numeric),
-                        ),
+                        LogicalVec2 {
+                            block: &Sizes::new(
+                                content_box_size
+                                    .block
+                                    .non_auto()
+                                    .map_or(Size::Initial, Size::Numeric),
+                                Size::Numeric(min_size.block),
+                                max_size.block.map_or(Size::Initial, Size::Numeric),
+                            ),
+                            inline: &Sizes::new(
+                                content_box_size
+                                    .inline
+                                    .non_auto()
+                                    .map_or(Size::Initial, Size::Numeric),
+                                Size::Numeric(min_size.inline),
+                                max_size.inline.map_or(Size::Initial, Size::Numeric),
+                            ),
+                        },
+                        Size::FitContent.into(),
                         padding_border_margin.padding_border_sums +
                             padding_border_margin.margin.auto_is(Au::zero).sum(),
                     )

--- a/components/layout_2020/geom.rs
+++ b/components/layout_2020/geom.rs
@@ -68,7 +68,23 @@ impl<T: Default> Default for LogicalVec2<T> {
     }
 }
 
+impl<T: Copy> From<T> for LogicalVec2<T> {
+    fn from(value: T) -> Self {
+        Self {
+            inline: value,
+            block: value,
+        }
+    }
+}
+
 impl<T> LogicalVec2<T> {
+    pub(crate) fn as_ref(&self) -> LogicalVec2<&T> {
+        LogicalVec2 {
+            inline: &self.inline,
+            block: &self.block,
+        }
+    }
+
     pub fn map_inline_and_block_axes<U>(
         &self,
         inline_f: impl FnOnce(&T) -> U,

--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -537,12 +537,25 @@ impl HoistedAbsolutelyPositionedBox {
                 inline: inline_axis_solver.inset_sum(),
                 block: block_axis_solver.inset_sum(),
             };
+            let automatic_size = |alignment: AlignFlags, offsets: &AbsoluteBoxOffsets| {
+                if alignment.value() == AlignFlags::STRETCH && !offsets.either_auto() {
+                    Size::Stretch
+                } else {
+                    Size::FitContent
+                }
+            };
             let used_size = replaced.used_size_as_if_inline_element_from_content_box_sizes(
                 containing_block,
                 &style,
                 context.preferred_aspect_ratio(&pbm.padding_border_sums),
-                &block_axis_solver.computed_sizes,
-                &inline_axis_solver.computed_sizes,
+                LogicalVec2 {
+                    inline: &inline_axis_solver.computed_sizes,
+                    block: &block_axis_solver.computed_sizes,
+                },
+                LogicalVec2 {
+                    inline: automatic_size(inline_alignment, &inline_axis_solver.box_offsets),
+                    block: automatic_size(block_alignment, &block_axis_solver.box_offsets),
+                },
                 pbm.padding_border_sums + pbm.margin.auto_is(Au::zero).sum() + inset_sums,
             );
             inline_axis_solver.override_size(used_size.inline);

--- a/components/layout_2020/taffy/layout.rs
+++ b/components/layout_2020/taffy/layout.rs
@@ -161,16 +161,19 @@ impl taffy::LayoutPartialTree for TaffyContainerContext<'_> {
                                 style,
                                 independent_context
                                     .preferred_aspect_ratio(&pbm.padding_border_sums),
-                                &Sizes::new(
-                                    option_f32_to_size(content_box_known_dimensions.height),
-                                    Size::Initial,
-                                    Size::Initial,
-                                ),
-                                &Sizes::new(
-                                    option_f32_to_size(content_box_known_dimensions.width),
-                                    Size::Initial,
-                                    Size::Initial,
-                                ),
+                                LogicalVec2 {
+                                    block: &Sizes::new(
+                                        option_f32_to_size(content_box_known_dimensions.height),
+                                        Size::Initial,
+                                        Size::Initial,
+                                    ),
+                                    inline: &Sizes::new(
+                                        option_f32_to_size(content_box_known_dimensions.width),
+                                        Size::Initial,
+                                        Size::Initial,
+                                    ),
+                                },
+                                Size::FitContent.into(),
                                 pbm.padding_border_sums + pbm.margin.auto_is(Au::zero).sum(),
                             )
                             .to_physical_size(self.style.writing_mode);

--- a/tests/wpt/meta/css/css-align/abspos/stretch-intrinsic-size-htb-htb.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/stretch-intrinsic-size-htb-htb.html.ini
@@ -13,9 +13,3 @@
 
   [.item 10]
     expected: FAIL
-
-  [.item 11]
-    expected: FAIL
-
-  [.item 12]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/stretch-intrinsic-size-htb-vrl.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/stretch-intrinsic-size-htb-vrl.html.ini
@@ -13,9 +13,3 @@
 
   [.item 10]
     expected: FAIL
-
-  [.item 11]
-    expected: FAIL
-
-  [.item 12]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/stretch-intrinsic-size-vrl-htb.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/stretch-intrinsic-size-vrl-htb.html.ini
@@ -16,6 +16,3 @@
 
   [.item 11]
     expected: FAIL
-
-  [.item 12]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/stretch-intrinsic-size-vrl-vrl.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/stretch-intrinsic-size-vrl-vrl.html.ini
@@ -16,6 +16,3 @@
 
   [.item 11]
     expected: FAIL
-
-  [.item 12]
-    expected: FAIL


### PR DESCRIPTION
If an absolutely position element which is replaced has `justify-self` or `align-self` set to `stretch`, and no inset is `auto` on that axis, then an automatic size should behave as `stretch`, not as `fit-content`.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #34248
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
