### PR TITLE
layout: Fix border widths of table wrapper with collapsed borders

### DIFF
--- a/components/layout_2020/display_list/mod.rs
+++ b/components/layout_2020/display_list/mod.rs
@@ -933,35 +933,22 @@ impl<'a> BuilderForBoxFragment<'a> {
                     bottom_border.width,
                     left_border.width,
                 );
-
-                let mut origin = PhysicalPoint::new(column_sum, row_sum);
-                let mut size = PhysicalSize::new(*column_size, *row_size);
-                if x == 0 {
-                    origin.x -= table_info.wrapper_border.left;
-                    size.width += table_info.wrapper_border.left;
+                let left_adjustment = if x == 0 {
+                    -border_widths.left / 2
                 } else {
-                    border_widths.left = Au::zero();
-                    origin.x += left_border.width / 2;
-                    size.width -= left_border.width / 2;
-                }
-                if y == 0 {
-                    origin.y -= table_info.wrapper_border.top;
-                    size.height += table_info.wrapper_border.top;
+                    std::mem::take(&mut border_widths.left) / 2
+                };
+                let top_adjustment = if y == 0 {
+                    -border_widths.top / 2
                 } else {
-                    border_widths.top = Au::zero();
-                    origin.y += top_border.width / 2;
-                    size.height -= top_border.width / 2;
-                }
-                if x + 1 == table_info.track_sizes.x.len() {
-                    size.width += table_info.wrapper_border.right;
-                } else {
-                    size.width += border_widths.right / 2;
-                }
-                if y + 1 == table_info.track_sizes.y.len() {
-                    size.height += table_info.wrapper_border.bottom;
-                } else {
-                    size.height += border_widths.bottom / 2;
-                }
+                    std::mem::take(&mut border_widths.top) / 2
+                };
+                let origin =
+                    PhysicalPoint::new(column_sum + left_adjustment, row_sum + top_adjustment);
+                let size = PhysicalSize::new(
+                    *column_size - left_adjustment + border_widths.right / 2,
+                    *row_size - top_adjustment + border_widths.bottom / 2,
+                );
                 let border_rect = PhysicalRect::new(origin, size)
                     .translate(self.fragment.content_rect.origin.to_vector())
                     .translate(self.containing_block.origin.to_vector())

--- a/components/layout_2020/formatting_contexts.rs
+++ b/components/layout_2020/formatting_contexts.rs
@@ -288,7 +288,7 @@ impl IndependentNonReplacedContents {
             IndependentNonReplacedContents::Flow(fc) => fc.layout_style(base),
             IndependentNonReplacedContents::Flex(fc) => fc.layout_style(),
             IndependentNonReplacedContents::Grid(fc) => fc.layout_style(),
-            IndependentNonReplacedContents::Table(fc) => fc.layout_style(),
+            IndependentNonReplacedContents::Table(fc) => fc.layout_style(None),
         }
     }
 

--- a/components/layout_2020/table/mod.rs
+++ b/components/layout_2020/table/mod.rs
@@ -84,9 +84,10 @@ use crate::cell::ArcRefCell;
 use crate::flow::BlockContainer;
 use crate::formatting_contexts::IndependentFormattingContext;
 use crate::fragment_tree::BaseFragmentInfo;
-use crate::geom::{PhysicalSides, PhysicalVec};
+use crate::geom::PhysicalVec;
 use crate::layout_box_base::LayoutBoxBase;
 use crate::style_ext::BorderStyleColor;
+use crate::table::layout::TableLayout;
 
 pub type TableSize = Size2D<usize, UnknownUnit>;
 
@@ -336,5 +337,9 @@ pub(crate) struct CollapsedBorderLine {
 pub(crate) struct SpecificTableGridInfo {
     pub collapsed_borders: PhysicalVec<Vec<CollapsedBorderLine>>,
     pub track_sizes: PhysicalVec<Vec<Au>>,
-    pub wrapper_border: PhysicalSides<Au>,
+}
+
+pub(crate) struct TableLayoutStyle<'a> {
+    table: &'a Table,
+    layout: Option<&'a TableLayout<'a>>,
 }

--- a/tests/wpt/meta/css/CSS2/borders/border-applies-to-001.xht.ini
+++ b/tests/wpt/meta/css/CSS2/borders/border-applies-to-001.xht.ini
@@ -1,2 +1,0 @@
-[border-applies-to-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/borders/border-applies-to-002.xht.ini
+++ b/tests/wpt/meta/css/CSS2/borders/border-applies-to-002.xht.ini
@@ -1,2 +1,0 @@
-[border-applies-to-002.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/borders/border-applies-to-003.xht.ini
+++ b/tests/wpt/meta/css/CSS2/borders/border-applies-to-003.xht.ini
@@ -1,2 +1,0 @@
-[border-applies-to-003.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/borders/border-applies-to-004.xht.ini
+++ b/tests/wpt/meta/css/CSS2/borders/border-applies-to-004.xht.ini
@@ -1,2 +1,0 @@
-[border-applies-to-004.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/borders/border-applies-to-005.xht.ini
+++ b/tests/wpt/meta/css/CSS2/borders/border-applies-to-005.xht.ini
@@ -1,2 +1,0 @@
-[border-applies-to-005.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/borders/border-applies-to-007.xht.ini
+++ b/tests/wpt/meta/css/CSS2/borders/border-applies-to-007.xht.ini
@@ -1,2 +1,0 @@
-[border-applies-to-007.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/borders/border-color-applies-to-001.xht.ini
+++ b/tests/wpt/meta/css/CSS2/borders/border-color-applies-to-001.xht.ini
@@ -1,2 +1,0 @@
-[border-color-applies-to-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/borders/border-color-applies-to-002.xht.ini
+++ b/tests/wpt/meta/css/CSS2/borders/border-color-applies-to-002.xht.ini
@@ -1,2 +1,0 @@
-[border-color-applies-to-002.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/borders/border-color-applies-to-003.xht.ini
+++ b/tests/wpt/meta/css/CSS2/borders/border-color-applies-to-003.xht.ini
@@ -1,2 +1,0 @@
-[border-color-applies-to-003.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/borders/border-color-applies-to-004.xht.ini
+++ b/tests/wpt/meta/css/CSS2/borders/border-color-applies-to-004.xht.ini
@@ -1,2 +1,0 @@
-[border-color-applies-to-004.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/borders/border-color-applies-to-005.xht.ini
+++ b/tests/wpt/meta/css/CSS2/borders/border-color-applies-to-005.xht.ini
@@ -1,2 +1,0 @@
-[border-color-applies-to-005.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/borders/border-color-applies-to-007.xht.ini
+++ b/tests/wpt/meta/css/CSS2/borders/border-color-applies-to-007.xht.ini
@@ -1,2 +1,0 @@
-[border-color-applies-to-007.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/collapsing-border-model-003.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/collapsing-border-model-003.xht.ini
@@ -1,2 +1,0 @@
-[collapsing-border-model-003.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/collapsing-border-model-009.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/collapsing-border-model-009.xht.ini
@@ -1,2 +1,0 @@
-[collapsing-border-model-009.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-tables/border-collapse-dynamic-section.html.ini
+++ b/tests/wpt/meta/css/css-tables/border-collapse-dynamic-section.html.ini
@@ -1,2 +1,0 @@
-[border-collapse-dynamic-section.html]
-  expected: FAIL

--- a/tests/wpt/tests/css/css-tables/visibility-collapse-rowspan-004-dynamic.html
+++ b/tests/wpt/tests/css/css-tables/visibility-collapse-rowspan-004-dynamic.html
@@ -70,105 +70,114 @@ table td {
                 tests[i][2]);
         };
     }
+    function width(element) {
+        return element.getBoundingClientRect().width;
+    }
+    function height(element) {
+        return element.getBoundingClientRect().height;
+    }
     document.getElementById("thirdRow").style.visibility = "collapse";
     tests = [
         [
-            document.getElementById('two').offsetWidth,
-            document.getElementById('one').offsetWidth,
+            width(document.getElementById('two')),
+            width(document.getElementById('one')),
             "spanning row visibility:collapse doesn't change table width"
         ],
         [
-            document.getElementById('firstRow').offsetHeight,
-            document.getElementById('firstRowRef').offsetHeight,
+            height(document.getElementById('firstRow')),
+            height(document.getElementById('firstRowRef')),
             "when third row is collapsed, first row stays the same height"
         ],
         [
-            document.getElementById('secondRow').offsetHeight,
-            document.getElementById('secondRowRef').offsetHeight,
+            height(document.getElementById('secondRow')),
+            height(document.getElementById('secondRowRef')),
             "when third row is collapsed, second row stays the same height"
         ],
-        [   document.getElementById('thirdRow').offsetHeight,
+        [
+            height(document.getElementById('thirdRow')),
             0,
             "third row visibility:collapse makes row height 0"
         ],
-           [
-               document.getElementById('fourthRow').offsetHeight,
-            document.getElementById('fourthRowRef').offsetHeight,
+        [
+            height(document.getElementById('fourthRow')),
+            height(document.getElementById('fourthRowRef')),
             "when third row is collapsed, fourth row stays the same height"
         ],
         [
-            document.getElementById('spanningCell').offsetHeight,
-            document.getElementById('firstRow').offsetHeight +
-            document.getElementById('secondRow').offsetHeight +
-            document.getElementById('fourthRow').offsetHeight +
-            document.getElementById('fifthRow').offsetHeight,
+            height(document.getElementById('spanningCell')),
+            height(document.getElementById('firstRow')) +
+            height(document.getElementById('secondRow')) +
+            height(document.getElementById('fourthRow')) +
+            height(document.getElementById('fifthRow')),
             "spanning cell shrinks to sum of remaining three rows' height"
         ]];
     runTests();
     document.getElementById("thirdRow").style.visibility = "visible";
     tests = [
         [
-            document.getElementById('firstRow').offsetHeight,
-            document.getElementById('firstRowRef').offsetHeight,
+            height(document.getElementById('firstRow')),
+            height(document.getElementById('firstRowRef')),
             "when third row is visible, first row stays the same height"
         ],
         [
-            document.getElementById('secondRow').offsetHeight,
-            document.getElementById('secondRowRef').offsetHeight,
+            height(document.getElementById('secondRow')),
+            height(document.getElementById('secondRowRef')),
             "when third row is visible, second row stays the same height"
         ],
-        [   document.getElementById('thirdRow').offsetHeight,
-            document.getElementById('secondRowRef').offsetHeight,
+        [
+            height(document.getElementById('thirdRow')),
+            height(document.getElementById('secondRowRef')),
             "when third row is visible, third row stays the same height"
         ],
         [
-            document.getElementById('fourthRow').offsetHeight,
-            document.getElementById('fourthRowRef').offsetHeight,
+            height(document.getElementById('fourthRow')),
+            height(document.getElementById('fourthRowRef')),
             "when third row is visible, fourth row stays the same height"
         ],
         [
-            document.getElementById('fifthRow').offsetHeight,
-            document.getElementById('fifthRowRef').offsetHeight,
+            height(document.getElementById('fifthRow')),
+            height(document.getElementById('fifthRowRef')),
             "when third row is visible, fifth row stays the same height"
         ],
         [
-            document.getElementById('spanningCell').offsetHeight,
-            document.getElementById('spanningCellRef').offsetHeight,
+            height(document.getElementById('spanningCell')),
+            height(document.getElementById('spanningCellRef')),
             "when third row is visible, spanning cell stays the same height"
         ]];
     runTests();
     document.getElementById("thirdRow").style.visibility = "collapse";
     tests = [
         [
-            document.getElementById('two').offsetWidth,
-            document.getElementById('one').offsetWidth,
+            width(document.getElementById('two')),
+            width(document.getElementById('one')),
             "(2nd collapse) spanning row visibility:collapse doesn't change table width"
         ],
         [
-            document.getElementById('firstRow').offsetHeight,
-            document.getElementById('firstRowRef').offsetHeight,
+            height(document.getElementById('firstRow')),
+            height(document.getElementById('firstRowRef')),
             "when third row is collapsed again, first row stays the same height"
         ],
         [
-            document.getElementById('secondRow').offsetHeight,
-            document.getElementById('secondRowRef').offsetHeight,
+            height(document.getElementById('secondRow')),
+            height(document.getElementById('secondRowRef')),
             "when third row is collapsed again, second row stays the same height"
         ],
-        [   document.getElementById('thirdRow').offsetHeight,
+        [
+            height(document.getElementById('thirdRow')),
             0,
             "(2nd collapse) third row visibility:collapse makes row height 0"
         ],
         [
-            document.getElementById('fourthRow').offsetHeight,
-            document.getElementById('fourthRowRef').offsetHeight,
+            height(document.getElementById('fourthRow')),
+            height(document.getElementById('fourthRowRef')),
             "when third row is collapsed again, fourth row stays the same height"
         ],
         [
-            document.getElementById('spanningCell').offsetHeight,
-            document.getElementById('firstRow').offsetHeight +
-            document.getElementById('secondRow').offsetHeight +
-            document.getElementById('fourthRow').offsetHeight +
-            document.getElementById('fifthRow').offsetHeight,
+            height(document.getElementById('spanningCell')),
+            height(document.getElementById('firstRow')) +
+            height(document.getElementById('secondRow')) +
+            height(document.getElementById('fourthRow')) +
+            height(document.getElementById('fifthRow')),
             "(2nd collapse) spanning cell shrinks to sum of remaining three rows' height"
         ]];
     runTests();


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
For a table wrapper in collapsed-borders mode we were just halving the border widths from the computed style. However, it needs to actually receive half of the resulting collapsed border, which can be bigger.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #34949
- [X] There are tests for these changes

Note I'm modifying `/css/css-tables/visibility-collapse-rowspan-004-dynamic.html` to use `getBoundingClientRect()` instead of `offsetWidth` and `offsetHeight`, because the latter are rounded to an integer so the arithmetic wouldn't work well.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
