### PR TITLE
layout: Fix conflict resolution for collapsed borders differing in color

### DIFF
--- a/components/layout_2020/table/layout.rs
+++ b/components/layout_2020/table/layout.rs
@@ -2228,37 +2228,8 @@ impl<'a> TableLayout<'a> {
             };
         let all_rows = 0..self.table.size.height;
         let all_columns = 0..self.table.size.width;
-        apply_border(&self.table.layout_style_for_grid(), &all_rows, &all_columns);
-        for column_group in &self.table.column_groups {
-            apply_border(
-                &column_group.layout_style(),
-                &all_rows,
-                &column_group.track_range,
-            );
-        }
-        for (column_index, column) in self.table.columns.iter().enumerate() {
-            apply_border(
-                &column.layout_style(),
-                &all_rows,
-                &(column_index..column_index + 1),
-            );
-        }
-        for row_group in &self.table.row_groups {
-            apply_border(
-                &row_group.layout_style(),
-                &row_group.track_range,
-                &all_columns,
-            );
-        }
-        for (row_index, row) in self.table.rows.iter().enumerate() {
-            apply_border(
-                &row.layout_style(),
-                &(row_index..row_index + 1),
-                &all_columns,
-            );
-        }
-        for row_index in 0..self.table.size.height {
-            for column_index in 0..self.table.size.width {
+        for row_index in all_rows.clone() {
+            for column_index in all_columns.clone() {
                 let cell = match self.table.slots[row_index][column_index] {
                     TableSlot::Cell(ref cell) => cell,
                     _ => continue,
@@ -2271,6 +2242,35 @@ impl<'a> TableLayout<'a> {
                 );
             }
         }
+        for (row_index, row) in self.table.rows.iter().enumerate() {
+            apply_border(
+                &row.layout_style(),
+                &(row_index..row_index + 1),
+                &all_columns,
+            );
+        }
+        for row_group in &self.table.row_groups {
+            apply_border(
+                &row_group.layout_style(),
+                &row_group.track_range,
+                &all_columns,
+            );
+        }
+        for (column_index, column) in self.table.columns.iter().enumerate() {
+            apply_border(
+                &column.layout_style(),
+                &all_rows,
+                &(column_index..column_index + 1),
+            );
+        }
+        for column_group in &self.table.column_groups {
+            apply_border(
+                &column_group.layout_style(),
+                &all_rows,
+                &column_group.track_range,
+            );
+        }
+        apply_border(&self.table.layout_style_for_grid(), &all_rows, &all_columns);
 
         self.collapsed_borders = Some(collapsed_borders);
     }

--- a/tests/wpt/meta/css/css-tables/subpixel-collapsed-borders-003.html.ini
+++ b/tests/wpt/meta/css/css-tables/subpixel-collapsed-borders-003.html.ini
@@ -1,2 +1,0 @@
-[subpixel-collapsed-borders-003.html]
-  expected: FAIL

--- a/tests/wpt/tests/css/CSS2/borders/border-conflict-style-107.html
+++ b/tests/wpt/tests/css/CSS2/borders/border-conflict-style-107.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<title>CSS Test: border conflict resolution - border styles that differ only in color</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#border-conflict-resolution">
+<link rel="match" href="../../reference/ref-filled-green-200px-square.html">
+<meta name="assert" content="If border styles differ only in color,
+  then a style set on a cell wins over one on a row,
+  which wins over a row group, column, column group and, lastly, table.
+">
+<style>
+br { clear: both }
+table { border-collapse: collapse; float: left; }
+td { padding: 0 }
+.loser { border: 25px solid red }
+.winner { border: 25px solid green }
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<!-- Cell wins over row -->
+<table>
+  <tr class="loser">
+    <td class="winner"></td>
+  </tr>
+</table>
+
+<!-- Cell wins over row group -->
+<table>
+  <tbody class="loser">
+    <td class="winner"></td>
+  </tbody>
+</table>
+
+<!-- Cell wins over column -->
+<table>
+  <col class="loser"></col>
+  <td class="winner"></td>
+</table>
+
+<!-- Cell wins over column group -->
+<table>
+  <colgroup class="loser"></col>
+  <td class="winner"></td>
+</table>
+
+<br>
+
+<!-- Cell wins over table -->
+<table class="loser">
+  <td class="winner"></td>
+</table>
+
+<!-- Row wins over row group -->
+<table>
+  <tbody class="loser"></col>
+    <tr class="winner">
+      <td></td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- Row wins over column -->
+<table>
+  <col class="loser"></col>
+  <tr class="winner">
+    <td></td>
+  </tr>
+</table>
+
+<!-- Row wins over column group -->
+<table>
+  <colgroup class="loser"></colgroup>
+  <tr class="winner">
+    <td></td>
+  </tr>
+</table>
+
+<br>
+
+<!-- Row wins over table -->
+<table class="loser">
+  <tr class="winner">
+    <td></td>
+  </tr>
+</table>
+
+<!-- Row group wins over column -->
+<table>
+  <col class="loser"></col>
+  <tbody class="winner"></col>
+    <td></td>
+  </tbody>
+</table>
+
+<!-- Row group wins over column group -->
+<table>
+  <colgroup class="loser"></colgroup>
+  <tbody class="winner"></col>
+    <td></td>
+  </tbody>
+</table>
+
+<!-- Row group wins over table -->
+<table class="loser">
+  <tbody class="winner"></col>
+    <td></td>
+  </tbody>
+</table>
+
+<br>
+
+<!-- Column wins over column group -->
+<table>
+  <colgroup class="loser">
+    <col class="winner"></col>
+  </colgroup>
+  <td></td>
+</table>
+
+<!-- Column wins over table -->
+<table class="loser">
+  <col class="winner"></col>
+  <td></td>
+</table>
+
+<!-- Column group wins over table -->
+<table class="loser">
+  <colgroup class="winner"></colgroup>
+  <td></td>
+</table>
+
+<!-- Table wins when alone -->
+<table class="winner">
+  <td></td>
+</table>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
https://www.w3.org/TR/CSS21/tables.html#border-conflict-resolution
> If border styles differ only in color, then a style set on a cell wins
> over one on a row, which wins over a row group, column, column group
> and, lastly, table.

We were actually using the opposite order.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
