### PR TITLE
Make naming of variables consistent with `SpecificLayoutInfo`

### DIFF
--- a/components/layout_2020/display_list/mod.rs
+++ b/components/layout_2020/display_list/mod.rs
@@ -904,7 +904,7 @@ impl<'a> BuilderForBoxFragment<'a> {
 
     fn build_collapsed_table_borders(&mut self, builder: &mut DisplayListBuilder) {
         let Some(SpecificLayoutInfo::TableGridWithCollapsedBorders(table_info)) =
-            &self.fragment.detailed_layout_info
+            &self.fragment.specific_layout_info
         else {
             return;
         };

--- a/components/layout_2020/display_list/stacking_context.rs
+++ b/components/layout_2020/display_list/stacking_context.rs
@@ -1212,7 +1212,7 @@ impl BoxFragment {
 
         if let Fragment::Box(box_fragment) = &fragment {
             if matches!(
-                box_fragment.borrow().detailed_layout_info,
+                box_fragment.borrow().specific_layout_info,
                 Some(SpecificLayoutInfo::TableGridWithCollapsedBorders(_))
             ) {
                 add_fragment(StackingContextSection::CollapsedTableBorders);

--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -979,7 +979,7 @@ impl FlexContainer {
             content_inline_size_for_table: None,
             baselines,
             depends_on_block_constraints,
-            detailed_layout_info: None,
+            specific_layout_info: None,
         }
     }
 

--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -389,7 +389,7 @@ impl BlockFormattingContext {
             content_inline_size_for_table: None,
             baselines: flow_layout.baselines,
             depends_on_block_constraints: flow_layout.depends_on_block_constraints,
-            detailed_layout_info: None,
+            specific_layout_info: None,
         }
     }
 
@@ -1157,7 +1157,7 @@ impl IndependentNonReplacedContents {
             block_margins_collapsed_with_children,
         )
         .with_baselines(layout.baselines)
-        .with_detailed_layout_info(layout.detailed_layout_info)
+        .with_specific_layout_info(layout.specific_layout_info)
     }
 
     /// Lay out a normal in flow non-replaced block that establishes an independent
@@ -1469,7 +1469,7 @@ impl IndependentNonReplacedContents {
             CollapsedBlockMargins::from_margin(&margin),
         )
         .with_baselines(layout.baselines)
-        .with_detailed_layout_info(layout.detailed_layout_info)
+        .with_specific_layout_info(layout.specific_layout_info)
     }
 }
 

--- a/components/layout_2020/formatting_contexts.rs
+++ b/components/layout_2020/formatting_contexts.rs
@@ -87,7 +87,7 @@ pub(crate) struct IndependentLayout {
     pub depends_on_block_constraints: bool,
 
     /// Additional information of this layout that could be used by Javascripts and devtools.
-    pub detailed_layout_info: Option<SpecificLayoutInfo>,
+    pub specific_layout_info: Option<SpecificLayoutInfo>,
 }
 
 pub(crate) struct IndependentLayoutResult {

--- a/components/layout_2020/fragment_tree/box_fragment.rs
+++ b/components/layout_2020/fragment_tree/box_fragment.rs
@@ -89,7 +89,7 @@ pub(crate) struct BoxFragment {
     pub background_mode: BackgroundMode,
 
     /// Additional information of from layout that could be used by Javascripts and devtools.
-    pub detailed_layout_info: Option<SpecificLayoutInfo>,
+    pub specific_layout_info: Option<SpecificLayoutInfo>,
 }
 
 impl BoxFragment {
@@ -124,7 +124,7 @@ impl BoxFragment {
             scrollable_overflow_from_children,
             resolved_sticky_insets: AtomicRefCell::default(),
             background_mode: BackgroundMode::Normal,
-            detailed_layout_info: None,
+            specific_layout_info: None,
         }
     }
 
@@ -177,8 +177,8 @@ impl BoxFragment {
         self.background_mode = BackgroundMode::None;
     }
 
-    pub fn with_detailed_layout_info(mut self, info: Option<SpecificLayoutInfo>) -> Self {
-        self.detailed_layout_info = info;
+    pub fn with_specific_layout_info(mut self, info: Option<SpecificLayoutInfo>) -> Self {
+        self.specific_layout_info = info;
         self
     }
 
@@ -354,13 +354,13 @@ impl BoxFragment {
     /// <https://www.w3.org/TR/css-tables-3/#table-wrapper-box>
     pub(crate) fn is_table_wrapper(&self) -> bool {
         matches!(
-            self.detailed_layout_info,
+            self.specific_layout_info,
             Some(SpecificLayoutInfo::TableWrapper)
         )
     }
 
     pub(crate) fn has_collapsed_borders(&self) -> bool {
-        match &self.detailed_layout_info {
+        match &self.specific_layout_info {
             Some(SpecificLayoutInfo::TableCellWithCollapsedBorders) => true,
             Some(SpecificLayoutInfo::TableGridWithCollapsedBorders(_)) => true,
             Some(SpecificLayoutInfo::TableWrapper) => {

--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -579,7 +579,7 @@ impl HoistedAbsolutelyPositionedBox {
         let mut new_fragment = {
             let content_size: LogicalVec2<Au>;
             let fragments;
-            let mut detailed_layout_info: Option<SpecificLayoutInfo> = None;
+            let mut specific_layout_info: Option<SpecificLayoutInfo> = None;
             match &context.contents {
                 IndependentFormattingContextContents::Replaced(replaced) => {
                     // https://drafts.csswg.org/css2/visudet.html#abs-replaced-width
@@ -648,7 +648,7 @@ impl HoistedAbsolutelyPositionedBox {
                         block: block_size,
                     };
                     fragments = independent_layout.fragments;
-                    detailed_layout_info = independent_layout.detailed_layout_info;
+                    specific_layout_info = independent_layout.specific_layout_info;
                 },
             };
 
@@ -696,7 +696,7 @@ impl HoistedAbsolutelyPositionedBox {
                 // elements are not inflow.
                 CollapsedBlockMargins::zero(),
             )
-            .with_detailed_layout_info(detailed_layout_info)
+            .with_specific_layout_info(specific_layout_info)
         };
         positioning_context.layout_collected_children(layout_context, &mut new_fragment);
 

--- a/components/layout_2020/query.rs
+++ b/components/layout_2020/query.rs
@@ -190,7 +190,7 @@ pub fn process_resolved_style_request<'dom>(
                 return None;
             }
 
-            let (content_rect, margins, padding, detailed_layout_info) = match fragment {
+            let (content_rect, margins, padding, specific_layout_info) = match fragment {
                 Fragment::Box(ref box_fragment) | Fragment::Float(ref box_fragment) => {
                     let box_fragment = box_fragment.borrow();
                     if style.get_box().position != Position::Static {
@@ -214,8 +214,8 @@ pub fn process_resolved_style_request<'dom>(
                     let content_rect = box_fragment.content_rect;
                     let margins = box_fragment.margin;
                     let padding = box_fragment.padding;
-                    let detailed_layout_info = box_fragment.detailed_layout_info.clone();
-                    (content_rect, margins, padding, detailed_layout_info)
+                    let specific_layout_info = box_fragment.specific_layout_info.clone();
+                    (content_rect, margins, padding, specific_layout_info)
                 },
                 Fragment::Positioning(positioning_fragment) => {
                     let content_rect = positioning_fragment.borrow().rect;
@@ -235,7 +235,7 @@ pub fn process_resolved_style_request<'dom>(
             //
             // > When an element generates a grid container box...
             if display.inside() == DisplayInside::Grid {
-                if let Some(SpecificLayoutInfo::Grid(info)) = detailed_layout_info {
+                if let Some(SpecificLayoutInfo::Grid(info)) = specific_layout_info {
                     if let Some(value) = resolve_grid_template(&info, style, longhand_id) {
                         return Some(value);
                     }

--- a/components/layout_2020/table/layout.rs
+++ b/components/layout_2020/table/layout.rs
@@ -1566,7 +1566,7 @@ impl<'a> TableLayout<'a> {
             content_inline_size_for_table: None,
             baselines: Baselines::default(),
             depends_on_block_constraints,
-            detailed_layout_info: Some(SpecificLayoutInfo::TableWrapper),
+            specific_layout_info: Some(SpecificLayoutInfo::TableWrapper),
         };
 
         table_layout
@@ -1759,7 +1759,7 @@ impl<'a> TableLayout<'a> {
                 None, /* clearance */
                 CollapsedBlockMargins::zero(),
             )
-            .with_detailed_layout_info(self.specific_layout_info_for_grid());
+            .with_specific_layout_info(self.specific_layout_info_for_grid());
         }
 
         let mut table_fragments = Vec::new();
@@ -1886,7 +1886,7 @@ impl<'a> TableLayout<'a> {
             CollapsedBlockMargins::zero(),
         )
         .with_baselines(baselines)
-        .with_detailed_layout_info(self.specific_layout_info_for_grid())
+        .with_specific_layout_info(self.specific_layout_info_for_grid())
     }
 
     fn specific_layout_info_for_grid(&mut self) -> Option<SpecificLayoutInfo> {
@@ -2818,7 +2818,7 @@ impl TableSlotCell {
             );
         positioning_context.append(layout.positioning_context);
 
-        let detailed_layout_info = (table_style.get_inherited_table().border_collapse ==
+        let specific_layout_info = (table_style.get_inherited_table().border_collapse ==
             BorderCollapse::Collapse)
             .then_some(SpecificLayoutInfo::TableCellWithCollapsedBorders);
 
@@ -2834,7 +2834,7 @@ impl TableSlotCell {
             CollapsedBlockMargins::zero(),
         )
         .with_baselines(layout.layout.baselines)
-        .with_detailed_layout_info(detailed_layout_info)
+        .with_specific_layout_info(specific_layout_info)
     }
 }
 


### PR DESCRIPTION
This is a followup to #34926.

Fixes #35078.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they just rename variables.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
