### PR TITLE
fix: ohos workflow expression error

### DIFF
--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -45,7 +45,7 @@ jobs:
       matrix:
         target: ['aarch64-unknown-linux-ohos', 'x86_64-unknown-linux-ohos']
     outputs:
-      signed: $${{ steps.signing-config.outputs.signed }}
+      signed: ${{ steps.signing_config.outputs.signed }}
     steps:
       - uses: actions/checkout@v4
         if: github.event_name != 'pull_request_target'
@@ -82,7 +82,7 @@ jobs:
           npm install "@ohos/hvigor@5" "@ohos/hvigor-ohos-plugin@5"
           echo "HVIGOR_PATH=$PWD" >> $GITHUB_ENV
       - name: "Setup HAP signing config"
-        id: signing-config
+        id: signing_config
         env:
           SIGNING_MATERIAL: ${{ secrets.SERVO_OHOS_SIGNING_MATERIAL }}
         if: ${{ inputs.upload || env.SIGNING_MATERIAL != '' }} # Allows the build to pass on forks.
@@ -143,7 +143,7 @@ jobs:
     with:
       target: ohos-${{ matrix.target }}
       profile: ${{ inputs.profile }}
-      compressed-file-path: ${{ inputs.profile }}-binary-ohos-${{ matrix.target }}/servoshell-default-${{ needs.build.outputs.signed == true && 'signed' || 'unsigned' }}.hap
+      compressed-file-path: ${{ inputs.profile }}-binary-ohos-${{ matrix.target }}/servoshell-default-${{ needs.build.outputs.signed && 'signed' || 'unsigned' }}.hap
       binary-path: libs/${{ matrix.target == 'aarch64-unknown-linux-ohos' && 'arm64-v8a' || matrix.target == 'x86_64-unknown-linux-ohos' && 'x86_64' }}/libservoshell.so
       file-size: true
       speedometer: false


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Fixed an error in `ohos.yml` resulting in the artifact name not passed properly.

[Here's a test](https://github.com/dklassic/servo/actions/runs/12889558425/job/35938226596#step:1:33) showing the result can now be properly set with ohos signed hap setup. The workflow itself failed because there's no trivial way of having building a signed hap in personal fork, so I can only test it with unsigned setup.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #34744 's [follow up problem](https://github.com/servo/servo/pull/34744#issuecomment-2603483731)

<!-- Either: -->
- [x] These changes do not require tests because there is no behavior change

