### PR TITLE
Install rust-src in rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -12,5 +12,7 @@ components = [
     "rust-docs",
     # For formatting
     "rustfmt",
+    # For rust-analyzer
+    "rust-src",
 ]
 profile = "minimal"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -3,16 +3,10 @@
 channel = "1.83.0"
 
 components = [
-    "clippy",
     # For support/crown
     "llvm-tools",
     # For support/crown
     "rustc-dev",
-    # For docs building
-    "rust-docs",
-    # For formatting
-    "rustfmt",
     # For rust-analyzer
     "rust-src",
 ]
-profile = "minimal"


### PR DESCRIPTION
This patch ensures that rustup installs the rust-src component, so that rust-analyzer can autocomplete and jump to standard library methods.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] ~~These changes fix #___ (GitHub issue number if applicable)~~

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because there are no functional changes