### PR TITLE
libservo: Add an initial WebView data structure to the API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4233,6 +4233,7 @@ dependencies = [
  "style_traits",
  "surfman",
  "tracing",
+ "url",
  "webdriver_server",
  "webgpu",
  "webrender",

--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -156,7 +156,7 @@ pub struct IOCompositor {
     ready_to_save_state: ReadyState,
 
     /// The webrender renderer.
-    webrender: webrender::Renderer,
+    webrender: Option<webrender::Renderer>,
 
     /// The active webrender document.
     webrender_document: DocumentId,
@@ -386,7 +386,7 @@ impl IOCompositor {
             constellation_chan: state.constellation_chan,
             time_profiler_chan: state.time_profiler_chan,
             ready_to_save_state: ReadyState::Unknown,
-            webrender: state.webrender,
+            webrender: Some(state.webrender),
             webrender_document: state.webrender_document,
             webrender_api: state.webrender_api,
             rendering_context: state.rendering_context,
@@ -411,11 +411,13 @@ impl IOCompositor {
         compositor
     }
 
-    pub fn deinit(self) {
+    pub fn deinit(&mut self) {
         if let Err(err) = self.rendering_context.make_current() {
             warn!("Failed to make the rendering context current: {:?}", err);
         }
-        self.webrender.deinit();
+        if let Some(webrender) = self.webrender.take() {
+            webrender.deinit();
+        }
     }
 
     fn update_cursor(&mut self, result: CompositorHitTestResult) {
@@ -515,10 +517,12 @@ impl IOCompositor {
                 self.remove_webview(top_level_browsing_context_id);
             },
 
+            // TODO: remove this
             CompositorMsg::MoveResizeWebView(webview_id, rect) => {
                 self.move_resize_webview(webview_id, rect);
             },
 
+            // TODO: remove this
             CompositorMsg::ShowWebView(webview_id, hide_others) => {
                 if let Err(UnknownWebView(webview_id)) = self.show_webview(webview_id, hide_others)
                 {
@@ -526,12 +530,14 @@ impl IOCompositor {
                 }
             },
 
+            // TODO: remove this
             CompositorMsg::HideWebView(webview_id) => {
                 if let Err(UnknownWebView(webview_id)) = self.hide_webview(webview_id) {
                     warn!("{webview_id}: HideWebView on unknown webview id");
                 }
             },
 
+            // TODO: remove this
             CompositorMsg::RaiseWebViewToTop(webview_id, hide_others) => {
                 if let Err(UnknownWebView(webview_id)) =
                     self.raise_webview_to_top(webview_id, hide_others)
@@ -1941,7 +1947,8 @@ impl IOCompositor {
                 for id in self.pipeline_details.keys() {
                     if let Some(WebRenderEpoch(epoch)) = self
                         .webrender
-                        .current_epoch(self.webrender_document, id.into())
+                        .as_ref()
+                        .and_then(|wr| wr.current_epoch(self.webrender_document, id.into()))
                     {
                         let epoch = Epoch(epoch);
                         pipeline_epochs.insert(*id, epoch);
@@ -2016,7 +2023,9 @@ impl IOCompositor {
         }
         self.assert_no_gl_error();
 
-        self.webrender.update();
+        if let Some(webrender) = self.webrender.as_mut() {
+            webrender.update();
+        }
 
         let wait_for_stable_image = matches!(
             target,
@@ -2073,7 +2082,9 @@ impl IOCompositor {
                 // Paint the scene.
                 // TODO(gw): Take notice of any errors the renderer returns!
                 self.clear_background();
-                self.webrender.render(size, 0 /* buffer_age */).ok();
+                if let Some(webrender) = self.webrender.as_mut() {
+                    webrender.render(size, 0 /* buffer_age */).ok();
+                }
             },
         );
 
@@ -2204,7 +2215,8 @@ impl IOCompositor {
         for (pipeline_id, pending_epochs) in pending_paint_metrics.iter_mut() {
             let Some(WebRenderEpoch(current_epoch)) = self
                 .webrender
-                .current_epoch(self.webrender_document, pipeline_id.into())
+                .as_ref()
+                .and_then(|wr| wr.current_epoch(self.webrender_document, pipeline_id.into()))
             else {
                 continue;
             };
@@ -2427,7 +2439,10 @@ impl IOCompositor {
     }
 
     pub fn toggle_webrender_debug(&mut self, option: WebRenderDebugOption) {
-        let mut flags = self.webrender.get_debug_flags();
+        let Some(webrender) = self.webrender.as_mut() else {
+            return;
+        };
+        let mut flags = webrender.get_debug_flags();
         let flag = match option {
             WebRenderDebugOption::Profiler => {
                 webrender::DebugFlags::PROFILER_DBG |
@@ -2438,7 +2453,7 @@ impl IOCompositor {
             WebRenderDebugOption::RenderTargetDebug => webrender::DebugFlags::RENDER_TARGET_DBG,
         };
         flags.toggle(flag);
-        self.webrender.set_debug_flags(flags);
+        webrender.set_debug_flags(flags);
 
         let mut txn = Transaction::new();
         self.generate_frame(&mut txn, RenderReasons::TESTING);

--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -294,8 +294,7 @@ impl WindowProxy {
             .unwrap();
         let msg = EmbedderMsg::AllowOpeningWebView(chan);
         window.send_to_embedder(msg);
-        if port.recv().unwrap() {
-            let new_top_level_browsing_context_id = TopLevelBrowsingContextId::new();
+        if let Some(new_top_level_browsing_context_id) = port.recv().unwrap() {
             let new_browsing_context_id =
                 BrowsingContextId::from(new_top_level_browsing_context_id);
             let new_pipeline_id = PipelineId::new();

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -89,6 +89,7 @@ servo_url = { path = "../url" }
 style = { workspace = true }
 style_traits = { workspace = true }
 tracing = { workspace = true, optional = true }
+url = { workspace = true }
 webdriver_server = { path = "../webdriver_server", optional = true }
 webgpu = { path = "../webgpu" }
 webrender = { workspace = true }

--- a/components/servo/proxies.rs
+++ b/components/servo/proxies.rs
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use compositing_traits::ConstellationMsg;
+use crossbeam_channel::{SendError, Sender};
+use log::warn;
+
+#[derive(Clone)]
+pub(crate) struct ConstellationProxy {
+    sender: Sender<ConstellationMsg>,
+    disconnected: Arc<AtomicBool>,
+}
+
+impl ConstellationProxy {
+    pub fn new(sender: Sender<ConstellationMsg>) -> Self {
+        Self {
+            sender,
+            disconnected: Arc::default(),
+        }
+    }
+
+    pub fn send(&self, msg: ConstellationMsg) {
+        if self.try_send(msg).is_err() {
+            warn!("Lost connection to Constellation. Will report to embedder.")
+        }
+    }
+
+    pub fn try_send(&self, msg: ConstellationMsg) -> Result<(), SendError<ConstellationMsg>> {
+        if self.disconnected.load(Ordering::SeqCst) {
+            return Err(SendError(msg));
+        }
+        if let Err(error) = self.sender.send(msg) {
+            self.disconnected.store(true, Ordering::SeqCst);
+            return Err(error);
+        }
+
+        Ok(())
+    }
+
+    pub fn sender(&self) -> Sender<ConstellationMsg> {
+        self.sender.clone()
+    }
+}

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -1,0 +1,117 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use base::id::WebViewId;
+use compositing::IOCompositor;
+use compositing_traits::ConstellationMsg;
+use webrender_api::units::DeviceRect;
+
+use crate::ConstellationProxy;
+
+pub struct WebView(Rc<WebViewInner>);
+
+struct WebViewInner {
+    // TODO: ensure that WebView instances interact with the correct Servo instance
+    pub(crate) id: WebViewId,
+    pub(crate) constellation_proxy: ConstellationProxy,
+    pub(crate) compositor: Rc<RefCell<IOCompositor>>,
+}
+
+impl Drop for WebViewInner {
+    fn drop(&mut self) {
+        self.constellation_proxy
+            .send(ConstellationMsg::CloseWebView(self.id));
+    }
+}
+
+/// Handle for a webview.
+///
+/// - The webview exists for exactly as long as there are WebView handles
+///   (FIXME: this is not true yet; webviews can still close of their own volition)
+/// - All methods are infallible; if the constellation dies, the embedder finds out when calling
+///   [Servo::handle_events](crate::Servo::handle_events)
+impl WebView {
+    pub(crate) fn new(
+        constellation_proxy: &ConstellationProxy,
+        compositor: Rc<RefCell<IOCompositor>>,
+        url: url::Url,
+    ) -> Self {
+        let webview_id = WebViewId::new();
+        constellation_proxy.send(ConstellationMsg::NewWebView(url.into(), webview_id));
+
+        Self(Rc::new(WebViewInner {
+            id: webview_id,
+            constellation_proxy: constellation_proxy.clone(),
+            compositor,
+        }))
+    }
+
+    /// FIXME: Remove this once we have a webview delegate.
+    pub(crate) fn new_auxiliary(
+        constellation_proxy: &ConstellationProxy,
+        compositor: Rc<RefCell<IOCompositor>>,
+    ) -> Self {
+        let webview_id = WebViewId::new();
+
+        Self(
+            WebViewInner {
+                id: webview_id,
+                constellation_proxy: constellation_proxy.clone(),
+                compositor,
+            }
+            .into(),
+        )
+    }
+
+    /// FIXME: Remove this once we have a webview delegate.
+    pub fn id(&self) -> WebViewId {
+        self.0.id
+    }
+
+    pub fn focus(&self) {
+        self.0
+            .constellation_proxy
+            .send(ConstellationMsg::FocusWebView(self.id()));
+    }
+
+    pub fn blur(&self) {
+        self.0
+            .constellation_proxy
+            .send(ConstellationMsg::BlurWebView);
+    }
+
+    pub fn move_resize(&self, rect: DeviceRect) {
+        self.0
+            .compositor
+            .borrow_mut()
+            .move_resize_webview(self.id(), rect);
+    }
+
+    pub fn show(&self, hide_others: bool) {
+        self.0
+            .compositor
+            .borrow_mut()
+            .show_webview(self.id(), hide_others)
+            .expect("BUG: invalid WebView instance");
+    }
+
+    pub fn hide(&self) {
+        self.0
+            .compositor
+            .borrow_mut()
+            .hide_webview(self.id())
+            .expect("BUG: invalid WebView instance");
+    }
+
+    pub fn raise_to_top(&self, hide_others: bool) {
+        self.0
+            .compositor
+            .borrow_mut()
+            .raise_webview_to_top(self.id(), hide_others)
+            .expect("BUG: invalid WebView instance");
+    }
+}

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -181,7 +181,7 @@ pub enum EmbedderMsg {
     /// Whether or not to allow a pipeline to load a url.
     AllowNavigationRequest(PipelineId, ServoUrl),
     /// Whether or not to allow script to open a new tab/browser
-    AllowOpeningWebView(IpcSender<bool>),
+    AllowOpeningWebView(IpcSender<Option<WebViewId>>),
     /// A webview was created.
     WebViewOpened(TopLevelBrowsingContextId),
     /// A webview was destroyed.

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -19,7 +19,7 @@ use servo::config::opts::Opts;
 use servo::config::prefs::Preferences;
 use servo::embedder_traits::EventLoopWaker;
 use servo::servo_config::pref;
-use servo::url::ServoUrl;
+use servo::servo_url::ServoUrl;
 use servo::webrender_traits::SurfmanRenderingContext;
 use servo::Servo;
 use surfman::Connection;

--- a/ports/servoshell/desktop/webview.rs
+++ b/ports/servoshell/desktop/webview.rs
@@ -809,7 +809,7 @@ where
                 EmbedderMsg::AllowOpeningWebView(response_chan) => {
                     // Note: would be a place to handle pop-ups config.
                     // see Step 7 of #the-rules-for-choosing-a-browsing-context-given-a-browsing-context-name
-                    if let Err(e) = response_chan.send(true) {
+                    if let Err(e) = response_chan.send(Some(WebViewId::new())) {
                         warn!("Failed to send AllowOpeningWebView response: {}", e);
                     };
                 },

--- a/ports/servoshell/egl/servo_glue.rs
+++ b/ports/servoshell/egl/servo_glue.rs
@@ -526,7 +526,7 @@ impl ServoGlue {
                 EmbedderMsg::AllowOpeningWebView(response_chan) => {
                     // Note: would be a place to handle pop-ups config.
                     // see Step 7 of #the-rules-for-choosing-a-browsing-context-given-a-browsing-context-name
-                    if let Err(e) = response_chan.send(true) {
+                    if let Err(e) = response_chan.send(Some(WebViewId::new())) {
                         warn!("Failed to send AllowOpeningBrowser response: {}", e);
                     };
                 },

--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -14,7 +14,7 @@ use log::{error, warn};
 use serde_json::Value;
 use servo::config::opts::{DebugOptions, Opts, OutputOptions};
 use servo::config::prefs::{PrefValue, Preferences};
-use servo::url::ServoUrl;
+use servo::servo_url::ServoUrl;
 use url::Url;
 
 #[cfg_attr(any(target_os = "android", target_env = "ohos"), allow(dead_code))]


### PR DESCRIPTION
This patch introduces a new handle-based webview API to libservo, with
two main design goals:

1. The lifetime of the handles controls the lifetime of the webview,
   giving the embedder full control over exactly when webviews are
   created and destroyed. This is consistent with how WebKitGTK’s
   WebView[^1] works; the engine can only create webviews via a create
   request[^2], and can only destroy them via a close request.
2. All methods are infallible; if the constellation dies, the embedder
   finds out when calling Servo::handle_events.

For the moment, the embedder is only responsible for creating the
WebView id, and not the internal TopLevelBrowsingContext data
structures. This is so that the ScriptThread is able to get a handle on
the new WebView's WindowProxy in the case that it's an auxiliary
browsing context. In the future, the embedder should also be responsible
for creating the TopLevelBrowsingContext and the ScriptThread should
have mechanism to associate the two views so that WebView creation is
always executed through the same code path in the embedding layer. For
now, it's enough that the embedder can get a handle to the new WebView
when it's creation is requested.

Once we replace EmbedderMsg with a webview delegate trait, we will pass
WebView handles to the embedder, rather than webview ids. We’ll also add
detailed docs, once the design settles.

Signed-off-by: Delan Azabani <dazabani@igalia.com>
Co-authored-by: Martin Robinson <mrobinson@igalia.com>


[^1]: https://webkitgtk.org/reference/webkitgtk/stable/class.WebView.html
[^2]: (https://webkitgtk.org/reference/webkitgtk/stable/vfunc.WebView.create.html

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
