### PR TITLE
Remove type parameter from Servo and IOCompositor

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -97,9 +97,9 @@ impl FrameTreeId {
 }
 
 /// NB: Never block on the constellation, because sometimes the constellation blocks on us.
-pub struct IOCompositor<Window: WindowMethods + ?Sized> {
+pub struct IOCompositor {
     /// The application window.
-    pub window: Rc<Window>,
+    pub window: Rc<dyn WindowMethods>,
 
     /// The port on which we receive messages.
     port: CompositorReceiver,
@@ -356,9 +356,9 @@ pub enum CompositeTarget {
     PngFile(Rc<String>),
 }
 
-impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
+impl IOCompositor {
     pub fn new(
-        window: Rc<Window>,
+        window: Rc<dyn WindowMethods>,
         state: InitialCompositorState,
         composite_target: CompositeTarget,
         exit_after_load: bool,

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -175,8 +175,8 @@ mod media_platform {
 /// application Servo is embedded in. Clients then create an event
 /// loop to pump messages between the embedding application and
 /// various browser components.
-pub struct Servo<Window: WindowMethods + 'static + ?Sized> {
-    compositor: IOCompositor<Window>,
+pub struct Servo {
+    compositor: IOCompositor,
     constellation_chan: Sender<ConstellationMsg>,
     embedder_receiver: EmbedderReceiver,
     messages_for_embedder: Vec<(Option<TopLevelBrowsingContextId>, EmbedderMsg)>,
@@ -220,10 +220,7 @@ impl webrender_api::RenderNotifier for RenderNotifier {
     }
 }
 
-impl<Window> Servo<Window>
-where
-    Window: WindowMethods + 'static + ?Sized,
-{
+impl Servo {
     #[cfg_attr(
         feature = "tracing",
         tracing::instrument(
@@ -232,16 +229,15 @@ where
             level = "trace",
         )
     )]
-    #[allow(clippy::new_ret_no_self)]
     pub fn new(
         opts: Opts,
         preferences: Preferences,
         rendering_context: RenderingContext,
         mut embedder: Box<dyn EmbedderMethods>,
-        window: Rc<Window>,
+        window: Rc<dyn WindowMethods>,
         user_agent: Option<String>,
         composite_target: CompositeTarget,
-    ) -> Servo<Window> {
+    ) -> Self {
         // Global configuration options, parsed from the command line.
         opts::set_options(opts);
         let opts = opts::get();
@@ -991,7 +987,7 @@ where
         log::set_max_level(filter);
     }
 
-    pub fn window(&self) -> &Window {
+    pub fn window(&self) -> &Rc<dyn WindowMethods> {
         &self.compositor.window
     }
 

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -13,7 +13,7 @@ use std::{env, fs};
 use log::{info, trace};
 use raw_window_handle::HasDisplayHandle;
 use servo::base::id::WebViewId;
-use servo::compositing::windowing::EmbedderEvent;
+use servo::compositing::windowing::{EmbedderEvent, WindowMethods};
 use servo::compositing::CompositeTarget;
 use servo::config::opts::Opts;
 use servo::config::prefs::Preferences;
@@ -45,7 +45,7 @@ pub struct App {
     opts: Opts,
     preferences: Preferences,
     servo_shell_preferences: ServoShellPreferences,
-    servo: Option<Servo<dyn WindowPortsMethods>>,
+    servo: Option<Servo>,
     webviews: Option<WebViewManager<dyn WindowPortsMethods>>,
     event_queue: Vec<EmbedderEvent>,
     suspended: Cell<bool>,
@@ -194,7 +194,18 @@ impl App {
             None
         };
 
-        let window = window.clone();
+        // TODO: Remove this once dyn upcasting coercion stabilises
+        // <https://github.com/rust-lang/rust/issues/65991>
+        struct UpcastedWindow(Rc<dyn WindowPortsMethods>);
+        impl WindowMethods for UpcastedWindow {
+            fn get_coordinates(&self) -> servo::compositing::windowing::EmbedderCoordinates {
+                self.0.get_coordinates()
+            }
+            fn set_animation_state(&self, state: servo::compositing::windowing::AnimationState) {
+                self.0.set_animation_state(state);
+            }
+        }
+        let window = UpcastedWindow(window.clone());
         // Implements embedder methods, used by libservo and constellation.
         let embedder = Box::new(EmbedderCallbacks::new(self.waker.clone(), xr_discovery));
 
@@ -208,7 +219,7 @@ impl App {
             self.preferences.clone(),
             rendering_context,
             embedder,
-            window.clone(),
+            Rc::new(window),
             self.servo_shell_preferences.user_agent.clone(),
             composite_target,
         );


### PR DESCRIPTION
This patch removes the `<Window: WindowMethods>` type parameter on Servo and IOCompositor, simplifying future webview API changes like #35119.

Unfortunately this comes at the expense of servoshell, which uses its own trait object (dyn WindowPortsMethods) to abstract over headed and headless windows. Coercion of `Rc<dyn WindowPortsMethods>` to `Rc<dyn WindowMethods>` is unstable, so for now we need to create a concrete wrapper type that coerces to `Rc<dyn WindowMethods>`.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #34522

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because there are no functional changes