### PR TITLE
layout: simplify `CollapsedBorderLine`

### DIFF
--- a/components/layout_2020/display_list/mod.rs
+++ b/components/layout_2020/display_list/mod.rs
@@ -915,10 +915,10 @@ impl<'a> BuilderForBoxFragment<'a> {
         for (x, column_size) in table_info.track_sizes.x.iter().enumerate() {
             let mut row_sum = Au::zero();
             for (y, row_size) in table_info.track_sizes.y.iter().enumerate() {
-                let left_border = &table_info.collapsed_borders.x[x].list[y];
-                let right_border = &table_info.collapsed_borders.x[x + 1].list[y];
-                let top_border = &table_info.collapsed_borders.y[y].list[x];
-                let bottom_border = &table_info.collapsed_borders.y[y + 1].list[x];
+                let left_border = &table_info.collapsed_borders.x[x][y];
+                let right_border = &table_info.collapsed_borders.x[x + 1][y];
+                let top_border = &table_info.collapsed_borders.y[y][x];
+                let bottom_border = &table_info.collapsed_borders.y[y + 1][x];
                 let details = wr::BorderDetails::Normal(wr::NormalBorder {
                     left: self.build_border_side(left_border.style_color.clone()),
                     right: self.build_border_side(right_border.style_color.clone()),

--- a/components/layout_2020/table/mod.rs
+++ b/components/layout_2020/table/mod.rs
@@ -327,11 +327,7 @@ pub(crate) struct CollapsedBorder {
 }
 
 /// Represents a piecewise sequence of collapsed borders along a line.
-#[derive(Clone, Debug, Default)]
-pub(crate) struct CollapsedBorderLine {
-    max_width: Au,
-    pub list: Vec<CollapsedBorder>,
-}
+pub(crate) type CollapsedBorderLine = Vec<CollapsedBorder>;
 
 #[derive(Clone, Debug)]
 pub(crate) struct SpecificTableGridInfo {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This used to be a struct that had a list of `CollapsedBorder`s, and the maximum border width among that list.

However, this cached maximum border width was only used when resolving the borders of the table. Therefore, for all grid lines except the first and last ones per axis, this data was useless.

Also, in order to address #35123 I plan to retroactively zero out some collapsed borders, which could invalidate this cache.

So this patch just removes the field and turns `CollapsedBorderLine` into an alias of `Vec<CollapsedBorder>`.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because there is no behavior change

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
