### PR TITLE
layout: Hide collapsed borders crossed by spanning cells

### DIFF
--- a/components/layout_2020/style_ext.rs
+++ b/components/layout_2020/style_ext.rs
@@ -240,6 +240,10 @@ impl BorderStyleColor {
             Self::new(border.border_left_style, border.border_left_color.clone()),
         )
     }
+
+    pub(crate) fn hidden() -> Self {
+        Self::new(BorderStyle::Hidden, Color::TRANSPARENT_BLACK)
+    }
 }
 
 impl Default for BorderStyleColor {

--- a/tests/wpt/tests/css/css-tables/tentative/border-collapse-spanning-cells-001.html
+++ b/tests/wpt/tests/css/css-tables/tentative/border-collapse-spanning-cells-001.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test (Tables): spanning cells crossing collapsed track borders</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-tables/#border-collapsing">
+<link rel="help" href="https://github.com/servo/servo/issues/35123">
+<link rel="match" href="../../reference/ref-filled-green-200px-square.html">
+<meta name="assert" content="
+  The cells with colspan cross columns with red borders.
+  These red borders shouldn't be visible.
+">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+
+<style>
+table { border-collapse: collapse; font: 20px/1 Ahem; color: transparent; background: green; }
+table { border: 30px solid green; }
+tr, col { border: 20px solid red }
+td { padding: 0; border:  20px solid green; }
+td[rowspan], td[colspan] { border: none }
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<table>
+  <col></col> <col></col> <col></col> <col></col>
+  <tr>
+    <td>X</td>
+    <td>X</td>
+    <td>X</td>
+    <td>X</td>
+  </tr>
+  <tr>
+    <td colspan="4">X X X X</td>
+  </tr>
+  <tr>
+    <td>X</td>
+    <td>X</td>
+    <td>X</td>
+    <td>X</td>
+  </tr>
+  <tr>
+    <td colspan="4">X X X X</td>
+  </tr>
+</table>

--- a/tests/wpt/tests/css/css-tables/tentative/border-collapse-spanning-cells-002.html
+++ b/tests/wpt/tests/css/css-tables/tentative/border-collapse-spanning-cells-002.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test (Tables): spanning cells crossing collapsed track borders</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-tables/#border-collapsing">
+<link rel="help" href="https://github.com/servo/servo/issues/35123">
+<link rel="match" href="../../reference/ref-filled-green-200px-square.html">
+<meta name="assert" content="
+  The cells with rowspan cross rows with red borders.
+  These red borders shouldn't be visible.
+">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+
+<style>
+table { border-collapse: collapse; font: 20px/1 Ahem; color: transparent; background: green; }
+table { border: 30px solid green; }
+tr, col { border: 20px solid red }
+td { padding: 0; border:  20px solid green; }
+td[rowspan], td[colspan] { border: none }
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<table>
+  <col></col> <col></col> <col></col> <col></col>
+  <tr>
+    <td>X</td>
+    <td rowspan="4">X<br><br>X<br><br>X<br><br>X</td>
+    <td>X</td>
+    <td rowspan="4">X<br><br>X<br><br>X<br><br>X</td>
+  </tr>
+  <tr>
+    <td>X</td>
+    <td>X</td>
+  </tr>
+  <tr>
+    <td>X</td>
+    <td>X</td>
+  </tr>
+  <tr>
+    <td>X</td>
+    <td>X</td>
+  </tr>
+</table>

--- a/tests/wpt/tests/css/css-tables/tentative/border-collapse-spanning-cells-003.html
+++ b/tests/wpt/tests/css/css-tables/tentative/border-collapse-spanning-cells-003.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test (Tables): spanning cells crossing collapsed track borders</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-tables/#border-collapsing">
+<link rel="help" href="https://github.com/servo/servo/issues/35123">
+<link rel="match" href="../../reference/ref-filled-green-200px-square.html">
+<meta name="assert" content="
+  The cell with colspan and rowspan crosses columns and rows with red borders.
+  These red borders shouldn't be visible.
+">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+
+<style>
+table { border-collapse: collapse; font: 20px/1 Ahem; color: transparent; background: green; }
+table { border: 30px solid green; }
+tr, col { border: 20px solid red }
+td { padding: 0; border:  20px solid green; }
+td[rowspan], td[colspan] { border: none }
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<table>
+  <col></col> <col></col> <col></col> <col></col>
+  <tr>
+    <td>X</td>
+    <td>X</td>
+    <td>X</td>
+    <td>X</td>
+  </tr>
+  <tr>
+    <td>X</td>
+    <td colspan="2" rowspan="2">X X<br><br>X X</td>
+    <td>X</td>
+  </tr>
+  <tr>
+    <td>X</td>
+    <td>X</td>
+  </tr>
+  <tr>
+    <td>X</td>
+    <td>X</td>
+    <td>X</td>
+    <td>X</td>
+  </tr>
+</table>

--- a/tests/wpt/tests/css/css-tables/tentative/border-collapse-spanning-cells-004.html
+++ b/tests/wpt/tests/css/css-tables/tentative/border-collapse-spanning-cells-004.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test (Tables): spanning cells crossing collapsed track borders</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-tables/#border-collapsing">
+<link rel="help" href="https://github.com/servo/servo/issues/35123">
+<link rel="match" href="../../reference/ref-filled-green-200px-square.html">
+<meta name="assert" content="
+  The cells with colspan cross columns with red borders.
+  The cells with rowspan cross rows with red borders.
+  These red borders shouldn't be visible.
+">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+
+<style>
+table { border-collapse: collapse; font: 20px/1 Ahem; color: transparent; background: green; }
+table { border: 30px solid green; }
+tr, col { border: 20px solid red }
+td { padding: 0; border:  20px solid green; }
+td[rowspan], td[colspan] { border: none }
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<table>
+  <col></col> <col></col> <col></col> <col></col>
+  <tr>
+    <td>X</td>
+    <td rowspan="4">X<br><br>X<br><br>X<br><br>X</td>
+    <td>X</td>
+    <td rowspan="4">X<br><br>X<br><br>X<br><br>X</td>
+  </tr>
+  <tr>
+    <td colspan="4">X X X X</td>
+  </tr>
+  <tr>
+    <td>X</td>
+    <td>X</td>
+  </tr>
+  <tr>
+    <td colspan="4">X X X X</td>
+  </tr>
+</table>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
For example, a cell with `rowspan="2"` can cross a collapsed border that was set on the rows. Now the slice of this row border that is crossed by the cell will be hidden.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #35123
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
