### PR TITLE
script: Avoid unwraps in DocumentOrShadowRoot::element_from_point.

### DIFF
--- a/components/script/dom/documentorshadowroot.rs
+++ b/components/script/dom/documentorshadowroot.rs
@@ -18,12 +18,14 @@ use style::stylesheets::{Stylesheet, StylesheetContents};
 use super::bindings::trace::HashMapTracedValues;
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::NodeBinding::Node_Binding::NodeMethods;
+use crate::dom::bindings::codegen::Bindings::ShadowRootBinding::ShadowRootMethods;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::num::Finite;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::element::Element;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::node::{self, Node, VecPreOrderInsertionHelper};
+use crate::dom::shadowroot::ShadowRoot;
 use crate::dom::window::Window;
 use crate::script_runtime::CanGc;
 use crate::stylesheet_set::StylesheetSetRef;
@@ -143,9 +145,17 @@ impl DocumentOrShadowRoot {
             Some(address) => {
                 let node = unsafe { node::from_untrusted_node_address(*address) };
                 let parent_node = node.GetParentNode().unwrap();
+                let shadow_host = parent_node
+                    .downcast::<ShadowRoot>()
+                    .map(ShadowRootMethods::Host);
                 let element_ref = node
                     .downcast::<Element>()
-                    .unwrap_or_else(|| parent_node.downcast::<Element>().unwrap());
+                    .or_else(|| shadow_host.as_deref())
+                    .unwrap_or_else(|| {
+                        parent_node
+                            .downcast::<Element>()
+                            .expect("Hit node should have an element or shadowroot parent")
+                    });
 
                 Some(DomRoot::from_ref(element_ref))
             },

--- a/components/script/dom/documentorshadowroot.rs
+++ b/components/script/dom/documentorshadowroot.rs
@@ -150,7 +150,7 @@ impl DocumentOrShadowRoot {
                     .map(ShadowRootMethods::Host);
                 let element_ref = node
                     .downcast::<Element>()
-                    .or_else(|| shadow_host.as_deref())
+                    .or(shadow_host.as_deref())
                     .unwrap_or_else(|| {
                         parent_node
                             .downcast::<Element>()

--- a/tests/wpt/meta/shadow-dom/DocumentOrShadowRoot-prototype-elementFromPoint.html.ini
+++ b/tests/wpt/meta/shadow-dom/DocumentOrShadowRoot-prototype-elementFromPoint.html.ini
@@ -1,24 +1,5 @@
 [DocumentOrShadowRoot-prototype-elementFromPoint.html]
-  expected: CRASH
-  [document.elementFromPoint and shadow.ElementFromPoint must return the shadow host of the hit-tested text node when the hit-tested text node is a direct child of the root and the host has display: inline]
-    expected: FAIL
-
-  [document.elementFromPoint and shadow.ElementFromPoint must return the shadow host of the hit-tested text node when the hit-tested text node is a direct child of the root and the host has display: block]
-    expected: FAIL
-
-  [document.elementFromPoint and shadow.ElementFromPoint must return the shadow host of the hit-tested text node when the hit-tested text node is a direct child of the root and the host has display: inline-block]
-    expected: FAIL
-
   [document.elementFromPoint and shadowRoot.elementFromPoint must return the shadow host when the hit-tested text node is assigned to a slot and the host has display: inline]
-    expected: FAIL
-
-  [document.elementFromPoint and shadowRoot.elementFromPoint must return the shadow host when the hit-tested text node is assigned to a slot and the host has display: block]
-    expected: FAIL
-
-  [document.elementFromPoint and shadowRoot.elementFromPoint must return the shadow host when the hit-tested text node is assigned to a slot and the host has display: inline-block]
-    expected: FAIL
-
-  [document.elementFromPoint and shadowRoot.elementFromPoint must return the element assigned to a slot when hit-tested text node under an element is assigned to a slot in the shadow tree and the shadow host of the slot has display: inline]
     expected: FAIL
 
   [document.elementFromPoint and shadowRoot.elementFromPoint must return the element assigned to a slot when hit-tested text node under an element is assigned to a slot in the shadow tree and the shadow host of the slot has display: block]


### PR DESCRIPTION
There's no need to unwrap here when the method already returns an optional value.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are existing WPT tests for these changes