### PR TITLE
script: Handle shadow roots when determining common ancestors of dirty roots

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -606,8 +606,15 @@ impl Document {
             ancestor.set_flag(NodeFlags::HAS_DIRTY_DESCENDANTS, has_dirty_descendants);
             has_dirty_descendants &= *ancestor != *new_dirty_root;
         }
-        self.dirty_root
-            .set(Some(new_dirty_root.downcast::<Element>().unwrap()));
+
+        let maybe_shadow_host = new_dirty_root
+            .downcast::<ShadowRoot>()
+            .map(ShadowRootMethods::Host);
+        let new_dirty_root_element = new_dirty_root
+            .downcast::<Element>()
+            .or(maybe_shadow_host.as_deref());
+
+        self.dirty_root.set(new_dirty_root_element);
     }
 
     pub(crate) fn take_dirty_root(&self) -> Option<DomRoot<Element>> {

--- a/tests/wpt/meta/shadow-dom/untriaged/events/event-dispatch/test-003.html.ini
+++ b/tests/wpt/meta/shadow-dom/untriaged/events/event-dispatch/test-003.html.ini
@@ -1,2 +1,4 @@
 [test-003.html]
-  expected: CRASH
+  expected: TIMEOUT
+  [A_05_05_03_T01]
+    expected: TIMEOUT


### PR DESCRIPTION
We need to find the closest element to the common ancestor of the existing dirty root and the new dirty node. If the closest ancestor is a shadow root, we need to use the host element.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are existing WPT tests for these changes