### PR TITLE
layout: Proper check for BoxFragment generated by a table wrapper box

### DIFF
--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -1930,9 +1930,7 @@ impl<'container> PlacementState<'container> {
         // > When finding the first/last baseline set of an inline-block, any baselines
         // > contributed by table boxes must be skipped. (This quirk is a legacy behavior from
         // > [CSS2].)
-        let display = box_fragment.style.clone_display();
-        let is_table = display == Display::Table;
-        if self.is_inline_block_context && is_table {
+        if self.is_inline_block_context && box_fragment.is_table_wrapper() {
             return;
         }
 


### PR DESCRIPTION
We were just checking the computed `display` style, but a few HTML elements can ignore some `display` values and generate a different kind of box.

This uses the right check, though for now there is no difference in behavior since we don't have special HTML layouts.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because there is no behavior change at the current time

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
