### PR TITLE
ci: remove explicit `permissions` block in bencher.yml

### DIFF
--- a/.github/workflows/bencher.yml
+++ b/.github/workflows/bencher.yml
@@ -35,10 +35,6 @@ on:
         default: false
         type: boolean
 
-permissions:
-  checks: write
-  pull-requests: write
-
 env:
   RUST_BACKTRACE: 1
   SHELL: /bin/bash


### PR DESCRIPTION
This is causing a validation error because Github's static analysis sees nightly.yml is calling bencher.yml but the latter requires permissions that are more relaxed than the former (for android & ohos). Since other workflows are not failing validation, they presumably already run with default permissions that are satisfy bencher.yml's requirements (bencher.yml is not relaxing the parent workflow's permissions as that would defeat the usefulness of the validation that Github is enforcing).

In the long run we should move to default-restrictive permissions and then have the top-level workflows declare the required permissions. The permissions in bencher.yml seems to serve only as machine-checked documentation, but as it is causing issues with nested calls that are not possible at runtime, it seems like we have to either pass additional permissions in top-level workflows (that are not needed, so that is bad) or not declare them in nested workflows.

Fixes #35141.

---

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #35141 
- [x] These changes do not require tests because they are part of the CI infrastructure. 
