### PR TITLE
ci: Fix ohos test artifact name

### DIFF
--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -232,6 +232,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: test_output
+          name: hos-${{ inputs.profile }}-test-output
       - name: Check success
         run: |
           # would be empty if servo crashed.


### PR DESCRIPTION
I'm not quite sure why a workflow run would
have a duplicate artifact name for test_output,
but hopefully this patch should fix upload failures such as in https://github.com/servo/servo/actions/runs/12922254914/job/36037850582


---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix: an artifact upload failure due to duplicate artifact names
