### PR TITLE
layout: Remove min and max container sizes from `FlexContext`

### DIFF
--- a/components/layout_2020/flexbox/geom.rs
+++ b/components/layout_2020/flexbox/geom.rs
@@ -14,6 +14,15 @@ pub(super) struct FlexRelativeVec2<T> {
     pub cross: T,
 }
 
+impl<T> FlexRelativeVec2<T> {
+    pub fn map<U>(&self, f: impl Fn(&T) -> U) -> FlexRelativeVec2<U> {
+        FlexRelativeVec2 {
+            main: f(&self.main),
+            cross: f(&self.cross),
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug)]
 pub(super) struct FlexRelativeSides<T> {
     pub cross_start: T,

--- a/components/layout_2020/formatting_contexts.rs
+++ b/components/layout_2020/formatting_contexts.rs
@@ -265,7 +265,6 @@ impl IndependentNonReplacedContents {
                 layout_context,
                 positioning_context,
                 containing_block_for_children,
-                containing_block,
             ),
             IndependentNonReplacedContents::Grid(fc) => fc.layout(
                 layout_context,


### PR DESCRIPTION
Thanks to #34946 we don't have to recompute the min and max sizes, we can get them from the `ContainingBlock`.

And then in `FlexContext` there is no need to store both the definite and the min & max sizes of the container, we can instead make do with a single `FlexRelativeVec2<SizeConstraint>`.

This removes 1 of the 3 usages of `ContentBoxSizesAndPBMDeprecated`, which is also good.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because there is no behavior change

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
