### PR TITLE
dom: set composed flag when constructing `ClipboardEvent`

### DIFF
--- a/components/script/dom/clipboardevent.rs
+++ b/components/script/dom/clipboardevent.rs
@@ -71,10 +71,9 @@ impl ClipboardEventMethods<crate::DomTypeHolder> for ClipboardEvent {
         type_: DOMString,
         init: &ClipboardEventInit,
     ) -> DomRoot<ClipboardEvent> {
-        // Missing composed field
         let bubbles = EventBubbles::from(init.parent.bubbles);
         let cancelable = EventCancelable::from(init.parent.cancelable);
-        ClipboardEvent::new(
+        let event = ClipboardEvent::new(
             window,
             proto,
             type_,
@@ -82,7 +81,9 @@ impl ClipboardEventMethods<crate::DomTypeHolder> for ClipboardEvent {
             cancelable,
             init.clipboardData.as_deref(),
             can_gc,
-        )
+        );
+        event.upcast::<Event>().set_composed(init.parent.composed);
+        event
     }
 
     /// <https://www.w3.org/TR/clipboard-apis/#dom-clipboardevent-clipboarddata>

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -1589,6 +1589,7 @@ impl Document {
         // Step 9
         event.set_trusted(trusted);
         // Step 10 Set event’s composed to true.
+        event.set_composed(true);
         // Step 11
         event.dispatch(target, false, can_gc);
     }

--- a/components/script/dom/event.rs
+++ b/components/script/dom/event.rs
@@ -623,6 +623,10 @@ impl Event {
         self.is_trusted.set(trusted);
     }
 
+    pub(crate) fn set_composed(&self, composed: bool) {
+        self.composed.set(composed);
+    }
+
     /// <https://html.spec.whatwg.org/multipage/#fire-a-simple-event>
     pub(crate) fn fire(&self, target: &EventTarget, can_gc: CanGc) -> EventStatus {
         self.set_trusted(true);

--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -3,6 +3,8 @@ skip: true
   skip: false
 [_webgl]
   skip: false
+[clipboard-apis]
+  skip: false
 [console]
   skip: false
 [cookies]

--- a/tests/wpt/meta/clipboard-apis/clipboard-item.https.html.ini
+++ b/tests/wpt/meta/clipboard-apis/clipboard-item.https.html.ini
@@ -1,0 +1,84 @@
+[clipboard-item.https.html]
+  [ClipboardItem({string, Blob}) succeeds with different types]
+    expected: FAIL
+
+  [ClipboardItem() succeeds with empty options]
+    expected: FAIL
+
+  [ClipboardItem({}) fails with empty dictionary input]
+    expected: FAIL
+
+  [ClipboardItem(Blob) fails]
+    expected: FAIL
+
+  [ClipboardItem() fails with null input]
+    expected: FAIL
+
+  [ClipboardItem() fails with no input]
+    expected: FAIL
+
+  [types() returns correct values]
+    expected: FAIL
+
+  [getType(DOMString valid type) succeeds with correct output]
+    expected: FAIL
+
+  [getType(DOMString invalid type) succeeds with correct output]
+    expected: FAIL
+
+  [getType(DOMString type) rejects correctly when querying for missing type]
+    expected: FAIL
+
+  [getType(DOMString valid type) converts DOMString to Blob]
+    expected: FAIL
+
+  [getType(DOMString invalid type) converts DOMString to Blob]
+    expected: FAIL
+
+  [supports(text/plain) returns true]
+    expected: FAIL
+
+  [supports(text/html) returns true]
+    expected: FAIL
+
+  [supports(image/png) returns true]
+    expected: FAIL
+
+  [supports(text/uri-list) returns true]
+    expected: FAIL
+
+  [supports(image/svg+xml) returns true]
+    expected: FAIL
+
+  [supports(web foo/bar) returns true]
+    expected: FAIL
+
+  [supports(web text/html) returns true]
+    expected: FAIL
+
+  [supports(web ) returns false]
+    expected: FAIL
+
+  [supports(web) returns false]
+    expected: FAIL
+
+  [supports(web foo) returns false]
+    expected: FAIL
+
+  [supports(foo/bar) returns false]
+    expected: FAIL
+
+  [supports(weB text/html) returns false]
+    expected: FAIL
+
+  [supports( web text/html) returns false]
+    expected: FAIL
+
+  [supports(not a/real type) returns false]
+    expected: FAIL
+
+  [supports() returns false]
+    expected: FAIL
+
+  [supports( ) returns false]
+    expected: FAIL

--- a/tests/wpt/meta/clipboard-apis/data-transfer-file-list-change-reference-updates.html.ini
+++ b/tests/wpt/meta/clipboard-apis/data-transfer-file-list-change-reference-updates.html.ini
@@ -1,0 +1,3 @@
+[data-transfer-file-list-change-reference-updates.html]
+  [expect changed contents]
+    expected: FAIL

--- a/tests/wpt/meta/clipboard-apis/idlharness.https.window.js.ini
+++ b/tests/wpt/meta/clipboard-apis/idlharness.https.window.js.ini
@@ -1,0 +1,93 @@
+[idlharness.https.window.html]
+  [ClipboardItem interface: existence and properties of interface object]
+    expected: FAIL
+
+  [ClipboardItem interface object length]
+    expected: FAIL
+
+  [ClipboardItem interface object name]
+    expected: FAIL
+
+  [ClipboardItem interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [ClipboardItem interface: existence and properties of interface prototype object's "constructor" property]
+    expected: FAIL
+
+  [ClipboardItem interface: existence and properties of interface prototype object's @@unscopables property]
+    expected: FAIL
+
+  [ClipboardItem interface: attribute presentationStyle]
+    expected: FAIL
+
+  [ClipboardItem interface: attribute types]
+    expected: FAIL
+
+  [ClipboardItem interface: operation getType(DOMString)]
+    expected: FAIL
+
+  [ClipboardItem interface: operation supports(DOMString)]
+    expected: FAIL
+
+  [Clipboard interface: existence and properties of interface object]
+    expected: FAIL
+
+  [Clipboard interface object length]
+    expected: FAIL
+
+  [Clipboard interface object name]
+    expected: FAIL
+
+  [Clipboard interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [Clipboard interface: existence and properties of interface prototype object's "constructor" property]
+    expected: FAIL
+
+  [Clipboard interface: existence and properties of interface prototype object's @@unscopables property]
+    expected: FAIL
+
+  [Clipboard interface: operation read(optional ClipboardUnsanitizedFormats)]
+    expected: FAIL
+
+  [Clipboard interface: operation readText()]
+    expected: FAIL
+
+  [Clipboard interface: operation write(ClipboardItems)]
+    expected: FAIL
+
+  [Clipboard interface: operation writeText(DOMString)]
+    expected: FAIL
+
+  [Clipboard must be primary interface of navigator.clipboard]
+    expected: FAIL
+
+  [Stringification of navigator.clipboard]
+    expected: FAIL
+
+  [Clipboard interface: navigator.clipboard must inherit property "read(optional ClipboardUnsanitizedFormats)" with the proper type]
+    expected: FAIL
+
+  [Clipboard interface: calling read(optional ClipboardUnsanitizedFormats) on navigator.clipboard with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [Clipboard interface: navigator.clipboard must inherit property "readText()" with the proper type]
+    expected: FAIL
+
+  [Clipboard interface: navigator.clipboard must inherit property "write(ClipboardItems)" with the proper type]
+    expected: FAIL
+
+  [Clipboard interface: calling write(ClipboardItems) on navigator.clipboard with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [Clipboard interface: navigator.clipboard must inherit property "writeText(DOMString)" with the proper type]
+    expected: FAIL
+
+  [Clipboard interface: calling writeText(DOMString) on navigator.clipboard with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [Navigator interface: attribute clipboard]
+    expected: FAIL
+
+  [Navigator interface: navigator must inherit property "clipboard" with the proper type]
+    expected: FAIL


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Accessing composed flag is enough for clipboardevent interface, and documentation does not mention the steps outlined in #35124.
Added clipboard api test expectations

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
