### PR TITLE
Fix winit_minimal.rs build

### DIFF
--- a/components/servo/examples/winit_minimal.rs
+++ b/components/servo/examples/winit_minimal.rs
@@ -18,7 +18,7 @@ use servo_url::ServoUrl;
 use surfman::{Connection, SurfaceType};
 use tracing::warn;
 use webrender_api::units::{DeviceIntPoint, DeviceIntRect, DevicePixel};
-use webrender_traits::RenderingContext;
+use webrender_traits::SurfmanRenderingContext;
 use winit::application::ApplicationHandler;
 use winit::dpi::{PhysicalPosition, PhysicalSize};
 use winit::event::WindowEvent;
@@ -69,7 +69,7 @@ impl ApplicationHandler<WakerEvent> for App {
             let adapter = connection
                 .create_adapter()
                 .expect("Failed to create adapter");
-            let rendering_context = RenderingContext::create(&connection, &adapter, None)
+            let rendering_context = SurfmanRenderingContext::create(&connection, &adapter, None)
                 .expect("Failed to create rendering context");
             let native_widget = rendering_context
                 .connection()
@@ -93,7 +93,7 @@ impl ApplicationHandler<WakerEvent> for App {
             let mut servo = Servo::new(
                 Default::default(),
                 Default::default(),
-                rendering_context,
+                Rc::new(rendering_context),
                 Box::new(EmbedderDelegate {
                     waker: waker.clone(),
                 }),


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Not sure why that was not caught in CI, but since https://github.com/servo/servo/pull/35052 merged, building the minimal example with `cargo run -p libservo --example winit_minimal` was broken.
