### PR TITLE
Remove type parameter from Servo and IOCompositor (#35121)

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -97,9 +97,9 @@ impl FrameTreeId {
 }
 
 /// NB: Never block on the constellation, because sometimes the constellation blocks on us.
-pub struct IOCompositor<Window: WindowMethods + ?Sized> {
+pub struct IOCompositor {
     /// The application window.
-    pub window: Rc<Window>,
+    pub window: Rc<dyn WindowMethods>,
 
     /// The port on which we receive messages.
     port: CompositorReceiver,
@@ -356,9 +356,9 @@ pub enum CompositeTarget {
     PngFile(Rc<String>),
 }
 
-impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
+impl IOCompositor {
     pub fn new(
-        window: Rc<Window>,
+        window: Rc<dyn WindowMethods>,
         state: InitialCompositorState,
         composite_target: CompositeTarget,
         exit_after_load: bool,

--- a/components/servo/examples/winit_minimal.rs
+++ b/components/servo/examples/winit_minimal.rs
@@ -44,7 +44,7 @@ enum App {
     Initial(Waker),
     Running {
         window_delegate: Rc<WindowDelegate>,
-        servo: Servo<WindowDelegate>,
+        servo: Servo,
     },
     Exiting,
 }

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -176,8 +176,8 @@ mod media_platform {
 /// application Servo is embedded in. Clients then create an event
 /// loop to pump messages between the embedding application and
 /// various browser components.
-pub struct Servo<Window: WindowMethods + 'static + ?Sized> {
-    compositor: IOCompositor<Window>,
+pub struct Servo {
+    compositor: IOCompositor,
     constellation_chan: Sender<ConstellationMsg>,
     embedder_receiver: EmbedderReceiver,
     messages_for_embedder: Vec<(Option<TopLevelBrowsingContextId>, EmbedderMsg)>,
@@ -221,10 +221,7 @@ impl webrender_api::RenderNotifier for RenderNotifier {
     }
 }
 
-impl<Window> Servo<Window>
-where
-    Window: WindowMethods + 'static + ?Sized,
-{
+impl Servo {
     #[cfg_attr(
         feature = "tracing",
         tracing::instrument(
@@ -233,16 +230,15 @@ where
             level = "trace",
         )
     )]
-    #[allow(clippy::new_ret_no_self)]
     pub fn new(
         opts: Opts,
         preferences: Preferences,
         rendering_context: Rc<dyn RenderingContext>,
         mut embedder: Box<dyn EmbedderMethods>,
-        window: Rc<Window>,
+        window: Rc<dyn WindowMethods>,
         user_agent: Option<String>,
         composite_target: CompositeTarget,
-    ) -> Servo<Window> {
+    ) -> Self {
         // Global configuration options, parsed from the command line.
         opts::set_options(opts);
         let opts = opts::get();
@@ -982,7 +978,7 @@ where
         log::set_max_level(filter);
     }
 
-    pub fn window(&self) -> &Window {
+    pub fn window(&self) -> &Rc<dyn WindowMethods> {
         &self.compositor.window
     }
 

--- a/ports/servoshell/egl/servo_glue.rs
+++ b/ports/servoshell/egl/servo_glue.rs
@@ -80,7 +80,7 @@ pub struct WebView {}
 
 pub struct ServoGlue {
     rendering_context: SurfmanRenderingContext,
-    servo: Servo<ServoWindowCallbacks>,
+    servo: Servo,
     batch_mode: bool,
     need_present: bool,
     callbacks: Rc<ServoWindowCallbacks>,
@@ -107,7 +107,7 @@ pub struct ServoGlue {
 impl ServoGlue {
     pub(super) fn new(
         rendering_context: SurfmanRenderingContext,
-        servo: Servo<ServoWindowCallbacks>,
+        servo: Servo,
         callbacks: Rc<ServoWindowCallbacks>,
         servoshell_preferences: ServoShellPreferences,
     ) -> Self {


### PR DESCRIPTION
This patch relands #35121, which was merged into the branch for #35116 by mistake.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #34522

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because there are no functional changes