### PR TITLE
ohos: Support resizing the window

### DIFF
--- a/components/compositing/webview.rs
+++ b/components/compositing/webview.rs
@@ -20,7 +20,7 @@ pub struct WebViewManager<WebView> {
     webviews: HashMap<WebViewId, WebView>,
 
     /// The order to paint them in, topmost last.
-    painting_order: Vec<WebViewId>,
+    pub(crate) painting_order: Vec<WebViewId>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -85,6 +85,7 @@ backtrace = { workspace = true }
 
 [target.'cfg(target_env = "ohos")'.dependencies]
 env_filter = "0.1.3"
+euclid = { workspace = true }
 # force inprocess, until libc-rs 0.2.156 is released containing
 # https://github.com/rust-lang/libc/commit/9e248e212c5602cb4e98676e4c21ea0382663a12
 ipc-channel = { workspace = true, features = ["force-inprocess"] }

--- a/ports/servoshell/egl/ohos/simpleservo.rs
+++ b/ports/servoshell/egl/ohos/simpleservo.rs
@@ -9,7 +9,6 @@ use std::rc::Rc;
 
 use log::{debug, info};
 use servo::compositing::CompositeTarget;
-use servo::euclid::Size2D;
 use servo::webrender_traits::SurfmanRenderingContext;
 /// The EventLoopWaker::wake function will be called from any thread.
 /// It will be called to notify embedder that some events are available,
@@ -17,7 +16,7 @@ use servo::webrender_traits::SurfmanRenderingContext;
 pub use servo::EventLoopWaker;
 use servo::{self, resources, Servo};
 use surfman::{Connection, SurfaceType};
-use xcomponent_sys::{OH_NativeXComponent, OH_NativeXComponent_GetXComponentSize};
+use xcomponent_sys::OH_NativeXComponent;
 
 use crate::egl::host_trait::HostTrait;
 use crate::egl::ohos::resources::ResourceReaderInstance;
@@ -68,24 +67,13 @@ pub fn init(
         .create_adapter()
         .or(Err("Failed to create adapter"))?;
 
-    let mut width: u64 = 0;
-    let mut height: u64 = 0;
-    let res = unsafe {
-        OH_NativeXComponent_GetXComponentSize(
-            xcomponent,
-            native_window,
-            &mut width as *mut _,
-            &mut height as *mut _,
-        )
+    let Ok(window_size) = (unsafe { super::get_xcomponent_size(xcomponent, native_window) }) else {
+        return Err("Failed to get xcomponent size");
     };
-    assert_eq!(res, 0, "OH_NativeXComponent_GetXComponentSize failed");
-    let width: i32 = width.try_into().expect("Width too large");
-    let height: i32 = height.try_into().expect("Height too large");
 
-    debug!("Creating surfman widget with width {width} and height {height}");
-    let native_widget = unsafe {
-        connection.create_native_widget_from_ptr(native_window, Size2D::new(width, height))
-    };
+    debug!("Creating surfman widget with {window_size:?}");
+    let native_widget =
+        unsafe { connection.create_native_widget_from_ptr(native_window, window_size) };
     let surface_type = SurfaceType::Widget { native_widget };
 
     info!("Creating rendering context");
@@ -102,7 +90,14 @@ pub fn init(
 
     let window_callbacks = Rc::new(ServoWindowCallbacks::new(
         callbacks,
-        RefCell::new(Coordinates::new(0, 0, width, height, width, height)),
+        RefCell::new(Coordinates::new(
+            0,
+            0,
+            window_size.width,
+            window_size.height,
+            window_size.width,
+            window_size.height,
+        )),
         options.display_density as f32,
     ));
 


### PR DESCRIPTION
A window resize requires to also resize the webviews, otherwise they will stay at the original size.

## Servo when foldable device is folded

![servo_main_folded](https://github.com/user-attachments/assets/165af13c-fe36-4ed7-8083-df47c0814fc1)

## Servo on main branch after unfolding the device 

The ohos port on the main branch currently ignores resize events, so the content gets stretched.

![servo_main_after_unfold](https://github.com/user-attachments/assets/d5c007db-a495-499c-9184-47d5d33f0db8)

## Servo with this PR but without `MoveResizeWebView`

If we don't manually resize the webview, the webview sizes are not updated, so half the screen is unused.
If we open servo with the screen unfolded and fold it afterwards, then the webview is too large and half the content off screen 

![servo_with_ohos_path_without_compisitor](https://github.com/user-attachments/assets/f97cdb37-9587-4c2c-8113-67e3c4c8d358)

## Servo with this PR

After adding the compositor changes, the content looks as expected and resizes properly

![servo_with_patch](https://github.com/user-attachments/assets/d736dc77-2f35-4191-b662-26967568f56a)


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix resizing the window on OpenHarmony
- [x] These changes do not require tests because: Probably not possible to test currently.

