### PR TITLE
Move media GL context setup to embedding layer.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6753,6 +6753,7 @@ dependencies = [
  "raw-window-handle",
  "rustls",
  "serde_json",
+ "servo-media",
  "servo_allocator",
  "shellwords",
  "sig",

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -88,6 +88,7 @@ servo_geometry = { path = "../geometry" }
 servo_url = { path = "../url" }
 style = { workspace = true }
 style_traits = { workspace = true }
+surfman = { workspace = true }
 tracing = { workspace = true, optional = true }
 webdriver_server = { path = "../webdriver_server", optional = true }
 webgpu = { path = "../webgpu" }
@@ -96,12 +97,6 @@ webrender_api = { workspace = true }
 webrender_traits = { workspace = true }
 webxr = { workspace = true, optional = true }
 webxr-api = { workspace = true, optional = true }
-
-[target.'cfg(any(target_os = "android", target_env = "ohos"))'.dependencies]
-surfman = { workspace = true, features = ["sm-angle-default"] }
-
-[target.'cfg(not(any(target_os = "android", target_env = "ohos")))'.dependencies]
-surfman = { workspace = true, features = ["sm-x11", "sm-raw-window-handle-06"] }
 
 [target.'cfg(all(not(target_os = "windows"), not(target_os = "ios"), not(target_os = "android"), not(target_env = "ohos"), not(target_arch = "arm"), not(target_arch = "aarch64")))'.dependencies]
 gaol = "0.2.1"

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -119,6 +119,7 @@ net = { path = "../../components/net" }
 net_traits = { workspace = true }
 raw-window-handle = "0.6"
 serde_json = { workspace = true }
+servo-media = { workspace = true }
 shellwords = "1.0.0"
 surfman = { workspace = true, features = ["sm-x11", "sm-raw-window-handle-06"] }
 tinyfiledialogs = "3.0"

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -36,6 +36,7 @@ use super::minibrowser::Minibrowser;
 use super::webview::WebViewManager;
 use super::{headed_window, headless_window};
 use crate::desktop::embedder::{EmbedderCallbacks, XrDiscovery};
+use crate::desktop::media::get_native_media_display_and_gl_context;
 use crate::desktop::tracing::trace_winit_event;
 use crate::desktop::window_trait::WindowPortsMethods;
 use crate::parser::get_default_url;
@@ -214,14 +215,17 @@ impl App {
         } else {
             CompositeTarget::Window
         };
+        let rendering_context = Rc::new(rendering_context);
+        let media_setup = get_native_media_display_and_gl_context(&rendering_context);
         let mut servo = Servo::new(
             self.opts.clone(),
             self.preferences.clone(),
-            Rc::new(rendering_context),
+            rendering_context,
             embedder,
             Rc::new(window),
             self.servo_shell_preferences.user_agent.clone(),
             composite_target,
+            media_setup,
         );
 
         servo.handle_events(vec![EmbedderEvent::NewWebView(

--- a/ports/servoshell/desktop/media.rs
+++ b/ports/servoshell/desktop/media.rs
@@ -1,0 +1,73 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::rc::Rc;
+
+use servo::webrender_traits::SurfmanRenderingContext;
+use servo::MediaGlSetup;
+#[allow(unused_imports)]
+use servo_media::player::context::GlContext;
+#[cfg(all(target_os = "linux", not(target_env = "ohos")))]
+use surfman::platform::generic::multi::connection::NativeConnection as LinuxNativeConnection;
+#[cfg(all(target_os = "linux", not(target_env = "ohos")))]
+use surfman::platform::generic::multi::context::NativeContext as LinuxNativeContext;
+#[cfg(all(target_os = "linux", not(target_env = "ohos")))]
+use surfman::{NativeConnection, NativeContext};
+
+#[cfg(all(target_os = "linux", not(target_env = "ohos")))]
+pub(crate) fn get_native_media_display_and_gl_context(
+    rendering_context: &Rc<SurfmanRenderingContext>,
+) -> Option<MediaGlSetup> {
+    let gl_context = match rendering_context.context() {
+        NativeContext::Default(LinuxNativeContext::Default(native_context)) => {
+            GlContext::Egl(native_context.egl_context as usize)
+        },
+        NativeContext::Default(LinuxNativeContext::Alternate(native_context)) => {
+            GlContext::Egl(native_context.egl_context as usize)
+        },
+        NativeContext::Alternate(_) => return None,
+    };
+
+    let native_display = match rendering_context.connection().native_connection() {
+        NativeConnection::Default(LinuxNativeConnection::Default(connection)) => {
+            NativeDisplay::Egl(connection.0 as usize)
+        },
+        NativeConnection::Default(LinuxNativeConnection::Alternate(connection)) => {
+            NativeDisplay::X11(connection.x11_display as usize)
+        },
+        NativeConnection::Alternate(_) => return None,
+    };
+    Some(MediaGlSetup {
+        native_display,
+        gl_context,
+    })
+}
+
+// @TODO(victor): https://github.com/servo/media/pull/315
+#[cfg(target_os = "windows")]
+pub(crate) fn get_native_media_display_and_gl_context(
+    rendering_context: &Rc<SurfmanRenderingContext>,
+) -> Option<MediaGlSetup> {
+    #[cfg(feature = "no-wgl")]
+    {
+        let gl_context = GlContext::Egl(rendering_context.context().egl_context as usize);
+        let native_display = NativeDisplay::Egl(rendering_context.device().egl_display as usize);
+        Some(MediaGlSetup {
+            native_display,
+            gl_context,
+        })
+    }
+    #[cfg(not(feature = "no-wgl"))]
+    None
+}
+
+#[cfg(not(any(
+    target_os = "windows",
+    all(target_os = "linux", not(target_env = "ohos"))
+)))]
+pub(crate) fn get_native_media_display_and_gl_context(
+    _rendering_context: &Rc<SurfmanRenderingContext>,
+) -> Option<MediaGlSetup> {
+    None
+}

--- a/ports/servoshell/desktop/mod.rs
+++ b/ports/servoshell/desktop/mod.rs
@@ -13,6 +13,7 @@ pub mod geometry;
 mod headed_window;
 mod headless_window;
 mod keyutils;
+mod media;
 mod minibrowser;
 mod protocols;
 mod tracing;

--- a/ports/servoshell/egl/android/simpleservo.rs
+++ b/ports/servoshell/egl/android/simpleservo.rs
@@ -127,6 +127,7 @@ pub fn init(
         window_callbacks.clone(),
         None,
         CompositeTarget::Window,
+        None,
     );
 
     SERVO.with(|s| {

--- a/ports/servoshell/egl/ohos/simpleservo.rs
+++ b/ports/servoshell/egl/ohos/simpleservo.rs
@@ -124,6 +124,7 @@ pub fn init(
         window_callbacks.clone(),
         None, /* user_agent */
         CompositeTarget::Window,
+        None,
     );
 
     let mut servo_glue = ServoGlue::new(


### PR DESCRIPTION
The servo crate should avoid platform-specific code as much as possible, and expose arguments/hooks for the embedder to customize platform-specific behaviour. These changes replace the media GL context setup with an optional parameter to the Servo constructor.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because we can't test hardware accelerated video.