### PR TITLE
chore: update wgpu to include pointer_composite_access WGSL language extension

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4599,7 +4599,7 @@ checksum = "956787520e75e9bd233246045d19f42fb73242759cc57fba9611d940ae96d4b0"
 [[package]]
 name = "naga"
 version = "24.0.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=779261e64daa6cf76c826532b7a1561d8ec203fd#779261e64daa6cf76c826532b7a1561d8ec203fd"
+source = "git+https://github.com/gfx-rs/wgpu?rev=d8e7ab1ad13f2bf2f9702401d1bc625e26b1c2e6#d8e7ab1ad13f2bf2f9702401d1bc625e26b1c2e6"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -8497,13 +8497,14 @@ checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
 [[package]]
 name = "wgpu-core"
 version = "24.0.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=779261e64daa6cf76c826532b7a1561d8ec203fd#779261e64daa6cf76c826532b7a1561d8ec203fd"
+source = "git+https://github.com/gfx-rs/wgpu?rev=d8e7ab1ad13f2bf2f9702401d1bc625e26b1c2e6#d8e7ab1ad13f2bf2f9702401d1bc625e26b1c2e6"
 dependencies = [
  "arrayvec",
  "bit-vec",
  "bitflags 2.8.0",
  "cfg_aliases",
  "document-features",
+ "hashbrown",
  "indexmap",
  "log",
  "naga",
@@ -8521,7 +8522,7 @@ dependencies = [
 [[package]]
 name = "wgpu-hal"
 version = "24.0.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=779261e64daa6cf76c826532b7a1561d8ec203fd#779261e64daa6cf76c826532b7a1561d8ec203fd"
+source = "git+https://github.com/gfx-rs/wgpu?rev=d8e7ab1ad13f2bf2f9702401d1bc625e26b1c2e6#d8e7ab1ad13f2bf2f9702401d1bc625e26b1c2e6"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -8537,6 +8538,7 @@ dependencies = [
  "gpu-alloc",
  "gpu-allocator",
  "gpu-descriptor",
+ "hashbrown",
  "js-sys",
  "khronos-egl",
  "libc",
@@ -8565,7 +8567,7 @@ dependencies = [
 [[package]]
 name = "wgpu-types"
 version = "24.0.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=779261e64daa6cf76c826532b7a1561d8ec203fd#779261e64daa6cf76c826532b7a1561d8ec203fd"
+source = "git+https://github.com/gfx-rs/wgpu?rev=d8e7ab1ad13f2bf2f9702401d1bc625e26b1c2e6#d8e7ab1ad13f2bf2f9702401d1bc625e26b1c2e6"
 dependencies = [
  "bitflags 2.8.0",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,8 +160,8 @@ webrender_api = { git = "https://github.com/servo/webrender", branch = "0.65" }
 webrender_traits = { path = "components/shared/webrender" }
 webxr = { git = "https://github.com/servo/webxr" }
 webxr-api = { git = "https://github.com/servo/webxr" }
-wgpu-core = { git = "https://github.com/gfx-rs/wgpu", rev = "779261e64daa6cf76c826532b7a1561d8ec203fd" }
-wgpu-types = { git = "https://github.com/gfx-rs/wgpu", rev = "779261e64daa6cf76c826532b7a1561d8ec203fd" }
+wgpu-core = { git = "https://github.com/gfx-rs/wgpu", rev = "d8e7ab1ad13f2bf2f9702401d1bc625e26b1c2e6" }
+wgpu-types = { git = "https://github.com/gfx-rs/wgpu", rev = "d8e7ab1ad13f2bf2f9702401d1bc625e26b1c2e6" }
 windows-sys = "0.59"
 wr_malloc_size_of = { git = "https://github.com/servo/webrender", branch = "0.65" }
 xi-unicode = "0.3.0"


### PR DESCRIPTION
This was implemented in https://github.com/gfx-rs/wgpu/pull/6913 (by me), but because of adaptive infra for WGSL language extension there is no need for any code changes on servo side. Naga now also supports parsing `@must_use` annotation in WGSL, but it's currently ignored.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes in WebGPU CTS

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
