### PR TITLE
layout: Zero out collapsed track sizes when painting collapsed borders

### DIFF
--- a/tests/wpt/tests/css/CSS2/tables/border-collapse-visibility-collapse-001.tentative.html
+++ b/tests/wpt/tests/css/CSS2/tables/border-collapse-visibility-collapse-001.tentative.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<title>CSS Test: Table with collapsed borders and collapsed tracks</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://www.w3.org/TR/CSS21/tables.html#collapsing-borders">
+<link rel="help" href="https://www.w3.org/TR/CSS21/tables.html#dynamic-effects">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
+<style>
+td { border: 50px solid green; padding: 0; }
+</style>
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<table style="border-collapse: collapse; background: red">
+  <col style="visibility: collapse"></col>
+  <tr style="visibility: collapse">
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td></td>
+    <td></td>
+  </tr>
+</table>

--- a/tests/wpt/tests/css/CSS2/tables/border-collapse-visibility-collapse-002.tentative.html
+++ b/tests/wpt/tests/css/CSS2/tables/border-collapse-visibility-collapse-002.tentative.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<title>CSS Test: Table with collapsed borders and collapsed tracks</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://www.w3.org/TR/CSS21/tables.html#collapsing-borders">
+<link rel="help" href="https://www.w3.org/TR/CSS21/tables.html#dynamic-effects">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
+<style>
+td { padding: 0; }
+</style>
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<table style="border-collapse: collapse; background: red; min-width: 100px">
+  <colgroup>
+    <col style="border-right: 100px solid green"></col>
+    <col style="visibility: collapse"></col>
+    <col style="border-left: 100px solid green"></col>
+  </colgroup>
+  <tr style="border-bottom: 100px solid green">
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr style="visibility: collapse">
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr style="border-top: 100px solid green">
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+</table>


### PR DESCRIPTION
We were painting collapsed borders without taking into account that some tracks might have been "removed" by `visibility: collapse`.

This just sets the sizes of these tracks to zero. Note this implies that collapsed borders may overlap each other, or overlap cell contents, but this seems to match Blink.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #35139
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
