### PR TITLE
[35131] Borrow hazard in Document::broadcast_active_resize_observations

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -3213,11 +3213,14 @@ impl Document {
         // Breaking potential re-borrow cycle on `resize_observers`:
         // broadcasting resize observations calls into a JS callback,
         // which can add new observers.
-        for observer in self
+        let iterator: Vec<DomRoot<ResizeObserver>> = self
             .resize_observers
             .borrow()
             .iter()
-            .map(|obs| DomRoot::from_ref(&**obs))
+            .cloned()
+            .map(|obs| DomRoot::from_ref(&*obs))
+            .collect();
+        for observer in iterator
         {
             observer.broadcast_active_resize_observations(&mut shallowest, can_gc);
         }

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -3220,8 +3220,7 @@ impl Document {
             .cloned()
             .map(|obs| DomRoot::from_ref(&*obs))
             .collect();
-        for observer in iterator
-        {
+        for observer in iterator {
             observer.broadcast_active_resize_observations(&mut shallowest, can_gc);
         }
         shallowest

--- a/tests/wpt/meta/resize-observer/calculate-depth-for-node.html.ini
+++ b/tests/wpt/meta/resize-observer/calculate-depth-for-node.html.ini
@@ -1,4 +1,5 @@
 [calculate-depth-for-node.html]
-  expected: CRASH
+  expected: ERROR
+
   ["Calculate depth for node" algorithm with Shadow DOM]
     expected: FAIL


### PR DESCRIPTION
Added cloned and collect


---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #35131

- [x] These changes do not require tests because they just exist

N.B.
I don't not work on making tests pass because I think the scope of the issue is avoid panicking.
