### PR TITLE
Make generated bindings generic over DOM types

### DIFF
--- a/components/script/dom/bindings/proxyhandler.rs
+++ b/components/script/dom/bindings/proxyhandler.rs
@@ -42,7 +42,7 @@ use crate::dom::bindings::principals::ServoJSPrincipalsRef;
 use crate::dom::bindings::reflector::DomObject;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::bindings::utils::delete_property_by_id;
-use crate::dom::globalscope::GlobalScope;
+use crate::dom::globalscope::{GlobalScope, GlobalScopeHelpers};
 use crate::realms::{AlreadyInRealm, InRealm};
 use crate::script_runtime::JSContext as SafeJSContext;
 
@@ -376,7 +376,7 @@ pub(crate) unsafe extern "C" fn maybe_cross_origin_get_prototype_if_ordinary_raw
 /// Implementation of `[[GetPrototypeOf]]` for [`Location`].
 ///
 /// [`Location`]: https://html.spec.whatwg.org/multipage/#location-getprototypeof
-pub(crate) unsafe fn maybe_cross_origin_get_prototype(
+pub(crate) unsafe fn maybe_cross_origin_get_prototype<D: crate::DomTypes>(
     cx: SafeJSContext,
     proxy: RawHandleObject,
     get_proto_object: unsafe fn(cx: SafeJSContext, global: HandleObject, rval: MutableHandleObject),
@@ -385,7 +385,7 @@ pub(crate) unsafe fn maybe_cross_origin_get_prototype(
     // > 1. If ! IsPlatformObjectSameOrigin(this) is true, then return ! OrdinaryGetPrototypeOf(this).
     if is_platform_object_same_origin(cx, proxy) {
         let ac = JSAutoRealm::new(*cx, proxy.get());
-        let global = GlobalScope::from_context(*cx, InRealm::Entered(&ac));
+        let global = D::GlobalScope::from_context(*cx, InRealm::Entered(&ac));
         get_proto_object(
             cx,
             global.reflector().get_jsobject(),

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -3272,3 +3272,15 @@ unsafe fn global_scope_from_global_static(global: *mut JSObject) -> DomRoot<Glob
     );
     root_from_object_static(global).unwrap()
 }
+
+#[allow(unsafe_code)]
+pub(crate) trait GlobalScopeHelpers<D: crate::DomTypes> {
+    unsafe fn from_context(cx: *mut JSContext, realm: InRealm) -> DomRoot<D::GlobalScope>;
+}
+
+#[allow(unsafe_code)]
+impl GlobalScopeHelpers<crate::DomTypeHolder> for GlobalScope {
+    unsafe fn from_context(cx: *mut JSContext, realm: InRealm) -> DomRoot<Self> {
+        GlobalScope::from_context(cx, realm)
+    }
+}

--- a/components/script/init.rs
+++ b/components/script/init.rs
@@ -70,7 +70,7 @@ pub fn init() -> JSEngineSetup {
         // Create the global vtables used by the (generated) DOM
         // bindings to implement JS proxies.
         RegisterBindings::RegisterProxyHandlers();
-        RegisterBindings::InitAllStatics();
+        RegisterBindings::InitAllStatics::<crate::DomTypeHolder>();
 
         js::glue::InitializeMemoryReporter(Some(is_dom_object));
     }

--- a/components/script/init.rs
+++ b/components/script/init.rs
@@ -69,7 +69,7 @@ pub fn init() -> JSEngineSetup {
 
         // Create the global vtables used by the (generated) DOM
         // bindings to implement JS proxies.
-        RegisterBindings::RegisterProxyHandlers();
+        RegisterBindings::RegisterProxyHandlers::<crate::DomTypeHolder>();
         RegisterBindings::InitAllStatics::<crate::DomTypeHolder>();
 
         js::glue::InitializeMemoryReporter(Some(is_dom_object));

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -180,6 +180,10 @@ DOMInterfaces = {
     'canGc': ['PlayEffect', 'Reset'],
 },
 
+'GlobalScope': {
+    'additionalTraits': ['crate::dom::globalscope::GlobalScopeHelpers<Self>'],
+},
+
 'GPU': {
     'inRealms': ['RequestAdapter'],
     'canGc': ['RequestAdapter', 'WgslLanguageFeatures'],

--- a/components/script_bindings/codegen/Configuration.py
+++ b/components/script_bindings/codegen/Configuration.py
@@ -245,6 +245,7 @@ class Descriptor(DescriptorProvider):
         self.path = desc.get('path', pathDefault)
         self.inRealmMethods = [name for name in desc.get('inRealms', [])]
         self.canGcMethods = [name for name in desc.get('canGc', [])]
+        self.additionalTraits = [name for name in desc.get('additionalTraits', [])]
         self.bindingPath = f"{getModuleFromObject(self.interface)}::{ifaceName}_Binding"
         self.outerObjectHook = desc.get('outerObjectHook', 'None')
         self.proxy = False


### PR DESCRIPTION
These changes make all of the generated binding methods generic over the DomTypes trait without actually using the new generic type. This reduces the size of future diffs which can incrementally start using the trait's associated types instead of concrete DOM type names.

These changes also start converting some hand-written code to be generic over the trait. These functions should be able to be moved over to the `script_bindings` crate without further modification once we make the DomTypes trait part of the `script_bindings` crate.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #1799.
- [x] There are existing WPT tests for these changes