### PR TITLE
layout: Improve fixed table layout

### DIFF
--- a/components/layout_2020/geom.rs
+++ b/components/layout_2020/geom.rs
@@ -10,7 +10,7 @@ use std::ops::{Add, AddAssign, Neg, Sub, SubAssign};
 use app_units::Au;
 use style::logical_geometry::{BlockFlowDirection, InlineBaseDirection, WritingMode};
 use style::values::computed::{
-    CSSPixelLength, LengthPercentage, MaxSize as StyleMaxSize, Size as StyleSize,
+    CSSPixelLength, LengthPercentage, MaxSize as StyleMaxSize, Percentage, Size as StyleSize,
 };
 use style::values::generics::length::GenericLengthPercentageOrAuto as AutoOr;
 use style::Zero;
@@ -673,11 +673,6 @@ impl<T> Default for Size<T> {
 
 impl<T> Size<T> {
     #[inline]
-    pub(crate) fn is_numeric(&self) -> bool {
-        matches!(self, Self::Numeric(_))
-    }
-
-    #[inline]
     pub(crate) fn is_initial(&self) -> bool {
         matches!(self, Self::Initial)
     }
@@ -744,6 +739,14 @@ impl From<StyleMaxSize> for Size<LengthPercentage> {
             StyleMaxSize::Stretch => Size::Stretch,
             StyleMaxSize::AnchorSizeFunction(_) => unreachable!("anchor-size() should be disabled"),
         }
+    }
+}
+
+impl Size<LengthPercentage> {
+    #[inline]
+    pub(crate) fn to_percentage(&self) -> Option<Percentage> {
+        self.to_numeric()
+            .and_then(|length_percentage| length_percentage.to_percentage())
     }
 }
 

--- a/tests/wpt/meta/css/CSS2/borders/border-applies-to-006.xht.ini
+++ b/tests/wpt/meta/css/CSS2/borders/border-applies-to-006.xht.ini
@@ -1,2 +1,0 @@
-[border-applies-to-006.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/borders/border-color-applies-to-006.xht.ini
+++ b/tests/wpt/meta/css/CSS2/borders/border-color-applies-to-006.xht.ini
@@ -1,2 +1,0 @@
-[border-color-applies-to-006.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003e07.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003e07.xht.ini
@@ -1,2 +1,0 @@
-[fixed-table-layout-003e07.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003e08.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003e08.xht.ini
@@ -1,2 +1,0 @@
-[fixed-table-layout-003e08.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003e09.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003e09.xht.ini
@@ -1,2 +1,0 @@
-[fixed-table-layout-003e09.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003e10.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003e10.xht.ini
@@ -1,2 +1,0 @@
-[fixed-table-layout-003e10.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003e11.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003e11.xht.ini
@@ -1,2 +1,0 @@
-[fixed-table-layout-003e11.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003e12.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003e12.xht.ini
@@ -1,2 +1,0 @@
-[fixed-table-layout-003e12.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003f03.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003f03.xht.ini
@@ -1,2 +1,0 @@
-[fixed-table-layout-003f03.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003f04.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003f04.xht.ini
@@ -1,2 +1,0 @@
-[fixed-table-layout-003f04.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003f05.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003f05.xht.ini
@@ -1,2 +1,0 @@
-[fixed-table-layout-003f05.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003f06.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003f06.xht.ini
@@ -1,2 +1,0 @@
-[fixed-table-layout-003f06.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003f07.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003f07.xht.ini
@@ -1,2 +1,0 @@
-[fixed-table-layout-003f07.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003f08.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003f08.xht.ini
@@ -1,2 +1,0 @@
-[fixed-table-layout-003f08.xht]
-  expected: FAIL


### PR DESCRIPTION
If `width` is indefinite, treat the outer size as zero, instead of treating the content size as zero and then adding padding and borders.

Also, we don't want a default minimum of zero to get added padding and borders, and then defeat the point above. So just ignore minimums and maximums.

That seems to roughly match what other browsers do, but as usual, the details are not interoperable, e.g. some browsers may obey min or max sizing properties in some cases.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #35099
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
