### PR TITLE
Remove UTF-8 BOM before parsing JSON

### DIFF
--- a/tests/wpt/meta/fetch/api/response/json.any.js.ini
+++ b/tests/wpt/meta/fetch/api/response/json.any.js.ini
@@ -1,8 +1,0 @@
-[json.any.worker.html]
-  [Ensure the correct JSON parser is used]
-    expected: FAIL
-
-
-[json.any.html]
-  [Ensure the correct JSON parser is used]
-    expected: FAIL


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Remove UTF-8 BOM before parsing JSON, which fixes a failing test.

[Try](https://github.com/shanehandley/servo/actions/runs/12972914812)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
