### PR TITLE
Propagate events from slottables to their assigned slot instead of their parent

### DIFF
--- a/tests/wpt/meta/shadow-dom/event-composed-path.html.ini
+++ b/tests/wpt/meta/shadow-dom/event-composed-path.html.ini
@@ -1,11 +1,5 @@
 [event-composed-path.html]
-  [Event Path with a slot in an open Shadow Root.]
-    expected: FAIL
-
   [Event Path with a slot in a closed Shadow Root.]
-    expected: FAIL
-
-  [Event Path with slots in nested ShadowRoots: open > open.]
     expected: FAIL
 
   [Event Path with slots in nested ShadowRoots: closed > closed.]


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

[try run](https://github.com/simonwuelker/servo/actions/runs/12979912431/job/36196702947)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are a part of #34318 
- [X] There are tests for these changes (covered by wpt)


