### PR TITLE
CI: temporarily stop running libservo builds by default

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           {
             echo 'result<<EOF'
-            python ./python/servo/try_parser.py ${{ github.event_name == 'pull_request' && 'linux-unit-tests linux-build-libservo lint' || github.event_name == 'push' && 'fail-fast full bencher production-bencher' || 'fail-fast full' }}
+            python ./python/servo/try_parser.py ${{ github.event_name == 'pull_request' && 'linux-unit-tests lint' || github.event_name == 'push' && 'fail-fast full bencher production-bencher' || 'fail-fast full' }}
             echo EOF
            } >> $GITHUB_OUTPUT
 

--- a/python/servo/try_parser.py
+++ b/python/servo/try_parser.py
@@ -181,11 +181,8 @@ class Config(object):
                 self.fail_fast = True
                 continue  # skip over keyword
             if word == "full":
-                words.extend(["linux-unit-tests", "linux-build-libservo", "linux-wpt-2020", "linux-bencher"])
-                words.extend([
-                    "macos-unit-tests", "macos-build-libservo", "windows-unit-tests", "windows-build-libservo",
-                    "android", "ohos", "lint",
-                ])
+                words.extend(["linux-unit-tests", "linux-wpt-2020", "linux-bencher"])
+                words.extend(["macos-unit-tests", "windows-unit-tests", "android", "ohos", "lint"])
                 continue  # skip over keyword
             if word == "bencher":
                 words.extend(["linux-bencher", "macos-bencher", "windows-bencher", "android-bencher", "ohos-bencher"])
@@ -240,32 +237,32 @@ class TestParser(unittest.TestCase):
         self.assertDictEqual(json.loads(Config("").to_json()),
                              {"fail_fast": False, "matrix": [
                               {
-                                  "name": "Linux (Unit Tests, Build libservo, WPT, Bencher)",
+                                  "name": "Linux (Unit Tests, WPT, Bencher)",
                                   "workflow": "linux",
                                   "wpt_layout": "2020",
                                   "profile": "release",
                                   "unit_tests": True,
-                                  'build_libservo': True,
+                                  'build_libservo': False,
                                   'bencher': True,
                                   "wpt_args": ""
                               },
                               {
-                                  "name": "MacOS (Unit Tests, Build libservo)",
+                                  "name": "MacOS (Unit Tests)",
                                   "workflow": "macos",
                                   "wpt_layout": "none",
                                   "profile": "release",
                                   "unit_tests": True,
-                                  'build_libservo': True,
+                                  'build_libservo': False,
                                   'bencher': False,
                                   "wpt_args": ""
                               },
                               {
-                                  "name": "Windows (Unit Tests, Build libservo)",
+                                  "name": "Windows (Unit Tests)",
                                   "workflow": "windows",
                                   "wpt_layout": "none",
                                   "profile": "release",
                                   "unit_tests": True,
-                                  'build_libservo': True,
+                                  'build_libservo': False,
                                   'bencher': False,
                                   "wpt_args": ""
                               },


### PR DESCRIPTION
This patch removes `build-libservo` from the default pull request and `mach try full` try job lists, because the GitHub-hosted runners don’t have enough disk space to run `linux-build-libservo` in the same job as `linux-unit-tests`.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #35179

<!-- Either: -->
- [x] CI test plan:
  - [x] [`pull_request` build](https://github.com/servo/servo/actions/runs/12984933933)
  - [x] [`mach try full` build](https://github.com/servo/servo/actions/runs/12984935944)