### PR TITLE
ci: Free some disc space on GitHub hosted runners

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -132,6 +132,13 @@ jobs:
         run: |
           git switch --detach
           git reset --hard FETCH_HEAD
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        if: ${{ runner.environment != 'self-hosted' }}
+        with:
+          tool-cache: false
+          large-packages: false
+          swap-storage: false
       - name: Install LLVM and Clang
         # Expliclity install Clang 14 on Ubuntu 20.04 used by the nightly job (#34713).
         if: ${{ runner.environment != 'self-hosted' && inputs.upload }}


### PR DESCRIPTION
Speculative fix for #35179


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #35179
- [x] These changes do not require tests because it fixes CI

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
