### PR TITLE
CI: separate libservo build job

### DIFF
--- a/.github/workflows/dispatch-workflow.yml
+++ b/.github/workflows/dispatch-workflow.yml
@@ -14,6 +14,9 @@ on:
       wpt-layout:
         required: true
         type: string
+      build-servoshell:
+        required: true
+        type: boolean
       unit-tests:
         required: true
         type: boolean
@@ -32,6 +35,7 @@ jobs:
     secrets: inherit
     with:
       profile: ${{ inputs.profile }}
+      build-servoshell: ${{ inputs.build-servoshell }}
       unit-tests: ${{ inputs.unit-tests }}
       build-libservo: ${{ inputs.build-libservo }}
       bencher: ${{ inputs.bencher }}
@@ -44,6 +48,7 @@ jobs:
     with:
       profile: ${{ inputs.profile }}
       wpt-layout: ${{ inputs.wpt-layout }}
+      build-servoshell: ${{ inputs.build-servoshell }}
       unit-tests: ${{ inputs.unit-tests }}
       build-libservo: ${{ inputs.build-libservo }}
       wpt-args: ${{ inputs.wpt-args }}
@@ -57,6 +62,7 @@ jobs:
     with:
       profile: ${{ inputs.profile }}
       wpt-layout: ${{ inputs.wpt-layout }}
+      build-servoshell: ${{ inputs.build-servoshell }}
       unit-tests: ${{ inputs.unit-tests }}
       build-libservo: ${{ inputs.build-libservo }}
       wpt-args: ${{ inputs.wpt-args }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -17,6 +17,10 @@ on:
       wpt-layout:
         required: false
         type: string
+      build-servoshell:
+        required: false
+        default: true
+        type: boolean
       unit-tests:
         required: false
         default: false
@@ -59,6 +63,10 @@ on:
         required: false
         type: choice
         options: ["none", "2013", "2020", "all"]
+      build-servoshell:
+        required: false
+        default: true
+        type: boolean
       unit-tests:
         required: false
         default: false
@@ -159,12 +167,15 @@ jobs:
         run: cargo install --path support/crown
 
       - name: Build (${{ inputs.profile }})
+        if: ${{ inputs.build-servoshell }}
         run: |
           ./mach build --use-crown --locked --${{ inputs.profile }} --features "layout_2013"
           cp -r target/cargo-timings target/cargo-timings-linux
       - name: Smoketest
+        if: ${{ inputs.build-servoshell }}
         run: xvfb-run ./mach smoketest --${{ inputs.profile  }}
       - name: Script tests
+        if: ${{ inputs.build-servoshell }}
         run: ./mach test-scripts
       - name: Unit tests
         if: ${{ inputs.unit-tests }}
@@ -178,20 +189,23 @@ jobs:
         continue-on-error: true
         run: cargo build -p libservo --all-targets
       - name: Archive build timing
+        if: ${{ inputs.build-servoshell }}
         uses: actions/upload-artifact@v4
         with:
           name: cargo-timings-linux-${{ inputs.profile }}
           # Using a wildcard here ensures that the archive includes the path.
           path: target/cargo-timings-*
       - name: Build mach package
+        if: ${{ inputs.build-servoshell }}
         run: ./mach package --${{ inputs.profile }}
       - name: Upload artifact for mach package
+        if: ${{ inputs.build-servoshell }}
         uses: actions/upload-artifact@v4
         with:
           name: linux-${{ inputs.profile }}
           path: target/${{ inputs.profile }}/servo-tech-demo.tar.gz
       - name: Upload nightly
-        if: ${{ inputs.upload }}
+        if: ${{ inputs.build-servoshell && inputs.upload }}
         run: |
           ./mach upload-nightly linux \
             --secret-from-environment \
@@ -201,8 +215,10 @@ jobs:
           NIGHTLY_REPO_TOKEN: ${{ secrets.NIGHTLY_REPO_TOKEN }}
           NIGHTLY_REPO: ${{ github.repository_owner }}/servo-nightly-builds
       - name: Build package for target
+        if: ${{ inputs.build-servoshell }}
         run: tar -czf target.tar.gz target/${{ inputs.profile }}/servo resources
       - name: Upload artifact for target
+        if: ${{ inputs.build-servoshell }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.profile }}-binary-linux

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -14,6 +14,10 @@ on:
       wpt-layout:
         required: false
         type: string
+      build-servoshell:
+        required: false
+        default: true
+        type: boolean
       unit-tests:
         required: false
         default: false
@@ -52,6 +56,10 @@ on:
         required: false
         type: choice
         options: ["none", "2013", "2020", "all"]
+      build-servoshell:
+        required: false
+        default: true
+        type: boolean
       unit-tests:
         required: false
         default: false
@@ -142,16 +150,19 @@ jobs:
           ./mach bootstrap --skip-lints
           brew install gnu-tar
       - name: Build (${{ inputs.profile }})
+        if: ${{ inputs.build-servoshell }}
         run: |
           ./mach build --use-crown --locked --${{ inputs.profile }}
           cp -r target/cargo-timings target/cargo-timings-macos
       - name: Smoketest
+        if: ${{ inputs.build-servoshell }}
         uses: nick-fields/retry@v3
         with: # See https://github.com/servo/servo/issues/30757
           timeout_minutes: 5
           max_attempts: 2
           command: ./mach smoketest --${{ inputs.profile }}
       - name: Script tests
+        if: ${{ inputs.build-servoshell }}
         run: ./mach test-scripts
       - name: Unit tests
         if: ${{ inputs.unit-tests }}
@@ -165,26 +176,30 @@ jobs:
         continue-on-error: true
         run: cargo build -p libservo --all-targets
       - name: Build mach package
+        if: ${{ inputs.build-servoshell }}
         run: ./mach package --${{ inputs.profile }}
       - name: Run DMG smoketest
+        if: ${{ inputs.build-servoshell }}
         uses: nick-fields/retry@v3
         with: # See https://github.com/servo/servo/issues/30757
           timeout_minutes: 5
           max_attempts: 2
           command: ./etc/ci/macos_package_smoketest.sh target/${{ inputs.profile }}/servo-tech-demo.dmg
       - name: Archive build timing
+        if: ${{ inputs.build-servoshell }}
         uses: actions/upload-artifact@v4
         with:
           name: cargo-timings-macos-${{ inputs.profile }}
           # Using a wildcard here ensures that the archive includes the path.
           path: target/cargo-timings-*
       - name: Upload artifact for mach package
+        if: ${{ inputs.build-servoshell }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.profile }}-binary-mac
           path: target/${{ inputs.profile }}/servo-tech-demo.dmg
       - name: Upload nightly
-        if: ${{ inputs.upload }}
+        if: ${{ inputs.build-servoshell && inputs.upload }}
         run: |
           ./mach upload-nightly mac --secret-from-environment \
             --github-release-id ${{ inputs.github-release-id }}
@@ -194,8 +209,10 @@ jobs:
           NIGHTLY_REPO_TOKEN: ${{ secrets.NIGHTLY_REPO_TOKEN }}
           NIGHTLY_REPO: ${{ github.repository_owner }}/servo-nightly-builds
       - name: Build package for target
+        if: ${{ inputs.build-servoshell }}
         run: gtar -czf target.tar.gz target/${{ inputs.profile }}/servo target/${{ inputs.profile }}/lib/*.dylib resources
       - name: Upload package for target
+        if: ${{ inputs.build-servoshell }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.profile }}-binary-macos

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           {
             echo 'result<<EOF'
-            python ./python/servo/try_parser.py ${{ github.event_name == 'pull_request' && 'linux-unit-tests lint' || github.event_name == 'push' && 'fail-fast full bencher production-bencher' || 'fail-fast full' }}
+            python ./python/servo/try_parser.py ${{ github.event_name == 'pull_request' && 'linux-unit-tests linux-build-libservo lint' || github.event_name == 'push' && 'fail-fast full bencher production-bencher' || 'fail-fast full' }}
             echo EOF
            } >> $GITHUB_OUTPUT
 
@@ -53,6 +53,7 @@ jobs:
       workflow: ${{ matrix.workflow }}
       wpt-layout: ${{ matrix.wpt_layout }}
       profile: ${{ matrix.profile }}
+      build-servoshell: ${{ matrix.build_servoshell }}
       unit-tests: ${{ matrix.unit_tests }}
       build-libservo: ${{ matrix.build_libservo }}
       wpt-args: ${{ matrix.wpt_args }}

--- a/.github/workflows/try-label.yml
+++ b/.github/workflows/try-label.yml
@@ -136,6 +136,7 @@ jobs:
       workflow: ${{ matrix.workflow }}
       wpt-layout: ${{ matrix.wpt_layout }}
       profile: ${{ matrix.profile }}
+      build-servoshell: ${{ matrix.build_servoshell }}
       unit-tests: ${{ matrix.unit_tests }}
       build-libservo: ${{ matrix.build_libservo }}
       wpt-args: ${{ matrix.wpt_args }}

--- a/.github/workflows/try.yml
+++ b/.github/workflows/try.yml
@@ -106,6 +106,7 @@ jobs:
       workflow: ${{ matrix.workflow }}
       wpt-layout: ${{ matrix.wpt_layout }}
       profile: ${{ matrix.profile }}
+      build-servoshell: ${{ matrix.build_servoshell }}
       unit-tests: ${{ matrix.unit_tests }}
       build-libservo: ${{ matrix.build_libservo }}
       wpt-args: ${{ matrix.wpt_args }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -7,6 +7,10 @@ on:
         required: false
         default: "release"
         type: string
+      build-servoshell:
+        required: false
+        default: true
+        type: boolean
       unit-tests:
         required: false
         default: false
@@ -37,6 +41,10 @@ on:
         default: "release"
         options: ["release", "debug", "production"]
         type: choice
+      build-servoshell:
+        required: false
+        default: true
+        type: boolean
       unit-tests:
         required: false
         default: false
@@ -160,6 +168,7 @@ jobs:
           echo "`$env:PATH now = $env:PATH"
 
       - name: Build (${{ inputs.profile }})
+        if: ${{ inputs.build-servoshell }}
         run: |
           .\mach build --use-crown --locked --${{ inputs.profile }}
           cp C:\a\servo\servo\target\cargo-timings C:\a\servo\servo\target\cargo-timings-windows -Recurse
@@ -168,6 +177,7 @@ jobs:
         # GitHub-hosted runners check out the repo on D: drive.
         run: cp D:\a\servo\servo\resources C:\a\servo\servo -Recurse
       - name: Smoketest
+        if: ${{ inputs.build-servoshell }}
         run: .\mach smoketest --${{ inputs.profile }}
       - name: Unit tests
         if: ${{ inputs.unit-tests }}
@@ -181,14 +191,17 @@ jobs:
         continue-on-error: true
         run: cargo build -p libservo --all-targets
       - name: Archive build timing
+        if: ${{ inputs.build-servoshell }}
         uses: actions/upload-artifact@v4
         with:
           name: cargo-timings-windows-${{ inputs.profile }}
           # Using a wildcard here ensures that the archive includes the path.
           path: C:\\a\\servo\\servo\\target\\cargo-timings-*
       - name: Build mach package
+        if: ${{ inputs.build-servoshell }}
         run: .\mach package --${{ inputs.profile }}
       - name: Upload artifact for mach package
+        if: ${{ inputs.build-servoshell }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.profile }}-binary-windows
@@ -198,7 +211,7 @@ jobs:
           # Zip: C:\a\servo\servo\target\${{ inputs.profile }}\msi\Servo.zip
           path: C:\\a\\servo\\servo\\target\\${{ inputs.profile }}\\msi\\Servo.exe
       - name: Upload nightly
-        if: ${{ inputs.upload }}
+        if: ${{ inputs.build-servoshell && inputs.upload }}
         run: |
           .\mach upload-nightly windows-msvc --secret-from-environment `
             --github-release-id ${{ inputs.github-release-id }}


### PR DESCRIPTION
This patch reintroduces libservo to the default pull request and `mach try full` try job lists (added in #35116 and removed in #35180), but now keeps it separate from any job that builds servoshell and/or runs unit tests.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are related to #35179

<!-- Either: -->
- [x] CI test plan
  - [ ] [`pull_request` build](https://github.com/servo/servo/actions/runs/12988309628)
  - [ ] [`mach try full` build](https://github.com/servo/servo/actions/runs/12988316291)