### PR TITLE
libservo: Add `WebViewDelegate` and `ServoDelegate` and port `winit_minimal`

### DIFF
--- a/components/servo/proxies.rs
+++ b/components/servo/proxies.rs
@@ -23,6 +23,10 @@ impl ConstellationProxy {
         }
     }
 
+    pub fn disconnected(&self) -> bool {
+        self.disconnected.load(Ordering::SeqCst)
+    }
+
     pub fn send(&self, msg: ConstellationMsg) {
         if self.try_send(msg).is_err() {
             warn!("Lost connection to Constellation. Will report to embedder.")
@@ -30,7 +34,7 @@ impl ConstellationProxy {
     }
 
     pub fn try_send(&self, msg: ConstellationMsg) -> Result<(), SendError<ConstellationMsg>> {
-        if self.disconnected.load(Ordering::SeqCst) {
+        if self.disconnected() {
             return Err(SendError(msg));
         }
         if let Err(error) = self.sender.send(msg) {

--- a/components/servo/servo_delegate.rs
+++ b/components/servo/servo_delegate.rs
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use embedder_traits::{WebResourceRequest, WebResourceResponseMsg};
+use ipc_channel::ipc::IpcSender;
+
+use crate::webview_delegate::AllowOrDenyRequest;
+use crate::{Servo, WebView};
+
+#[derive(Clone, Copy, Debug, Hash, PartialEq)]
+pub enum ServoError {
+    /// The channel to the off-the-main-thread web engine has been lost. No further
+    /// attempts to communicate will happen. This is an unrecoverable error in Servo.
+    LostConnectionWithBackend,
+    /// The devtools server, used to expose pages to remote web inspectors has failed
+    /// to start.
+    DevtoolsFailedToStart,
+}
+
+pub trait ServoDelegate {
+    /// Notification that Servo has received a major error.
+    fn notify_error(&self, _servo: &Servo, _error: ServoError) {}
+    /// Report that the DevTools server has started on the given `port`. The `token` that
+    /// be used to bypass the permission prompt from the DevTools client.
+    fn notify_devtools_server_started(&self, _servo: &Servo, _port: u16, _token: String) {}
+    /// Request a DevTools connection from a DevTools client. Typically an embedder application
+    /// will show a permissions prompt when this happens to confirm a connection is allowed.
+    fn request_devtools_connection(&self, _servo: &Servo, _request: AllowOrDenyRequest) {}
+    /// Potentially intercept a resource request. If not handled, the request will not be intercepted.
+    ///
+    /// Note: If this request is associated with a `WebView`,  the `WebViewDelegate` will
+    /// receive this notification first and have a chance to intercept the request.
+    ///
+    /// TODO: This API needs to be reworked to match the new model of how responses are sent.
+    fn intercept_web_resource_load(
+        &self,
+        _webview: Option<WebView>,
+        _request: &WebResourceRequest,
+        response_sender: IpcSender<WebResourceResponseMsg>,
+    ) {
+        let _ = response_sender.send(WebResourceResponseMsg::None);
+    }
+}
+
+pub(crate) struct DefaultServoDelegate;
+impl ServoDelegate for DefaultServoDelegate {}

--- a/components/servo/webview_delegate.rs
+++ b/components/servo/webview_delegate.rs
@@ -1,0 +1,262 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::path::PathBuf;
+
+use base::id::PipelineId;
+use compositing_traits::ConstellationMsg;
+use embedder_traits::{
+    CompositorEventVariant, ContextMenuResult, Cursor, FilterPattern, GamepadHapticEffectType,
+    InputMethodType, LoadStatus, MediaSessionEvent, PermissionPrompt, PermissionRequest,
+    PromptDefinition, PromptOrigin, WebResourceRequest, WebResourceResponseMsg,
+};
+use ipc_channel::ipc::IpcSender;
+use keyboard_types::KeyboardEvent;
+use url::Url;
+use webrender_api::units::{DeviceIntPoint, DeviceIntRect, DeviceIntSize};
+
+use crate::{ConstellationProxy, WebView};
+
+/// A request to navigate a [`WebView`] or one of its inner frames. This can be handled
+/// asynchronously. If not handled, the request will automatically be allowed.
+pub struct NavigationRequest {
+    pub url: Url,
+    pub(crate) pipeline_id: PipelineId,
+    pub(crate) constellation_proxy: ConstellationProxy,
+    pub(crate) response_sent: bool,
+}
+
+impl NavigationRequest {
+    pub fn allow(mut self) {
+        self.constellation_proxy
+            .send(ConstellationMsg::AllowNavigationResponse(
+                self.pipeline_id,
+                true,
+            ));
+        self.response_sent = true;
+    }
+
+    pub fn deny(mut self) {
+        self.constellation_proxy
+            .send(ConstellationMsg::AllowNavigationResponse(
+                self.pipeline_id,
+                false,
+            ));
+        self.response_sent = true;
+    }
+}
+
+impl Drop for NavigationRequest {
+    fn drop(&mut self) {
+        if !self.response_sent {
+            self.constellation_proxy
+                .send(ConstellationMsg::AllowNavigationResponse(
+                    self.pipeline_id,
+                    true,
+                ));
+        }
+    }
+}
+
+pub struct AllowOrDenyRequest {
+    pub(crate) response_sender: IpcSender<bool>,
+    pub(crate) response_sent: bool,
+    pub(crate) default_response: bool,
+}
+
+impl AllowOrDenyRequest {
+    pub fn allow(mut self) {
+        let _ = self.response_sender.send(true);
+        self.response_sent = true;
+    }
+
+    pub fn deny(mut self) {
+        let _ = self.response_sender.send(false);
+        self.response_sent = true;
+    }
+}
+
+impl Drop for AllowOrDenyRequest {
+    fn drop(&mut self) {
+        if !self.response_sent {
+            let _ = self.response_sender.send(self.default_response);
+        }
+    }
+}
+
+pub trait WebViewDelegate {
+    /// The URL of the currently loaded page in this [`WebView`] has changed. The new
+    /// URL can accessed via [`WebView::url`].
+    fn notify_url_changed(&self, _webview: WebView, _url: Url) {}
+    /// The page title of the currently loaded page in this [`WebView`] has changed. The new
+    /// title can accessed via [`WebView::page_title`].
+    fn notify_page_title_changed(&self, _webview: WebView, _title: Option<String>) {}
+    /// The status text of the currently loaded page in this [`WebView`] has changed. The new
+    /// status text can accessed via [`WebView::status_text`].
+    fn notify_status_text_changed(&self, _webview: WebView, _status: Option<String>) {}
+    /// This [`WebView`] has either become focused or lost focus. Whether or not the
+    /// [`WebView`] is focused can be accessed via [`WebView::focused`].
+    fn notify_focus_changed(&self, _webview: WebView, _focused: bool) {}
+    /// The `LoadStatus` of the currently loading or loaded page in this [`WebView`] has changed. The new
+    /// status can accessed via [`WebView::load_status`].
+    fn notify_load_status_changed(&self, _webview: WebView, _status: LoadStatus) {}
+    /// The [`Cursor`] of the currently loaded page in this [`WebView`] has changed. The new
+    /// cursor can accessed via [`WebView::cursor`].
+    fn notify_cursor_changed(&self, _webview: WebView, _: Cursor) {}
+    /// The favicon [`Url`] of the currently loaded page in this [`WebView`] has changed. The new
+    /// favicon [`Url`] can accessed via [`WebView::favicon_url`].
+    fn notify_favicon_url_changed(&self, _webview: WebView, _: Url) {}
+
+    /// A [`WebView`] was created and is now ready to show in the user interface.
+    fn notify_ready_to_show(&self, _webview: WebView) {}
+    /// Notify the embedder that it needs to present a new frame.
+    fn notify_new_frame_ready(&self, _webview: WebView) {}
+    /// The given event was delivered to a pipeline in the given webview.
+    fn notify_event_delivered(&self, _webview: WebView, _event: CompositorEventVariant) {}
+    /// The history state has changed.
+    // changed pattern; maybe wasteful if embedder doesn’t care?
+    fn notify_history_changed(&self, _webview: WebView, _: Vec<Url>, _: usize) {}
+
+    /// A keyboard event has been sent to Servo, but remains unprocessed. This allows the
+    /// embedding application to handle key events while first letting the [`WebView`]
+    /// have an opportunity to handle it first. Apart from builtin keybindings, page
+    /// content may expose custom keybindings as well.
+    fn notify_keyboard_event(&self, _webview: WebView, _: KeyboardEvent) {}
+    /// A pipeline in the webview panicked. First string is the reason, second one is the backtrace.
+    fn notify_crashed(&self, _webview: WebView, _reason: String, _backtrace: Option<String>) {}
+    /// Notifies the embedder about media session events
+    /// (i.e. when there is metadata for the active media session, playback state changes...).
+    fn notify_media_session_event(&self, _webview: WebView, _event: MediaSessionEvent) {}
+
+    /// Whether or not to allow a [`WebView`] to load a URL in its main frame or one of its
+    /// nested `<iframe>`s. [`NavigationRequest`]s are accepted by default.
+    fn request_navigation(&self, _webview: WebView, _navigation_request: NavigationRequest) {}
+    /// Whether or not to allow a [`WebView`]  to unload a `Document` in its main frame or one
+    /// of its nested `<iframe>`s. By default, unloads are allowed.
+    fn request_unload(&self, _webview: WebView, _unload_request: AllowOrDenyRequest) {}
+    /// Move the window to a point
+    fn request_move_to(&self, _webview: WebView, _: DeviceIntPoint) {}
+    /// Resize the window to size
+    fn request_resize_to(&self, _webview: WebView, _: DeviceIntSize) {}
+    /// Whether or not to allow script to open a new `WebView`. If not handled by the
+    /// embedder, these requests are automatically denied.
+    fn request_open_auxiliary_webview(&self, _parent_webview: WebView) -> Option<WebView> {
+        None
+    }
+    /// Page content has requested that this [`WebView`] be closed. It's the embedder's
+    /// responsibility to either ignore this request or to remove the [`WebView`] from the
+    /// interface.
+    fn request_close(&self, _webview: WebView) {}
+    /// Open interface to request permission specified by prompt.
+    fn request_permission(
+        &self,
+        _webview: WebView,
+        _: PermissionPrompt,
+        result_sender: IpcSender<PermissionRequest>,
+    ) {
+        let _ = result_sender.send(PermissionRequest::Denied);
+    }
+
+    /// Show dialog to user
+    /// TODO: This API needs to be reworked to match the new model of how responses are sent.
+    fn show_prompt(&self, _webview: WebView, prompt: PromptDefinition, _: PromptOrigin) {
+        let _ = match prompt {
+            PromptDefinition::Alert(_, response_sender) => response_sender.send(()),
+            PromptDefinition::OkCancel(_, response_sender) => {
+                response_sender.send(embedder_traits::PromptResult::Dismissed)
+            },
+            PromptDefinition::Input(_, _, response_sender) => response_sender.send(None),
+            PromptDefinition::Credentials(response_sender) => {
+                response_sender.send(Default::default())
+            },
+        };
+    }
+    /// Show a context menu to the user
+    fn show_context_menu(
+        &self,
+        _webview: WebView,
+        result_sender: IpcSender<ContextMenuResult>,
+        _: Option<String>,
+        _: Vec<String>,
+    ) {
+        let _ = result_sender.send(ContextMenuResult::Ignored);
+    }
+
+    /// Inform embedder to clear the clipboard
+    fn clear_clipboard_contents(&self, _webview: WebView) {}
+    /// Gets system clipboard contents
+    fn get_clipboard_contents(&self, _webview: WebView, _: IpcSender<String>) {}
+    /// Sets system clipboard contents
+    fn set_clipboard_contents(&self, _webview: WebView, _: String) {}
+
+    /// Enter or exit fullscreen
+    fn request_fullscreen_state_change(&self, _webview: WebView, _: bool) {}
+    /// Open dialog to select bluetooth device.
+    /// TODO: This API needs to be reworked to match the new model of how responses are sent.
+    fn show_bluetooth_device_dialog(
+        &self,
+        _webview: WebView,
+        _: Vec<String>,
+        response_sender: IpcSender<Option<String>>,
+    ) {
+        let _ = response_sender.send(None);
+    }
+
+    /// Open file dialog to select files. Set boolean flag to true allows to select multiple files.
+    fn show_file_selection_dialog(
+        &self,
+        _webview: WebView,
+        _filter_pattern: Vec<FilterPattern>,
+        _allow_select_mutiple: bool,
+        response_sender: IpcSender<Option<Vec<PathBuf>>>,
+    ) {
+        let _ = response_sender.send(None);
+    }
+
+    /// Request to present an IME to the user when an editable element is focused.
+    /// If `type` is [`InputMethodType::Text`], then the `text` parameter specifies
+    /// the pre-existing text content and the zero-based index into the string
+    /// of the insertion point.
+    fn show_ime(
+        &self,
+        _webview: WebView,
+        _type: InputMethodType,
+        _text: Option<(String, i32)>,
+        _multiline: bool,
+        _position: DeviceIntRect,
+    ) {
+    }
+
+    /// Request to hide the IME when the editable element is blurred.
+    fn hide_ime(&self, _webview: WebView) {}
+
+    /// Request to play a haptic effect on a connected gamepad.
+    fn play_gamepad_haptic_effect(
+        &self,
+        _webview: WebView,
+        _: usize,
+        _: GamepadHapticEffectType,
+        _: IpcSender<bool>,
+    ) {
+    }
+    /// Request to stop a haptic effect on a connected gamepad.
+    fn stop_gamepad_haptic_effect(&self, _webview: WebView, _: usize, _: IpcSender<bool>) {}
+
+    /// Potentially intercept a resource request. If not handled, the request will not be intercepted.
+    ///
+    /// Note: The `ServoDelegate` will also receive this notification and have a chance to intercept
+    /// the request.
+    ///
+    /// TODO: This API needs to be reworked to match the new model of how responses are sent.
+    fn intercept_web_resource_load(
+        &self,
+        _webview: WebView,
+        _request: &WebResourceRequest,
+        _response_sender: IpcSender<WebResourceResponseMsg>,
+    ) {
+    }
+}
+
+pub(crate) struct DefaultWebViewDelegate;
+impl WebViewDelegate for DefaultWebViewDelegate {}

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -114,15 +114,13 @@ pub enum PromptDefinition {
     Alert(String, IpcSender<()>),
     /// Ask a Ok/Cancel question.
     OkCancel(String, IpcSender<PromptResult>),
-    /// Ask a Yes/No question.
-    YesNo(String, IpcSender<PromptResult>),
     /// Ask the user to enter text.
     Input(String, String, IpcSender<Option<String>>),
     /// Ask user to enter their username and password
     Credentials(IpcSender<PromptCredentialsInput>),
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Default, Deserialize, Serialize)]
 pub struct PromptCredentialsInput {
     /// Username for http request authentication
     pub username: Option<String>,

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -249,7 +249,7 @@ impl App {
 
         // Take any new embedder messages from Servo.
         let servo = self.servo.as_mut().expect("Servo should be running.");
-        let mut embedder_messages: Vec<_> = servo.get_events().collect();
+        let mut embedder_messages = servo.get_events();
         let mut need_present = false;
         let mut need_update = false;
         loop {
@@ -271,7 +271,7 @@ impl App {
             }
 
             // Take any new embedder messages from Servo itself.
-            embedder_messages = servo.get_events().collect();
+            embedder_messages = servo.get_events();
             if embedder_messages.is_empty() {
                 break;
             }

--- a/ports/servoshell/desktop/webview.rs
+++ b/ports/servoshell/desktop/webview.rs
@@ -28,7 +28,7 @@ use servo::{
     PermissionRequest, PromptCredentialsInput, PromptDefinition, PromptOrigin, PromptResult, Servo,
     TouchEventType,
 };
-use tinyfiledialogs::{self, MessageBoxIcon, OkCancel, YesNo};
+use tinyfiledialogs::{self, MessageBoxIcon, OkCancel};
 
 use super::dialog::Dialog;
 use super::keyutils::CMD_OR_CONTROL;
@@ -487,9 +487,6 @@ impl WebViewManager {
                     let res = if opts.headless {
                         match definition {
                             PromptDefinition::Alert(_message, sender) => sender.send(()),
-                            PromptDefinition::YesNo(_message, sender) => {
-                                sender.send(PromptResult::Primary)
-                            },
                             PromptDefinition::OkCancel(_message, sender) => {
                                 sender.send(PromptResult::Primary)
                             },
@@ -517,21 +514,6 @@ impl WebViewManager {
                                         MessageBoxIcon::Warning,
                                     );
                                     sender.send(())
-                                },
-                                PromptDefinition::YesNo(mut message, sender) => {
-                                    if origin == PromptOrigin::Untrusted {
-                                        message = tiny_dialog_escape(&message);
-                                    }
-                                    let result = tinyfiledialogs::message_box_yes_no(
-                                        "",
-                                        &message,
-                                        MessageBoxIcon::Warning,
-                                        YesNo::No,
-                                    );
-                                    sender.send(match result {
-                                        YesNo::Yes => PromptResult::Primary,
-                                        YesNo::No => PromptResult::Secondary,
-                                    })
                                 },
                                 PromptDefinition::OkCancel(mut message, sender) => {
                                     if origin == PromptOrigin::Untrusted {
@@ -824,6 +806,8 @@ impl WebViewManager {
 
 #[cfg(target_os = "linux")]
 fn prompt_user(prompt: PermissionPrompt) -> PermissionRequest {
+    use tinyfiledialogs::YesNo;
+
     let message = match prompt {
         PermissionPrompt::Request(permission_name) => {
             format!("Do you want to grant permission for {:?}?", permission_name)

--- a/ports/servoshell/egl/servo_glue.rs
+++ b/ports/servoshell/egl/servo_glue.rs
@@ -455,7 +455,7 @@ impl ServoGlue {
 
     fn handle_servo_events(&mut self) -> Result<(), &'static str> {
         let mut need_update = false;
-        let messages: Vec<_> = self.servo.get_events().collect();
+        let messages = self.servo.get_events();
         for message in messages {
             match message {
                 EmbedderMsg::ChangePageTitle(_, title) => {
@@ -513,9 +513,6 @@ impl ServoGlue {
                         },
                         PromptDefinition::OkCancel(message, sender) => {
                             sender.send(cb.prompt_ok_cancel(message, trusted))
-                        },
-                        PromptDefinition::YesNo(message, sender) => {
-                            sender.send(cb.prompt_yes_no(message, trusted))
                         },
                         PromptDefinition::Input(message, default, sender) => {
                             sender.send(cb.prompt_input(message, default, trusted))


### PR DESCRIPTION
This change adds the second major part of the new API: delegates which
have methods called by the Servo loop. When a delegate is set on a
`WebView` or on `Servo` itself, the event loop will call into
appropriate delegate methods. Applications can implement the delegate on
their own structs to add special behavior per-`WebView` or for all
`WebView`s.

In addition, each delegate has a default implementation, which
automatically exposes "reasonable" behavior such as by-default allowing
navigation.

There's a lot more work to do here, such as refining the delegate
methods so that they all have nice interfaces, particulary with regard
to delegate methods that need an asynchronous response. This will be
handed gradually as we keep working on the API.

Co-authored-by: Martin Robinson <mrobinson@igalia.com>
Co-authored-by: Mukilan Thiyagarajan <mukilan@igalia.com>
Signed-off-by: Delan Azabani <dazabani@igalia.com>

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
