### PR TITLE
Update implementations of `HTTP-network fetch` and `HTTP-network-or-cache fetch` to take `fetchParams` as an argument

### DIFF
--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -1825,7 +1825,6 @@ async fn http_network_fetch(
 ) -> Response {
     let mut response_end_timer = ResponseEndTimer(Some(context.timing.clone()));
 
-
     // Step 1: Let request be fetchParams’s request.
     let request = &mut fetch_params.request;
 

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -1113,7 +1113,7 @@ async fn http_network_or_cache_fetch(
 
     // Step 2. Let httpFetchParams be null.
     let http_fetch_params: &mut FetchParams;
-    let mut http_fetch_params_obj: FetchParams;
+    let mut fetch_params_copy: FetchParams;
 
     // Step 3. Let httpRequest be null. (See step 8 for initialization)
 
@@ -1136,9 +1136,9 @@ async fn http_network_or_cache_fetch(
     else {
         // Step 8.2.1 - 8.2.3: Set httpRequest to a clone of request
         // and Set httpFetchParams to a copy of fetchParams.
-        http_fetch_params_obj = fetch_params.clone();
+        fetch_params_copy = fetch_params.clone();
+        http_fetch_params = &mut fetch_params_copy;
 
-        http_fetch_params = &mut http_fetch_params_obj;
         &mut http_fetch_params.request
     };
 

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -1594,8 +1594,8 @@ async fn http_network_or_cache_fetch(
         }
 
         // Step 14.3 If request’s use-URL-credentials flag is unset or isAuthenticationFetch is true, then:
-        if !http_request.use_url_credentials || authentication_fetch_flag {
-            let Some(webview_id) = http_request.target_webview_id else {
+        if !request.use_url_credentials || authentication_fetch_flag {
+            let Some(webview_id) = request.target_webview_id else {
                 return response;
             };
             let Some(credentials) =
@@ -1654,7 +1654,7 @@ async fn http_network_or_cache_fetch(
 
         // Step 15.4 Prompt the end user as appropriate in request’s window
         // window and store the result as a proxy-authentication entry.
-        let Some(webview_id) = http_request.target_webview_id else {
+        let Some(webview_id) = request.target_webview_id else {
             return response;
         };
         let Some(credentials) =

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -1516,8 +1516,9 @@ async fn http_network_or_cache_fetch(
         // Step 10.2 Let forwardResponse be the result of running HTTP-network fetch given httpFetchParams,
         // includeCredentials, and isNewConnectionFetch.
         let forward_response =
-            http_network_fetch(http_request, include_credentials, done_chan, context).await;
+            http_network_fetch(http_fetch_params, include_credentials, done_chan, context).await;
 
+        let http_request = &mut http_fetch_params.request;
         // Step 10.3 If httpRequest’s method is unsafe and forwardResponse’s status is in the range 200 to 399,
         // inclusive, invalidate appropriate stored responses in httpCache, as per the
         // "Invalidating Stored Responses" chapter of HTTP Caching, and set storedResponse to null.
@@ -1554,6 +1555,8 @@ async fn http_network_or_cache_fetch(
             }
         }
     }
+
+    let http_request = &mut http_fetch_params.request;
     // The cache has been updated, set its state to ready to construct.
     update_http_cache_state(context, http_request);
 
@@ -1815,15 +1818,16 @@ fn prompt_user_for_credentials(
 
 /// [HTTP network fetch](https://fetch.spec.whatwg.org/#http-network-fetch)
 async fn http_network_fetch(
-    request: &mut Request,
+    fetch_params: &mut FetchParams,
     credentials_flag: bool,
     done_chan: &mut DoneChannel,
     context: &FetchContext,
 ) -> Response {
     let mut response_end_timer = ResponseEndTimer(Some(context.timing.clone()));
 
-    // Step 1
-    // nothing to do here, since credentials_flag is already a boolean
+
+    // Step 1: Let request be fetchParams’s request.
+    let request = &mut fetch_params.request;
 
     // Step 2
     // TODO be able to create connection using current url's origin and credentials


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Update implementations of `HTTP-network fetch` and `HTTP-network-or-cache fetch` to take `fetchParams` as an argument instead of `request`.

`Http-network-or-cache fetch` spec: https://fetch.spec.whatwg.org/#http-network-or-cache-fetch
`Http-network fetch` spec: https://fetch.spec.whatwg.org/#http-network-fetch

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes partially fixes #34741

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because this is a refactor to use fetch params instead of request. `FetchParams` contains the request that is used in the implementations of the fetch methods.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
