### PR TITLE
layout: Remove wrong optimization when placing table among floats

### DIFF
--- a/components/layout_2020/flow/float.rs
+++ b/components/layout_2020/flow/float.rs
@@ -251,18 +251,6 @@ impl<'a> PlacementAmongFloats<'a> {
         }
     }
 
-    /// After placing a table and then laying it out, it may turn out wider than what
-    /// we initially expected. This method takes care of updating the data so that
-    /// the next place() can find the right area for the new size.
-    /// Note that if the new size is smaller, placement won't backtrack to consider
-    /// areas that weren't big enough for the old size.
-    pub(crate) fn set_inline_size(&mut self, inline_size: Au, pbm: &PaddingBorderMargin) {
-        self.object_size.inline = inline_size;
-        self.max_inline_end = (self.float_context.containing_block_info.inline_end -
-            pbm.margin.inline_end.auto_is(Au::zero))
-        .max(self.min_inline_start + inline_size);
-    }
-
     /// After placing an object with `height: auto` (and using the minimum inline and
     /// block size as the object size) and then laying it out, try to fit the object into
     /// the current set of bands, given block size after layout and the available inline

--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -1361,11 +1361,10 @@ impl IndependentNonReplacedContents {
                     // up until after trying to place it. If the table doesn't fit into this
                     // positioning rectangle due to incompatibility in the inline axis,
                     // then retry at another location.
-                    // Even if it would fit in the inline axis, we may end up having to retry
-                    // at another location due to incompatibility in the block axis. Therefore,
-                    // always update the size in the PlacementAmongFloats as an optimization.
+                    // Note if we get a narrower size due to collapsed columns, we don't backtrack
+                    // to consider areas that we thought weren't big enough.
+                    // TODO: Should `minimum_size_of_block.inline` be zero for tables?
                     let outer_inline_size = inline_size + pbm.padding_border_sums.inline;
-                    placement.set_inline_size(outer_inline_size, &pbm);
                     if outer_inline_size > placement_rect.size.inline {
                         positioning_context.truncate(&positioning_context_length);
                         continue;

--- a/tests/wpt/tests/css/CSS2/floats-clear/table-among-floats-001.html
+++ b/tests/wpt/tests/css/CSS2/floats-clear/table-among-floats-001.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<title>Table among floats</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://www.w3.org/TR/CSS22/visuren.html#floats">
+<link rel="help" href="https://www.w3.org/TR/CSS22/tables.html">
+<link rel="match" href="../../reference/ref-filled-green-200px-square.html">
+<meta name="assert" content="
+  The table needs to be at least 75px wide, but can grow up to 150px if there is enough space.
+  There are 125px available next to the 1st float, so the table can fit with a width of 125px.
+  However, in that case it needs a height of 200px, overlapping the 2nd float.
+  Therefore, the table needs to be 75px wide and 200px tall, thus fitting in the available
+  space next to both floats.
+">
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div style="width: 200px; overflow: hidden; position: relative; background: red">
+  <div style="width: 75px; height: 100px; float: left; clear: left; background: green"></div>
+  <div style="width: 125px; height: 100px; float: left; clear: left; background: green"></div>
+  <table cellpadding="0" cellspacing="0">
+    <td>
+      <div style="float: left; width: 75px; height: 100px; background: green"></div>
+      <div style="float: left; width: 75px; height: 100px; background: green"></div>
+    </td>
+  </table>
+  <div style="position: absolute; left: 75px; top: 0; width: 50px; height: 100px; background: green"></div>
+</div>


### PR DESCRIPTION
When we try to place a table next to some floats, and it doesn't fit vertically, then we try again considering more floats. And as an optimization we were using the previous width of the table as a minimum. However, this was wrong, because the table might accept a smaller width when the available space is smaller than beforehand.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #35206
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
