### PR TITLE
layout: Limit `content_inline_size_for_table` override to collapsed columns

### DIFF
--- a/components/layout_2020/formatting_contexts.rs
+++ b/components/layout_2020/formatting_contexts.rs
@@ -74,9 +74,9 @@ pub(crate) struct IndependentLayout {
     /// <https://drafts.csswg.org/css2/visudet.html#root-height>
     pub content_block_size: Au,
 
-    /// The contents of a table may force it to become wider than what we would expect
-    /// from 'width' and 'min-width'. It can also become smaller due to collapsed columns.
-    /// This is the resulting inline content size, or None for non-table layouts.
+    /// If a table has collapsed columns, it can become smaller than what the parent
+    /// formatting context decided. This is the resulting inline content size.
+    /// This is None for non-table layouts and for tables without collapsed columns.
     pub content_inline_size_for_table: Option<Au>,
 
     /// The offset of the last inflow baseline of this layout in the content area, if

--- a/components/layout_2020/replaced.rs
+++ b/components/layout_2020/replaced.rs
@@ -533,10 +533,12 @@ impl ReplacedContents {
             .into()
         };
         let (preferred_inline, min_inline, max_inline) = sizes.inline.resolve_each(
+            Direction::Inline,
             automatic_size.inline,
             Au::zero(),
             inline_stretch_size,
             get_inline_content_size,
+            false, /* is_table */
         );
         let inline_size = preferred_inline.clamp_between_extremums(min_inline, max_inline);
 
@@ -560,10 +562,12 @@ impl ReplacedContents {
             .into()
         });
         let block_size = sizes.block.resolve(
+            Direction::Block,
             automatic_size.block,
             Au::zero(),
             block_stretch_size.unwrap_or_else(|| block_content_size.max_content),
             || *block_content_size,
+            false, /* is_table */
         );
 
         LogicalVec2 {


### PR DESCRIPTION
A box is usually sized by the formatting context in which it participates.
However, tables have some special sizing behaviors that we implemented
with a `content_inline_size_for_table` override.

However, breaking the assumptions of the formatting context isn't great.
It was also bad for performance that we could try to layout a table
among floats even though it wouldn't en up fitting because of a larger
min-content size.

Therefore, this changes the logic so that formatting contexts use some
special sizing for tables, and then tables only override that amount
when there are collapsed columns. Eventually, we should try to remove
that case too, see https://github.com/w3c/csswg-drafts/issues/11408


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because there is no behavior change

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
