### PR TITLE
layout: Fix painting order of collapsed table borders

### DIFF
--- a/tests/wpt/tests/css/css-tables/tentative/collapsed-borders-painting-order-001.html
+++ b/tests/wpt/tests/css/css-tables/tentative/collapsed-borders-painting-order-001.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<title>Painting order of collapsed table borders</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-tables/#border-collapsing">
+<link rel="help" href="https://drafts.csswg.org/css-position-4/#painting-order">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/11570">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="
+  The collapsed border of the table is painted in front of the border of the
+  block descendant.
+">
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<table style="border-collapse: collapse">
+  <td style="border: 50px solid green; padding: 0">
+    <div style="border: 50px solid red; margin: -50px"></div>
+  </td>
+</table>

--- a/tests/wpt/tests/css/css-tables/tentative/collapsed-borders-painting-order-002.html
+++ b/tests/wpt/tests/css/css-tables/tentative/collapsed-borders-painting-order-002.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<title>Painting order of collapsed table borders</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-tables/#border-collapsing">
+<link rel="help" href="https://drafts.csswg.org/css-position-4/#painting-order">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/11570">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="
+  The collapsed border of the table is painted in front of the border of the
+  block descendant, even if the table has `position: relative`.
+  Gecko disagrees with this test.
+">
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<table style="border-collapse: collapse; position: relative">
+  <td style="border: 50px solid green; padding: 0">
+    <div style="border: 50px solid red; margin: -50px"></div>
+  </td>
+</table>

--- a/tests/wpt/tests/css/css-tables/tentative/collapsed-borders-painting-order-003.html
+++ b/tests/wpt/tests/css/css-tables/tentative/collapsed-borders-painting-order-003.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<title>Painting order of collapsed table borders</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-tables/#border-collapsing">
+<link rel="help" href="https://drafts.csswg.org/css-position-4/#painting-order">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/11570">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="
+  The collapsed border of the table is painted in front of the border of the
+  block descendant, even if the table has `display: inline-table`.
+  Gecko disagrees with this test.
+">
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<table style="border-collapse: collapse; display: inline-table">
+  <td style="border: 50px solid green; padding: 0">
+    <div style="border: 50px solid red; margin: -50px"></div>
+  </td>
+</table>

--- a/tests/wpt/tests/css/css-tables/tentative/collapsed-borders-painting-order-004.html
+++ b/tests/wpt/tests/css/css-tables/tentative/collapsed-borders-painting-order-004.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<title>Painting order of collapsed table borders</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-tables/#border-collapsing">
+<link rel="help" href="https://drafts.csswg.org/css-position-4/#painting-order">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/11570">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="
+  The collapsed border of the table is painted behind the border of the
+  following block sibling.
+">
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<table style="border-collapse: collapse">
+  <td style="border: 50px solid red; padding: 0"></td>
+</table>
+<div style="border: 50px solid green; width: 0px; margin-top: -100px"></div>

--- a/tests/wpt/tests/css/css-tables/tentative/collapsed-borders-painting-order-005.html
+++ b/tests/wpt/tests/css/css-tables/tentative/collapsed-borders-painting-order-005.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<title>Painting order of collapsed table borders</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-tables/#border-collapsing">
+<link rel="help" href="https://drafts.csswg.org/css-position-4/#painting-order">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/11570">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="
+  The collapsed border of the table is painted in front of the border of the
+  following block sibling, when the table has `position: relative`.
+">
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<table style="border-collapse: collapse; position: relative">
+  <td style="border: 50px solid green; padding: 0"></td>
+</table>
+<div style="border: 50px solid red; width: 0px; margin-top: -100px"></div>

--- a/tests/wpt/tests/css/css-tables/tentative/collapsed-borders-painting-order-006.html
+++ b/tests/wpt/tests/css/css-tables/tentative/collapsed-borders-painting-order-006.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<title>Painting order of collapsed table borders</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-tables/#border-collapsing">
+<link rel="help" href="https://drafts.csswg.org/css-position-4/#painting-order">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/11570">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="
+  The collapsed border of the table is painted in front of the border of the
+  following block sibling, when the table has `display: inline-table`.
+">
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<table style="border-collapse: collapse; display: inline-table; vertical-align: top">
+  <td style="border: 50px solid green; padding: 0"></td>
+</table>
+<div style="border: 50px solid red; width: 0px; margin-top: -100px"></div>

--- a/tests/wpt/tests/css/css-tables/tentative/collapsed-borders-painting-order-007.html
+++ b/tests/wpt/tests/css/css-tables/tentative/collapsed-borders-painting-order-007.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<title>Painting order of collapsed table borders</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-tables/#border-collapsing">
+<link rel="help" href="https://drafts.csswg.org/css-position-4/#painting-order">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/11570">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="
+  The collapsed border of the outer table is painted in front of the collapsed border
+  of the inner table.
+">
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<table style="border-collapse: collapse">
+  <td style="border: 50px solid green; padding: 0">
+    <table style="border-collapse: collapse; margin: -50px">
+      <td style="border: 50px solid red; padding: 0"></td>
+    </table>
+  </td>
+</table>

--- a/tests/wpt/tests/css/css-tables/tentative/collapsed-borders-painting-order-008.html
+++ b/tests/wpt/tests/css/css-tables/tentative/collapsed-borders-painting-order-008.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<title>Painting order of collapsed table borders</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-tables/#border-collapsing">
+<link rel="help" href="https://drafts.csswg.org/css-position-4/#painting-order">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/11570">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="
+  The collapsed border of the outer table is painted in front of the collapsed border
+  of the inner table, even if the outer table has `position: relative`.
+  Gecko disagrees with this test.
+">
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<table style="border-collapse: collapse; position: relative">
+  <td style="border: 50px solid green; padding: 0">
+    <table style="border-collapse: collapse; margin: -50px">
+      <td style="border: 50px solid red; padding: 0"></td>
+    </table>
+  </td>
+</table>

--- a/tests/wpt/tests/css/css-tables/tentative/collapsed-borders-painting-order-009.html
+++ b/tests/wpt/tests/css/css-tables/tentative/collapsed-borders-painting-order-009.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<title>Painting order of collapsed table borders</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-tables/#border-collapsing">
+<link rel="help" href="https://drafts.csswg.org/css-position-4/#painting-order">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/11570">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="
+  The collapsed border of the outer table is painted behind the collapsed border
+  of the inner table, when the inner table has `position: relative`.
+">
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<table style="border-collapse: collapse">
+  <td style="border: 50px solid red; padding: 0">
+    <table style="border-collapse: collapse; margin: -50px; position: relative">
+      <td style="border: 50px solid green; padding: 0"></td>
+    </table>
+  </td>
+</table>

--- a/tests/wpt/tests/css/css-tables/tentative/collapsed-borders-painting-order-010.html
+++ b/tests/wpt/tests/css/css-tables/tentative/collapsed-borders-painting-order-010.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<title>Painting order of collapsed table borders</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-tables/#border-collapsing">
+<link rel="help" href="https://drafts.csswg.org/css-position-4/#painting-order">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/11570">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="
+  The collapsed border of the outer table is painted behind the collapsed border
+  of the inner table, when both tables have `position: relative`.
+">
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<table style="border-collapse: collapse; position: relative">
+  <td style="border: 50px solid red; padding: 0">
+    <table style="border-collapse: collapse; margin: -50px; position: relative">
+      <td style="border: 50px solid green; padding: 0"></td>
+    </table>
+  </td>
+</table>

--- a/tests/wpt/tests/css/css-tables/tentative/collapsed-borders-painting-order-011.html
+++ b/tests/wpt/tests/css/css-tables/tentative/collapsed-borders-painting-order-011.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<title>Painting order of collapsed table borders</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-tables/#border-collapsing">
+<link rel="help" href="https://drafts.csswg.org/css-position-4/#painting-order">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/11570">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="
+  The collapsed border of the outer table is painted in front of the collapsed border
+  of the inner table, even if the outer table has `display: inline-table`.
+  Gecko disagrees with this test.
+">
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<table style="border-collapse: collapse; display: inline-table">
+  <td style="border: 50px solid green; padding: 0">
+    <table style="border-collapse: collapse; margin: -50px">
+      <td style="border: 50px solid red; padding: 0"></td>
+    </table>
+  </td>
+</table>

--- a/tests/wpt/tests/css/css-tables/tentative/collapsed-borders-painting-order-012.html
+++ b/tests/wpt/tests/css/css-tables/tentative/collapsed-borders-painting-order-012.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<title>Painting order of collapsed table borders</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-tables/#border-collapsing">
+<link rel="help" href="https://drafts.csswg.org/css-position-4/#painting-order">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/11570">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="
+  The collapsed border of the outer table is painted behind the collapsed border
+  of the inner table, when the inner table has `display: inline-table`.
+">
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<table style="border-collapse: collapse; line-height: 0">
+  <td style="border: 50px solid red; padding: 0">
+    <table style="border-collapse: collapse; margin: -50px; display: inline-table; vertical-align: top">
+      <td style="border: 50px solid green; padding: 0"></td>
+    </table>
+  </td>
+</table>

--- a/tests/wpt/tests/css/css-tables/tentative/collapsed-borders-painting-order-013.html
+++ b/tests/wpt/tests/css/css-tables/tentative/collapsed-borders-painting-order-013.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<title>Painting order of collapsed table borders</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-tables/#border-collapsing">
+<link rel="help" href="https://drafts.csswg.org/css-position-4/#painting-order">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/11570">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="
+  The collapsed border of the outer table is painted behind the collapsed border
+  of the inner table, when both tables have `display: inline-table`.
+">
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<table style="border-collapse: collapse; line-height: 0; display: inline-table">
+  <td style="border: 50px solid red; padding: 0">
+    <table style="border-collapse: collapse; margin: -50px; display: inline-table; vertical-align: top">
+      <td style="border: 50px solid green; padding: 0"></td>
+    </table>
+  </td>
+</table>


### PR DESCRIPTION
In #35075 I painted them in front of the decorations (backgrounds and borders) of any block-level box in the same stacking context. I did that because other browsers paint them in front of the decorations of the descendants of the table, but my approach also painted them in front of decorations of following siblings of the table, which was wrong.

This patch makes it so that collapsed table orders are painted in the same step as decorations. However, tables defer painting their collapsed borders after the decorations of their descendants.

This matches Blink and WebKit, and brings us closer to Gecko (which is slightly different in some corner cases).

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #35173
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
