### PR TITLE
Don't fire slotchange events when there's already a pending event for the same slot

### DIFF
--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -2171,7 +2171,7 @@ impl Node {
             if parent.is_in_a_shadow_tree() {
                 if let Some(slot_element) = parent.downcast::<HTMLSlotElement>() {
                     if !slot_element.has_assigned_nodes() {
-                        ScriptThread::signal_a_slot_change(slot_element);
+                        slot_element.signal_a_slot_change();
                     }
                 }
             }
@@ -2373,7 +2373,7 @@ impl Node {
         if parent.is_in_a_shadow_tree() {
             if let Some(slot_element) = parent.downcast::<HTMLSlotElement>() {
                 if !slot_element.has_assigned_nodes() {
-                    ScriptThread::signal_a_slot_change(slot_element);
+                    slot_element.signal_a_slot_change();
                 }
             }
         }

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -529,6 +529,9 @@ impl ScriptThread {
                 .signal_slots
                 .take()
                 .into_iter()
+                .inspect(|slot| {
+                    slot.remove_from_signal_slots();
+                })
                 .map(|slot| slot.as_rooted())
                 .collect()
         })
@@ -3745,15 +3748,6 @@ impl ScriptThread {
                 can_gc,
             )
         }
-    }
-
-    /// <https://dom.spec.whatwg.org/#signal-a-slot-change>
-    pub(crate) fn signal_a_slot_change(slot: &HTMLSlotElement) {
-        // Step 1. Append slot to slot’s relevant agent’s signal slots.
-        ScriptThread::add_signal_slot(slot);
-
-        // Step 2. Queue a mutation observer microtask.
-        MutationObserver::queue_mutation_observer_microtask();
     }
 }
 

--- a/tests/wpt/meta/shadow-dom/slotchange-event.html.ini
+++ b/tests/wpt/meta/shadow-dom/slotchange-event.html.ini
@@ -1,40 +1,4 @@
 [slotchange-event.html]
-  [slotchange event must fire on a default slot element inside an open shadow root  in a document]
-    expected: FAIL
-
-  [slotchange event must fire on a default slot element inside a closed shadow root  in a document]
-    expected: FAIL
-
-  [slotchange event must fire on a default slot element inside an open shadow root  not in a document]
-    expected: FAIL
-
-  [slotchange event must fire on a default slot element inside a closed shadow root  not in a document]
-    expected: FAIL
-
-  [slotchange event must fire on a named slot element insidean open shadow root  in a document]
-    expected: FAIL
-
-  [slotchange event must fire on a named slot element insidea closed shadow root  in a document]
-    expected: FAIL
-
-  [slotchange event must fire on a named slot element insidean open shadow root  not in a document]
-    expected: FAIL
-
-  [slotchange event must fire on a named slot element insidea closed shadow root  not in a document]
-    expected: FAIL
-
-  [slotchange event must fire on a slot element inside an open shadow root  in a document even if the slot was removed immediately after the assigned nodes were mutated]
-    expected: FAIL
-
-  [slotchange event must fire on a slot element inside a closed shadow root  in a document even if the slot was removed immediately after the assigned nodes were mutated]
-    expected: FAIL
-
-  [slotchange event must fire on a slot element inside an open shadow root  not in a document even if the slot was removed immediately after the assigned nodes were mutated]
-    expected: FAIL
-
-  [slotchange event must fire on a slot element inside a closed shadow root  not in a document even if the slot was removed immediately after the assigned nodes were mutated]
-    expected: FAIL
-
   [slotchange event must fire on a slot element inside an open shadow root  in a document when innerHTML modifies the children of the shadow host]
     expected: FAIL
 


### PR DESCRIPTION
Depends on https://github.com/servo/servo/pull/35221 (to avoid merge conflicts)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes (covered by wpt)

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
