### PR TITLE
servoshell: Remove debugging `println!`

### DIFF
--- a/ports/servoshell/desktop/webview.rs
+++ b/ports/servoshell/desktop/webview.rs
@@ -575,7 +575,6 @@ impl WebViewManager {
                     }
                 },
                 EmbedderMsg::WebViewOpened(new_webview_id) => {
-                    println!("WebView opened: {:?}", new_webview_id);
                     let scale = self.window.hidpi_factor().get();
                     let toolbar = self.window.toolbar_height().get();
 


### PR DESCRIPTION
This was left over from debugging the new `WebView` API.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they just remove a `println!`
