### PR TITLE
libservo: Move Android `MediaSessionAction` conversion to servoshell

### DIFF
--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -729,20 +729,3 @@ pub enum MediaSessionActionType {
     /// The action intent is to move the playback time to a specific time.
     SeekTo,
 }
-
-impl From<i32> for MediaSessionActionType {
-    fn from(value: i32) -> MediaSessionActionType {
-        match value {
-            1 => MediaSessionActionType::Play,
-            2 => MediaSessionActionType::Pause,
-            3 => MediaSessionActionType::SeekBackward,
-            4 => MediaSessionActionType::SeekForward,
-            5 => MediaSessionActionType::PreviousTrack,
-            6 => MediaSessionActionType::NextTrack,
-            7 => MediaSessionActionType::SkipAd,
-            8 => MediaSessionActionType::Stop,
-            9 => MediaSessionActionType::SeekTo,
-            _ => panic!("Unknown MediaSessionActionType"),
-        }
-    }
-}

--- a/ports/servoshell/egl/android.rs
+++ b/ports/servoshell/egl/android.rs
@@ -15,6 +15,7 @@ use jni::objects::{GlobalRef, JClass, JObject, JString, JValue, JValueOwned};
 use jni::sys::{jboolean, jfloat, jint, jobject};
 use jni::{JNIEnv, JavaVM};
 use log::{debug, error, info, warn};
+use servo::MediaSessionActionType;
 use simpleservo::{
     DeviceIntRect, EventLoopWaker, InitOptions, InputMethodType, MediaSessionPlaybackState,
     PromptResult, SERVO,
@@ -414,7 +415,20 @@ pub extern "C" fn Java_org_servo_servoview_JNIServo_mediaSessionAction<'local>(
     action: jint,
 ) {
     debug!("mediaSessionAction");
-    call(&mut env, |s| s.media_session_action((action).into()));
+
+    let action = match action {
+        1 => MediaSessionActionType::Play,
+        2 => MediaSessionActionType::Pause,
+        3 => MediaSessionActionType::SeekBackward,
+        4 => MediaSessionActionType::SeekForward,
+        5 => MediaSessionActionType::PreviousTrack,
+        6 => MediaSessionActionType::NextTrack,
+        7 => MediaSessionActionType::SkipAd,
+        8 => MediaSessionActionType::Stop,
+        9 => MediaSessionActionType::SeekTo,
+        _ => return warn!("Ignoring unknown MediaSessionAction"),
+    };
+    call(&mut env, |s| s.media_session_action(action.clone()));
 }
 
 pub struct WakeupCallback {


### PR DESCRIPTION
The conversion of an integer into a `MediaSessionAction` is
Android-specific and thus shouldn't be used throughout the source code.
This change moves the conversion to the Android port of servoshell.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they do not have a functional change.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
