### PR TITLE
script_traits: Rename `ConstellationControlMsg` to `ScriptThreadMessage`

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -31,7 +31,7 @@ use profile_traits::time::{self as profile_time, ProfilerCategory};
 use profile_traits::time_profile;
 use script_traits::CompositorEvent::{MouseButtonEvent, MouseMoveEvent, TouchEvent, WheelEvent};
 use script_traits::{
-    AnimationState, AnimationTickType, ConstellationControlMsg, ScrollState, WindowSizeData,
+    AnimationState, AnimationTickType, ScriptThreadMessage, ScrollState, WindowSizeData,
     WindowSizeType,
 };
 use servo_geometry::{DeviceIndependentPixel, FramebufferUintLength};
@@ -1886,7 +1886,7 @@ impl IOCompositor {
         });
 
         if let Some(pipeline) = details.pipeline.as_ref() {
-            let message = ConstellationControlMsg::SetScrollStates(*pipeline_id, scroll_states);
+            let message = ScriptThreadMessage::SetScrollStates(*pipeline_id, scroll_states);
             let _ = pipeline.script_chan.send(message);
         }
     }
@@ -2226,14 +2226,13 @@ impl IOCompositor {
             // be painted.
             pending_epochs.drain(0..index);
 
-            if let Err(error) =
-                pipeline
-                    .script_chan
-                    .send(ConstellationControlMsg::SetEpochPaintTime(
-                        *pipeline_id,
-                        current_epoch,
-                        paint_time,
-                    ))
+            if let Err(error) = pipeline
+                .script_chan
+                .send(ScriptThreadMessage::SetEpochPaintTime(
+                    *pipeline_id,
+                    current_epoch,
+                    paint_time,
+                ))
             {
                 warn!("Sending RequestLayoutPaintMetric message to layout failed ({error:?}).");
             }

--- a/components/constellation/event_loop.rs
+++ b/components/constellation/event_loop.rs
@@ -11,25 +11,23 @@ use std::rc::Rc;
 
 use ipc_channel::ipc::IpcSender;
 use ipc_channel::Error;
-use script_traits::ConstellationControlMsg;
+use script_traits::ScriptThreadMessage;
 
 /// <https://html.spec.whatwg.org/multipage/#event-loop>
 pub struct EventLoop {
-    script_chan: IpcSender<ConstellationControlMsg>,
+    script_chan: IpcSender<ScriptThreadMessage>,
     dont_send_or_sync: PhantomData<Rc<()>>,
 }
 
 impl Drop for EventLoop {
     fn drop(&mut self) {
-        let _ = self
-            .script_chan
-            .send(ConstellationControlMsg::ExitScriptThread);
+        let _ = self.script_chan.send(ScriptThreadMessage::ExitScriptThread);
     }
 }
 
 impl EventLoop {
     /// Create a new event loop from the channel to its script thread.
-    pub fn new(script_chan: IpcSender<ConstellationControlMsg>) -> Rc<EventLoop> {
+    pub fn new(script_chan: IpcSender<ScriptThreadMessage>) -> Rc<EventLoop> {
         Rc::new(EventLoop {
             script_chan,
             dont_send_or_sync: PhantomData,
@@ -37,12 +35,12 @@ impl EventLoop {
     }
 
     /// Send a message to the event loop.
-    pub fn send(&self, msg: ConstellationControlMsg) -> Result<(), Error> {
+    pub fn send(&self, msg: ScriptThreadMessage) -> Result<(), Error> {
         self.script_chan.send(msg)
     }
 
     /// The underlying channel to the script thread.
-    pub fn sender(&self) -> IpcSender<ConstellationControlMsg> {
+    pub fn sender(&self) -> IpcSender<ScriptThreadMessage> {
         self.script_chan.clone()
     }
 }

--- a/components/constellation/pipeline.rs
+++ b/components/constellation/pipeline.rs
@@ -33,9 +33,9 @@ use net_traits::ResourceThreads;
 use profile_traits::{mem as profile_mem, time};
 use script_layout_interface::{LayoutFactory, ScriptThreadFactory};
 use script_traits::{
-    AnimationState, ConstellationControlMsg, DiscardBrowsingContext, DocumentActivity,
-    InitialScriptState, LayoutMsg, LoadData, NewLayoutInfo, SWManagerMsg,
-    ScriptToConstellationChan, WindowSizeData,
+    AnimationState, DiscardBrowsingContext, DocumentActivity, InitialScriptState, LayoutMsg,
+    LoadData, NewLayoutInfo, SWManagerMsg, ScriptThreadMessage, ScriptToConstellationChan,
+    WindowSizeData,
 };
 use serde::{Deserialize, Serialize};
 use servo_config::opts::{self, Opts};
@@ -223,8 +223,7 @@ impl Pipeline {
                     window_size: state.window_size,
                 };
 
-                if let Err(e) =
-                    script_chan.send(ConstellationControlMsg::AttachLayout(new_layout_info))
+                if let Err(e) = script_chan.send(ScriptThreadMessage::AttachLayout(new_layout_info))
                 {
                     warn!("Sending to script during pipeline creation failed ({})", e);
                 }
@@ -393,7 +392,7 @@ impl Pipeline {
 
         // Script thread handles shutting down layout, and layout handles shutting down the painter.
         // For now, if the script thread has failed, we give up on clean shutdown.
-        let msg = ConstellationControlMsg::ExitPipeline(self.id, discard_bc);
+        let msg = ScriptThreadMessage::ExitPipeline(self.id, discard_bc);
         if let Err(e) = self.event_loop.send(msg) {
             warn!("Sending script exit message failed ({}).", e);
         }
@@ -402,7 +401,7 @@ impl Pipeline {
     /// A forced exit of the shutdown, which does not wait for the compositor,
     /// or for the script thread to shut down layout.
     pub fn force_exit(&self, discard_bc: DiscardBrowsingContext) {
-        let msg = ConstellationControlMsg::ExitPipeline(self.id, discard_bc);
+        let msg = ScriptThreadMessage::ExitPipeline(self.id, discard_bc);
         if let Err(e) = self.event_loop.send(msg) {
             warn!("Sending script exit message failed ({}).", e);
         }
@@ -410,7 +409,7 @@ impl Pipeline {
 
     /// Notify this pipeline of its activity.
     pub fn set_activity(&self, activity: DocumentActivity) {
-        let msg = ConstellationControlMsg::SetDocumentActivity(self.id, activity);
+        let msg = ScriptThreadMessage::SetDocumentActivity(self.id, activity);
         if let Err(e) = self.event_loop.send(msg) {
             warn!("Sending activity message failed ({}).", e);
         }
@@ -452,7 +451,7 @@ impl Pipeline {
     /// Set whether to make pipeline use less resources, by stopping animations and
     /// running timers at a heavily limited rate.
     pub fn set_throttled(&self, throttled: bool) {
-        let script_msg = ConstellationControlMsg::SetThrottled(self.id, throttled);
+        let script_msg = ScriptThreadMessage::SetThrottled(self.id, throttled);
         let compositor_msg = CompositorMsg::SetThrottled(self.id, throttled);
         let err = self.event_loop.send(script_msg);
         if let Err(e) = err {
@@ -485,9 +484,9 @@ pub struct UnprivilegedPipelineContent {
     time_profiler_chan: time::ProfilerChan,
     mem_profiler_chan: profile_mem::ProfilerChan,
     window_size: WindowSizeData,
-    script_chan: IpcSender<ConstellationControlMsg>,
+    script_chan: IpcSender<ScriptThreadMessage>,
     load_data: LoadData,
-    script_port: IpcReceiver<ConstellationControlMsg>,
+    script_port: IpcReceiver<ScriptThreadMessage>,
     opts: Opts,
     prefs: Box<Preferences>,
     pipeline_namespace_id: PipelineNamespaceId,

--- a/components/layout_thread_2020/lib.rs
+++ b/components/layout_thread_2020/lib.rs
@@ -51,7 +51,7 @@ use script_layout_interface::{
     ReflowRequest, ReflowResult, TrustedNodeAddress,
 };
 use script_traits::{
-    ConstellationControlMsg, DrawAPaintImageResult, PaintWorkletError, Painter, ScrollState,
+    DrawAPaintImageResult, PaintWorkletError, Painter, ScriptThreadMessage, ScrollState,
     UntrustedNodeAddress, WindowSizeData,
 };
 use servo_arc::Arc as ServoArc;
@@ -118,7 +118,7 @@ pub struct LayoutThread {
     is_iframe: bool,
 
     /// The channel on which messages can be sent to the script thread.
-    script_chan: IpcSender<ConstellationControlMsg>,
+    script_chan: IpcSender<ScriptThreadMessage>,
 
     /// The channel on which messages can be sent to the time profiler.
     time_profiler_chan: profile_time::ProfilerChan,
@@ -594,10 +594,7 @@ impl LayoutThread {
         let web_font_finished_loading_callback = move |succeeded: bool| {
             let _ = locked_script_channel
                 .lock()
-                .send(ConstellationControlMsg::WebFontLoaded(
-                    pipeline_id,
-                    succeeded,
-                ));
+                .send(ScriptThreadMessage::WebFontLoaded(pipeline_id, succeeded));
         };
 
         self.font_context.add_all_web_fonts_from_stylesheet(

--- a/components/metrics/lib.rs
+++ b/components/metrics/lib.rs
@@ -14,7 +14,7 @@ use ipc_channel::ipc::IpcSender;
 use log::warn;
 use malloc_size_of_derive::MallocSizeOf;
 use profile_traits::time::{send_profile_data, ProfilerCategory, ProfilerChan, TimerMetadata};
-use script_traits::{ConstellationControlMsg, LayoutMsg, ProgressiveWebMetricType};
+use script_traits::{LayoutMsg, ProgressiveWebMetricType, ScriptThreadMessage};
 use servo_config::opts;
 use servo_url::ServoUrl;
 
@@ -258,7 +258,7 @@ pub struct PaintTimeMetrics {
     pipeline_id: PipelineId,
     time_profiler_chan: ProfilerChan,
     constellation_chan: IpcSender<LayoutMsg>,
-    script_chan: IpcSender<ConstellationControlMsg>,
+    script_chan: IpcSender<ScriptThreadMessage>,
     url: ServoUrl,
 }
 
@@ -267,7 +267,7 @@ impl PaintTimeMetrics {
         pipeline_id: PipelineId,
         time_profiler_chan: ProfilerChan,
         constellation_chan: IpcSender<LayoutMsg>,
-        script_chan: IpcSender<ConstellationControlMsg>,
+        script_chan: IpcSender<ScriptThreadMessage>,
         url: ServoUrl,
         navigation_start: CrossProcessInstant,
     ) -> PaintTimeMetrics {
@@ -369,7 +369,7 @@ impl ProgressiveWebMetric for PaintTimeMetrics {
         name: ProgressiveWebMetricType,
         time: CrossProcessInstant,
     ) {
-        let msg = ConstellationControlMsg::PaintMetric(self.pipeline_id, name, time);
+        let msg = ScriptThreadMessage::PaintMetric(self.pipeline_id, name, time);
         if let Err(e) = self.script_chan.send(msg) {
             warn!("Sending metric to script thread failed ({}).", e);
         }

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -58,8 +58,8 @@ use script_layout_interface::{
 };
 use script_traits::webdriver_msg::{WebDriverJSError, WebDriverJSResult};
 use script_traits::{
-    ConstellationControlMsg, DocumentState, LoadData, LoadOrigin, NavigationHistoryBehavior,
-    ScriptMsg, ScriptToConstellationChan, ScrollState, StructuredSerializedData, WindowSizeData,
+    DocumentState, LoadData, LoadOrigin, NavigationHistoryBehavior, ScriptMsg, ScriptThreadMessage,
+    ScriptToConstellationChan, ScrollState, StructuredSerializedData, WindowSizeData,
     WindowSizeType,
 };
 use selectors::attr::CaseSensitivity;
@@ -2760,7 +2760,7 @@ impl Window {
         time_profiler_chan: TimeProfilerChan,
         devtools_chan: Option<IpcSender<ScriptToDevtoolsControlMsg>>,
         constellation_chan: ScriptToConstellationChan,
-        control_chan: IpcSender<ConstellationControlMsg>,
+        control_chan: IpcSender<ScriptThreadMessage>,
         pipeline_id: PipelineId,
         parent_info: Option<PipelineId>,
         window_size: WindowSizeData,
@@ -3035,7 +3035,7 @@ pub(crate) struct CSSErrorReporter {
     // which is necessary to fulfill the bounds required by the
     // uses of the ParseErrorReporter trait.
     #[ignore_malloc_size_of = "Arc is defined in libstd"]
-    pub(crate) script_chan: Arc<Mutex<IpcSender<ConstellationControlMsg>>>,
+    pub(crate) script_chan: Arc<Mutex<IpcSender<ScriptThreadMessage>>>,
 }
 unsafe_no_jsmanaged_fields!(CSSErrorReporter);
 
@@ -3061,7 +3061,7 @@ impl ParseErrorReporter for CSSErrorReporter {
             .script_chan
             .lock()
             .unwrap()
-            .send(ConstellationControlMsg::ReportCSSError(
+            .send(ScriptThreadMessage::ReportCSSError(
                 self.pipelineid,
                 url.0.to_string(),
                 location.line,

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -82,9 +82,9 @@ use script_layout_interface::{
 };
 use script_traits::webdriver_msg::WebDriverScriptCommand;
 use script_traits::{
-    CompositorEvent, ConstellationControlMsg, DiscardBrowsingContext, DocumentActivity,
-    EventResult, InitialScriptState, JsEvalResult, LoadData, LoadOrigin, NavigationHistoryBehavior,
-    NewLayoutInfo, Painter, ProgressiveWebMetricType, ScriptMsg, ScriptToConstellationChan,
+    CompositorEvent, DiscardBrowsingContext, DocumentActivity, EventResult, InitialScriptState,
+    JsEvalResult, LoadData, LoadOrigin, NavigationHistoryBehavior, NewLayoutInfo, Painter,
+    ProgressiveWebMetricType, ScriptMsg, ScriptThreadMessage, ScriptToConstellationChan,
     ScrollState, StructuredSerializedData, UntrustedNodeAddress, UpdatePipelineIdReason,
     WindowSizeData, WindowSizeType,
 };
@@ -1411,7 +1411,7 @@ impl ScriptThread {
                 // This has to be handled before the ResizeMsg below,
                 // otherwise the page may not have been added to the
                 // child list yet, causing the find() to fail.
-                MixedMessage::FromConstellation(ConstellationControlMsg::AttachLayout(
+                MixedMessage::FromConstellation(ScriptThreadMessage::AttachLayout(
                     new_layout_info,
                 )) => {
                     let pipeline_id = new_layout_info.new_pipeline_id;
@@ -1449,19 +1449,18 @@ impl ScriptThread {
                         },
                     )
                 },
-                MixedMessage::FromConstellation(ConstellationControlMsg::Resize(
+                MixedMessage::FromConstellation(ScriptThreadMessage::Resize(
                     id,
                     size,
                     size_type,
                 )) => {
                     self.handle_resize_message(id, size, size_type);
                 },
-                MixedMessage::FromConstellation(ConstellationControlMsg::Viewport(id, rect)) => {
-                    self.profile_event(ScriptThreadEventCategory::SetViewport, Some(id), || {
+                MixedMessage::FromConstellation(ScriptThreadMessage::Viewport(id, rect)) => self
+                    .profile_event(ScriptThreadEventCategory::SetViewport, Some(id), || {
                         self.handle_viewport(id, rect);
-                    })
-                },
-                MixedMessage::FromConstellation(ConstellationControlMsg::TickAllAnimations(
+                    }),
+                MixedMessage::FromConstellation(ScriptThreadMessage::TickAllAnimations(
                     pipeline_id,
                     tick_type,
                 )) => {
@@ -1475,7 +1474,7 @@ impl ScriptThread {
                         )
                     }
                 },
-                MixedMessage::FromConstellation(ConstellationControlMsg::SendEvent(id, event)) => {
+                MixedMessage::FromConstellation(ScriptThreadMessage::SendEvent(id, event)) => {
                     self.handle_event(id, event)
                 },
                 MixedMessage::FromScript(MainThreadScriptMsg::Common(CommonScriptMsg::Task(
@@ -1492,11 +1491,10 @@ impl ScriptThread {
                     // An event came-in from a document that is not fully-active, it has been stored by the task-queue.
                     // Continue without adding it to "sequential".
                 },
-                MixedMessage::FromConstellation(ConstellationControlMsg::ExitFullScreen(id)) => {
-                    self.profile_event(ScriptThreadEventCategory::ExitFullscreen, Some(id), || {
+                MixedMessage::FromConstellation(ScriptThreadMessage::ExitFullScreen(id)) => self
+                    .profile_event(ScriptThreadEventCategory::ExitFullscreen, Some(id), || {
                         self.handle_exit_fullscreen(id, can_gc);
-                    })
-                },
+                    }),
                 _ => {
                     sequential.push(event);
                 },
@@ -1525,11 +1523,11 @@ impl ScriptThread {
             if self.closing.load(Ordering::SeqCst) {
                 // If we've received the closed signal from the BHM, only handle exit messages.
                 match msg {
-                    MixedMessage::FromConstellation(ConstellationControlMsg::ExitScriptThread) => {
+                    MixedMessage::FromConstellation(ScriptThreadMessage::ExitScriptThread) => {
                         self.handle_exit_script_thread_msg(can_gc);
                         return false;
                     },
-                    MixedMessage::FromConstellation(ConstellationControlMsg::ExitPipeline(
+                    MixedMessage::FromConstellation(ScriptThreadMessage::ExitPipeline(
                         pipeline_id,
                         discard_browsing_context,
                     )) => {
@@ -1546,7 +1544,7 @@ impl ScriptThread {
 
             let exiting = self.profile_event(category, pipeline_id, move || {
                 match msg {
-                    MixedMessage::FromConstellation(ConstellationControlMsg::ExitScriptThread) => {
+                    MixedMessage::FromConstellation(ScriptThreadMessage::ExitScriptThread) => {
                         self.handle_exit_script_thread_msg(can_gc);
                         return true;
                     },
@@ -1601,7 +1599,7 @@ impl ScriptThread {
     fn categorize_msg(&self, msg: &MixedMessage) -> ScriptThreadEventCategory {
         match *msg {
             MixedMessage::FromConstellation(ref inner_msg) => match *inner_msg {
-                ConstellationControlMsg::SendEvent(_, _) => ScriptThreadEventCategory::DomEvent,
+                ScriptThreadMessage::SendEvent(_, _) => ScriptThreadEventCategory::DomEvent,
                 _ => ScriptThreadEventCategory::ConstellationMsg,
             },
             // TODO https://github.com/servo/servo/issues/18998
@@ -1779,12 +1777,12 @@ impl ScriptThread {
         value
     }
 
-    fn handle_msg_from_constellation(&self, msg: ConstellationControlMsg, can_gc: CanGc) {
+    fn handle_msg_from_constellation(&self, msg: ScriptThreadMessage, can_gc: CanGc) {
         match msg {
-            ConstellationControlMsg::StopDelayingLoadEventsMode(pipeline_id) => {
+            ScriptThreadMessage::StopDelayingLoadEventsMode(pipeline_id) => {
                 self.handle_stop_delaying_load_events_mode(pipeline_id)
             },
-            ConstellationControlMsg::NavigateIframe(
+            ScriptThreadMessage::NavigateIframe(
                 parent_pipeline_id,
                 browsing_context_id,
                 load_data,
@@ -1796,25 +1794,23 @@ impl ScriptThread {
                 history_handling,
                 can_gc,
             ),
-            ConstellationControlMsg::UnloadDocument(pipeline_id) => {
+            ScriptThreadMessage::UnloadDocument(pipeline_id) => {
                 self.handle_unload_document(pipeline_id, can_gc)
             },
-            ConstellationControlMsg::ResizeInactive(id, new_size) => {
+            ScriptThreadMessage::ResizeInactive(id, new_size) => {
                 self.handle_resize_inactive_msg(id, new_size)
             },
-            ConstellationControlMsg::ThemeChange(_, theme) => {
+            ScriptThreadMessage::ThemeChange(_, theme) => {
                 self.handle_theme_change_msg(theme);
             },
-            ConstellationControlMsg::GetTitle(pipeline_id) => {
-                self.handle_get_title_msg(pipeline_id)
-            },
-            ConstellationControlMsg::SetDocumentActivity(pipeline_id, activity) => {
+            ScriptThreadMessage::GetTitle(pipeline_id) => self.handle_get_title_msg(pipeline_id),
+            ScriptThreadMessage::SetDocumentActivity(pipeline_id, activity) => {
                 self.handle_set_document_activity_msg(pipeline_id, activity)
             },
-            ConstellationControlMsg::SetThrottled(pipeline_id, throttled) => {
+            ScriptThreadMessage::SetThrottled(pipeline_id, throttled) => {
                 self.handle_set_throttled_msg(pipeline_id, throttled)
             },
-            ConstellationControlMsg::SetThrottledInContainingIframe(
+            ScriptThreadMessage::SetThrottledInContainingIframe(
                 parent_pipeline_id,
                 browsing_context_id,
                 throttled,
@@ -1823,7 +1819,7 @@ impl ScriptThread {
                 browsing_context_id,
                 throttled,
             ),
-            ConstellationControlMsg::PostMessage {
+            ScriptThreadMessage::PostMessage {
                 target: target_pipeline_id,
                 source: source_pipeline_id,
                 source_browsing_context,
@@ -1838,7 +1834,7 @@ impl ScriptThread {
                 source_origin,
                 data,
             ),
-            ConstellationControlMsg::UpdatePipelineId(
+            ScriptThreadMessage::UpdatePipelineId(
                 parent_pipeline_id,
                 browsing_context_id,
                 top_level_browsing_context_id,
@@ -1852,27 +1848,27 @@ impl ScriptThread {
                 reason,
                 can_gc,
             ),
-            ConstellationControlMsg::UpdateHistoryState(pipeline_id, history_state_id, url) => {
+            ScriptThreadMessage::UpdateHistoryState(pipeline_id, history_state_id, url) => {
                 self.handle_update_history_state_msg(pipeline_id, history_state_id, url, can_gc)
             },
-            ConstellationControlMsg::RemoveHistoryStates(pipeline_id, history_states) => {
+            ScriptThreadMessage::RemoveHistoryStates(pipeline_id, history_states) => {
                 self.handle_remove_history_states(pipeline_id, history_states)
             },
-            ConstellationControlMsg::FocusIFrame(parent_pipeline_id, frame_id) => {
+            ScriptThreadMessage::FocusIFrame(parent_pipeline_id, frame_id) => {
                 self.handle_focus_iframe_msg(parent_pipeline_id, frame_id, can_gc)
             },
-            ConstellationControlMsg::WebDriverScriptCommand(pipeline_id, msg) => {
+            ScriptThreadMessage::WebDriverScriptCommand(pipeline_id, msg) => {
                 self.handle_webdriver_msg(pipeline_id, msg, can_gc)
             },
-            ConstellationControlMsg::WebFontLoaded(pipeline_id, success) => {
+            ScriptThreadMessage::WebFontLoaded(pipeline_id, success) => {
                 self.handle_web_font_loaded(pipeline_id, success)
             },
-            ConstellationControlMsg::DispatchIFrameLoadEvent {
+            ScriptThreadMessage::DispatchIFrameLoadEvent {
                 target: browsing_context_id,
                 parent: parent_id,
                 child: child_id,
             } => self.handle_iframe_load_event(parent_id, browsing_context_id, child_id, can_gc),
-            ConstellationControlMsg::DispatchStorageEvent(
+            ScriptThreadMessage::DispatchStorageEvent(
                 pipeline_id,
                 storage,
                 url,
@@ -1880,37 +1876,37 @@ impl ScriptThread {
                 old_value,
                 new_value,
             ) => self.handle_storage_event(pipeline_id, storage, url, key, old_value, new_value),
-            ConstellationControlMsg::ReportCSSError(pipeline_id, filename, line, column, msg) => {
+            ScriptThreadMessage::ReportCSSError(pipeline_id, filename, line, column, msg) => {
                 self.handle_css_error_reporting(pipeline_id, filename, line, column, msg)
             },
-            ConstellationControlMsg::Reload(pipeline_id) => self.handle_reload(pipeline_id, can_gc),
-            ConstellationControlMsg::ExitPipeline(pipeline_id, discard_browsing_context) => {
+            ScriptThreadMessage::Reload(pipeline_id) => self.handle_reload(pipeline_id, can_gc),
+            ScriptThreadMessage::ExitPipeline(pipeline_id, discard_browsing_context) => {
                 self.handle_exit_pipeline_msg(pipeline_id, discard_browsing_context, can_gc)
             },
-            ConstellationControlMsg::PaintMetric(pipeline_id, metric_type, metric_value) => {
+            ScriptThreadMessage::PaintMetric(pipeline_id, metric_type, metric_value) => {
                 self.handle_paint_metric(pipeline_id, metric_type, metric_value, can_gc)
             },
-            ConstellationControlMsg::MediaSessionAction(pipeline_id, action) => {
+            ScriptThreadMessage::MediaSessionAction(pipeline_id, action) => {
                 self.handle_media_session_action(pipeline_id, action, can_gc)
             },
             #[cfg(feature = "webgpu")]
-            ConstellationControlMsg::SetWebGPUPort(port) => {
+            ScriptThreadMessage::SetWebGPUPort(port) => {
                 *self.receivers.webgpu_receiver.borrow_mut() =
                     ROUTER.route_ipc_receiver_to_new_crossbeam_receiver(port);
             },
-            msg @ ConstellationControlMsg::AttachLayout(..) |
-            msg @ ConstellationControlMsg::Viewport(..) |
-            msg @ ConstellationControlMsg::Resize(..) |
-            msg @ ConstellationControlMsg::ExitFullScreen(..) |
-            msg @ ConstellationControlMsg::SendEvent(..) |
-            msg @ ConstellationControlMsg::TickAllAnimations(..) |
-            msg @ ConstellationControlMsg::ExitScriptThread => {
+            msg @ ScriptThreadMessage::AttachLayout(..) |
+            msg @ ScriptThreadMessage::Viewport(..) |
+            msg @ ScriptThreadMessage::Resize(..) |
+            msg @ ScriptThreadMessage::ExitFullScreen(..) |
+            msg @ ScriptThreadMessage::SendEvent(..) |
+            msg @ ScriptThreadMessage::TickAllAnimations(..) |
+            msg @ ScriptThreadMessage::ExitScriptThread => {
                 panic!("should have handled {:?} already", msg)
             },
-            ConstellationControlMsg::SetScrollStates(pipeline_id, scroll_states) => {
+            ScriptThreadMessage::SetScrollStates(pipeline_id, scroll_states) => {
                 self.handle_set_scroll_states_msg(pipeline_id, scroll_states)
             },
-            ConstellationControlMsg::SetEpochPaintTime(pipeline_id, epoch, time) => {
+            ScriptThreadMessage::SetEpochPaintTime(pipeline_id, epoch, time) => {
                 self.handle_set_epoch_paint_time(pipeline_id, epoch, time)
             },
         }

--- a/components/shared/compositing/lib.rs
+++ b/components/shared/compositing/lib.rs
@@ -17,7 +17,7 @@ use euclid::Rect;
 use ipc_channel::ipc::IpcSender;
 use log::warn;
 use pixels::Image;
-use script_traits::{AnimationState, ConstellationControlMsg, EventResult};
+use script_traits::{AnimationState, EventResult, ScriptThreadMessage};
 use style_traits::CSSPixel;
 use webrender_api::DocumentId;
 use webrender_traits::{CrossProcessCompositorApi, CrossProcessCompositorMessage};
@@ -112,7 +112,7 @@ pub struct SendableFrameTree {
 pub struct CompositionPipeline {
     pub id: PipelineId,
     pub top_level_browsing_context_id: TopLevelBrowsingContextId,
-    pub script_chan: IpcSender<ConstellationControlMsg>,
+    pub script_chan: IpcSender<ScriptThreadMessage>,
 }
 
 impl Debug for CompositorMsg {

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -286,10 +286,10 @@ pub enum UpdatePipelineIdReason {
     Traversal,
 }
 
-/// Messages sent from the constellation or layout to the script thread.
-// FIXME: https://github.com/servo/servo/issues/34591
+/// Messages sent to the `ScriptThread` event loop from the `Constellation`, `Compositor`, and (for
+/// now) `Layout`.
 #[derive(Deserialize, Serialize)]
-pub enum ConstellationControlMsg {
+pub enum ScriptThreadMessage {
     /// Takes the associated window proxy out of "delaying-load-events-mode",
     /// used if a scheduled navigated was refused by the embedder.
     /// <https://html.spec.whatwg.org/multipage/#delaying-load-events-mode>
@@ -406,9 +406,9 @@ pub enum ConstellationControlMsg {
     SetEpochPaintTime(PipelineId, Epoch, CrossProcessInstant),
 }
 
-impl fmt::Debug for ConstellationControlMsg {
+impl fmt::Debug for ScriptThreadMessage {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        use self::ConstellationControlMsg::*;
+        use self::ScriptThreadMessage::*;
         let variant = match *self {
             StopDelayingLoadEventsMode(..) => "StopDelayingLoadsEventMode",
             AttachLayout(..) => "AttachLayout",
@@ -551,9 +551,9 @@ pub struct InitialScriptState {
     /// Loading into a Secure Context
     pub inherited_secure_context: Option<bool>,
     /// A channel with which messages can be sent to us (the script thread).
-    pub constellation_sender: IpcSender<ConstellationControlMsg>,
+    pub constellation_sender: IpcSender<ScriptThreadMessage>,
     /// A port on which messages sent by the constellation to script can be received.
-    pub constellation_receiver: IpcReceiver<ConstellationControlMsg>,
+    pub constellation_receiver: IpcReceiver<ScriptThreadMessage>,
     /// A channel on which messages can be sent to the constellation from script.
     pub pipeline_to_constellation_sender: ScriptToConstellationChan,
     /// A handle to register script-(and associated layout-)threads for hang monitoring.

--- a/components/shared/script_layout/lib.rs
+++ b/components/shared/script_layout/lib.rs
@@ -33,8 +33,8 @@ use net_traits::image_cache::{ImageCache, PendingImageId};
 use profile_traits::mem::Report;
 use profile_traits::time;
 use script_traits::{
-    ConstellationControlMsg, InitialScriptState, LoadData, Painter, ScrollState,
-    UntrustedNodeAddress, WindowSizeData,
+    InitialScriptState, LoadData, Painter, ScriptThreadMessage, ScrollState, UntrustedNodeAddress,
+    WindowSizeData,
 };
 use serde::{Deserialize, Serialize};
 use servo_arc::Arc as ServoArc;
@@ -185,7 +185,7 @@ pub struct LayoutConfig {
     pub webview_id: WebViewId,
     pub url: ServoUrl,
     pub is_iframe: bool,
-    pub script_chan: IpcSender<ConstellationControlMsg>,
+    pub script_chan: IpcSender<ScriptThreadMessage>,
     pub image_cache: Arc<dyn ImageCache>,
     pub font_context: Arc<FontContext>,
     pub time_profiler_chan: time::ProfilerChan,


### PR DESCRIPTION
At some point in the past this message was only sent from the
`Constellation` to `script`, but nowadays this is sent from various
parts of servo to the `ScriptThread`, so this is a better name. In
particular, the current name makes it seeem like this message controls
the `Constellation`, which it does not.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they do not have any functional changes.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
