### PR TITLE
Avoid starting transitions if values can't be interpolated

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1659,7 +1659,7 @@ dependencies = [
 [[package]]
 name = "dom"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-01-02#b2aff706472aa08db61ad1cae0e3dd54306f6fdf"
+source = "git+https://github.com/servo/stylo?branch=2025-01-02#06e3f12281781e087d06f03ed506eb6c9355c3c1"
 dependencies = [
  "bitflags 2.8.0",
  "malloc_size_of",
@@ -4424,7 +4424,7 @@ dependencies = [
 [[package]]
 name = "malloc_size_of"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-01-02#b2aff706472aa08db61ad1cae0e3dd54306f6fdf"
+source = "git+https://github.com/servo/stylo?branch=2025-01-02#06e3f12281781e087d06f03ed506eb6c9355c3c1"
 dependencies = [
  "app_units",
  "cssparser",
@@ -6437,7 +6437,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.26.0"
-source = "git+https://github.com/servo/stylo?branch=2025-01-02#b2aff706472aa08db61ad1cae0e3dd54306f6fdf"
+source = "git+https://github.com/servo/stylo?branch=2025-01-02#06e3f12281781e087d06f03ed506eb6c9355c3c1"
 dependencies = [
  "bitflags 2.8.0",
  "cssparser",
@@ -6722,7 +6722,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.0"
-source = "git+https://github.com/servo/stylo?branch=2025-01-02#b2aff706472aa08db61ad1cae0e3dd54306f6fdf"
+source = "git+https://github.com/servo/stylo?branch=2025-01-02#06e3f12281781e087d06f03ed506eb6c9355c3c1"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -6731,7 +6731,7 @@ dependencies = [
 [[package]]
 name = "servo_atoms"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-01-02#b2aff706472aa08db61ad1cae0e3dd54306f6fdf"
+source = "git+https://github.com/servo/stylo?branch=2025-01-02#06e3f12281781e087d06f03ed506eb6c9355c3c1"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -7100,7 +7100,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "static_prefs"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-01-02#b2aff706472aa08db61ad1cae0e3dd54306f6fdf"
+source = "git+https://github.com/servo/stylo?branch=2025-01-02#06e3f12281781e087d06f03ed506eb6c9355c3c1"
 
 [[package]]
 name = "strck"
@@ -7181,7 +7181,7 @@ dependencies = [
 [[package]]
 name = "style"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-01-02#b2aff706472aa08db61ad1cae0e3dd54306f6fdf"
+source = "git+https://github.com/servo/stylo?branch=2025-01-02#06e3f12281781e087d06f03ed506eb6c9355c3c1"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -7239,7 +7239,7 @@ dependencies = [
 [[package]]
 name = "style_config"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-01-02#b2aff706472aa08db61ad1cae0e3dd54306f6fdf"
+source = "git+https://github.com/servo/stylo?branch=2025-01-02#06e3f12281781e087d06f03ed506eb6c9355c3c1"
 dependencies = [
  "lazy_static",
 ]
@@ -7247,7 +7247,7 @@ dependencies = [
 [[package]]
 name = "style_derive"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-01-02#b2aff706472aa08db61ad1cae0e3dd54306f6fdf"
+source = "git+https://github.com/servo/stylo?branch=2025-01-02#06e3f12281781e087d06f03ed506eb6c9355c3c1"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -7277,7 +7277,7 @@ dependencies = [
 [[package]]
 name = "style_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-01-02#b2aff706472aa08db61ad1cae0e3dd54306f6fdf"
+source = "git+https://github.com/servo/stylo?branch=2025-01-02#06e3f12281781e087d06f03ed506eb6c9355c3c1"
 dependencies = [
  "app_units",
  "bitflags 2.8.0",
@@ -7672,7 +7672,7 @@ dependencies = [
 [[package]]
 name = "to_shmem"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-01-02#b2aff706472aa08db61ad1cae0e3dd54306f6fdf"
+source = "git+https://github.com/servo/stylo?branch=2025-01-02#06e3f12281781e087d06f03ed506eb6c9355c3c1"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -7685,7 +7685,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-01-02#b2aff706472aa08db61ad1cae0e3dd54306f6fdf"
+source = "git+https://github.com/servo/stylo?branch=2025-01-02#06e3f12281781e087d06f03ed506eb6c9355c3c1"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/tests/wpt/tests/css/css-transitions/transition-behavior-events.html
+++ b/tests/wpt/tests/css/css-transitions/transition-behavior-events.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<title>CSS transition event dispatch depending on transition-behavior</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-transitions-1/#event-transitionevent">
+<link rel="help" href="https://drafts.csswg.org/css-transitions-2/#transition-behavior-property">
+<meta name="assert" content="
+  Even for a property like `width` which has a non-discrete animation type,
+  transitions among non-interpolable values should only start (as observed
+  by the `transitionrun` and `transitionstart` events) if discrete transitions
+  are allowed by `transition-behavior`.
+">
+<style>
+#width1, #width2 {
+  width: auto;
+  transition: width 3s -1s linear;
+}
+</style>
+<div id="width1" style="transition-behavior: normal"></div>
+<div id="width2" style="transition-behavior: allow-discrete"></div>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+promise_setup(() => new Promise((resolve, reject) => {
+  for (let event of ["transitionrun", "transitionstart"]) {
+    let event_log = [];
+    addEventListener(event, event => {
+      event_log.push(event.target.id);
+    });
+    promise_test(async function() {
+      assert_array_equals(event_log, ["width2"], "Should only get " + event + " event on #width2");
+    }, event + " events");
+  }
+  document.body.offsetLeft;
+  addEventListener("error", event => reject(event.message));
+  requestAnimationFrame(() => {
+      document.getElementById("width1").style.width = document.getElementById("width2").style.width = "100px";
+      requestAnimationFrame(resolve);
+
+  });
+}));
+</script>


### PR DESCRIPTION
Bumps Stylo to https://github.com/servo/stylo/pull/115

This is mainly to avoid firing events like `transitionstart` when the transition isn't actually allowed.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #35233
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
