### PR TITLE
script: Fix crash in screenX and screenY getters returning negative values

### DIFF
--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1849,10 +1849,10 @@ impl Window {
             .compositor_api
             .sender()
             .send(webrender_traits::CrossProcessCompositorMessage::GetClientWindowRect(send));
-        let rect = recv.recv().unwrap_or_default().to_u32();
+        let rect = recv.recv().unwrap_or_default();
         (
-            Size2D::new(rect.size().width, rect.size().height),
-            Point2D::new(rect.min.x as i32, rect.min.y as i32),
+            Size2D::new(rect.size().width as u32, rect.size().height as u32),
+            Point2D::new(rect.min.x, rect.min.y),
         )
     }
 


### PR DESCRIPTION
Instead of casting the window client rect to `u32`, keep it as `i32` and just cast the size dimensions to `u32`.

You can check the crash doesn't happen anymore and the coordinates are correct by loading `data:text/html,<span id=x style="margin-left: 400px"></span><script>setInterval("x.textContent=screenX",100)</script>` and moving the window.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #35193 (GitHub issue number if applicable)

