### PR TITLE
webgpu: implement get image for webgpu canvas

### DIFF
--- a/components/script/dom/htmlcanvaselement.rs
+++ b/components/script/dom/htmlcanvaselement.rs
@@ -420,10 +420,7 @@ impl HTMLCanvasElement {
                 return None;
             },
             #[cfg(feature = "webgpu")]
-            Some(&CanvasContext::WebGPU(_)) => {
-                // TODO: add a method in GPUCanvasContext to get the pixels.
-                return None;
-            },
+            Some(CanvasContext::WebGPU(context)) => Some(context.get_ipc_image()),
             Some(CanvasContext::Placeholder(context)) => {
                 let (sender, receiver) =
                     ipc::channel(self.global().time_profiler_chan().clone()).unwrap();
@@ -450,9 +447,8 @@ impl HTMLCanvasElement {
             Some(CanvasContext::WebGL2(ref context)) => {
                 context.base_context().get_image_data(self.get_size())
             },
-            //TODO: Add method get_image_data to GPUCanvasContext
             #[cfg(feature = "webgpu")]
-            Some(CanvasContext::WebGPU(_)) => None,
+            Some(CanvasContext::WebGPU(ref context)) => Some(context.get_image_data()),
             Some(CanvasContext::Placeholder(_)) | None => {
                 // Each pixel is fully-transparent black.
                 Some(vec![0; (self.Width() * self.Height() * 4) as usize])

--- a/components/script/dom/webgpu/gpucanvascontext.rs
+++ b/components/script/dom/webgpu/gpucanvascontext.rs
@@ -307,7 +307,9 @@ impl GPUCanvasContext {
         }
     }
 
+    /// <https://gpuweb.github.io/gpuweb/#ref-for-abstract-opdef-get-a-copy-of-the-image-contents-of-a-context%E2%91%A5>
     pub(crate) fn get_ipc_image(&self) -> IpcSharedMemory {
+        // 1. Return a copy of the image contents of context.
         if self.drawing_buffer.borrow().cleared {
             IpcSharedMemory::from_byte(0, self.size().area() as usize * 4)
         } else {

--- a/components/webgpu/ipc_messages/recv.rs
+++ b/components/webgpu/ipc_messages/recv.rs
@@ -154,6 +154,11 @@ pub enum WebGPURequest {
         texture_id: id::TextureId,
         encoder_id: id::CommandEncoderId,
     },
+    /// Obtains image from latest presentation buffer (same as wr update)
+    GetImage {
+        context_id: WebGPUContextId,
+        sender: IpcSender<IpcSharedMemory>,
+    },
     ValidateTextureDescriptor {
         device_id: id::DeviceId,
         texture_id: id::TextureId,

--- a/components/webgpu/swapchain.rs
+++ b/components/webgpu/swapchain.rs
@@ -9,7 +9,7 @@ use std::sync::{Arc, Mutex};
 
 use arrayvec::ArrayVec;
 use euclid::default::Size2D;
-use ipc_channel::ipc::IpcSender;
+use ipc_channel::ipc::{IpcSender, IpcSharedMemory};
 use log::{error, warn};
 use malloc_size_of::MallocSizeOf;
 use serde::{Deserialize, Serialize};
@@ -380,6 +380,22 @@ impl crate::WGPU {
                 .is_none(),
             "Context should be created only once!"
         );
+    }
+
+    pub(crate) fn get_image(&self, context_id: WebGPUContextId) -> IpcSharedMemory {
+        let webgpu_contexts = self.wgpu_image_map.lock().unwrap();
+        let context_data = webgpu_contexts.get(&context_id).unwrap();
+        let buffer_size = context_data.image_desc.buffer_size();
+        let data = if let Some(present_buffer) = context_data
+            .swap_chain
+            .as_ref()
+            .and_then(|swap_chain| swap_chain.data.as_ref())
+        {
+            IpcSharedMemory::from_bytes(present_buffer.slice())
+        } else {
+            IpcSharedMemory::from_byte(0, buffer_size as usize)
+        };
+        data
     }
 
     pub(crate) fn update_context(

--- a/components/webgpu/wgpu_thread.rs
+++ b/components/webgpu/wgpu_thread.rs
@@ -531,6 +531,9 @@ impl WGPU {
                             log::error!("Error occured in SwapChainPresent: {e:?}");
                         }
                     },
+                    WebGPURequest::GetImage { context_id, sender } => {
+                        sender.send(self.get_image(context_id)).unwrap()
+                    },
                     WebGPURequest::ValidateTextureDescriptor {
                         device_id,
                         texture_id,


### PR DESCRIPTION
We currently just use latest presentation buffer (the one that WebRender uses), but in the future we will probably need to do this as part of swapchain present for offscreen canvas to work too.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes in WebGPU CTS

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
