### PR TITLE
Only consider fully active documents when running the 'update the rendering' steps

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -2264,6 +2264,10 @@ impl Document {
             &mut *self.animation_frame_list.borrow_mut(),
         );
 
+        self.pending_animation_ticks
+            .borrow_mut()
+            .remove(AnimationTickType::REQUEST_ANIMATION_FRAME);
+
         self.running_animation_callbacks.set(true);
         let was_faking_animation_frames = self.is_faking_animation_frames();
         let timing = self.global().performance().Now();


### PR DESCRIPTION
This is specified in https://html.spec.whatwg.org/multipage/#update-the-rendering step 3.2 but we where not filtering out inactive documents.

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #35236 (GitHub issue number if applicable)


