### PR TITLE
Update window.screenX and window.screenY when moving the embedder window

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -1290,6 +1290,10 @@ impl IOCompositor {
         self.pipeline_details.remove(&pipeline_id);
     }
 
+    pub fn on_embedder_window_moved(&mut self) {
+        self.embedder_coordinates = self.window.get_coordinates();
+    }
+
     pub fn on_rendering_context_resized(&mut self) -> bool {
         if self.shutdown_state != ShutdownState::NotShuttingDown {
             return false;

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -352,6 +352,13 @@ impl WebView {
             .on_rendering_context_resized();
     }
 
+    pub fn notify_embedder_window_moved(&self) {
+        self.inner()
+            .compositor
+            .borrow_mut()
+            .on_embedder_window_moved();
+    }
+
     pub fn set_zoom(&self, new_zoom: f32) {
         self.inner()
             .compositor

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -391,7 +391,7 @@ impl ApplicationHandler<WakerEvent> for App {
         };
 
         let window = window.clone();
-        if event == winit::event::WindowEvent::RedrawRequested {
+        if event == WindowEvent::RedrawRequested {
             // We need to redraw the window for some reason.
             trace!("RedrawRequested");
 
@@ -441,7 +441,7 @@ impl ApplicationHandler<WakerEvent> for App {
                             "Sync WebView size with Window Resize event",
                         );
                     }
-                    if response.repaint && *event != winit::event::WindowEvent::RedrawRequested {
+                    if response.repaint && *event != WindowEvent::RedrawRequested {
                         // Request a winit redraw event, so we can recomposite, update and paint
                         // the minibrowser, and present the new frame.
                         window.winit_window().unwrap().request_redraw();


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This hooks up the winit `WindowEvent::Moved` event to a new function that updates the embedder coordinates.  Also did a bit of cleanup to shorten some variant names :)

That works fine on MacOS. For some reason none of the screenX/Y work on Linux using GnomeShell (but Firefox also fails the same way as Servo so I guess it's a wayland issue).

Note that once we have support for several winit windows this will need to be updated to track per winit window.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #35195 (GitHub issue number if applicable)

