### PR TITLE
Let `resolve_color()` take its parameter by reference

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1659,7 +1659,7 @@ dependencies = [
 [[package]]
 name = "dom"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-01-02#06e3f12281781e087d06f03ed506eb6c9355c3c1"
+source = "git+https://github.com/servo/stylo?branch=2025-01-02#816c35500ca077f88b5d38a3bcc79c8c568d307a"
 dependencies = [
  "bitflags 2.8.0",
  "malloc_size_of",
@@ -4424,7 +4424,7 @@ dependencies = [
 [[package]]
 name = "malloc_size_of"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-01-02#06e3f12281781e087d06f03ed506eb6c9355c3c1"
+source = "git+https://github.com/servo/stylo?branch=2025-01-02#816c35500ca077f88b5d38a3bcc79c8c568d307a"
 dependencies = [
  "app_units",
  "cssparser",
@@ -6437,7 +6437,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.26.0"
-source = "git+https://github.com/servo/stylo?branch=2025-01-02#06e3f12281781e087d06f03ed506eb6c9355c3c1"
+source = "git+https://github.com/servo/stylo?branch=2025-01-02#816c35500ca077f88b5d38a3bcc79c8c568d307a"
 dependencies = [
  "bitflags 2.8.0",
  "cssparser",
@@ -6722,7 +6722,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.0"
-source = "git+https://github.com/servo/stylo?branch=2025-01-02#06e3f12281781e087d06f03ed506eb6c9355c3c1"
+source = "git+https://github.com/servo/stylo?branch=2025-01-02#816c35500ca077f88b5d38a3bcc79c8c568d307a"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -6731,7 +6731,7 @@ dependencies = [
 [[package]]
 name = "servo_atoms"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-01-02#06e3f12281781e087d06f03ed506eb6c9355c3c1"
+source = "git+https://github.com/servo/stylo?branch=2025-01-02#816c35500ca077f88b5d38a3bcc79c8c568d307a"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -7100,7 +7100,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "static_prefs"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-01-02#06e3f12281781e087d06f03ed506eb6c9355c3c1"
+source = "git+https://github.com/servo/stylo?branch=2025-01-02#816c35500ca077f88b5d38a3bcc79c8c568d307a"
 
 [[package]]
 name = "strck"
@@ -7181,7 +7181,7 @@ dependencies = [
 [[package]]
 name = "style"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-01-02#06e3f12281781e087d06f03ed506eb6c9355c3c1"
+source = "git+https://github.com/servo/stylo?branch=2025-01-02#816c35500ca077f88b5d38a3bcc79c8c568d307a"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -7239,7 +7239,7 @@ dependencies = [
 [[package]]
 name = "style_config"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-01-02#06e3f12281781e087d06f03ed506eb6c9355c3c1"
+source = "git+https://github.com/servo/stylo?branch=2025-01-02#816c35500ca077f88b5d38a3bcc79c8c568d307a"
 dependencies = [
  "lazy_static",
 ]
@@ -7247,7 +7247,7 @@ dependencies = [
 [[package]]
 name = "style_derive"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-01-02#06e3f12281781e087d06f03ed506eb6c9355c3c1"
+source = "git+https://github.com/servo/stylo?branch=2025-01-02#816c35500ca077f88b5d38a3bcc79c8c568d307a"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -7277,7 +7277,7 @@ dependencies = [
 [[package]]
 name = "style_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-01-02#06e3f12281781e087d06f03ed506eb6c9355c3c1"
+source = "git+https://github.com/servo/stylo?branch=2025-01-02#816c35500ca077f88b5d38a3bcc79c8c568d307a"
 dependencies = [
  "app_units",
  "bitflags 2.8.0",
@@ -7672,7 +7672,7 @@ dependencies = [
 [[package]]
 name = "to_shmem"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-01-02#06e3f12281781e087d06f03ed506eb6c9355c3c1"
+source = "git+https://github.com/servo/stylo?branch=2025-01-02#816c35500ca077f88b5d38a3bcc79c8c568d307a"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -7685,7 +7685,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-01-02#06e3f12281781e087d06f03ed506eb6c9355c3c1"
+source = "git+https://github.com/servo/stylo?branch=2025-01-02#816c35500ca077f88b5d38a3bcc79c8c568d307a"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/components/layout/display_list/builder.rs
+++ b/components/layout/display_list/builder.rs
@@ -611,7 +611,7 @@ impl Fragment {
         absolute_bounds: Rect<Au>,
     ) {
         let background = style.get_background();
-        let background_color = style.resolve_color(background.background_color.clone());
+        let background_color = style.resolve_color(&background.background_color);
         // XXXManishearth the below method should ideally use an iterator over
         // backgrounds
         self.build_display_list_for_background_if_applicable_with_background(
@@ -1015,9 +1015,7 @@ impl Fragment {
                 webrender_api::BoxShadowDisplayItem {
                     common: items::empty_common_item_properties(),
                     box_bounds: absolute_bounds.to_layout(),
-                    color: style
-                        .resolve_color(box_shadow.base.color.clone())
-                        .to_layout(),
+                    color: style.resolve_color(&box_shadow.base.color).to_layout(),
                     offset: LayoutVector2D::new(
                         box_shadow.base.horizontal.px(),
                         box_shadow.base.vertical.px(),
@@ -1120,19 +1118,19 @@ impl Fragment {
         }
         let details = BorderDetails::Normal(NormalBorder {
             left: BorderSide {
-                color: style.resolve_color(colors.left).to_layout(),
+                color: style.resolve_color(&colors.left).to_layout(),
                 style: border_style.left.to_layout(),
             },
             right: BorderSide {
-                color: style.resolve_color(colors.right).to_layout(),
+                color: style.resolve_color(&colors.right).to_layout(),
                 style: border_style.right.to_layout(),
             },
             top: BorderSide {
-                color: style.resolve_color(colors.top).to_layout(),
+                color: style.resolve_color(&colors.top).to_layout(),
                 style: border_style.top.to_layout(),
             },
             bottom: BorderSide {
-                color: style.resolve_color(colors.bottom).to_layout(),
+                color: style.resolve_color(&colors.bottom).to_layout(),
                 style: border_style.bottom.to_layout(),
             },
             radius: border_radius,
@@ -1302,7 +1300,7 @@ impl Fragment {
 
         // Append the outline to the display list.
         let color = style
-            .resolve_color(style.get_outline().outline_color.clone())
+            .resolve_color(&style.get_outline().outline_color)
             .to_layout();
         let base = state.create_base_display_item(
             clip,
@@ -1343,8 +1341,7 @@ impl Fragment {
         // TODO: Allow non-text fragments to be selected too.
         if scanned_text_fragment_info.selected() {
             let style = self.selected_style();
-            let background_color =
-                style.resolve_color(style.get_background().background_color.clone());
+            let background_color = style.resolve_color(&style.get_background().background_color);
             let base = state.create_base_display_item(
                 stacking_relative_border_box,
                 self.node,
@@ -1929,7 +1926,7 @@ impl Fragment {
                     base: base.clone(),
                     shadow: webrender_api::Shadow {
                         offset: LayoutVector2D::new(shadow.horizontal.px(), shadow.vertical.px()),
-                        color: self.style.resolve_color(shadow.color.clone()).to_layout(),
+                        color: self.style.resolve_color(&shadow.color).to_layout(),
                         blur_radius: shadow.blur.px(),
                     },
                 },

--- a/components/layout/display_list/gradient.rs
+++ b/components/layout/display_list/gradient.rs
@@ -195,7 +195,7 @@ fn convert_gradient_stops(
         assert!(offset.is_finite());
         stops.push(GradientStop {
             offset,
-            color: style.resolve_color(stop.color.clone()).to_layout(),
+            color: style.resolve_color(stop.color).to_layout(),
         })
     }
     stops

--- a/components/layout/table.rs
+++ b/components/layout/table.rs
@@ -1340,7 +1340,7 @@ impl TableCellStyleInfo<'_> {
 
             let build_dl = |sty: &ComputedValues, state: &mut &mut DisplayListBuildState| {
                 let background = sty.get_background();
-                let background_color = sty.resolve_color(background.background_color.clone());
+                let background_color = sty.resolve_color(&background.background_color);
                 cell_flow.build_display_list_for_background_if_applicable_with_background(
                     state,
                     background,

--- a/components/layout_2020/display_list/gradient.rs
+++ b/components/layout_2020/display_list/gradient.rs
@@ -346,11 +346,11 @@ fn conic_gradient_items_to_color_stops(
         .filter_map(|item| {
             match item {
                 GradientItem::SimpleColorStop(color) => Some(ColorStop {
-                    color: super::rgba(style.resolve_color(color.clone())),
+                    color: super::rgba(style.resolve_color(color)),
                     position: None,
                 }),
                 GradientItem::ComplexColorStop { color, position } => Some(ColorStop {
-                    color: super::rgba(style.resolve_color(color.clone())),
+                    color: super::rgba(style.resolve_color(color)),
                     position: match position {
                         AngleOrPercentage::Percentage(percentage) => Some(percentage.0),
                         AngleOrPercentage::Angle(angle) => Some(angle.degrees() / 360.),
@@ -384,11 +384,11 @@ fn gradient_items_to_color_stops(
         .filter_map(|item| {
             match item {
                 GradientItem::SimpleColorStop(color) => Some(ColorStop {
-                    color: super::rgba(style.resolve_color(color.clone())),
+                    color: super::rgba(style.resolve_color(color)),
                     position: None,
                 }),
                 GradientItem::ComplexColorStop { color, position } => Some(ColorStop {
-                    color: super::rgba(style.resolve_color(color.clone())),
+                    color: super::rgba(style.resolve_color(color)),
                     position: Some(if gradient_line_length.is_zero() {
                         0.
                     } else {

--- a/components/layout_2020/display_list/mod.rs
+++ b/components/layout_2020/display_list/mod.rs
@@ -708,7 +708,7 @@ impl<'a> BuilderForBoxFragment<'a> {
         painter: &BackgroundPainter,
     ) {
         let b = painter.style.get_background();
-        let background_color = painter.style.resolve_color(b.background_color.clone());
+        let background_color = painter.style.resolve_color(&b.background_color);
         if background_color.alpha > 0.0 {
             // https://drafts.csswg.org/css-backgrounds/#background-color
             // “The background color is clipped according to the background-clip
@@ -1119,7 +1119,7 @@ impl<'a> BuilderForBoxFragment<'a> {
         };
         let side = self.build_border_side(BorderStyleColor {
             style: border_style,
-            color: style.resolve_color(outline.outline_color.clone()),
+            color: style.resolve_color(&outline.outline_color),
         });
         let details = wr::BorderDetails::Normal(wr::NormalBorder {
             top: side,
@@ -1156,11 +1156,7 @@ impl<'a> BuilderForBoxFragment<'a> {
                     box_shadow.base.horizontal.px(),
                     box_shadow.base.vertical.px(),
                 ),
-                rgba(
-                    self.fragment
-                        .style
-                        .resolve_color(box_shadow.base.color.clone()),
-                ),
+                rgba(self.fragment.style.resolve_color(&box_shadow.base.color)),
                 box_shadow.base.blur.px(),
                 box_shadow.spread.px(),
                 self.border_radius,

--- a/components/layout_2020/display_list/stacking_context.rs
+++ b/components/layout_2020/display_list/stacking_context.rs
@@ -576,7 +576,7 @@ impl StackingContext {
             .union(&fragment_tree.scrollable_overflow)
             .to_webrender();
 
-        let background_color = style.resolve_color(style.get_background().background_color.clone());
+        let background_color = style.resolve_color(&style.get_background().background_color);
         if background_color.alpha > 0.0 {
             let common = builder.common_properties(painting_area, style);
             let color = super::rgba(background_color);

--- a/components/layout_2020/style_ext.rs
+++ b/components/layout_2020/style_ext.rs
@@ -741,7 +741,7 @@ impl ComputedValuesExt for ComputedValues {
     /// Whether or not this style specifies a non-transparent background.
     fn background_is_transparent(&self) -> bool {
         let background = self.get_background();
-        let color = self.resolve_color(background.background_color.clone());
+        let color = self.resolve_color(&background.background_color);
         color.alpha == 0.0 &&
             background
                 .background_image

--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -1308,12 +1308,11 @@ fn get_root_flow_background_color(flow: &mut dyn Flow) -> ColorF {
 
     let kid_block_flow = kid.as_block();
     let color = kid_block_flow.fragment.style.resolve_color(
-        kid_block_flow
+        &kid_block_flow
             .fragment
             .style
             .get_background()
-            .background_color
-            .clone(),
+            .background_color,
     );
     color.to_layout()
 }


### PR DESCRIPTION
Bumps Stylo to https://github.com/servo/stylo/pull/116

This way the callers don't have to clone it if they don't have ownership or want to use the value later.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because there is no behavior change

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
