### PR TITLE
Chore: servoshell cleanup

### DIFF
--- a/ports/servoshell/desktop/headless_window.rs
+++ b/ports/servoshell/desktop/headless_window.rs
@@ -58,6 +58,10 @@ impl Window {
 
         Rc::new(window)
     }
+
+    pub fn new_uninit() -> Rc<dyn WindowPortsMethods> {
+        Self::new(Default::default(), None, None)
+    }
 }
 
 impl WindowPortsMethods for Window {

--- a/ports/servoshell/desktop/minibrowser.rs
+++ b/ports/servoshell/desktop/minibrowser.rs
@@ -257,7 +257,7 @@ impl Minibrowser {
         &mut self,
         window: &Window,
         webviews: &mut WebViewManager,
-        servo: Option<&mut Servo>,
+        servo: Option<&Servo>,
         reason: &'static str,
     ) {
         let now = Instant::now();

--- a/ports/servoshell/desktop/webview.rs
+++ b/ports/servoshell/desktop/webview.rs
@@ -94,13 +94,13 @@ pub struct HapticEffect {
 }
 
 impl WebViewManager {
-    pub fn new(window: Rc<dyn WindowPortsMethods>) -> WebViewManager {
+    pub fn new() -> WebViewManager {
         WebViewManager {
             status_text: None,
             webviews: HashMap::default(),
             creation_order: vec![],
             focused_webview_id: None,
-            window,
+            window: crate::desktop::headless_window::Window::new_uninit(),
             gamepad: match Gilrs::new() {
                 Ok(g) => Some(g),
                 Err(e) => {
@@ -111,6 +111,10 @@ impl WebViewManager {
             haptic_effects: HashMap::default(),
             shutdown_requested: false,
         }
+    }
+
+    pub fn set_window(&mut self, window: Rc<dyn WindowPortsMethods>) {
+        self.window = window;
     }
 
     pub fn get_mut(&mut self, webview_id: WebViewId) -> Option<&mut WebView> {


### PR DESCRIPTION
I didn't like that we have so many `unwrap()` in servoshell so I fixed some. Mostly replaced `Option<WebViewManager>` to not be optional. Because it requires a window, it's now initialized with a dummy headless one and we set it to the proper one later in the App init().

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

