### PR TITLE
chore: Rename `CompositeTarget` enum

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -2247,7 +2247,7 @@ impl IOCompositor {
     }
 
     /// Return the OpenGL framebuffer name of the most-recently-completed frame when compositing to
-    /// [`CompositeTarget::Fbo`], or None otherwise.
+    /// [`CompositeTarget::OffscreenFbo`], or None otherwise.
     pub fn offscreen_framebuffer_id(&self) -> Option<gleam::gl::GLuint> {
         self.prev_offscreen_framebuffer
             .as_ref()

--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -192,12 +192,12 @@ pub struct IOCompositor {
 
     /// Offscreen framebuffer object to render our next frame to.
     /// We use this and `prev_offscreen_framebuffer` for double buffering when compositing to
-    /// [`CompositeTarget::Fbo`].
+    /// [`CompositeTarget::OffscreenFbo`].
     next_offscreen_framebuffer: OnceCell<gl::RenderTargetInfo>,
 
     /// Offscreen framebuffer object for our most-recently-completed frame.
     /// We use this and `next_offscreen_framebuffer` for double buffering when compositing to
-    /// [`CompositeTarget::Fbo`].
+    /// [`CompositeTarget::OffscreenFbo`].
     prev_offscreen_framebuffer: Option<gl::RenderTargetInfo>,
 
     /// Whether to invalidate `prev_offscreen_framebuffer` at the end of the next frame.
@@ -342,12 +342,13 @@ impl PipelineDetails {
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum CompositeTarget {
-    /// Draw directly to a window.
-    Window,
+    /// Draw to a OpenGL framebuffer object that will then be used by the compositor to composite
+    /// to [`RenderingContext::framebuffer_object`]
+    ContextFbo,
 
     /// Draw to an offscreen OpenGL framebuffer object, which can be retrieved once complete at
     /// [`IOCompositor::offscreen_framebuffer_id`].
-    Fbo,
+    OffscreenFbo,
 
     /// Draw to an uncompressed image in shared memory.
     SharedMemory,
@@ -2016,7 +2017,9 @@ impl IOCompositor {
         ) || self.exit_after_load;
         let use_offscreen_framebuffer = matches!(
             target,
-            CompositeTarget::SharedMemory | CompositeTarget::PngFile(_) | CompositeTarget::Fbo
+            CompositeTarget::SharedMemory |
+                CompositeTarget::PngFile(_) |
+                CompositeTarget::OffscreenFbo
         );
 
         if wait_for_stable_image {
@@ -2089,8 +2092,8 @@ impl IOCompositor {
         };
 
         let rv = match target {
-            CompositeTarget::Window => None,
-            CompositeTarget::Fbo => {
+            CompositeTarget::ContextFbo => None,
+            CompositeTarget::OffscreenFbo => {
                 self.next_offscreen_framebuffer
                     .get()
                     .expect("Guaranteed by needs_fbo")

--- a/components/servo/examples/winit_minimal.rs
+++ b/components/servo/examples/winit_minimal.rs
@@ -100,7 +100,7 @@ impl ApplicationHandler<WakerEvent> for App {
                 }),
                 window_delegate.clone(),
                 Default::default(),
-                compositing::CompositeTarget::Window,
+                compositing::CompositeTarget::ContextFbo,
             );
             servo.setup_logging();
             let webviews = vec![servo.new_webview(

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -1016,7 +1016,7 @@ impl Servo {
     }
 
     /// Return the OpenGL framebuffer name of the most-recently-completed frame when compositing to
-    /// [`CompositeTarget::Fbo`], or None otherwise.
+    /// [`CompositeTarget::OffscreenFbo`], or None otherwise.
     pub fn offscreen_framebuffer_id(&self) -> Option<u32> {
         self.compositor.borrow().offscreen_framebuffer_id()
     }

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -209,9 +209,9 @@ impl App {
         let embedder = Box::new(EmbedderCallbacks::new(self.waker.clone(), xr_discovery));
 
         let composite_target = if self.minibrowser.is_some() {
-            CompositeTarget::Fbo
+            CompositeTarget::OffscreenFbo
         } else {
-            CompositeTarget::Window
+            CompositeTarget::ContextFbo
         };
         let servo = Servo::new(
             self.opts.clone(),

--- a/ports/servoshell/egl/android/simpleservo.rs
+++ b/ports/servoshell/egl/android/simpleservo.rs
@@ -113,7 +113,7 @@ pub fn init(
         embedder_callbacks,
         window_callbacks.clone(),
         None,
-        CompositeTarget::Window,
+        CompositeTarget::ContextFbo,
     );
 
     SERVO.with(|s| {

--- a/ports/servoshell/egl/ohos/simpleservo.rs
+++ b/ports/servoshell/egl/ohos/simpleservo.rs
@@ -114,7 +114,7 @@ pub fn init(
         embedder_callbacks,
         window_callbacks.clone(),
         None, /* user_agent */
-        CompositeTarget::Window,
+        CompositeTarget::ContextFbo,
     );
 
     let servo_glue = ServoGlue::new(


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Renamed `CompositeTarget::Window` to `CompositeTarget::ContextFbo` and `CompositeTarget::Fbo` to `CompositeTarget::OffscreenFbo` for usage clarity and updated the documentation to more clearly state how the `CompositeTarget::ContextFbo` is being used.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #35254

<!-- Either: -->
- [x] These changes do not require tests because this is just a simple renaming

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
