### PR TITLE
layout: Don't let table grid boxes inherit `display: inline-table`

### DIFF
--- a/components/layout_2020/display_list/stacking_context.rs
+++ b/components/layout_2020/display_list/stacking_context.rs
@@ -1216,7 +1216,8 @@ impl BoxFragment {
                 });
         };
 
-        add_fragment(self.get_stacking_context_section());
+        let section = self.get_stacking_context_section();
+        add_fragment(section);
         if !self.style.get_outline().outline_width.is_zero() {
             add_fragment(StackingContextSection::Outline);
         }
@@ -1239,7 +1240,7 @@ impl BoxFragment {
                     scroll_node_id: new_scroll_node_id,
                     reference_frame_scroll_node_id: reference_frame_scroll_node_id_for_fragments,
                     clip_chain_id: new_clip_chain_id,
-                    section: self.get_stacking_context_section(),
+                    section,
                     containing_block: containing_block.rect,
                     fragment: fragment.clone(),
                     is_hit_test_for_scrollable_overflow: true,
@@ -1303,8 +1304,7 @@ impl BoxFragment {
                     scroll_node_id: new_scroll_node_id,
                     reference_frame_scroll_node_id: reference_frame_scroll_node_id_for_fragments,
                     clip_chain_id: new_clip_chain_id,
-                    // TODO: should this use `self.get_stacking_context_section()`?
-                    section: StackingContextSection::DescendantBackgroundsAndBorders,
+                    section,
                     containing_block: containing_block.rect,
                     fragment: fragment.clone(),
                     is_hit_test_for_scrollable_overflow: false,

--- a/resources/servo.css
+++ b/resources/servo.css
@@ -269,6 +269,9 @@ svg > * {
   contain: unset;
   container: unset;
   scroll-margin: unset;
+
+  /* The grid needs to be block-level, so avoid inheriting `display: inline-table`. */
+  display: table;
 }
 
 *|*::-servo-legacy-anonymous-block {


### PR DESCRIPTION
The outer display type of a table element applies to the table wrapper box. The table grid box needs to be block-level as defined in https://drafts.csswg.org/css-tables/#table-grid-box

Therefore this sets `display: table` on table grid boxes, and then when painting collapsed table borders we can use the usual logic to compute the StackingContextSection.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because there is no behavior change

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
