### PR TITLE
libservo: Remove `EmbedderEvent::WindowResize`

### DIFF
--- a/components/compositing/windowing.rs
+++ b/components/compositing/windowing.rs
@@ -51,8 +51,6 @@ pub enum EmbedderEvent {
     /// Sent when part of the window is marked dirty and needs to be redrawn. Before sending this
     /// message, the window must make the same GL context as in `PrepareRenderingEvent` current.
     Refresh,
-    /// Sent when the window is resized.
-    WindowResize,
     /// Sent when the platform theme changes.
     ThemeChange(Theme),
     /// Sent when a navigation request from script is allowed/refused.
@@ -142,7 +140,6 @@ impl Debug for EmbedderEvent {
         match *self {
             EmbedderEvent::Idle => write!(f, "Idle"),
             EmbedderEvent::Refresh => write!(f, "Refresh"),
-            EmbedderEvent::WindowResize => write!(f, "Resize"),
             EmbedderEvent::ThemeChange(..) => write!(f, "ThemeChange"),
             EmbedderEvent::Keyboard(..) => write!(f, "Keyboard"),
             EmbedderEvent::IMEComposition(..) => write!(f, "IMEComposition"),


### PR DESCRIPTION
Remove this event which is completely unused. In addition, lots of code
becomes dead once this happens, so remove that as well. It may be
possible that a different behavior is necessary immediately following a
window resize, but the new API will handle this in a different way than
this embedder event -- which complicates how the event loop is spun in
both the API and servoshell.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they just remove dead code.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
