### PR TITLE
libservo: Remove `Servo::repaint_synchronously`

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -2388,25 +2388,6 @@ impl IOCompositor {
         self.shutdown_state != ShutdownState::FinishedShuttingDown
     }
 
-    /// Repaints and recomposites synchronously. You must be careful when calling this, as if a
-    /// paint is not scheduled the compositor will hang forever.
-    ///
-    /// This is used when resizing the window.
-    pub fn repaint_synchronously(&mut self) {
-        while self.shutdown_state != ShutdownState::ShuttingDown {
-            let msg = self.port.recv_compositor_msg();
-            let need_recomposite = matches!(msg, CompositorMsg::NewWebRenderFrameReady(..));
-            let keep_going = self.handle_browser_message(msg);
-            if need_recomposite {
-                self.composite();
-                break;
-            }
-            if !keep_going {
-                break;
-            }
-        }
-    }
-
     pub fn pinch_zoom_level(&self) -> Scale<f32, DevicePixel, DevicePixel> {
         Scale::new(self.viewport_zoom.get())
     }

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -965,10 +965,6 @@ impl Servo {
         }
     }
 
-    pub fn repaint_synchronously(&mut self) {
-        self.compositor.borrow_mut().repaint_synchronously()
-    }
-
     pub fn pinch_zoom_level(&self) -> f32 {
         self.compositor.borrow_mut().pinch_zoom_level().get()
     }


### PR DESCRIPTION
This method is unused, so remove it and comments that refer to using it
hypothetically.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they just remove dead code.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
