### PR TITLE
Show shadow roots in devtools inspector

### DIFF
--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -11,6 +11,7 @@ use style::shared_lock::SharedRwLockReadGuard;
 use style::stylesheets::Stylesheet;
 use style::stylist::{CascadeData, Stylist};
 
+use crate::conversions::Convert;
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::ShadowRootBinding::ShadowRoot_Binding::ShadowRootMethods;
 use crate::dom::bindings::codegen::Bindings::ShadowRootBinding::{
@@ -418,6 +419,15 @@ impl<'dom> LayoutShadowRootHelpers<'dom> for LayoutDom<'dom, ShadowRoot> {
         let author_styles = self.unsafe_get().author_styles.borrow_mut_for_layout();
         if author_styles.stylesheets.dirty() {
             author_styles.flush::<E>(stylist, guard);
+        }
+    }
+}
+
+impl Convert<devtools_traits::ShadowRootMode> for ShadowRootMode {
+    fn convert(self) -> devtools_traits::ShadowRootMode {
+        match self {
+            ShadowRootMode::Open => devtools_traits::ShadowRootMode::Open,
+            ShadowRootMode::Closed => devtools_traits::ShadowRootMode::Closed,
         }
     }
 }

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -10,6 +10,7 @@
 #![crate_type = "rlib"]
 #![deny(unsafe_code)]
 
+use core::fmt;
 use std::collections::HashMap;
 use std::net::TcpStream;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -125,6 +126,7 @@ pub struct AttrInfo {
 #[serde(rename_all = "camelCase")]
 pub struct NodeInfo {
     pub unique_id: String,
+    pub host: Option<String>,
     #[serde(rename = "baseURI")]
     pub base_uri: String,
     pub parent: String,
@@ -134,6 +136,8 @@ pub struct NodeInfo {
     pub num_children: usize,
     pub attrs: Vec<AttrInfo>,
     pub is_top_level_document: bool,
+    pub shadow_root_mode: Option<ShadowRootMode>,
+    pub is_shadow_host: bool,
 }
 
 pub struct StartedTimelineMarker {
@@ -516,6 +520,21 @@ impl ConsoleMessageBuilder {
             column_number: self.column_number as usize,
             arguments: self.arguments,
             stacktrace: self.stack_trace,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub enum ShadowRootMode {
+    Open,
+    Closed,
+}
+
+impl fmt::Display for ShadowRootMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Open => write!(f, "open"),
+            Self::Closed => write!(f, "close"),
         }
     }
 }


### PR DESCRIPTION
This change involves two things:
1) Adding shadow roots to the list of children sent to the devtools
2) Adding a bunch more node info to the `NodeInfo` struct which is sent to the devtools, so they know which node's are shadow roots

I believe sending shadow roots as children is the way the devtools API was intended to be used, but I can't know for sure, since the only info i have comes from reading source code for the node/walker actors in gecko.

![image](https://github.com/user-attachments/assets/b4428969-282c-4f36-86c1-693ce9bad4f7)


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors


<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because we do not (yet) test devtools messages, though that may be interesting to do in the future.
