### PR TITLE
Don't require index parameter in `CSSGroupingRule`'s `insertRule()`

### DIFF
--- a/components/script_bindings/webidls/CSSGroupingRule.webidl
+++ b/components/script_bindings/webidls/CSSGroupingRule.webidl
@@ -6,7 +6,7 @@
 [Abstract, Exposed=Window]
 interface CSSGroupingRule : CSSRule {
   [SameObject] readonly attribute CSSRuleList cssRules;
-  [Throws] unsigned long insertRule(DOMString rule, unsigned long index);
+  [Throws] unsigned long insertRule(DOMString rule, optional unsigned long index = 0);
   [Throws] undefined deleteRule(unsigned long index);
 };
 

--- a/tests/wpt/meta/css/cssom/CSSGroupingRule-insertRule.html.ini
+++ b/tests/wpt/meta/css/cssom/CSSGroupingRule-insertRule.html.ini
@@ -1,4 +1,0 @@
-[CSSGroupingRule-insertRule.html]
-  [index not specified]
-    expected: FAIL
-

--- a/tests/wpt/meta/css/cssom/idlharness.html.ini
+++ b/tests/wpt/meta/css/cssom/idlharness.html.ini
@@ -215,9 +215,6 @@
   [CSSRule interface: sheet.cssRules[2\].cssRules[0\] must inherit property "MARGIN_RULE" with the proper type]
     expected: FAIL
 
-  [CSSGroupingRule interface: operation insertRule(CSSOMString, optional unsigned long)]
-    expected: FAIL
-
   [CSSImportRule interface: sheet.cssRules[0\] must inherit property "styleSheet" with the proper type]
     expected: FAIL
 


### PR DESCRIPTION
Make it optional, defaulting to 0 if omitted, as defined in the spec: https://drafts.csswg.org/cssom/#ref-for-dom-cssgroupingrule-insertrule

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
