### PR TITLE
webxr: Rename sender & receiver type aliases to `WebXrSender` and `WebXrReceiver`

### DIFF
--- a/components/shared/webxr/device.rs
+++ b/components/shared/webxr/device.rs
@@ -8,8 +8,8 @@ use euclid::{Point2D, RigidTransform3D};
 
 use crate::{
     ContextId, EnvironmentBlendMode, Error, Event, Floor, Frame, HitTestId, HitTestSource,
-    InputSource, LayerId, LayerInit, Native, Quitter, Sender, Session, SessionBuilder, SessionInit,
-    SessionMode, Viewports,
+    InputSource, LayerId, LayerInit, Native, Quitter, Session, SessionBuilder, SessionInit,
+    SessionMode, Viewports, WebXrSender,
 };
 
 /// A trait for discovering XR devices
@@ -47,7 +47,7 @@ pub trait DeviceAPI: 'static {
     fn initial_inputs(&self) -> Vec<InputSource>;
 
     /// Sets the event handling channel
-    fn set_event_dest(&mut self, dest: Sender<Event>);
+    fn set_event_dest(&mut self, dest: WebXrSender<Event>);
 
     /// Quit the session
     fn quit(&mut self);

--- a/components/shared/webxr/events.rs
+++ b/components/shared/webxr/events.rs
@@ -5,7 +5,8 @@
 use euclid::RigidTransform3D;
 
 use crate::{
-    ApiSpace, BaseSpace, Frame, InputFrame, InputId, InputSource, SelectEvent, SelectKind, Sender,
+    ApiSpace, BaseSpace, Frame, InputFrame, InputId, InputSource, SelectEvent, SelectKind,
+    WebXrSender,
 };
 
 #[derive(Clone, Debug)]
@@ -45,7 +46,7 @@ pub enum Visibility {
 /// when no event callback has been set
 pub enum EventBuffer {
     Buffered(Vec<Event>),
-    Sink(Sender<Event>),
+    Sink(WebXrSender<Event>),
 }
 
 impl Default for EventBuffer {
@@ -64,7 +65,7 @@ impl EventBuffer {
         }
     }
 
-    pub fn upgrade(&mut self, dest: Sender<Event>) {
+    pub fn upgrade(&mut self, dest: WebXrSender<Event>) {
         if let EventBuffer::Buffered(ref mut events) = *self {
             for event in events.drain(..) {
                 let _ = dest.send(event);

--- a/components/shared/webxr/lib.rs
+++ b/components/shared/webxr/lib.rs
@@ -20,7 +20,7 @@ pub mod util;
 mod view;
 
 #[cfg(not(feature = "ipc"))]
-pub use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender};
+pub use std::sync::mpsc::{RecvTimeoutError, WebXrReceiver, WebXrSender};
 #[cfg(feature = "ipc")]
 use std::thread;
 use std::time::Duration;
@@ -37,11 +37,11 @@ pub use input::{
     Handedness, InputFrame, InputId, InputSource, SelectEvent, SelectKind, TargetRayMode,
 };
 #[cfg(feature = "ipc")]
-pub use ipc_channel::ipc::channel;
+pub use ipc_channel::ipc::channel as webxr_channel;
 #[cfg(feature = "ipc")]
-pub use ipc_channel::ipc::IpcReceiver as Receiver;
+pub use ipc_channel::ipc::IpcReceiver as WebXrReceiver;
 #[cfg(feature = "ipc")]
-pub use ipc_channel::ipc::IpcSender as Sender;
+pub use ipc_channel::ipc::IpcSender as WebXrSender;
 pub use layer::{
     ContextId, GLContexts, GLTypes, LayerGrandManager, LayerGrandManagerAPI, LayerId, LayerInit,
     LayerLayout, LayerManager, LayerManagerAPI, LayerManagerFactory, SubImage, SubImages,
@@ -63,18 +63,21 @@ pub use view::{
 };
 
 #[cfg(not(feature = "ipc"))]
-pub fn channel<T>() -> Result<(Sender<T>, Receiver<T>), ()> {
+pub fn webxr_channel<T>() -> Result<(WebXrWebXrSender<T>, WebXrWebXrReceiver<T>), ()> {
     Ok(std::sync::mpsc::channel())
 }
 
 #[cfg(not(feature = "ipc"))]
-pub fn recv_timeout<T>(receiver: &Receiver<T>, timeout: Duration) -> Result<T, RecvTimeoutError> {
+pub fn recv_timeout<T>(
+    receiver: &WebXrReceiver<T>,
+    timeout: Duration,
+) -> Result<T, RecvTimeoutError> {
     receiver.recv_timeout(timeout)
 }
 
 #[cfg(feature = "ipc")]
 pub fn recv_timeout<T>(
-    receiver: &Receiver<T>,
+    receiver: &WebXrReceiver<T>,
     timeout: Duration,
 ) -> Result<T, ipc_channel::ipc::TryRecvError>
 where

--- a/components/shared/webxr/mock.rs
+++ b/components/shared/webxr/mock.rs
@@ -8,8 +8,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     DiscoveryAPI, Display, EntityType, Error, Floor, Handedness, Input, InputId, InputSource,
-    LeftEye, Native, Receiver, RightEye, SelectEvent, SelectKind, Sender, TargetRayMode, Triangle,
-    Viewer, Viewport, Visibility,
+    LeftEye, Native, RightEye, SelectEvent, SelectKind, TargetRayMode, Triangle, Viewer, Viewport,
+    Visibility, WebXrReceiver, WebXrSender,
 };
 
 /// A trait for discovering mock XR devices
@@ -17,7 +17,7 @@ pub trait MockDiscoveryAPI<GL>: 'static {
     fn simulate_device_connection(
         &mut self,
         init: MockDeviceInit,
-        receiver: Receiver<MockDeviceMsg>,
+        receiver: WebXrReceiver<MockDeviceMsg>,
     ) -> Result<Box<dyn DiscoveryAPI<GL>>, Error>;
 }
 
@@ -62,7 +62,7 @@ pub enum MockDeviceMsg {
     VisibilityChange(Visibility),
     SetWorld(MockWorld),
     ClearWorld,
-    Disconnect(Sender<()>),
+    Disconnect(WebXrSender<()>),
     SetBoundsGeometry(Vec<Point2D<f32, Floor>>),
     SimulateResetPose,
 }

--- a/components/webxr/glwindow/mod.rs
+++ b/components/webxr/glwindow/mod.rs
@@ -18,10 +18,10 @@ use surfman::{
 use webxr_api::util::ClipPlanes;
 use webxr_api::{
     ContextId, DeviceAPI, DiscoveryAPI, Display, Error, Event, EventBuffer, Floor, Frame,
-    InputSource, LayerGrandManager, LayerId, LayerInit, LayerManager, Native, Quitter, Sender,
-    Session, SessionBuilder, SessionInit, SessionMode, SomeEye, View, Viewer, ViewerPose, Viewport,
-    Viewports, Views, CUBE_BACK, CUBE_BOTTOM, CUBE_LEFT, CUBE_RIGHT, CUBE_TOP, LEFT_EYE, RIGHT_EYE,
-    VIEWER,
+    InputSource, LayerGrandManager, LayerId, LayerInit, LayerManager, Native, Quitter, Session,
+    SessionBuilder, SessionInit, SessionMode, SomeEye, View, Viewer, ViewerPose, Viewport,
+    Viewports, Views, WebXrSender, CUBE_BACK, CUBE_BOTTOM, CUBE_LEFT, CUBE_RIGHT, CUBE_TOP,
+    LEFT_EYE, RIGHT_EYE, VIEWER,
 };
 
 use crate::{SurfmanGL, SurfmanLayerManager};
@@ -305,7 +305,7 @@ impl DeviceAPI for GlWindowDevice {
         vec![]
     }
 
-    fn set_event_dest(&mut self, dest: Sender<Event>) {
+    fn set_event_dest(&mut self, dest: WebXrSender<Event>) {
         self.events.upgrade(dest)
     }
 

--- a/components/webxr/headless/mod.rs
+++ b/components/webxr/headless/mod.rs
@@ -13,8 +13,8 @@ use webxr_api::{
     Frame, FrameUpdateEvent, HitTestId, HitTestResult, HitTestSource, Input, InputFrame, InputId,
     InputSource, LayerGrandManager, LayerId, LayerInit, LayerManager, MockButton, MockDeviceInit,
     MockDeviceMsg, MockDiscoveryAPI, MockInputMsg, MockViewInit, MockViewsInit, MockWorld, Native,
-    Quitter, Ray, Receiver, SelectEvent, SelectKind, Sender, Session, SessionBuilder, SessionInit,
-    SessionMode, Space, SubImages, View, Viewer, ViewerPose, Viewports, Views,
+    Quitter, Ray, SelectEvent, SelectKind, Session, SessionBuilder, SessionInit, SessionMode,
+    Space, SubImages, View, Viewer, ViewerPose, Viewports, Views, WebXrReceiver, WebXrSender,
 };
 
 use crate::{SurfmanGL, SurfmanLayerManager};
@@ -74,7 +74,7 @@ impl MockDiscoveryAPI<SurfmanGL> for HeadlessMockDiscovery {
     fn simulate_device_connection(
         &mut self,
         init: MockDeviceInit,
-        receiver: Receiver<MockDeviceMsg>,
+        receiver: WebXrReceiver<MockDeviceMsg>,
     ) -> Result<Box<dyn DiscoveryAPI<SurfmanGL>>, Error> {
         let viewer_origin = init.viewer_origin;
         let floor_transform = init.floor_origin.map(|f| f.inverse());
@@ -107,7 +107,7 @@ impl MockDiscoveryAPI<SurfmanGL> for HeadlessMockDiscovery {
     }
 }
 
-fn run_loop(receiver: Receiver<MockDeviceMsg>, data: Arc<Mutex<HeadlessDeviceData>>) {
+fn run_loop(receiver: WebXrReceiver<MockDeviceMsg>, data: Arc<Mutex<HeadlessDeviceData>>) {
     while let Ok(msg) = receiver.recv() {
         if !data.lock().expect("Mutex poisoned").handle_msg(msg) {
             break;
@@ -283,7 +283,7 @@ impl DeviceAPI for HeadlessDevice {
         vec![]
     }
 
-    fn set_event_dest(&mut self, dest: Sender<Event>) {
+    fn set_event_dest(&mut self, dest: WebXrSender<Event>) {
         self.with_per_session(|s| s.events.upgrade(dest))
     }
 

--- a/components/webxr/openxr/mod.rs
+++ b/components/webxr/openxr/mod.rs
@@ -29,9 +29,9 @@ use webxr_api::util::{self, ClipPlanes};
 use webxr_api::{
     BaseSpace, Capture, ContextId, DeviceAPI, DiscoveryAPI, Display, Error, Event, EventBuffer,
     Floor, Frame, GLContexts, InputId, InputSource, LayerGrandManager, LayerId, LayerInit,
-    LayerManager, LayerManagerAPI, LeftEye, Native, Quitter, RightEye, SelectKind, Sender,
+    LayerManager, LayerManagerAPI, LeftEye, Native, Quitter, RightEye, SelectKind,
     Session as WebXrSession, SessionBuilder, SessionInit, SessionMode, SubImage, SubImages, View,
-    ViewerPose, Viewport, Viewports, Views, Visibility,
+    ViewerPose, Viewport, Viewports, Views, Visibility, WebXrSender,
 };
 
 use crate::gl_utils::GlClearer;
@@ -1421,7 +1421,7 @@ impl DeviceAPI for OpenXrDevice {
         ]
     }
 
-    fn set_event_dest(&mut self, dest: Sender<Event>) {
+    fn set_event_dest(&mut self, dest: WebXrSender<Event>) {
         self.events.upgrade(dest)
     }
 


### PR DESCRIPTION
This will prevent rust-analyzer from suggesting the import of these
types when dealing with `crossbeam` channels.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they just rename type aliases.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
