### PR TITLE
[35027] Websocket requests are missing some settings

### DIFF
--- a/components/script/dom/websocket.rs
+++ b/components/script/dom/websocket.rs
@@ -13,7 +13,10 @@ use js::jsapi::{JSAutoRealm, JSObject};
 use js::jsval::UndefinedValue;
 use js::rust::{CustomAutoRooterGuard, HandleObject};
 use js::typedarray::{ArrayBuffer, ArrayBufferView, CreateWith};
-use net_traits::request::{Referrer, RequestBuilder, RequestMode};
+use net_traits::request::{
+    CacheMode, CredentialsMode, RedirectMode, Referrer, RequestBuilder, RequestMode,
+    ServiceWorkersMode,
+};
 use net_traits::{
     CoreResourceMsg, FetchChannels, MessageData, WebSocketDomAction, WebSocketNetworkEvent,
 };
@@ -258,7 +261,11 @@ impl WebSocketMethods<crate::DomTypeHolder> for WebSocket {
         let request = RequestBuilder::new(global.webview_id(), url_record, Referrer::NoReferrer)
             .origin(global.origin().immutable().clone())
             .insecure_requests_policy(global.insecure_requests_policy())
-            .mode(RequestMode::WebSocket { protocols });
+            .mode(RequestMode::WebSocket { protocols })
+            .service_workers_mode(ServiceWorkersMode::None)
+            .credentials_mode(CredentialsMode::Include)
+            .cache_mode(CacheMode::NoCache)
+            .redirect_mode(RedirectMode::Error);
 
         let channels = FetchChannels::WebSocket {
             event_sender: resource_event_sender,

--- a/components/shared/net/request.rs
+++ b/components/shared/net/request.rs
@@ -434,6 +434,19 @@ impl RequestBuilder {
         self
     }
 
+    pub fn service_workers_mode(
+        mut self,
+        service_workers_mode: ServiceWorkersMode,
+    ) -> RequestBuilder {
+        self.service_workers_mode = service_workers_mode;
+        self
+    }
+
+    pub fn cache_mode(mut self, cache_mode: CacheMode) -> RequestBuilder {
+        self.cache_mode = cache_mode;
+        self
+    }
+
     pub fn build(self) -> Request {
         let mut request = Request::new(
             self.id,

--- a/tests/wpt/tests/websockets/constants.sub.js
+++ b/tests/wpt/tests/websockets/constants.sub.js
@@ -15,6 +15,7 @@ if (url_has_flag('h2')) {
 }
 
 const SCHEME_DOMAIN_PORT = __SCHEME + '://' + __SERVER__NAME + ':' + __PORT;
+const SCHEME_CROSSDOMAIN_PORT = __SCHEME + '://' + '{{hosts[alt][www]}}' + ':' + __PORT;
 
 function url_has_variant(variant) {
   const params = new URLSearchParams(location.search);

--- a/tests/wpt/tests/websockets/cookies/cross-origin-cookie-set.html
+++ b/tests/wpt/tests/websockets/cookies/cross-origin-cookie-set.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<title>Include credentials in cross-origin websocket requests</title>
+<meta name=author title="Domenico Rizzo" href="mailto:domenico.rizzo@gmail.com">
+
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src="/websockets/constants.sub.js"></script>
+
+<h1>WebSocket - Set Cross-origin cookie</h1>
+<div id=log></div>
+<script>
+    var resp_test = async_test('Cookie should be set')
+
+    resp_test.step(function() {
+        var ws = new WebSocket(SCHEME_CROSSDOMAIN_PORT + "/set-cookie?cookie_test");
+        ws.onerror = resp_test.step_func_done(function () {
+            assert_unreached("ws no error");
+        });
+        ws.onclose = resp_test.step_func_done(function () {
+            assert_unreached("'close' should not fire before 'open'.");
+        });
+        ws.onopen = resp_test.step_func(function (e) {
+            ws.onclose = null;
+            ws.close();
+
+            var ws2 = new WebSocket(SCHEME_CROSSDOMAIN_PORT + "/echo-cookie");
+            ws2.onerror = resp_test.step_func_done(function () {
+                assert_unreached("ws2 no error");
+            });
+            ws2.onclose = resp_test.step_func_done(function () {
+                assert_unreached("'close' should not fire before 'open'.");
+            });
+            ws2.onmessage = resp_test.step_func_done(function (e) {
+                ws2.onclose = null;
+                ws2.close();
+                assert_true(/ws_test_cookie_test=test/.test(e.data));
+            });
+        });
+    })
+</script>

--- a/tests/wpt/tests/websockets/opening-handshake/received-301-code.html
+++ b/tests/wpt/tests/websockets/opening-handshake/received-301-code.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<title>WebSockets: 301 Code Failed</title>
+<meta name=author title="Domenico Rizzo" href="mailto:domenico.rizzo@gmail.com">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../constants.sub.js"></script>
+<div id="log"></div>
+<script>
+async_test(function(t) {
+    t.step(function() {
+        const ws = new WebSocket(new URL("resources/redirect_response.py", location.href));
+
+        ws.onopen = t.step_func(function() {
+            assert_unreached("onopen");
+        });
+
+        ws.onerror = t.step_func(function() {
+            assert_true(true)
+            t.done()
+        });
+      });
+}, 'Websockets - Received 301 code');
+</script>

--- a/tests/wpt/tests/websockets/opening-handshake/resources/redirect_response.py
+++ b/tests/wpt/tests/websockets/opening-handshake/resources/redirect_response.py
@@ -1,0 +1,3 @@
+def main(request, response):
+    headers = [('Location', '/echo')]
+    return (301, "moved"), headers, ''


### PR DESCRIPTION
- I added some setting to websocket request and support method in request.
- Added tests as explained in the task


---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #35027 

- [x] There are tests for these changes
