### PR TITLE
Only compile platform samplers when cargo feature enabled

### DIFF
--- a/components/background_hang_monitor/Cargo.toml
+++ b/components/background_hang_monitor/Cargo.toml
@@ -24,11 +24,11 @@ log = { workspace = true }
 serde_json = { workspace = true }
 
 [features]
-sampler = ["unwind-sys", "mach2"]
+sampler = ["unwind-sys", "mach2", "nix"]
 
 [target.'cfg(target_os = "macos")'.dependencies]
 mach2 = { version = "0.4", optional = true }
 
 [target.'cfg(all(target_os = "linux", not(any(target_arch = "arm", target_arch = "aarch64", target_env = "ohos", target_env = "musl"))))'.dependencies]
-nix = { workspace = true, features = ["signal"] }
+nix = { workspace = true, features = ["signal"], optional = true }
 unwind-sys = { version = "0.1.4", optional = true }

--- a/components/background_hang_monitor/lib.rs
+++ b/components/background_hang_monitor/lib.rs
@@ -7,6 +7,7 @@
 pub mod background_hang_monitor;
 mod sampler;
 #[cfg(all(
+    feature = "sampler",
     target_os = "linux",
     not(any(
         target_arch = "arm",
@@ -16,9 +17,9 @@ mod sampler;
     ))
 ))]
 mod sampler_linux;
-#[cfg(target_os = "macos")]
+#[cfg(all(feature = "sampler", target_os = "macos"))]
 mod sampler_mac;
-#[cfg(target_os = "windows")]
+#[cfg(all(feature = "sampler", target_os = "windows"))]
 mod sampler_windows;
 
 pub use self::background_hang_monitor::*;


### PR DESCRIPTION
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #35311
- [x] These changes do not require tests because it's a build-time configuration.