### PR TITLE
libservo: Enable file directory listing by default

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -370,7 +370,7 @@ impl Preferences {
             network_enforce_tls_localhost: false,
             network_enforce_tls_onion: false,
             network_http_cache_disabled: false,
-            network_local_directory_listing_enabled: false,
+            network_local_directory_listing_enabled: true,
             network_mime_sniff: false,
             session_history_max_length: 20,
             shell_background_color_rgba: [1.0, 1.0, 1.0, 1.0],


### PR DESCRIPTION
This is a useful feature to have in a browser engine, so I think it
should be enabled by default. I believe that the original concern was
that there was a security issue, but this certainly has the same
security concerns as normal file loading.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because testing was handled when this landed.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
