### PR TITLE
libservo: Remove the `layout_flexbox_enabled` preference

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -24,7 +24,6 @@ pub fn set(preferences: Preferences) {
     style_config::set_bool("layout.unimplemented", preferences.layout_unimplemented);
     style_config::set_i32("layout.threads", preferences.layout_threads as i32);
     style_config::set_bool("layout.legacy_layout", preferences.layout_legacy_layout);
-    style_config::set_bool("layout.flexbox.enabled", preferences.layout_flexbox_enabled);
     style_config::set_bool("layout.columns.enabled", preferences.layout_columns_enabled);
     style_config::set_bool("layout.grid.enabled", preferences.layout_grid_enabled);
     style_config::set_bool(
@@ -194,7 +193,6 @@ pub struct Preferences {
     pub layout_grid_enabled: bool,
     pub layout_container_queries_enabled: bool,
     pub layout_css_transition_behavior_enabled: bool,
-    pub layout_flexbox_enabled: bool,
     pub layout_legacy_layout: bool,
     pub layout_threads: i64,
     pub layout_unimplemented: bool,
@@ -357,7 +355,6 @@ impl Preferences {
             layout_columns_enabled: false,
             layout_container_queries_enabled: false,
             layout_css_transition_behavior_enabled: true,
-            layout_flexbox_enabled: true,
             layout_grid_enabled: false,
             layout_legacy_layout: false,
             // TODO(mrobinson): This should likely be based on the number of processors.

--- a/components/script_bindings/codegen/run.py
+++ b/components/script_bindings/codegen/run.py
@@ -100,7 +100,6 @@ def add_css_properties_attributes(css_properties_json, parser):
             ["layout.unimplemented", "layout_unimplemented"],
             ["layout.threads", "layout_threads"],
             ["layout.legacy_layout", "layout_legacy_layout"],
-            ["layout.flexbox.enabled", "layout_flexbox_enabled"],
             ["layout.columns.enabled", "layout_columns_enabled"],
             ["layout.grid.enabled", "layout_grid_enabled"],
             ["layout.css.transition-behavior.enabled", "layout_css_transition_behavior_enabled"],

--- a/tests/wpt/meta-legacy-layout/css/css-flexbox/__dir__.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-flexbox/__dir__.ini
@@ -1,1 +1,1 @@
-prefs: ["layout_columns_enabled:true", "layout_flexbox_enabled:true"]
+prefs: ["layout_columns_enabled:true"]

--- a/tests/wpt/meta/css/css-align/__dir__.ini
+++ b/tests/wpt/meta/css/css-align/__dir__.ini
@@ -1,1 +1,1 @@
-prefs: ["layout_columns_enabled:true", "layout_flexbox_enabled:true"]
+prefs: ["layout_columns_enabled:true"]

--- a/tests/wpt/meta/css/css-flexbox/__dir__.ini
+++ b/tests/wpt/meta/css/css-flexbox/__dir__.ini
@@ -1,1 +1,1 @@
-prefs: ["layout_columns_enabled:true", "layout_flexbox_enabled:true"]
+prefs: ["layout_columns_enabled:true"]

--- a/tests/wpt/meta/css/css-grid/__dir__.ini
+++ b/tests/wpt/meta/css/css-grid/__dir__.ini
@@ -1,1 +1,1 @@
-prefs: ["layout_columns_enabled:true", "layout_flexbox_enabled:true", "layout_grid_enabled:true"]
+prefs: ["layout_columns_enabled:true", "layout_grid_enabled:true"]

--- a/tests/wpt/mozilla/meta/css/flex_align_content_stretch_subpixel.html.ini
+++ b/tests/wpt/mozilla/meta/css/flex_align_content_stretch_subpixel.html.ini
@@ -1,2 +1,0 @@
-[flex_align_content_stretch_subpixel.html]
-  prefs: ["layout_flexbox_enabled:true"]


### PR DESCRIPTION
This preference is enabled by default and is no longer present in stylo.
In addition, flexbox passes enough tests that it's probably fine to
remove this preference entirely now.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes. The WPT tests.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
