### PR TITLE
Cleanup blocking fetch operations with bad ports

### DIFF
--- a/components/net/websocket_loader.rs
+++ b/components/net/websocket_loader.rs
@@ -39,7 +39,7 @@ use url::Url;
 use crate::async_runtime::HANDLE;
 use crate::connector::{create_tls_config, CACertificates, TlsConfig};
 use crate::cookie::ServoCookie;
-use crate::fetch::methods::should_be_blocked_due_to_bad_port;
+use crate::fetch::methods::should_request_be_blocked_due_to_a_bad_port;
 use crate::hosts::replace_host;
 use crate::http_loader::HttpState;
 /// Create a tungstenite Request object for the initial HTTP request.
@@ -371,7 +371,7 @@ fn connect(
 
     let req_url = req_builder.url.clone();
 
-    if should_be_blocked_due_to_bad_port(&req_url) {
+    if should_request_be_blocked_due_to_a_bad_port(&req_url) {
         return Err("Port blocked".to_string());
     }
 


### PR DESCRIPTION
Blocking a fetch due to a bad port should be grouped together with CSP blocks as per the spec, but these steps were previously seperated.

Additionally, remove handling of the ftp scheme in
`should_request_be_blocked_due_to_a_bad_port`, since it did nothing anyways.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are covered by existing tests


