### PR TITLE
deps: Upgrade to `webrender@0.66`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,6 +124,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "android-activity"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -411,7 +420,7 @@ dependencies = [
  "serde",
  "servo_malloc_size_of",
  "static_assertions",
- "time 0.3.37",
+ "time",
  "webrender_api",
  "windows-sys 0.59.0",
 ]
@@ -1153,7 +1162,7 @@ version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
 dependencies = [
- "time 0.3.37",
+ "time",
  "version_check",
 ]
 
@@ -1163,7 +1172,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
- "time 0.3.37",
+ "time",
  "version_check",
 ]
 
@@ -2399,7 +2408,7 @@ checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -4160,7 +4169,7 @@ dependencies = [
  "servo_url",
  "style",
  "style_traits",
- "time 0.3.37",
+ "time",
  "tracing",
  "url",
  "webrender_api",
@@ -4652,7 +4661,7 @@ checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.52.0",
 ]
 
@@ -4862,7 +4871,7 @@ dependencies = [
  "servo_malloc_size_of",
  "servo_url",
  "sha2",
- "time 0.3.37",
+ "time",
  "tokio",
  "tokio-rustls",
  "tokio-stream",
@@ -5500,7 +5509,7 @@ dependencies = [
 [[package]]
 name = "peek-poke"
 version = "0.3.0"
-source = "git+https://github.com/servo/webrender?branch=0.65#8468e81608b00d83c62466f1c0f5ef73d44fda76"
+source = "git+https://github.com/servo/webrender?branch=0.66#9f552bebab81a73e62068c42d94be2f9c0586ce4"
 dependencies = [
  "euclid",
  "peek-poke-derive",
@@ -5509,7 +5518,7 @@ dependencies = [
 [[package]]
 name = "peek-poke-derive"
 version = "0.3.0"
-source = "git+https://github.com/servo/webrender?branch=0.65#8468e81608b00d83c62466f1c0f5ef73d44fda76"
+source = "git+https://github.com/servo/webrender?branch=0.66#9f552bebab81a73e62068c42d94be2f9c0586ce4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5787,7 +5796,7 @@ dependencies = [
  "servo_config",
  "task_info",
  "tikv-jemalloc-sys",
- "time 0.3.37",
+ "time",
 ]
 
 [[package]]
@@ -5798,7 +5807,7 @@ dependencies = [
  "profile",
  "profile_traits",
  "servo_config",
- "time 0.3.37",
+ "time",
 ]
 
 [[package]]
@@ -5812,7 +5821,7 @@ dependencies = [
  "serde",
  "servo_config",
  "signpost",
- "time 0.3.37",
+ "time",
  "tracing",
 ]
 
@@ -6304,7 +6313,7 @@ dependencies = [
  "swapper",
  "tempfile",
  "tendril",
- "time 0.3.37",
+ "time",
  "timers",
  "tracing",
  "unicode-bidi",
@@ -6970,7 +6979,7 @@ checksum = "8e7e46c8c90251d47d08b28b8a419ffb4aede0f87c2eea95e17d1d5bacbf3ef1"
 dependencies = [
  "colored",
  "log",
- "time 0.3.37",
+ "time",
  "windows-sys 0.48.0",
 ]
 
@@ -7568,17 +7577,6 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
-name = "time"
 version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
@@ -8120,7 +8118,7 @@ dependencies = [
  "anyhow",
  "derive_builder",
  "rustversion",
- "time 0.3.37",
+ "time",
  "vergen-lib",
 ]
 
@@ -8134,7 +8132,7 @@ dependencies = [
  "derive_builder",
  "git2",
  "rustversion",
- "time 0.3.37",
+ "time",
  "vergen",
  "vergen-lib",
 ]
@@ -8213,12 +8211,6 @@ dependencies = [
  "tower-service",
  "tracing",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"
@@ -8451,7 +8443,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "thiserror 1.0.69",
- "time 0.3.37",
+ "time",
  "tokio",
  "tokio-stream",
  "url",
@@ -8517,8 +8509,9 @@ dependencies = [
 [[package]]
 name = "webrender"
 version = "0.65.0"
-source = "git+https://github.com/servo/webrender?branch=0.65#8468e81608b00d83c62466f1c0f5ef73d44fda76"
+source = "git+https://github.com/servo/webrender?branch=0.66#9f552bebab81a73e62068c42d94be2f9c0586ce4"
 dependencies = [
+ "allocator-api2",
  "bincode",
  "bitflags 2.8.0",
  "build-parallel",
@@ -8540,7 +8533,6 @@ dependencies = [
  "serde",
  "smallvec",
  "svg_fmt",
- "time 0.1.45",
  "topological-sort",
  "tracy-rs",
  "webrender_api",
@@ -8552,26 +8544,28 @@ dependencies = [
 [[package]]
 name = "webrender_api"
 version = "0.65.0"
-source = "git+https://github.com/servo/webrender?branch=0.65#8468e81608b00d83c62466f1c0f5ef73d44fda76"
+source = "git+https://github.com/servo/webrender?branch=0.66#9f552bebab81a73e62068c42d94be2f9c0586ce4"
 dependencies = [
  "app_units",
  "bitflags 2.8.0",
  "byteorder",
  "crossbeam-channel",
  "euclid",
+ "libc",
+ "mach2",
  "malloc_size_of_derive",
  "peek-poke",
  "serde",
  "serde_bytes",
  "serde_derive",
- "time 0.1.45",
+ "windows-sys 0.59.0",
  "wr_malloc_size_of",
 ]
 
 [[package]]
 name = "webrender_build"
 version = "0.0.2"
-source = "git+https://github.com/servo/webrender?branch=0.65#8468e81608b00d83c62466f1c0f5ef73d44fda76"
+source = "git+https://github.com/servo/webrender?branch=0.66#9f552bebab81a73e62068c42d94be2f9c0586ce4"
 dependencies = [
  "bitflags 2.8.0",
  "lazy_static",
@@ -8620,7 +8614,7 @@ dependencies = [
  "ipc-channel",
  "log",
  "serde",
- "time 0.3.37",
+ "time",
 ]
 
 [[package]]
@@ -9176,7 +9170,7 @@ dependencies = [
 [[package]]
 name = "wr_glyph_rasterizer"
 version = "0.1.0"
-source = "git+https://github.com/servo/webrender?branch=0.65#8468e81608b00d83c62466f1c0f5ef73d44fda76"
+source = "git+https://github.com/servo/webrender?branch=0.66#9f552bebab81a73e62068c42d94be2f9c0586ce4"
 dependencies = [
  "core-foundation 0.9.4",
  "core-graphics",
@@ -9201,7 +9195,7 @@ dependencies = [
 [[package]]
 name = "wr_malloc_size_of"
 version = "0.0.3"
-source = "git+https://github.com/servo/webrender?branch=0.65#8468e81608b00d83c62466f1c0f5ef73d44fda76"
+source = "git+https://github.com/servo/webrender?branch=0.66#9f552bebab81a73e62068c42d94be2f9c0586ce4"
 dependencies = [
  "app_units",
  "euclid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,7 +140,7 @@ taffy = { version = "0.7.5", default-features = false, features = ["detailed_lay
 thin-vec = "0.2.13"
 tikv-jemalloc-sys = "0.6.0"
 tikv-jemallocator = "0.6.0"
-time_03 = { package = "time", version = "0.3", features = ["large-dates", "local-offset", "serde"] }
+time = { package = "time", version = "0.3", features = ["large-dates", "local-offset", "serde"] }
 to_shmem = { git = "https://github.com/servo/stylo", branch = "2025-02-03" }
 tokio = "1"
 tokio-rustls = { version = "0.26", default-features = false, features = ["logging"] }
@@ -158,8 +158,8 @@ url = "2.5"
 uuid = { version = "1.12.1", features = ["v4"] }
 webdriver = "0.51.0"
 webpki-roots = "0.26"
-webrender = { git = "https://github.com/servo/webrender", branch = "0.65", features = ["capture"] }
-webrender_api = { git = "https://github.com/servo/webrender", branch = "0.65" }
+webrender = { git = "https://github.com/servo/webrender", branch = "0.66", features = ["capture"] }
+webrender_api = { git = "https://github.com/servo/webrender", branch = "0.66" }
 webrender_traits = { path = "components/shared/webrender" }
 webxr-api = { path = "components/shared/webxr" }
 wgpu-core = { git = "https://github.com/gfx-rs/wgpu", rev = "d8e7ab1ad13f2bf2f9702401d1bc625e26b1c2e6" }
@@ -167,7 +167,7 @@ wgpu-types = { git = "https://github.com/gfx-rs/wgpu", rev = "d8e7ab1ad13f2bf2f9
 winapi = "0.3"
 windows-sys = "0.59"
 wio = "0.2"
-wr_malloc_size_of = { git = "https://github.com/servo/webrender", branch = "0.65" }
+wr_malloc_size_of = { git = "https://github.com/servo/webrender", branch = "0.66" }
 xi-unicode = "0.3.0"
 xml5ever = "0.20"
 

--- a/components/canvas/webgl_thread.rs
+++ b/components/canvas/webgl_thread.rs
@@ -955,6 +955,7 @@ impl WebGLThread {
             id: ExternalImageId(context_id.0),
             channel_index: 0,
             image_type: ExternalImageType::TextureHandle(image_buffer_kind),
+            normalized_uvs: false,
         };
         ImageData::External(data)
     }

--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -905,7 +905,7 @@ impl IOCompositor {
     /// Queue a new frame in the transaction and increase the pending frames count.
     fn generate_frame(&mut self, transaction: &mut Transaction, reason: RenderReasons) {
         self.pending_frames += 1;
-        transaction.generate_frame(0, reason);
+        transaction.generate_frame(0, true /* present */, reason);
     }
 
     /// Sets or unsets the animations-running flag for the given pipeline, and schedules a

--- a/components/layout/display_list/webrender_helpers.rs
+++ b/components/layout/display_list/webrender_helpers.rs
@@ -455,6 +455,7 @@ impl DisplayItem {
                     &[],
                     RasterSpace::Screen,
                     Default::default(),
+                    None, // snapshot
                 );
 
                 IsContentful(false)

--- a/components/layout_2020/display_list/stacking_context.rs
+++ b/components/layout_2020/display_list/stacking_context.rs
@@ -565,6 +565,7 @@ impl StackingContext {
             &[], // filter_primitives
             wr::RasterSpace::Screen,
             wr::StackingContextFlags::empty(),
+            None, // snapshot
         );
 
         true

--- a/components/layout_thread/Cargo.toml
+++ b/components/layout_thread/Cargo.toml
@@ -44,7 +44,7 @@ servo_config = { path = "../config" }
 servo_url = { path = "../url" }
 style = { workspace = true }
 style_traits = { workspace = true }
-time_03 = { workspace = true }
+time = { workspace = true }
 tracing = { workspace = true, optional = true }
 url = { workspace = true }
 webrender_api = { workspace = true }

--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -100,7 +100,7 @@ use style::values::computed::font::GenericFontFamily;
 use style::values::computed::{FontSize, Length, NonNegativeLength};
 use style::values::specified::font::KeywordInfo;
 use style_traits::{CSSPixel, SpeculativePainter};
-use time_03::Duration;
+use time::Duration;
 use url::Url;
 use webrender_api::units::DevicePixel;
 use webrender_api::{units, ColorF, HitTestFlags};

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -60,7 +60,7 @@ servo_config = { path = "../config" }
 servo_url = { path = "../url" }
 sha2 = "0.10"
 chrono = { workspace = true }
-time_03 = { workspace = true }
+time = { workspace = true }
 tokio = { workspace = true, features = ["sync", "macros", "rt-multi-thread"] }
 tokio-util = { version = "0.7.12", default-features = false, features = ["codec", "io"] }
 tokio-rustls = { workspace = true }

--- a/components/net/tests/hsts.rs
+++ b/components/net/tests/hsts.rs
@@ -8,7 +8,7 @@ use std::time::Duration as StdDuration;
 use base::cross_process_instant::CrossProcessInstant;
 use net::hsts::{HstsEntry, HstsList};
 use net_traits::IncludeSubdomains;
-use time_03::Duration;
+use time::Duration;
 
 #[test]
 fn test_hsts_entry_is_not_expired_when_it_has_no_timestamp() {

--- a/components/profile/Cargo.toml
+++ b/components/profile/Cargo.toml
@@ -18,7 +18,7 @@ profile_traits = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 servo_config = { path = "../config" }
-time_03 = { workspace = true }
+time = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 task_info = { path = "../../support/rust-task_info" }

--- a/components/profile/time.rs
+++ b/components/profile/time.rs
@@ -17,7 +17,7 @@ use profile_traits::time::{
     TimerMetadataFrameType, TimerMetadataReflowType,
 };
 use servo_config::opts::OutputOptions;
-use time_03::Duration;
+use time::Duration;
 
 use crate::trace_dump::TraceDump;
 

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -117,7 +117,7 @@ style_traits = { workspace = true }
 swapper = "0.1"
 tempfile = "3"
 tendril = { version = "0.4.1", features = ["encoding_rs"] }
-time_03 = { workspace = true }
+time = { workspace = true }
 timers = { path = "../timers" }
 tracing = { workspace = true, optional = true }
 unicode-bidi = { workspace = true }

--- a/components/script/dom/bindings/str.rs
+++ b/components/script/dom/bindings/str.rs
@@ -7,7 +7,7 @@ use std::sync::LazyLock;
 use num_traits::Zero;
 use regex::Regex;
 pub use script_bindings::str::*;
-use time_03::{Date, Month, OffsetDateTime, Time, Weekday};
+use time::{Date, Month, OffsetDateTime, Time, Weekday};
 
 /// <https://html.spec.whatwg.org/multipage/#parse-a-month-component>
 fn parse_month_component(value: &str) -> Option<(i32, u32)> {

--- a/components/script/dom/file.rs
+++ b/components/script/dom/file.rs
@@ -8,7 +8,7 @@ use dom_struct::dom_struct;
 use js::rust::HandleObject;
 use net_traits::filemanager_thread::SelectedFile;
 use script_traits::serializable::BlobImpl;
-use time_03::{Duration, OffsetDateTime};
+use time::{Duration, OffsetDateTime};
 
 use crate::dom::bindings::codegen::Bindings::FileBinding;
 use crate::dom::bindings::codegen::Bindings::FileBinding::FileMethods;

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -30,7 +30,7 @@ use servo_atoms::Atom;
 use style::attr::AttrValue;
 use style::str::{split_commas, str_join};
 use style_dom::ElementState;
-use time_03::{Month, OffsetDateTime, Time};
+use time::{Month, OffsetDateTime, Time};
 use unicode_bidi::{bidi_class, BidiClass};
 use url::Url;
 

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -256,6 +256,7 @@ impl VideoFrameRenderer for MediaFrameRenderer {
                         id: ExternalImageId(self.player_id.unwrap()),
                         channel_index: 0,
                         image_type: ExternalImageType::TextureHandle(texture_target),
+                        normalized_uvs: false,
                     })
                 } else {
                     SerializableImageData::Raw(IpcSharedMemory::from_bytes(&frame.get_data()))
@@ -289,6 +290,7 @@ impl VideoFrameRenderer for MediaFrameRenderer {
                         id: ExternalImageId(self.player_id.unwrap()),
                         channel_index: 0,
                         image_type: ExternalImageType::TextureHandle(texture_target),
+                        normalized_uvs: false,
                     })
                 } else {
                     SerializableImageData::Raw(IpcSharedMemory::from_bytes(&frame.get_data()))

--- a/components/script/dom/macros.rs
+++ b/components/script/dom/macros.rs
@@ -656,7 +656,7 @@ macro_rules! rooted_vec {
 macro_rules! impl_performance_entry_struct(
     ($binding:ident, $struct:ident, $type:expr) => (
         use base::cross_process_instant::CrossProcessInstant;
-        use time_03::Duration;
+        use time::Duration;
 
         use crate::dom::bindings::reflector::reflect_dom_object;
         use crate::dom::bindings::root::DomRoot;

--- a/components/script/dom/performance.rs
+++ b/components/script/dom/performance.rs
@@ -8,7 +8,7 @@ use std::collections::VecDeque;
 
 use base::cross_process_instant::CrossProcessInstant;
 use dom_struct::dom_struct;
-use time_03::Duration;
+use time::Duration;
 
 use super::bindings::refcounted::Trusted;
 use crate::dom::bindings::cell::DomRefCell;

--- a/components/script/dom/performanceentry.rs
+++ b/components/script/dom/performanceentry.rs
@@ -4,7 +4,7 @@
 
 use base::cross_process_instant::CrossProcessInstant;
 use dom_struct::dom_struct;
-use time_03::Duration;
+use time::Duration;
 
 use super::performance::ToDOMHighResTimeStamp;
 use crate::dom::bindings::codegen::Bindings::PerformanceBinding::DOMHighResTimeStamp;
@@ -22,7 +22,7 @@ pub(crate) struct PerformanceEntry {
     entry_type: DOMString,
     #[no_trace]
     start_time: Option<CrossProcessInstant>,
-    /// The duration of this [`PerformanceEntry`]. This is a [`time_03::Duration`],
+    /// The duration of this [`PerformanceEntry`]. This is a [`time::Duration`],
     /// because it can be negative and `std::time::Duration` cannot be.
     #[no_trace]
     #[ignore_malloc_size_of = "No MallocSizeOf support for `time` crate"]

--- a/components/script/dom/performancepainttiming.rs
+++ b/components/script/dom/performancepainttiming.rs
@@ -5,7 +5,7 @@
 use base::cross_process_instant::CrossProcessInstant;
 use dom_struct::dom_struct;
 use script_traits::ProgressiveWebMetricType;
-use time_03::Duration;
+use time::Duration;
 
 use crate::dom::bindings::reflector::reflect_dom_object;
 use crate::dom::bindings::root::DomRoot;

--- a/components/script/dom/performanceresourcetiming.rs
+++ b/components/script/dom/performanceresourcetiming.rs
@@ -6,7 +6,7 @@ use base::cross_process_instant::CrossProcessInstant;
 use dom_struct::dom_struct;
 use net_traits::ResourceFetchTiming;
 use servo_url::ServoUrl;
-use time_03::Duration;
+use time::Duration;
 
 use crate::dom::bindings::codegen::Bindings::PerformanceBinding::DOMHighResTimeStamp;
 use crate::dom::bindings::codegen::Bindings::PerformanceResourceTimingBinding::PerformanceResourceTimingMethods;

--- a/components/script/dom/visibilitystateentry.rs
+++ b/components/script/dom/visibilitystateentry.rs
@@ -6,7 +6,7 @@ use std::ops::Deref;
 
 use base::cross_process_instant::CrossProcessInstant;
 use dom_struct::dom_struct;
-use time_03::Duration;
+use time::Duration;
 
 use crate::dom::bindings::codegen::Bindings::DocumentBinding::DocumentVisibilityState;
 use crate::dom::bindings::codegen::Bindings::PerformanceEntryBinding::PerformanceEntryMethods;

--- a/components/shared/base/Cargo.toml
+++ b/components/shared/base/Cargo.toml
@@ -20,7 +20,7 @@ malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
 parking_lot = { workspace = true }
 serde = { workspace = true }
-time_03 = { workspace = true }
+time = { workspace = true }
 webrender_api = { workspace = true }
 static_assertions = { workspace = true }
 

--- a/components/shared/base/cross_process_instant.rs
+++ b/components/shared/base/cross_process_instant.rs
@@ -15,11 +15,11 @@ use std::ops::{Add, Sub};
 
 use malloc_size_of_derive::MallocSizeOf;
 use serde::{Deserialize, Serialize};
-use time_03::Duration;
+use time::Duration;
 
 /// A monotonic, nanosecond precision timer that can be used cross-process. The value
 /// stored internally is purposefully opaque as the origin is platform-specific. They can
-/// be compared and [`time_03::Duration`] can be found by subtracting one from another.
+/// be compared and [`time::Duration`] can be found by subtracting one from another.
 /// The `time` crate is used in this case instead of `std::time` so that durations can
 /// be negative.
 #[derive(

--- a/components/shared/profile/Cargo.toml
+++ b/components/shared/profile/Cargo.toml
@@ -22,5 +22,5 @@ log = { workspace = true }
 serde = { workspace = true }
 servo_config = { path = "../../config" }
 signpost = { git = "https://github.com/pcwalton/signpost.git" }
-time_03 = { workspace = true }
+time = { workspace = true }
 tracing = { workspace = true, optional = true }

--- a/components/shared/profile/time.rs
+++ b/components/shared/profile/time.rs
@@ -7,7 +7,7 @@ use ipc_channel::ipc::IpcSender;
 use log::warn;
 use serde::{Deserialize, Serialize};
 use servo_config::opts;
-use time_03::Duration;
+use time::Duration;
 
 #[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
 pub struct TimerMetadata {

--- a/components/shared/webxr/Cargo.toml
+++ b/components/shared/webxr/Cargo.toml
@@ -23,4 +23,4 @@ euclid = { workspace = true }
 ipc-channel = { workspace = true, optional = true }
 log = { workspace = true }
 serde = { workspace = true, optional = true }
-time_03 = { workspace = true, optional = true }
+time = { workspace = true, optional = true }

--- a/components/webgpu/swapchain.rs
+++ b/components/webgpu/swapchain.rs
@@ -224,6 +224,7 @@ impl ContextData {
             id: ExternalImageId(context_id.0),
             channel_index: 0,
             image_type: ExternalImageType::Buffer,
+            normalized_uvs: false,
         });
 
         Self {

--- a/deny.toml
+++ b/deny.toml
@@ -12,8 +12,6 @@ feature-depth = 1
 # https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
 [advisories]
 ignore = [
-    # This is for the usage of time@0.1.45 in WebRender, which should be removed soon.
-    "RUSTSEC-2020-0071",
     # This has been yanked, but upgrading to the next version breaks some WPT tests.
     # It needs investigation.
     "url@2.5.3",
@@ -87,8 +85,6 @@ skip = [
     "futures",
     "hermit-abi",
     "redox_syscall",
-    "time",
-    "wasi",
     "wayland-sys",
 
     # Duplicated by aws-lc-rs

--- a/tests/unit/profile/Cargo.toml
+++ b/tests/unit/profile/Cargo.toml
@@ -17,4 +17,4 @@ ipc-channel = { workspace = true }
 profile = { path = "../../../components/profile" }
 profile_traits = { workspace = true }
 servo_config = { path = "../../../components/config" }
-time_03 = { workspace = true }
+time = { workspace = true }

--- a/tests/unit/profile/time.rs
+++ b/tests/unit/profile/time.rs
@@ -4,12 +4,12 @@
 
 use std::thread;
 
+use ::time::Duration;
 use ipc_channel::ipc;
 use profile::time;
 use profile_traits::ipc as ProfiledIpc;
 use profile_traits::time::{ProfilerCategory, ProfilerData, ProfilerMsg};
 use servo_config::opts::OutputOptions;
-use time_03::Duration;
 
 #[test]
 fn time_profiler_smoke_test() {


### PR DESCRIPTION
In addition to some small API changes, this downstream version of
WebRender no longer depends on a very old version of time. This is the
last step toward removing the dependency on `time0.1`.

The review for this commit should also include: https://github.com/servo/webrender/commit/9f552bebab81a73e62068c42d94be2f9c0586ce4

<!-- Please describe your changes on the following line: -->

This is part of #30150.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
