### PR TITLE
Mach:  use blessed instead of blessings for terminal wrapper library

### DIFF
--- a/python/mach/mach/logging.py
+++ b/python/mach/mach/logging.py
@@ -9,9 +9,9 @@
 from __future__ import absolute_import, unicode_literals
 
 try:
-    import blessings
+    import blessed
 except ImportError:
-    blessings = None
+    blessed = None
 
 import json
 import logging
@@ -93,7 +93,7 @@ class StructuredTerminalFormatter(StructuredHumanFormatter):
 
     def set_terminal(self, terminal):
         self.terminal = terminal
-        self._sgr0 = terminal.normal if terminal and blessings else ''
+        self._sgr0 = terminal.normal if terminal and blessed else ''
 
     def format(self, record):
         f = record.msg.format(**record.params)
@@ -172,11 +172,11 @@ class LoggingManager(object):
 
     @property
     def terminal(self):
-        if not self._terminal and blessings:
+        if not self._terminal and blessed:
             # Sometimes blessings fails to set up the terminal. In that case,
             # silently fail.
             try:
-                terminal = blessings.Terminal(stream=sys.stdout)
+                terminal = blessed.Terminal(stream=sys.stdout)
 
                 if terminal.is_a_tty:
                     self._terminal = terminal

--- a/python/mach/setup.py
+++ b/python/mach/setup.py
@@ -29,7 +29,7 @@ setup(
         'Programming Language :: Python :: 3.10',
     ],
     install_requires=[
-        'blessings',
+        'blessed',
         'mozfile',
         'mozprocess',
         'six',

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,7 +1,7 @@
 # Ensure all versions are pinned for repeatability,
 # since `--system-site-packages` is enabled
 
-blessings == 1.7
+blessed == 1.20.0
 distro == 1.4
 mozinfo == 1.2.3
 mozlog == 8.0.0

--- a/python/wpt/grouping_formatter.py
+++ b/python/wpt/grouping_formatter.py
@@ -238,8 +238,8 @@ class ServoFormatter(mozlog.formatters.base.BaseFormatter, ServoHandler):
             self.clear_eol = DEFAULT_CLEAR_EOL_CODE
 
             try:
-                import blessings
-                self.terminal = blessings.Terminal()
+                import blessed
+                self.terminal = blessed.Terminal()
                 self.move_up = self.terminal.move_up
                 self.clear_eol = self.terminal.clear_eol
             except Exception as exception:


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Based on the [comment](https://github.com/erikrose/blessings/issues/166#issuecomment-1859025370) in the Python dependency package's GitHub repository, replace the unmaintained library with its actively maintained fork.



---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes help with running wpt-test in windows https://github.com/servo/servo/issues/35238

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
