### PR TITLE
Correctly compute traversal parent for assigned `Text` nodes

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -613,43 +613,6 @@ impl Element {
             Some(node) => node.is::<Document>(),
         }
     }
-
-    pub(crate) fn assigned_slot(&self) -> Option<DomRoot<HTMLSlotElement>> {
-        let assigned_slot = self
-            .rare_data
-            .borrow()
-            .as_ref()?
-            .slottable_data
-            .assigned_slot
-            .as_ref()?
-            .as_rooted();
-        Some(assigned_slot)
-    }
-
-    pub(crate) fn set_assigned_slot(&self, assigned_slot: Option<&HTMLSlotElement>) {
-        self.ensure_rare_data().slottable_data.assigned_slot = assigned_slot.map(Dom::from_ref);
-    }
-
-    pub(crate) fn manual_slot_assignment(&self) -> Option<DomRoot<HTMLSlotElement>> {
-        let manually_assigned_slot = self
-            .rare_data
-            .borrow()
-            .as_ref()?
-            .slottable_data
-            .manual_slot_assignment
-            .as_ref()?
-            .as_rooted();
-        Some(manually_assigned_slot)
-    }
-
-    pub(crate) fn set_manual_slot_assignment(
-        &self,
-        manually_assigned_slot: Option<&HTMLSlotElement>,
-    ) {
-        self.ensure_rare_data()
-            .slottable_data
-            .manual_slot_assignment = manually_assigned_slot.map(Dom::from_ref);
-    }
 }
 
 /// <https://dom.spec.whatwg.org/#valid-shadow-host-name>
@@ -727,7 +690,6 @@ pub(crate) trait LayoutElementHelpers<'dom> {
     ) -> Option<&'dom AttrValue>;
     fn get_attr_val_for_layout(self, namespace: &Namespace, name: &LocalName) -> Option<&'dom str>;
     fn get_attr_vals_for_layout(self, name: &LocalName) -> Vec<&'dom AttrValue>;
-    fn get_assigned_slot(&self) -> Option<LayoutDom<'dom, HTMLSlotElement>>;
 }
 
 impl LayoutDom<'_, Element> {
@@ -1260,20 +1222,6 @@ impl<'dom> LayoutElementHelpers<'dom> for LayoutDom<'dom, Element> {
                 }
             })
             .collect()
-    }
-
-    #[allow(unsafe_code)]
-    fn get_assigned_slot(&self) -> Option<LayoutDom<'dom, HTMLSlotElement>> {
-        unsafe {
-            self.unsafe_get()
-                .rare_data
-                .borrow_for_layout()
-                .as_ref()?
-                .slottable_data
-                .assigned_slot
-                .as_ref()
-                .map(|slot| slot.to_layout())
-        }
     }
 }
 

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -41,7 +41,6 @@ use crate::dom::bindings::codegen::Bindings::NodeBinding::GetRootNodeOptions;
 use crate::dom::bindings::codegen::Bindings::NodeBinding::Node_Binding::NodeMethods;
 use crate::dom::bindings::codegen::Bindings::ShadowRootBinding::ShadowRoot_Binding::ShadowRootMethods;
 use crate::dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
-use crate::dom::bindings::codegen::InheritTypes::{CharacterDataTypeId, NodeTypeId};
 use crate::dom::bindings::codegen::UnionTypes::{
     AddEventListenerOptionsOrBoolean, EventListenerOptionsOrBoolean, EventOrString,
 };
@@ -61,7 +60,6 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::htmlformelement::FormControlElementHelpers;
 use crate::dom::node::{Node, NodeTraits};
 use crate::dom::shadowroot::ShadowRoot;
-use crate::dom::text::Text;
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::dom::window::Window;
 use crate::dom::workerglobalscope::WorkerGlobalScope;
@@ -821,25 +819,7 @@ impl EventTarget {
         if let Some(node) = self.downcast::<Node>() {
             // > A node’s get the parent algorithm, given an event, returns the node’s assigned slot,
             // > if node is assigned; otherwise node’s parent.
-            let assigned_slot = match node.type_id() {
-                NodeTypeId::Element(_) => {
-                    let element = node.downcast::<Element>().unwrap();
-                    element
-                        .assigned_slot()
-                        .map(|slot| DomRoot::from_ref(slot.upcast::<EventTarget>()))
-                },
-                NodeTypeId::CharacterData(CharacterDataTypeId::Text(_)) => {
-                    let text = node.downcast::<Text>().unwrap();
-                    text.slottable_data()
-                        .borrow()
-                        .assigned_slot
-                        .as_ref()
-                        .map(|slot| DomRoot::from_ref(slot.upcast::<EventTarget>()))
-                },
-                _ => None,
-            };
-
-            return assigned_slot.or_else(|| {
+            return node.assigned_slot().map(DomRoot::upcast).or_else(|| {
                 node.GetParentNode()
                     .map(|parent| DomRoot::from_ref(parent.upcast::<EventTarget>()))
             });

--- a/components/script/dom/raredata.rs
+++ b/components/script/dom/raredata.rs
@@ -32,6 +32,8 @@ pub(crate) struct NodeRareData {
     pub(crate) mutation_observers: Vec<RegisteredObserver>,
     /// Lazily-generated Unique Id for this node.
     pub(crate) unique_id: Option<UniqueId>,
+
+    pub(crate) slottable_data: SlottableData,
 }
 
 #[derive(Default, JSTraceable, MallocSizeOf)]
@@ -39,8 +41,6 @@ pub(crate) struct NodeRareData {
 pub(crate) struct ElementRareData {
     /// <https://dom.spec.whatwg.org/#dom-element-shadowroot>
     /// The ShadowRoot this element is host of.
-    /// XXX This is currently not exposed to web content. Only for
-    ///     internal use.
     pub(crate) shadow_root: Option<Dom<ShadowRoot>>,
     /// <https://html.spec.whatwg.org/multipage/#custom-element-reaction-queue>
     pub(crate) custom_element_reaction_queue: Vec<CustomElementReaction>,
@@ -58,6 +58,4 @@ pub(crate) struct ElementRareData {
     pub(crate) client_rect: Option<LayoutValue<Rect<i32>>>,
     /// <https://html.spec.whatwg.org/multipage#elementinternals>
     pub(crate) element_internals: Option<Dom<ElementInternals>>,
-
-    pub(crate) slottable_data: SlottableData,
 }

--- a/components/script/dom/text.rs
+++ b/components/script/dom/text.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::cell::RefCell;
-
 use dom_struct::dom_struct;
 use js::rust::HandleObject;
 
@@ -19,7 +17,7 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::characterdata::CharacterData;
 use crate::dom::document::Document;
 use crate::dom::globalscope::GlobalScope;
-use crate::dom::htmlslotelement::{HTMLSlotElement, Slottable, SlottableData};
+use crate::dom::htmlslotelement::{HTMLSlotElement, Slottable};
 use crate::dom::node::Node;
 use crate::dom::window::Window;
 use crate::script_runtime::CanGc;
@@ -28,14 +26,12 @@ use crate::script_runtime::CanGc;
 #[dom_struct]
 pub(crate) struct Text {
     characterdata: CharacterData,
-    slottable_data: RefCell<SlottableData>,
 }
 
 impl Text {
     pub(crate) fn new_inherited(text: DOMString, document: &Document) -> Text {
         Text {
             characterdata: CharacterData::new_inherited(text, document),
-            slottable_data: Default::default(),
         }
     }
 
@@ -55,10 +51,6 @@ impl Text {
             proto,
             can_gc,
         )
-    }
-
-    pub(crate) fn slottable_data(&self) -> &RefCell<SlottableData> {
-        &self.slottable_data
     }
 }
 

--- a/components/script/layout_dom/element.rs
+++ b/components/script/layout_dom/element.rs
@@ -140,11 +140,6 @@ impl<'dom> ServoLayoutElement<'dom> {
             Some(node) => matches!(node.script_type_id(), NodeTypeId::Document(_)),
         }
     }
-
-    fn assigned_slot(&self) -> Option<Self> {
-        let slot = self.element.get_assigned_slot()?;
-        Some(Self::from_layout_js(slot.upcast()))
-    }
 }
 
 pub enum DOMDescendantIterator<E>
@@ -204,11 +199,7 @@ impl<'dom> style::dom::TElement for ServoLayoutElement<'dom> {
     }
 
     fn traversal_parent(&self) -> Option<Self> {
-        if let Some(assigned_slot) = self.assigned_slot() {
-            Some(assigned_slot)
-        } else {
-            self.as_node().traversal_parent()
-        }
+        self.as_node().traversal_parent()
     }
 
     fn is_html_element(&self) -> bool {
@@ -752,7 +743,7 @@ impl<'dom> ::selectors::Element for ServoLayoutElement<'dom> {
 
     #[allow(unsafe_code)]
     fn assigned_slot(&self) -> Option<Self> {
-        self.assigned_slot()
+        self.as_node().assigned_slot()
     }
 
     fn is_html_element_in_html_document(&self) -> bool {

--- a/components/script/layout_dom/node.rs
+++ b/components/script/layout_dom/node.rs
@@ -94,6 +94,14 @@ impl<'dom> ServoLayoutNode<'dom> {
     pub(crate) fn get_jsmanaged(self) -> LayoutDom<'dom, Node> {
         self.node
     }
+
+    pub(crate) fn assigned_slot(self) -> Option<ServoLayoutElement<'dom>> {
+        self.node
+            .assigned_slot_for_layout()
+            .as_ref()
+            .map(LayoutDom::upcast)
+            .map(ServoLayoutElement::from_layout_js)
+    }
 }
 
 impl style::dom::NodeInfo for ServoLayoutNode<'_> {
@@ -139,6 +147,9 @@ impl<'dom> style::dom::TNode for ServoLayoutNode<'dom> {
     }
 
     fn traversal_parent(&self) -> Option<ServoLayoutElement<'dom>> {
+        if let Some(assigned_slot) = self.assigned_slot() {
+            return Some(assigned_slot);
+        }
         let parent = self.parent_node()?;
         if let Some(shadow) = parent.as_shadow_root() {
             return Some(shadow.host());

--- a/tests/unit/script/size_of.rs
+++ b/tests/unit/script/size_of.rs
@@ -35,5 +35,5 @@ sizeof_checker!(size_element, Element, 376);
 sizeof_checker!(size_htmlelement, HTMLElement, 392);
 sizeof_checker!(size_div, HTMLDivElement, 392);
 sizeof_checker!(size_span, HTMLSpanElement, 392);
-sizeof_checker!(size_text, Text, 256);
+sizeof_checker!(size_text, Text, 232);
 sizeof_checker!(size_characterdata, CharacterData, 232);


### PR DESCRIPTION
Implements ServoLayoutNode::traversal_parent. This fixes common crash related to slottables, currently present on wpt.fyi and in #35261.

Previously, the traversal parent of `Text` nodes was incorrectly assumed to always be the parent or shadow host. That caused crashes inside stylo's bloom filter. Now the traversal parent is the slot that the node is assigned to, if any, and the parent/shadow host otherwise.

The slottable data for Text/Element nodes is now stored in NodeRareData. This is very cheap, because NodeRareData will already be instantiated for assigned slottables anyways, because the containing_shadow_root field will be set (since assigned slottables are always in a shadow tree). This change is necessary because we need to hand out references to the assigned slot to stylo and that is not possible to do (without unsafe code) if we need to downcast the node first.

As a side effect, this reduces the size of `Text` from 256 to 232 bytes, because the slottable data is no longer stored there.

For reference, here is the backtrace from the stylo crash:
<details><summary>Log</summary>

```
assertion `left == right` failed
  left: 9
 right: 8 (thread Script(1,1), at /home/alaska/.cargo/git/checkouts/stylo-d5871ad1ba1940d3/4359cb6/style/traversal.rs:591)
   0: servoshell::backtrace::print
   1: servoshell::panic_hook::panic_hook
   2: std::panicking::rust_panic_with_hook
   3: std::panicking::begin_panic_handler::{{closure}}
   4: std::sys::backtrace::__rust_end_short_backtrace
   5: rust_begin_unwind
   6: core::panicking::panic_fmt
   7: core::panicking::assert_failed_inner
   8: core::panicking::assert_failed
   9: <layout_2020::traversal::RecalcStyle as style::traversal::DomTraversal<E>>::process_preorder
  10: style::parallel::style_trees
  11: style::driver::traverse_dom::{{closure}}
  12: style::driver::with_pool_in_place_scope
  13: style::driver::traverse_dom
  14: <layout_thread_2020::LayoutThread as script_layout_interface::Layout>::reflow
  15: script::dom::window::Window::reflow
  16: script::script_thread::ScriptThread::update_the_rendering
  17: script::script_thread::ScriptThread::handle_msgs
  18: script::script_thread::ScriptThread::start
  19: profile_traits::mem::ProfilerChan::run_with_memory_reporting
  20: std::sys::backtrace::__rust_begin_short_backtrace
  21: core::ops::function::FnOnce::call_once{{vtable.shim}}
  22: std::sys::pal::unix::thread::Thread::new::thread_start
  23: start_thread
  24: __clone3
```
</details>

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] **These changes are not covered by tests**. I did not find a reduced reproduction for the crash before I fixed it. However, this is covered by `/html/semantics/interactive-elements/the-details-element/details-cq-crash.html` once #35261 merges

