### PR TITLE
make report_pending_exception safe and adjust callers

### DIFF
--- a/components/script/dom/bindings/callback.rs
+++ b/components/script/dom/bindings/callback.rs
@@ -278,12 +278,12 @@ impl Drop for CallSetup {
     fn drop(&mut self) {
         unsafe {
             LeaveRealm(*self.cx, self.old_realm);
-            if self.handling == ExceptionHandling::Report {
-                let ar = enter_realm(&*self.exception_global);
-                report_pending_exception(*self.cx, true, InRealm::Entered(&ar), CanGc::note());
-            }
-            drop(self.incumbent_script.take());
-            drop(self.entry_script.take().unwrap());
         }
+        if self.handling == ExceptionHandling::Report {
+            let ar = enter_realm(&*self.exception_global);
+            report_pending_exception(self.cx, true, InRealm::Entered(&ar), CanGc::note());
+        }
+        drop(self.incumbent_script.take());
+        drop(self.entry_script.take().unwrap());
     }
 }

--- a/components/script/dom/create.rs
+++ b/components/script/dom/create.rs
@@ -187,11 +187,10 @@ fn create_html_element(
 
                             // Substep 1. Report exception for definition’s constructor’s corresponding
                             // JavaScript object’s associated realm’s global object.
-                            unsafe {
-                                let ar = enter_realm(&*global);
-                                throw_dom_exception(cx, &global, error);
-                                report_pending_exception(*cx, true, InRealm::Entered(&ar), can_gc);
-                            }
+
+                            let ar = enter_realm(&*global);
+                            throw_dom_exception(cx, &global, error);
+                            report_pending_exception(cx, true, InRealm::Entered(&ar), can_gc);
 
                             // Substep 2. Set result to a new element that implements the HTMLUnknownElement interface,
                             // with no attributes, namespace set to the HTML namespace, namespace prefix set to prefix,

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -786,7 +786,6 @@ impl CustomElementDefinition {
 }
 
 /// <https://html.spec.whatwg.org/multipage/#concept-upgrade-an-element>
-#[allow(unsafe_code)]
 pub(crate) fn upgrade_element(
     definition: Rc<CustomElementDefinition>,
     element: &Element,
@@ -848,11 +847,9 @@ pub(crate) fn upgrade_element(
         // Step 8.exception.3
         let global = GlobalScope::current().expect("No current global");
         let cx = GlobalScope::get_cx();
-        unsafe {
-            let ar = enter_realm(&*global);
-            throw_dom_exception(cx, &global, error);
-            report_pending_exception(*cx, true, InRealm::Entered(&ar), can_gc);
-        }
+        let ar = enter_realm(&*global);
+        throw_dom_exception(cx, &global, error);
+        report_pending_exception(cx, true, InRealm::Entered(&ar), can_gc);
 
         return;
     }

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -582,11 +582,9 @@ impl EventTarget {
         });
         if handler.get().is_null() {
             // Step 3.7
-            unsafe {
-                let ar = enter_realm(self);
-                // FIXME(#13152): dispatch error event.
-                report_pending_exception(*cx, false, InRealm::Entered(&ar), can_gc);
-            }
+            let ar = enter_realm(self);
+            // FIXME(#13152): dispatch error event.
+            report_pending_exception(cx, false, InRealm::Entered(&ar), can_gc);
             return None;
         }
 

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -2549,7 +2549,7 @@ impl GlobalScope {
 
                     if compiled_script.is_null() {
                         debug!("error compiling Dom string");
-                        report_pending_exception(*cx, true, InRealm::Entered(&ar), can_gc);
+                        report_pending_exception(cx, true, InRealm::Entered(&ar), can_gc);
                         return false;
                     }
                 },
@@ -2598,7 +2598,7 @@ impl GlobalScope {
 
             if !result {
                 debug!("error evaluating Dom string");
-                report_pending_exception(*cx, true, InRealm::Entered(&ar), can_gc);
+                report_pending_exception(cx, true, InRealm::Entered(&ar), can_gc);
             }
 
             maybe_resume_unwind();

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -499,7 +499,12 @@ impl WorkerGlobalScope {
                     println!("evaluate_script failed");
                     unsafe {
                         let ar = enter_realm(self);
-                        report_pending_exception(cx, true, InRealm::Entered(&ar), can_gc);
+                        report_pending_exception(
+                            JSContext::from_ptr(cx),
+                            true,
+                            InRealm::Entered(&ar),
+                            can_gc,
+                        );
                     }
                 }
             },

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -593,20 +593,15 @@ impl ModuleTree {
         let module_error = self.rethrow_error.borrow();
 
         if let Some(exception) = &*module_error {
+            let ar = enter_realm(global);
             unsafe {
-                let ar = enter_realm(global);
                 JS_SetPendingException(
                     *GlobalScope::get_cx(),
                     exception.handle(),
                     ExceptionStackBehavior::Capture,
                 );
-                report_pending_exception(
-                    *GlobalScope::get_cx(),
-                    true,
-                    InRealm::Entered(&ar),
-                    can_gc,
-                );
             }
+            report_pending_exception(GlobalScope::get_cx(), true, InRealm::Entered(&ar), can_gc);
         }
     }
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This makes report_pending_exception safe as noted in #35339. I also adjusted the callers, but the body of the function is still unsafe due to unsafe JS_* functions and the scope needed to call those. This might be not in the spirit of the request; open to suggestions. 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #35339  (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because they were specifically not requested in the issue.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
