### PR TITLE
Add support for the `::slotted` selector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1008,7 +1008,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1668,7 +1668,7 @@ dependencies = [
 [[package]]
 name = "dom"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-02-03#4359cb61ff09a1db6f11d523aad6796395d7b5ba"
+source = "git+https://github.com/servo/stylo?branch=2025-02-03#ac16e64ad4c1fe44adef412a30f6f317f01637a7"
 dependencies = [
  "bitflags 2.8.0",
  "malloc_size_of",
@@ -1945,7 +1945,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2472,7 +2472,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3924,7 +3924,7 @@ checksum = "e19b23d53f35ce9f56aebc7d1bb4e6ac1e9c0db7ac85c8d1760c04379edced37"
 dependencies = [
  "hermit-abi 0.4.0",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4270,7 +4270,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -4446,7 +4446,7 @@ dependencies = [
 [[package]]
 name = "malloc_size_of"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-02-03#4359cb61ff09a1db6f11d523aad6796395d7b5ba"
+source = "git+https://github.com/servo/stylo?branch=2025-02-03#ac16e64ad4c1fe44adef412a30f6f317f01637a7"
 dependencies = [
  "app_units",
  "cssparser",
@@ -6131,7 +6131,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6441,7 +6441,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.26.0"
-source = "git+https://github.com/servo/stylo?branch=2025-02-03#4359cb61ff09a1db6f11d523aad6796395d7b5ba"
+source = "git+https://github.com/servo/stylo?branch=2025-02-03#ac16e64ad4c1fe44adef412a30f6f317f01637a7"
 dependencies = [
  "bitflags 2.8.0",
  "cssparser",
@@ -6726,7 +6726,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.0"
-source = "git+https://github.com/servo/stylo?branch=2025-02-03#4359cb61ff09a1db6f11d523aad6796395d7b5ba"
+source = "git+https://github.com/servo/stylo?branch=2025-02-03#ac16e64ad4c1fe44adef412a30f6f317f01637a7"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -6735,7 +6735,7 @@ dependencies = [
 [[package]]
 name = "servo_atoms"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-02-03#4359cb61ff09a1db6f11d523aad6796395d7b5ba"
+source = "git+https://github.com/servo/stylo?branch=2025-02-03#ac16e64ad4c1fe44adef412a30f6f317f01637a7"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -7104,7 +7104,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "static_prefs"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-02-03#4359cb61ff09a1db6f11d523aad6796395d7b5ba"
+source = "git+https://github.com/servo/stylo?branch=2025-02-03#ac16e64ad4c1fe44adef412a30f6f317f01637a7"
 
 [[package]]
 name = "strck"
@@ -7184,7 +7184,7 @@ dependencies = [
 [[package]]
 name = "style"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-02-03#4359cb61ff09a1db6f11d523aad6796395d7b5ba"
+source = "git+https://github.com/servo/stylo?branch=2025-02-03#ac16e64ad4c1fe44adef412a30f6f317f01637a7"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -7242,7 +7242,7 @@ dependencies = [
 [[package]]
 name = "style_config"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-02-03#4359cb61ff09a1db6f11d523aad6796395d7b5ba"
+source = "git+https://github.com/servo/stylo?branch=2025-02-03#ac16e64ad4c1fe44adef412a30f6f317f01637a7"
 dependencies = [
  "lazy_static",
 ]
@@ -7250,7 +7250,7 @@ dependencies = [
 [[package]]
 name = "style_derive"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-02-03#4359cb61ff09a1db6f11d523aad6796395d7b5ba"
+source = "git+https://github.com/servo/stylo?branch=2025-02-03#ac16e64ad4c1fe44adef412a30f6f317f01637a7"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -7280,7 +7280,7 @@ dependencies = [
 [[package]]
 name = "style_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-02-03#4359cb61ff09a1db6f11d523aad6796395d7b5ba"
+source = "git+https://github.com/servo/stylo?branch=2025-02-03#ac16e64ad4c1fe44adef412a30f6f317f01637a7"
 dependencies = [
  "app_units",
  "bitflags 2.8.0",
@@ -7445,7 +7445,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7686,7 +7686,7 @@ dependencies = [
 [[package]]
 name = "to_shmem"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-02-03#4359cb61ff09a1db6f11d523aad6796395d7b5ba"
+source = "git+https://github.com/servo/stylo?branch=2025-02-03#ac16e64ad4c1fe44adef412a30f6f317f01637a7"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -7699,7 +7699,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-02-03#4359cb61ff09a1db6f11d523aad6796395d7b5ba"
+source = "git+https://github.com/servo/stylo?branch=2025-02-03#ac16e64ad4c1fe44adef412a30f6f317f01637a7"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -8745,7 +8745,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/tests/wpt/meta/css/css-cascade/layer-slotted-rule.html.ini
+++ b/tests/wpt/meta/css/css-cascade/layer-slotted-rule.html.ini
@@ -1,2 +1,0 @@
-[layer-slotted-rule.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-cascade/revert-layer-014.html.ini
+++ b/tests/wpt/meta/css/css-cascade/revert-layer-014.html.ini
@@ -1,2 +1,0 @@
-[revert-layer-014.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/selectors/i18n/lang-pseudo-class-across-shadow-boundaries.html.ini
+++ b/tests/wpt/meta/css/selectors/i18n/lang-pseudo-class-across-shadow-boundaries.html.ini
@@ -1,2 +1,0 @@
-[lang-pseudo-class-across-shadow-boundaries.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/selectors/parsing/parse-slotted.html.ini
+++ b/tests/wpt/meta/css/selectors/parsing/parse-slotted.html.ini
@@ -1,27 +1,3 @@
 [parse-slotted.html]
-  ["::slotted(bar)" should be a valid selector]
-    expected: FAIL
-
-  ["::slotted([attr=\\"foo\\"\])" should be a valid selector]
-    expected: FAIL
-
-  ["::slotted(*)" should be a valid selector]
-    expected: FAIL
-
-  ["::slotted(.class)" should be a valid selector]
-    expected: FAIL
-
-  ["::slotted(:not(foo))" should be a valid selector]
-    expected: FAIL
-
-  ["::slotted(:not(:nth-last-of-type(2)):not([slot=\\"foo\\"\]))" should be a valid selector]
-    expected: FAIL
-
-  ["::slotted(:first-child)" should be a valid selector]
-    expected: FAIL
-
-  ["::slotted(:hover)" should be a valid selector]
-    expected: FAIL
-
   ["::slotted(:has(:first-child:last-child))" should be a valid selector]
     expected: FAIL

--- a/tests/wpt/meta/dom/nodes/ParentNode-querySelector-All-xht.xht.ini
+++ b/tests/wpt/meta/dom/nodes/ParentNode-querySelector-All-xht.xht.ini
@@ -1,7 +1,4 @@
 [ParentNode-querySelector-All-xht.xht]
-  [Detached Element.querySelectorAll: Slotted selector (no matching closing paren): ::slotted(foo]
-    expected: FAIL
-
   [Document.querySelector: :first-line pseudo-element (one-colon syntax) selector, not matching any elements: #pseudo-element:first-line]
     expected: FAIL
 
@@ -17,16 +14,7 @@
   [In-document Element.querySelectorAll: :first-line pseudo-element (one-colon syntax) selector, not matching any elements: #pseudo-element:first-line]
     expected: FAIL
 
-  [Document.querySelectorAll: Slotted selector (no matching closing paren): ::slotted(foo]
-    expected: FAIL
-
   [Fragment.querySelectorAll: :first-line pseudo-element (one-colon syntax) selector, not matching any elements: #pseudo-element:first-line]
-    expected: FAIL
-
-  [Document.querySelector: Slotted selector: ::slotted(foo)]
-    expected: FAIL
-
-  [Detached Element.querySelector: Slotted selector (no matching closing paren): ::slotted(foo]
     expected: FAIL
 
   [In-document Element.querySelector: :first-line pseudo-element (one-colon syntax) selector, not matching any elements: #pseudo-element:first-line]
@@ -44,28 +32,13 @@
   [Document.querySelector: ::first-letter pseudo-element (two-colon syntax) selector, not matching any elements: #pseudo-element::first-letter]
     expected: FAIL
 
-  [Detached Element.querySelector: Slotted selector: ::slotted(foo)]
-    expected: FAIL
-
-  [In-document Element.querySelector: Slotted selector: ::slotted(foo)]
-    expected: FAIL
-
-  [Fragment.querySelector: Slotted selector (no matching closing paren): ::slotted(foo]
-    expected: FAIL
-
   [Detached Element.querySelector: :first-line pseudo-element (one-colon syntax) selector, not matching any elements: #pseudo-element:first-line]
     expected: FAIL
 
   [Document.querySelector: :link and :visited pseudo-class selectors, matching no elements: #head :link, #head :visited]
     expected: FAIL
 
-  [Fragment.querySelector: Slotted selector: ::slotted(foo)]
-    expected: FAIL
-
   [In-document Element.querySelectorAll: :first-letter pseudo-element (one-colon syntax) selector, not matching any elements: #pseudo-element:first-letter]
-    expected: FAIL
-
-  [Fragment.querySelectorAll: Slotted selector: ::slotted(foo)]
     expected: FAIL
 
   [Fragment.querySelector: :first-letter pseudo-element (one-colon syntax) selector, not matching any elements: #pseudo-element:first-letter]
@@ -83,16 +56,10 @@
   [Detached Element.querySelectorAll: :first-line pseudo-element (one-colon syntax) selector, not matching any elements: #pseudo-element:first-line]
     expected: FAIL
 
-  [Detached Element.querySelectorAll: Slotted selector: ::slotted(foo)]
-    expected: FAIL
-
   [Detached Element.querySelector: ::first-letter pseudo-element (two-colon syntax) selector, not matching any elements: #pseudo-element::first-letter]
     expected: FAIL
 
   [In-document Element.querySelectorAll: ::first-letter pseudo-element (two-colon syntax) selector, not matching any elements: #pseudo-element::first-letter]
-    expected: FAIL
-
-  [In-document Element.querySelectorAll: Slotted selector (no matching closing paren): ::slotted(foo]
     expected: FAIL
 
   [Document.querySelectorAll: :first-letter pseudo-element (one-colon syntax) selector, not matching any elements: #pseudo-element:first-letter]
@@ -104,19 +71,10 @@
   [Detached Element.querySelectorAll: ::first-line pseudo-element (two-colon syntax) selector, not matching any elements: #pseudo-element::first-line]
     expected: FAIL
 
-  [Document.querySelectorAll: Slotted selector: ::slotted(foo)]
-    expected: FAIL
-
-  [Fragment.querySelectorAll: Slotted selector (no matching closing paren): ::slotted(foo]
-    expected: FAIL
-
   [Detached Element.querySelectorAll: :first-letter pseudo-element (one-colon syntax) selector, not matching any elements: #pseudo-element:first-letter]
     expected: FAIL
 
   [Document.querySelectorAll: :first-line pseudo-element (one-colon syntax) selector, not matching any elements: #pseudo-element:first-line]
-    expected: FAIL
-
-  [Document.querySelector: Slotted selector (no matching closing paren): ::slotted(foo]
     expected: FAIL
 
   [Fragment.querySelectorAll: ::first-letter pseudo-element (two-colon syntax) selector, not matching any elements: #pseudo-element::first-letter]
@@ -128,16 +86,10 @@
   [Fragment.querySelector: ::first-letter pseudo-element (two-colon syntax) selector, not matching any elements: #pseudo-element::first-letter]
     expected: FAIL
 
-  [In-document Element.querySelectorAll: Slotted selector: ::slotted(foo)]
-    expected: FAIL
-
   [Fragment.querySelector: ::first-line pseudo-element (two-colon syntax) selector, not matching any elements: #pseudo-element::first-line]
     expected: FAIL
 
   [In-document Element.querySelector: :first-letter pseudo-element (one-colon syntax) selector, not matching any elements: #pseudo-element:first-letter]
-    expected: FAIL
-
-  [In-document Element.querySelector: Slotted selector (no matching closing paren): ::slotted(foo]
     expected: FAIL
 
   [Fragment.querySelector: :first-line pseudo-element (one-colon syntax) selector, not matching any elements: #pseudo-element:first-line]
@@ -148,4 +100,3 @@
 
   [Document.querySelectorAll: ::first-line pseudo-element (two-colon syntax) selector, not matching any elements: #pseudo-element::first-line]
     expected: FAIL
-

--- a/tests/wpt/meta/dom/nodes/ParentNode-querySelector-All.html.ini
+++ b/tests/wpt/meta/dom/nodes/ParentNode-querySelector-All.html.ini
@@ -1,7 +1,4 @@
 [ParentNode-querySelector-All.html]
-  [Detached Element.querySelectorAll: Slotted selector (no matching closing paren): ::slotted(foo]
-    expected: FAIL
-
   [Document.querySelector: :first-line pseudo-element (one-colon syntax) selector, not matching any elements: #pseudo-element:first-line]
     expected: FAIL
 
@@ -17,16 +14,7 @@
   [In-document Element.querySelectorAll: :first-line pseudo-element (one-colon syntax) selector, not matching any elements: #pseudo-element:first-line]
     expected: FAIL
 
-  [Document.querySelectorAll: Slotted selector (no matching closing paren): ::slotted(foo]
-    expected: FAIL
-
   [Fragment.querySelectorAll: :first-line pseudo-element (one-colon syntax) selector, not matching any elements: #pseudo-element:first-line]
-    expected: FAIL
-
-  [Document.querySelector: Slotted selector: ::slotted(foo)]
-    expected: FAIL
-
-  [Detached Element.querySelector: Slotted selector (no matching closing paren): ::slotted(foo]
     expected: FAIL
 
   [In-document Element.querySelector: :first-line pseudo-element (one-colon syntax) selector, not matching any elements: #pseudo-element:first-line]
@@ -44,28 +32,13 @@
   [Document.querySelector: ::first-letter pseudo-element (two-colon syntax) selector, not matching any elements: #pseudo-element::first-letter]
     expected: FAIL
 
-  [Detached Element.querySelector: Slotted selector: ::slotted(foo)]
-    expected: FAIL
-
-  [In-document Element.querySelector: Slotted selector: ::slotted(foo)]
-    expected: FAIL
-
-  [Fragment.querySelector: Slotted selector (no matching closing paren): ::slotted(foo]
-    expected: FAIL
-
   [Detached Element.querySelector: :first-line pseudo-element (one-colon syntax) selector, not matching any elements: #pseudo-element:first-line]
     expected: FAIL
 
   [Document.querySelector: :link and :visited pseudo-class selectors, matching no elements: #head :link, #head :visited]
     expected: FAIL
 
-  [Fragment.querySelector: Slotted selector: ::slotted(foo)]
-    expected: FAIL
-
   [In-document Element.querySelectorAll: :first-letter pseudo-element (one-colon syntax) selector, not matching any elements: #pseudo-element:first-letter]
-    expected: FAIL
-
-  [Fragment.querySelectorAll: Slotted selector: ::slotted(foo)]
     expected: FAIL
 
   [Fragment.querySelector: :first-letter pseudo-element (one-colon syntax) selector, not matching any elements: #pseudo-element:first-letter]
@@ -83,16 +56,10 @@
   [Detached Element.querySelectorAll: :first-line pseudo-element (one-colon syntax) selector, not matching any elements: #pseudo-element:first-line]
     expected: FAIL
 
-  [Detached Element.querySelectorAll: Slotted selector: ::slotted(foo)]
-    expected: FAIL
-
   [Detached Element.querySelector: ::first-letter pseudo-element (two-colon syntax) selector, not matching any elements: #pseudo-element::first-letter]
     expected: FAIL
 
   [In-document Element.querySelectorAll: ::first-letter pseudo-element (two-colon syntax) selector, not matching any elements: #pseudo-element::first-letter]
-    expected: FAIL
-
-  [In-document Element.querySelectorAll: Slotted selector (no matching closing paren): ::slotted(foo]
     expected: FAIL
 
   [Document.querySelectorAll: :first-letter pseudo-element (one-colon syntax) selector, not matching any elements: #pseudo-element:first-letter]
@@ -104,19 +71,10 @@
   [Detached Element.querySelectorAll: ::first-line pseudo-element (two-colon syntax) selector, not matching any elements: #pseudo-element::first-line]
     expected: FAIL
 
-  [Document.querySelectorAll: Slotted selector: ::slotted(foo)]
-    expected: FAIL
-
-  [Fragment.querySelectorAll: Slotted selector (no matching closing paren): ::slotted(foo]
-    expected: FAIL
-
   [Detached Element.querySelectorAll: :first-letter pseudo-element (one-colon syntax) selector, not matching any elements: #pseudo-element:first-letter]
     expected: FAIL
 
   [Document.querySelectorAll: :first-line pseudo-element (one-colon syntax) selector, not matching any elements: #pseudo-element:first-line]
-    expected: FAIL
-
-  [Document.querySelector: Slotted selector (no matching closing paren): ::slotted(foo]
     expected: FAIL
 
   [Fragment.querySelectorAll: ::first-letter pseudo-element (two-colon syntax) selector, not matching any elements: #pseudo-element::first-letter]
@@ -128,16 +86,10 @@
   [Fragment.querySelector: ::first-letter pseudo-element (two-colon syntax) selector, not matching any elements: #pseudo-element::first-letter]
     expected: FAIL
 
-  [In-document Element.querySelectorAll: Slotted selector: ::slotted(foo)]
-    expected: FAIL
-
   [Fragment.querySelector: ::first-line pseudo-element (two-colon syntax) selector, not matching any elements: #pseudo-element::first-line]
     expected: FAIL
 
   [In-document Element.querySelector: :first-letter pseudo-element (one-colon syntax) selector, not matching any elements: #pseudo-element:first-letter]
-    expected: FAIL
-
-  [In-document Element.querySelector: Slotted selector (no matching closing paren): ::slotted(foo]
     expected: FAIL
 
   [Fragment.querySelector: :first-line pseudo-element (one-colon syntax) selector, not matching any elements: #pseudo-element:first-line]
@@ -148,4 +100,3 @@
 
   [Document.querySelectorAll: ::first-line pseudo-element (two-colon syntax) selector, not matching any elements: #pseudo-element::first-line]
     expected: FAIL
-


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Part of #34318

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
