### PR TITLE
fix: Add support for Upgrade request to a potentially trustworthy URL

### DIFF
--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -921,13 +921,10 @@ fn should_upgrade_request_to_potentially_trustworty(
         // request’s header list if any of the following criteria are met:
         // * request’s URL is not a potentially trustworthy URL
         // * request’s URL's host is not a preloadable HSTS host
-        if !request.current_url().is_origin_trustworthy() ||
-            !context
-                .state
-                .hsts_list
-                .read()
-                .unwrap()
-                .is_host_secure(request.current_url().host_str().unwrap())
+        if !request.current_url().is_potentially_trustworthy() ||
+            !request.current_url().host_str().is_some_and(|host| {
+                !context.state.hsts_list.read().unwrap().is_host_secure(host)
+            })
         {
             debug!("Appending the Upgrade-Insecure-Requests header to request’s header list");
             request

--- a/components/net/tests/http_loader.rs
+++ b/components/net/tests/http_loader.rs
@@ -171,7 +171,6 @@ fn test_check_default_headers_loaded_in_every_request() {
         HeaderName::from_static("sec-fetch-user"),
         HeaderValue::from_static("?1"),
     );
-    headers.insert("Upgrade-Insecure-Requests", HeaderValue::from_static("1"));
 
     *expected_headers.lock().unwrap() = Some(headers.clone());
 
@@ -326,7 +325,6 @@ fn test_request_and_response_data_with_network_messages() {
         HeaderName::from_static("sec-fetch-user"),
         HeaderValue::from_static("?1"),
     );
-    headers.insert("Upgrade-Insecure-Requests", HeaderValue::from_static("1"));
 
     let httprequest = DevtoolsHttpRequest {
         url: url,


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This PR includes following changes
1. Corrected with reference to spec to check whether url is potentially trustworthy
2. Checking of host (Option<&str>) will cause a crash, so used is_some_and in conjunction 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
