### PR TITLE
fix: bring back connection method to fix WebGL texture error

### DIFF
--- a/components/canvas/webgl_mode/inprocess.rs
+++ b/components/canvas/webgl_mode/inprocess.rs
@@ -48,7 +48,9 @@ impl WebGLComm {
         let webxr_init = crate::webxr::WebXRBridgeInit::new(sender.clone());
         #[cfg(feature = "webxr")]
         let webxr_layer_grand_manager = webxr_init.layer_grand_manager();
-        let connection = surfman::Connection::new().expect("Failed to create connection");
+        let connection = rendering_context
+            .connection()
+            .expect("Failed to get connection");
         let adapter = connection
             .create_adapter()
             .expect("Failed to create adapter");

--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -409,8 +409,9 @@ impl IOCompositor {
         };
 
         let gl = &compositor.webrender_gl;
-        println!("Running on {}", gl.get_string(gleam::gl::RENDERER));
-        println!("OpenGL Version {}", gl.get_string(gleam::gl::VERSION));
+        info!("Running on {}", gl.get_string(gleam::gl::RENDERER));
+        info!("OpenGL Version {}", gl.get_string(gleam::gl::VERSION));
+        compositor.assert_gl_framebuffer_complete();
         compositor
     }
 

--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -408,7 +408,9 @@ impl IOCompositor {
             version_string,
         };
 
-        compositor.assert_gl_framebuffer_complete();
+        let gl = &compositor.webrender_gl;
+        println!("Running on {}", gl.get_string(gleam::gl::RENDERER));
+        println!("OpenGL Version {}", gl.get_string(gleam::gl::VERSION));
         compositor
     }
 

--- a/components/shared/webrender/rendering_context.rs
+++ b/components/shared/webrender/rendering_context.rs
@@ -67,6 +67,11 @@ pub trait RenderingContext {
     fn destroy_texture(&self, _surface_texture: SurfaceTexture) -> Option<Surface> {
         None
     }
+
+    /// The connection to the display server for WebGL. Default to `None`.
+    fn connection(&self) -> Option<Connection> {
+        None
+    }
 }
 
 /// A rendering context that uses the Surfman library to create and manage
@@ -222,6 +227,10 @@ impl RenderingContext for SurfmanRenderingContext {
 
     fn destroy_texture(&self, surface_texture: SurfaceTexture) -> Option<Surface> {
         self.destroy_surface_texture(surface_texture).ok()
+    }
+
+    fn connection(&self) -> Option<Connection> {
+        Some(self.connection())
     }
 }
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Looks like it needs to be the same EGLDisplay on Linux to share the texture.
I brought back `connection` with `Option` as return value. Because the `NativeConnection` also require either x11 or wayland display. I need some time to figure out how to do it in GTK demo.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #35356 (GitHub issue number if applicable)

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
