### PR TITLE
Fixes #35340 : Make throw_invalid_this and throw_constructor_without_new safe functions

### DIFF
--- a/components/script/dom/bindings/constructor.rs
+++ b/components/script/dom/bindings/constructor.rs
@@ -412,7 +412,7 @@ pub(crate) unsafe fn call_default_constructor(
     constructor: impl FnOnce(JSContext, &CallArgs, &GlobalScope, HandleObject) -> bool,
 ) -> bool {
     if !args.is_constructing() {
-        throw_constructor_without_new(*cx, ctor_name);
+        throw_constructor_without_new(cx, ctor_name);
         return false;
     }
 

--- a/components/script/dom/bindings/error.rs
+++ b/components/script/dom/bindings/error.rs
@@ -310,19 +310,19 @@ pub(crate) unsafe fn report_pending_exception(
 
 /// Throw an exception to signal that a `JSObject` can not be converted to a
 /// given DOM type.
-pub(crate) unsafe fn throw_invalid_this(cx: *mut JSContext, proto_id: u16) {
-    debug_assert!(!JS_IsExceptionPending(cx));
+pub(crate) fn throw_invalid_this(cx: SafeJSContext, proto_id: u16) {
+    debug_assert!(unsafe { !JS_IsExceptionPending(*cx) });
     let error = format!(
         "\"this\" object does not implement interface {}.",
         proto_id_to_name(proto_id)
     );
-    throw_type_error(cx, &error);
+    unsafe { throw_type_error(*cx, &error) };
 }
 
-pub(crate) unsafe fn throw_constructor_without_new(cx: *mut JSContext, name: &str) {
-    debug_assert!(!JS_IsExceptionPending(cx));
+pub(crate) fn throw_constructor_without_new(cx: SafeJSContext, name: &str) {
+    debug_assert!(unsafe { !JS_IsExceptionPending(*cx) });
     let error = format!("{} constructor: 'new' is required", name);
-    throw_type_error(cx, &error);
+    unsafe { throw_type_error(*cx, &error) };
 }
 
 impl Error {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #35340 (GitHub issue number if applicable)

<!-- Either: -->
- [X] There are tests for these changes 

https://github.com/stephenmuss/servo/actions/runs/13197185081

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
