### PR TITLE
Enable surfman's sm-x11 feature for webrender_traits

### DIFF
--- a/components/shared/webrender/Cargo.toml
+++ b/components/shared/webrender/Cargo.toml
@@ -26,4 +26,4 @@ webrender_api = { workspace = true }
 serde = { workspace = true }
 servo_geometry = { path = "../../geometry" }
 servo-media = { workspace = true }
-surfman = { workspace = true }
+surfman = { workspace = true, features = ["sm-x11"] }


### PR DESCRIPTION
This fixes errors when running `./mach clippy -r -p webrender_traits`.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #35361
- [X] These changes do not require tests because it's just a compile error fix

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
