### PR TITLE
libservo: Don't bounce ready-to-present frame notifications to the Constellation

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -1459,16 +1459,6 @@ where
             FromCompositorMsg::SetWebViewThrottled(webview_id, throttled) => {
                 self.set_webview_throttled(webview_id, throttled);
             },
-            FromCompositorMsg::ReadyToPresent(webview_ids) => {
-                #[cfg(feature = "tracing")]
-                let _span = tracing::trace_span!(
-                    "FromCompositorMsg::ReadyToPresent",
-                    servo_profiling = true,
-                )
-                .entered();
-                self.embedder_proxy
-                    .send(EmbedderMsg::ReadyToPresent(webview_ids));
-            },
             FromCompositorMsg::Gamepad(gamepad_event) => {
                 self.handle_gamepad_msg(gamepad_event);
             },

--- a/components/constellation/tracing.rs
+++ b/components/constellation/tracing.rs
@@ -90,7 +90,6 @@ mod from_compositor {
                 Self::MediaSessionAction(_) => target!("MediaSessionAction"),
                 Self::SetWebViewThrottled(_, _) => target!("SetWebViewThrottled"),
                 Self::IMEDismissed => target!("IMEDismissed"),
-                Self::ReadyToPresent(..) => target!("ReadyToPresent"),
                 Self::Gamepad(..) => target!("Gamepad"),
                 Self::Clipboard(..) => target!("Clipboard"),
             }
@@ -248,7 +247,6 @@ mod from_script {
                 Self::MediaSessionEvent(..) => target_variant!("MediaSessionEvent"),
                 Self::OnDevtoolsStarted(..) => target_variant!("OnDevtoolsStarted"),
                 Self::RequestDevtoolsConnection(..) => target_variant!("RequestDevtoolsConnection"),
-                Self::ReadyToPresent(..) => target_variant!("ReadyToPresent"),
                 Self::EventDelivered(..) => target_variant!("EventDelivered"),
                 Self::PlayGamepadHapticEffect(..) => target_variant!("PlayGamepadHapticEffect"),
                 Self::StopGamepadHapticEffect(..) => target_variant!("StopGamepadHapticEffect"),

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -441,10 +441,6 @@ impl WebView {
         self.inner().compositor.borrow_mut().capture_webrender();
     }
 
-    pub fn composite(&self) {
-        self.inner().compositor.borrow_mut().composite();
-    }
-
     pub fn toggle_sampling_profiler(&self, rate: Duration, max_duration: Duration) {
         self.inner()
             .constellation_proxy

--- a/components/shared/compositing/constellation_msg.rs
+++ b/components/shared/compositing/constellation_msg.rs
@@ -84,8 +84,6 @@ pub enum ConstellationMsg {
     SetWebViewThrottled(TopLevelBrowsingContextId, bool),
     /// Virtual keyboard was dismissed
     IMEDismissed,
-    /// Notify the embedder that it needs to present a new frame.
-    ReadyToPresent(Vec<WebViewId>),
     /// Gamepad state has changed
     Gamepad(GamepadEvent),
     /// Inform the constellation of a clipboard event.
@@ -133,7 +131,6 @@ impl ConstellationMsg {
             SetWebViewThrottled(..) => "SetWebViewThrottled",
             IMEDismissed => "IMEDismissed",
             ClearCache => "ClearCache",
-            ReadyToPresent(..) => "ReadyToPresent",
             Gamepad(..) => "Gamepad",
             Clipboard(..) => "Clipboard",
         }

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -250,8 +250,6 @@ pub enum EmbedderMsg {
     OnDevtoolsStarted(Result<u16, ()>, String),
     /// Ask the user to allow a devtools client to connect.
     RequestDevtoolsConnection(IpcSender<AllowOrDeny>),
-    /// Notify the embedder that it needs to present a new frame.
-    ReadyToPresent(Vec<WebViewId>),
     /// The given event was delivered to a pipeline in the given browser.
     EventDelivered(WebViewId, CompositorEventVariant),
     /// Request to play a haptic effect on a connected gamepad.
@@ -314,7 +312,6 @@ impl Debug for EmbedderMsg {
             EmbedderMsg::OnDevtoolsStarted(..) => write!(f, "OnDevtoolsStarted"),
             EmbedderMsg::RequestDevtoolsConnection(..) => write!(f, "RequestDevtoolsConnection"),
             EmbedderMsg::ShowContextMenu(..) => write!(f, "ShowContextMenu"),
-            EmbedderMsg::ReadyToPresent(..) => write!(f, "ReadyToPresent"),
             EmbedderMsg::EventDelivered(..) => write!(f, "HitTestedEvent"),
             EmbedderMsg::PlayGamepadHapticEffect(..) => write!(f, "PlayGamepadHapticEffect"),
             EmbedderMsg::StopGamepadHapticEffect(..) => write!(f, "StopGamepadHapticEffect"),

--- a/ports/servoshell/egl/android.rs
+++ b/ports/servoshell/egl/android.rs
@@ -223,15 +223,6 @@ pub extern "C" fn Java_org_servo_servoview_JNIServo_stop<'local>(
 }
 
 #[no_mangle]
-pub extern "C" fn Java_org_servo_servoview_JNIServo_refresh<'local>(
-    mut env: JNIEnv<'local>,
-    _class: JClass<'local>,
-) {
-    debug!("refresh");
-    call(&mut env, |s| s.refresh());
-}
-
-#[no_mangle]
 pub extern "C" fn Java_org_servo_servoview_JNIServo_goBack<'local>(
     mut env: JNIEnv<'local>,
     _class: JClass<'local>,

--- a/ports/servoshell/egl/app_state.rs
+++ b/ports/servoshell/egl/app_state.rs
@@ -401,13 +401,6 @@ impl RunningAppState {
         self.perform_updates();
     }
 
-    /// Redraw the page.
-    pub fn refresh(&self) {
-        info!("refresh");
-        self.active_webview().composite();
-        self.perform_updates();
-    }
-
     /// Stop loading the page.
     pub fn stop(&self) {
         warn!("TODO can't stop won't stop");

--- a/support/android/apk/servoview/src/main/java/org/servo/servoview/JNIServo.java
+++ b/support/android/apk/servoview/src/main/java/org/servo/servoview/JNIServo.java
@@ -35,8 +35,6 @@ public class JNIServo {
 
     public native void stop();
 
-    public native void refresh();
-
     public native void goBack();
 
     public native void goForward();

--- a/support/android/apk/servoview/src/main/java/org/servo/servoview/Servo.java
+++ b/support/android/apk/servoview/src/main/java/org/servo/servoview/Servo.java
@@ -87,10 +87,6 @@ public class Servo {
         mRunCallback.inGLThread(() -> mJNI.resize(coords));
     }
 
-    public void refresh() {
-        mRunCallback.inGLThread(() -> mJNI.refresh());
-    }
-
     public void reload() {
         mRunCallback.inGLThread(() -> mJNI.reload());
     }


### PR DESCRIPTION
Instead of telling the Constellation to tell the embedder that new
frames are ready, have the compositor tell the embedder directly. This
should reduce frame latency. Now, after processing compositor
updates, run any pending `WebView::new_frame_ready` delegate methods.

This change also removes the `refresh` call from the Java interface as
that was the only other place that the compositor was rendering the
WebRender scene outside of event looping spinning. This `refresh` call
was completely unused.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because it should not change how pages are rendered.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
