### PR TITLE
Add cli option for tracing-filter

### DIFF
--- a/ports/servoshell/desktop/cli.rs
+++ b/ports/servoshell/desktop/cli.rs
@@ -11,7 +11,6 @@ use crate::prefs::{parse_command_line_arguments, ArgumentParsingResult};
 
 pub fn main() {
     crate::crash_handler::install();
-    crate::init_tracing();
     crate::init_crypto();
     crate::resources::init();
 
@@ -26,6 +25,8 @@ pub fn main() {
             (opts, preferences, servoshell_preferences)
         },
     };
+
+    crate::init_tracing(servoshell_preferences.tracing_filter.as_deref());
 
     let clean_shutdown = servoshell_preferences.clean_shutdown;
     let event_loop = EventsLoop::new(servoshell_preferences.headless, opts.output_file.is_some())

--- a/ports/servoshell/egl/android/simpleservo.rs
+++ b/ports/servoshell/egl/android/simpleservo.rs
@@ -52,7 +52,6 @@ pub fn init(
     waker: Box<dyn EventLoopWaker>,
     callbacks: Box<dyn HostTrait>,
 ) -> Result<(), &'static str> {
-    crate::init_tracing();
     crate::init_crypto();
     resources::set(Box::new(ResourceReaderInstance::new()));
 
@@ -68,6 +67,8 @@ pub fn init(
             (opts, preferences, servoshell_preferences)
         },
     };
+
+    crate::init_tracing(servoshell_preferences.tracing_filter.as_deref());
 
     // Initialize surfman
     let connection = Connection::new().or(Err("Failed to create connection"))?;

--- a/ports/servoshell/egl/ohos/simpleservo.rs
+++ b/ports/servoshell/egl/ohos/simpleservo.rs
@@ -36,7 +36,6 @@ pub fn init(
     callbacks: Box<dyn HostTrait>,
 ) -> Result<Rc<RunningAppState>, &'static str> {
     info!("Entered simpleservo init function");
-    crate::init_tracing();
     crate::init_crypto();
     let resource_dir = PathBuf::from(&options.resource_dir).join("servo");
     resources::set(Box::new(ResourceReaderInstance::new(resource_dir)));
@@ -60,6 +59,8 @@ pub fn init(
             (opts, preferences, servoshell_preferences)
         },
     };
+
+    crate::init_tracing(servoshell_preferences.tracing_filter.as_deref());
 
     // Initialize surfman
     let connection = Connection::new().or(Err("Failed to create connection"))?;

--- a/ports/servoshell/lib.rs
+++ b/ports/servoshell/lib.rs
@@ -44,7 +44,13 @@ pub fn init_crypto() {
         .expect("Error initializing crypto provider");
 }
 
-pub fn init_tracing() {
+pub fn init_tracing(filter_directives: Option<&str>) {
+    #[cfg(not(feature = "tracing"))]
+    {
+        if filter_directives.is_some() {
+            log::debug!("The tracing feature was not selected - ignoring trace filter directives");
+        }
+    }
     #[cfg(feature = "tracing")]
     {
         use tracing_subscriber::layer::SubscriberExt;
@@ -69,10 +75,16 @@ pub fn init_tracing() {
 
         // Filter events and spans by the directives in SERVO_TRACING, using EnvFilter as a global filter.
         // <https://docs.rs/tracing-subscriber/0.3.18/tracing_subscriber/layer/index.html#global-filtering>
-        let filter = tracing_subscriber::EnvFilter::builder()
-            .with_default_directive(tracing::level_filters::LevelFilter::OFF.into())
-            .with_env_var("SERVO_TRACING")
-            .from_env_lossy();
+        let filter_builder = tracing_subscriber::EnvFilter::builder()
+            .with_default_directive(tracing::level_filters::LevelFilter::OFF.into());
+        let filter = if let Some(filters) = &filter_directives {
+            filter_builder.parse_lossy(filters)
+        } else {
+            filter_builder
+                .with_env_var("SERVO_TRACING")
+                .from_env_lossy()
+        };
+
         let subscriber = subscriber.with(filter);
 
         // Same as SubscriberInitExt::init, but avoids initialising the tracing-log compat layer,


### PR DESCRIPTION
Using environment variables is not really an option on ohos/android, so add a CLI option to configure tracing.
We probably also want to be able to persist the setting, so making it a preference seems reasonable. Since tracing should be controlled by the embedder, I put it into servoshell preferences.


---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

