### PR TITLE
servoshell: Move `headless` setting to ServoShellPreferences

### DIFF
--- a/components/config/opts.rs
+++ b/components/config/opts.rs
@@ -48,8 +48,6 @@ pub struct Opts {
 
     pub output_file: Option<String>,
 
-    pub headless: bool,
-
     /// True to exit on thread failure instead of displaying about:failure.
     pub hard_fail: bool,
 
@@ -218,7 +216,6 @@ impl Default for Opts {
             userscripts: None,
             user_stylesheets: Vec::new(),
             output_file: None,
-            headless: false,
             hard_fail: true,
             webdriver_port: None,
             initial_window_size: Size2D::new(1024, 740),

--- a/components/script/dom/dissimilaroriginwindow.rs
+++ b/components/script/dom/dissimilaroriginwindow.rs
@@ -64,7 +64,6 @@ impl DissimilarOriginWindow {
                 // FIXME(nox): The microtask queue is probably not important
                 // here, but this whole DOM interface is a hack anyway.
                 global_to_clone_from.microtask_queue().clone(),
-                global_to_clone_from.is_headless(),
                 global_to_clone_from.get_user_agent(),
                 #[cfg(feature = "webgpu")]
                 global_to_clone_from.wgpu_id_hub(),

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -316,9 +316,6 @@ pub(crate) struct GlobalScope {
     #[allow(clippy::vec_box)]
     consumed_rejections: DomRefCell<Vec<Box<Heap<*mut JSObject>>>>,
 
-    /// True if headless mode.
-    is_headless: bool,
-
     /// An optional string allowing the user agent to be set for testing.
     user_agent: Cow<'static, str>,
 
@@ -716,7 +713,6 @@ impl GlobalScope {
         origin: MutableOrigin,
         creation_url: Option<ServoUrl>,
         microtask_queue: Rc<MicrotaskQueue>,
-        is_headless: bool,
         user_agent: Cow<'static, str>,
         #[cfg(feature = "webgpu")] gpu_id_hub: Arc<IdentityHub>,
         inherited_secure_context: Option<bool>,
@@ -751,7 +747,6 @@ impl GlobalScope {
             event_source_tracker: DOMTracker::new(),
             uncaught_rejections: Default::default(),
             consumed_rejections: Default::default(),
-            is_headless,
             user_agent,
             #[cfg(feature = "webgpu")]
             gpu_id_hub,
@@ -2909,10 +2904,6 @@ impl GlobalScope {
             cx,
             retval,
         );
-    }
-
-    pub(crate) fn is_headless(&self) -> bool {
-        self.is_headless
     }
 
     pub(crate) fn get_user_agent(&self) -> Cow<'static, str> {

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2778,7 +2778,6 @@ impl Window {
         unminify_css: bool,
         local_script_source: Option<String>,
         userscripts_path: Option<String>,
-        is_headless: bool,
         replace_surrogates: bool,
         user_agent: Cow<'static, str>,
         player_context: WindowGLContext,
@@ -2807,7 +2806,6 @@ impl Window {
                 origin,
                 Some(creator_url),
                 microtask_queue,
-                is_headless,
                 user_agent,
                 #[cfg(feature = "webgpu")]
                 gpu_id_hub,

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -79,7 +79,6 @@ pub(crate) fn prepare_workerscope_init(
         pipeline_id: global.pipeline_id(),
         origin: global.origin().immutable().clone(),
         creation_url: global.creation_url().clone(),
-        is_headless: global.is_headless(),
         user_agent: global.get_user_agent(),
         inherited_secure_context: Some(global.is_secure_context()),
     };
@@ -165,7 +164,6 @@ impl WorkerGlobalScope {
                 MutableOrigin::new(init.origin),
                 init.creation_url,
                 runtime.microtask_queue.clone(),
-                init.is_headless,
                 init.user_agent,
                 #[cfg(feature = "webgpu")]
                 gpu_id_hub,

--- a/components/script/dom/workletglobalscope.rs
+++ b/components/script/dom/workletglobalscope.rs
@@ -96,7 +96,6 @@ impl WorkletGlobalScope {
                 MutableOrigin::new(ImmutableOrigin::new_opaque()),
                 None,
                 Default::default(),
-                init.is_headless,
                 init.user_agent.clone(),
                 #[cfg(feature = "webgpu")]
                 init.gpu_id_hub.clone(),
@@ -186,8 +185,6 @@ pub(crate) struct WorkletGlobalScopeInit {
     pub(crate) to_constellation_sender: IpcSender<(PipelineId, ScriptMsg)>,
     /// The image cache
     pub(crate) image_cache: Arc<dyn ImageCache>,
-    /// True if in headless mode
-    pub(crate) is_headless: bool,
     /// An optional string allowing the user agent to be set for testing
     pub(crate) user_agent: Cow<'static, str>,
     /// Identity manager for WebGPU resources

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -318,9 +318,6 @@ pub struct ScriptThread {
     /// won't be loaded
     userscripts_path: Option<String>,
 
-    /// True if headless mode.
-    headless: bool,
-
     /// Replace unpaired surrogates in DOM strings with U+FFFD.
     /// See <https://github.com/servo/servo/issues/6564>
     replace_surrogates: bool,
@@ -753,7 +750,6 @@ impl ScriptThread {
                             .pipeline_to_constellation_sender
                             .clone(),
                         image_cache: script_thread.image_cache.clone(),
-                        is_headless: script_thread.headless,
                         user_agent: script_thread.user_agent.clone(),
                         #[cfg(feature = "webgpu")]
                         gpu_id_hub: script_thread.gpu_id_hub.clone(),
@@ -961,7 +957,6 @@ impl ScriptThread {
             local_script_source: opts.local_script_source.clone(),
             unminify_css: opts.unminify_css,
             userscripts_path: opts.userscripts.clone(),
-            headless: opts.headless,
             replace_surrogates: opts.debug.replace_surrogates,
             user_agent,
             player_context: state.player_context,
@@ -3151,7 +3146,6 @@ impl ScriptThread {
             self.unminify_css,
             self.local_script_source.clone(),
             self.userscripts_path.clone(),
-            self.headless,
             self.replace_surrogates,
             self.user_agent.clone(),
             self.player_context.clone(),

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -770,8 +770,6 @@ pub struct WorkerGlobalScopeInit {
     pub origin: ImmutableOrigin,
     /// The creation URL
     pub creation_url: Option<ServoUrl>,
-    /// True if headless mode
-    pub is_headless: bool,
     /// An optional string allowing the user agnet to be set for testing.
     pub user_agent: Cow<'static, str>,
     /// True if secure context

--- a/ports/servoshell/desktop/cli.rs
+++ b/ports/servoshell/desktop/cli.rs
@@ -28,7 +28,7 @@ pub fn main() {
     };
 
     let clean_shutdown = servoshell_preferences.clean_shutdown;
-    let event_loop = EventsLoop::new(opts.headless, opts.output_file.is_some())
+    let event_loop = EventsLoop::new(servoshell_preferences.headless, opts.output_file.is_some())
         .expect("Failed to create events loop");
 
     {

--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -34,6 +34,9 @@ pub(crate) struct ServoShellPreferences {
     /// URL string of the search engine page with '%s' standing in for the search term.
     /// For example <https://duckduckgo.com/html/?q=%s>.
     pub searchpage: String,
+    /// Whether or not to run servoshell in headless mode. While running in headless
+    /// mode, image output is supported.
+    pub headless: bool,
 }
 
 impl Default for ServoShellPreferences {
@@ -46,6 +49,7 @@ impl Default for ServoShellPreferences {
             homepage: "https://servo.org".into(),
             no_native_titlebar: true,
             searchpage: "https://duckduckgo.com/html/?q=%s".into(),
+            headless: false,
         }
     }
 }
@@ -539,11 +543,11 @@ pub(crate) fn parse_command_line_arguments(args: Vec<String>) -> ArgumentParsing
         no_native_titlebar,
         device_pixel_ratio_override,
         clean_shutdown: opt_match.opt_present("clean-shutdown"),
+        headless: opt_match.opt_present("z"),
         ..Default::default()
     };
 
-    let headless = opt_match.opt_present("z");
-    if headless && preferences.media_glvideo_enabled {
+    if servoshell_preferences.headless && preferences.media_glvideo_enabled {
         warn!("GL video rendering is not supported on headless windows.");
         preferences.media_glvideo_enabled = false;
     }
@@ -558,7 +562,6 @@ pub(crate) fn parse_command_line_arguments(args: Vec<String>) -> ArgumentParsing
         userscripts: opt_match.opt_default("userscripts", ""),
         user_stylesheets,
         output_file,
-        headless,
         hard_fail: opt_match.opt_present("f") && !opt_match.opt_present("F"),
         webdriver_port,
         initial_window_size,


### PR DESCRIPTION
This is only used in servoshell, even though it was plumbed through
script previously. It's just about how the `RenderingContext` is set up,
which is something managed entirely outside of servo itself.

In addition, make the name of `servo_shell_preferences` in `app.rs` more
consistent with the rest of the codebase.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they do not change any internal engine behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
