### PR TITLE
winit_minimal: resize rendering context on window resize

### DIFF
--- a/components/servo/examples/winit_minimal.rs
+++ b/components/servo/examples/winit_minimal.rs
@@ -206,6 +206,16 @@ impl ApplicationHandler<WakerEvent> for App {
                     }
                 }
             },
+            WindowEvent::Resized(new_size) => {
+                if let Self::Running(state) = self {
+                    if let Some(webview) = state.webviews.borrow().last() {
+                        let mut rect = webview.rect();
+                        rect.set_size(winit_size_to_euclid_size(new_size).to_f32());
+                        webview.move_resize(rect);
+                        webview.notify_rendering_context_resized();
+                    }
+                }
+            },
             _ => (),
         }
     }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This resizes the current webview with the winit window. This works, but I have a couple of questions:
- we need to call `webview.notify_rendering_context_resized()` for the size change to be taken into account. Should that be done in `webview.move_resize()` instead to simplify embedders?
- the rendering is flickering when you keep resizing. I could not find a way to prevent that, any idea welcome!

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
