### PR TITLE
suppress build warnings when disabling webgpu and webxr

### DIFF
--- a/components/script/conversions.rs
+++ b/components/script/conversions.rs
@@ -14,6 +14,7 @@ pub(crate) trait Convert<T> {
 /// to convert between two types that are not defined in the script crate.
 /// This is intended to be used on dict/enum types generated from WebIDL once
 /// those types are moved out of the script crate.
+#[cfg(feature = "webgpu")]
 pub(crate) trait TryConvert<T> {
     type Error;
 

--- a/components/script/dom/bindings/buffer_source.rs
+++ b/components/script/dom/bindings/buffer_source.rs
@@ -4,24 +4,29 @@
 
 #![allow(unsafe_code)]
 
+#[cfg(feature = "webgpu")]
 use std::ffi::c_void;
 use std::marker::PhantomData;
+#[cfg(feature = "webgpu")]
 use std::ops::Range;
 use std::ptr;
+#[cfg(feature = "webgpu")]
 use std::sync::Arc;
 
+#[cfg(feature = "webgpu")]
+use js::jsapi::NewExternalArrayBuffer;
 use js::jsapi::{
     GetArrayBufferByteLength, Heap, IsDetachedArrayBufferObject, JSObject,
     JS_GetArrayBufferViewBuffer, JS_GetArrayBufferViewByteLength, JS_IsArrayBufferViewObject,
-    JS_IsTypedArrayObject, NewExternalArrayBuffer,
+    JS_IsTypedArrayObject,
 };
 use js::rust::wrappers::DetachArrayBuffer;
 use js::rust::{CustomAutoRooterGuard, Handle, MutableHandleObject};
-use js::typedarray::{
-    ArrayBuffer, CreateWith, HeapArrayBuffer, TypedArray, TypedArrayElement,
-    TypedArrayElementCreator,
-};
+#[cfg(feature = "webgpu")]
+use js::typedarray::{ArrayBuffer, HeapArrayBuffer};
+use js::typedarray::{CreateWith, TypedArray, TypedArrayElement, TypedArrayElementCreator};
 
+#[cfg(feature = "webgpu")]
 use crate::dom::globalscope::GlobalScope;
 use crate::script_runtime::JSContext;
 
@@ -372,6 +377,7 @@ where
     }
 }
 
+#[cfg(feature = "webgpu")]
 #[derive(JSTraceable, MallocSizeOf)]
 pub(crate) struct DataBlock {
     #[ignore_malloc_size_of = "Arc"]
@@ -382,10 +388,12 @@ pub(crate) struct DataBlock {
 
 /// Returns true if two non-inclusive ranges overlap
 // https://stackoverflow.com/questions/3269434/whats-the-most-efficient-way-to-test-if-two-ranges-overlap
+#[cfg(feature = "webgpu")]
 fn range_overlap<T: std::cmp::PartialOrd>(range1: &Range<T>, range2: &Range<T>) -> bool {
     range1.start < range2.end && range2.start < range1.end
 }
 
+#[cfg(feature = "webgpu")]
 impl DataBlock {
     pub(crate) fn new_zeroed(size: usize) -> Self {
         let data = vec![0; size];
@@ -449,6 +457,7 @@ impl DataBlock {
     }
 }
 
+#[cfg(feature = "webgpu")]
 #[derive(JSTraceable, MallocSizeOf)]
 pub(crate) struct DataView {
     #[no_trace]
@@ -457,12 +466,14 @@ pub(crate) struct DataView {
     buffer: HeapArrayBuffer,
 }
 
+#[cfg(feature = "webgpu")]
 impl DataView {
     pub(crate) fn array_buffer(&self) -> ArrayBuffer {
         unsafe { ArrayBuffer::from(self.buffer.underlying_object().get()).unwrap() }
     }
 }
 
+#[cfg(feature = "webgpu")]
 impl Drop for DataView {
     #[allow(unsafe_code)]
     fn drop(&mut self) {

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -109,6 +109,7 @@ use crate::dom::bindings::reflector::{reflect_dom_object_with_proto, DomGlobal};
 use crate::dom::bindings::root::{Dom, DomRoot, DomSlice, LayoutDom, MutNullableDom};
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::bindings::trace::{HashMapTracedValues, NoTrace};
+#[cfg(feature = "webgpu")]
 use crate::dom::bindings::weakref::WeakRef;
 use crate::dom::bindings::xmlname::XMLName::Invalid;
 use crate::dom::bindings::xmlname::{

--- a/components/script/dom/gpucanvascontext.rs
+++ b/components/script/dom/gpucanvascontext.rs
@@ -8,9 +8,8 @@ use script_layout_interface::HTMLCanvasDataSource;
 use crate::dom::bindings::codegen::Bindings::GPUCanvasContextBinding::GPUCanvasContextMethods;
 use crate::dom::bindings::codegen::UnionTypes;
 use crate::dom::bindings::reflector::Reflector;
-use crate::dom::bindings::root::{DomRoot, LayoutDom};
-use crate::dom::globalscope::GlobalScope;
-use crate::dom::htmlcanvaselement::{HTMLCanvasElement, LayoutCanvasRenderingContextHelpers};
+use crate::dom::bindings::root::LayoutDom;
+use crate::dom::htmlcanvaselement::LayoutCanvasRenderingContextHelpers;
 
 #[dom_struct]
 pub(crate) struct GPUCanvasContext {
@@ -20,10 +19,6 @@ pub(crate) struct GPUCanvasContext {
 impl GPUCanvasContext {
     #[allow(dead_code)]
     fn new_inherited() -> Self {
-        unimplemented!()
-    }
-
-    pub(crate) fn new(_global: &GlobalScope, _canvas: &HTMLCanvasElement) -> DomRoot<Self> {
         unimplemented!()
     }
 }

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -618,8 +618,6 @@ pub(crate) mod webgpu;
 pub(crate) use self::webgpu::*;
 #[cfg(not(feature = "webgpu"))]
 pub(crate) mod gpucanvascontext;
-#[cfg(not(feature = "webgpu"))]
-pub(crate) use gpucanvascontext::GPUCanvasContext;
 pub(crate) mod wheelevent;
 #[allow(dead_code)]
 pub(crate) mod window;

--- a/components/script/dom/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl2renderingcontext.rs
@@ -5,6 +5,7 @@
 use std::cell::Cell;
 use std::cmp;
 use std::ptr::{self, NonNull};
+#[cfg(feature = "webxr")]
 use std::rc::Rc;
 
 use bitflags::bitflags;
@@ -42,6 +43,7 @@ use crate::dom::bindings::root::{Dom, DomRoot, LayoutDom, MutNullableDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::htmlcanvaselement::LayoutCanvasRenderingContextHelpers;
+#[cfg(feature = "webxr")]
 use crate::dom::promise::Promise;
 use crate::dom::webgl_validations::tex_image_2d::{
     TexImage2DValidator, TexImage2DValidatorResult, TexStorageValidator, TexStorageValidatorResult,

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -5,6 +5,7 @@
 use std::cell::Cell;
 use std::cmp;
 use std::ptr::{self, NonNull};
+#[cfg(feature = "webxr")]
 use std::rc::Rc;
 
 #[cfg(feature = "webgl_backtrace")]
@@ -58,6 +59,7 @@ use crate::dom::element::cors_setting_for_element;
 use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::htmlcanvaselement::{utils as canvas_utils, LayoutCanvasRenderingContextHelpers};
 use crate::dom::node::{Node, NodeDamage, NodeTraits};
+#[cfg(feature = "webxr")]
 use crate::dom::promise::Promise;
 use crate::dom::vertexarrayobject::VertexAttribData;
 use crate::dom::webgl_extensions::WebGLExtensions;

--- a/components/script/messaging.rs
+++ b/components/script/messaging.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use core::fmt;
+#[cfg(feature = "webgpu")]
 use std::cell::RefCell;
 use std::option::Option;
 use std::result::Result;
@@ -402,7 +403,7 @@ impl ScriptThreadReceivers {
                 }
                 #[cfg(not(feature = "webgpu"))]
                 {
-                    unreachable!("This should never be hit when webgpu is disabled");
+                    unreachable!("This should never be hit when webgpu is disabled ({msg:?})");
                 }
             }
         }


### PR DESCRIPTION
They are due to not enabling webgpu and webxr features. The `TryConvert()` trait could be generic but is only used in webgpu related code.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
