### PR TITLE
script: Add shadow dom check to custom element constructor

### DIFF
--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -917,7 +917,7 @@ fn run_upgrade_constructor(
     }
     rooted!(in(*cx) let mut construct_result = ptr::null_mut::<JSObject>());
     {
-        // Step 8.1
+        // Step 8.1. If definition's disable shadow is true and element's shadow root is non-null, then throw a "NotSupportedError" DOMException.
         if definition.disable_shadow && element.is_shadow_host() {
             return Err(Error::NotSupported);
         }

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -903,7 +903,7 @@ pub(crate) fn upgrade_element(
 /// Steps 8.1-8.3
 #[allow(unsafe_code)]
 fn run_upgrade_constructor(
-    definition: Rc<CustomElementDefinition>,
+    definition: &CustomElementDefinition,
     element: &Element,
     can_gc: CanGc,
 ) -> ErrorResult {

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -948,7 +948,7 @@ fn run_upgrade_constructor(
         // Step 8.3
         let mut same = false;
         rooted!(in(*cx) let construct_result_val = ObjectValue(construct_result.get()));
-        // Step 8.4
+        // Step 8.4. If SameValue(constructResult, element) is false, then throw a TypeError.
         if unsafe {
             !SameValue(
                 *cx,

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -832,7 +832,7 @@ pub(crate) fn upgrade_element(
         .push(ConstructionStackEntry::Element(DomRoot::from_ref(element)));
 
     // Steps 7-8, successful case
-    let result = run_upgrade_constructor(definition.clone(), element, can_gc);
+    let result = run_upgrade_constructor(&definition, element, can_gc);
 
     // "regardless of whether the above steps threw an exception" step
     definition.construction_stack.borrow_mut().pop();

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -917,7 +917,8 @@ fn run_upgrade_constructor(
     }
     rooted!(in(*cx) let mut construct_result = ptr::null_mut::<JSObject>());
     {
-        // Step 8.1. If definition's disable shadow is true and element's shadow root is non-null, then throw a "NotSupportedError" DOMException.
+        // Step 8.1. If definition's disable shadow is true and element's shadow root is non-null,
+        // then throw a "NotSupportedError" DOMException.
         if definition.disable_shadow && element.is_shadow_host() {
             return Err(Error::NotSupported);
         }
@@ -925,7 +926,7 @@ fn run_upgrade_constructor(
         // Go into the constructor's realm
         let _ac = JSAutoRealm::new(*cx, constructor.callback());
         let args = HandleValueArray::empty();
-        // Step 8.2
+        // Step 8.2. Set element's custom element state to "precustomized".
         if unsafe {
             !Construct1(
                 *cx,
@@ -945,7 +946,7 @@ fn run_upgrade_constructor(
                 .perform_a_microtask_checkpoint(can_gc);
         }
 
-        // Step 8.3
+        // Step 8.3. Let constructResult be the result of constructing C, with no arguments.
         let mut same = false;
         rooted!(in(*cx) let construct_result_val = ObjectValue(construct_result.get()));
         // Step 8.4. If SameValue(constructResult, element) is false, then throw a TypeError.

--- a/tests/wpt/meta/custom-elements/upgrading.html.ini
+++ b/tests/wpt/meta/custom-elements/upgrading.html.ini
@@ -1,3 +1,0 @@
-[upgrading.html]
-  [If definition's disable shadow is true and element's shadow root is non-null, then throw a "NotSupportedError" DOMException.]
-    expected: PASS

--- a/tests/wpt/meta/custom-elements/upgrading.html.ini
+++ b/tests/wpt/meta/custom-elements/upgrading.html.ini
@@ -1,3 +1,3 @@
 [upgrading.html]
   [If definition's disable shadow is true and element's shadow root is non-null, then throw a "NotSupportedError" DOMException.]
-    expected: FAIL
+    expected: PASS


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Add the shadow dom check for the custom element constructor as described in the linked issue.

Caveats:
- this is my first contribution to servo (or any major OSS project really)
- this is my first time writing Rust

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #35346

<!-- Either: -->
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
