### PR TITLE
libservo: Flesh out permissions API

### DIFF
--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -26,7 +26,7 @@ use devtools_traits::{
     DevtoolsControlMsg, DevtoolsPageInfo, LogLevel, NavigationState, NetworkEvent, PageError,
     ScriptToDevtoolsControlMsg, WorkerId,
 };
-use embedder_traits::{EmbedderMsg, EmbedderProxy};
+use embedder_traits::{AllowOrDeny, EmbedderMsg, EmbedderProxy};
 use ipc_channel::ipc::{self, IpcSender};
 use log::{debug, trace, warn};
 use serde::Serialize;
@@ -764,5 +764,5 @@ fn allow_devtools_client(stream: &mut TcpStream, embedder: &EmbedderProxy, token
     // No token found. Prompt user
     let (request_sender, request_receiver) = ipc::channel().expect("Failed to create IPC channel!");
     embedder.send(EmbedderMsg::RequestDevtoolsConnection(request_sender));
-    request_receiver.recv().unwrap()
+    request_receiver.recv().unwrap() == AllowOrDeny::Allow
 }

--- a/components/script/dom/bluetooth.rs
+++ b/components/script/dom/bluetooth.rs
@@ -29,7 +29,7 @@ use crate::dom::bluetoothpermissionresult::BluetoothPermissionResult;
 use crate::dom::bluetoothuuid::{BluetoothServiceUUID, BluetoothUUID, UUID};
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
-use crate::dom::permissions::{get_descriptor_permission_state, PermissionAlgorithm};
+use crate::dom::permissions::{descriptor_permission_state, PermissionAlgorithm};
 use crate::dom::promise::Promise;
 use crate::script_runtime::{CanGc, JSContext};
 use crate::task::TaskOnce;
@@ -227,7 +227,7 @@ impl Bluetooth {
 
         // Step 4 - 5.
         if let PermissionState::Denied =
-            get_descriptor_permission_state(PermissionName::Bluetooth, None)
+            descriptor_permission_state(PermissionName::Bluetooth, None)
         {
             return p.reject_error(Error::NotFound);
         }
@@ -649,7 +649,7 @@ impl PermissionAlgorithm for Bluetooth {
         // Step 1: We are not using the `global` variable.
 
         // Step 2.
-        status.set_state(get_descriptor_permission_state(status.get_query(), None));
+        status.set_state(descriptor_permission_state(status.get_query(), None));
 
         // Step 3.
         if let PermissionState::Denied = status.get_state() {

--- a/components/script/dom/permissions.rs
+++ b/components/script/dom/permissions.rs
@@ -5,18 +5,21 @@
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
-use embedder_traits::{self, EmbedderMsg, PermissionPrompt, PermissionRequest};
+use embedder_traits::{self, AllowOrDeny, EmbedderMsg, PermissionFeature};
 use ipc_channel::ipc;
 use js::conversions::ConversionResult;
 use js::jsapi::JSObject;
 use js::jsval::{ObjectValue, UndefinedValue};
+use script_bindings::inheritance::Castable;
 use servo_config::pref;
 
+use super::window::Window;
 use crate::conversions::Convert;
 use crate::dom::bindings::codegen::Bindings::PermissionStatusBinding::{
     PermissionDescriptor, PermissionName, PermissionState, PermissionStatusMethods,
 };
 use crate::dom::bindings::codegen::Bindings::PermissionsBinding::PermissionsMethods;
+use crate::dom::bindings::codegen::Bindings::WindowBinding::Window_Binding::WindowMethods;
 use crate::dom::bindings::error::Error;
 use crate::dom::bindings::reflector::{reflect_dom_object, DomGlobal, Reflector};
 use crate::dom::bindings::root::DomRoot;
@@ -142,7 +145,7 @@ impl Permissions {
                         globalscope
                             .permission_state_invocation_results()
                             .borrow_mut()
-                            .remove(&root_desc.name.to_string());
+                            .remove(&root_desc.name);
 
                         // (Revoke) Step 4.
                         Bluetooth::permission_revoke(&bluetooth_desc, &result, can_gc)
@@ -174,7 +177,7 @@ impl Permissions {
                         globalscope
                             .permission_state_invocation_results()
                             .borrow_mut()
-                            .remove(&root_desc.name.to_string());
+                            .remove(&root_desc.name);
 
                         // (Revoke) Step 4.
                         Permissions::permission_revoke(&root_desc, &status, can_gc);
@@ -231,15 +234,25 @@ impl PermissionAlgorithm for Permissions {
         }
     }
 
-    // https://w3c.github.io/permissions/#boolean-permission-query-algorithm
+    /// <https://w3c.github.io/permissions/#dfn-permission-query-algorithm>
+    ///
+    /// > permission query algorithm:
+    /// > Takes an instance of the permission descriptor type and a new or existing instance of
+    /// > the permission result type, and updates the permission result type instance with the
+    /// > query result. Used by Permissions' query(permissionDesc) method and the
+    /// > PermissionStatus update steps. If unspecified, this defaults to the default permission
+    /// > query algorithm.
+    ///
+    /// > The default permission query algorithm, given a PermissionDescriptor
+    /// > permissionDesc and a PermissionStatus status, runs the following steps:
     fn permission_query(
         _cx: JSContext,
         _promise: &Rc<Promise>,
         _descriptor: &PermissionDescriptor,
         status: &PermissionStatus,
     ) {
-        // Step 1.
-        status.set_state(get_descriptor_permission_state(status.get_query(), None));
+        // Step 1. Set status's state to permissionDesc's permission state.
+        status.set_state(descriptor_permission_state(status.get_query(), None));
     }
 
     // https://w3c.github.io/permissions/#boolean-permission-request-algorithm
@@ -255,16 +268,14 @@ impl PermissionAlgorithm for Permissions {
         match status.State() {
             // Step 3.
             PermissionState::Prompt => {
-                let perm_name = status.get_query();
-                let prompt = PermissionPrompt::Request(perm_name.convert());
-
                 // https://w3c.github.io/permissions/#request-permission-to-use (Step 3 - 4)
+                let permission_name = status.get_query();
                 let globalscope = GlobalScope::current().expect("No current global object");
-                let state = prompt_user_from_embedder(prompt, &globalscope);
+                let state = prompt_user_from_embedder(permission_name, &globalscope);
                 globalscope
                     .permission_state_invocation_results()
                     .borrow_mut()
-                    .insert(perm_name.to_string(), state);
+                    .insert(permission_name, state);
             },
 
             // Step 2.
@@ -283,95 +294,73 @@ impl PermissionAlgorithm for Permissions {
     }
 }
 
-// https://w3c.github.io/permissions/#permission-state
-pub(crate) fn get_descriptor_permission_state(
-    permission_name: PermissionName,
+/// <https://w3c.github.io/permissions/#dfn-permission-state>
+pub(crate) fn descriptor_permission_state(
+    feature: PermissionName,
     env_settings_obj: Option<&GlobalScope>,
 ) -> PermissionState {
-    // Step 1.
-    let globalscope = match env_settings_obj {
+    // Step 1. If settings wasn't passed, set it to the current settings object.
+    let global_scope = match env_settings_obj {
         Some(env_settings_obj) => DomRoot::from_ref(env_settings_obj),
         None => GlobalScope::current().expect("No current global object"),
     };
 
-    // Step 2.
-    // TODO: The `is the environment settings object a non-secure context` check is missing.
-    // The current solution is a workaround with a message box to warn about this,
-    // if the feature is not allowed in non-secure contexcts,
-    // and let the user decide to grant the permission or not.
-    let state = if allowed_in_nonsecure_contexts(&permission_name) {
-        PermissionState::Prompt
-    } else if pref!(dom_permissions_testing_allowed_in_nonsecure_contexts) {
-        PermissionState::Granted
-    } else {
-        globalscope
-            .permission_state_invocation_results()
-            .borrow_mut()
-            .remove(&permission_name.to_string());
-        prompt_user_from_embedder(
-            PermissionPrompt::Insecure(permission_name.convert()),
-            &globalscope,
-        )
-    };
+    // Step 2. If settings is a non-secure context, return "denied".
+    if !global_scope.is_secure_context() {
+        if pref!(dom_permissions_testing_allowed_in_nonsecure_contexts) {
+            return PermissionState::Granted;
+        }
+        return PermissionState::Denied;
+    }
 
-    // Step 3.
-    if let Some(prev_result) = globalscope
+    // Step 3. Let feature be descriptor's name.
+    // The caller has already converted the descriptor into a name.
+
+    // Step 4. If there exists a policy-controlled feature for feature and settings'
+    // relevant global object has an associated Document run the following step:
+    //   1. Let document be settings' relevant global object's associated Document.
+    //   2. If document is not allowed to use feature, return "denied".
+    if let Some(window) = global_scope.downcast::<Window>() {
+        if !window.Document().allowed_to_use_feature(feature) {
+            return PermissionState::Denied;
+        }
+    }
+
+    // Step 5. Let key be the result of generating a permission key for descriptor with settings.
+    // Step 6. Let entry be the result of getting a permission store entry with descriptor and key.
+    // Step 7. If entry is not null, return a PermissionState enum value from entry's state.
+    //
+    // TODO: We aren't making a key based on the descriptor, but on the descriptor's name. This really
+    // only matters for WebBluetooth, which adds more fields to the descriptor beyond the name.
+    if let Some(entry) = global_scope
         .permission_state_invocation_results()
         .borrow()
-        .get(&permission_name.to_string())
+        .get(&feature)
     {
-        return *prev_result;
+        return *entry;
     }
 
-    // Store the invocation result
-    globalscope
-        .permission_state_invocation_results()
-        .borrow_mut()
-        .insert(permission_name.to_string(), state);
-
-    // Step 4.
-    state
+    // Step 8. Return the PermissionState enum value that represents the permission state
+    // of feature, taking into account any permission state constraints for descriptor's
+    // name.
+    PermissionState::Prompt
 }
 
-// https://w3c.github.io/permissions/#allowed-in-non-secure-contexts
-fn allowed_in_nonsecure_contexts(permission_name: &PermissionName) -> bool {
-    match *permission_name {
-        // https://w3c.github.io/permissions/#dom-permissionname-geolocation
-        PermissionName::Geolocation => true,
-        // https://w3c.github.io/permissions/#dom-permissionname-notifications
-        PermissionName::Notifications => true,
-        // https://w3c.github.io/permissions/#dom-permissionname-push
-        PermissionName::Push => false,
-        // https://w3c.github.io/permissions/#dom-permissionname-midi
-        PermissionName::Midi => true,
-        // https://w3c.github.io/permissions/#dom-permissionname-camera
-        PermissionName::Camera => false,
-        // https://w3c.github.io/permissions/#dom-permissionname-microphone
-        PermissionName::Microphone => false,
-        // https://w3c.github.io/permissions/#dom-permissionname-speaker
-        PermissionName::Speaker => false,
-        // https://w3c.github.io/permissions/#dom-permissionname-device-info
-        PermissionName::Device_info => false,
-        // https://w3c.github.io/permissions/#dom-permissionname-background-sync
-        PermissionName::Background_sync => false,
-        // https://webbluetoothcg.github.io/web-bluetooth/#dom-permissionname-bluetooth
-        PermissionName::Bluetooth => false,
-        // https://storage.spec.whatwg.org/#dom-permissionname-persistent-storage
-        PermissionName::Persistent_storage => false,
-    }
-}
-
-fn prompt_user_from_embedder(prompt: PermissionPrompt, gs: &GlobalScope) -> PermissionState {
-    let Some(webview_id) = gs.webview_id() else {
+fn prompt_user_from_embedder(name: PermissionName, global_scope: &GlobalScope) -> PermissionState {
+    let Some(webview_id) = global_scope.webview_id() else {
         warn!("Requesting permissions from non-webview-associated global scope");
         return PermissionState::Denied;
     };
     let (sender, receiver) = ipc::channel().expect("Failed to create IPC channel!");
-    gs.send_to_embedder(EmbedderMsg::PromptPermission(webview_id, prompt, sender));
+    global_scope.send_to_embedder(EmbedderMsg::PromptPermission(
+        webview_id,
+        name.convert(),
+        sender,
+    ));
 
     match receiver.recv() {
-        Ok(PermissionRequest::Granted) => PermissionState::Granted,
-        Ok(PermissionRequest::Denied) => PermissionState::Denied,
+        Ok(AllowOrDeny::Allow) => PermissionState::Granted,
+        Ok(AllowOrDeny::Deny) => PermissionState::Denied,
         Err(e) => {
             warn!(
                 "Failed to receive permission state from embedder ({:?}).",
@@ -382,22 +371,20 @@ fn prompt_user_from_embedder(prompt: PermissionPrompt, gs: &GlobalScope) -> Perm
     }
 }
 
-impl Convert<embedder_traits::PermissionName> for PermissionName {
-    fn convert(self) -> embedder_traits::PermissionName {
+impl Convert<PermissionFeature> for PermissionName {
+    fn convert(self) -> PermissionFeature {
         match self {
-            PermissionName::Geolocation => embedder_traits::PermissionName::Geolocation,
-            PermissionName::Notifications => embedder_traits::PermissionName::Notifications,
-            PermissionName::Push => embedder_traits::PermissionName::Push,
-            PermissionName::Midi => embedder_traits::PermissionName::Midi,
-            PermissionName::Camera => embedder_traits::PermissionName::Camera,
-            PermissionName::Microphone => embedder_traits::PermissionName::Microphone,
-            PermissionName::Speaker => embedder_traits::PermissionName::Speaker,
-            PermissionName::Device_info => embedder_traits::PermissionName::DeviceInfo,
-            PermissionName::Background_sync => embedder_traits::PermissionName::BackgroundSync,
-            PermissionName::Bluetooth => embedder_traits::PermissionName::Bluetooth,
-            PermissionName::Persistent_storage => {
-                embedder_traits::PermissionName::PersistentStorage
-            },
+            PermissionName::Geolocation => PermissionFeature::Geolocation,
+            PermissionName::Notifications => PermissionFeature::Notifications,
+            PermissionName::Push => PermissionFeature::Push,
+            PermissionName::Midi => PermissionFeature::Midi,
+            PermissionName::Camera => PermissionFeature::Camera,
+            PermissionName::Microphone => PermissionFeature::Microphone,
+            PermissionName::Speaker => PermissionFeature::Speaker,
+            PermissionName::Device_info => PermissionFeature::DeviceInfo,
+            PermissionName::Background_sync => PermissionFeature::BackgroundSync,
+            PermissionName::Bluetooth => PermissionFeature::Bluetooth,
+            PermissionName::Persistent_storage => PermissionFeature::PersistentStorage,
         }
     }
 }

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -596,7 +596,10 @@ Dictionaries = {
 
 Enums = {
 'GPUFeatureName': {
-    'derives': ['Hash', 'Eq']
+    'derives': ['Eq', 'Hash', ]
+},
+'PermissionName': {
+    'derives': ['Eq', 'Hash']
 }
 }
 

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -147,6 +147,13 @@ pub enum PromptResult {
     Dismissed,
 }
 
+/// A response to a request to allow or deny an action.
+#[derive(Clone, Copy, Deserialize, PartialEq, Serialize)]
+pub enum AllowOrDeny {
+    Allow,
+    Deny,
+}
+
 #[derive(Deserialize, Serialize)]
 pub enum EmbedderMsg {
     /// A status message to be displayed by the browser chrome.
@@ -179,7 +186,7 @@ pub enum EmbedderMsg {
     /// All webviews lost focus for keyboard events.
     WebViewBlurred,
     /// Wether or not to unload a document
-    AllowUnload(WebViewId, IpcSender<bool>),
+    AllowUnload(WebViewId, IpcSender<AllowOrDeny>),
     /// Sends an unconsumed key event back to the embedder.
     Keyboard(WebViewId, KeyboardEvent),
     /// Inform embedder to clear the clipboard
@@ -215,7 +222,7 @@ pub enum EmbedderMsg {
         IpcSender<Option<Vec<PathBuf>>>,
     ),
     /// Open interface to request permission specified by prompt.
-    PromptPermission(WebViewId, PermissionPrompt, IpcSender<PermissionRequest>),
+    PromptPermission(WebViewId, PermissionFeature, IpcSender<AllowOrDeny>),
     /// Request to present an IME to the user when an editable element is focused.
     /// If the input is text, the second parameter defines the pre-existing string
     /// text content and the zero-based index into the string locating the insertion point.
@@ -237,7 +244,7 @@ pub enum EmbedderMsg {
     /// Report the status of Devtools Server with a token that can be used to bypass the permission prompt.
     OnDevtoolsStarted(Result<u16, ()>, String),
     /// Ask the user to allow a devtools client to connect.
-    RequestDevtoolsConnection(IpcSender<bool>),
+    RequestDevtoolsConnection(IpcSender<AllowOrDeny>),
     /// Notify the embedder that it needs to present a new frame.
     ReadyToPresent(Vec<WebViewId>),
     /// The given event was delivered to a pipeline in the given browser.
@@ -377,8 +384,8 @@ pub enum MediaSessionEvent {
 }
 
 /// Enum with variants that match the DOM PermissionName enum
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub enum PermissionName {
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+pub enum PermissionFeature {
     Geolocation,
     Notifications,
     Push,
@@ -390,20 +397,6 @@ pub enum PermissionName {
     BackgroundSync,
     Bluetooth,
     PersistentStorage,
-}
-
-/// Information required to display a permission prompt
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub enum PermissionPrompt {
-    Insecure(PermissionName),
-    Request(PermissionName),
-}
-
-/// Status for prompting user for permission.
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub enum PermissionRequest {
-    Granted,
-    Denied,
 }
 
 /// Used to specify the kind of input method editor appropriate to edit a field.


### PR DESCRIPTION
- Update the script crate to better reflect the modern Permission
  specifcation -- removing the necessity for an `Insecure` variant of
  the permissions prompt.
- Have all allow/deny type requests in the internal API use an
  `AllowOrDeny` enum for clarity.
- Expose `PermissionsRequest` and `PermissionFeature` data types to the
  API and use them in the delegate method.
- Update both servoshell implementations to use the API.

Co-authored-by: Mukilan Thiyagarajan <mukilan@igalia.com>
Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because the API does not currently have tests.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
