### PR TITLE
libservo: Add a delegate method for HTTP authentication

### DIFF
--- a/components/constellation/tracing.rs
+++ b/components/constellation/tracing.rs
@@ -209,6 +209,7 @@ mod from_script {
                 Self::MoveTo(..) => target_variant!("MoveTo"),
                 Self::ResizeTo(..) => target_variant!("ResizeTo"),
                 Self::Prompt(..) => target_variant!("Prompt"),
+                Self::RequestAuthentication(..) => target_variant!("RequestAuthentication"),
                 Self::ShowContextMenu(..) => target_variant!("ShowContextMenu"),
                 Self::AllowNavigationRequest(..) => target_variant!("AllowNavigationRequest"),
                 Self::AllowOpeningWebView(..) => target_variant!("AllowOpeningWebView"),

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -9,15 +9,13 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use async_recursion::async_recursion;
 use base::cross_process_instant::CrossProcessInstant;
-use base::id::{HistoryStateId, PipelineId, WebViewId};
+use base::id::{HistoryStateId, PipelineId};
 use crossbeam_channel::Sender;
 use devtools_traits::{
     ChromeToDevtoolsControlMsg, DevtoolsControlMsg, HttpRequest as DevtoolsHttpRequest,
     HttpResponse as DevtoolsHttpResponse, NetworkEvent,
 };
-use embedder_traits::{
-    EmbedderMsg, EmbedderProxy, PromptCredentialsInput, PromptDefinition, PromptOrigin,
-};
+use embedder_traits::{AuthenticationResponse, EmbedderMsg, EmbedderProxy};
 use futures::{future, TryFutureExt, TryStreamExt};
 use headers::authorization::Basic;
 use headers::{
@@ -105,6 +103,28 @@ pub struct HttpState {
     pub client: Client<Connector, crate::connector::BoxedBody>,
     pub override_manager: CertificateErrorOverrideManager,
     pub embedder_proxy: Mutex<EmbedderProxy>,
+}
+
+impl HttpState {
+    fn request_authentication(
+        &self,
+        request: &Request,
+        response: &Response,
+    ) -> Option<AuthenticationResponse> {
+        // We do not make an authentication request for non-WebView associated HTTP requests.
+        let webview_id = request.target_webview_id?;
+        let for_proxy = response.status == StatusCode::PROXY_AUTHENTICATION_REQUIRED;
+
+        let embedder_proxy = self.embedder_proxy.lock().unwrap();
+        let (ipc_sender, ipc_receiver) = ipc::channel().unwrap();
+        embedder_proxy.send(EmbedderMsg::RequestAuthentication(
+            webview_id,
+            request.url(),
+            for_proxy,
+            ipc_sender,
+        ));
+        ipc_receiver.recv().ok()?
+    }
 }
 
 /// Step 13 of <https://fetch.spec.whatwg.org/#concept-fetch>.
@@ -1595,27 +1615,22 @@ async fn http_network_or_cache_fetch(
 
         // Step 14.3 If request’s use-URL-credentials flag is unset or isAuthenticationFetch is true, then:
         if !request.use_url_credentials || authentication_fetch_flag {
-            let Some(webview_id) = request.target_webview_id else {
-                return response;
-            };
-            let Some(credentials) =
-                prompt_user_for_credentials(&context.state.embedder_proxy, webview_id)
-            else {
-                return response;
-            };
-            let Some(username) = credentials.username else {
-                return response;
-            };
-            let Some(password) = credentials.password else {
+            let Some(credentials) = context.state.request_authentication(request, &response) else {
                 return response;
             };
 
-            if let Err(err) = request.current_url_mut().set_username(&username) {
+            if let Err(err) = request
+                .current_url_mut()
+                .set_username(&credentials.username)
+            {
                 error!("error setting username for url: {:?}", err);
                 return response;
             };
 
-            if let Err(err) = request.current_url_mut().set_password(Some(&password)) {
+            if let Err(err) = request
+                .current_url_mut()
+                .set_password(Some(&credentials.password))
+            {
                 error!("error setting password for url: {:?}", err);
                 return response;
             };
@@ -1654,25 +1669,14 @@ async fn http_network_or_cache_fetch(
 
         // Step 15.4 Prompt the end user as appropriate in request’s window
         // window and store the result as a proxy-authentication entry.
-        let Some(webview_id) = request.target_webview_id else {
-            return response;
-        };
-        let Some(credentials) =
-            prompt_user_for_credentials(&context.state.embedder_proxy, webview_id)
-        else {
-            return response;
-        };
-        let Some(user_name) = credentials.username else {
-            return response;
-        };
-        let Some(password) = credentials.password else {
+        let Some(credentials) = context.state.request_authentication(request, &response) else {
             return response;
         };
 
-        // store the credentials as a proxy-authentication entry.
+        // Store the credentials as a proxy-authentication entry.
         let entry = AuthCacheEntry {
-            user_name,
-            password,
+            user_name: credentials.username,
+            password: credentials.password,
         };
         {
             let mut auth_cache = context.state.auth_cache.write().unwrap();
@@ -1792,28 +1796,6 @@ impl Drop for ResponseEndTimer {
                 .set_attribute(ResourceAttribute::ResponseEnd);
         })
     }
-}
-
-fn prompt_user_for_credentials(
-    embedder_proxy: &Mutex<EmbedderProxy>,
-    webview_id: WebViewId,
-) -> Option<PromptCredentialsInput> {
-    let proxy = embedder_proxy.lock().unwrap();
-
-    let (ipc_sender, ipc_receiver) = ipc::channel().unwrap();
-
-    proxy.send(EmbedderMsg::Prompt(
-        webview_id,
-        PromptDefinition::Credentials(ipc_sender),
-        PromptOrigin::Trusted,
-    ));
-
-    let Ok(credentials) = ipc_receiver.recv() else {
-        warn!("error getting user credentials");
-        return None;
-    };
-
-    Some(credentials)
 }
 
 /// [HTTP network fetch](https://fetch.spec.whatwg.org/#http-network-fetch)

--- a/components/net/tests/http_loader.rs
+++ b/components/net/tests/http_loader.rs
@@ -17,6 +17,7 @@ use devtools_traits::{
     ChromeToDevtoolsControlMsg, DevtoolsControlMsg, HttpRequest as DevtoolsHttpRequest,
     HttpResponse as DevtoolsHttpResponse, NetworkEvent,
 };
+use embedder_traits::AuthenticationResponse;
 use flate2::write::{GzEncoder, ZlibEncoder};
 use flate2::Compression;
 use headers::authorization::Basic;
@@ -1577,8 +1578,10 @@ fn test_user_credentials_prompt_when_proxy_authentication_is_required() {
     let (embedder_proxy, embedder_receiver) = create_embedder_proxy_and_receiver();
     let _ = receive_credential_prompt_msgs(
         embedder_receiver,
-        Some("username".to_string()),
-        Some("test".to_string()),
+        Some(AuthenticationResponse {
+            username: "username".into(),
+            password: "test".into(),
+        }),
     );
 
     let mut context = new_fetch_context(None, Some(embedder_proxy), None);
@@ -1625,8 +1628,10 @@ fn test_prompt_credentials_when_client_receives_unauthorized_response() {
     let (embedder_proxy, embedder_receiver) = create_embedder_proxy_and_receiver();
     let _ = receive_credential_prompt_msgs(
         embedder_receiver,
-        Some("username".to_string()),
-        Some("test".to_string()),
+        Some(AuthenticationResponse {
+            username: "username".into(),
+            password: "test".into(),
+        }),
     );
     let mut context = new_fetch_context(None, Some(embedder_proxy), None);
 
@@ -1670,7 +1675,7 @@ fn test_prompt_credentials_user_cancels_dialog_input() {
         .build();
 
     let (embedder_proxy, embedder_receiver) = create_embedder_proxy_and_receiver();
-    let _ = receive_credential_prompt_msgs(embedder_receiver, None, None);
+    let _ = receive_credential_prompt_msgs(embedder_receiver, None);
     let mut context = new_fetch_context(None, Some(embedder_proxy), None);
 
     let response = fetch_with_context(request, &mut context);
@@ -1715,8 +1720,10 @@ fn test_prompt_credentials_user_input_incorrect_credentials() {
     let (embedder_proxy, embedder_receiver) = create_embedder_proxy_and_receiver();
     let _ = receive_credential_prompt_msgs(
         embedder_receiver,
-        Some("test".to_string()),
-        Some("test".to_string()),
+        Some(AuthenticationResponse {
+            username: "test".into(),
+            password: "test".into(),
+        }),
     );
     let mut context = new_fetch_context(None, Some(embedder_proxy), None);
 

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -119,7 +119,8 @@ use crate::proxies::ConstellationProxy;
 pub use crate::servo_delegate::{ServoDelegate, ServoError};
 pub use crate::webview::WebView;
 pub use crate::webview_delegate::{
-    AllowOrDenyRequest, NavigationRequest, PermissionRequest, WebViewDelegate,
+    AllowOrDenyRequest, AuthenticationRequest, NavigationRequest, PermissionRequest,
+    WebViewDelegate,
 };
 
 #[cfg(feature = "webdriver")]
@@ -914,6 +915,19 @@ impl Servo {
                         allow_select_multiple,
                         response_sender,
                     );
+                }
+            },
+            EmbedderMsg::RequestAuthentication(webview_id, url, for_proxy, response_sender) => {
+                let authentication_request = AuthenticationRequest {
+                    url: url.into_url(),
+                    for_proxy,
+                    response_sender,
+                    response_sent: false,
+                };
+                if let Some(webview) = self.get_webview_handle(webview_id) {
+                    webview
+                        .delegate()
+                        .request_authentication(webview, authentication_request);
                 }
             },
             EmbedderMsg::PromptPermission(webview_id, requested_feature, response_sender) => {

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -116,16 +116,14 @@ pub enum PromptDefinition {
     OkCancel(String, IpcSender<PromptResult>),
     /// Ask the user to enter text.
     Input(String, String, IpcSender<Option<String>>),
-    /// Ask user to enter their username and password
-    Credentials(IpcSender<PromptCredentialsInput>),
 }
 
 #[derive(Debug, Default, Deserialize, Serialize)]
-pub struct PromptCredentialsInput {
+pub struct AuthenticationResponse {
     /// Username for http request authentication
-    pub username: Option<String>,
+    pub username: String,
     /// Password for http request authentication
-    pub password: Option<String>,
+    pub password: String,
 }
 
 #[derive(Deserialize, PartialEq, Serialize)]
@@ -166,6 +164,13 @@ pub enum EmbedderMsg {
     ResizeTo(WebViewId, DeviceIntSize),
     /// Show dialog to user
     Prompt(WebViewId, PromptDefinition, PromptOrigin),
+    /// Request authentication for a load or navigation from the embedder.
+    RequestAuthentication(
+        WebViewId,
+        ServoUrl,
+        bool, /* for proxy */
+        IpcSender<Option<AuthenticationResponse>>,
+    ),
     /// Show a context menu to the user
     ShowContextMenu(
         WebViewId,
@@ -278,6 +283,7 @@ impl Debug for EmbedderMsg {
             EmbedderMsg::MoveTo(..) => write!(f, "MoveTo"),
             EmbedderMsg::ResizeTo(..) => write!(f, "ResizeTo"),
             EmbedderMsg::Prompt(..) => write!(f, "Prompt"),
+            EmbedderMsg::RequestAuthentication(..) => write!(f, "RequestAuthentication"),
             EmbedderMsg::AllowUnload(..) => write!(f, "AllowUnload"),
             EmbedderMsg::AllowNavigationRequest(..) => write!(f, "AllowNavigationRequest"),
             EmbedderMsg::Keyboard(..) => write!(f, "Keyboard"),

--- a/ports/servoshell/egl/app_state.rs
+++ b/ports/servoshell/egl/app_state.rs
@@ -255,10 +255,6 @@ impl WebViewDelegate for RunningAppState {
             PromptDefinition::Input(message, default, response_sender) => {
                 response_sender.send(cb.prompt_input(message, default, trusted))
             },
-            PromptDefinition::Credentials(response_sender) => {
-                warn!("implement credentials prompt for OpenHarmony OS and Android");
-                response_sender.send(Default::default())
-            },
         };
     }
 


### PR DESCRIPTION
Add a delegate method for HTTP authentication and a related
`AuthenticationRequest` object that carries with it the URL as well as
whether or not the authentication request is for a proxy or not.

This is now separate from the prompt API because requesting
authentication doesn't necessarily involve prompting -- this is an
implementation detail of the embedder. In addition, the internal bits
are cleaned up slightly.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they are changes to the API which currently have no tests.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
