### PR TITLE
servoshell: Move `initial_window_size` and `screen_size_override` into `ServoShellPreferences` from `Opts`

### DIFF
--- a/components/config/opts.rs
+++ b/components/config/opts.rs
@@ -9,9 +9,7 @@ use std::default::Default;
 use std::path::PathBuf;
 use std::sync::{LazyLock, RwLock, RwLockReadGuard};
 
-use euclid::Size2D;
 use serde::{Deserialize, Serialize};
-use servo_geometry::DeviceIndependentPixel;
 use servo_url::ServoUrl;
 
 /// Global flags for Servo, currently set on the command line.
@@ -58,13 +56,6 @@ pub struct Opts {
     /// `None` to disable WebDriver or `Some` with a port number to start a server to listen to
     /// remote WebDriver commands.
     pub webdriver_port: Option<u16>,
-
-    /// The initial requested size of the window.
-    pub initial_window_size: Size2D<u32, DeviceIndependentPixel>,
-
-    /// An override for the screen resolution. This is useful for testing behavior on different screen sizes,
-    /// such as the screen of a mobile device.
-    pub screen_size_override: Option<Size2D<u32, DeviceIndependentPixel>>,
 
     /// Whether we're running in multiprocess mode.
     pub multiprocess: bool,
@@ -213,8 +204,6 @@ impl Default for Opts {
             output_file: None,
             hard_fail: true,
             webdriver_port: None,
-            initial_window_size: Size2D::new(1024, 740),
-            screen_size_override: None,
             multiprocess: false,
             background_hang_monitor: false,
             random_pipeline_closure_probability: None,

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -103,6 +103,7 @@ impl App {
     /// Initialize Application once event loop start running.
     pub fn init(&mut self, event_loop: Option<&ActiveEventLoop>) {
         // Create rendering context
+        let initial_window_size = self.servoshell_preferences.initial_window_size;
         let rendering_context = if self.servoshell_preferences.headless {
             let connection = Connection::new().expect("Failed to create connection");
             let adapter = connection
@@ -111,7 +112,7 @@ impl App {
             SurfmanRenderingContext::create(
                 &connection,
                 &adapter,
-                Some(self.opts.initial_window_size.to_untyped().to_i32()),
+                Some(initial_window_size.to_untyped().to_i32()),
             )
             .expect("Failed to create WR surfman")
         } else {
@@ -130,19 +131,13 @@ impl App {
 
         let headless = self.servoshell_preferences.headless;
         let window = if headless {
-            headless_window::Window::new(
-                self.opts.initial_window_size,
-                self.servoshell_preferences.device_pixel_ratio_override,
-                self.opts.screen_size_override,
-            )
+            headless_window::Window::new(&self.servoshell_preferences)
         } else {
             Rc::new(headed_window::Window::new(
                 &self.opts,
+                &self.servoshell_preferences,
                 &rendering_context,
-                self.opts.initial_window_size,
                 event_loop.unwrap(),
-                self.servoshell_preferences.no_native_titlebar,
-                self.servoshell_preferences.device_pixel_ratio_override,
             ))
         };
 

--- a/ports/servoshell/desktop/headless_window.rs
+++ b/ports/servoshell/desktop/headless_window.rs
@@ -15,6 +15,7 @@ use servo::webrender_api::units::{DeviceIntSize, DevicePixel};
 
 use super::app_state::RunningAppState;
 use crate::desktop::window_trait::WindowPortsMethods;
+use crate::prefs::ServoShellPreferences;
 
 pub struct Window {
     animation_state: Cell<AnimationState>,
@@ -27,20 +28,17 @@ pub struct Window {
 
 impl Window {
     #[allow(clippy::new_ret_no_self)]
-    pub fn new(
-        size: Size2D<u32, DeviceIndependentPixel>,
-        device_pixel_ratio_override: Option<f32>,
-        screen_size_override: Option<Size2D<u32, DeviceIndependentPixel>>,
-    ) -> Rc<dyn WindowPortsMethods> {
+    pub fn new(servoshell_preferences: &ServoShellPreferences) -> Rc<dyn WindowPortsMethods> {
+        let device_pixel_ratio_override = servoshell_preferences.device_pixel_ratio_override;
         let device_pixel_ratio_override: Option<Scale<f32, DeviceIndependentPixel, DevicePixel>> =
             device_pixel_ratio_override.map(Scale::new);
         let hidpi_factor = device_pixel_ratio_override.unwrap_or_else(Scale::identity);
 
-        let size = size.to_i32();
+        let size = servoshell_preferences.initial_window_size.to_i32();
         let inner_size = Cell::new((size.to_f32() * hidpi_factor).to_i32());
         let window_rect = Box2D::from_origin_and_size(Point2D::zero(), size);
 
-        let screen_size = screen_size_override.map_or_else(
+        let screen_size = servoshell_preferences.screen_size_override.map_or_else(
             || window_rect.size(),
             |screen_size_override| screen_size_override.to_i32(),
         );


### PR DESCRIPTION
These settings just configure `servoshell` so should be in
`ServoShellPreferences` instead.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because these kind of `servoshell` changes are currently untested.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
