### PR TITLE
 `DataTransferItem`: improve spec compliance

### DIFF
--- a/components/script/dom/datatransferitem.rs
+++ b/components/script/dom/datatransferitem.rs
@@ -51,8 +51,8 @@ impl DataTransferItemMethods<crate::DomTypeHolder> for DataTransferItem {
     /// <https://html.spec.whatwg.org/multipage/#dom-datatransferitem-kind>
     fn Kind(&self) -> DOMString {
         match self.item {
-            Kind::Text(_) => DOMString::from("string"),
-            Kind::File(_) => DOMString::from("file"),
+            Kind::Text { .. } => DOMString::from("string"),
+            Kind::File { .. } => DOMString::from("file"),
         }
     }
 

--- a/components/script/dom/datatransferitem.rs
+++ b/components/script/dom/datatransferitem.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::cell::{Ref, RefCell};
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
@@ -15,61 +16,106 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::file::File;
 use crate::dom::globalscope::GlobalScope;
-use crate::drag_data_store::Kind;
+use crate::drag_data_store::{DragDataStore, Kind, Mode};
 use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct DataTransferItem {
     reflector_: Reflector,
-    #[ignore_malloc_size_of = "TODO"]
+    #[ignore_malloc_size_of = "Rc"]
     #[no_trace]
-    item: Kind,
+    data_store: Rc<RefCell<Option<DragDataStore>>>,
+    id: u16,
 }
 
 impl DataTransferItem {
-    fn new_inherited(item: Kind) -> DataTransferItem {
+    fn new_inherited(data_store: Rc<RefCell<Option<DragDataStore>>>, id: u16) -> DataTransferItem {
         DataTransferItem {
             reflector_: Reflector::new(),
-            item,
+            data_store,
+            id,
         }
     }
 
     pub(crate) fn new(
         global: &GlobalScope,
+        data_store: Rc<RefCell<Option<DragDataStore>>>,
+        id: u16,
         can_gc: CanGc,
-        item: Kind,
     ) -> DomRoot<DataTransferItem> {
         reflect_dom_object(
-            Box::new(DataTransferItem::new_inherited(item)),
+            Box::new(DataTransferItem::new_inherited(data_store, id)),
             global,
             can_gc,
         )
+    }
+
+    fn item_kind(&self) -> Option<Ref<Kind>> {
+        Ref::filter_map(self.data_store.borrow(), |data_store| {
+            data_store
+                .as_ref()
+                .and_then(|data_store| data_store.get_by_id(&self.id))
+        })
+        .ok()
+    }
+
+    fn can_read(&self) -> bool {
+        self.data_store
+            .borrow()
+            .as_ref()
+            .is_some_and(|data_store| data_store.mode() != Mode::Protected)
     }
 }
 
 impl DataTransferItemMethods<crate::DomTypeHolder> for DataTransferItem {
     /// <https://html.spec.whatwg.org/multipage/#dom-datatransferitem-kind>
     fn Kind(&self) -> DOMString {
-        match self.item {
-            Kind::Text { .. } => DOMString::from("string"),
-            Kind::File { .. } => DOMString::from("file"),
-        }
+        self.item_kind()
+            .map_or(DOMString::new(), |item| match *item {
+                Kind::Text { .. } => DOMString::from("string"),
+                Kind::File { .. } => DOMString::from("file"),
+            })
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-datatransferitem-type>
     fn Type(&self) -> DOMString {
-        self.item.type_()
+        self.item_kind()
+            .map_or(DOMString::new(), |item| item.type_())
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-datatransferitem-getasstring>
     fn GetAsString(&self, callback: Option<Rc<FunctionStringCallback>>) {
-        if let (Some(callback), Some(data)) = (callback, self.item.as_string()) {
-            let _ = callback.Call__(data, ExceptionHandling::Report);
+        // Step 1 If the callback is null, return.
+        let Some(callback) = callback else {
+            return;
+        };
+
+        // Step 2 If the DataTransferItem object is not in the read/write mode or the read-only mode, return.
+        if !self.can_read() {
+            return;
+        }
+
+        // Step 3 If the drag data item kind is not text, then return.
+        if let Some(item_kind) = self.item_kind() {
+            if let Kind::Text { data, .. } = &*item_kind {
+                // Step 4 Otherwise, queue a task to invoke callback,
+                // passing the actual data of the item represented by the DataTransferItem object as the argument.
+                let _ = callback.Call__(data.clone(), ExceptionHandling::Report);
+            }
         }
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-datatransferitem-getasfile>
     fn GetAsFile(&self, can_gc: CanGc) -> Option<DomRoot<File>> {
-        self.item.as_file(&self.global(), can_gc)
+        // Step 1 If the DataTransferItem object is not in the read/write mode or the read-only mode, then return null.
+        if !self.can_read() {
+            return None;
+        }
+
+        // Step 2 If the drag data item kind is not File, then return null.
+        // Step 3 Return a new File object representing the actual data
+        // of the item represented by the DataTransferItem object.
+        self.item_kind()
+            .and_then(|item| item.as_file(&self.global(), can_gc))
     }
 }

--- a/components/script/dom/datatransferitemlist.rs
+++ b/components/script/dom/datatransferitemlist.rs
@@ -17,7 +17,7 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::datatransferitem::DataTransferItem;
 use crate::dom::file::File;
 use crate::dom::window::Window;
-use crate::drag_data_store::{Binary, DragDataStore, Kind, Mode, PlainString};
+use crate::drag_data_store::{DragDataStore, Kind, Mode};
 use crate::script_runtime::{CanGc, JSContext};
 
 #[dom_struct]
@@ -113,7 +113,7 @@ impl DataTransferItemListMethods<crate::DomTypeHolder> for DataTransferItemList 
         // whose type string is equal to the value of the method's second argument, converted to ASCII lowercase,
         // and whose data is the string given by the method's first argument.
         type_.make_ascii_lowercase();
-        data_store.add(Kind::Text(PlainString::new(data, type_)))?;
+        data_store.add(Kind::Text { data, type_ })?;
 
         self.frozen_types.clear();
 
@@ -141,13 +141,10 @@ impl DataTransferItemListMethods<crate::DomTypeHolder> for DataTransferItemList 
         // and whose data is the same as the File's data.
         let mut type_ = data.file_type();
         type_.make_ascii_lowercase();
-        let binary = Binary::new(
-            data.file_bytes().unwrap_or_default(),
-            data.name().clone(),
-            type_,
-        );
+        let bytes = data.file_bytes().unwrap_or_default();
+        let name = data.name().clone();
 
-        data_store.add(Kind::File(binary))?;
+        data_store.add(Kind::File { bytes, name, type_ })?;
 
         self.frozen_types.clear();
 

--- a/components/script/dom/datatransferitemlist.rs
+++ b/components/script/dom/datatransferitemlist.rs
@@ -90,9 +90,9 @@ impl DataTransferItemListMethods<crate::DomTypeHolder> for DataTransferItemList 
         };
 
         // Step 2
-        data_store
-            .get_item(index as usize)
-            .map(|item| DataTransferItem::new(&self.global(), can_gc, item))
+        data_store.get_by_index(index as usize).map(|(id, _)| {
+            DataTransferItem::new(&self.global(), Rc::clone(&self.data_store), *id, can_gc)
+        })
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-datatransferitemlist-add>
@@ -113,18 +113,18 @@ impl DataTransferItemListMethods<crate::DomTypeHolder> for DataTransferItemList 
         // whose type string is equal to the value of the method's second argument, converted to ASCII lowercase,
         // and whose data is the string given by the method's first argument.
         type_.make_ascii_lowercase();
-        data_store.add(Kind::Text { data, type_ })?;
+        data_store.add(Kind::Text { data, type_ }).map(|id| {
+            self.frozen_types.clear();
 
-        self.frozen_types.clear();
-
-        // Step 3 Determine the value of the indexed property corresponding to the newly added item,
-        // and return that value (a newly created DataTransferItem object).
-        let index = data_store.list_len() - 1;
-        let item = data_store
-            .get_item(index)
-            .map(|item| DataTransferItem::new(&self.global(), can_gc, item));
-
-        Ok(item)
+            // Step 3 Determine the value of the indexed property corresponding to the newly added item,
+            // and return that value (a newly created DataTransferItem object).
+            Some(DataTransferItem::new(
+                &self.global(),
+                Rc::clone(&self.data_store),
+                id,
+                can_gc,
+            ))
+        })
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-datatransferitemlist-add>
@@ -144,18 +144,18 @@ impl DataTransferItemListMethods<crate::DomTypeHolder> for DataTransferItemList 
         let bytes = data.file_bytes().unwrap_or_default();
         let name = data.name().clone();
 
-        data_store.add(Kind::File { bytes, name, type_ })?;
+        data_store.add(Kind::File { bytes, name, type_ }).map(|id| {
+            self.frozen_types.clear();
 
-        self.frozen_types.clear();
-
-        // Step 3 Determine the value of the indexed property corresponding to the newly added item,
-        // and return that value (a newly created DataTransferItem object).
-        let index = data_store.list_len() - 1;
-        let item = data_store
-            .get_item(index)
-            .map(|item| DataTransferItem::new(&self.global(), can_gc, item));
-
-        Ok(item)
+            // Step 3 Determine the value of the indexed property corresponding to the newly added item,
+            // and return that value (a newly created DataTransferItem object).
+            Some(DataTransferItem::new(
+                &self.global(),
+                Rc::clone(&self.data_store),
+                id,
+                can_gc,
+            ))
+        })
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-datatransferitemlist-remove>

--- a/components/script/drag_data_store.rs
+++ b/components/script/drag_data_store.rs
@@ -36,9 +36,9 @@ impl Kind {
         }
     }
 
-    fn as_string(&self) -> Option<DOMString> {
+    pub(crate) fn as_string(&self) -> Option<String> {
         match self {
-            Kind::Text { data, .. } => Some(data.clone()),
+            Kind::Text { data, .. } => Some(data.to_string()),
             Kind::File { .. } => None,
         }
     }
@@ -158,6 +158,7 @@ impl DragDataStore {
             .values()
             .find(|item| item.text_type_matches(type_))
             .and_then(|item| item.as_string())
+            .map(DOMString::from)
     }
 
     pub(crate) fn add(&mut self, kind: Kind) -> Fallible<u16> {

--- a/components/script/textinput.rs
+++ b/components/script/textinput.rs
@@ -1140,8 +1140,8 @@ impl<T: ClipboardProvider> TextInput<T> {
 
     fn paste_contents(&mut self, drag_data_store: &DragDataStore) {
         for item in drag_data_store.iter_item_list() {
-            if let Kind::Text(string) = item {
-                self.insert_string(string.data());
+            if let Kind::Text { data, .. } = item {
+                self.insert_string(data.to_string());
             }
         }
     }

--- a/tests/wpt/tests/html/editing/dnd/datastore/datatransferitemlist-remove.html
+++ b/tests/wpt/tests/html/editing/dnd/datastore/datatransferitemlist-remove.html
@@ -20,4 +20,20 @@ test(() => {
   // Must not throw
   dt.items.remove(1);
 }, "remove()ing an out-of-bounds index does nothing");
+
+test(() => {
+  const file = new File(["🕺💃"], "test.png", {
+        type: "image/png"
+  });
+
+  const dt = new DataTransfer();
+  dt.items.add(file);
+
+  let item = dt.items[0];
+  dt.items.remove(0);
+
+  assert_equals(item.kind, "");
+  assert_equals(item.type, "");
+  assert_equals(item.getAsFile(), null);
+}, "remove()ing an item will put the associated DataTransferItem object in the disabled mode");
 </script>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Avoid copying the kind enum inside DataTransferItem when constructing it; fetch it through drag_data_store instead.
According to spec if an item is removed from the drag data store item list, the corresponding `DataTransferItem` will be in a disabled mode.

I decided to use IndexMap since it was already a dependency and access by both index and a key was required.
For key i simply used a u16, maybe use a newtype for clarity?

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
