### PR TITLE
Support non-object this values for webidl callbacks.

### DIFF
--- a/components/script/dom/bindings/import.rs
+++ b/components/script/dom/bindings/import.rs
@@ -14,11 +14,11 @@ pub(crate) mod base {
     };
     pub(crate) use js::jsval::{JSVal, NullValue, ObjectOrNullValue, ObjectValue, UndefinedValue};
     pub(crate) use js::panic::maybe_resume_unwind;
-    pub(crate) use js::rust::wrappers::{JS_CallFunctionValue, JS_WrapValue};
+    pub(crate) use js::rust::wrappers::{Call, JS_WrapValue};
     pub(crate) use js::rust::{HandleObject, HandleValue, MutableHandleObject, MutableHandleValue};
 
     pub(crate) use crate::dom::bindings::callback::{
-        wrap_call_this_object, CallSetup, CallbackContainer, CallbackFunction, CallbackInterface,
+        wrap_call_this_value, CallSetup, CallbackContainer, CallbackFunction, CallbackInterface,
         CallbackObject, ExceptionHandling, ThisReflector,
     };
     pub(crate) use crate::dom::bindings::codegen::Bindings::AudioNodeBinding::{


### PR DESCRIPTION
This matches Gecko's behaviour from https://bugzilla.mozilla.org/show_bug.cgi?id=1146234 and allows an additional test to pass in #34844.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #35398
- [x] There are tests for these changes