### PR TITLE
script: reset spurious frame counter *only* when reflow is triggered

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -2403,9 +2403,10 @@ impl Document {
 
         // Update the counter of spurious animation frames.
         let spurious_frames = self.spurious_animation_frames.get();
-        if callbacks_did_not_trigger_reflow && spurious_frames < SPURIOUS_ANIMATION_FRAME_THRESHOLD
-        {
-            self.spurious_animation_frames.set(spurious_frames + 1);
+        if callbacks_did_not_trigger_reflow {
+            if spurious_frames < SPURIOUS_ANIMATION_FRAME_THRESHOLD {
+                self.spurious_animation_frames.set(spurious_frames + 1);
+            }
         } else {
             self.spurious_animation_frames.set(0);
         }

--- a/tests/wpt/tests/html/webappapis/animation-frames/spurious-frame-callbacks-optimization.html
+++ b/tests/wpt/tests/html/webappapis/animation-frames/spurious-frame-callbacks-optimization.html
@@ -10,30 +10,30 @@
 </body>
 <script>
 "use strict";
-let frame = 0;
-const draw = (t) => {
-  frame += 1;
-  if (frame < 11) {
-    // Don't mutate the DOM for 10 frames to meet the threshold for Servo's
-    // spurious frame optimization to kick in.
-    requestAnimationFrame(draw);
-  } else if (frame == 11) {
-    // Don't schedule next rAF so the compositor's tick is disabled.
-    // This is specific to Servo as the spurious frame detection at the
-    // time of this test was broken.
-    setTimeout(() => {
-      requestAnimationFrame(draw);
-    }, 10);
-  } else {
-    // Normal frames.
-    document.getElementById('target').innerText = t;
-    requestAnimationFrame(draw);
-  }
-};
-
 async_test(function(test) {
+  let frame = 0;
+  const draw = (t) => {
+    frame += 1;
+    if (frame < 11) {
+      // Don't mutate the DOM for 10 frames to meet the threshold for Servo's
+      // spurious frame optimization to kick in.
+      requestAnimationFrame(draw);
+    } else if (frame == 11) {
+      // Don't schedule next rAF so the compositor's tick is disabled.
+      // This is specific to Servo as the spurious frame detection at the
+      // time of this test was broken.
+      test.step_timeout(() => {
+        requestAnimationFrame(draw);
+      }, 0);
+    } else {
+      // Normal frames.
+      document.getElementById('target').innerText = t;
+      requestAnimationFrame(draw);
+    }
+  };
+
   let target = document.getElementById('target');
-  setTimeout(test.step_func_done(() => {
+  test.step_timeout(test.step_func_done(() => {
     assert_greater_than(parseInt(target.innerText), 500);
   }), 550);
   requestAnimationFrame(draw);


### PR DESCRIPTION
I had applied a review suggestion in the previous PR (#35387) to combine the nested conditions, but this is wrong as this meant the spurious frame counter was getting reset not just when the reflow was triggered by the callback, but also each time the counter reached the threshold.

The test added in the previous PR also had issues with the upstream WPT repo's lint checks - `test.step_timeout` should be used instead of the `setTimeout` function.

This patch fixes the counter update logic and also addresses the linting issue caught by upstream's linter.

---

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes 
