### PR TITLE
Correct page zoom default value,

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -379,7 +379,7 @@ impl IOCompositor {
             pending_scroll_zoom_events: Vec::new(),
             composite_target,
             shutdown_state: ShutdownState::NotShuttingDown,
-            page_zoom: Scale::new(1.0),
+            page_zoom: Scale::new(1.2),
             viewport_zoom: PinchZoomFactor::new(1.0),
             min_viewport_zoom: Some(PinchZoomFactor::new(1.0)),
             max_viewport_zoom: None,
@@ -1008,9 +1008,12 @@ impl IOCompositor {
 
         let scaled_viewport_size =
             self.embedder_coordinates.get_viewport().size().to_f32() / zoom_factor;
+        dbg!("{}",scaled_viewport_size, &self.embedder_coordinates, zoom_factor);
         let scaled_viewport_size = LayoutSize::from_untyped(scaled_viewport_size.to_untyped());
+        dbg!("{}",scaled_viewport_size);
         let scaled_viewport_rect =
             LayoutRect::from_origin_and_size(LayoutPoint::zero(), scaled_viewport_size);
+        dbg!("{}",scaled_viewport_rect);
 
         let root_clip_id = builder.define_clip_rect(zoom_reference_frame, scaled_viewport_rect);
         let clip_chain_id = builder.define_clip_chain(None, [root_clip_id]);
@@ -1773,6 +1776,7 @@ impl IOCompositor {
     fn device_pixels_per_page_pixel_not_including_page_zoom(
         &self,
     ) -> Scale<f32, CSSPixel, DevicePixel> {
+        dbg!("{}", &self.hidpi_factor());
         self.page_zoom * self.hidpi_factor()
     }
 


### PR DESCRIPTION
In Linux Desktop, Page is Zoomed Out. 

Steps: 
1. Open Browser in Desktop Maximized Mode. 
2. Open "https://servo.org/"

Observe the page in Servo, Firefox and Chrome.

Servo ![Screenshot from 2025-02-13 10-34-14](https://github.com/user-attachments/assets/0f6d7c74-1e47-49b7-9ca1-16e77cb035f6)
Firefox ![Screenshot from 2025-02-13 10-35-14](https://github.com/user-attachments/assets/3ccbbacc-35db-4a60-a4ff-9559f337a0fd)
Chrome ![Screenshot from 2025-02-13 10-34-07](https://github.com/user-attachments/assets/12e02f36-dd67-46ad-a506-6b459593b17c)


<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [X] These changes fix #35451 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
