### PR TITLE
script: Add `CanvasContext` trait

### DIFF
--- a/components/script/canvas_context.rs
+++ b/components/script/canvas_context.rs
@@ -1,0 +1,78 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+//! Common interfaces for Canvas Contexts
+
+use canvas_traits::canvas::CanvasId;
+use euclid::default::Size2D;
+use ipc_channel::ipc::IpcSharedMemory;
+use script_layout_interface::{HTMLCanvasData, HTMLCanvasDataSource};
+
+use crate::dom::bindings::codegen::UnionTypes::HTMLCanvasElementOrOffscreenCanvas;
+use crate::dom::bindings::inheritance::Castable;
+use crate::dom::node::{Node, NodeDamage};
+
+pub(crate) trait LayoutCanvasRenderingContextHelpers {
+    fn canvas_data_source(self) -> HTMLCanvasDataSource;
+}
+
+pub(crate) trait LayoutHTMLCanvasElementHelpers {
+    fn data(self) -> HTMLCanvasData;
+    fn get_canvas_id_for_layout(self) -> CanvasId;
+}
+
+pub(crate) trait CanvasContext {
+    type ID;
+
+    fn context_id(&self) -> Self::ID;
+
+    fn canvas(&self) -> HTMLCanvasElementOrOffscreenCanvas;
+
+    fn update_rendering(&self);
+
+    fn resize(&self);
+
+    fn get_image_data_as_shared_memory(&self) -> Option<IpcSharedMemory>;
+
+    // fn layout_handle(&self) -> HTMLCanvasDataSource;
+
+    fn get_image_data(&self) -> Option<Vec<u8>> {
+        self.get_image_data_as_shared_memory().map(|sm| sm.to_vec())
+    }
+
+    fn origin_is_clean(&self) -> bool {
+        true
+    }
+
+    fn size(&self) -> Size2D<u64> {
+        self.canvas().size()
+    }
+
+    fn mark_as_dirty(&self) {
+        if let HTMLCanvasElementOrOffscreenCanvas::HTMLCanvasElement(canvas) = &self.canvas() {
+            canvas.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
+        }
+    }
+
+    fn onscreen(&self) -> bool {
+        match self.canvas() {
+            HTMLCanvasElementOrOffscreenCanvas::HTMLCanvasElement(ref canvas) => {
+                canvas.upcast::<Node>().is_connected()
+            },
+            // TODO: Handle this properly
+            HTMLCanvasElementOrOffscreenCanvas::OffscreenCanvas(_) => false,
+        }
+    }
+}
+
+impl HTMLCanvasElementOrOffscreenCanvas {
+    pub(crate) fn size(&self) -> Size2D<u64> {
+        match self {
+            HTMLCanvasElementOrOffscreenCanvas::HTMLCanvasElement(canvas) => {
+                canvas.get_size().cast()
+            },
+            HTMLCanvasElementOrOffscreenCanvas::OffscreenCanvas(canvas) => canvas.get_size(),
+        }
+    }
+}

--- a/components/script/canvas_context.rs
+++ b/components/script/canvas_context.rs
@@ -29,13 +29,9 @@ pub(crate) trait CanvasContext {
 
     fn canvas(&self) -> HTMLCanvasElementOrOffscreenCanvas;
 
-    fn update_rendering(&self);
-
     fn resize(&self);
 
     fn get_image_data_as_shared_memory(&self) -> Option<IpcSharedMemory>;
-
-    // fn layout_handle(&self) -> HTMLCanvasDataSource;
 
     fn get_image_data(&self) -> Option<Vec<u8>> {
         self.get_image_data_as_shared_memory().map(|sm| sm.to_vec())
@@ -55,12 +51,15 @@ pub(crate) trait CanvasContext {
         }
     }
 
+    fn update_rendering(&self) {}
+
     fn onscreen(&self) -> bool {
         match self.canvas() {
             HTMLCanvasElementOrOffscreenCanvas::HTMLCanvasElement(ref canvas) => {
                 canvas.upcast::<Node>().is_connected()
             },
-            // TODO: Handle this properly
+            // FIXME(34628): Offscreen canvases should be considered offscreen if a placeholder is set.
+            // <https://www.w3.org/TR/webgpu/#abstract-opdef-updating-the-rendering-of-a-webgpu-canvas>
             HTMLCanvasElementOrOffscreenCanvas::OffscreenCanvas(_) => false,
         }
     }

--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -143,10 +143,10 @@ impl LayoutCanvasRenderingContext2DHelpers for LayoutDom<'_, CanvasRenderingCont
     }
 }
 
-#[cfg_attr(crown, allow(crown::unrooted_must_root))] // ID is not jsmanaged
 impl CanvasContext for CanvasRenderingContext2D {
     type ID = CanvasId;
 
+    #[cfg_attr(crown, allow(crown::unrooted_must_root))] // Crown is wrong here #35570
     fn context_id(&self) -> Self::ID {
         self.canvas_state.get_canvas_id()
     }

--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -159,10 +159,6 @@ impl CanvasContext for CanvasRenderingContext2D {
         }
     }
 
-    fn update_rendering(&self) {
-        // not done here
-    }
-
     fn resize(&self) {
         self.set_bitmap_dimensions(self.size().cast())
     }

--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -11,12 +11,15 @@ use ipc_channel::ipc::{IpcSender, IpcSharedMemory};
 use profile_traits::ipc;
 use servo_url::ServoUrl;
 
+use crate::canvas_context::CanvasContext;
 use crate::canvas_state::CanvasState;
 use crate::dom::bindings::codegen::Bindings::CanvasRenderingContext2DBinding::{
     CanvasDirection, CanvasFillRule, CanvasImageSource, CanvasLineCap, CanvasLineJoin,
     CanvasRenderingContext2DMethods, CanvasTextAlign, CanvasTextBaseline,
 };
-use crate::dom::bindings::codegen::UnionTypes::StringOrCanvasGradientOrCanvasPattern;
+use crate::dom::bindings::codegen::UnionTypes::{
+    HTMLCanvasElementOrOffscreenCanvas, StringOrCanvasGradientOrCanvasPattern,
+};
 use crate::dom::bindings::error::{ErrorResult, Fallible};
 use crate::dom::bindings::num::Finite;
 use crate::dom::bindings::reflector::{reflect_dom_object, DomGlobal, Reflector};
@@ -91,10 +94,6 @@ impl CanvasRenderingContext2D {
         self.canvas_state.set_bitmap_dimensions(size);
     }
 
-    pub(crate) fn mark_as_dirty(&self) {
-        self.canvas_state.mark_as_dirty(self.canvas.as_deref())
-    }
-
     pub(crate) fn take_missing_image_urls(&self) -> Vec<ServoUrl> {
         std::mem::take(&mut self.canvas_state.get_missing_image_urls().borrow_mut())
     }
@@ -105,10 +104,6 @@ impl CanvasRenderingContext2D {
 
     pub(crate) fn send_canvas_2d_msg(&self, msg: Canvas2dMsg) {
         self.canvas_state.send_canvas_2d_msg(msg)
-    }
-
-    pub(crate) fn origin_is_clean(&self) -> bool {
-        self.canvas_state.origin_is_clean()
     }
 
     pub(crate) fn get_rect(&self, rect: Rect<u32>) -> Vec<u8> {
@@ -122,14 +117,6 @@ impl CanvasRenderingContext2D {
                 .map_or(Size2D::zero(), |c| c.get_size().to_u64()),
             rect,
         )
-    }
-
-    pub(crate) fn fetch_data(&self) -> IpcSharedMemory {
-        let (sender, receiver) = ipc::channel(self.global().time_profiler_chan().clone()).unwrap();
-        let msg = CanvasMsg::FromScript(FromScriptMsg::SendPixels(sender), self.get_canvas_id());
-        self.canvas_state.get_ipc_renderer().send(msg).unwrap();
-
-        receiver.recv().unwrap()
     }
 
     pub(crate) fn send_data(&self, sender: IpcSender<CanvasImageData>) {
@@ -153,6 +140,58 @@ impl LayoutCanvasRenderingContext2DHelpers for LayoutDom<'_, CanvasRenderingCont
         // does nothing fancy but it would be easier to trust a
         // LayoutDom<_>-like type that would wrap the &CanvasState.
         self.unsafe_get().canvas_state.get_canvas_id()
+    }
+}
+
+#[cfg_attr(crown, allow(crown::unrooted_must_root))] // ID is not jsmanaged
+impl CanvasContext for CanvasRenderingContext2D {
+    type ID = CanvasId;
+
+    fn context_id(&self) -> Self::ID {
+        self.canvas_state.get_canvas_id()
+    }
+
+    fn canvas(&self) -> HTMLCanvasElementOrOffscreenCanvas {
+        if let Some(ref canvas) = self.canvas {
+            HTMLCanvasElementOrOffscreenCanvas::HTMLCanvasElement(canvas.as_rooted())
+        } else {
+            unimplemented!()
+        }
+    }
+
+    fn update_rendering(&self) {
+        // not done here
+    }
+
+    fn resize(&self) {
+        self.set_bitmap_dimensions(self.size().cast())
+    }
+
+    fn get_image_data_as_shared_memory(&self) -> Option<IpcSharedMemory> {
+        let (sender, receiver) = ipc::channel(self.global().time_profiler_chan().clone()).unwrap();
+        let msg = CanvasMsg::FromScript(FromScriptMsg::SendPixels(sender), self.get_canvas_id());
+        self.canvas_state.get_ipc_renderer().send(msg).unwrap();
+
+        Some(receiver.recv().unwrap())
+    }
+
+    fn get_image_data(&self) -> Option<Vec<u8>> {
+        Some(self.get_rect(Rect::from_size(self.size().cast())))
+    }
+
+    fn origin_is_clean(&self) -> bool {
+        self.canvas_state.origin_is_clean()
+    }
+
+    fn mark_as_dirty(&self) {
+        self.canvas_state.mark_as_dirty(self.canvas.as_deref())
+    }
+
+    fn size(&self) -> Size2D<u64> {
+        self.canvas
+            .as_ref()
+            .map(|c| c.get_size().cast())
+            .unwrap_or(Size2D::zero())
     }
 }
 

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -77,6 +77,7 @@ use webrender_api::units::DeviceIntRect;
 use super::bindings::codegen::Bindings::XPathEvaluatorBinding::XPathEvaluatorMethods;
 use crate::animation_timeline::AnimationTimeline;
 use crate::animations::Animations;
+use crate::canvas_context::CanvasContext as _;
 use crate::document_loader::{DocumentLoader, LoadType};
 use crate::dom::attr::Attr;
 use crate::dom::beforeunloadevent::BeforeUnloadEvent;
@@ -3206,7 +3207,7 @@ impl Document {
             .iter()
             .filter_map(|(_, context)| context.root())
             .filter(|context| context.onscreen())
-            .for_each(|context| context.update_rendering_of_webgpu_canvas());
+            .for_each(|context| context.update_rendering());
     }
 
     pub(crate) fn id_map(&self) -> Ref<HashMapTracedValues<Atom, Vec<Dom<Element>>>> {

--- a/components/script/dom/htmlcanvaselement.rs
+++ b/components/script/dom/htmlcanvaselement.rs
@@ -160,7 +160,7 @@ impl HTMLCanvasElement {
         )
     }
 
-    fn recreate_contexts(&self) {
+    fn recreate_contexts_after_resize(&self) {
         if let Some(ref context) = *self.context.borrow() {
             match *context {
                 CanvasContext::Context2d(ref context) => context.resize(),
@@ -717,7 +717,7 @@ impl VirtualMethods for HTMLCanvasElement {
     fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation) {
         self.super_type().unwrap().attribute_mutated(attr, mutation);
         match attr.local_name() {
-            &local_name!("width") | &local_name!("height") => self.recreate_contexts(),
+            &local_name!("width") | &local_name!("height") => self.recreate_contexts_after_resize(),
             _ => (),
         };
     }

--- a/components/script/dom/htmlcanvaselement.rs
+++ b/components/script/dom/htmlcanvaselement.rs
@@ -9,7 +9,7 @@ use std::rc::Rc;
 use canvas_traits::canvas::{CanvasId, CanvasMsg, FromScriptMsg};
 use canvas_traits::webgl::{GLContextAttributes, WebGLVersion};
 use dom_struct::dom_struct;
-use euclid::default::{Rect, Size2D};
+use euclid::default::Size2D;
 use html5ever::{local_name, namespace_url, ns, LocalName, Prefix};
 use image::codecs::jpeg::JpegEncoder;
 use image::codecs::png::PngEncoder;
@@ -29,6 +29,8 @@ use servo_media::streams::registry::MediaStreamId;
 use servo_media::streams::MediaStreamType;
 use style::attr::AttrValue;
 
+use crate::canvas_context::CanvasContext as _;
+pub(crate) use crate::canvas_context::*;
 use crate::dom::attr::Attr;
 use crate::dom::bindings::cell::{ref_filter_map, DomRefCell, Ref};
 use crate::dom::bindings::codegen::Bindings::HTMLCanvasElementBinding::{
@@ -159,18 +161,15 @@ impl HTMLCanvasElement {
     }
 
     fn recreate_contexts(&self) {
-        let size = self.get_size();
         if let Some(ref context) = *self.context.borrow() {
             match *context {
-                CanvasContext::Context2d(ref context) => {
-                    context.set_canvas_bitmap_dimensions(size.to_u64())
-                },
-                CanvasContext::WebGL(ref context) => context.recreate(size),
-                CanvasContext::WebGL2(ref context) => context.recreate(size),
+                CanvasContext::Context2d(ref context) => context.resize(),
+                CanvasContext::WebGL(ref context) => context.resize(),
+                CanvasContext::WebGL2(ref context) => context.resize(),
                 #[cfg(feature = "webgpu")]
                 CanvasContext::WebGPU(ref context) => context.resize(),
                 CanvasContext::Placeholder(ref context) => {
-                    context.set_canvas_bitmap_dimensions(size.to_u64())
+                    context.set_canvas_bitmap_dimensions(self.get_size().to_u64())
                 },
             }
         }
@@ -206,15 +205,6 @@ impl HTMLCanvasElement {
         let element = self.upcast::<Element>();
         element.set_uint_attribute(&html5ever::local_name!("height"), value, CanGc::note());
     }
-}
-
-pub(crate) trait LayoutCanvasRenderingContextHelpers {
-    fn canvas_data_source(self) -> HTMLCanvasDataSource;
-}
-
-pub(crate) trait LayoutHTMLCanvasElementHelpers {
-    fn data(self) -> HTMLCanvasData;
-    fn get_canvas_id_for_layout(self) -> CanvasId;
 }
 
 impl LayoutHTMLCanvasElementHelpers for LayoutDom<'_, HTMLCanvasElement> {
@@ -400,17 +390,17 @@ impl HTMLCanvasElement {
         }
 
         let data = match self.context.borrow().as_ref() {
-            Some(CanvasContext::Context2d(context)) => Some(context.fetch_data()),
-            Some(&CanvasContext::WebGL(_)) => {
+            Some(CanvasContext::Context2d(context)) => context.get_image_data_as_shared_memory(),
+            Some(CanvasContext::WebGL(_context)) => {
                 // TODO: add a method in WebGLRenderingContext to get the pixels.
                 return None;
             },
-            Some(&CanvasContext::WebGL2(_)) => {
+            Some(CanvasContext::WebGL2(_context)) => {
                 // TODO: add a method in WebGL2RenderingContext to get the pixels.
                 return None;
             },
             #[cfg(feature = "webgpu")]
-            Some(CanvasContext::WebGPU(context)) => Some(context.get_ipc_image()),
+            Some(CanvasContext::WebGPU(context)) => context.get_image_data_as_shared_memory(),
             Some(CanvasContext::Placeholder(context)) => {
                 let (sender, receiver) =
                     ipc::channel(self.global().time_profiler_chan().clone()).unwrap();
@@ -430,15 +420,11 @@ impl HTMLCanvasElement {
 
     fn get_content(&self) -> Option<Vec<u8>> {
         match *self.context.borrow() {
-            Some(CanvasContext::Context2d(ref context)) => {
-                Some(context.get_rect(Rect::from_size(self.get_size())))
-            },
-            Some(CanvasContext::WebGL(ref context)) => context.get_image_data(self.get_size()),
-            Some(CanvasContext::WebGL2(ref context)) => {
-                context.base_context().get_image_data(self.get_size())
-            },
+            Some(CanvasContext::Context2d(ref context)) => context.get_image_data(),
+            Some(CanvasContext::WebGL(ref context)) => context.get_image_data(),
+            Some(CanvasContext::WebGL2(ref context)) => context.get_image_data(),
             #[cfg(feature = "webgpu")]
-            Some(CanvasContext::WebGPU(ref context)) => Some(context.get_image_data()),
+            Some(CanvasContext::WebGPU(ref context)) => context.get_image_data(),
             Some(CanvasContext::Placeholder(_)) | None => {
                 // Each pixel is fully-transparent black.
                 Some(vec![0; (self.Width() * self.Height() * 4) as usize])

--- a/components/script/dom/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl2renderingcontext.rs
@@ -912,10 +912,6 @@ impl CanvasContext for WebGL2RenderingContext {
         self.base.canvas().clone()
     }
 
-    fn update_rendering(&self) {
-        // done per document for all WebGL canvases
-    }
-
     fn resize(&self) {
         self.base.resize();
     }

--- a/components/script/dom/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl2renderingcontext.rs
@@ -900,10 +900,10 @@ impl WebGL2RenderingContext {
     }
 }
 
-#[cfg_attr(crown, allow(crown::unrooted_must_root))] // ID is not jsmanaged
 impl CanvasContext for WebGL2RenderingContext {
     type ID = WebGLContextId;
 
+    #[cfg_attr(crown, allow(crown::unrooted_must_root))] // Crown is wrong here #35570
     fn context_id(&self) -> Self::ID {
         self.base.context_id()
     }

--- a/components/script/dom/webglprogram.rs
+++ b/components/script/dom/webglprogram.rs
@@ -12,6 +12,7 @@ use canvas_traits::webgl::{
 use dom_struct::dom_struct;
 use fnv::FnvHashSet;
 
+use crate::canvas_context::CanvasContext;
 use crate::dom::bindings::cell::{DomRefCell, Ref};
 use crate::dom::bindings::codegen::Bindings::WebGL2RenderingContextBinding::WebGL2RenderingContextConstants as constants2;
 use crate::dom::bindings::codegen::Bindings::WebGLRenderingContextBinding::WebGLRenderingContextConstants as constants;

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -1861,10 +1861,10 @@ impl WebGLRenderingContext {
     }
 }
 
-#[cfg_attr(crown, allow(crown::unrooted_must_root))] // ID is not jsmanaged
 impl CanvasContext for WebGLRenderingContext {
     type ID = WebGLContextId;
 
+    #[cfg_attr(crown, allow(crown::unrooted_must_root))] // Crown is wrong here #35570
     fn context_id(&self) -> Self::ID {
         self.webgl_sender.context_id()
     }

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -1873,10 +1873,6 @@ impl CanvasContext for WebGLRenderingContext {
         self.canvas.clone()
     }
 
-    fn update_rendering(&self) {
-        // done per document for all WebGL canvases
-    }
-
     fn resize(&self) {
         let size = self.size().cast();
         let (sender, receiver) = webgl_channel().unwrap();

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -36,6 +36,7 @@ use serde::{Deserialize, Serialize};
 use servo_config::pref;
 use webrender_api::ImageKey;
 
+use crate::canvas_context::CanvasContext;
 use crate::dom::bindings::cell::{DomRefCell, Ref, RefMut};
 use crate::dom::bindings::codegen::Bindings::ANGLEInstancedArraysBinding::ANGLEInstancedArraysConstants;
 use crate::dom::bindings::codegen::Bindings::EXTBlendMinmaxBinding::EXTBlendMinmaxConstants;
@@ -351,68 +352,6 @@ impl WebGLRenderingContext {
         self.current_vertex_attribs.borrow_mut()
     }
 
-    pub(crate) fn recreate(&self, size: Size2D<u32>) {
-        let (sender, receiver) = webgl_channel().unwrap();
-        self.webgl_sender.send_resize(size, sender).unwrap();
-        // FIXME(#21718) The backend is allowed to choose a size smaller than
-        // what was requested
-        self.size.set(size);
-
-        if let Err(msg) = receiver.recv().unwrap() {
-            error!("Error resizing WebGLContext: {}", msg);
-            return;
-        };
-
-        // ClearColor needs to be restored because after a resize the GLContext is recreated
-        // and the framebuffer is cleared using the default black transparent color.
-        let color = self.current_clear_color.get();
-        self.send_command(WebGLCommand::ClearColor(color.0, color.1, color.2, color.3));
-
-        // WebGL Spec: Scissor rect must not change if the canvas is resized.
-        // See: webgl/conformance-1.0.3/conformance/rendering/gl-scissor-canvas-dimensions.html
-        // NativeContext handling library changes the scissor after a resize, so we need to reset the
-        // default scissor when the canvas was created or the last scissor that the user set.
-        let rect = self.current_scissor.get();
-        self.send_command(WebGLCommand::Scissor(rect.0, rect.1, rect.2, rect.3));
-
-        // Bound texture must not change when the canvas is resized.
-        // Right now surfman generates a new FBO and the bound texture is changed
-        // in order to create a new render to texture attachment.
-        // Send a command to re-bind the TEXTURE_2D, if any.
-        if let Some(texture) = self
-            .textures
-            .active_texture_slot(constants::TEXTURE_2D, self.webgl_version())
-            .unwrap()
-            .get()
-        {
-            self.send_command(WebGLCommand::BindTexture(
-                constants::TEXTURE_2D,
-                Some(texture.id()),
-            ));
-        }
-
-        // Bound framebuffer must not change when the canvas is resized.
-        // Right now surfman generates a new FBO on resize.
-        // Send a command to re-bind the framebuffer, if any.
-        if let Some(fbo) = self.bound_draw_framebuffer.get() {
-            let id = WebGLFramebufferBindingRequest::Explicit(fbo.id());
-            self.send_command(WebGLCommand::BindFramebuffer(constants::FRAMEBUFFER, id));
-        }
-    }
-
-    pub(crate) fn context_id(&self) -> WebGLContextId {
-        self.webgl_sender.context_id()
-    }
-
-    pub(crate) fn onscreen(&self) -> bool {
-        match self.canvas {
-            HTMLCanvasElementOrOffscreenCanvas::HTMLCanvasElement(ref canvas) => {
-                canvas.upcast::<Node>().is_connected()
-            },
-            HTMLCanvasElementOrOffscreenCanvas::OffscreenCanvas(_) => false,
-        }
-    }
-
     #[inline]
     pub(crate) fn send_command(&self, command: WebGLCommand) {
         self.webgl_sender
@@ -535,27 +474,6 @@ impl WebGLRenderingContext {
                 Size2D::new(info.width(), info.height()),
                 info.data_type().unwrap_or(TexDataType::UnsignedByte),
             );
-        }
-    }
-
-    pub(crate) fn mark_as_dirty(&self) {
-        // If we have a bound framebuffer, then don't mark the canvas as dirty.
-        if self.bound_draw_framebuffer.get().is_some() {
-            return;
-        }
-
-        // Dirtying the canvas is unnecessary if we're actively displaying immersive
-        // XR content right now.
-        if self.global().as_window().in_immersive_xr_session() {
-            return;
-        }
-
-        match self.canvas {
-            HTMLCanvasElementOrOffscreenCanvas::HTMLCanvasElement(ref canvas) => {
-                canvas.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
-                canvas.owner_document().add_dirty_webgl_canvas(self);
-            },
-            HTMLCanvasElementOrOffscreenCanvas::OffscreenCanvas(_) => {},
         }
     }
 
@@ -1131,33 +1049,6 @@ impl WebGLRenderingContext {
                 .vertex_attrib_divisor(index, divisor),
         };
         self.send_command(WebGLCommand::VertexAttribDivisor { index, divisor });
-    }
-
-    // Used by HTMLCanvasElement.toDataURL
-    //
-    // This emits errors quite liberally, but the spec says that this operation
-    // can fail and that it is UB what happens in that case.
-    //
-    // https://www.khronos.org/registry/webgl/specs/latest/1.0/#2.2
-    pub(crate) fn get_image_data(&self, mut size: Size2D<u32>) -> Option<Vec<u8>> {
-        handle_potential_webgl_error!(self, self.validate_framebuffer(), return None);
-
-        let (fb_width, fb_height) = handle_potential_webgl_error!(
-            self,
-            self.get_current_framebuffer_size().ok_or(InvalidOperation),
-            return None
-        );
-        size.width = cmp::min(size.width, fb_width as u32);
-        size.height = cmp::min(size.height, fb_height as u32);
-
-        let (sender, receiver) = ipc::bytes_channel().unwrap();
-        self.send_command(WebGLCommand::ReadPixels(
-            Rect::from_size(size),
-            constants::RGBA,
-            constants::UNSIGNED_BYTE,
-            sender,
-        ));
-        Some(receiver.recv().unwrap())
     }
 
     pub(crate) fn array_buffer(&self) -> Option<DomRoot<WebGLBuffer>> {
@@ -1967,6 +1858,127 @@ impl WebGLRenderingContext {
                 NullValue()
             },
         })
+    }
+}
+
+#[cfg_attr(crown, allow(crown::unrooted_must_root))] // ID is not jsmanaged
+impl CanvasContext for WebGLRenderingContext {
+    type ID = WebGLContextId;
+
+    fn context_id(&self) -> Self::ID {
+        self.webgl_sender.context_id()
+    }
+
+    fn canvas(&self) -> HTMLCanvasElementOrOffscreenCanvas {
+        self.canvas.clone()
+    }
+
+    fn update_rendering(&self) {
+        // done per document for all WebGL canvases
+    }
+
+    fn resize(&self) {
+        let size = self.size().cast();
+        let (sender, receiver) = webgl_channel().unwrap();
+        self.webgl_sender.send_resize(size, sender).unwrap();
+        // FIXME(#21718) The backend is allowed to choose a size smaller than
+        // what was requested
+        self.size.set(size);
+
+        if let Err(msg) = receiver.recv().unwrap() {
+            error!("Error resizing WebGLContext: {}", msg);
+            return;
+        };
+
+        // ClearColor needs to be restored because after a resize the GLContext is recreated
+        // and the framebuffer is cleared using the default black transparent color.
+        let color = self.current_clear_color.get();
+        self.send_command(WebGLCommand::ClearColor(color.0, color.1, color.2, color.3));
+
+        // WebGL Spec: Scissor rect must not change if the canvas is resized.
+        // See: webgl/conformance-1.0.3/conformance/rendering/gl-scissor-canvas-dimensions.html
+        // NativeContext handling library changes the scissor after a resize, so we need to reset the
+        // default scissor when the canvas was created or the last scissor that the user set.
+        let rect = self.current_scissor.get();
+        self.send_command(WebGLCommand::Scissor(rect.0, rect.1, rect.2, rect.3));
+
+        // Bound texture must not change when the canvas is resized.
+        // Right now surfman generates a new FBO and the bound texture is changed
+        // in order to create a new render to texture attachment.
+        // Send a command to re-bind the TEXTURE_2D, if any.
+        if let Some(texture) = self
+            .textures
+            .active_texture_slot(constants::TEXTURE_2D, self.webgl_version())
+            .unwrap()
+            .get()
+        {
+            self.send_command(WebGLCommand::BindTexture(
+                constants::TEXTURE_2D,
+                Some(texture.id()),
+            ));
+        }
+
+        // Bound framebuffer must not change when the canvas is resized.
+        // Right now surfman generates a new FBO on resize.
+        // Send a command to re-bind the framebuffer, if any.
+        if let Some(fbo) = self.bound_draw_framebuffer.get() {
+            let id = WebGLFramebufferBindingRequest::Explicit(fbo.id());
+            self.send_command(WebGLCommand::BindFramebuffer(constants::FRAMEBUFFER, id));
+        }
+    }
+
+    fn get_image_data_as_shared_memory(&self) -> Option<IpcSharedMemory> {
+        // TODO: add a method in WebGLRenderingContext to get the pixels.
+        None
+    }
+
+    // Used by HTMLCanvasElement.toDataURL
+    //
+    // This emits errors quite liberally, but the spec says that this operation
+    // can fail and that it is UB what happens in that case.
+    //
+    // https://www.khronos.org/registry/webgl/specs/latest/1.0/#2.2
+    fn get_image_data(&self) -> Option<Vec<u8>> {
+        handle_potential_webgl_error!(self, self.validate_framebuffer(), return None);
+        let mut size = self.size().cast();
+
+        let (fb_width, fb_height) = handle_potential_webgl_error!(
+            self,
+            self.get_current_framebuffer_size().ok_or(InvalidOperation),
+            return None
+        );
+        size.width = cmp::min(size.width, fb_width as u32);
+        size.height = cmp::min(size.height, fb_height as u32);
+
+        let (sender, receiver) = ipc::bytes_channel().unwrap();
+        self.send_command(WebGLCommand::ReadPixels(
+            Rect::from_size(size),
+            constants::RGBA,
+            constants::UNSIGNED_BYTE,
+            sender,
+        ));
+        Some(receiver.recv().unwrap())
+    }
+
+    fn mark_as_dirty(&self) {
+        // If we have a bound framebuffer, then don't mark the canvas as dirty.
+        if self.bound_draw_framebuffer.get().is_some() {
+            return;
+        }
+
+        // Dirtying the canvas is unnecessary if we're actively displaying immersive
+        // XR content right now.
+        if self.global().as_window().in_immersive_xr_session() {
+            return;
+        }
+
+        match self.canvas {
+            HTMLCanvasElementOrOffscreenCanvas::HTMLCanvasElement(ref canvas) => {
+                canvas.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
+                canvas.owner_document().add_dirty_webgl_canvas(self);
+            },
+            HTMLCanvasElementOrOffscreenCanvas::OffscreenCanvas(_) => {},
+        }
     }
 }
 

--- a/components/script/dom/webgpu/gpucanvascontext.rs
+++ b/components/script/dom/webgpu/gpucanvascontext.rs
@@ -249,10 +249,10 @@ impl GPUCanvasContext {
     }
 }
 
-#[cfg_attr(crown, allow(crown::unrooted_must_root))] // ID is not jsmanaged
 impl CanvasContext for GPUCanvasContext {
     type ID = WebGPUContextId;
 
+    #[cfg_attr(crown, allow(crown::unrooted_must_root))] // Crown is wrong here #35570
     fn context_id(&self) -> WebGPUContextId {
         self.context_id
     }

--- a/components/script/dom/webgpu/gpucanvascontext.rs
+++ b/components/script/dom/webgpu/gpucanvascontext.rs
@@ -7,7 +7,6 @@ use std::cell::RefCell;
 
 use arrayvec::ArrayVec;
 use dom_struct::dom_struct;
-use euclid::default::Size2D;
 use ipc_channel::ipc::{self, IpcSharedMemory};
 use script_layout_interface::HTMLCanvasDataSource;
 use webgpu::swapchain::WebGPUContextId;
@@ -20,6 +19,7 @@ use webrender_api::ImageKey;
 
 use super::gpuconvert::convert_texture_descriptor;
 use super::gputexture::GPUTexture;
+use crate::canvas_context::CanvasContext;
 use crate::conversions::Convert;
 use crate::dom::bindings::codegen::Bindings::GPUCanvasContextBinding::GPUCanvasContextMethods;
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::GPUTexture_Binding::GPUTextureMethods;
@@ -30,7 +30,6 @@ use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
 };
 use crate::dom::bindings::codegen::UnionTypes::HTMLCanvasElementOrOffscreenCanvas;
 use crate::dom::bindings::error::{Error, Fallible};
-use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::{reflect_dom_object, DomGlobal, Reflector};
 use crate::dom::bindings::root::{DomRoot, LayoutDom, MutNullableDom};
 use crate::dom::bindings::str::USVString;
@@ -38,19 +37,8 @@ use crate::dom::bindings::weakref::WeakRef;
 use crate::dom::document::WebGPUContextsMap;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::htmlcanvaselement::{HTMLCanvasElement, LayoutCanvasRenderingContextHelpers};
-use crate::dom::node::{Node, NodeDamage, NodeTraits};
+use crate::dom::node::NodeTraits;
 use crate::script_runtime::CanGc;
-
-impl HTMLCanvasElementOrOffscreenCanvas {
-    fn size(&self) -> Size2D<u64> {
-        match self {
-            HTMLCanvasElementOrOffscreenCanvas::HTMLCanvasElement(canvas) => {
-                canvas.get_size().cast()
-            },
-            HTMLCanvasElementOrOffscreenCanvas::OffscreenCanvas(canvas) => canvas.get_size(),
-        }
-    }
-}
 
 /// <https://gpuweb.github.io/gpuweb/#supported-context-formats>
 fn supported_context_format(format: GPUTextureFormat) -> bool {
@@ -259,43 +247,24 @@ impl GPUCanvasContext {
             );
         }
     }
-
-    fn size(&self) -> Size2D<u64> {
-        self.canvas.size()
-    }
 }
 
-// public methods for canvas handling
-// these methods should probably be behind trait for all canvases
-impl GPUCanvasContext {
-    pub(crate) fn context_id(&self) -> WebGPUContextId {
+#[cfg_attr(crown, allow(crown::unrooted_must_root))] // ID is not jsmanaged
+impl CanvasContext for GPUCanvasContext {
+    type ID = WebGPUContextId;
+
+    fn context_id(&self) -> WebGPUContextId {
         self.context_id
     }
 
-    pub(crate) fn mark_as_dirty(&self) {
-        if let HTMLCanvasElementOrOffscreenCanvas::HTMLCanvasElement(canvas) = &self.canvas {
-            canvas.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
-        }
-    }
-
-    pub(crate) fn onscreen(&self) -> bool {
-        match self.canvas {
-            HTMLCanvasElementOrOffscreenCanvas::HTMLCanvasElement(ref canvas) => {
-                canvas.upcast::<Node>().is_connected()
-            },
-            // FIXME(#34628): Handle this properly
-            HTMLCanvasElementOrOffscreenCanvas::OffscreenCanvas(_) => false,
-        }
-    }
-
     /// <https://gpuweb.github.io/gpuweb/#abstract-opdef-updating-the-rendering-of-a-webgpu-canvas>
-    pub(crate) fn update_rendering_of_webgpu_canvas(&self) {
+    fn update_rendering(&self) {
         // Step 1
         self.expire_current_texture();
     }
 
     /// <https://gpuweb.github.io/gpuweb/#abstract-opdef-update-the-canvas-size>
-    pub(crate) fn resize(&self) {
+    fn resize(&self) {
         // Step 1
         self.replace_drawing_buffer();
         // Step 2
@@ -308,9 +277,9 @@ impl GPUCanvasContext {
     }
 
     /// <https://gpuweb.github.io/gpuweb/#ref-for-abstract-opdef-get-a-copy-of-the-image-contents-of-a-context%E2%91%A5>
-    pub(crate) fn get_ipc_image(&self) -> IpcSharedMemory {
+    fn get_image_data_as_shared_memory(&self) -> Option<IpcSharedMemory> {
         // 1. Return a copy of the image contents of context.
-        if self.drawing_buffer.borrow().cleared {
+        Some(if self.drawing_buffer.borrow().cleared {
             IpcSharedMemory::from_byte(0, self.size().area() as usize * 4)
         } else {
             let (sender, receiver) = ipc::channel().unwrap();
@@ -322,11 +291,11 @@ impl GPUCanvasContext {
                 })
                 .unwrap();
             receiver.recv().unwrap()
-        }
+        })
     }
 
-    pub(crate) fn get_image_data(&self) -> Vec<u8> {
-        self.get_ipc_image().to_vec()
+    fn canvas(&self) -> HTMLCanvasElementOrOffscreenCanvas {
+        self.canvas.clone()
     }
 }
 

--- a/components/script/dom/webxr/xrlayer.rs
+++ b/components/script/dom/webxr/xrlayer.rs
@@ -6,6 +6,7 @@ use canvas_traits::webgl::WebGLContextId;
 use dom_struct::dom_struct;
 use webxr_api::LayerId;
 
+use crate::canvas_context::CanvasContext as _;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::Dom;
 use crate::dom::eventtarget::EventTarget;

--- a/components/script/dom/webxr/xrsession.rs
+++ b/components/script/dom/webxr/xrsession.rs
@@ -25,6 +25,7 @@ use webxr_api::{
 };
 
 use crate::conversions::Convert;
+use crate::canvas_context::CanvasContext;
 use crate::dom::bindings::trace::HashMapTracedValues;
 use crate::dom::bindings::buffer_source::create_buffer_source;
 use crate::dom::bindings::callback::ExceptionHandling;

--- a/components/script/dom/webxr/xrwebgllayer.rs
+++ b/components/script/dom/webxr/xrwebgllayer.rs
@@ -10,6 +10,7 @@ use euclid::{Rect, Size2D};
 use js::rust::HandleObject;
 use webxr_api::{ContextId as WebXRContextId, LayerId, LayerInit, Viewport};
 
+use crate::canvas_context::CanvasContext as _;
 use crate::dom::bindings::codegen::Bindings::WebGL2RenderingContextBinding::WebGL2RenderingContextConstants as constants;
 use crate::dom::bindings::codegen::Bindings::WebGLRenderingContextBinding::WebGLRenderingContextMethods;
 use crate::dom::bindings::codegen::Bindings::XRWebGLLayerBinding::{

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -35,6 +35,7 @@ mod devtools;
 pub(crate) mod document_loader;
 #[macro_use]
 mod dom;
+mod canvas_context;
 mod canvas_state;
 pub(crate) mod fetch;
 mod init;


### PR DESCRIPTION
Avoiding some code duplication and make canvas contexts more unified.

There is still more work to be done like unifying `get_image_data`, but this is left for followup.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #35286
- [x] There are tests for these changes in WPT

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
