### PR TITLE
fix issue #35449: handle touch events in on_input_event.

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -1353,6 +1353,11 @@ impl IOCompositor {
             return;
         }
 
+        if let InputEvent::Touch(event) = event {
+            self.on_touch_event(event);
+            return;
+        }
+
         if self.convert_mouse_to_touch {
             match event {
                 InputEvent::MouseButton(event) => {


### PR DESCRIPTION
This fixes a regression, which caused touch input to not be handled by the touch event handler.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #35449

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
