### PR TITLE
chore: Remove outdated FIXME.

### DIFF
--- a/components/script/dom/bindings/iterable.rs
+++ b/components/script/dom/bindings/iterable.rs
@@ -54,7 +54,6 @@ pub trait Iterable {
 }
 
 /// An iterator over the iterable entries of a given DOM interface.
-//FIXME: #12811 prevents dom_struct with type parameters
 #[dom_struct]
 pub struct IterableIterator<T: DomObjectIteratorWrap + JSTraceable + Iterable> {
     reflector: Reflector,


### PR DESCRIPTION
#12811 is closed, and the code clearly works with type parameters already.