### PR TITLE
script: Make callbacks generic over DOM interfaces.

### DIFF
--- a/components/script/dom/bindings/callback.rs
+++ b/components/script/dom/bindings/callback.rs
@@ -20,12 +20,13 @@ use crate::dom::bindings::codegen::Bindings::WindowBinding::Window_Binding::Wind
 use crate::dom::bindings::error::{report_pending_exception, Error, Fallible};
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::{Dom, DomRoot};
-use crate::dom::bindings::settings_stack::{AutoEntryScript, AutoIncumbentScript};
+use crate::dom::bindings::settings_stack::{GenericAutoEntryScript, GenericAutoIncumbentScript};
 use crate::dom::bindings::utils::AsCCharPtrPtr;
-use crate::dom::globalscope::GlobalScope;
-use crate::dom::window::Window;
+use crate::dom::document::DocumentHelpers;
+use crate::dom::globalscope::GlobalScopeHelpers;
 use crate::realms::{enter_realm, InRealm};
 use crate::script_runtime::{CanGc, JSContext};
+use crate::DomTypes;
 
 /// The exception handling used for a call.
 #[derive(Clone, Copy, PartialEq)]
@@ -40,7 +41,7 @@ pub(crate) enum ExceptionHandling {
 /// callback interface types.
 #[derive(JSTraceable)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
-pub(crate) struct CallbackObject {
+pub(crate) struct CallbackObject<D: DomTypes> {
     /// The underlying `JSObject`.
     callback: Heap<*mut JSObject>,
     permanent_js_root: Heap<JSVal>,
@@ -56,18 +57,18 @@ pub(crate) struct CallbackObject {
     ///
     /// ["callback context"]: https://heycam.github.io/webidl/#dfn-callback-context
     /// [sometimes]: https://github.com/whatwg/html/issues/2248
-    incumbent: Option<Dom<GlobalScope>>,
+    incumbent: Option<Dom<D::GlobalScope>>,
 }
 
-impl CallbackObject {
+impl<D: DomTypes> CallbackObject<D> {
     #[cfg_attr(crown, allow(crown::unrooted_must_root))]
     // These are used by the bindings and do not need `default()` functions.
     #[allow(clippy::new_without_default)]
-    fn new() -> CallbackObject {
-        CallbackObject {
+    fn new() -> Self {
+        Self {
             callback: Heap::default(),
             permanent_js_root: Heap::default(),
-            incumbent: GlobalScope::incumbent().map(|i| Dom::from_ref(&*i)),
+            incumbent: D::GlobalScope::incumbent().map(|i| Dom::from_ref(&*i)),
         }
     }
 
@@ -87,7 +88,7 @@ impl CallbackObject {
     }
 }
 
-impl Drop for CallbackObject {
+impl<D: DomTypes> Drop for CallbackObject<D> {
     #[allow(unsafe_code)]
     fn drop(&mut self) {
         unsafe {
@@ -98,19 +99,19 @@ impl Drop for CallbackObject {
     }
 }
 
-impl PartialEq for CallbackObject {
-    fn eq(&self, other: &CallbackObject) -> bool {
+impl<D: DomTypes> PartialEq for CallbackObject<D> {
+    fn eq(&self, other: &CallbackObject<D>) -> bool {
         self.callback.get() == other.callback.get()
     }
 }
 
 /// A trait to be implemented by concrete IDL callback function and
 /// callback interface types.
-pub(crate) trait CallbackContainer {
+pub(crate) trait CallbackContainer<D: DomTypes> {
     /// Create a new CallbackContainer object for the given `JSObject`.
     unsafe fn new(cx: JSContext, callback: *mut JSObject) -> Rc<Self>;
     /// Returns the underlying `CallbackObject`.
-    fn callback_holder(&self) -> &CallbackObject;
+    fn callback_holder(&self) -> &CallbackObject<D>;
     /// Returns the underlying `JSObject`.
     fn callback(&self) -> *mut JSObject {
         self.callback_holder().get()
@@ -119,7 +120,7 @@ pub(crate) trait CallbackContainer {
     /// incumbent global when calling the callback.
     ///
     /// ["callback context"]: https://heycam.github.io/webidl/#dfn-callback-context
-    fn incumbent(&self) -> Option<&GlobalScope> {
+    fn incumbent(&self) -> Option<&D::GlobalScope> {
         self.callback_holder().incumbent.as_deref()
     }
 }
@@ -127,23 +128,23 @@ pub(crate) trait CallbackContainer {
 /// A common base class for representing IDL callback function types.
 #[derive(JSTraceable, PartialEq)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
-pub(crate) struct CallbackFunction {
-    object: CallbackObject,
+pub(crate) struct CallbackFunction<D: DomTypes> {
+    object: CallbackObject<D>,
 }
 
-impl CallbackFunction {
+impl<D: DomTypes> CallbackFunction<D> {
     /// Create a new `CallbackFunction` for this object.
     #[cfg_attr(crown, allow(crown::unrooted_must_root))]
     // These are used by the bindings and do not need `default()` functions.
     #[allow(clippy::new_without_default)]
-    pub(crate) fn new() -> CallbackFunction {
-        CallbackFunction {
+    pub(crate) fn new() -> Self {
+        Self {
             object: CallbackObject::new(),
         }
     }
 
     /// Returns the underlying `CallbackObject`.
-    pub(crate) fn callback_holder(&self) -> &CallbackObject {
+    pub(crate) fn callback_holder(&self) -> &CallbackObject<D> {
         &self.object
     }
 
@@ -157,22 +158,22 @@ impl CallbackFunction {
 /// A common base class for representing IDL callback interface types.
 #[derive(JSTraceable, PartialEq)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
-pub(crate) struct CallbackInterface {
-    object: CallbackObject,
+pub(crate) struct CallbackInterface<D: DomTypes> {
+    object: CallbackObject<D>,
 }
 
-impl CallbackInterface {
+impl<D: DomTypes> CallbackInterface<D> {
     /// Create a new CallbackInterface object for the given `JSObject`.
     // These are used by the bindings and do not need `default()` functions.
     #[allow(clippy::new_without_default)]
-    pub(crate) fn new() -> CallbackInterface {
-        CallbackInterface {
+    pub(crate) fn new() -> Self {
+        Self {
             object: CallbackObject::new(),
         }
     }
 
     /// Returns the underlying `CallbackObject`.
-    pub(crate) fn callback_holder(&self) -> &CallbackObject {
+    pub(crate) fn callback_holder(&self) -> &CallbackObject<D> {
         &self.object
     }
 
@@ -227,10 +228,10 @@ pub(crate) fn wrap_call_this_value<T: ThisReflector>(
 
 /// A class that performs whatever setup we need to safely make a call while
 /// this class is on the stack. After `new` returns, the call is safe to make.
-pub(crate) struct CallSetup {
+pub(crate) struct CallSetup<D: DomTypes> {
     /// The global for reporting exceptions. This is the global object of the
     /// (possibly wrapped) callback object.
-    exception_global: DomRoot<GlobalScope>,
+    exception_global: DomRoot<D::GlobalScope>,
     /// The `JSContext` used for the call.
     cx: JSContext,
     /// The realm we were in before the call.
@@ -239,27 +240,24 @@ pub(crate) struct CallSetup {
     handling: ExceptionHandling,
     /// <https://heycam.github.io/webidl/#es-invoking-callback-functions>
     /// steps 8 and 18.2.
-    entry_script: Option<AutoEntryScript>,
+    entry_script: Option<GenericAutoEntryScript<D>>,
     /// <https://heycam.github.io/webidl/#es-invoking-callback-functions>
     /// steps 9 and 18.1.
-    incumbent_script: Option<AutoIncumbentScript>,
+    incumbent_script: Option<GenericAutoIncumbentScript<D>>,
 }
 
-impl CallSetup {
+impl<D: DomTypes> CallSetup<D> {
     /// Performs the setup needed to make a call.
     #[cfg_attr(crown, allow(crown::unrooted_must_root))]
-    pub(crate) fn new<T: CallbackContainer>(
-        callback: &T,
-        handling: ExceptionHandling,
-    ) -> CallSetup {
-        let global = unsafe { GlobalScope::from_object(callback.callback()) };
-        if let Some(window) = global.downcast::<Window>() {
+    pub(crate) fn new<T: CallbackContainer<D>>(callback: &T, handling: ExceptionHandling) -> Self {
+        let global = unsafe { D::GlobalScope::from_object(callback.callback()) };
+        if let Some(window) = global.downcast::<D::Window>() {
             window.Document().ensure_safe_to_run_script_or_layout();
         }
-        let cx = GlobalScope::get_cx();
+        let cx = D::GlobalScope::get_cx();
 
-        let aes = AutoEntryScript::new(&global);
-        let ais = callback.incumbent().map(AutoIncumbentScript::new);
+        let aes = GenericAutoEntryScript::<D>::new(&global);
+        let ais = callback.incumbent().map(GenericAutoIncumbentScript::new);
         CallSetup {
             exception_global: global,
             cx,
@@ -276,7 +274,7 @@ impl CallSetup {
     }
 }
 
-impl Drop for CallSetup {
+impl<D: DomTypes> Drop for CallSetup<D> {
     fn drop(&mut self) {
         unsafe {
             LeaveRealm(*self.cx, self.old_realm);

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -205,6 +205,7 @@ use crate::stylesheet_set::StylesheetSetRef;
 use crate::task::TaskBox;
 use crate::task_source::TaskSourceName;
 use crate::timers::OneshotTimerCallback;
+use crate::DomTypes;
 
 /// The number of times we are allowed to see spurious `requestAnimationFrame()` calls before
 /// falling back to fake ones.
@@ -6213,4 +6214,14 @@ fn is_named_element_with_id_attribute(elem: &Element) -> bool {
     // “exposed”, a concept that doesn’t fully make sense until embed/object
     // behaviour is actually implemented
     elem.is::<HTMLImageElement>() && elem.get_name().is_some_and(|name| !name.is_empty())
+}
+
+pub(crate) trait DocumentHelpers<D: DomTypes> {
+    fn ensure_safe_to_run_script_or_layout(&self);
+}
+
+impl DocumentHelpers<crate::DomTypeHolder> for Document {
+    fn ensure_safe_to_run_script_or_layout(&self) {
+        Document::ensure_safe_to_run_script_or_layout(self)
+    }
 }

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -77,7 +77,7 @@ pub(crate) enum CommonEventHandler {
 }
 
 impl CommonEventHandler {
-    fn parent(&self) -> &CallbackFunction {
+    fn parent(&self) -> &CallbackFunction<crate::DomTypeHolder> {
         match *self {
             CommonEventHandler::EventHandler(ref handler) => &handler.parent,
             CommonEventHandler::ErrorEventHandler(ref handler) => &handler.parent,
@@ -612,7 +612,7 @@ impl EventTarget {
     }
 
     #[allow(unsafe_code)]
-    pub(crate) fn set_event_handler_common<T: CallbackContainer>(
+    pub(crate) fn set_event_handler_common<T: CallbackContainer<crate::DomTypeHolder>>(
         &self,
         ty: &str,
         listener: Option<Rc<T>>,
@@ -628,7 +628,7 @@ impl EventTarget {
     }
 
     #[allow(unsafe_code)]
-    pub(crate) fn set_error_event_handler<T: CallbackContainer>(
+    pub(crate) fn set_error_event_handler<T: CallbackContainer<crate::DomTypeHolder>>(
         &self,
         ty: &str,
         listener: Option<Rc<T>>,
@@ -644,7 +644,7 @@ impl EventTarget {
     }
 
     #[allow(unsafe_code)]
-    pub(crate) fn set_beforeunload_event_handler<T: CallbackContainer>(
+    pub(crate) fn set_beforeunload_event_handler<T: CallbackContainer<crate::DomTypeHolder>>(
         &self,
         ty: &str,
         listener: Option<Rc<T>>,
@@ -660,7 +660,7 @@ impl EventTarget {
     }
 
     #[allow(unsafe_code)]
-    pub(crate) fn get_event_handler_common<T: CallbackContainer>(
+    pub(crate) fn get_event_handler_common<T: CallbackContainer<crate::DomTypeHolder>>(
         &self,
         ty: &str,
         can_gc: CanGc,

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -3348,6 +3348,10 @@ pub(crate) trait GlobalScopeHelpers<D: crate::DomTypes> {
     ) -> DomRoot<D::GlobalScope>;
 
     fn origin(&self) -> &MutableOrigin;
+
+    fn incumbent() -> Option<DomRoot<D::GlobalScope>>;
+
+    fn perform_a_microtask_checkpoint(&self, can_gc: CanGc);
 }
 
 #[allow(unsafe_code)]
@@ -3374,5 +3378,13 @@ impl GlobalScopeHelpers<crate::DomTypeHolder> for GlobalScope {
 
     fn origin(&self) -> &MutableOrigin {
         GlobalScope::origin(self)
+    }
+
+    fn incumbent() -> Option<DomRoot<Self>> {
+        GlobalScope::incumbent()
+    }
+
+    fn perform_a_microtask_checkpoint(&self, can_gc: CanGc) {
+        GlobalScope::perform_a_microtask_checkpoint(self, can_gc)
     }
 }

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -96,6 +96,7 @@ DOMInterfaces = {
 },
 
 'Document': {
+    'additionalTraits': ["crate::dom::document::DocumentHelpers<Self>"],
     'canGc': ['Close', 'CreateElement', 'CreateElementNS', 'ImportNode', 'SetTitle', 'Write', 'Writeln', 'CreateEvent', 'CreateRange', 'Open', 'Open_', 'CreateComment', 'CreateAttribute', 'CreateAttributeNS', 'CreateDocumentFragment', 'CreateTextNode', 'CreateCDATASection', 'CreateProcessingInstruction', 'Prepend', 'Append', 'ReplaceChildren', 'SetBgColor', 'SetFgColor', 'Fonts', 'ElementFromPoint', 'ElementsFromPoint', 'ExitFullscreen', 'CreateExpression', 'CreateNSResolver', 'Evaluate'],
 },
 

--- a/components/script_bindings/codegen/Configuration.py
+++ b/components/script_bindings/codegen/Configuration.py
@@ -228,9 +228,9 @@ class Descriptor(DescriptorProvider):
             self.nativeType = typeName
             pathDefault = 'crate::dom::types::%s' % typeName
         elif self.interface.isCallback():
-            ty = 'crate::dom::bindings::codegen::Bindings::%sBinding::%s' % (ifaceName, ifaceName)
+            ty = 'crate::dom::bindings::codegen::GenericBindings::%sBinding::%s' % (ifaceName, ifaceName)
             pathDefault = ty
-            self.returnType = "Rc<%s>" % ty
+            self.returnType = "Rc<%s<D>>" % ty
             self.argumentType = "???"
             self.nativeType = ty
         else:


### PR DESCRIPTION
These changes make all the callback-related code generic in preparation for moving it into script_bindings.

Depends on #35457.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #1799
- [x] There are tests for these changes (existing WPT coverage)