### PR TITLE
Fix scroll_sensitivity related naming issue

### DIFF
--- a/components/layout_2020/flow/root.rs
+++ b/components/layout_2020/flow/root.rs
@@ -41,7 +41,7 @@ pub struct BoxTree {
     canvas_background: CanvasBackground,
 
     /// Whether or not the viewport should be sensitive to scrolling input events in two axes
-    scroll_sensitivity: AxesScrollSensitivity,
+    viewport_scroll_sensitivity: AxesScrollSensitivity,
 }
 
 impl BoxTree {
@@ -94,7 +94,7 @@ impl BoxTree {
                 contains_floats,
             },
             canvas_background: CanvasBackground::for_root_element(context, root_element),
-            scroll_sensitivity: AxesScrollSensitivity {
+            viewport_scroll_sensitivity: AxesScrollSensitivity {
                 x: viewport_overflow.x.to_scrollable().into(),
                 y: viewport_overflow.y.to_scrollable().into(),
             },
@@ -401,7 +401,7 @@ impl BoxTree {
             scrollable_overflow,
             initial_containing_block: physical_containing_block,
             canvas_background: self.canvas_background.clone(),
-            root_scroll_sensitivity: self.scroll_sensitivity,
+            viewport_scroll_sensitivity: self.viewport_scroll_sensitivity,
         }
     }
 }

--- a/components/layout_2020/fragment_tree/fragment_tree.rs
+++ b/components/layout_2020/fragment_tree/fragment_tree.rs
@@ -37,8 +37,8 @@ pub struct FragmentTree {
     /// <https://drafts.csswg.org/css-backgrounds/#special-backgrounds>
     pub(crate) canvas_background: CanvasBackground,
 
-    /// Whether or not the root element is sensitive to scroll input events.
-    pub root_scroll_sensitivity: AxesScrollSensitivity,
+    /// Whether or not the viewport is sensitive to scroll input events.
+    pub viewport_scroll_sensitivity: AxesScrollSensitivity,
 }
 
 impl FragmentTree {

--- a/components/layout_thread_2020/lib.rs
+++ b/components/layout_thread_2020/lib.rs
@@ -854,7 +854,7 @@ impl LayoutThread {
             fragment_tree.scrollable_overflow(),
             self.id.into(),
             epoch.into(),
-            fragment_tree.root_scroll_sensitivity,
+            fragment_tree.viewport_scroll_sensitivity,
         );
         display_list.wr.begin();
 

--- a/components/shared/webrender/display_list.rs
+++ b/components/shared/webrender/display_list.rs
@@ -315,7 +315,7 @@ impl CompositorDisplayListInfo {
         content_size: LayoutSize,
         pipeline_id: PipelineId,
         epoch: Epoch,
-        root_scroll_sensitivity: AxesScrollSensitivity,
+        viewport_scroll_sensitivity: AxesScrollSensitivity,
     ) -> Self {
         let mut scroll_tree = ScrollTree::default();
         let root_reference_frame_id = scroll_tree.add_scroll_tree_node(
@@ -329,7 +329,7 @@ impl CompositorDisplayListInfo {
             Some(ScrollableNodeInfo {
                 external_id: ExternalScrollId(0, pipeline_id),
                 scrollable_size: content_size - viewport_size,
-                scroll_sensitivity: root_scroll_sensitivity,
+                scroll_sensitivity: viewport_scroll_sensitivity,
                 offset: LayoutVector2D::zero(),
             }),
         );


### PR DESCRIPTION
Rename to `viewport_scroll_sensitivity` for BoxTree, FragmentTree, CompositorDisplayListInfo

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #35461

<!-- Either: -->
- [x] These changes do not require tests

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
