### PR TITLE
layout: Fully support sizing keywords on main size property of flex item

### DIFF
--- a/tests/wpt/meta/css/css-sizing/keyword-sizes-on-flex-item-001.html.ini
+++ b/tests/wpt/meta/css/css-sizing/keyword-sizes-on-flex-item-001.html.ini
@@ -80,9 +80,6 @@
   [.test 36]
     expected: FAIL
 
-  [.test 39]
-    expected: FAIL
-
   [.test 40]
     expected: FAIL
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Still lacking support on min and max main size properties, and on the various cross size properties.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #32853
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
