### PR TITLE
script: remove non-actionable todo from script/dom/document.rs

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -5743,8 +5743,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
             self.window.upcast::<EventTarget>().remove_all_listeners();
         }
 
-        // Step 11
-        // TODO: https://github.com/servo/servo/issues/21936
+        // Step 11. Replace all with null within document.
         Node::replace_all(None, self.upcast::<Node>());
 
         // Specs and tests are in a state of flux about whether


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
See https://github.com/servo/servo/issues/21936 - It looks like step 11 of the [dom-document-open](https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#document-open-steps) steps no longer specifies that this should happen without firing mutation events, so no action is required.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #21936
- [x] These changes do not require tests because the change is limited to a comment

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
