### PR TITLE
script: Take away Fallible from new_resolved and new_rejected

### DIFF
--- a/components/script/dom/defaultteeunderlyingsource.rs
+++ b/components/script/dom/defaultteeunderlyingsource.rs
@@ -107,7 +107,7 @@ impl DefaultTeeUnderlyingSource {
     /// <https://streams.spec.whatwg.org/#abstract-opdef-readablestreamdefaulttee>
     /// Let pullAlgorithm be the following steps:
     #[cfg_attr(crown, allow(crown::unrooted_must_root))]
-    pub(crate) fn pull_algorithm(&self, can_gc: CanGc) -> Option<Result<Rc<Promise>, Error>> {
+    pub(crate) fn pull_algorithm(&self, can_gc: CanGc) -> Rc<Promise> {
         // If reading is true,
         if self.reading.get() {
             // Set readAgain to true.
@@ -115,11 +115,7 @@ impl DefaultTeeUnderlyingSource {
             // Return a promise resolved with undefined.
             let cx = GlobalScope::get_cx();
             rooted!(in(*cx) let mut rval = UndefinedValue());
-            return Some(Ok(Promise::new_resolved(
-                &self.stream.global(),
-                cx,
-                rval.handle(),
-            )));
+            return Promise::new_resolved(&self.stream.global(), cx, rval.handle());
         }
 
         // Set reading to true.
@@ -151,11 +147,7 @@ impl DefaultTeeUnderlyingSource {
         // Return a promise resolved with undefined.
         let cx = GlobalScope::get_cx();
         rooted!(in(*cx) let mut rval = UndefinedValue());
-        Some(Ok(Promise::new_resolved(
-            &self.stream.global(),
-            GlobalScope::get_cx(),
-            rval.handle(),
-        )))
+        Promise::new_resolved(&self.stream.global(), GlobalScope::get_cx(), rval.handle())
     }
 
     /// <https://streams.spec.whatwg.org/#abstract-opdef-readablestreamdefaulttee>

--- a/components/script/dom/defaultteeunderlyingsource.rs
+++ b/components/script/dom/defaultteeunderlyingsource.rs
@@ -115,11 +115,11 @@ impl DefaultTeeUnderlyingSource {
             // Return a promise resolved with undefined.
             let cx = GlobalScope::get_cx();
             rooted!(in(*cx) let mut rval = UndefinedValue());
-            return Some(Promise::new_resolved(
+            return Some(Ok(Promise::new_resolved(
                 &self.stream.global(),
                 cx,
                 rval.handle(),
-            ));
+            )));
         }
 
         // Set reading to true.
@@ -151,11 +151,11 @@ impl DefaultTeeUnderlyingSource {
         // Return a promise resolved with undefined.
         let cx = GlobalScope::get_cx();
         rooted!(in(*cx) let mut rval = UndefinedValue());
-        Some(Promise::new_resolved(
+        Some(Ok(Promise::new_resolved(
             &self.stream.global(),
             GlobalScope::get_cx(),
             rval.handle(),
-        ))
+        )))
     }
 
     /// <https://streams.spec.whatwg.org/#abstract-opdef-readablestreamdefaulttee>

--- a/components/script/dom/promise.rs
+++ b/components/script/dom/promise.rs
@@ -31,7 +31,7 @@ use js::rust::wrappers::{
 use js::rust::{HandleObject, HandleValue, MutableHandleObject, Runtime};
 
 use crate::dom::bindings::conversions::root_from_object;
-use crate::dom::bindings::error::{Error, Fallible};
+use crate::dom::bindings::error::Error;
 use crate::dom::bindings::reflector::{DomGlobal, DomObject, MutDomObject, Reflector};
 use crate::dom::bindings::settings_stack::AutoEntryScript;
 use crate::dom::globalscope::GlobalScope;
@@ -153,14 +153,14 @@ impl Promise {
         global: &GlobalScope,
         cx: SafeJSContext,
         value: impl ToJSValConvertible,
-    ) -> Fallible<Rc<Promise>> {
+    ) -> Rc<Promise> {
         let _ac = JSAutoRealm::new(*cx, global.reflector().get_jsobject().get());
         unsafe {
             rooted!(in(*cx) let mut rval = UndefinedValue());
             value.to_jsval(*cx, rval.handle_mut());
             rooted!(in(*cx) let p = CallOriginalPromiseResolve(*cx, rval.handle()));
             assert!(!p.handle().is_null());
-            Ok(Promise::new_with_js_promise(p.handle(), cx))
+            Promise::new_with_js_promise(p.handle(), cx)
         }
     }
 
@@ -170,14 +170,14 @@ impl Promise {
         global: &GlobalScope,
         cx: SafeJSContext,
         value: impl ToJSValConvertible,
-    ) -> Fallible<Rc<Promise>> {
+    ) -> Rc<Promise> {
         let _ac = JSAutoRealm::new(*cx, global.reflector().get_jsobject().get());
         unsafe {
             rooted!(in(*cx) let mut rval = UndefinedValue());
             value.to_jsval(*cx, rval.handle_mut());
             rooted!(in(*cx) let p = CallOriginalPromiseReject(*cx, rval.handle()));
             assert!(!p.handle().is_null());
-            Ok(Promise::new_with_js_promise(p.handle(), cx))
+            Promise::new_with_js_promise(p.handle(), cx)
         }
     }
 

--- a/components/script/dom/readablestreambyobreader.rs
+++ b/components/script/dom/readablestreambyobreader.rs
@@ -144,7 +144,7 @@ impl ReadableStreamBYOBReader {
         }
 
         // Perform ! ReadableStreamReaderGenericInitialize(reader, stream).
-        self.generic_initialize(global, stream, can_gc)?;
+        self.generic_initialize(global, stream, can_gc);
 
         // Set reader.[[readIntoRequests]] to a new empty list.
         self.read_into_requests.borrow_mut().clear();

--- a/components/script/dom/readablestreamdefaultreader.rs
+++ b/components/script/dom/readablestreamdefaultreader.rs
@@ -370,7 +370,7 @@ impl ReadableStreamDefaultReaderMethods<crate::DomTypeHolder> for ReadableStream
                 &self.global(),
                 error.handle_mut(),
             );
-            return Promise::new_rejected(&self.global(), cx, error.handle()).unwrap();
+            return Promise::new_rejected(&self.global(), cx, error.handle());
         }
         // Let promise be a new promise.
         let promise = Promise::new(&self.reflector_.global(), can_gc);

--- a/components/script/dom/readablestreamdefaultreader.rs
+++ b/components/script/dom/readablestreamdefaultreader.rs
@@ -189,7 +189,7 @@ impl ReadableStreamDefaultReader {
         }
         // Perform ! ReadableStreamReaderGenericInitialize(reader, stream).
 
-        self.generic_initialize(global, stream, can_gc)?;
+        self.generic_initialize(global, stream, can_gc);
 
         // Set reader.[[readRequests]] to a new empty list.
         self.read_requests.borrow_mut().clear();

--- a/components/script/dom/readablestreamgenericreader.rs
+++ b/components/script/dom/readablestreamgenericreader.rs
@@ -23,12 +23,7 @@ use crate::script_runtime::CanGc;
 pub(crate) trait ReadableStreamGenericReader {
     /// <https://streams.spec.whatwg.org/#readable-stream-reader-generic-initialize>
     #[cfg_attr(crown, allow(crown::unrooted_must_root))]
-    fn generic_initialize(
-        &self,
-        global: &GlobalScope,
-        stream: &ReadableStream,
-        can_gc: CanGc,
-    ) -> Fallible<()> {
+    fn generic_initialize(&self, global: &GlobalScope, stream: &ReadableStream, can_gc: CanGc) {
         // Set reader.[[stream]] to stream.
         self.set_stream(Some(stream));
 
@@ -64,8 +59,6 @@ pub(crate) trait ReadableStreamGenericReader {
             // Set reader.[[closedPromise]].[[PromiseIsHandled]] to true
             self.get_closed_promise().set_promise_is_handled();
         }
-
-        Ok(())
     }
 
     /// <https://streams.spec.whatwg.org/#readable-stream-reader-generic-cancel>

--- a/components/script/dom/readablestreamgenericreader.rs
+++ b/components/script/dom/readablestreamgenericreader.rs
@@ -50,7 +50,7 @@ pub(crate) trait ReadableStreamGenericReader {
             // Otherwise, if stream.[[state]] is "closed",
             // Set reader.[[closedPromise]] to a promise resolved with undefined.
             let cx = GlobalScope::get_cx();
-            self.set_closed_promise(Promise::new_resolved(global, cx, ())?);
+            self.set_closed_promise(Promise::new_resolved(global, cx, ()));
         } else {
             // Assert: stream.[[state]] is "errored"
             assert!(stream.is_errored());
@@ -59,7 +59,7 @@ pub(crate) trait ReadableStreamGenericReader {
             let cx = GlobalScope::get_cx();
             rooted!(in(*cx) let mut error = UndefinedValue());
             stream.get_stored_error(error.handle_mut());
-            self.set_closed_promise(Promise::new_rejected(global, cx, error.handle())?);
+            self.set_closed_promise(Promise::new_rejected(global, cx, error.handle()));
 
             // Set reader.[[closedPromise]].[[PromiseIsHandled]] to true
             self.get_closed_promise().set_promise_is_handled();
@@ -107,9 +107,11 @@ pub(crate) trait ReadableStreamGenericReader {
                     error.handle_mut(),
                 );
 
-                self.set_closed_promise(
-                    Promise::new_rejected(&stream.global(), cx, error.handle()).unwrap(),
-                );
+                self.set_closed_promise(Promise::new_rejected(
+                    &stream.global(),
+                    cx,
+                    error.handle(),
+                ));
             }
             // Set reader.[[closedPromise]].[[PromiseIsHandled]] to true.
             self.get_closed_promise().set_promise_is_handled();

--- a/components/script/dom/testbinding.rs
+++ b/components/script/dom/testbinding.rs
@@ -971,12 +971,12 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
     }
 
     #[cfg_attr(crown, allow(crown::unrooted_must_root))]
-    fn ReturnResolvedPromise(&self, cx: SafeJSContext, v: HandleValue) -> Fallible<Rc<Promise>> {
+    fn ReturnResolvedPromise(&self, cx: SafeJSContext, v: HandleValue) -> Rc<Promise> {
         Promise::new_resolved(&self.global(), cx, v)
     }
 
     #[cfg_attr(crown, allow(crown::unrooted_must_root))]
-    fn ReturnRejectedPromise(&self, cx: SafeJSContext, v: HandleValue) -> Fallible<Rc<Promise>> {
+    fn ReturnRejectedPromise(&self, cx: SafeJSContext, v: HandleValue) -> Rc<Promise> {
         Promise::new_rejected(&self.global(), cx, v)
     }
 

--- a/components/script/dom/underlyingsourcecontainer.rs
+++ b/components/script/dom/underlyingsourcecontainer.rs
@@ -154,7 +154,7 @@ impl UnderlyingSourceContainer {
             },
             UnderlyingSourceType::Tee(tee_underlyin_source) => {
                 // Call the pull algorithm for the appropriate branch.
-                tee_underlyin_source.pull_algorithm(can_gc)
+                Some(Ok(tee_underlyin_source.pull_algorithm(can_gc)))
             },
             // Note: other source type have no pull steps for now.
             _ => None,

--- a/components/script_bindings/codegen/CodegenRust.py
+++ b/components/script_bindings/codegen/CodegenRust.py
@@ -807,13 +807,7 @@ def getJSToNativeConversionInfo(type, descriptorProvider, failureCode=None,
                 if !JS_WrapValue(*cx, valueToResolve.handle_mut()) {
                 $*{exceptionCode}
                 }
-                match Promise::new_resolved(&promiseGlobal, cx, valueToResolve.handle()) {
-                    Ok(value) => value,
-                    Err(error) => {
-                    throw_dom_exception(cx, &promiseGlobal, error);
-                    $*{exceptionCode}
-                    }
-                }
+                Promise::new_resolved(&promiseGlobal, cx, valueToResolve.handle())
             }
             """,
             exceptionCode=exceptionCode)

--- a/components/script_bindings/webidls/TestBinding.webidl
+++ b/components/script_bindings/webidls/TestBinding.webidl
@@ -562,9 +562,7 @@ interface TestBinding {
   [Func="TestBinding::condition_satisfied"]
   const unsigned short funcControlledConstEnabled = 0;
 
-  [Throws]
   Promise<any> returnResolvedPromise(any value);
-  [Throws]
   Promise<any> returnRejectedPromise(any value);
   readonly attribute Promise<boolean> promiseAttribute;
   undefined acceptPromise(Promise<DOMString> string);


### PR DESCRIPTION
Both Promise::new_resolved and new_rejected only return `Ok`. We don't need them to be fallible. Simply return `Rc<Promise>`, instead of `Fallible<Rc<Promise>>`. Also, clean up relevant code.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #35463 

<!-- Either: -->
- [x] These changes do not require tests because the returned types in tests also changes along with the code. 

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
