### PR TITLE
net: Use the unfiltered response status when comparing against cached resources.

### DIFF
--- a/components/net/http_cache.rs
+++ b/components/net/http_cache.rs
@@ -625,13 +625,15 @@ impl HttpCache {
             Some(resources) => resources,
         };
 
+        let actual_response = response.actual_response();
+
         // Ensure we only wake-up consumers of relevant resources,
         // ie we don't want to wake-up 200 awaiting consumers with a 206.
         let relevant_cached_resources = cached_resources.iter().filter(|resource| {
-            if response.actual_response().is_network_error() {
+            if actual_response.is_network_error() {
                 return *resource.body.lock().unwrap() == ResponseBody::Empty;
             }
-            resource.status == response.status
+            resource.status == actual_response.status
         });
 
         for cached_resource in relevant_cached_resources {

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -12758,6 +12758,13 @@
       {}
      ]
     ],
+    "cache-crossorigin.sub.html": [
+     "b186dff229d06886fb613629a6f37cb1f526985f",
+     [
+      null,
+      {}
+     ]
+    ],
     "cache_crossorigin_response.sub.html": [
      "266995f30afa3e9b3472e4cc43be6493c562aef6",
      [

--- a/tests/wpt/mozilla/tests/mozilla/cache-crossorigin.sub.html
+++ b/tests/wpt/mozilla/tests/mozilla/cache-crossorigin.sub.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf=8">
+    <title>Cache entries update when cross-origin requests complete</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <script>
+      var t = async_test("Prefetched cross-origin script loads correctly");
+    </script>
+    <!-- Load a script from a cross-origin domain. Prefetching will ensure a
+         cache entry is created for this resource, then the actual load should
+         read from the cache entry rather than the network. -->
+    <script src="http://{{domains[www]}}:{{ports[http][0]}}/common/get-host-info.sub.js?pipe=trickle(1:d1)|header(Cache-Control,max-age=604800)|header(Pragma,ignored)" onload="t.done()"></script>
+  </body>
+</html>


### PR DESCRIPTION
When a response is filtered due to being cross-origin, its status is reported as 0. We need to use the unfiltered response status when finding matching cached resources instead.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #35477
- [x] There are tests for these changes