### PR TITLE
libservo: Expose `SoftwareRenderingContext` and `WindowRenderingContext`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6876,6 +6876,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "dirs",
+ "dpi",
  "egui",
  "egui-file-dialog",
  "egui-winit",
@@ -8592,6 +8593,7 @@ name = "webrender_traits"
 version = "0.0.1"
 dependencies = [
  "base",
+ "dpi",
  "embedder_traits",
  "euclid",
  "gleam",
@@ -8600,6 +8602,7 @@ dependencies = [
  "ipc-channel",
  "libc",
  "log",
+ "raw-window-handle",
  "serde",
  "servo-media",
  "servo_geometry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ ctr = "0.9.2"
 darling = { version = "0.20", default-features = false }
 data-url = "0.3"
 devtools_traits = { path = "components/shared/devtools" }
+dpi = { version = "0.1" }
 embedder_traits = { path = "components/shared/embedder" }
 encoding_rs = "0.8"
 env_logger = "0.10"

--- a/components/compositing/Cargo.toml
+++ b/components/compositing/Cargo.toml
@@ -36,7 +36,6 @@ script_traits = { workspace = true }
 servo_config = { path = "../config" }
 servo_geometry = { path = "../geometry" }
 style_traits = { workspace = true }
-surfman = { workspace = true }
 tracing = { workspace = true, optional = true }
 webrender = { workspace = true }
 webrender_api = { workspace = true }

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -101,7 +101,11 @@ pub use webgpu;
 use webgpu::swapchain::WGPUImageMap;
 use webrender::{RenderApiSender, ShaderPrecacheFlags, UploadMethod, ONE_TIME_USAGE_HINT};
 use webrender_api::{ColorF, DocumentId, FramePublishId};
-use webrender_traits::rendering_context::{GLVersion, RenderingContext};
+use webrender_traits::rendering_context::GLVersion;
+pub use webrender_traits::rendering_context::{
+    OffscreenRenderingContext, RenderingContext, SoftwareRenderingContext, SurfmanRenderingContext,
+    WindowRenderingContext,
+};
 use webrender_traits::{
     CrossProcessCompositorApi, WebrenderExternalImageHandlers, WebrenderExternalImageRegistry,
     WebrenderImageHandlerType,
@@ -113,7 +117,7 @@ pub use {
     background_hang_monitor, base, canvas, canvas_traits, compositing, devtools, devtools_traits,
     euclid, fonts, ipc_channel, layout_thread_2020, media, net, net_traits, profile,
     profile_traits, script, script_layout_interface, script_traits, servo_config as config,
-    servo_config, servo_geometry, servo_url, style, style_traits, webrender_api, webrender_traits,
+    servo_config, servo_geometry, servo_url, style, style_traits, webrender_api,
 };
 #[cfg(feature = "bluetooth")]
 pub use {bluetooth, bluetooth_traits};

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -414,4 +414,8 @@ impl WebView {
             .constellation_proxy
             .send(ConstellationMsg::SendError(Some(self.id()), message));
     }
+
+    pub fn paint_immediately(&self) {
+        self.inner().compositor.borrow_mut().composite();
+    }
 }

--- a/components/shared/webrender/Cargo.toml
+++ b/components/shared/webrender/Cargo.toml
@@ -31,3 +31,5 @@ servo_geometry = { path = "../../geometry" }
 servo-media = { workspace = true }
 style = { workspace = true }
 surfman = { workspace = true, features = ["sm-x11"] }
+raw-window-handle = { version = "0.6" }
+dpi = { version = "0.1" }

--- a/components/shared/webrender/lib.rs
+++ b/components/shared/webrender/lib.rs
@@ -28,8 +28,6 @@ use webrender_api::{
     ImageKey, NativeFontHandle, PipelineId as WebRenderPipelineId,
 };
 
-pub use crate::rendering_context::SurfmanRenderingContext;
-
 #[derive(Deserialize, Serialize)]
 pub enum CrossProcessCompositorMessage {
     /// Inform WebRender of the existence of this pipeline.

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -57,6 +57,7 @@ webxr = ["libservo/webxr"]
 webgpu = ["libservo/webgpu"]
 
 [dependencies]
+dpi = { workspace = true }
 euclid = { workspace = true }
 libc = { workspace = true }
 libservo = { path = "../../components/servo", features = ["background_hang_monitor", "bluetooth"] }
@@ -67,6 +68,7 @@ getopts = { workspace = true }
 hitrace = { workspace = true, optional = true }
 mime_guess = { workspace = true }
 url = { workspace = true }
+raw-window-handle = { workspace = true }
 rustls = { workspace = true, features = ["aws-lc-rs"] }
 tokio = { workspace = true }
 tracing = { workspace = true, optional = true }
@@ -116,7 +118,6 @@ headers = { workspace = true }
 http = { workspace = true }
 net = { path = "../../components/net" }
 net_traits = { workspace = true }
-raw-window-handle = "0.6"
 serde_json = { workspace = true }
 shellwords = "1.0.0"
 surfman = { workspace = true, features = ["sm-x11", "sm-raw-window-handle-06"] }

--- a/ports/servoshell/desktop/minibrowser.rs
+++ b/ports/servoshell/desktop/minibrowser.rs
@@ -21,8 +21,7 @@ use servo::base::id::WebViewId;
 use servo::servo_geometry::DeviceIndependentPixel;
 use servo::servo_url::ServoUrl;
 use servo::webrender_api::units::DevicePixel;
-use servo::webrender_traits::rendering_context::{OffscreenRenderingContext, RenderingContext};
-use servo::{LoadStatus, WebView};
+use servo::{LoadStatus, OffscreenRenderingContext, RenderingContext, WebView};
 use winit::event::{ElementState, MouseButton, WindowEvent};
 use winit::event_loop::ActiveEventLoop;
 use winit::window::Window;
@@ -429,7 +428,7 @@ impl Minibrowser {
             .parent_context()
             .prepare_for_rendering();
         self.context.paint(window);
-        let _ = self.rendering_context.parent_context().present();
+        self.rendering_context.parent_context().present();
     }
 
     /// Updates the location field from the given [WebViewManager], unless the user has started

--- a/ports/servoshell/desktop/window_trait.rs
+++ b/ports/servoshell/desktop/window_trait.rs
@@ -11,8 +11,7 @@ use euclid::{Length, Scale};
 use servo::compositing::windowing::WindowMethods;
 use servo::servo_geometry::DeviceIndependentPixel;
 use servo::webrender_api::units::{DeviceIntPoint, DeviceIntSize, DevicePixel};
-use servo::webrender_traits::rendering_context::RenderingContext;
-use servo::{Cursor, WebView};
+use servo::{Cursor, RenderingContext, WebView};
 
 use super::app_state::RunningAppState;
 

--- a/ports/servoshell/egl/android/simpleservo.rs
+++ b/ports/servoshell/egl/android/simpleservo.rs
@@ -4,19 +4,17 @@
 
 use std::cell::RefCell;
 use std::mem;
-use std::os::raw::c_void;
 use std::rc::Rc;
 
+use raw_window_handle::{DisplayHandle, RawDisplayHandle, RawWindowHandle, WindowHandle};
 use servo::compositing::CompositeTarget;
 pub use servo::webrender_api::units::DeviceIntRect;
-use servo::webrender_traits::SurfmanRenderingContext;
 /// The EventLoopWaker::wake function will be called from any thread.
 /// It will be called to notify embedder that some events are available,
 /// and that perform_updates need to be called
 pub use servo::EventLoopWaker;
 use servo::{self, resources, Servo};
-pub use servo::{InputMethodType, MediaSessionPlaybackState, PromptResult};
-use surfman::{Connection, SurfaceType};
+pub use servo::{InputMethodType, MediaSessionPlaybackState, PromptResult, WindowRenderingContext};
 
 use crate::egl::android::resources::ResourceReaderInstance;
 use crate::egl::app_state::{
@@ -36,13 +34,8 @@ pub struct InitOptions {
     pub density: f32,
     #[cfg(feature = "webxr")]
     pub xr_discovery: Option<servo::webxr::Discovery>,
-    pub surfman_integration: SurfmanIntegration,
-}
-
-/// Controls how this embedding's rendering will integrate with the embedder.
-pub enum SurfmanIntegration {
-    /// Render directly to a provided native widget (see surfman::NativeWidget).
-    Widget(*mut c_void),
+    pub window_handle: RawWindowHandle,
+    pub display_handle: RawDisplayHandle,
 }
 
 /// Initialize Servo. At that point, we need a valid GL context.
@@ -70,30 +63,20 @@ pub fn init(
 
     crate::init_tracing(servoshell_preferences.tracing_filter.as_deref());
 
-    // Initialize surfman
-    let connection = Connection::new().or(Err("Failed to create connection"))?;
-    let adapter = connection
-        .create_adapter()
-        .or(Err("Failed to create adapter"))?;
-    let surface_type = match init_opts.surfman_integration {
-        SurfmanIntegration::Widget(native_widget) => {
-            let native_widget = unsafe {
-                connection.create_native_widget_from_ptr(
-                    native_widget,
-                    init_opts.coordinates.framebuffer.to_untyped(),
-                )
-            };
-            SurfaceType::Widget { native_widget }
-        },
+    let (display_handle, window_handle) = unsafe {
+        (
+            DisplayHandle::borrow_raw(init_opts.display_handle),
+            WindowHandle::borrow_raw(init_opts.window_handle),
+        )
     };
-    let rendering_context = SurfmanRenderingContext::create(&connection, &adapter, None)
-        .or(Err("Failed to create surface manager"))?;
-    let surface = rendering_context
-        .create_surface(surface_type)
-        .or(Err("Failed to create surface"))?;
-    rendering_context
-        .bind_surface(surface)
-        .or(Err("Failed to bind surface"))?;
+    let rendering_context = Rc::new(
+        WindowRenderingContext::new(
+            display_handle,
+            window_handle,
+            &init_opts.coordinates.framebuffer_size(),
+        )
+        .expect("Could not create RenderingContext"),
+    );
 
     let window_callbacks = Rc::new(ServoWindowCallbacks::new(
         callbacks,
@@ -110,7 +93,7 @@ pub fn init(
     let servo = Servo::new(
         opts,
         preferences,
-        Rc::new(rendering_context.clone()),
+        rendering_context.clone(),
         embedder_callbacks,
         window_callbacks.clone(),
         None,


### PR DESCRIPTION
Expose two easy-to-use wrappers around `SurfmanRenderingContext` that
make the API simpler to use:

- `WindowRenderingContext`: This `RenderingContext` is a newtype around
  `SurfmanRenderingContext` takes a `raw-window-handle` display and window
   and creates a full window rendering context.
- `SoftwareRenderingContext`: is wraps `SurfmanRenderingContext` and
   adds a swap chain in order to expose a software GL rendering context.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>
<!-- Please describe your changes on the following line: -->

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they just expose easier to use API types.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
