### PR TITLE
Don't remove live fonts in collect_unused_webrender_resources

### DIFF
--- a/components/fonts/font_context.rs
+++ b/components/fonts/font_context.rs
@@ -524,7 +524,7 @@ impl FontContextWebFontMethods for Arc<FontContext> {
             });
         }
 
-        font_data.retain(|font_identifier, _| unused_identifiers.contains(font_identifier));
+        font_data.retain(|font_identifier, _| !unused_identifiers.contains(font_identifier));
 
         self.have_removed_web_fonts.store(false, Ordering::Relaxed);
 


### PR DESCRIPTION
The check on whether or not a font should be retained was inverted.

This was a regression from https://github.com/servo/servo/commit/0553789d4839c4bf750f386f3f07a71b4a21f38e#diff-a29077880e6caa90ce845be66fd39d5746717795b5e79a2a603e31bd57eb464dL536-R541

cc @mrobinson 


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #35152 (GitHub issue number if applicable)
- [ ] There are no tests for these changes, I don't know how I would test for them and I'm not familiar with the font code in general

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
