### PR TITLE
servoshell: Port Authentication dialog code to use `egui` instead of `tinyfiledialogs`

### DIFF
--- a/ports/servoshell/desktop/app_state.rs
+++ b/ports/servoshell/desktop/app_state.rs
@@ -161,7 +161,13 @@ impl RunningAppState {
     }
 
     pub(crate) fn for_each_active_dialog(&self, callback: impl Fn(&mut Dialog) -> bool) {
-        let Some(webview_id) = self.focused_webview().as_ref().map(WebView::id) else {
+        let last_created_webview_id = self.inner().creation_order.last().cloned();
+        let Some(webview_id) = self
+            .focused_webview()
+            .as_ref()
+            .map(WebView::id)
+            .or(last_created_webview_id)
+        else {
             return;
         };
 
@@ -381,19 +387,17 @@ impl WebViewDelegate for RunningAppState {
 
     fn request_authentication(
         &self,
-        _webview: WebView,
+        webview: WebView,
         authentication_request: AuthenticationRequest,
     ) {
         if self.inner().headless {
             return;
         }
 
-        if let (Some(username), Some(password)) = (
-            tinyfiledialogs::input_box("", "username", ""),
-            tinyfiledialogs::input_box("", "password", ""),
-        ) {
-            authentication_request.authenticate(username, password);
-        }
+        self.add_dialog(
+            webview,
+            Dialog::new_authentication_dialog(authentication_request),
+        );
     }
 
     fn request_open_auxiliary_webview(


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
- Part of migration from `tinyfiledialogs` to `egui`
- Issues:
1. Enter key when dialog is open, interacts with the webview that is behind the dialog (and not in focus) and ends up queuing another dialog behind.
2. Authentication dialog does not show up without this work around:
```
pub(crate) fn new_toplevel_webview(self: &Rc<Self>, url: Url) {
        let webview = self.servo().new_webview(url);
        webview.set_delegate(self.clone());
        if self.inner_mut().focused_webview_id.is_none() {
            self.inner_mut().focused_webview_id = Some(webview.id());
        }
        self.add(webview);
    }
```
3. Cannot access another tab when a dialog is open

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
