### PR TITLE
script: avoid NonNull<JSObject> in Window::NamedGetter

### DIFF
--- a/components/script/window_named_properties.rs
+++ b/components/script/window_named_properties.rs
@@ -132,7 +132,7 @@ unsafe extern "C" fn get_own_property_descriptor(
 
     let window = Root::downcast::<Window>(GlobalScope::from_object(proxy.get()))
         .expect("global is not a window");
-    if let Some(obj) = window.NamedGetter(cx, s.into()) {
+    if let Some(obj) = window.NamedGetter(s.into()) {
         rooted!(in(*cx) let mut rval = UndefinedValue());
         obj.to_jsval(*cx, rval.handle_mut());
         set_property_descriptor(

--- a/components/script_bindings/webidls/Window.webidl
+++ b/components/script_bindings/webidls/Window.webidl
@@ -45,7 +45,7 @@
                              optional DOMString features = "");
   //getter WindowProxy (unsigned long index);
 
-  getter object (DOMString name);
+  getter NamedPropertyValue (DOMString name);
 
   // the user agent
   readonly attribute Navigator navigator;


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
used the same typedef from #31841, is it fine keeping it inside `Document.webidl` or is there a file to keep common definitions?

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [X] These changes do not require tests because

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
