### PR TITLE
servoshell: Support `xdg-activation` on linux

### DIFF
--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -81,14 +81,31 @@ impl Window {
         let visible = opts.output_file.is_none() && !servoshell_preferences.no_native_titlebar;
 
         let window_size = servoshell_preferences.initial_window_size;
-        let window_attr = winit::window::Window::default_attributes()
+        #[allow(unused_mut)]
+        let mut window_attr = winit::window::Window::default_attributes()
             .with_title("Servo".to_string())
             .with_decorations(!no_native_titlebar)
             .with_transparent(no_native_titlebar)
             .with_inner_size(LogicalSize::new(window_size.width, window_size.height))
             .with_visible(visible);
 
-        #[allow(deprecated)]
+        #[cfg(all(
+            unix,
+            not(target_os = "macos"),
+            not(target_os = "ios"),
+            not(target_os = "android"),
+            not(target_env = "ohos")
+        ))]
+        {
+            use winit::platform::startup_notify::{
+                self, EventLoopExtStartupNotify, WindowAttributesExtStartupNotify,
+            };
+            if let Some(token) = event_loop.read_token_from_env() {
+                startup_notify::reset_activation_token_env();
+                window_attr = window_attr.with_activation_token(token);
+            }
+        }
+
         let winit_window = event_loop
             .create_window(window_attr)
             .expect("Failed to create window.");
@@ -630,10 +647,28 @@ impl WindowPortsMethods for Window {
     ) -> Rc<dyn servo::webxr::glwindow::GlWindow> {
         let size = self.winit_window.outer_size();
 
-        let window_attr = winit::window::Window::default_attributes()
+        #[allow(unused_mut)]
+        let mut window_attr = winit::window::Window::default_attributes()
             .with_title("Servo XR".to_string())
             .with_inner_size(size)
             .with_visible(false);
+
+        #[cfg(all(
+            unix,
+            not(target_os = "macos"),
+            not(target_os = "ios"),
+            not(target_os = "android"),
+            not(target_env = "ohos")
+        ))]
+        {
+            use winit::platform::startup_notify::{
+                self, EventLoopExtStartupNotify, WindowAttributesExtStartupNotify,
+            };
+            if let Some(token) = event_loop.read_token_from_env() {
+                startup_notify::reset_activation_token_env();
+                window_attr = window_attr.with_activation_token(token);
+            }
+        }
 
         let winit_window = event_loop
             .create_window(window_attr)


### PR DESCRIPTION
This allows servoshell to gain window focus on compositors with a strict focus policy, and is also used on x11 for things like cursor loading indicators.
See this winit example: https://github.com/rust-windowing/winit/blob/c09160d1a8cb6bb560cce32b72d6c0b0b673c9dc/examples/window.rs#L147-L152 - this implementation is identical.

The `cfg` tries to gate this to all freedesktop platforms, matching the one used for `default_config_dir` using xdg basedir:
```rs
#[cfg(all(
    unix,
    not(target_os = "macos"),
    not(target_os = "ios"),
    not(target_os = "android"),
    not(target_env = "ohos")
))]
```
I think it'll be better to have cfg aliases, see [this zulip thread](https://servo.zulipchat.com/#narrow/channel/263398-general/topic/servoshell.3A.20Linux.20desktop.20.60cfg.60.20gating), but this seems fine for now.

<!-- Please describe your changes on the following line: -->

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors (due to issues with the way I cloned with repository with jj, I ran `cargo fmt -- --config unstable_features=true --config binop_separator=Back --config imports_granularity=Module --config group_imports=StdExternalCrate --check` manually)
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they add platform specific behavior that is not tested (and cannot reasonably be tested without full wayland compositor e2e testing) 

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
