### PR TITLE
libservo: Rework and clarify the rendering model of the `WebView`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1035,6 +1035,7 @@ name = "compositing"
 version = "0.0.1"
 dependencies = [
  "base",
+ "bitflags 2.8.0",
  "compositing_traits",
  "crossbeam-channel",
  "embedder_traits",

--- a/components/compositing/Cargo.toml
+++ b/components/compositing/Cargo.toml
@@ -19,6 +19,7 @@ webxr = ["dep:webxr"]
 
 [dependencies]
 base = { workspace = true }
+bitflags = { workspace = true }
 compositing_traits = { workspace = true }
 crossbeam-channel = { workspace = true }
 embedder_traits = { workspace = true }

--- a/ports/servoshell/desktop/minibrowser.rs
+++ b/ports/servoshell/desktop/minibrowser.rs
@@ -403,6 +403,8 @@ impl Minibrowser {
                     );
                 }
 
+                state.repaint_servo_if_necessary();
+
                 if let Some(render_to_parent) = rendering_context.render_to_parent_callback() {
                     ui.painter().add(PaintCallback {
                         rect,

--- a/ports/servoshell/egl/app_state.rs
+++ b/ports/servoshell/egl/app_state.rs
@@ -680,8 +680,8 @@ impl RunningAppState {
     pub fn present_if_needed(&self) {
         if self.inner().need_present {
             self.inner_mut().need_present = false;
-            self.active_webview().paint_immediately();
-            self.servo.present();
+            self.active_webview().paint();
+            self.rendering_context.present();
         }
     }
 }


### PR DESCRIPTION
Make the rendering model of the `WebView` clearer:

 1. `WebViewDelegate::notify_new_frame_ready()` indicates that the
    WebView has become dirty and needs to be repainted.
 2. `WebView::paint()` asks Servo to paint the contents of the `WebView`
    into the `RenderingContext`.
 3. `RenderingContext::present()` does a buffer swap if the
    `RenderingContext` is actually double-buffered.

This is documented and all in-tree embedders are updated to work with
this new model.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because these just change the API surface.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
