### PR TITLE
Support the `<progress>` element

### DIFF
--- a/components/script/dom/virtualmethods.rs
+++ b/components/script/dom/virtualmethods.rs
@@ -42,6 +42,7 @@ use crate::dom::htmloptgroupelement::HTMLOptGroupElement;
 use crate::dom::htmloptionelement::HTMLOptionElement;
 use crate::dom::htmloutputelement::HTMLOutputElement;
 use crate::dom::htmlpreelement::HTMLPreElement;
+use crate::dom::htmlprogresselement::HTMLProgressElement;
 use crate::dom::htmlscriptelement::HTMLScriptElement;
 use crate::dom::htmlselectelement::HTMLSelectElement;
 use crate::dom::htmlslotelement::HTMLSlotElement;
@@ -252,6 +253,9 @@ pub(crate) fn vtable_for(node: &Node) -> &dyn VirtualMethods {
         },
         NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLPreElement)) => {
             node.downcast::<HTMLPreElement>().unwrap() as &dyn VirtualMethods
+        },
+        NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLProgressElement)) => {
+            node.downcast::<HTMLProgressElement>().unwrap() as &dyn VirtualMethods
         },
         NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLScriptElement)) => {
             node.downcast::<HTMLScriptElement>().unwrap() as &dyn VirtualMethods

--- a/resources/servo.css
+++ b/resources/servo.css
@@ -341,3 +341,18 @@ details > summary:first-of-type {
 details[open] > summary:first-of-type {
   list-style-type: disclosure-open;
 }
+
+/* Styles for the <progress> element */
+progress {
+  display: inline-block;
+  width: 200px;
+  height: 6px;
+  border-radius: 3px;
+  border: 1px solid rgba(0, 0, 0, 0.5);
+}
+/* FIXME: This should use ::-moz-progress-bar */
+progress #-servo-progress-bar {
+  display: block;
+  height: 100%;
+  background-color: #7a3;
+}


### PR DESCRIPTION
This uses the recent shadow-dom improvements to implement a widget for `<progress>` elements.

The `<progress>` element is essentially just a simpler version of the `<meter>` element implemented in #35524.

With these changes, the `<progress>` element now looks like this:
![image](https://github.com/user-attachments/assets/d4a4e5fa-7810-460a-a66b-db52abb3fbaa)

I would have liked to replace the green with one of the system-theme dependent css colors (like [`AccentColor`](https://developer.mozilla.org/en-US/docs/Web/CSS/system-color#accentcolor)), but it doesn't look like servo supports those yet.

<details><summary>HTML for example image</summary>

```html
<label for="file">File progress:</label>

<progress id="file" max="100" value="70">70%</progress>
```
</details>

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because the visual appearance of the `<progress>` element is not specified

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
