### PR TITLE
feat: support pre-edit text display for IME

### DIFF
--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -2652,14 +2652,18 @@ impl VirtualMethods for HTMLInputElement {
             event.type_() == atom!("compositionend")) &&
             self.input_type().is_textual_or_password()
         {
-            // TODO: Update DOM on start and continue
-            // and generally do proper CompositionEvent handling.
             if let Some(compositionevent) = event.downcast::<CompositionEvent>() {
                 if event.type_() == atom!("compositionend") {
                     let _ = self
                         .textinput
                         .borrow_mut()
                         .handle_compositionend(compositionevent);
+                    self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
+                } else if event.type_() == atom!("compositionupdate") {
+                    let _ = self
+                        .textinput
+                        .borrow_mut()
+                        .handle_compositionupdate(compositionevent);
                     self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
                 }
                 event.mark_as_handled();

--- a/components/script/dom/htmltextareaelement.rs
+++ b/components/script/dom/htmltextareaelement.rs
@@ -668,14 +668,18 @@ impl VirtualMethods for HTMLTextAreaElement {
             event.type_() == atom!("compositionupdate") ||
             event.type_() == atom!("compositionend")
         {
-            // TODO: Update DOM on start and continue
-            // and generally do proper CompositionEvent handling.
             if let Some(compositionevent) = event.downcast::<CompositionEvent>() {
                 if event.type_() == atom!("compositionend") {
                     let _ = self
                         .textinput
                         .borrow_mut()
                         .handle_compositionend(compositionevent);
+                    self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
+                } else if event.type_() == atom!("compositionupdate") {
+                    let _ = self
+                        .textinput
+                        .borrow_mut()
+                        .handle_compositionupdate(compositionevent);
                     self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
                 }
                 event.mark_as_handled();

--- a/components/script/textinput.rs
+++ b/components/script/textinput.rs
@@ -988,6 +988,17 @@ impl<T: ClipboardProvider> TextInput<T> {
         KeyReaction::DispatchInput
     }
 
+    pub(crate) fn handle_compositionupdate(&mut self, event: &CompositionEvent) -> KeyReaction {
+        let start = self.selection_start_offset().0;
+        self.insert_string(event.data());
+        self.set_selection_range(
+            start as u32,
+            (start + event.data().len_utf8().0) as u32,
+            SelectionDirection::Forward,
+        );
+        KeyReaction::DispatchInput
+    }
+
     /// Whether the content is empty.
     pub(crate) fn is_empty(&self) -> bool {
         self.lines.len() <= 1 && self.lines.first().map_or(true, |line| line.is_empty())

--- a/ports/servoshell/desktop/app_state.rs
+++ b/ports/servoshell/desktop/app_state.rs
@@ -516,6 +516,22 @@ impl WebViewDelegate for RunningAppState {
         };
         let _ = haptic_stop_sender.send(stopped);
     }
+    fn show_ime(
+        &self,
+        _webview: WebView,
+        input_type: servo::InputMethodType,
+        text: Option<(String, i32)>,
+        multiline: bool,
+        position: servo::webrender_api::units::DeviceIntRect,
+    ) {
+        self.inner()
+            .window
+            .show_ime(input_type, text, multiline, position);
+    }
+
+    fn hide_ime(&self, _webview: WebView) {
+        self.inner().window.hide_ime();
+    }
 }
 
 #[cfg(target_os = "linux")]

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -139,8 +139,6 @@ impl Window {
         let rendering_context =
             Rc::new(window_rendering_context.offscreen_context(rendering_context_size));
 
-        winit_window.set_ime_allowed(true);
-
         debug!("Created window {:?}", winit_window.id());
         Window {
             winit_window,
@@ -703,6 +701,19 @@ impl WindowPortsMethods for Window {
 
     fn rendering_context(&self) -> Rc<dyn RenderingContext> {
         self.rendering_context.clone()
+    }
+    fn show_ime(
+        &self,
+        _input_type: servo::InputMethodType,
+        _text: Option<(String, i32)>,
+        _multiline: bool,
+        _position: servo::webrender_api::units::DeviceIntRect,
+    ) {
+        self.winit_window.set_ime_allowed(true);
+    }
+
+    fn hide_ime(&self) {
+        self.winit_window.set_ime_allowed(false);
     }
 }
 

--- a/ports/servoshell/desktop/window_trait.rs
+++ b/ports/servoshell/desktop/window_trait.rs
@@ -47,4 +47,14 @@ pub trait WindowPortsMethods: WindowMethods {
     fn toolbar_height(&self) -> Length<f32, DeviceIndependentPixel>;
     fn set_toolbar_height(&self, height: Length<f32, DeviceIndependentPixel>);
     fn rendering_context(&self) -> Rc<dyn RenderingContext>;
+    fn show_ime(
+        &self,
+        _input_type: servo::InputMethodType,
+        _text: Option<(String, i32)>,
+        _multiline: bool,
+        _position: servo::webrender_api::units::DeviceIntRect,
+    ) {
+    }
+
+    fn hide_ime(&self) {}
 }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This PR added:
- the handling of `compositionupdate` IME event in `htmlinputelement.rs` and `htmltextareaelement.rs`
- `handle_compositionupdate` method in `textinput`
- The handling of `winit::event::WindowEvent::Ime` events

What `handle_compositionupdate` does is that it replaces current selection with the text provided by IME and then continue to select the text, therefore whenever the IME provided the latest text it'll be updated accordingly.

In order to enable IME event in Winit we'll have to perform a `set_ime_allowed` on the Winit window, which is currently naively done during the initialization of the Winit window.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #35532 (GitHub issue number if applicable)

<!-- Either: -->
- [x] There are tests for these changes uievents/textinput should pass

I've ran it through WPT2020 and seems like there's no unexpected result:

https://github.com/dklassic/servo/actions/runs/13407191015

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

**Working examples**

https://github.com/user-attachments/assets/5c251dac-a7a2-4728-af93-b7a49413b3d7

https://github.com/user-attachments/assets/22661e4c-a179-430d-87dd-2114c009ab4c