### PR TITLE
compositing: Split non-WebView-specific data into `ServoRenderer`

### DIFF
--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -629,14 +629,14 @@ impl Servo {
     /// The return value of this method indicates whether or not Servo, false indicates that Servo
     /// has finished shutting down and you should not spin the event loop any longer.
     pub fn spin_event_loop(&self) -> bool {
-        if self.compositor.borrow().shutdown_state == ShutdownState::FinishedShuttingDown {
+        if self.compositor.borrow().shutdown_state() == ShutdownState::FinishedShuttingDown {
             return false;
         }
 
         self.compositor.borrow_mut().receive_messages();
 
         // Only handle incoming embedder messages if the compositor hasn't already started shutting down.
-        if self.compositor.borrow().shutdown_state == ShutdownState::NotShuttingDown {
+        if self.compositor.borrow().shutdown_state() == ShutdownState::NotShuttingDown {
             while let Ok(message) = self.embedder_receiver.try_recv() {
                 self.handle_embedder_message(message)
             }
@@ -650,7 +650,7 @@ impl Servo {
         self.compositor.borrow_mut().perform_updates();
         self.send_new_frame_ready_messages();
 
-        if self.compositor.borrow().shutdown_state == ShutdownState::FinishedShuttingDown {
+        if self.compositor.borrow().shutdown_state() == ShutdownState::FinishedShuttingDown {
             return false;
         }
 


### PR DESCRIPTION
This will become the new global Servo renderer while each WebView will
also have its renderer (but not yet).

Co-authored-by: Ngo Iok Ui (Wu Yu Wei) <yuweiwu@pm.me>
Signed-off-by: Martin Robinson <mrobinson@igalia.com>


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they just move code around a little.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
