### PR TITLE
compositing: Move image output and shutdown management out of the compositor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1042,7 +1042,6 @@ dependencies = [
  "euclid",
  "fnv",
  "gleam",
- "image",
  "ipc-channel",
  "libc",
  "log",

--- a/components/compositing/Cargo.toml
+++ b/components/compositing/Cargo.toml
@@ -26,7 +26,6 @@ embedder_traits = { workspace = true }
 euclid = { workspace = true }
 fnv = { workspace = true }
 gleam = { workspace = true }
-image = { workspace = true }
 ipc-channel = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true }

--- a/components/compositing/lib.rs
+++ b/components/compositing/lib.rs
@@ -4,16 +4,18 @@
 
 #![deny(unsafe_code)]
 
+use std::cell::Cell;
 use std::rc::Rc;
 
 use compositing_traits::{CompositorProxy, CompositorReceiver, ConstellationMsg};
 use crossbeam_channel::Sender;
+use embedder_traits::ShutdownState;
 use profile_traits::{mem, time};
 use webrender::RenderApi;
 use webrender_api::DocumentId;
 use webrender_traits::rendering_context::RenderingContext;
 
-pub use crate::compositor::{CompositeTarget, IOCompositor, ShutdownState};
+pub use crate::compositor::IOCompositor;
 
 #[macro_use]
 mod tracing;
@@ -35,6 +37,9 @@ pub struct InitialCompositorState {
     pub time_profiler_chan: time::ProfilerChan,
     /// A channel to the memory profiler thread.
     pub mem_profiler_chan: mem::ProfilerChan,
+    /// A shared state which tracks whether Servo has started or has finished
+    /// shutting down.
+    pub shutdown_state: Rc<Cell<ShutdownState>>,
     /// Instance of webrender API
     pub webrender: webrender::Renderer,
     pub webrender_document: DocumentId,

--- a/components/compositing/tracing.rs
+++ b/components/compositing/tracing.rs
@@ -30,7 +30,6 @@ mod from_constellation {
     impl LogTarget for compositing_traits::CompositorMsg {
         fn log_target(&self) -> &'static str {
             match self {
-                Self::ShutdownComplete => target!("ShutdownComplete"),
                 Self::ChangeRunningAnimationsState(..) => target!("ChangeRunningAnimationsState"),
                 Self::CreateOrUpdateWebView(..) => target!("CreateOrUpdateWebView"),
                 Self::RemoveWebView(..) => target!("RemoveWebView"),

--- a/components/config/opts.rs
+++ b/components/config/opts.rs
@@ -15,6 +15,11 @@ use servo_url::ServoUrl;
 /// Global flags for Servo, currently set on the command line.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Opts {
+    /// Whether or not Servo should wait for web content to go into an idle state, therefore
+    /// likely producing a stable output image. This is useful for taking screenshots of pages
+    /// after they have loaded.
+    pub wait_for_stable_image: bool,
+
     /// Whether or not the legacy layout system is enabled.
     pub legacy_layout: bool,
 
@@ -44,8 +49,6 @@ pub struct Opts {
 
     pub user_stylesheets: Vec<(Vec<u8>, ServoUrl)>,
 
-    pub output_file: Option<String>,
-
     /// True to exit on thread failure instead of displaying about:failure.
     pub hard_fail: bool,
 
@@ -73,9 +76,6 @@ pub struct Opts {
     /// The seed for the RNG used to randomly close pipelines,
     /// used for testing the hardening of the constellation.
     pub random_pipeline_closure_seed: Option<usize>,
-
-    /// True to exit after the page load (`-x`).
-    pub exit_after_load: bool,
 
     /// Load shaders from disk.
     pub shaders_dir: Option<PathBuf>,
@@ -194,6 +194,7 @@ pub enum OutputOptions {
 impl Default for Opts {
     fn default() -> Self {
         Self {
+            wait_for_stable_image: false,
             legacy_layout: false,
             time_profiling: None,
             time_profiler_trace_path: None,
@@ -201,7 +202,6 @@ impl Default for Opts {
             nonincremental_layout: false,
             userscripts: None,
             user_stylesheets: Vec::new(),
-            output_file: None,
             hard_fail: true,
             webdriver_port: None,
             multiprocess: false,
@@ -210,7 +210,6 @@ impl Default for Opts {
             random_pipeline_closure_seed: None,
             sandbox: false,
             debug: Default::default(),
-            exit_after_load: false,
             config_dir: None,
             shaders_dir: None,
             certificate_path: None,

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -2698,8 +2698,8 @@ where
             }
         }
 
-        debug!("Asking compositor to complete shutdown.");
-        self.compositor_proxy.send(CompositorMsg::ShutdownComplete);
+        debug!("Asking embedding layer to complete shutdown.");
+        self.embedder_proxy.send(EmbedderMsg::ShutdownComplete);
 
         debug!("Shutting-down IPC router thread in constellation.");
         ROUTER.shutdown();

--- a/components/constellation/tracing.rs
+++ b/components/constellation/tracing.rs
@@ -247,6 +247,7 @@ mod from_script {
                 Self::RequestDevtoolsConnection(..) => target_variant!("RequestDevtoolsConnection"),
                 Self::PlayGamepadHapticEffect(..) => target_variant!("PlayGamepadHapticEffect"),
                 Self::StopGamepadHapticEffect(..) => target_variant!("StopGamepadHapticEffect"),
+                Self::ShutdownComplete => target_variant!("ShutdownComplete"),
             }
         }
     }

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -298,9 +298,6 @@ pub struct ScriptThread {
     /// Emits notifications when there is a relayout.
     relayout_event: bool,
 
-    /// True if it is safe to write to the image.
-    prepare_for_screenshot: bool,
-
     /// Unminify Javascript.
     unminify_js: bool,
 
@@ -835,10 +832,6 @@ impl ScriptThread {
         system_font_service: Arc<SystemFontServiceProxy>,
         user_agent: Cow<'static, str>,
     ) -> ScriptThread {
-        let opts = opts::get();
-        let prepare_for_screenshot =
-            opts.output_file.is_some() || opts.exit_after_load || opts.webdriver_port.is_some();
-
         let (self_sender, self_receiver) = unbounded();
         let runtime = Runtime::new(Some(SendableTaskSource {
             sender: ScriptEventLoopSender::MainThread(self_sender.clone()),
@@ -898,6 +891,7 @@ impl ScriptThread {
             webgpu_receiver: RefCell::new(crossbeam_channel::never()),
         };
 
+        let opts = opts::get();
         let senders = ScriptThreadSenders {
             self_sender,
             #[cfg(feature = "bluetooth")]
@@ -946,7 +940,6 @@ impl ScriptThread {
             profile_script_events: opts.debug.profile_script_events,
             print_pwm: opts.print_pwm,
             relayout_event: opts.debug.relayout_event,
-            prepare_for_screenshot,
             unminify_js: opts.unminify_js,
             local_script_source: opts.local_script_source.clone(),
             unminify_css: opts.unminify_css,
@@ -3099,7 +3092,6 @@ impl ScriptThread {
             self.webrender_document,
             self.compositor_api.clone(),
             self.relayout_event,
-            self.prepare_for_screenshot,
             self.unminify_js,
             self.unminify_css,
             self.local_script_source.clone(),

--- a/components/servo/examples/winit_minimal.rs
+++ b/components/servo/examples/winit_minimal.rs
@@ -111,7 +111,6 @@ impl ApplicationHandler<WakerEvent> for App {
                 }),
                 window_delegate.clone(),
                 Default::default(),
-                compositing::CompositeTarget::ContextFbo,
             );
             servo.setup_logging();
 

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -436,7 +436,10 @@ impl WebView {
             .send(ConstellationMsg::SendError(Some(self.id()), message));
     }
 
-    pub fn paint(&self) {
-        self.inner().compositor.borrow_mut().composite();
+    /// Paint the contents of this [`WebView`] into its `RenderingContext`. This will
+    /// always paint, unless the `Opts::wait_for_stable_image` option is enabled. In
+    /// that case, this might do nothing. Returns true if a paint was actually performed.
+    pub fn paint(&self) -> bool {
+        self.inner().compositor.borrow_mut().render()
     }
 }

--- a/components/shared/compositing/lib.rs
+++ b/components/shared/compositing/lib.rs
@@ -58,10 +58,6 @@ impl CompositorReceiver {
 
 /// Messages from (or via) the constellation thread to the compositor.
 pub enum CompositorMsg {
-    /// Informs the compositor that the constellation has completed shutdown.
-    /// Required because the constellation can have pending calls to make
-    /// (e.g. SetFrameTree) at the time that we send it an ExitMsg.
-    ShutdownComplete,
     /// Alerts the compositor that the given pipeline has changed whether it is running animations.
     ChangeRunningAnimationsState(PipelineId, AnimationState),
     /// Create or update a webview, given its frame tree.
@@ -118,7 +114,6 @@ pub struct CompositionPipeline {
 impl Debug for CompositorMsg {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
         match *self {
-            CompositorMsg::ShutdownComplete => write!(f, "ShutdownComplete"),
             CompositorMsg::ChangeRunningAnimationsState(_, state) => {
                 write!(f, "ChangeRunningAnimationsState({:?})", state)
             },

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -22,6 +22,15 @@ use webrender_api::units::{DeviceIntPoint, DeviceIntRect, DeviceIntSize};
 
 pub use crate::input_events::*;
 
+/// Tracks whether Servo isn't shutting down, is in the process of shutting down,
+/// or has finished shutting down.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum ShutdownState {
+    NotShuttingDown,
+    ShuttingDown,
+    FinishedShuttingDown,
+}
+
 /// A cursor for the window. This is different from a CSS cursor (see
 /// `CursorKind`) in that it has no `Auto` value.
 #[repr(u8)]
@@ -257,6 +266,10 @@ pub enum EmbedderMsg {
     PlayGamepadHapticEffect(WebViewId, usize, GamepadHapticEffectType, IpcSender<bool>),
     /// Request to stop a haptic effect on a connected gamepad.
     StopGamepadHapticEffect(WebViewId, usize, IpcSender<bool>),
+    /// Informs the embedder that the constellation has completed shutdown.
+    /// Required because the constellation can have pending calls to make
+    /// (e.g. SetFrameTree) at the time that we send it an ExitMsg.
+    ShutdownComplete,
 }
 
 impl Debug for EmbedderMsg {
@@ -302,6 +315,7 @@ impl Debug for EmbedderMsg {
             EmbedderMsg::ShowContextMenu(..) => write!(f, "ShowContextMenu"),
             EmbedderMsg::PlayGamepadHapticEffect(..) => write!(f, "PlayGamepadHapticEffect"),
             EmbedderMsg::StopGamepadHapticEffect(..) => write!(f, "StopGamepadHapticEffect"),
+            EmbedderMsg::ShutdownComplete => write!(f, "ShutdownComplete"),
         }
     }
 }

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -66,6 +66,7 @@ keyboard-types = { workspace = true }
 log = { workspace = true }
 getopts = { workspace = true }
 hitrace = { workspace = true, optional = true }
+image = { workspace = true }
 mime_guess = { workspace = true }
 url = { workspace = true }
 raw-window-handle = { workspace = true }
@@ -124,9 +125,6 @@ surfman = { workspace = true, features = ["sm-x11", "sm-raw-window-handle-06"] }
 tinyfiledialogs = "3.0"
 egui-file-dialog = "0.9.0"
 winit = "0.30.9"
-
-[target.'cfg(any(all(target_os = "linux", not(target_env = "ohos")), target_os = "windows"))'.dependencies]
-image = { workspace = true }
 
 [target.'cfg(any(all(target_os = "linux", not(target_env = "ohos")), target_os = "macos"))'.dependencies]
 sig = "1.0"

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -12,7 +12,6 @@ use std::{env, fs};
 
 use log::{info, trace, warn};
 use servo::compositing::windowing::{AnimationState, WindowMethods};
-use servo::compositing::CompositeTarget;
 use servo::config::opts::Opts;
 use servo::config::prefs::Preferences;
 use servo::servo_config::pref;
@@ -99,11 +98,7 @@ impl App {
         assert_eq!(headless, event_loop.is_none());
         let window = match event_loop {
             Some(event_loop) => {
-                let window = headed_window::Window::new(
-                    &self.opts,
-                    &self.servoshell_preferences,
-                    event_loop,
-                );
+                let window = headed_window::Window::new(&self.servoshell_preferences, event_loop);
                 self.minibrowser = Some(Minibrowser::new(
                     window.offscreen_rendering_context(),
                     event_loop,
@@ -158,11 +153,14 @@ impl App {
             embedder,
             Rc::new(UpcastedWindow(window.clone())),
             self.servoshell_preferences.user_agent.clone(),
-            CompositeTarget::ContextFbo,
         );
         servo.setup_logging();
 
-        let running_state = Rc::new(RunningAppState::new(servo, window.clone(), headless));
+        let running_state = Rc::new(RunningAppState::new(
+            servo,
+            window.clone(),
+            self.servoshell_preferences.clone(),
+        ));
         running_state.new_toplevel_webview(self.initial_url.clone().into_url());
 
         if let Some(ref mut minibrowser) = self.minibrowser {

--- a/ports/servoshell/desktop/cli.rs
+++ b/ports/servoshell/desktop/cli.rs
@@ -29,7 +29,8 @@ pub fn main() {
     crate::init_tracing(servoshell_preferences.tracing_filter.as_deref());
 
     let clean_shutdown = servoshell_preferences.clean_shutdown;
-    let event_loop = EventsLoop::new(servoshell_preferences.headless, opts.output_file.is_some())
+    let has_output_file = servoshell_preferences.output_image_path.is_some();
+    let event_loop = EventsLoop::new(servoshell_preferences.headless, has_output_file)
         .expect("Failed to create events loop");
 
     {

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -17,7 +17,6 @@ use raw_window_handle::{HasDisplayHandle, HasWindowHandle};
 use servo::compositing::windowing::{
     AnimationState, EmbedderCoordinates, WebRenderDebugOption, WindowMethods,
 };
-use servo::config::opts::Opts;
 use servo::servo_config::pref;
 use servo::servo_geometry::DeviceIndependentPixel;
 use servo::webrender_api::units::{DeviceIntPoint, DeviceIntRect, DeviceIntSize, DevicePixel};
@@ -78,24 +77,17 @@ pub struct Window {
 
 impl Window {
     pub fn new(
-        opts: &Opts,
         servoshell_preferences: &ServoShellPreferences,
         event_loop: &ActiveEventLoop,
     ) -> Window {
-        // If there's no chrome, start off with the window invisible. It will be set to visible in
-        // `load_end()`. This avoids an ugly flash of unstyled content (especially important since
-        // unstyled content is white and chrome often has a transparent background). See issue
-        // #9996.
         let no_native_titlebar = servoshell_preferences.no_native_titlebar;
-        let visible = opts.output_file.is_none() && !servoshell_preferences.no_native_titlebar;
-
         let window_size = servoshell_preferences.initial_window_size;
         let window_attr = winit::window::Window::default_attributes()
             .with_title("Servo".to_string())
             .with_decorations(!no_native_titlebar)
             .with_transparent(no_native_titlebar)
             .with_inner_size(LogicalSize::new(window_size.width, window_size.height))
-            .with_visible(visible);
+            .with_visible(true);
 
         #[allow(deprecated)]
         let winit_window = event_loop

--- a/ports/servoshell/egl/android/simpleservo.rs
+++ b/ports/servoshell/egl/android/simpleservo.rs
@@ -7,7 +7,6 @@ use std::mem;
 use std::rc::Rc;
 
 use raw_window_handle::{DisplayHandle, RawDisplayHandle, RawWindowHandle, WindowHandle};
-use servo::compositing::CompositeTarget;
 pub use servo::webrender_api::units::DeviceIntRect;
 /// The EventLoopWaker::wake function will be called from any thread.
 /// It will be called to notify embedder that some events are available,
@@ -97,7 +96,6 @@ pub fn init(
         embedder_callbacks,
         window_callbacks.clone(),
         None,
-        CompositeTarget::ContextFbo,
     );
 
     APP.with(|app| {

--- a/ports/servoshell/egl/ohos/simpleservo.rs
+++ b/ports/servoshell/egl/ohos/simpleservo.rs
@@ -12,7 +12,6 @@ use raw_window_handle::{
     DisplayHandle, OhosDisplayHandle, OhosNdkWindowHandle, RawDisplayHandle, RawWindowHandle,
     WindowHandle,
 };
-use servo::compositing::CompositeTarget;
 /// The EventLoopWaker::wake function will be called from any thread.
 /// It will be called to notify embedder that some events are available,
 /// and that perform_updates need to be called
@@ -113,7 +112,6 @@ pub fn init(
         embedder_callbacks,
         window_callbacks.clone(),
         None, /* user_agent */
-        CompositeTarget::ContextFbo,
     );
 
     let app_state = RunningAppState::new(

--- a/tests/wpt/tests/tools/wptrunner/wptrunner/executors/executorservo.py
+++ b/tests/wpt/tests/tools/wptrunner/wptrunner/executors/executorservo.py
@@ -226,6 +226,7 @@ class ServoRefTestExecutor(ServoExecutor):
 
     def screenshot(self, test, viewport_size, dpi, page_ranges):
         with TempFilename(self.tempdir) as output_path:
+            output_path = f"{output_path}.png"
             extra_args = ["--exit",
                           "--output=%s" % output_path,
                           "--window-size", viewport_size or "800x600"]


### PR DESCRIPTION
This is a step toward the renderer-per-WebView goal. It moves various
details out of `IOCompositor`.

- Image output: This is moved to servoshell as now applications can
  access the image contents of a `WebView` via
  `RenderingContext::read_to_image`. Most options for this are moved to
  `ServoShellPreferences` apart from `wait_for_stable_image` as this
  requires a specific kind of coordination in the `ScriptThread` that is
  also very expensive. Instead, paint is now simply delayed until a
  stable image is reached and `WebView::paint()` returns a boolean.
  Maybe this can be revisited in the future.
- Shutdown: Shutdown is now managed by libservo itself. Shutdown state
  is shared between the compositor and `Servo` instance. In the future,
  this sharing might be unecessary.

This change also allows saving others types of image output just as JPEG.

Co-authored-by: Ngo Iok Ui (Wu Yu Wei) <yuweiwu@pm.me>
Signed-off-by: Martin Robinson <mrobinson@igalia.com>

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because this is mainly a refactor. Image output is tested by the WPT suite itself.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
