### PR TITLE
Propagate `CanGc` arguments through callers in constructors

### DIFF
--- a/components/script/body.rs
+++ b/components/script/body.rs
@@ -255,7 +255,7 @@ impl TransmitBodyConnectHandler {
                 });
 
                 let handler =
-                    PromiseNativeHandler::new(&global, Some(promise_handler), Some(rejection_handler));
+                    PromiseNativeHandler::new(&global, Some(promise_handler), Some(rejection_handler), CanGc::note());
 
                 let realm = enter_realm(&*global);
                 let comp = InRealm::Entered(&realm);
@@ -704,8 +704,12 @@ impl Callback for ConsumeBodyPromiseHandler {
                 result_promise: self.result_promise.clone(),
             });
 
-            let handler =
-                PromiseNativeHandler::new(&global, Some(promise_handler), Some(rejection_handler));
+            let handler = PromiseNativeHandler::new(
+                &global,
+                Some(promise_handler),
+                Some(rejection_handler),
+                can_gc,
+            );
 
             let realm = enter_realm(&*global);
             let comp = InRealm::Entered(&realm);
@@ -792,6 +796,7 @@ fn consume_body_with_promise<T: BodyMixin + DomObject>(
         &object.global(),
         promise_handler.take().map(|h| Box::new(h) as Box<_>),
         Some(rejection_handler),
+        can_gc,
     );
     // We are already in a realm and a script.
     read_promise.append_native_handler(&handler, comp, can_gc);

--- a/components/script/canvas_state.rs
+++ b/components/script/canvas_state.rs
@@ -852,6 +852,7 @@ impl CanvasState {
         CanvasGradient::new(
             global,
             CanvasGradientStyle::Linear(LinearGradientStyle::new(*x0, *y0, *x1, *y1, Vec::new())),
+            CanGc::note(),
         )
     }
 
@@ -882,6 +883,7 @@ impl CanvasState {
                 *r1,
                 Vec::new(),
             )),
+            CanGc::note(),
         ))
     }
 
@@ -939,6 +941,7 @@ impl CanvasState {
                 image_size,
                 rep,
                 self.is_origin_clean(image),
+                CanGc::note(),
             )))
         } else {
             Err(Error::Syntax)
@@ -1079,6 +1082,7 @@ impl CanvasState {
             metrics.hanging_baseline.into(),
             metrics.alphabetic_baseline.into(),
             metrics.ideographic_baseline.into(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/abstractrange.rs
+++ b/components/script/dom/abstractrange.rs
@@ -43,6 +43,7 @@ impl AbstractRange {
         start_offset: u32,
         end_container: &Node,
         end_offset: u32,
+        can_gc: CanGc,
     ) -> DomRoot<AbstractRange> {
         let abstractrange = reflect_dom_object(
             Box::new(AbstractRange::new_inherited(
@@ -52,7 +53,7 @@ impl AbstractRange {
                 end_offset,
             )),
             document.window(),
-            CanGc::note(),
+            can_gc,
         );
         abstractrange
     }

--- a/components/script/dom/audiobuffersourcenode.rs
+++ b/components/script/dom/audiobuffersourcenode.rs
@@ -68,6 +68,7 @@ impl AudioBufferSourceNode {
             *options.playbackRate,
             f32::MIN,
             f32::MAX,
+            CanGc::note(),
         );
         let detune = AudioParam::new(
             window,
@@ -79,6 +80,7 @@ impl AudioBufferSourceNode {
             *options.detune,
             f32::MIN,
             f32::MAX,
+            CanGc::note(),
         );
         let node = AudioBufferSourceNode {
             source_node,

--- a/components/script/dom/audiodestinationnode.rs
+++ b/components/script/dom/audiodestinationnode.rs
@@ -43,9 +43,10 @@ impl AudioDestinationNode {
         global: &GlobalScope,
         context: &BaseAudioContext,
         options: &AudioNodeOptions,
+        can_gc: CanGc,
     ) -> DomRoot<AudioDestinationNode> {
         let node = AudioDestinationNode::new_inherited(context, options);
-        reflect_dom_object(Box::new(node), global, CanGc::note())
+        reflect_dom_object(Box::new(node), global, can_gc)
     }
 }
 

--- a/components/script/dom/audiolistener.rs
+++ b/components/script/dom/audiolistener.rs
@@ -49,6 +49,7 @@ impl AudioListener {
             0.,       // default value
             f32::MIN, // min value
             f32::MAX, // max value
+            CanGc::note(),
         );
         let position_y = AudioParam::new(
             window,
@@ -60,6 +61,7 @@ impl AudioListener {
             0.,       // default value
             f32::MIN, // min value
             f32::MAX, // max value
+            CanGc::note(),
         );
         let position_z = AudioParam::new(
             window,
@@ -71,6 +73,7 @@ impl AudioListener {
             0.,       // default value
             f32::MIN, // min value
             f32::MAX, // max value
+            CanGc::note(),
         );
         let forward_x = AudioParam::new(
             window,
@@ -82,6 +85,7 @@ impl AudioListener {
             0.,       // default value
             f32::MIN, // min value
             f32::MAX, // max value
+            CanGc::note(),
         );
         let forward_y = AudioParam::new(
             window,
@@ -93,6 +97,7 @@ impl AudioListener {
             0.,       // default value
             f32::MIN, // min value
             f32::MAX, // max value
+            CanGc::note(),
         );
         let forward_z = AudioParam::new(
             window,
@@ -104,6 +109,7 @@ impl AudioListener {
             -1.,      // default value
             f32::MIN, // min value
             f32::MAX, // max value
+            CanGc::note(),
         );
         let up_x = AudioParam::new(
             window,
@@ -115,6 +121,7 @@ impl AudioListener {
             0.,       // default value
             f32::MIN, // min value
             f32::MAX, // max value
+            CanGc::note(),
         );
         let up_y = AudioParam::new(
             window,
@@ -126,6 +133,7 @@ impl AudioListener {
             1.,       // default value
             f32::MIN, // min value
             f32::MAX, // max value
+            CanGc::note(),
         );
         let up_z = AudioParam::new(
             window,
@@ -137,6 +145,7 @@ impl AudioListener {
             0.,       // default value
             f32::MIN, // min value
             f32::MAX, // max value
+            CanGc::note(),
         );
 
         AudioListener {

--- a/components/script/dom/audioparam.rs
+++ b/components/script/dom/audioparam.rs
@@ -78,6 +78,7 @@ impl AudioParam {
         default_value: f32,
         min_value: f32,
         max_value: f32,
+        can_gc: CanGc,
     ) -> DomRoot<AudioParam> {
         let audio_param = AudioParam::new_inherited(
             context,
@@ -89,7 +90,7 @@ impl AudioParam {
             min_value,
             max_value,
         );
-        reflect_dom_object(Box::new(audio_param), window, CanGc::note())
+        reflect_dom_object(Box::new(audio_param), window, can_gc)
     }
 
     fn message_node(&self, message: AudioNodeMessage) {

--- a/components/script/dom/audiotrack.rs
+++ b/components/script/dom/audiotrack.rs
@@ -52,13 +52,14 @@ impl AudioTrack {
         label: DOMString,
         language: DOMString,
         track_list: Option<&AudioTrackList>,
+        can_gc: CanGc,
     ) -> DomRoot<AudioTrack> {
         reflect_dom_object(
             Box::new(AudioTrack::new_inherited(
                 id, kind, label, language, track_list,
             )),
             window,
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/audiotracklist.rs
+++ b/components/script/dom/audiotracklist.rs
@@ -40,11 +40,12 @@ impl AudioTrackList {
         window: &Window,
         tracks: &[&AudioTrack],
         media_element: Option<&HTMLMediaElement>,
+        can_gc: CanGc,
     ) -> DomRoot<AudioTrackList> {
         reflect_dom_object(
             Box::new(AudioTrackList::new_inherited(tracks, media_element)),
             window,
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/baseaudiocontext.rs
+++ b/components/script/dom/baseaudiocontext.rs
@@ -324,7 +324,7 @@ impl BaseAudioContextMethods<crate::DomTypeHolder> for BaseAudioContext {
             options.channelCount = Some(self.channel_count);
             options.channelCountMode = Some(ChannelCountMode::Explicit);
             options.channelInterpretation = Some(ChannelInterpretation::Speakers);
-            AudioDestinationNode::new(&global, self, &options)
+            AudioDestinationNode::new(&global, self, &options, CanGc::note())
         })
     }
 
@@ -560,7 +560,7 @@ impl BaseAudioContextMethods<crate::DomTypeHolder> for BaseAudioContext {
                         let resolver = resolvers.remove(&uuid).unwrap();
                         if let Some(callback) = resolver.error_callback {
                             let _ = callback.Call__(
-                                &DOMException::new(&this.global(), DOMErrorName::DataCloneError),
+                                &DOMException::new(&this.global(), DOMErrorName::DataCloneError, CanGc::note()),
                                 ExceptionHandling::Report);
                         }
                         let error = format!("Audio decode error {:?}", error);

--- a/components/script/dom/beforeunloadevent.rs
+++ b/components/script/dom/beforeunloadevent.rs
@@ -33,12 +33,8 @@ impl BeforeUnloadEvent {
         }
     }
 
-    pub(crate) fn new_uninitialized(window: &Window) -> DomRoot<BeforeUnloadEvent> {
-        reflect_dom_object(
-            Box::new(BeforeUnloadEvent::new_inherited()),
-            window,
-            CanGc::note(),
-        )
+    pub(crate) fn new_uninitialized(window: &Window, can_gc: CanGc) -> DomRoot<BeforeUnloadEvent> {
+        reflect_dom_object(Box::new(BeforeUnloadEvent::new_inherited()), window, can_gc)
     }
 
     pub(crate) fn new(
@@ -47,7 +43,7 @@ impl BeforeUnloadEvent {
         bubbles: EventBubbles,
         cancelable: EventCancelable,
     ) -> DomRoot<BeforeUnloadEvent> {
-        let ev = BeforeUnloadEvent::new_uninitialized(window);
+        let ev = BeforeUnloadEvent::new_uninitialized(window, CanGc::note());
         {
             let event = ev.upcast::<Event>();
             event.init_event(type_, bool::from(bubbles), bool::from(cancelable));

--- a/components/script/dom/bindings/error.rs
+++ b/components/script/dom/bindings/error.rs
@@ -159,7 +159,7 @@ pub(crate) fn throw_dom_exception(cx: SafeJSContext, global: &GlobalScope, resul
 
     unsafe {
         assert!(!JS_IsExceptionPending(*cx));
-        let exception = DOMException::new(global, code);
+        let exception = DOMException::new(global, code, CanGc::note());
         rooted!(in(*cx) let mut thrown = UndefinedValue());
         exception.to_jsval(*cx, thrown.handle_mut());
         JS_SetPendingException(*cx, thrown.handle(), ExceptionStackBehavior::Capture);

--- a/components/script/dom/biquadfilternode.rs
+++ b/components/script/dom/biquadfilternode.rs
@@ -70,6 +70,7 @@ impl BiquadFilterNode {
             options.gain, // default value
             f32::MIN,     // min value
             f32::MAX,     // max value
+            CanGc::note(),
         );
         let q = AudioParam::new(
             window,
@@ -81,6 +82,7 @@ impl BiquadFilterNode {
             options.q, // default value
             f32::MIN,  // min value
             f32::MAX,  // max value
+            CanGc::note(),
         );
         let frequency = AudioParam::new(
             window,
@@ -92,6 +94,7 @@ impl BiquadFilterNode {
             options.frequency, // default value
             f32::MIN,          // min value
             f32::MAX,          // max value
+            CanGc::note(),
         );
         let detune = AudioParam::new(
             window,
@@ -103,6 +106,7 @@ impl BiquadFilterNode {
             options.detune, // default value
             f32::MIN,       // min value
             f32::MAX,       // max value
+            CanGc::note(),
         );
         Ok(BiquadFilterNode {
             node,

--- a/components/script/dom/bluetooth/bluetooth.rs
+++ b/components/script/dom/bluetooth/bluetooth.rs
@@ -151,8 +151,8 @@ impl Bluetooth {
         }
     }
 
-    pub(crate) fn new(global: &GlobalScope) -> DomRoot<Bluetooth> {
-        reflect_dom_object(Box::new(Bluetooth::new_inherited()), global, CanGc::note())
+    pub(crate) fn new(global: &GlobalScope, can_gc: CanGc) -> DomRoot<Bluetooth> {
+        reflect_dom_object(Box::new(Bluetooth::new_inherited()), global, can_gc)
     }
 
     fn get_bluetooth_thread(&self) -> IpcSender<BluetoothRequest> {
@@ -582,7 +582,7 @@ impl BluetoothMethods<crate::DomTypeHolder> for Bluetooth {
 }
 
 impl AsyncBluetoothListener for Bluetooth {
-    fn handle_response(&self, response: BluetoothResponse, promise: &Rc<Promise>, _can_gc: CanGc) {
+    fn handle_response(&self, response: BluetoothResponse, promise: &Rc<Promise>, can_gc: CanGc) {
         match response {
             // https://webbluetoothcg.github.io/web-bluetooth/#request-bluetooth-devices
             // Step 11, 13 - 14.
@@ -596,6 +596,7 @@ impl AsyncBluetoothListener for Bluetooth {
                     DOMString::from(device.id.clone()),
                     device.name.map(DOMString::from),
                     self,
+                    can_gc,
                 );
                 device_instance_map.insert(device.id.clone(), Dom::from_ref(&bt_device));
 

--- a/components/script/dom/bluetooth/bluetoothcharacteristicproperties.rs
+++ b/components/script/dom/bluetooth/bluetoothcharacteristicproperties.rs
@@ -65,6 +65,7 @@ impl BluetoothCharacteristicProperties {
         authenticatedSignedWrites: bool,
         reliableWrite: bool,
         writableAuxiliaries: bool,
+        can_gc: CanGc,
     ) -> DomRoot<BluetoothCharacteristicProperties> {
         reflect_dom_object(
             Box::new(BluetoothCharacteristicProperties::new_inherited(
@@ -79,7 +80,7 @@ impl BluetoothCharacteristicProperties {
                 writableAuxiliaries,
             )),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 }

--- a/components/script/dom/bluetooth/bluetoothdevice.rs
+++ b/components/script/dom/bluetooth/bluetoothdevice.rs
@@ -81,17 +81,18 @@ impl BluetoothDevice {
         id: DOMString,
         name: Option<DOMString>,
         context: &Bluetooth,
+        can_gc: CanGc,
     ) -> DomRoot<BluetoothDevice> {
         reflect_dom_object(
             Box::new(BluetoothDevice::new_inherited(id, name, context)),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 
     pub(crate) fn get_gatt(&self) -> DomRoot<BluetoothRemoteGATTServer> {
         self.gatt
-            .or_init(|| BluetoothRemoteGATTServer::new(&self.global(), self))
+            .or_init(|| BluetoothRemoteGATTServer::new(&self.global(), self, CanGc::note()))
     }
 
     fn get_context(&self) -> DomRoot<Bluetooth> {
@@ -114,6 +115,7 @@ impl BluetoothDevice {
             DOMString::from(service.uuid.clone()),
             service.is_primary,
             service.instance_id.clone(),
+            CanGc::note(),
         );
         service_map.insert(service.instance_id.clone(), Dom::from_ref(&bt_service));
         bt_service
@@ -140,6 +142,7 @@ impl BluetoothDevice {
             characteristic.authenticated_signed_writes,
             characteristic.reliable_write,
             characteristic.writable_auxiliaries,
+            CanGc::note(),
         );
         let bt_characteristic = BluetoothRemoteGATTCharacteristic::new(
             &service.global(),
@@ -147,6 +150,7 @@ impl BluetoothDevice {
             DOMString::from(characteristic.uuid.clone()),
             &properties,
             characteristic.instance_id.clone(),
+            CanGc::note(),
         );
         characteristic_map.insert(
             characteristic.instance_id.clone(),
@@ -181,6 +185,7 @@ impl BluetoothDevice {
             characteristic,
             DOMString::from(descriptor.uuid.clone()),
             descriptor.instance_id.clone(),
+            CanGc::note(),
         );
         descriptor_map.insert(
             descriptor.instance_id.clone(),

--- a/components/script/dom/bluetooth/bluetoothpermissionresult.rs
+++ b/components/script/dom/bluetooth/bluetoothpermissionresult.rs
@@ -48,11 +48,12 @@ impl BluetoothPermissionResult {
     pub(crate) fn new(
         global: &GlobalScope,
         status: &PermissionStatus,
+        can_gc: CanGc,
     ) -> DomRoot<BluetoothPermissionResult> {
         reflect_dom_object(
             Box::new(BluetoothPermissionResult::new_inherited(status)),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -96,7 +97,7 @@ impl BluetoothPermissionResultMethods<crate::DomTypeHolder> for BluetoothPermiss
 }
 
 impl AsyncBluetoothListener for BluetoothPermissionResult {
-    fn handle_response(&self, response: BluetoothResponse, promise: &Rc<Promise>, _can_gc: CanGc) {
+    fn handle_response(&self, response: BluetoothResponse, promise: &Rc<Promise>, can_gc: CanGc) {
         match response {
             // https://webbluetoothcg.github.io/web-bluetooth/#request-bluetooth-devices
             // Step 3, 11, 13 - 14.
@@ -118,6 +119,7 @@ impl AsyncBluetoothListener for BluetoothPermissionResult {
                     DOMString::from(device.id.clone()),
                     device.name.map(DOMString::from),
                     &bluetooth,
+                    can_gc,
                 );
                 device_instance_map.insert(device.id.clone(), Dom::from_ref(&bt_device));
                 self.global()

--- a/components/script/dom/bluetooth/bluetoothremotegattcharacteristic.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattcharacteristic.rs
@@ -70,6 +70,7 @@ impl BluetoothRemoteGATTCharacteristic {
         uuid: DOMString,
         properties: &BluetoothCharacteristicProperties,
         instance_id: String,
+        can_gc: CanGc,
     ) -> DomRoot<BluetoothRemoteGATTCharacteristic> {
         reflect_dom_object(
             Box::new(BluetoothRemoteGATTCharacteristic::new_inherited(
@@ -79,7 +80,7 @@ impl BluetoothRemoteGATTCharacteristic {
                 instance_id,
             )),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/bluetooth/bluetoothremotegattdescriptor.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattdescriptor.rs
@@ -58,6 +58,7 @@ impl BluetoothRemoteGATTDescriptor {
         characteristic: &BluetoothRemoteGATTCharacteristic,
         uuid: DOMString,
         instance_id: String,
+        can_gc: CanGc,
     ) -> DomRoot<BluetoothRemoteGATTDescriptor> {
         reflect_dom_object(
             Box::new(BluetoothRemoteGATTDescriptor::new_inherited(
@@ -66,7 +67,7 @@ impl BluetoothRemoteGATTDescriptor {
                 instance_id,
             )),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/bluetooth/bluetoothremotegattserver.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattserver.rs
@@ -42,11 +42,12 @@ impl BluetoothRemoteGATTServer {
     pub(crate) fn new(
         global: &GlobalScope,
         device: &BluetoothDevice,
+        can_gc: CanGc,
     ) -> DomRoot<BluetoothRemoteGATTServer> {
         reflect_dom_object(
             Box::new(BluetoothRemoteGATTServer::new_inherited(device)),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/bluetooth/bluetoothremotegattservice.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattservice.rs
@@ -54,13 +54,14 @@ impl BluetoothRemoteGATTService {
         uuid: DOMString,
         isPrimary: bool,
         instanceID: String,
+        can_gc: CanGc,
     ) -> DomRoot<BluetoothRemoteGATTService> {
         reflect_dom_object(
             Box::new(BluetoothRemoteGATTService::new_inherited(
                 device, uuid, isPrimary, instanceID,
             )),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/bluetooth/testrunner.rs
+++ b/components/script/dom/bluetooth/testrunner.rs
@@ -29,8 +29,8 @@ impl TestRunner {
         }
     }
 
-    pub(crate) fn new(global: &GlobalScope) -> DomRoot<TestRunner> {
-        reflect_dom_object(Box::new(TestRunner::new_inherited()), global, CanGc::note())
+    pub(crate) fn new(global: &GlobalScope, can_gc: CanGc) -> DomRoot<TestRunner> {
+        reflect_dom_object(Box::new(TestRunner::new_inherited()), global, can_gc)
     }
 
     fn get_bluetooth_thread(&self) -> IpcSender<BluetoothRequest> {

--- a/components/script/dom/canvasgradient.rs
+++ b/components/script/dom/canvasgradient.rs
@@ -42,11 +42,15 @@ impl CanvasGradient {
         }
     }
 
-    pub(crate) fn new(global: &GlobalScope, style: CanvasGradientStyle) -> DomRoot<CanvasGradient> {
+    pub(crate) fn new(
+        global: &GlobalScope,
+        style: CanvasGradientStyle,
+        can_gc: CanGc,
+    ) -> DomRoot<CanvasGradient> {
         reflect_dom_object(
             Box::new(CanvasGradient::new_inherited(style)),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 }

--- a/components/script/dom/canvaspattern.rs
+++ b/components/script/dom/canvaspattern.rs
@@ -53,6 +53,7 @@ impl CanvasPattern {
         surface_size: Size2D<u32>,
         repeat: RepetitionStyle,
         origin_clean: bool,
+        can_gc: CanGc,
     ) -> DomRoot<CanvasPattern> {
         reflect_dom_object(
             Box::new(CanvasPattern::new_inherited(
@@ -62,7 +63,7 @@ impl CanvasPattern {
                 origin_clean,
             )),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
     pub(crate) fn origin_is_clean(&self) -> bool {

--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -61,13 +61,14 @@ impl CanvasRenderingContext2D {
         global: &GlobalScope,
         canvas: &HTMLCanvasElement,
         size: Size2D<u32>,
+        can_gc: CanGc,
     ) -> DomRoot<CanvasRenderingContext2D> {
         let boxed = Box::new(CanvasRenderingContext2D::new_inherited(
             global,
             Some(canvas),
             size,
         ));
-        reflect_dom_object(boxed, global, CanGc::note())
+        reflect_dom_object(boxed, global, can_gc)
     }
 
     // https://html.spec.whatwg.org/multipage/#concept-canvas-set-bitmap-dimensions

--- a/components/script/dom/client.rs
+++ b/components/script/dom/client.rs
@@ -39,11 +39,11 @@ impl Client {
         }
     }
 
-    pub(crate) fn new(window: &Window) -> DomRoot<Client> {
+    pub(crate) fn new(window: &Window, can_gc: CanGc) -> DomRoot<Client> {
         reflect_dom_object(
             Box::new(Client::new_inherited(window.get_url())),
             window,
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/compositionevent.rs
+++ b/components/script/dom/compositionevent.rs
@@ -31,12 +31,8 @@ impl CompositionEvent {
         }
     }
 
-    pub(crate) fn new_uninitialized(window: &Window) -> DomRoot<CompositionEvent> {
-        reflect_dom_object(
-            Box::new(CompositionEvent::new_inherited()),
-            window,
-            CanGc::note(),
-        )
+    pub(crate) fn new_uninitialized(window: &Window, can_gc: CanGc) -> DomRoot<CompositionEvent> {
+        reflect_dom_object(Box::new(CompositionEvent::new_inherited()), window, can_gc)
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/components/script/dom/constantsourcenode.rs
+++ b/components/script/dom/constantsourcenode.rs
@@ -55,6 +55,7 @@ impl ConstantSourceNode {
             *options.offset,
             f32::MIN,
             f32::MAX,
+            CanGc::note(),
         );
 
         Ok(ConstantSourceNode {

--- a/components/script/dom/crypto.rs
+++ b/components/script/dom/crypto.rs
@@ -37,15 +37,16 @@ impl Crypto {
         }
     }
 
-    pub(crate) fn new(global: &GlobalScope) -> DomRoot<Crypto> {
-        reflect_dom_object(Box::new(Crypto::new_inherited()), global, CanGc::note())
+    pub(crate) fn new(global: &GlobalScope, can_gc: CanGc) -> DomRoot<Crypto> {
+        reflect_dom_object(Box::new(Crypto::new_inherited()), global, can_gc)
     }
 }
 
 impl CryptoMethods<crate::DomTypeHolder> for Crypto {
     /// <https://w3c.github.io/webcrypto/#dfn-Crypto-attribute-subtle>
     fn Subtle(&self) -> DomRoot<SubtleCrypto> {
-        self.subtle.or_init(|| SubtleCrypto::new(&self.global()))
+        self.subtle
+            .or_init(|| SubtleCrypto::new(&self.global(), CanGc::note()))
     }
 
     #[allow(unsafe_code)]

--- a/components/script/dom/cryptokey.rs
+++ b/components/script/dom/cryptokey.rs
@@ -78,6 +78,7 @@ impl CryptoKey {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         global: &GlobalScope,
         key_type: KeyType,
@@ -86,6 +87,7 @@ impl CryptoKey {
         algorithm_object: HandleObject,
         usages: Vec<KeyUsage>,
         handle: Handle,
+        can_gc: CanGc,
     ) -> DomRoot<CryptoKey> {
         let object = reflect_dom_object(
             Box::new(CryptoKey::new_inherited(
@@ -96,7 +98,7 @@ impl CryptoKey {
                 handle,
             )),
             global,
-            CanGc::note(),
+            can_gc,
         );
 
         object.algorithm_object.set(algorithm_object.get());

--- a/components/script/dom/cssfontfacerule.rs
+++ b/components/script/dom/cssfontfacerule.rs
@@ -39,6 +39,7 @@ impl CSSFontFaceRule {
         window: &Window,
         parent_stylesheet: &CSSStyleSheet,
         fontfacerule: Arc<Locked<FontFaceRule>>,
+        can_gc: CanGc,
     ) -> DomRoot<CSSFontFaceRule> {
         reflect_dom_object(
             Box::new(CSSFontFaceRule::new_inherited(
@@ -46,7 +47,7 @@ impl CSSFontFaceRule {
                 fontfacerule,
             )),
             window,
-            CanGc::note(),
+            can_gc,
         )
     }
 }

--- a/components/script/dom/cssgroupingrule.rs
+++ b/components/script/dom/cssgroupingrule.rs
@@ -16,6 +16,7 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::cssrule::CSSRule;
 use crate::dom::cssrulelist::{CSSRuleList, RulesSource};
 use crate::dom::cssstylesheet::CSSStyleSheet;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct CSSGroupingRule {
@@ -45,6 +46,7 @@ impl CSSGroupingRule {
                 self.global().as_window(),
                 parent_stylesheet,
                 RulesSource::Rules(self.rules.clone()),
+                CanGc::note(),
             )
         })
     }

--- a/components/script/dom/cssimportrule.rs
+++ b/components/script/dom/cssimportrule.rs
@@ -42,11 +42,12 @@ impl CSSImportRule {
         window: &Window,
         parent_stylesheet: &CSSStyleSheet,
         import_rule: Arc<Locked<ImportRule>>,
+        can_gc: CanGc,
     ) -> DomRoot<Self> {
         reflect_dom_object(
             Box::new(Self::new_inherited(parent_stylesheet, import_rule)),
             window,
-            CanGc::note(),
+            can_gc,
         )
     }
 }

--- a/components/script/dom/csskeyframerule.rs
+++ b/components/script/dom/csskeyframerule.rs
@@ -45,6 +45,7 @@ impl CSSKeyframeRule {
         window: &Window,
         parent_stylesheet: &CSSStyleSheet,
         keyframerule: Arc<Locked<Keyframe>>,
+        can_gc: CanGc,
     ) -> DomRoot<CSSKeyframeRule> {
         reflect_dom_object(
             Box::new(CSSKeyframeRule::new_inherited(
@@ -52,7 +53,7 @@ impl CSSKeyframeRule {
                 keyframerule,
             )),
             window,
-            CanGc::note(),
+            can_gc,
         )
     }
 }
@@ -70,6 +71,7 @@ impl CSSKeyframeRuleMethods<crate::DomTypeHolder> for CSSKeyframeRule {
                 ),
                 None,
                 CSSModificationAccess::ReadWrite,
+                CanGc::note(),
             )
         })
     }

--- a/components/script/dom/csskeyframesrule.rs
+++ b/components/script/dom/csskeyframesrule.rs
@@ -49,6 +49,7 @@ impl CSSKeyframesRule {
         window: &Window,
         parent_stylesheet: &CSSStyleSheet,
         keyframesrule: Arc<Locked<KeyframesRule>>,
+        can_gc: CanGc,
     ) -> DomRoot<CSSKeyframesRule> {
         reflect_dom_object(
             Box::new(CSSKeyframesRule::new_inherited(
@@ -56,7 +57,7 @@ impl CSSKeyframesRule {
                 keyframesrule,
             )),
             window,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -67,6 +68,7 @@ impl CSSKeyframesRule {
                 self.global().as_window(),
                 parent_stylesheet,
                 RulesSource::Keyframes(self.keyframesrule.clone()),
+                CanGc::note(),
             )
         })
     }

--- a/components/script/dom/csslayerblockrule.rs
+++ b/components/script/dom/csslayerblockrule.rs
@@ -45,6 +45,7 @@ impl CSSLayerBlockRule {
         window: &Window,
         parent_stylesheet: &CSSStyleSheet,
         layerblockrule: Arc<LayerBlockRule>,
+        can_gc: CanGc,
     ) -> DomRoot<CSSLayerBlockRule> {
         reflect_dom_object(
             Box::new(CSSLayerBlockRule::new_inherited(
@@ -52,7 +53,7 @@ impl CSSLayerBlockRule {
                 layerblockrule,
             )),
             window,
-            CanGc::note(),
+            can_gc,
         )
     }
 }

--- a/components/script/dom/csslayerstatementrule.rs
+++ b/components/script/dom/csslayerstatementrule.rs
@@ -43,6 +43,7 @@ impl CSSLayerStatementRule {
         window: &Window,
         parent_stylesheet: &CSSStyleSheet,
         layerstatementrule: Arc<LayerStatementRule>,
+        can_gc: CanGc,
     ) -> DomRoot<CSSLayerStatementRule> {
         reflect_dom_object(
             Box::new(CSSLayerStatementRule::new_inherited(
@@ -50,7 +51,7 @@ impl CSSLayerStatementRule {
                 layerstatementrule,
             )),
             window,
-            CanGc::note(),
+            can_gc,
         )
     }
 }

--- a/components/script/dom/cssmediarule.rs
+++ b/components/script/dom/cssmediarule.rs
@@ -43,11 +43,12 @@ impl CSSMediaRule {
         window: &Window,
         parent_stylesheet: &CSSStyleSheet,
         mediarule: Arc<MediaRule>,
+        can_gc: CanGc,
     ) -> DomRoot<CSSMediaRule> {
         reflect_dom_object(
             Box::new(CSSMediaRule::new_inherited(parent_stylesheet, mediarule)),
             window,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -57,6 +58,7 @@ impl CSSMediaRule {
                 self.global().as_window(),
                 self.cssconditionrule.parent_stylesheet(),
                 self.mediarule.media_queries.clone(),
+                CanGc::note(),
             )
         })
     }

--- a/components/script/dom/cssnamespacerule.rs
+++ b/components/script/dom/cssnamespacerule.rs
@@ -40,6 +40,7 @@ impl CSSNamespaceRule {
         window: &Window,
         parent_stylesheet: &CSSStyleSheet,
         namespacerule: Arc<NamespaceRule>,
+        can_gc: CanGc,
     ) -> DomRoot<CSSNamespaceRule> {
         reflect_dom_object(
             Box::new(CSSNamespaceRule::new_inherited(
@@ -47,7 +48,7 @@ impl CSSNamespaceRule {
                 namespacerule,
             )),
             window,
-            CanGc::note(),
+            can_gc,
         )
     }
 }

--- a/components/script/dom/cssrule.rs
+++ b/components/script/dom/cssrule.rs
@@ -25,6 +25,7 @@ use crate::dom::cssstylerule::CSSStyleRule;
 use crate::dom::cssstylesheet::CSSStyleSheet;
 use crate::dom::csssupportsrule::CSSSupportsRule;
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct CSSRule {
@@ -82,38 +83,65 @@ impl CSSRule {
     ) -> DomRoot<CSSRule> {
         // be sure to update the match in as_specific when this is updated
         match rule {
-            StyleCssRule::Import(s) => {
-                DomRoot::upcast(CSSImportRule::new(window, parent_stylesheet, s))
-            },
-            StyleCssRule::Style(s) => {
-                DomRoot::upcast(CSSStyleRule::new(window, parent_stylesheet, s))
-            },
-            StyleCssRule::FontFace(s) => {
-                DomRoot::upcast(CSSFontFaceRule::new(window, parent_stylesheet, s))
-            },
+            StyleCssRule::Import(s) => DomRoot::upcast(CSSImportRule::new(
+                window,
+                parent_stylesheet,
+                s,
+                CanGc::note(),
+            )),
+            StyleCssRule::Style(s) => DomRoot::upcast(CSSStyleRule::new(
+                window,
+                parent_stylesheet,
+                s,
+                CanGc::note(),
+            )),
+            StyleCssRule::FontFace(s) => DomRoot::upcast(CSSFontFaceRule::new(
+                window,
+                parent_stylesheet,
+                s,
+                CanGc::note(),
+            )),
             StyleCssRule::FontFeatureValues(_) => unimplemented!(),
             StyleCssRule::CounterStyle(_) => unimplemented!(),
-            StyleCssRule::Keyframes(s) => {
-                DomRoot::upcast(CSSKeyframesRule::new(window, parent_stylesheet, s))
-            },
-            StyleCssRule::Media(s) => {
-                DomRoot::upcast(CSSMediaRule::new(window, parent_stylesheet, s))
-            },
-            StyleCssRule::Namespace(s) => {
-                DomRoot::upcast(CSSNamespaceRule::new(window, parent_stylesheet, s))
-            },
-            StyleCssRule::Supports(s) => {
-                DomRoot::upcast(CSSSupportsRule::new(window, parent_stylesheet, s))
-            },
+            StyleCssRule::Keyframes(s) => DomRoot::upcast(CSSKeyframesRule::new(
+                window,
+                parent_stylesheet,
+                s,
+                CanGc::note(),
+            )),
+            StyleCssRule::Media(s) => DomRoot::upcast(CSSMediaRule::new(
+                window,
+                parent_stylesheet,
+                s,
+                CanGc::note(),
+            )),
+            StyleCssRule::Namespace(s) => DomRoot::upcast(CSSNamespaceRule::new(
+                window,
+                parent_stylesheet,
+                s,
+                CanGc::note(),
+            )),
+            StyleCssRule::Supports(s) => DomRoot::upcast(CSSSupportsRule::new(
+                window,
+                parent_stylesheet,
+                s,
+                CanGc::note(),
+            )),
             StyleCssRule::Page(_) => unreachable!(),
             StyleCssRule::Container(_) => unimplemented!(), // TODO
             StyleCssRule::Document(_) => unimplemented!(),  // TODO
-            StyleCssRule::LayerBlock(s) => {
-                DomRoot::upcast(CSSLayerBlockRule::new(window, parent_stylesheet, s))
-            },
-            StyleCssRule::LayerStatement(s) => {
-                DomRoot::upcast(CSSLayerStatementRule::new(window, parent_stylesheet, s))
-            },
+            StyleCssRule::LayerBlock(s) => DomRoot::upcast(CSSLayerBlockRule::new(
+                window,
+                parent_stylesheet,
+                s,
+                CanGc::note(),
+            )),
+            StyleCssRule::LayerStatement(s) => DomRoot::upcast(CSSLayerStatementRule::new(
+                window,
+                parent_stylesheet,
+                s,
+                CanGc::note(),
+            )),
             StyleCssRule::FontPaletteValues(_) => unimplemented!(), // TODO
             StyleCssRule::Property(_) => unimplemented!(),          // TODO
             StyleCssRule::Margin(_) => unimplemented!(),            // TODO

--- a/components/script/dom/cssrulelist.rs
+++ b/components/script/dom/cssrulelist.rs
@@ -87,11 +87,12 @@ impl CSSRuleList {
         window: &Window,
         parent_stylesheet: &CSSStyleSheet,
         rules: RulesSource,
+        can_gc: CanGc,
     ) -> DomRoot<CSSRuleList> {
         reflect_dom_object(
             Box::new(CSSRuleList::new_inherited(parent_stylesheet, rules)),
             window,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -193,6 +194,7 @@ impl CSSRuleList {
                         self.global().as_window(),
                         parent_stylesheet,
                         rules.read_with(&guard).keyframes[idx as usize].clone(),
+                        CanGc::note(),
                     )),
                 }
             })

--- a/components/script/dom/cssstyledeclaration.rs
+++ b/components/script/dom/cssstyledeclaration.rs
@@ -235,6 +235,7 @@ impl CSSStyleDeclaration {
         owner: CSSStyleOwner,
         pseudo: Option<PseudoElement>,
         modification_access: CSSModificationAccess,
+        can_gc: CanGc,
     ) -> DomRoot<CSSStyleDeclaration> {
         reflect_dom_object(
             Box::new(CSSStyleDeclaration::new_inherited(
@@ -243,7 +244,7 @@ impl CSSStyleDeclaration {
                 modification_access,
             )),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/cssstylerule.rs
+++ b/components/script/dom/cssstylerule.rs
@@ -50,11 +50,12 @@ impl CSSStyleRule {
         window: &Window,
         parent_stylesheet: &CSSStyleSheet,
         stylerule: Arc<Locked<StyleRule>>,
+        can_gc: CanGc,
     ) -> DomRoot<CSSStyleRule> {
         reflect_dom_object(
             Box::new(CSSStyleRule::new_inherited(parent_stylesheet, stylerule)),
             window,
-            CanGc::note(),
+            can_gc,
         )
     }
 }
@@ -86,6 +87,7 @@ impl CSSStyleRuleMethods<crate::DomTypeHolder> for CSSStyleRule {
                 ),
                 None,
                 CSSModificationAccess::ReadWrite,
+                CanGc::note(),
             )
         })
     }

--- a/components/script/dom/cssstylesheet.rs
+++ b/components/script/dom/cssstylesheet.rs
@@ -58,20 +58,26 @@ impl CSSStyleSheet {
         href: Option<DOMString>,
         title: Option<DOMString>,
         stylesheet: Arc<StyleStyleSheet>,
+        can_gc: CanGc,
     ) -> DomRoot<CSSStyleSheet> {
         reflect_dom_object(
             Box::new(CSSStyleSheet::new_inherited(
                 owner, type_, href, title, stylesheet,
             )),
             window,
-            CanGc::note(),
+            can_gc,
         )
     }
 
     fn rulelist(&self) -> DomRoot<CSSRuleList> {
         self.rulelist.or_init(|| {
             let rules = self.style_stylesheet.contents.rules.clone();
-            CSSRuleList::new(self.global().as_window(), self, RulesSource::Rules(rules))
+            CSSRuleList::new(
+                self.global().as_window(),
+                self,
+                RulesSource::Rules(rules),
+                CanGc::note(),
+            )
         })
     }
 
@@ -113,6 +119,7 @@ impl CSSStyleSheet {
             self.global().as_window(),
             self,
             self.style_stylesheet().media.clone(),
+            CanGc::note(),
         )
     }
 }

--- a/components/script/dom/cssstylevalue.rs
+++ b/components/script/dom/cssstylevalue.rs
@@ -27,11 +27,15 @@ impl CSSStyleValue {
         }
     }
 
-    pub(crate) fn new(global: &GlobalScope, value: String) -> DomRoot<CSSStyleValue> {
+    pub(crate) fn new(
+        global: &GlobalScope,
+        value: String,
+        can_gc: CanGc,
+    ) -> DomRoot<CSSStyleValue> {
         reflect_dom_object(
             Box::new(CSSStyleValue::new_inherited(value)),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 }

--- a/components/script/dom/csssupportsrule.rs
+++ b/components/script/dom/csssupportsrule.rs
@@ -42,6 +42,7 @@ impl CSSSupportsRule {
         window: &Window,
         parent_stylesheet: &CSSStyleSheet,
         supportsrule: Arc<SupportsRule>,
+        can_gc: CanGc,
     ) -> DomRoot<CSSSupportsRule> {
         reflect_dom_object(
             Box::new(CSSSupportsRule::new_inherited(
@@ -49,7 +50,7 @@ impl CSSSupportsRule {
                 supportsrule,
             )),
             window,
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -89,11 +89,11 @@ impl CustomElementRegistry {
         }
     }
 
-    pub(crate) fn new(window: &Window) -> DomRoot<CustomElementRegistry> {
+    pub(crate) fn new(window: &Window, can_gc: CanGc) -> DomRoot<CustomElementRegistry> {
         reflect_dom_object(
             Box::new(CustomElementRegistry::new_inherited(window)),
             window,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -581,6 +581,7 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
             promise.reject_native(&DOMException::new(
                 self.window.as_global_scope(),
                 DOMErrorName::SyntaxError,
+                CanGc::note(),
             ));
             return promise;
         }

--- a/components/script/dom/datatransfer.rs
+++ b/components/script/dom/datatransfer.rs
@@ -261,6 +261,6 @@ impl DataTransferMethods<crate::DomTypeHolder> for DataTransfer {
         }
 
         // Step 5
-        FileList::new(self.global().as_window(), files)
+        FileList::new(self.global().as_window(), files, can_gc)
     }
 }

--- a/components/script/dom/dissimilaroriginlocation.rs
+++ b/components/script/dom/dissimilaroriginlocation.rs
@@ -37,11 +37,14 @@ impl DissimilarOriginLocation {
         }
     }
 
-    pub(crate) fn new(window: &DissimilarOriginWindow) -> DomRoot<DissimilarOriginLocation> {
+    pub(crate) fn new(
+        window: &DissimilarOriginWindow,
+        can_gc: CanGc,
+    ) -> DomRoot<DissimilarOriginLocation> {
         reflect_dom_object(
             Box::new(DissimilarOriginLocation::new_inherited(window)),
             window,
-            CanGc::note(),
+            can_gc,
         )
     }
 }

--- a/components/script/dom/dissimilaroriginwindow.rs
+++ b/components/script/dom/dissimilaroriginwindow.rs
@@ -21,7 +21,7 @@ use crate::dom::bindings::trace::RootedTraceableBox;
 use crate::dom::dissimilaroriginlocation::DissimilarOriginLocation;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::windowproxy::WindowProxy;
-use crate::script_runtime::JSContext;
+use crate::script_runtime::{CanGc, JSContext};
 
 /// Represents a dissimilar-origin `Window` that exists in another script thread.
 ///
@@ -193,7 +193,7 @@ impl DissimilarOriginWindowMethods<crate::DomTypeHolder> for DissimilarOriginWin
     // https://html.spec.whatwg.org/multipage/#dom-location
     fn Location(&self) -> DomRoot<DissimilarOriginLocation> {
         self.location
-            .or_init(|| DissimilarOriginLocation::new(self))
+            .or_init(|| DissimilarOriginLocation::new(self, CanGc::note()))
     }
 }
 

--- a/components/script/dom/domexception.rs
+++ b/components/script/dom/domexception.rs
@@ -145,13 +145,17 @@ impl DOMException {
         }
     }
 
-    pub(crate) fn new(global: &GlobalScope, code: DOMErrorName) -> DomRoot<DOMException> {
+    pub(crate) fn new(
+        global: &GlobalScope,
+        code: DOMErrorName,
+        can_gc: CanGc,
+    ) -> DomRoot<DOMException> {
         let (message, name) = DOMException::get_error_data_by_code(code);
 
         reflect_dom_object(
             Box::new(DOMException::new_inherited(message, name)),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/domimplementation.rs
+++ b/components/script/dom/domimplementation.rs
@@ -47,12 +47,12 @@ impl DOMImplementation {
         }
     }
 
-    pub(crate) fn new(document: &Document) -> DomRoot<DOMImplementation> {
+    pub(crate) fn new(document: &Document, can_gc: CanGc) -> DomRoot<DOMImplementation> {
         let window = document.window();
         reflect_dom_object(
             Box::new(DOMImplementation::new_inherited(document)),
             window,
-            CanGc::note(),
+            can_gc,
         )
     }
 }
@@ -110,6 +110,7 @@ impl DOMImplementationMethods<crate::DomTypeHolder> for DOMImplementation {
             DocumentSource::NotFromParser,
             loader,
             Some(self.document.insecure_requests_policy()),
+            can_gc,
         );
 
         // Step 2. Let element be null.

--- a/components/script/dom/domstringlist.rs
+++ b/components/script/dom/domstringlist.rs
@@ -27,11 +27,15 @@ impl DOMStringList {
     }
 
     #[allow(unused)]
-    pub(crate) fn new(window: &Window, strings: Vec<DOMString>) -> DomRoot<DOMStringList> {
+    pub(crate) fn new(
+        window: &Window,
+        strings: Vec<DOMString>,
+        can_gc: CanGc,
+    ) -> DomRoot<DOMStringList> {
         reflect_dom_object(
             Box::new(DOMStringList::new_inherited(strings)),
             window,
-            CanGc::note(),
+            can_gc,
         )
     }
 }

--- a/components/script/dom/domstringmap.rs
+++ b/components/script/dom/domstringmap.rs
@@ -27,11 +27,11 @@ impl DOMStringMap {
         }
     }
 
-    pub(crate) fn new(element: &HTMLElement) -> DomRoot<DOMStringMap> {
+    pub(crate) fn new(element: &HTMLElement, can_gc: CanGc) -> DomRoot<DOMStringMap> {
         reflect_dom_object(
             Box::new(DOMStringMap::new_inherited(element)),
             &*element.owner_window(),
-            CanGc::note(),
+            can_gc,
         )
     }
 }

--- a/components/script/dom/domtokenlist.rs
+++ b/components/script/dom/domtokenlist.rs
@@ -45,6 +45,7 @@ impl DOMTokenList {
         element: &Element,
         local_name: &LocalName,
         supported_tokens: Option<Vec<Atom>>,
+        can_gc: CanGc,
     ) -> DomRoot<DOMTokenList> {
         reflect_dom_object(
             Box::new(DOMTokenList::new_inherited(
@@ -53,7 +54,7 @@ impl DOMTokenList {
                 supported_tokens,
             )),
             &*element.owner_window(),
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/dynamicmoduleowner.rs
+++ b/components/script/dom/dynamicmoduleowner.rs
@@ -45,11 +45,12 @@ impl DynamicModuleOwner {
         global: &GlobalScope,
         promise: Rc<Promise>,
         id: DynamicModuleId,
+        can_gc: CanGc,
     ) -> DomRoot<Self> {
         reflect_dom_object(
             Box::new(DynamicModuleOwner::new_inherited(promise, id)),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 }

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -546,6 +546,7 @@ impl Element {
             mode,
             slot_assignment_mode,
             clonable,
+            CanGc::note(),
         );
         self.ensure_rare_data().shadow_root = Some(Dom::from_ref(&*shadow_root));
         shadow_root
@@ -2182,7 +2183,7 @@ impl Element {
             let elem = self
                 .downcast::<HTMLElement>()
                 .expect("ensure_element_internals should only be called for an HTMLElement");
-            Dom::from_ref(&*ElementInternals::new(elem))
+            Dom::from_ref(&*ElementInternals::new(elem, CanGc::note()))
         }))
     }
 }
@@ -2245,7 +2246,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
     // https://dom.spec.whatwg.org/#dom-element-classlist
     fn ClassList(&self) -> DomRoot<DOMTokenList> {
         self.class_list
-            .or_init(|| DOMTokenList::new(self, &local_name!("class"), None))
+            .or_init(|| DOMTokenList::new(self, &local_name!("class"), None, CanGc::note()))
     }
 
     // https://dom.spec.whatwg.org/#dom-element-slot
@@ -2257,7 +2258,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
     // https://dom.spec.whatwg.org/#dom-element-attributes
     fn Attributes(&self) -> DomRoot<NamedNodeMap> {
         self.attr_list
-            .or_init(|| NamedNodeMap::new(&self.owner_window(), self))
+            .or_init(|| NamedNodeMap::new(&self.owner_window(), self, CanGc::note()))
     }
 
     // https://dom.spec.whatwg.org/#dom-element-hasattributes

--- a/components/script/dom/elementinternals.rs
+++ b/components/script/dom/elementinternals.rs
@@ -87,12 +87,12 @@ impl ElementInternals {
         }
     }
 
-    pub(crate) fn new(element: &HTMLElement) -> DomRoot<ElementInternals> {
+    pub(crate) fn new(element: &HTMLElement, can_gc: CanGc) -> DomRoot<ElementInternals> {
         let global = element.owner_window();
         reflect_dom_object(
             Box::new(ElementInternals::new_inherited(element)),
             &*global,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -350,6 +350,7 @@ impl Validatable for ElementInternals {
             ValidityState::new(
                 &self.target_element.owner_window(),
                 self.target_element.upcast(),
+                CanGc::note(),
             )
         })
     }

--- a/components/script/dom/filelist.rs
+++ b/components/script/dom/filelist.rs
@@ -30,13 +30,17 @@ impl FileList {
     }
 
     #[cfg_attr(crown, allow(crown::unrooted_must_root))]
-    pub(crate) fn new(window: &Window, files: Vec<DomRoot<File>>) -> DomRoot<FileList> {
+    pub(crate) fn new(
+        window: &Window,
+        files: Vec<DomRoot<File>>,
+        can_gc: CanGc,
+    ) -> DomRoot<FileList> {
         reflect_dom_object(
             Box::new(FileList::new_inherited(
                 files.iter().map(|r| Dom::from_ref(&**r)).collect(),
             )),
             window,
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/filereader.rs
+++ b/components/script/dom/filereader.rs
@@ -214,7 +214,7 @@ impl FileReader {
         fr.change_ready_state(FileReaderReadyState::Done);
         *fr.result.borrow_mut() = None;
 
-        let exception = DOMException::new(&fr.global(), error);
+        let exception = DOMException::new(&fr.global(), error, can_gc);
         fr.error.set(Some(&exception));
 
         fr.dispatch_progress_event(atom!("error"), 0, None, can_gc);
@@ -413,7 +413,7 @@ impl FileReaderMethods<crate::DomTypeHolder> for FileReader {
         // Steps 1 & 3
         *self.result.borrow_mut() = None;
 
-        let exception = DOMException::new(&self.global(), DOMErrorName::AbortError);
+        let exception = DOMException::new(&self.global(), DOMErrorName::AbortError, can_gc);
         self.error.set(Some(&exception));
 
         self.terminate_ongoing_reading();

--- a/components/script/dom/gainnode.rs
+++ b/components/script/dom/gainnode.rs
@@ -58,6 +58,7 @@ impl GainNode {
             *options.gain, // default value
             f32::MIN,      // min value
             f32::MAX,      // max value
+            CanGc::note(),
         );
         Ok(GainNode {
             node,

--- a/components/script/dom/gamepadbutton.rs
+++ b/components/script/dom/gamepadbutton.rs
@@ -35,11 +35,12 @@ impl GamepadButton {
         global: &GlobalScope,
         pressed: bool,
         touched: bool,
+        can_gc: CanGc,
     ) -> DomRoot<GamepadButton> {
         reflect_dom_object(
             Box::new(GamepadButton::new_inherited(pressed, touched)),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 }

--- a/components/script/dom/gamepadbuttonlist.rs
+++ b/components/script/dom/gamepadbuttonlist.rs
@@ -27,11 +27,15 @@ impl GamepadButtonList {
         }
     }
 
-    pub(crate) fn new(global: &GlobalScope, list: &[&GamepadButton]) -> DomRoot<GamepadButtonList> {
+    pub(crate) fn new(
+        global: &GlobalScope,
+        list: &[&GamepadButton],
+        can_gc: CanGc,
+    ) -> DomRoot<GamepadButtonList> {
         reflect_dom_object(
             Box::new(GamepadButtonList::new_inherited(list)),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 }
@@ -60,25 +64,25 @@ impl GamepadButtonList {
     /// <https://www.w3.org/TR/gamepad/#dfn-initializing-buttons>
     pub(crate) fn init_buttons(global: &GlobalScope) -> DomRoot<GamepadButtonList> {
         let standard_buttons = &[
-            GamepadButton::new(global, false, false), // Bottom button in right cluster
-            GamepadButton::new(global, false, false), // Right button in right cluster
-            GamepadButton::new(global, false, false), // Left button in right cluster
-            GamepadButton::new(global, false, false), // Top button in right cluster
-            GamepadButton::new(global, false, false), // Top left front button
-            GamepadButton::new(global, false, false), // Top right front button
-            GamepadButton::new(global, false, false), // Bottom left front button
-            GamepadButton::new(global, false, false), // Bottom right front button
-            GamepadButton::new(global, false, false), // Left button in center cluster
-            GamepadButton::new(global, false, false), // Right button in center cluster
-            GamepadButton::new(global, false, false), // Left stick pressed button
-            GamepadButton::new(global, false, false), // Right stick pressed button
-            GamepadButton::new(global, false, false), // Top button in left cluster
-            GamepadButton::new(global, false, false), // Bottom button in left cluster
-            GamepadButton::new(global, false, false), // Left button in left cluster
-            GamepadButton::new(global, false, false), // Right button in left cluster
-            GamepadButton::new(global, false, false), // Center button in center cluster
+            GamepadButton::new(global, false, false, CanGc::note()), // Bottom button in right cluster
+            GamepadButton::new(global, false, false, CanGc::note()), // Right button in right cluster
+            GamepadButton::new(global, false, false, CanGc::note()), // Left button in right cluster
+            GamepadButton::new(global, false, false, CanGc::note()), // Top button in right cluster
+            GamepadButton::new(global, false, false, CanGc::note()), // Top left front button
+            GamepadButton::new(global, false, false, CanGc::note()), // Top right front button
+            GamepadButton::new(global, false, false, CanGc::note()), // Bottom left front button
+            GamepadButton::new(global, false, false, CanGc::note()), // Bottom right front button
+            GamepadButton::new(global, false, false, CanGc::note()), // Left button in center cluster
+            GamepadButton::new(global, false, false, CanGc::note()), // Right button in center cluster
+            GamepadButton::new(global, false, false, CanGc::note()), // Left stick pressed button
+            GamepadButton::new(global, false, false, CanGc::note()), // Right stick pressed button
+            GamepadButton::new(global, false, false, CanGc::note()), // Top button in left cluster
+            GamepadButton::new(global, false, false, CanGc::note()), // Bottom button in left cluster
+            GamepadButton::new(global, false, false, CanGc::note()), // Left button in left cluster
+            GamepadButton::new(global, false, false, CanGc::note()), // Right button in left cluster
+            GamepadButton::new(global, false, false, CanGc::note()), // Center button in center cluster
         ];
         rooted_vec!(let buttons <- standard_buttons.iter().map(DomRoot::as_traced));
-        Self::new(global, buttons.r())
+        Self::new(global, buttons.r(), CanGc::note())
     }
 }

--- a/components/script/dom/gamepadpose.rs
+++ b/components/script/dom/gamepadpose.rs
@@ -44,12 +44,8 @@ impl GamepadPose {
         }
     }
 
-    pub(crate) fn new(global: &GlobalScope) -> DomRoot<GamepadPose> {
-        reflect_dom_object(
-            Box::new(GamepadPose::new_inherited()),
-            global,
-            CanGc::note(),
-        )
+    pub(crate) fn new(global: &GlobalScope, can_gc: CanGc) -> DomRoot<GamepadPose> {
+        reflect_dom_object(Box::new(GamepadPose::new_inherited()), global, can_gc)
     }
 }
 

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -814,7 +814,8 @@ impl GlobalScope {
         }
 
         // Step 2.1 -> 2.5
-        let new_registration = ServiceWorkerRegistration::new(self, scope.clone(), registration_id);
+        let new_registration =
+            ServiceWorkerRegistration::new(self, scope.clone(), registration_id, CanGc::note());
 
         // Step 2.6
         if let Some(worker_id) = installing_worker {
@@ -849,7 +850,13 @@ impl GlobalScope {
         } else {
             // Step 2.1
             // TODO: step 2.2, worker state.
-            let new_worker = ServiceWorker::new(self, script_url.clone(), scope.clone(), worker_id);
+            let new_worker = ServiceWorker::new(
+                self,
+                script_url.clone(),
+                scope.clone(),
+                worker_id,
+                CanGc::note(),
+            );
 
             // Step 2.3
             workers.insert(worker_id, Dom::from_ref(&*new_worker));
@@ -2136,7 +2143,7 @@ impl GlobalScope {
     }
 
     pub(crate) fn crypto(&self) -> DomRoot<Crypto> {
-        self.crypto.or_init(|| Crypto::new(self))
+        self.crypto.or_init(|| Crypto::new(self, CanGc::note()))
     }
 
     pub(crate) fn live_devtools_updates(&self) -> bool {
@@ -2719,7 +2726,8 @@ impl GlobalScope {
                         .map(|data| data.to_vec())
                         .unwrap_or_else(|| vec![0; size.area() as usize * 4]);
 
-                    let image_bitmap = ImageBitmap::new(self, size.width, size.height).unwrap();
+                    let image_bitmap =
+                        ImageBitmap::new(self, size.width, size.height, can_gc).unwrap();
 
                     image_bitmap.set_bitmap_data(data);
                     image_bitmap.set_origin_clean(canvas.origin_is_clean());
@@ -2739,7 +2747,8 @@ impl GlobalScope {
                         .map(|data| data.to_vec())
                         .unwrap_or_else(|| vec![0; size.area() as usize * 4]);
 
-                    let image_bitmap = ImageBitmap::new(self, size.width, size.height).unwrap();
+                    let image_bitmap =
+                        ImageBitmap::new(self, size.width, size.height, can_gc).unwrap();
                     image_bitmap.set_bitmap_data(data);
                     image_bitmap.set_origin_clean(canvas.origin_is_clean());
                     p.resolve_native(&(image_bitmap));

--- a/components/script/dom/history.rs
+++ b/components/script/dom/history.rs
@@ -62,12 +62,8 @@ impl History {
         }
     }
 
-    pub(crate) fn new(window: &Window) -> DomRoot<History> {
-        reflect_dom_object(
-            Box::new(History::new_inherited(window)),
-            window,
-            CanGc::note(),
-        )
+    pub(crate) fn new(window: &Window, can_gc: CanGc) -> DomRoot<History> {
+        reflect_dom_object(Box::new(History::new_inherited(window)), window, can_gc)
     }
 }
 

--- a/components/script/dom/htmlanchorelement.rs
+++ b/components/script/dom/htmlanchorelement.rs
@@ -153,6 +153,7 @@ impl HTMLAnchorElementMethods<crate::DomTypeHolder> for HTMLAnchorElement {
                     Atom::from("noreferrer"),
                     Atom::from("opener"),
                 ]),
+                CanGc::note(),
             )
         })
     }

--- a/components/script/dom/htmlareaelement.rs
+++ b/components/script/dom/htmlareaelement.rs
@@ -370,6 +370,7 @@ impl HTMLAreaElementMethods<crate::DomTypeHolder> for HTMLAreaElement {
                     Atom::from("noreferrer"),
                     Atom::from("opener"),
                 ]),
+                CanGc::note(),
             )
         })
     }

--- a/components/script/dom/htmlbuttonelement.rs
+++ b/components/script/dom/htmlbuttonelement.rs
@@ -333,7 +333,7 @@ impl Validatable for HTMLButtonElement {
 
     fn validity_state(&self) -> DomRoot<ValidityState> {
         self.validity_state
-            .or_init(|| ValidityState::new(&self.owner_window(), self.upcast()))
+            .or_init(|| ValidityState::new(&self.owner_window(), self.upcast(), CanGc::note()))
     }
 
     fn is_instance_validatable(&self) -> bool {

--- a/components/script/dom/htmlcanvaselement.rs
+++ b/components/script/dom/htmlcanvaselement.rs
@@ -276,7 +276,8 @@ impl HTMLCanvasElement {
 
         let window = self.owner_window();
         let size = self.get_size();
-        let context = CanvasRenderingContext2D::new(window.as_global_scope(), self, size);
+        let context =
+            CanvasRenderingContext2D::new(window.as_global_scope(), self, size, CanGc::note());
         *self.context.borrow_mut() = Some(CanvasContext::Context2d(Dom::from_ref(&*context)));
         Some(context)
     }
@@ -356,7 +357,7 @@ impl HTMLCanvasElement {
             .recv()
             .expect("Failed to get WebGPU channel")
             .map(|channel| {
-                let context = GPUCanvasContext::new(&global_scope, self, channel);
+                let context = GPUCanvasContext::new(&global_scope, self, channel, CanGc::note());
                 *self.context.borrow_mut() = Some(CanvasContext::WebGPU(Dom::from_ref(&*context)));
                 context
             })
@@ -717,7 +718,12 @@ impl HTMLCanvasElementMethods<crate::DomTypeHolder> for HTMLCanvasElement {
     ) -> DomRoot<MediaStream> {
         let global = self.global();
         let stream = MediaStream::new(&global, can_gc);
-        let track = MediaStreamTrack::new(&global, MediaStreamId::new(), MediaStreamType::Video);
+        let track = MediaStreamTrack::new(
+            &global,
+            MediaStreamId::new(),
+            MediaStreamType::Video,
+            can_gc,
+        );
         stream.AddTrack(&track);
         stream
     }

--- a/components/script/dom/htmlcollection.rs
+++ b/components/script/dom/htmlcollection.rs
@@ -96,7 +96,7 @@ impl HTMLCollection {
             }
         }
 
-        Self::new(window, root, Box::new(NoFilter))
+        Self::new(window, root, Box::new(NoFilter), CanGc::note())
     }
 
     #[cfg_attr(crown, allow(crown::unrooted_must_root))]
@@ -104,12 +104,9 @@ impl HTMLCollection {
         window: &Window,
         root: &Node,
         filter: Box<dyn CollectionFilter + 'static>,
+        can_gc: CanGc,
     ) -> DomRoot<Self> {
-        reflect_dom_object(
-            Box::new(Self::new_inherited(root, filter)),
-            window,
-            CanGc::note(),
-        )
+        reflect_dom_object(Box::new(Self::new_inherited(root, filter)), window, can_gc)
     }
 
     /// Create a new  [`HTMLCollection`] that just filters element using a static function.
@@ -135,6 +132,7 @@ impl HTMLCollection {
             window,
             root,
             Box::new(StaticFunctionFilter(filter_function)),
+            CanGc::note(),
         )
     }
 
@@ -143,7 +141,7 @@ impl HTMLCollection {
         root: &Node,
         filter: Box<dyn CollectionFilter + 'static>,
     ) -> DomRoot<Self> {
-        Self::new(window, root, filter)
+        Self::new(window, root, filter, CanGc::note())
     }
 
     fn validate_cache(&self) {

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -144,6 +144,7 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
                 CSSStyleOwner::Element(Dom::from_ref(self.upcast())),
                 None,
                 CSSModificationAccess::ReadWrite,
+                CanGc::note(),
             )
         })
     }
@@ -183,7 +184,8 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
 
     // https://html.spec.whatwg.org/multipage/#dom-dataset
     fn Dataset(&self) -> DomRoot<DOMStringMap> {
-        self.dataset.or_init(|| DOMStringMap::new(self))
+        self.dataset
+            .or_init(|| DOMStringMap::new(self, CanGc::note()))
     }
 
     // https://html.spec.whatwg.org/multipage/#handler-onerror

--- a/components/script/dom/htmlfieldsetelement.rs
+++ b/components/script/dom/htmlfieldsetelement.rs
@@ -271,7 +271,7 @@ impl Validatable for HTMLFieldSetElement {
 
     fn validity_state(&self) -> DomRoot<ValidityState> {
         self.validity_state
-            .or_init(|| ValidityState::new(&self.owner_window(), self.upcast()))
+            .or_init(|| ValidityState::new(&self.owner_window(), self.upcast(), CanGc::note()))
     }
 
     fn is_instance_validatable(&self) -> bool {

--- a/components/script/dom/htmlformcontrolscollection.rs
+++ b/components/script/dom/htmlformcontrolscollection.rs
@@ -45,11 +45,12 @@ impl HTMLFormControlsCollection {
         window: &Window,
         form: &HTMLFormElement,
         filter: Box<dyn CollectionFilter + 'static>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLFormControlsCollection> {
         reflect_dom_object(
             Box::new(HTMLFormControlsCollection::new_inherited(form, filter)),
             window,
-            CanGc::note(),
+            can_gc,
         )
     }
 }

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -420,7 +420,7 @@ impl HTMLFormElementMethods<crate::DomTypeHolder> for HTMLFormElement {
                 form: DomRoot::from_ref(self),
             });
             let window = self.owner_window();
-            HTMLFormControlsCollection::new(&window, self, filter)
+            HTMLFormControlsCollection::new(&window, self, filter, CanGc::note())
         }))
     }
 
@@ -502,6 +502,7 @@ impl HTMLFormElementMethods<crate::DomTypeHolder> for HTMLFormElement {
                     Atom::from("noreferrer"),
                     Atom::from("opener"),
                 ]),
+                CanGc::note(),
             )
         })
     }

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -597,6 +597,7 @@ impl HTMLIFrameElementMethods<crate::DomTypeHolder> for HTMLIFrameElement {
                     Atom::from("allow-scripts"),
                     Atom::from("allow-top-navigation"),
                 ]),
+                CanGc::note(),
             )
         })
     }

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -1179,6 +1179,7 @@ impl HTMLImageElement {
             promise.reject_native(&DOMException::new(
                 &document.global(),
                 DOMErrorName::EncodingError,
+                CanGc::note(),
             ));
         } else if matches!(
             self.current_request.borrow().state,
@@ -1206,6 +1207,7 @@ impl HTMLImageElement {
             promise.reject_native(&DOMException::new(
                 &document.global(),
                 DOMErrorName::EncodingError,
+                CanGc::note(),
             ));
         }
         self.image_decode_promises.borrow_mut().clear();

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -1326,7 +1326,7 @@ impl HTMLInputElementMethods<crate::DomTypeHolder> for HTMLInputElement {
             ValueMode::Filename => {
                 if value.is_empty() {
                     let window = self.owner_window();
-                    let fl = FileList::new(&window, vec![]);
+                    let fl = FileList::new(&window, vec![], can_gc);
                     self.filelist.set(Some(&fl));
                 } else {
                     return Err(Error::InvalidState);
@@ -1961,7 +1961,7 @@ impl HTMLInputElement {
         if let Some(err) = error {
             debug!("Input file select error: {:?}", err);
         } else {
-            let filelist = FileList::new(&window, files);
+            let filelist = FileList::new(&window, files, can_gc);
             self.filelist.set(Some(&filelist));
 
             target.fire_bubbling_event(atom!("input"), can_gc);
@@ -2380,7 +2380,7 @@ impl VirtualMethods for HTMLInputElement {
 
                         if new_type == InputType::File {
                             let window = self.owner_window();
-                            let filelist = FileList::new(&window, vec![]);
+                            let filelist = FileList::new(&window, vec![], CanGc::note());
                             self.filelist.set(Some(&filelist));
                         }
 
@@ -2722,7 +2722,7 @@ impl Validatable for HTMLInputElement {
 
     fn validity_state(&self) -> DomRoot<ValidityState> {
         self.validity_state
-            .or_init(|| ValidityState::new(&self.owner_window(), self.upcast()))
+            .or_init(|| ValidityState::new(&self.owner_window(), self.upcast(), CanGc::note()))
     }
 
     fn is_instance_validatable(&self) -> bool {

--- a/components/script/dom/htmllinkelement.rs
+++ b/components/script/dom/htmllinkelement.rs
@@ -183,6 +183,7 @@ impl HTMLLinkElement {
                     None, // todo handle location
                     None, // todo handle title
                     sheet,
+                    CanGc::note(),
                 )
             })
         })
@@ -582,6 +583,7 @@ impl HTMLLinkElementMethods<crate::DomTypeHolder> for HTMLLinkElement {
                     Atom::from("prerender"),
                     Atom::from("stylesheet"),
                 ]),
+                CanGc::note(),
             )
         })
     }

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -1014,8 +1014,7 @@ impl HTMLMediaElement {
                     // Step 1.
                     this.error.set(Some(&*MediaError::new(
                         &this.owner_window(),
-                        MEDIA_ERR_SRC_NOT_SUPPORTED,
-                    )));
+                        MEDIA_ERR_SRC_NOT_SUPPORTED, CanGc::note())));
 
                     // Step 2.
                     this.AudioTracks().clear();
@@ -1564,6 +1563,7 @@ impl HTMLMediaElement {
                 self.error.set(Some(&*MediaError::new(
                     &self.owner_window(),
                     MEDIA_ERR_DECODE,
+                    can_gc,
                 )));
 
                 // 3. Set the element's networkState attribute to the NETWORK_IDLE value.
@@ -1603,6 +1603,7 @@ impl HTMLMediaElement {
                             DOMString::new(),
                             DOMString::new(),
                             Some(&*self.AudioTracks()),
+                            can_gc,
                         );
 
                         // Steps 2. & 3.
@@ -1662,6 +1663,7 @@ impl HTMLMediaElement {
                             DOMString::new(),
                             DOMString::new(),
                             Some(&*self.VideoTracks()),
+                            can_gc,
                         );
 
                         // Steps 2. & 3.
@@ -2388,7 +2390,11 @@ impl HTMLMediaElementMethods<crate::DomTypeHolder> for HTMLMediaElement {
 
     // https://html.spec.whatwg.org/multipage/#dom-media-played
     fn Played(&self) -> DomRoot<TimeRanges> {
-        TimeRanges::new(self.global().as_window(), self.played.borrow().clone())
+        TimeRanges::new(
+            self.global().as_window(),
+            self.played.borrow().clone(),
+            CanGc::note(),
+        )
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-media-buffered
@@ -2401,28 +2407,28 @@ impl HTMLMediaElementMethods<crate::DomTypeHolder> for HTMLMediaElement {
                 }
             }
         }
-        TimeRanges::new(self.global().as_window(), buffered)
+        TimeRanges::new(self.global().as_window(), buffered, CanGc::note())
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-media-audiotracks
     fn AudioTracks(&self) -> DomRoot<AudioTrackList> {
         let window = self.owner_window();
         self.audio_tracks_list
-            .or_init(|| AudioTrackList::new(&window, &[], Some(self)))
+            .or_init(|| AudioTrackList::new(&window, &[], Some(self), CanGc::note()))
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-media-videotracks
     fn VideoTracks(&self) -> DomRoot<VideoTrackList> {
         let window = self.owner_window();
         self.video_tracks_list
-            .or_init(|| VideoTrackList::new(&window, &[], Some(self)))
+            .or_init(|| VideoTrackList::new(&window, &[], Some(self), CanGc::note()))
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-media-texttracks
     fn TextTracks(&self) -> DomRoot<TextTrackList> {
         let window = self.owner_window();
         self.text_tracks_list
-            .or_init(|| TextTrackList::new(&window, &[]))
+            .or_init(|| TextTrackList::new(&window, &[], CanGc::note()))
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-media-addtexttrack
@@ -2443,6 +2449,7 @@ impl HTMLMediaElementMethods<crate::DomTypeHolder> for HTMLMediaElement {
             language,
             TextTrackMode::Hidden,
             None,
+            CanGc::note(),
         );
         // Step 3 & 4
         self.TextTracks().add(&track);
@@ -2863,6 +2870,7 @@ impl FetchResponseListener for HTMLMediaElementFetchListener {
             elem.error.set(Some(&*MediaError::new(
                 &elem.owner_window(),
                 MEDIA_ERR_NETWORK,
+                CanGc::note(),
             )));
 
             // Step 3

--- a/components/script/dom/htmlobjectelement.rs
+++ b/components/script/dom/htmlobjectelement.rs
@@ -139,7 +139,7 @@ impl Validatable for HTMLObjectElement {
 
     fn validity_state(&self) -> DomRoot<ValidityState> {
         self.validity_state
-            .or_init(|| ValidityState::new(&self.owner_window(), self.upcast()))
+            .or_init(|| ValidityState::new(&self.owner_window(), self.upcast(), CanGc::note()))
     }
 
     fn is_instance_validatable(&self) -> bool {

--- a/components/script/dom/htmloptionscollection.rs
+++ b/components/script/dom/htmloptionscollection.rs
@@ -47,11 +47,12 @@ impl HTMLOptionsCollection {
         window: &Window,
         select: &HTMLSelectElement,
         filter: Box<dyn CollectionFilter + 'static>,
+        can_gc: CanGc,
     ) -> DomRoot<HTMLOptionsCollection> {
         reflect_dom_object(
             Box::new(HTMLOptionsCollection::new_inherited(select, filter)),
             window,
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/htmloutputelement.rs
+++ b/components/script/dom/htmloutputelement.rs
@@ -188,7 +188,7 @@ impl Validatable for HTMLOutputElement {
 
     fn validity_state(&self) -> DomRoot<ValidityState> {
         self.validity_state
-            .or_init(|| ValidityState::new(&self.owner_window(), self.upcast()))
+            .or_init(|| ValidityState::new(&self.owner_window(), self.upcast(), CanGc::note()))
     }
 
     fn is_instance_validatable(&self) -> bool {

--- a/components/script/dom/htmlselectelement.rs
+++ b/components/script/dom/htmlselectelement.rs
@@ -280,7 +280,7 @@ impl HTMLSelectElementMethods<crate::DomTypeHolder> for HTMLSelectElement {
     fn Options(&self) -> DomRoot<HTMLOptionsCollection> {
         self.options.or_init(|| {
             let window = self.owner_window();
-            HTMLOptionsCollection::new(&window, self, Box::new(OptionsFilter))
+            HTMLOptionsCollection::new(&window, self, Box::new(OptionsFilter), CanGc::note())
         })
     }
 
@@ -510,7 +510,7 @@ impl Validatable for HTMLSelectElement {
 
     fn validity_state(&self) -> DomRoot<ValidityState> {
         self.validity_state
-            .or_init(|| ValidityState::new(&self.owner_window(), self.upcast()))
+            .or_init(|| ValidityState::new(&self.owner_window(), self.upcast(), CanGc::note()))
     }
 
     fn is_instance_validatable(&self) -> bool {

--- a/components/script/dom/htmlstyleelement.rs
+++ b/components/script/dom/htmlstyleelement.rs
@@ -177,6 +177,7 @@ impl HTMLStyleElement {
                     None, // todo handle location
                     None, // todo handle title
                     sheet,
+                    CanGc::note(),
                 )
             })
         })

--- a/components/script/dom/htmltableelement.rs
+++ b/components/script/dom/htmltableelement.rs
@@ -187,7 +187,12 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
     // https://html.spec.whatwg.org/multipage/#dom-table-rows
     fn Rows(&self) -> DomRoot<HTMLCollection> {
         let filter = self.get_rows();
-        HTMLCollection::new(&self.owner_window(), self.upcast(), Box::new(filter))
+        HTMLCollection::new(
+            &self.owner_window(),
+            self.upcast(),
+            Box::new(filter),
+            CanGc::note(),
+        )
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-table-caption

--- a/components/script/dom/htmltextareaelement.rs
+++ b/components/script/dom/htmltextareaelement.rs
@@ -723,7 +723,7 @@ impl Validatable for HTMLTextAreaElement {
 
     fn validity_state(&self) -> DomRoot<ValidityState> {
         self.validity_state
-            .or_init(|| ValidityState::new(&self.owner_window(), self.upcast()))
+            .or_init(|| ValidityState::new(&self.owner_window(), self.upcast(), CanGc::note()))
     }
 
     fn is_instance_validatable(&self) -> bool {

--- a/components/script/dom/htmltrackelement.rs
+++ b/components/script/dom/htmltrackelement.rs
@@ -65,6 +65,7 @@ impl HTMLTrackElement {
             Default::default(),
             Default::default(),
             None,
+            can_gc,
         );
         Node::reflect_node_with_proto(
             Box::new(HTMLTrackElement::new_inherited(

--- a/components/script/dom/imagebitmap.rs
+++ b/components/script/dom/imagebitmap.rs
@@ -44,11 +44,12 @@ impl ImageBitmap {
         global: &GlobalScope,
         width: u32,
         height: u32,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<ImageBitmap>> {
         //assigning to a variable the return object of new_inherited
         let imagebitmap = Box::new(ImageBitmap::new_inherited(width, height));
 
-        Ok(reflect_dom_object(imagebitmap, global, CanGc::note()))
+        Ok(reflect_dom_object(imagebitmap, global, can_gc))
     }
 
     pub(crate) fn set_bitmap_data(&self, data: Vec<u8>) {

--- a/components/script/dom/location.rs
+++ b/components/script/dom/location.rs
@@ -57,12 +57,8 @@ impl Location {
         }
     }
 
-    pub(crate) fn new(window: &Window) -> DomRoot<Location> {
-        reflect_dom_object(
-            Box::new(Location::new_inherited(window)),
-            window,
-            CanGc::note(),
-        )
+    pub(crate) fn new(window: &Window, can_gc: CanGc) -> DomRoot<Location> {
+        reflect_dom_object(Box::new(Location::new_inherited(window)), window, can_gc)
     }
 
     /// Navigate the relevant `Document`'s browsing context.

--- a/components/script/dom/mediadeviceinfo.rs
+++ b/components/script/dom/mediadeviceinfo.rs
@@ -46,13 +46,14 @@ impl MediaDeviceInfo {
         kind: MediaDeviceKind,
         label: &str,
         group_id: &str,
+        can_gc: CanGc,
     ) -> DomRoot<MediaDeviceInfo> {
         reflect_dom_object(
             Box::new(MediaDeviceInfo::new_inherited(
                 device_id, kind, label, group_id,
             )),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 }

--- a/components/script/dom/mediadevices.rs
+++ b/components/script/dom/mediadevices.rs
@@ -40,12 +40,8 @@ impl MediaDevices {
         }
     }
 
-    pub(crate) fn new(global: &GlobalScope) -> DomRoot<MediaDevices> {
-        reflect_dom_object(
-            Box::new(MediaDevices::new_inherited()),
-            global,
-            CanGc::note(),
-        )
+    pub(crate) fn new(global: &GlobalScope, can_gc: CanGc) -> DomRoot<MediaDevices> {
+        reflect_dom_object(Box::new(MediaDevices::new_inherited()), global, can_gc)
     }
 }
 
@@ -63,13 +59,15 @@ impl MediaDevicesMethods<crate::DomTypeHolder> for MediaDevices {
         let stream = MediaStream::new(&self.global(), can_gc);
         if let Some(constraints) = convert_constraints(&constraints.audio) {
             if let Some(audio) = media.create_audioinput_stream(constraints) {
-                let track = MediaStreamTrack::new(&self.global(), audio, MediaStreamType::Audio);
+                let track =
+                    MediaStreamTrack::new(&self.global(), audio, MediaStreamType::Audio, can_gc);
                 stream.add_track(&track);
             }
         }
         if let Some(constraints) = convert_constraints(&constraints.video) {
             if let Some(video) = media.create_videoinput_stream(constraints) {
-                let track = MediaStreamTrack::new(&self.global(), video, MediaStreamType::Video);
+                let track =
+                    MediaStreamTrack::new(&self.global(), video, MediaStreamType::Video, can_gc);
                 stream.add_track(&track);
             }
         }
@@ -102,6 +100,7 @@ impl MediaDevicesMethods<crate::DomTypeHolder> for MediaDevices {
                         device.kind.convert(),
                         &device.label,
                         "",
+                        can_gc,
                     )
                 })
                 .collect(),

--- a/components/script/dom/mediaerror.rs
+++ b/components/script/dom/mediaerror.rs
@@ -25,12 +25,8 @@ impl MediaError {
         }
     }
 
-    pub(crate) fn new(window: &Window, code: u16) -> DomRoot<MediaError> {
-        reflect_dom_object(
-            Box::new(MediaError::new_inherited(code)),
-            window,
-            CanGc::note(),
-        )
+    pub(crate) fn new(window: &Window, code: u16, can_gc: CanGc) -> DomRoot<MediaError> {
+        reflect_dom_object(Box::new(MediaError::new_inherited(code)), window, can_gc)
     }
 }
 

--- a/components/script/dom/medialist.rs
+++ b/components/script/dom/medialist.rs
@@ -47,11 +47,12 @@ impl MediaList {
         window: &Window,
         parent_stylesheet: &CSSStyleSheet,
         media_queries: Arc<Locked<StyleMediaList>>,
+        can_gc: CanGc,
     ) -> DomRoot<MediaList> {
         reflect_dom_object(
             Box::new(MediaList::new_inherited(parent_stylesheet, media_queries)),
             window,
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/mediaquerylist.rs
+++ b/components/script/dom/mediaquerylist.rs
@@ -46,11 +46,15 @@ impl MediaQueryList {
         }
     }
 
-    pub(crate) fn new(document: &Document, media_query_list: MediaList) -> DomRoot<MediaQueryList> {
+    pub(crate) fn new(
+        document: &Document,
+        media_query_list: MediaList,
+        can_gc: CanGc,
+    ) -> DomRoot<MediaQueryList> {
         reflect_dom_object(
             Box::new(MediaQueryList::new_inherited(document, media_query_list)),
             document.window(),
-            CanGc::note(),
+            can_gc,
         )
     }
 }

--- a/components/script/dom/mediasession.rs
+++ b/components/script/dom/mediasession.rs
@@ -63,12 +63,8 @@ impl MediaSession {
         }
     }
 
-    pub(crate) fn new(window: &Window) -> DomRoot<MediaSession> {
-        reflect_dom_object(
-            Box::new(MediaSession::new_inherited()),
-            window,
-            CanGc::note(),
-        )
+    pub(crate) fn new(window: &Window, can_gc: CanGc) -> DomRoot<MediaSession> {
+        reflect_dom_object(Box::new(MediaSession::new_inherited()), window, can_gc)
     }
 
     pub(crate) fn register_media_instance(&self, media_instance: &HTMLMediaElement) {

--- a/components/script/dom/mediastream.rs
+++ b/components/script/dom/mediastream.rs
@@ -57,7 +57,7 @@ impl MediaStream {
         can_gc: CanGc,
     ) -> DomRoot<MediaStream> {
         let this = Self::new(global, can_gc);
-        let track = MediaStreamTrack::new(global, id, ty);
+        let track = MediaStreamTrack::new(global, id, ty, can_gc);
         this.AddTrack(&track);
         this
     }

--- a/components/script/dom/mediastreamtrack.rs
+++ b/components/script/dom/mediastreamtrack.rs
@@ -38,11 +38,12 @@ impl MediaStreamTrack {
         global: &GlobalScope,
         id: MediaStreamId,
         ty: MediaStreamType,
+        can_gc: CanGc,
     ) -> DomRoot<MediaStreamTrack> {
         reflect_dom_object(
             Box::new(MediaStreamTrack::new_inherited(id, ty)),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -71,6 +72,6 @@ impl MediaStreamTrackMethods<crate::DomTypeHolder> for MediaStreamTrack {
 
     /// <https://w3c.github.io/mediacapture-main/#dom-mediastreamtrack-clone>
     fn Clone(&self) -> DomRoot<MediaStreamTrack> {
-        MediaStreamTrack::new(&self.global(), self.id, self.ty)
+        MediaStreamTrack::new(&self.global(), self.id, self.ty, CanGc::note())
     }
 }

--- a/components/script/dom/messagechannel.rs
+++ b/components/script/dom/messagechannel.rs
@@ -27,10 +27,10 @@ impl MessageChannel {
         can_gc: CanGc,
     ) -> DomRoot<MessageChannel> {
         // Step 1
-        let port1 = MessagePort::new(incumbent);
+        let port1 = MessagePort::new(incumbent, can_gc);
 
         // Step 2
-        let port2 = MessagePort::new(incumbent);
+        let port2 = MessagePort::new(incumbent, can_gc);
 
         incumbent.track_message_port(&port1, None);
         incumbent.track_message_port(&port2, None);

--- a/components/script/dom/messageport.rs
+++ b/components/script/dom/messageport.rs
@@ -52,13 +52,9 @@ impl MessagePort {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#create-a-new-messageport-object>
-    pub(crate) fn new(owner: &GlobalScope) -> DomRoot<MessagePort> {
+    pub(crate) fn new(owner: &GlobalScope, can_gc: CanGc) -> DomRoot<MessagePort> {
         let port_id = MessagePortId::new();
-        reflect_dom_object(
-            Box::new(MessagePort::new_inherited(port_id)),
-            owner,
-            CanGc::note(),
-        )
+        reflect_dom_object(Box::new(MessagePort::new_inherited(port_id)), owner, can_gc)
     }
 
     /// Create a new port for an incoming transfer-received one.
@@ -66,6 +62,7 @@ impl MessagePort {
         owner: &GlobalScope,
         transferred_port: MessagePortId,
         entangled_port: Option<MessagePortId>,
+        can_gc: CanGc,
     ) -> DomRoot<MessagePort> {
         reflect_dom_object(
             Box::new(MessagePort {
@@ -75,7 +72,7 @@ impl MessagePort {
                 entangled_port: RefCell::new(entangled_port),
             }),
             owner,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -242,7 +239,7 @@ impl Transferable for MessagePort {
         };
 
         let transferred_port =
-            MessagePort::new_transferred(owner, id, port_impl.entangled_port_id());
+            MessagePort::new_transferred(owner, id, port_impl.entangled_port_id(), CanGc::note());
         owner.track_message_port(&transferred_port, Some(port_impl));
 
         return_object.set(transferred_port.reflector().rootable().get());

--- a/components/script/dom/mimetypearray.rs
+++ b/components/script/dom/mimetypearray.rs
@@ -24,12 +24,8 @@ impl MimeTypeArray {
         }
     }
 
-    pub(crate) fn new(global: &GlobalScope) -> DomRoot<MimeTypeArray> {
-        reflect_dom_object(
-            Box::new(MimeTypeArray::new_inherited()),
-            global,
-            CanGc::note(),
-        )
+    pub(crate) fn new(global: &GlobalScope, can_gc: CanGc) -> DomRoot<MimeTypeArray> {
+        reflect_dom_object(Box::new(MimeTypeArray::new_inherited()), global, can_gc)
     }
 }
 

--- a/components/script/dom/mutationobserver.rs
+++ b/components/script/dom/mutationobserver.rs
@@ -256,17 +256,30 @@ impl MutationObserver {
                     } else {
                         None
                     };
-                    MutationRecord::attribute_mutated(target, name, namespace, paired_string)
+                    MutationRecord::attribute_mutated(
+                        target,
+                        name,
+                        namespace,
+                        paired_string,
+                        CanGc::note(),
+                    )
                 },
                 Mutation::CharacterData { .. } => {
-                    MutationRecord::character_data_mutated(target, paired_string)
+                    MutationRecord::character_data_mutated(target, paired_string, CanGc::note())
                 },
                 Mutation::ChildList {
                     ref added,
                     ref removed,
                     ref next,
                     ref prev,
-                } => MutationRecord::child_list_mutated(target, *added, *removed, *next, *prev),
+                } => MutationRecord::child_list_mutated(
+                    target,
+                    *added,
+                    *removed,
+                    *next,
+                    *prev,
+                    CanGc::note(),
+                ),
             };
             // Step 4.8
             observer.record_queue.borrow_mut().push(record);

--- a/components/script/dom/mutationrecord.rs
+++ b/components/script/dom/mutationrecord.rs
@@ -34,6 +34,7 @@ impl MutationRecord {
         attribute_name: &LocalName,
         attribute_namespace: Option<&Namespace>,
         old_value: Option<DOMString>,
+        can_gc: CanGc,
     ) -> DomRoot<MutationRecord> {
         let record = Box::new(MutationRecord::new_inherited(
             "attributes",
@@ -46,12 +47,13 @@ impl MutationRecord {
             None,
             None,
         ));
-        reflect_dom_object(record, &*target.owner_window(), CanGc::note())
+        reflect_dom_object(record, &*target.owner_window(), can_gc)
     }
 
     pub(crate) fn character_data_mutated(
         target: &Node,
         old_value: Option<DOMString>,
+        can_gc: CanGc,
     ) -> DomRoot<MutationRecord> {
         reflect_dom_object(
             Box::new(MutationRecord::new_inherited(
@@ -66,7 +68,7 @@ impl MutationRecord {
                 None,
             )),
             &*target.owner_window(),
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -76,6 +78,7 @@ impl MutationRecord {
         removed_nodes: Option<&[&Node]>,
         next_sibling: Option<&Node>,
         prev_sibling: Option<&Node>,
+        can_gc: CanGc,
     ) -> DomRoot<MutationRecord> {
         let window = target.owner_window();
         let added_nodes = added_nodes.map(|list| NodeList::new_simple_list_slice(&window, list));
@@ -95,7 +98,7 @@ impl MutationRecord {
                 prev_sibling,
             )),
             &*window,
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/namednodemap.rs
+++ b/components/script/dom/namednodemap.rs
@@ -31,12 +31,8 @@ impl NamedNodeMap {
         }
     }
 
-    pub(crate) fn new(window: &Window, elem: &Element) -> DomRoot<NamedNodeMap> {
-        reflect_dom_object(
-            Box::new(NamedNodeMap::new_inherited(elem)),
-            window,
-            CanGc::note(),
-        )
+    pub(crate) fn new(window: &Window, elem: &Element, can_gc: CanGc) -> DomRoot<NamedNodeMap> {
+        reflect_dom_object(Box::new(NamedNodeMap::new_inherited(elem)), window, can_gc)
     }
 }
 

--- a/components/script/dom/navigationpreloadmanager.rs
+++ b/components/script/dom/navigationpreloadmanager.rs
@@ -38,9 +38,10 @@ impl NavigationPreloadManager {
     pub(crate) fn new(
         global: &GlobalScope,
         registration: &ServiceWorkerRegistration,
+        can_gc: CanGc,
     ) -> DomRoot<NavigationPreloadManager> {
         let manager = NavigationPreloadManager::new_inherited(registration);
-        reflect_dom_object(Box::new(manager), global, CanGc::note())
+        reflect_dom_object(Box::new(manager), global, can_gc)
     }
 }
 
@@ -54,6 +55,7 @@ impl NavigationPreloadManagerMethods<crate::DomTypeHolder> for NavigationPreload
             promise.reject_native(&DOMException::new(
                 &self.global(),
                 DOMErrorName::InvalidStateError,
+                can_gc,
             ));
         } else {
             // 3.
@@ -76,6 +78,7 @@ impl NavigationPreloadManagerMethods<crate::DomTypeHolder> for NavigationPreload
             promise.reject_native(&DOMException::new(
                 &self.global(),
                 DOMErrorName::InvalidStateError,
+                can_gc,
             ));
         } else {
             // 3.
@@ -98,6 +101,7 @@ impl NavigationPreloadManagerMethods<crate::DomTypeHolder> for NavigationPreload
             promise.reject_native(&DOMException::new(
                 &self.global(),
                 DOMErrorName::InvalidStateError,
+                can_gc,
             ));
         } else {
             // 3.

--- a/components/script/dom/navigator.rs
+++ b/components/script/dom/navigator.rs
@@ -82,8 +82,8 @@ impl Navigator {
         }
     }
 
-    pub(crate) fn new(window: &Window) -> DomRoot<Navigator> {
-        reflect_dom_object(Box::new(Navigator::new_inherited()), window, CanGc::note())
+    pub(crate) fn new(window: &Window, can_gc: CanGc) -> DomRoot<Navigator> {
+        reflect_dom_object(Box::new(Navigator::new_inherited()), window, can_gc)
     }
 
     #[cfg(feature = "webxr")]
@@ -200,7 +200,8 @@ impl NavigatorMethods<crate::DomTypeHolder> for Navigator {
     // https://webbluetoothcg.github.io/web-bluetooth/#dom-navigator-bluetooth
     #[cfg(feature = "bluetooth")]
     fn Bluetooth(&self) -> DomRoot<Bluetooth> {
-        self.bluetooth.or_init(|| Bluetooth::new(&self.global()))
+        self.bluetooth
+            .or_init(|| Bluetooth::new(&self.global(), CanGc::note()))
     }
 
     // https://html.spec.whatwg.org/multipage/#navigatorlanguage
@@ -216,13 +217,14 @@ impl NavigatorMethods<crate::DomTypeHolder> for Navigator {
 
     // https://html.spec.whatwg.org/multipage/#dom-navigator-plugins
     fn Plugins(&self) -> DomRoot<PluginArray> {
-        self.plugins.or_init(|| PluginArray::new(&self.global()))
+        self.plugins
+            .or_init(|| PluginArray::new(&self.global(), CanGc::note()))
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-navigator-mimetypes
     fn MimeTypes(&self) -> DomRoot<MimeTypeArray> {
         self.mime_types
-            .or_init(|| MimeTypeArray::new(&self.global()))
+            .or_init(|| MimeTypeArray::new(&self.global(), CanGc::note()))
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-navigator-javaenabled
@@ -233,7 +235,7 @@ impl NavigatorMethods<crate::DomTypeHolder> for Navigator {
     // https://w3c.github.io/ServiceWorker/#navigator-service-worker-attribute
     fn ServiceWorker(&self) -> DomRoot<ServiceWorkerContainer> {
         self.service_worker
-            .or_init(|| ServiceWorkerContainer::new(&self.global()))
+            .or_init(|| ServiceWorkerContainer::new(&self.global(), CanGc::note()))
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-navigator-cookieenabled
@@ -257,19 +259,20 @@ impl NavigatorMethods<crate::DomTypeHolder> for Navigator {
     // https://w3c.github.io/permissions/#navigator-and-workernavigator-extension
     fn Permissions(&self) -> DomRoot<Permissions> {
         self.permissions
-            .or_init(|| Permissions::new(&self.global()))
+            .or_init(|| Permissions::new(&self.global(), CanGc::note()))
     }
 
     /// <https://immersive-web.github.io/webxr/#dom-navigator-xr>
     #[cfg(feature = "webxr")]
     fn Xr(&self) -> DomRoot<XRSystem> {
-        self.xr.or_init(|| XRSystem::new(self.global().as_window()))
+        self.xr
+            .or_init(|| XRSystem::new(self.global().as_window(), CanGc::note()))
     }
 
     /// <https://w3c.github.io/mediacapture-main/#dom-navigator-mediadevices>
     fn MediaDevices(&self) -> DomRoot<MediaDevices> {
         self.mediadevices
-            .or_init(|| MediaDevices::new(&self.global()))
+            .or_init(|| MediaDevices::new(&self.global(), CanGc::note()))
     }
 
     /// <https://w3c.github.io/mediasession/#dom-navigator-mediasession>
@@ -284,14 +287,14 @@ impl NavigatorMethods<crate::DomTypeHolder> for Navigator {
             // - If a media instance (HTMLMediaElement so far) starts playing media.
             let global = self.global();
             let window = global.as_window();
-            MediaSession::new(window)
+            MediaSession::new(window, CanGc::note())
         })
     }
 
     // https://gpuweb.github.io/gpuweb/#dom-navigator-gpu
     #[cfg(feature = "webgpu")]
     fn Gpu(&self) -> DomRoot<GPU> {
-        self.gpu.or_init(|| GPU::new(&self.global()))
+        self.gpu.or_init(|| GPU::new(&self.global(), CanGc::note()))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-navigator-hardwareconcurrency>

--- a/components/script/dom/nodeiterator.rs
+++ b/components/script/dom/nodeiterator.rs
@@ -49,11 +49,12 @@ impl NodeIterator {
         root_node: &Node,
         what_to_show: u32,
         filter: Filter,
+        can_gc: CanGc,
     ) -> DomRoot<NodeIterator> {
         reflect_dom_object(
             Box::new(NodeIterator::new_inherited(root_node, what_to_show, filter)),
             document.window(),
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -67,7 +68,7 @@ impl NodeIterator {
             None => Filter::None,
             Some(jsfilter) => Filter::Callback(jsfilter),
         };
-        NodeIterator::new_with_filter(document, root_node, what_to_show, filter)
+        NodeIterator::new_with_filter(document, root_node, what_to_show, filter, CanGc::note())
     }
 }
 

--- a/components/script/dom/nodelist.rs
+++ b/components/script/dom/nodelist.rs
@@ -46,12 +46,12 @@ impl NodeList {
     }
 
     #[cfg_attr(crown, allow(crown::unrooted_must_root))]
-    pub(crate) fn new(window: &Window, list_type: NodeListType) -> DomRoot<NodeList> {
-        reflect_dom_object(
-            Box::new(NodeList::new_inherited(list_type)),
-            window,
-            CanGc::note(),
-        )
+    pub(crate) fn new(
+        window: &Window,
+        list_type: NodeListType,
+        can_gc: CanGc,
+    ) -> DomRoot<NodeList> {
+        reflect_dom_object(Box::new(NodeList::new_inherited(list_type)), window, can_gc)
     }
 
     pub(crate) fn new_simple_list<T>(window: &Window, iter: T) -> DomRoot<NodeList>
@@ -61,6 +61,7 @@ impl NodeList {
         NodeList::new(
             window,
             NodeListType::Simple(iter.map(|r| Dom::from_ref(&*r)).collect()),
+            CanGc::note(),
         )
     }
 
@@ -68,15 +69,24 @@ impl NodeList {
         NodeList::new(
             window,
             NodeListType::Simple(slice.iter().map(|r| Dom::from_ref(*r)).collect()),
+            CanGc::note(),
         )
     }
 
     pub(crate) fn new_child_list(window: &Window, node: &Node) -> DomRoot<NodeList> {
-        NodeList::new(window, NodeListType::Children(ChildrenList::new(node)))
+        NodeList::new(
+            window,
+            NodeListType::Children(ChildrenList::new(node)),
+            CanGc::note(),
+        )
     }
 
     pub(crate) fn new_labels_list(window: &Window, element: &HTMLElement) -> DomRoot<NodeList> {
-        NodeList::new(window, NodeListType::Labels(LabelsList::new(element)))
+        NodeList::new(
+            window,
+            NodeListType::Labels(LabelsList::new(element)),
+            CanGc::note(),
+        )
     }
 
     pub(crate) fn new_elements_by_name_list(
@@ -87,11 +97,12 @@ impl NodeList {
         NodeList::new(
             window,
             NodeListType::ElementsByName(ElementsByNameList::new(document, name)),
+            CanGc::note(),
         )
     }
 
     pub(crate) fn empty(window: &Window) -> DomRoot<NodeList> {
-        NodeList::new(window, NodeListType::Simple(vec![]))
+        NodeList::new(window, NodeListType::Simple(vec![]), CanGc::note())
     }
 }
 

--- a/components/script/dom/notification.rs
+++ b/components/script/dom/notification.rs
@@ -548,7 +548,7 @@ fn request_notification_permission(global: &GlobalScope) -> NotificationPermissi
     let descriptor = PermissionDescriptor {
         name: PermissionName::Notifications,
     };
-    let status = PermissionStatus::new(global, &descriptor);
+    let status = PermissionStatus::new(global, &descriptor, CanGc::note());
 
     // The implementation of `request_notification_permission` seemed to be synchronous
     Permissions::permission_request(cx, promise, &descriptor, &status);

--- a/components/script/dom/offscreencanvas.rs
+++ b/components/script/dom/offscreencanvas.rs
@@ -127,6 +127,7 @@ impl OffscreenCanvas {
             &self.global(),
             self,
             self.placeholder.as_deref(),
+            CanGc::note(),
         );
         *self.context.borrow_mut() = Some(OffscreenCanvasContext::OffscreenContext2d(
             Dom::from_ref(&*context),

--- a/components/script/dom/offscreencanvasrenderingcontext2d.rs
+++ b/components/script/dom/offscreencanvasrenderingcontext2d.rs
@@ -55,11 +55,12 @@ impl OffscreenCanvasRenderingContext2D {
         global: &GlobalScope,
         canvas: &OffscreenCanvas,
         htmlcanvas: Option<&HTMLCanvasElement>,
+        can_gc: CanGc,
     ) -> DomRoot<OffscreenCanvasRenderingContext2D> {
         let boxed = Box::new(OffscreenCanvasRenderingContext2D::new_inherited(
             global, canvas, htmlcanvas,
         ));
-        reflect_dom_object(boxed, global, CanGc::note())
+        reflect_dom_object(boxed, global, can_gc)
     }
 
     pub(crate) fn set_canvas_bitmap_dimensions(&self, size: Size2D<u64>) {

--- a/components/script/dom/oscillatornode.rs
+++ b/components/script/dom/oscillatornode.rs
@@ -68,6 +68,7 @@ impl OscillatorNode {
             440.,
             f32::MIN,
             f32::MAX,
+            CanGc::note(),
         );
         let detune = AudioParam::new(
             window,
@@ -79,6 +80,7 @@ impl OscillatorNode {
             0.,
             -440. / 2.,
             440. / 2.,
+            CanGc::note(),
         );
         Ok(OscillatorNode {
             source_node,

--- a/components/script/dom/paintrenderingcontext2d.rs
+++ b/components/script/dom/paintrenderingcontext2d.rs
@@ -47,11 +47,14 @@ impl PaintRenderingContext2D {
         }
     }
 
-    pub(crate) fn new(global: &PaintWorkletGlobalScope) -> DomRoot<PaintRenderingContext2D> {
+    pub(crate) fn new(
+        global: &PaintWorkletGlobalScope,
+        can_gc: CanGc,
+    ) -> DomRoot<PaintRenderingContext2D> {
         reflect_dom_object(
             Box::new(PaintRenderingContext2D::new_inherited(global)),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/paintsize.rs
+++ b/components/script/dom/paintsize.rs
@@ -32,12 +32,9 @@ impl PaintSize {
     pub(crate) fn new(
         global: &PaintWorkletGlobalScope,
         size: Size2D<f32, CSSPixel>,
+        can_gc: CanGc,
     ) -> DomRoot<PaintSize> {
-        reflect_dom_object(
-            Box::new(PaintSize::new_inherited(size)),
-            global,
-            CanGc::note(),
-        )
+        reflect_dom_object(Box::new(PaintSize::new_inherited(size)), global, can_gc)
     }
 }
 

--- a/components/script/dom/paintworkletglobalscope.rs
+++ b/components/script/dom/paintworkletglobalscope.rs
@@ -49,7 +49,7 @@ use crate::dom::paintsize::PaintSize;
 use crate::dom::stylepropertymapreadonly::StylePropertyMapReadOnly;
 use crate::dom::worklet::WorkletExecutor;
 use crate::dom::workletglobalscope::{WorkletGlobalScope, WorkletGlobalScopeInit, WorkletTask};
-use crate::script_runtime::JSContext;
+use crate::script_runtime::{CanGc, JSContext};
 
 /// <https://drafts.css-houdini.org/css-paint-api/#paintworkletglobalscope>
 #[dom_struct]
@@ -155,6 +155,7 @@ impl PaintWorkletGlobalScope {
                     let map = StylePropertyMapReadOnly::from_iter(
                         self.upcast(),
                         properties.iter().cloned(),
+                        CanGc::note(),
                     );
                     let result =
                         self.draw_a_paint_image(&name, size, device_pixel_ratio, &map, &arguments);
@@ -180,6 +181,7 @@ impl PaintWorkletGlobalScope {
                     let map = StylePropertyMapReadOnly::from_iter(
                         self.upcast(),
                         properties.iter().cloned(),
+                        CanGc::note(),
                     );
                     let result =
                         self.draw_a_paint_image(&name, size, device_pixel_ratio, &map, &arguments);
@@ -306,14 +308,14 @@ impl PaintWorkletGlobalScope {
         rendering_context.set_bitmap_dimensions(size_in_px, device_pixel_ratio);
 
         // Step 9
-        let paint_size = PaintSize::new(self, size_in_px);
+        let paint_size = PaintSize::new(self, size_in_px, CanGc::note());
 
         // TODO: Step 10
         // Steps 11-12
         debug!("Invoking paint function {}.", name);
         rooted_vec!(let mut arguments_values);
         for argument in arguments {
-            let style_value = CSSStyleValue::new(self.upcast(), argument.clone());
+            let style_value = CSSStyleValue::new(self.upcast(), argument.clone(), CanGc::note());
             arguments_values.push(ObjectValue(style_value.reflector().get_jsobject().get()));
         }
         let arguments_value_array = HandleValueArray::from(&arguments_values);
@@ -565,7 +567,7 @@ impl PaintWorkletGlobalScopeMethods<crate::DomTypeHolder> for PaintWorkletGlobal
         }
 
         // Step 19.
-        let context = PaintRenderingContext2D::new(self);
+        let context = PaintRenderingContext2D::new(self, CanGc::note());
         let definition = PaintDefinition::new(
             paint_val.handle(),
             paint_function.handle(),

--- a/components/script/dom/pannernode.rs
+++ b/components/script/dom/pannernode.rs
@@ -106,6 +106,7 @@ impl PannerNode {
             options.position_x, // default value
             f32::MIN,           // min value
             f32::MAX,           // max value
+            CanGc::note(),
         );
         let position_y = AudioParam::new(
             window,
@@ -117,6 +118,7 @@ impl PannerNode {
             options.position_y, // default value
             f32::MIN,           // min value
             f32::MAX,           // max value
+            CanGc::note(),
         );
         let position_z = AudioParam::new(
             window,
@@ -128,6 +130,7 @@ impl PannerNode {
             options.position_z, // default value
             f32::MIN,           // min value
             f32::MAX,           // max value
+            CanGc::note(),
         );
         let orientation_x = AudioParam::new(
             window,
@@ -139,6 +142,7 @@ impl PannerNode {
             options.orientation_x, // default value
             f32::MIN,              // min value
             f32::MAX,              // max value
+            CanGc::note(),
         );
         let orientation_y = AudioParam::new(
             window,
@@ -150,6 +154,7 @@ impl PannerNode {
             options.orientation_y, // default value
             f32::MIN,              // min value
             f32::MAX,              // max value
+            CanGc::note(),
         );
         let orientation_z = AudioParam::new(
             window,
@@ -161,6 +166,7 @@ impl PannerNode {
             options.orientation_z, // default value
             f32::MIN,              // min value
             f32::MAX,              // max value
+            CanGc::note(),
         );
         Ok(PannerNode {
             node,

--- a/components/script/dom/performance.rs
+++ b/components/script/dom/performance.rs
@@ -168,11 +168,12 @@ impl Performance {
     pub(crate) fn new(
         global: &GlobalScope,
         navigation_start: CrossProcessInstant,
+        can_gc: CanGc,
     ) -> DomRoot<Performance> {
         reflect_dom_object(
             Box::new(Performance::new_inherited(navigation_start)),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -446,7 +447,7 @@ impl PerformanceMethods<crate::DomTypeHolder> for Performance {
 
     // https://w3c.github.io/navigation-timing/#dom-performance-navigation
     fn Navigation(&self) -> DomRoot<PerformanceNavigation> {
-        PerformanceNavigation::new(&self.global())
+        PerformanceNavigation::new(&self.global(), CanGc::note())
     }
 
     // https://dvcs.w3.org/hg/webperf/raw-file/tip/specs/HighResolutionTime/Overview.html#dom-performance-now

--- a/components/script/dom/performanceentry.rs
+++ b/components/script/dom/performanceentry.rs
@@ -52,9 +52,10 @@ impl PerformanceEntry {
         entry_type: DOMString,
         start_time: CrossProcessInstant,
         duration: Duration,
+        can_gc: CanGc,
     ) -> DomRoot<PerformanceEntry> {
         let entry = PerformanceEntry::new_inherited(name, entry_type, Some(start_time), duration);
-        reflect_dom_object(Box::new(entry), global, CanGc::note())
+        reflect_dom_object(Box::new(entry), global, can_gc)
     }
 
     pub(crate) fn entry_type(&self) -> &DOMString {

--- a/components/script/dom/performancenavigation.rs
+++ b/components/script/dom/performancenavigation.rs
@@ -25,11 +25,11 @@ impl PerformanceNavigation {
         }
     }
 
-    pub(crate) fn new(global: &GlobalScope) -> DomRoot<PerformanceNavigation> {
+    pub(crate) fn new(global: &GlobalScope, can_gc: CanGc) -> DomRoot<PerformanceNavigation> {
         reflect_dom_object(
             Box::new(PerformanceNavigation::new_inherited()),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 }

--- a/components/script/dom/performancenavigationtiming.rs
+++ b/components/script/dom/performancenavigationtiming.rs
@@ -49,6 +49,7 @@ impl PerformanceNavigationTiming {
         global: &GlobalScope,
         fetch_start: CrossProcessInstant,
         document: &Document,
+        can_gc: CanGc,
     ) -> DomRoot<PerformanceNavigationTiming> {
         reflect_dom_object(
             Box::new(PerformanceNavigationTiming::new_inherited(
@@ -56,7 +57,7 @@ impl PerformanceNavigationTiming {
                 document,
             )),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 }

--- a/components/script/dom/performanceobserver.rs
+++ b/components/script/dom/performanceobserver.rs
@@ -98,7 +98,8 @@ impl PerformanceObserver {
             return;
         }
         let entry_list = PerformanceEntryList::new(self.entries.borrow_mut().drain(..).collect());
-        let observer_entry_list = PerformanceObserverEntryList::new(&self.global(), entry_list);
+        let observer_entry_list =
+            PerformanceObserverEntryList::new(&self.global(), entry_list, CanGc::note());
         // using self both as thisArg and as the second formal argument
         let _ = self
             .callback

--- a/components/script/dom/performanceobserverentrylist.rs
+++ b/components/script/dom/performanceobserverentrylist.rs
@@ -32,9 +32,10 @@ impl PerformanceObserverEntryList {
     pub(crate) fn new(
         global: &GlobalScope,
         entries: PerformanceEntryList,
+        can_gc: CanGc,
     ) -> DomRoot<PerformanceObserverEntryList> {
         let observer_entry_list = PerformanceObserverEntryList::new_inherited(entries);
-        reflect_dom_object(Box::new(observer_entry_list), global, CanGc::note())
+        reflect_dom_object(Box::new(observer_entry_list), global, can_gc)
     }
 }
 

--- a/components/script/dom/performancepainttiming.rs
+++ b/components/script/dom/performancepainttiming.rs
@@ -46,8 +46,9 @@ impl PerformancePaintTiming {
         global: &GlobalScope,
         metric_type: ProgressiveWebMetricType,
         start_time: CrossProcessInstant,
+        can_gc: CanGc,
     ) -> DomRoot<PerformancePaintTiming> {
         let entry = PerformancePaintTiming::new_inherited(metric_type, start_time);
-        reflect_dom_object(Box::new(entry), global, CanGc::note())
+        reflect_dom_object(Box::new(entry), global, can_gc)
     }
 }

--- a/components/script/dom/performanceresourcetiming.rs
+++ b/components/script/dom/performanceresourcetiming.rs
@@ -159,6 +159,7 @@ impl PerformanceResourceTiming {
         initiator_type: InitiatorType,
         next_hop: Option<DOMString>,
         resource_timing: &ResourceFetchTiming,
+        can_gc: CanGc,
     ) -> DomRoot<PerformanceResourceTiming> {
         reflect_dom_object(
             Box::new(PerformanceResourceTiming::from_resource_timing(
@@ -168,7 +169,7 @@ impl PerformanceResourceTiming {
                 resource_timing,
             )),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/permissions.rs
+++ b/components/script/dom/permissions.rs
@@ -75,12 +75,8 @@ impl Permissions {
         }
     }
 
-    pub(crate) fn new(global: &GlobalScope) -> DomRoot<Permissions> {
-        reflect_dom_object(
-            Box::new(Permissions::new_inherited()),
-            global,
-            CanGc::note(),
-        )
+    pub(crate) fn new(global: &GlobalScope, can_gc: CanGc) -> DomRoot<Permissions> {
+        reflect_dom_object(Box::new(Permissions::new_inherited()), global, can_gc)
     }
 
     // https://w3c.github.io/permissions/#dom-permissions-query
@@ -114,7 +110,7 @@ impl Permissions {
         };
 
         // (Query, Request) Step 5.
-        let status = PermissionStatus::new(&self.global(), &root_desc);
+        let status = PermissionStatus::new(&self.global(), &root_desc, can_gc);
 
         // (Query, Request, Revoke) Step 2.
         match root_desc.name {
@@ -129,7 +125,7 @@ impl Permissions {
                 };
 
                 // (Query, Request) Step 5.
-                let result = BluetoothPermissionResult::new(&self.global(), &status);
+                let result = BluetoothPermissionResult::new(&self.global(), &status, can_gc);
 
                 match op {
                     // (Request) Step 6 - 8.

--- a/components/script/dom/permissionstatus.rs
+++ b/components/script/dom/permissionstatus.rs
@@ -36,11 +36,12 @@ impl PermissionStatus {
     pub(crate) fn new(
         global: &GlobalScope,
         query: &PermissionDescriptor,
+        can_gc: CanGc,
     ) -> DomRoot<PermissionStatus> {
         reflect_dom_object(
             Box::new(PermissionStatus::new_inherited(query.name)),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/pluginarray.rs
+++ b/components/script/dom/pluginarray.rs
@@ -24,12 +24,8 @@ impl PluginArray {
         }
     }
 
-    pub(crate) fn new(global: &GlobalScope) -> DomRoot<PluginArray> {
-        reflect_dom_object(
-            Box::new(PluginArray::new_inherited()),
-            global,
-            CanGc::note(),
-        )
+    pub(crate) fn new(global: &GlobalScope, can_gc: CanGc) -> DomRoot<PluginArray> {
+        reflect_dom_object(Box::new(PluginArray::new_inherited()), global, can_gc)
     }
 }
 

--- a/components/script/dom/promisenativehandler.rs
+++ b/components/script/dom/promisenativehandler.rs
@@ -34,6 +34,7 @@ impl PromiseNativeHandler {
         global: &GlobalScope,
         resolve: Option<Box<dyn Callback>>,
         reject: Option<Box<dyn Callback>>,
+        can_gc: CanGc,
     ) -> DomRoot<PromiseNativeHandler> {
         reflect_dom_object(
             Box::new(PromiseNativeHandler {
@@ -42,7 +43,7 @@ impl PromiseNativeHandler {
                 reject,
             }),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/radionodelist.rs
+++ b/components/script/dom/radionodelist.rs
@@ -33,11 +33,15 @@ impl RadioNodeList {
     }
 
     #[cfg_attr(crown, allow(crown::unrooted_must_root))]
-    pub(crate) fn new(window: &Window, list_type: NodeListType) -> DomRoot<RadioNodeList> {
+    pub(crate) fn new(
+        window: &Window,
+        list_type: NodeListType,
+        can_gc: CanGc,
+    ) -> DomRoot<RadioNodeList> {
         reflect_dom_object(
             Box::new(RadioNodeList::new_inherited(list_type)),
             window,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -53,6 +57,7 @@ impl RadioNodeList {
                 RadioListMode::ControlsExceptImageInputs,
                 name.clone(),
             )),
+            CanGc::note(),
         )
     }
 
@@ -64,6 +69,7 @@ impl RadioNodeList {
         RadioNodeList::new(
             window,
             NodeListType::Radio(RadioList::new(form, RadioListMode::Images, name.clone())),
+            CanGc::note(),
         )
     }
 }

--- a/components/script/dom/readablestream.rs
+++ b/components/script/dom/readablestream.rs
@@ -716,8 +716,12 @@ impl ReadableStream {
         let rejection_handler = Box::new(SourceCancelPromiseRejectionHandler {
             result: result_promise.clone(),
         });
-        let handler =
-            PromiseNativeHandler::new(&global, Some(fulfillment_handler), Some(rejection_handler));
+        let handler = PromiseNativeHandler::new(
+            &global,
+            Some(fulfillment_handler),
+            Some(rejection_handler),
+            can_gc,
+        );
         let realm = enter_realm(&*global);
         let comp = InRealm::Entered(&realm);
         source_cancel_promise.append_native_handler(&handler, comp, can_gc);

--- a/components/script/dom/readablestreamdefaultcontroller.rs
+++ b/components/script/dom/readablestreamdefaultcontroller.rs
@@ -427,6 +427,7 @@ impl ReadableStreamDefaultController {
                 Some(Box::new(StartAlgorithmRejectionHandler {
                     controller: Dom::from_ref(&rooted_default_controller),
                 })),
+                can_gc,
             );
             let realm = enter_realm(global);
             let comp = InRealm::Entered(&realm);
@@ -521,6 +522,7 @@ impl ReadableStreamDefaultController {
             Some(Box::new(PullAlgorithmRejectionHandler {
                 controller: Dom::from_ref(&rooted_default_controller),
             })),
+            can_gc,
         );
 
         let realm = enter_realm(&*global);

--- a/components/script/dom/readablestreamdefaultreader.rs
+++ b/components/script/dom/readablestreamdefaultreader.rs
@@ -332,6 +332,7 @@ impl ReadableStreamDefaultReader {
                 canceled_2,
                 cancel_promise,
             })),
+            can_gc,
         );
 
         let realm = enter_realm(&*global);

--- a/components/script/dom/rtcdatachannel.rs
+++ b/components/script/dom/rtcdatachannel.rs
@@ -96,6 +96,7 @@ impl RTCDataChannel {
         label: USVString,
         options: &RTCDataChannelInit,
         servo_media_id: Option<DataChannelId>,
+        can_gc: CanGc,
     ) -> DomRoot<RTCDataChannel> {
         let rtc_data_channel = reflect_dom_object(
             Box::new(RTCDataChannel::new_inherited(
@@ -105,7 +106,7 @@ impl RTCDataChannel {
                 servo_media_id,
             )),
             global,
-            CanGc::note(),
+            can_gc,
         );
 
         peer_connection.register_data_channel(rtc_data_channel.servo_media_id, &rtc_data_channel);

--- a/components/script/dom/rtcerror.rs
+++ b/components/script/dom/rtcerror.rs
@@ -33,6 +33,7 @@ impl RTCError {
             exception: Dom::from_ref(&*DOMException::new(
                 global,
                 DOMErrorName::from(&message).unwrap(),
+                CanGc::note(),
             )),
             error_detail: init.errorDetail,
             sdp_line_number: init.sdpLineNumber,

--- a/components/script/dom/rtcpeerconnection.rs
+++ b/components/script/dom/rtcpeerconnection.rs
@@ -266,7 +266,7 @@ impl RTCPeerConnection {
         if self.closed.get() {
             return;
         }
-        let track = MediaStreamTrack::new(&self.global(), id, ty);
+        let track = MediaStreamTrack::new(&self.global(), id, ty, can_gc);
         let event =
             RTCTrackEvent::new(&self.global(), atom!("track"), false, false, &track, can_gc);
         event.upcast::<Event>().fire(self.upcast(), can_gc);
@@ -290,6 +290,7 @@ impl RTCPeerConnection {
                     USVString::from("".to_owned()),
                     &RTCDataChannelInit::empty(),
                     Some(channel_id),
+                    can_gc,
                 );
 
                 let event = RTCDataChannelEvent::new(
@@ -773,7 +774,7 @@ impl RTCPeerConnectionMethods<crate::DomTypeHolder> for RTCPeerConnection {
         label: USVString,
         init: &RTCDataChannelInit,
     ) -> DomRoot<RTCDataChannel> {
-        RTCDataChannel::new(&self.global(), self, label, init, None)
+        RTCDataChannel::new(&self.global(), self, label, init, None, CanGc::note())
     }
 
     /// <https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnection-addtransceiver>
@@ -782,7 +783,7 @@ impl RTCPeerConnectionMethods<crate::DomTypeHolder> for RTCPeerConnection {
         _track_or_kind: MediaStreamTrackOrString,
         init: &RTCRtpTransceiverInit,
     ) -> DomRoot<RTCRtpTransceiver> {
-        RTCRtpTransceiver::new(&self.global(), init.direction)
+        RTCRtpTransceiver::new(&self.global(), init.direction, CanGc::note())
     }
 }
 

--- a/components/script/dom/rtcrtpsender.rs
+++ b/components/script/dom/rtcrtpsender.rs
@@ -28,8 +28,8 @@ impl RTCRtpSender {
         }
     }
 
-    pub(crate) fn new(global: &GlobalScope) -> DomRoot<Self> {
-        reflect_dom_object(Box::new(Self::new_inherited()), global, CanGc::note())
+    pub(crate) fn new(global: &GlobalScope, can_gc: CanGc) -> DomRoot<Self> {
+        reflect_dom_object(Box::new(Self::new_inherited()), global, can_gc)
     }
 }
 

--- a/components/script/dom/rtcrtptransceiver.rs
+++ b/components/script/dom/rtcrtptransceiver.rs
@@ -24,7 +24,7 @@ pub(crate) struct RTCRtpTransceiver {
 
 impl RTCRtpTransceiver {
     fn new_inherited(global: &GlobalScope, direction: RTCRtpTransceiverDirection) -> Self {
-        let sender = RTCRtpSender::new(global);
+        let sender = RTCRtpSender::new(global, CanGc::note());
         Self {
             reflector_: Reflector::new(),
             direction: Cell::new(direction),
@@ -35,11 +35,12 @@ impl RTCRtpTransceiver {
     pub(crate) fn new(
         global: &GlobalScope,
         direction: RTCRtpTransceiverDirection,
+        can_gc: CanGc,
     ) -> DomRoot<Self> {
         reflect_dom_object(
             Box::new(Self::new_inherited(global, direction)),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 }

--- a/components/script/dom/screen.rs
+++ b/components/script/dom/screen.rs
@@ -30,12 +30,8 @@ impl Screen {
         }
     }
 
-    pub(crate) fn new(window: &Window) -> DomRoot<Screen> {
-        reflect_dom_object(
-            Box::new(Screen::new_inherited(window)),
-            window,
-            CanGc::note(),
-        )
+    pub(crate) fn new(window: &Window, can_gc: CanGc) -> DomRoot<Screen> {
+        reflect_dom_object(Box::new(Screen::new_inherited(window)), window, can_gc)
     }
 
     fn screen_size(&self) -> Size2D<u32, CSSPixel> {

--- a/components/script/dom/selection.rs
+++ b/components/script/dom/selection.rs
@@ -48,11 +48,11 @@ impl Selection {
         }
     }
 
-    pub(crate) fn new(document: &Document) -> DomRoot<Selection> {
+    pub(crate) fn new(document: &Document, can_gc: CanGc) -> DomRoot<Selection> {
         reflect_dom_object(
             Box::new(Selection::new_inherited(document)),
             &*document.global(),
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/serviceworker.rs
+++ b/components/script/dom/serviceworker.rs
@@ -63,6 +63,7 @@ impl ServiceWorker {
         script_url: ServoUrl,
         scope_url: ServoUrl,
         worker_id: ServiceWorkerId,
+        can_gc: CanGc,
     ) -> DomRoot<ServiceWorker> {
         reflect_dom_object(
             Box::new(ServiceWorker::new_inherited(
@@ -71,7 +72,7 @@ impl ServiceWorker {
                 worker_id,
             )),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/serviceworkercontainer.rs
+++ b/components/script/dom/serviceworkercontainer.rs
@@ -45,10 +45,10 @@ impl ServiceWorkerContainer {
     }
 
     #[cfg_attr(crown, allow(crown::unrooted_must_root))]
-    pub(crate) fn new(global: &GlobalScope) -> DomRoot<ServiceWorkerContainer> {
-        let client = Client::new(global.as_window());
+    pub(crate) fn new(global: &GlobalScope, can_gc: CanGc) -> DomRoot<ServiceWorkerContainer> {
+        let client = Client::new(global.as_window(), CanGc::note());
         let container = ServiceWorkerContainer::new_inherited(&client);
-        reflect_dom_object(Box::new(container), global, CanGc::note())
+        reflect_dom_object(Box::new(container), global, can_gc)
     }
 }
 

--- a/components/script/dom/serviceworkerregistration.rs
+++ b/components/script/dom/serviceworkerregistration.rs
@@ -68,6 +68,7 @@ impl ServiceWorkerRegistration {
         global: &GlobalScope,
         scope: ServoUrl,
         registration_id: ServiceWorkerRegistrationId,
+        can_gc: CanGc,
     ) -> DomRoot<ServiceWorkerRegistration> {
         reflect_dom_object(
             Box::new(ServiceWorkerRegistration::new_inherited(
@@ -75,7 +76,7 @@ impl ServiceWorkerRegistration {
                 registration_id,
             )),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -204,6 +205,6 @@ impl ServiceWorkerRegistrationMethods<crate::DomTypeHolder> for ServiceWorkerReg
     // https://w3c.github.io/ServiceWorker/#service-worker-registration-navigationpreload
     fn NavigationPreload(&self) -> DomRoot<NavigationPreloadManager> {
         self.navigation_preload
-            .or_init(|| NavigationPreloadManager::new(&self.global(), self))
+            .or_init(|| NavigationPreloadManager::new(&self.global(), self, CanGc::note()))
     }
 }

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -163,6 +163,7 @@ impl ServoParser {
                 document,
                 Tokenizer::AsyncHtml(self::async_html::Tokenizer::new(document, url, None)),
                 ParserKind::Normal,
+                can_gc,
             )
         } else {
             ServoParser::new(
@@ -174,6 +175,7 @@ impl ServoParser {
                     ParsingAlgorithm::Normal,
                 )),
                 ParserKind::Normal,
+                can_gc,
             )
         };
 
@@ -242,6 +244,7 @@ impl ServoParser {
                 ParsingAlgorithm::Fragment,
             )),
             ParserKind::Normal,
+            can_gc,
         );
         parser.parse_complete_string_chunk(String::from(input), can_gc);
 
@@ -262,6 +265,7 @@ impl ServoParser {
                 ParsingAlgorithm::Normal,
             )),
             ParserKind::ScriptCreated,
+            CanGc::note(),
         );
         *parser.bom_sniff.borrow_mut() = None;
         document.set_current_parser(Some(&parser));
@@ -277,6 +281,7 @@ impl ServoParser {
             document,
             Tokenizer::Xml(self::xml::Tokenizer::new(document, url)),
             ParserKind::Normal,
+            can_gc,
         );
 
         // Set as the document's current parser and initialize with `input`, if given.
@@ -463,11 +468,16 @@ impl ServoParser {
     }
 
     #[cfg_attr(crown, allow(crown::unrooted_must_root))]
-    fn new(document: &Document, tokenizer: Tokenizer, kind: ParserKind) -> DomRoot<Self> {
+    fn new(
+        document: &Document,
+        tokenizer: Tokenizer,
+        kind: ParserKind,
+        can_gc: CanGc,
+    ) -> DomRoot<Self> {
         reflect_dom_object(
             Box::new(ServoParser::new_inherited(document, tokenizer, kind)),
             document.window(),
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -1015,6 +1025,7 @@ impl FetchResponseListener for ParserContext {
                 &document.global(),
                 CrossProcessInstant::now(),
                 document,
+                CanGc::note(),
             );
             document
                 .global()
@@ -1048,6 +1059,7 @@ impl FetchResponseListener for ParserContext {
             &document.global(),
             CrossProcessInstant::now(),
             document,
+            CanGc::note(),
         );
         self.pushed_entry_index = document.global().performance().queue_entry(
             performance_entry.upcast::<PerformanceEntry>(),

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -104,6 +104,7 @@ impl ShadowRoot {
         mode: ShadowRootMode,
         slot_assignment_mode: SlotAssignmentMode,
         clonable: bool,
+        can_gc: CanGc,
     ) -> DomRoot<ShadowRoot> {
         reflect_dom_object(
             Box::new(ShadowRoot::new_inherited(
@@ -114,7 +115,7 @@ impl ShadowRoot {
                 clonable,
             )),
             document.window(),
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -290,6 +291,7 @@ impl ShadowRootMethods<crate::DomTypeHolder> for ShadowRoot {
             StyleSheetList::new(
                 &self.window,
                 StyleSheetListOwner::ShadowRoot(Dom::from_ref(self)),
+                CanGc::note(),
             )
         })
     }

--- a/components/script/dom/stereopannernode.rs
+++ b/components/script/dom/stereopannernode.rs
@@ -66,6 +66,7 @@ impl StereoPannerNode {
             *options.pan,
             -1.,
             1.,
+            CanGc::note(),
         );
 
         Ok(StereoPannerNode {

--- a/components/script/dom/storage.rs
+++ b/components/script/dom/storage.rs
@@ -37,11 +37,15 @@ impl Storage {
         }
     }
 
-    pub(crate) fn new(global: &Window, storage_type: StorageType) -> DomRoot<Storage> {
+    pub(crate) fn new(
+        global: &Window,
+        storage_type: StorageType,
+        can_gc: CanGc,
+    ) -> DomRoot<Storage> {
         reflect_dom_object(
             Box::new(Storage::new_inherited(storage_type)),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/stylepropertymapreadonly.rs
+++ b/components/script/dom/stylepropertymapreadonly.rs
@@ -38,6 +38,7 @@ impl StylePropertyMapReadOnly {
     pub(crate) fn from_iter<Entries>(
         global: &GlobalScope,
         entries: Entries,
+        can_gc: CanGc,
     ) -> DomRoot<StylePropertyMapReadOnly>
     where
         Entries: IntoIterator<Item = (Atom, String)>,
@@ -49,7 +50,7 @@ impl StylePropertyMapReadOnly {
         keys.reserve(lo);
         values.reserve(lo);
         for (key, value) in iter {
-            let value = CSSStyleValue::new(global, value);
+            let value = CSSStyleValue::new(global, value, can_gc);
             keys.push(key);
             values.push(Dom::from_ref(&*value));
         }
@@ -57,7 +58,7 @@ impl StylePropertyMapReadOnly {
         reflect_dom_object(
             Box::new(StylePropertyMapReadOnly::new_inherited(iter)),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 }

--- a/components/script/dom/stylesheetlist.rs
+++ b/components/script/dom/stylesheetlist.rs
@@ -83,11 +83,15 @@ impl StyleSheetList {
     }
 
     #[cfg_attr(crown, allow(crown::unrooted_must_root))]
-    pub(crate) fn new(window: &Window, doc_or_sr: StyleSheetListOwner) -> DomRoot<StyleSheetList> {
+    pub(crate) fn new(
+        window: &Window,
+        doc_or_sr: StyleSheetListOwner,
+        can_gc: CanGc,
+    ) -> DomRoot<StyleSheetList> {
         reflect_dom_object(
             Box::new(StyleSheetList::new_inherited(doc_or_sr)),
             window,
-            CanGc::note(),
+            can_gc,
         )
     }
 }

--- a/components/script/dom/subtlecrypto.rs
+++ b/components/script/dom/subtlecrypto.rs
@@ -127,12 +127,8 @@ impl SubtleCrypto {
         }
     }
 
-    pub(crate) fn new(global: &GlobalScope) -> DomRoot<SubtleCrypto> {
-        reflect_dom_object(
-            Box::new(SubtleCrypto::new_inherited()),
-            global,
-            CanGc::note(),
-        )
+    pub(crate) fn new(global: &GlobalScope, can_gc: CanGc) -> DomRoot<SubtleCrypto> {
+        reflect_dom_object(Box::new(SubtleCrypto::new_inherited()), global, can_gc)
     }
 }
 
@@ -2081,6 +2077,7 @@ impl SubtleCrypto {
             algorithm_object.handle(),
             usages,
             handle,
+            CanGc::note(),
         );
 
         Ok(crypto_key)
@@ -2158,6 +2155,7 @@ impl SubtleCrypto {
             algorithm_object.handle(),
             usages,
             Handle::Hmac(key_data),
+            CanGc::note(),
         );
 
         // Step 15. Return key.
@@ -2216,6 +2214,7 @@ impl SubtleCrypto {
             algorithm_object.handle(),
             usages,
             handle,
+            CanGc::note(),
         );
 
         Ok(crypto_key)
@@ -2320,6 +2319,7 @@ impl SubtleCrypto {
                 algorithm_object.handle(),
                 usages,
                 Handle::Hkdf(data.to_vec()),
+                CanGc::note(),
             );
 
             // Step 8. Return key.
@@ -2417,6 +2417,7 @@ impl SubtleCrypto {
             algorithm_object.handle(),
             usages,
             Handle::Hmac(truncated_data),
+            CanGc::note(),
         );
 
         // Step 15. Return key.
@@ -2568,6 +2569,7 @@ impl SubtleCrypto {
             algorithm_object.handle(),
             usages,
             Handle::Pbkdf2(data.to_vec()),
+            CanGc::note(),
         );
 
         // Step 9. Return key.

--- a/components/script/dom/svgelement.rs
+++ b/components/script/dom/svgelement.rs
@@ -76,6 +76,7 @@ impl SVGElementMethods<crate::DomTypeHolder> for SVGElement {
                 CSSStyleOwner::Element(Dom::from_ref(self.upcast())),
                 None,
                 CSSModificationAccess::ReadWrite,
+                CanGc::note(),
             )
         })
     }

--- a/components/script/dom/testbinding.rs
+++ b/components/script/dom/testbinding.rs
@@ -1017,6 +1017,7 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
             &global,
             resolve.map(SimpleHandler::new_boxed),
             reject.map(SimpleHandler::new_boxed),
+            can_gc,
         );
         let p = Promise::new_in_current_realm(comp, can_gc);
         p.append_native_handler(&handler, comp, can_gc);

--- a/components/script/dom/testworklet.rs
+++ b/components/script/dom/testworklet.rs
@@ -38,7 +38,7 @@ impl TestWorklet {
     }
 
     fn new(window: &Window, proto: Option<HandleObject>, can_gc: CanGc) -> DomRoot<TestWorklet> {
-        let worklet = Worklet::new(window, WorkletGlobalScopeType::Test);
+        let worklet = Worklet::new(window, WorkletGlobalScopeType::Test, can_gc);
         reflect_dom_object_with_proto(
             Box::new(TestWorklet::new_inherited(&worklet)),
             window,

--- a/components/script/dom/textmetrics.rs
+++ b/components/script/dom/textmetrics.rs
@@ -78,6 +78,7 @@ impl TextMetrics {
         hangingBaseline: f64,
         alphabeticBaseline: f64,
         ideographicBaseline: f64,
+        can_gc: CanGc,
     ) -> DomRoot<TextMetrics> {
         reflect_dom_object(
             Box::new(TextMetrics::new_inherited(
@@ -95,7 +96,7 @@ impl TextMetrics {
                 ideographicBaseline,
             )),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 }

--- a/components/script/dom/texttrack.rs
+++ b/components/script/dom/texttrack.rs
@@ -54,6 +54,7 @@ impl TextTrack {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         window: &Window,
         id: DOMString,
@@ -62,19 +63,20 @@ impl TextTrack {
         language: DOMString,
         mode: TextTrackMode,
         track_list: Option<&TextTrackList>,
+        can_gc: CanGc,
     ) -> DomRoot<TextTrack> {
         reflect_dom_object(
             Box::new(TextTrack::new_inherited(
                 id, kind, label, language, mode, track_list,
             )),
             window,
-            CanGc::note(),
+            can_gc,
         )
     }
 
     pub(crate) fn get_cues(&self) -> DomRoot<TextTrackCueList> {
         self.cue_list
-            .or_init(|| TextTrackCueList::new(self.global().as_window(), &[]))
+            .or_init(|| TextTrackCueList::new(self.global().as_window(), &[], CanGc::note()))
     }
 
     pub(crate) fn id(&self) -> &str {
@@ -133,7 +135,11 @@ impl TextTrackMethods<crate::DomTypeHolder> for TextTrack {
     fn GetActiveCues(&self) -> Option<DomRoot<TextTrackCueList>> {
         // XXX implement active cues logic
         //      https://github.com/servo/servo/issues/22314
-        Some(TextTrackCueList::new(self.global().as_window(), &[]))
+        Some(TextTrackCueList::new(
+            self.global().as_window(),
+            &[],
+            CanGc::note(),
+        ))
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-texttrack-addcue

--- a/components/script/dom/texttrackcue.rs
+++ b/components/script/dom/texttrackcue.rs
@@ -51,11 +51,12 @@ impl TextTrackCue {
         start_time: f64,
         end_time: f64,
         track: Option<&TextTrack>,
+        can_gc: CanGc,
     ) -> DomRoot<TextTrackCue> {
         reflect_dom_object(
             Box::new(TextTrackCue::new_inherited(id, start_time, end_time, track)),
             window,
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/texttrackcuelist.rs
+++ b/components/script/dom/texttrackcuelist.rs
@@ -27,11 +27,15 @@ impl TextTrackCueList {
         }
     }
 
-    pub(crate) fn new(window: &Window, cues: &[&TextTrackCue]) -> DomRoot<TextTrackCueList> {
+    pub(crate) fn new(
+        window: &Window,
+        cues: &[&TextTrackCue],
+        can_gc: CanGc,
+    ) -> DomRoot<TextTrackCueList> {
         reflect_dom_object(
             Box::new(TextTrackCueList::new_inherited(cues)),
             window,
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/texttracklist.rs
+++ b/components/script/dom/texttracklist.rs
@@ -33,11 +33,15 @@ impl TextTrackList {
         }
     }
 
-    pub(crate) fn new(window: &Window, tracks: &[&TextTrack]) -> DomRoot<TextTrackList> {
+    pub(crate) fn new(
+        window: &Window,
+        tracks: &[&TextTrack],
+        can_gc: CanGc,
+    ) -> DomRoot<TextTrackList> {
         reflect_dom_object(
             Box::new(TextTrackList::new_inherited(tracks)),
             window,
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/timeranges.rs
+++ b/components/script/dom/timeranges.rs
@@ -140,12 +140,12 @@ impl TimeRanges {
         }
     }
 
-    pub(crate) fn new(window: &Window, ranges: TimeRangesContainer) -> DomRoot<TimeRanges> {
-        reflect_dom_object(
-            Box::new(TimeRanges::new_inherited(ranges)),
-            window,
-            CanGc::note(),
-        )
+    pub(crate) fn new(
+        window: &Window,
+        ranges: TimeRangesContainer,
+        can_gc: CanGc,
+    ) -> DomRoot<TimeRanges> {
+        reflect_dom_object(Box::new(TimeRanges::new_inherited(ranges)), window, can_gc)
     }
 }
 

--- a/components/script/dom/touch.rs
+++ b/components/script/dom/touch.rs
@@ -61,13 +61,14 @@ impl Touch {
         client_y: Finite<f64>,
         page_x: Finite<f64>,
         page_y: Finite<f64>,
+        can_gc: CanGc,
     ) -> DomRoot<Touch> {
         reflect_dom_object(
             Box::new(Touch::new_inherited(
                 identifier, target, screen_x, screen_y, client_x, client_y, page_x, page_y,
             )),
             window,
-            CanGc::note(),
+            can_gc,
         )
     }
 }

--- a/components/script/dom/touchevent.rs
+++ b/components/script/dom/touchevent.rs
@@ -53,6 +53,7 @@ impl TouchEvent {
         touches: &TouchList,
         changed_touches: &TouchList,
         target_touches: &TouchList,
+        can_gc: CanGc,
     ) -> DomRoot<TouchEvent> {
         reflect_dom_object(
             Box::new(TouchEvent::new_inherited(
@@ -61,7 +62,7 @@ impl TouchEvent {
                 target_touches,
             )),
             window,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -81,7 +82,13 @@ impl TouchEvent {
         shift_key: bool,
         meta_key: bool,
     ) -> DomRoot<TouchEvent> {
-        let ev = TouchEvent::new_uninitialized(window, touches, changed_touches, target_touches);
+        let ev = TouchEvent::new_uninitialized(
+            window,
+            touches,
+            changed_touches,
+            target_touches,
+            CanGc::note(),
+        );
         ev.upcast::<UIEvent>().InitUIEvent(
             type_,
             bool::from(can_bubble),

--- a/components/script/dom/touchlist.rs
+++ b/components/script/dom/touchlist.rs
@@ -25,12 +25,8 @@ impl TouchList {
         }
     }
 
-    pub(crate) fn new(window: &Window, touches: &[&Touch]) -> DomRoot<TouchList> {
-        reflect_dom_object(
-            Box::new(TouchList::new_inherited(touches)),
-            window,
-            CanGc::note(),
-        )
+    pub(crate) fn new(window: &Window, touches: &[&Touch], can_gc: CanGc) -> DomRoot<TouchList> {
+        reflect_dom_object(Box::new(TouchList::new_inherited(touches)), window, can_gc)
     }
 }
 

--- a/components/script/dom/treewalker.rs
+++ b/components/script/dom/treewalker.rs
@@ -47,11 +47,12 @@ impl TreeWalker {
         root_node: &Node,
         what_to_show: u32,
         filter: Filter,
+        can_gc: CanGc,
     ) -> DomRoot<TreeWalker> {
         reflect_dom_object(
             Box::new(TreeWalker::new_inherited(root_node, what_to_show, filter)),
             document.window(),
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -65,7 +66,7 @@ impl TreeWalker {
             None => Filter::None,
             Some(jsfilter) => Filter::Dom(jsfilter),
         };
-        TreeWalker::new_with_filter(document, root_node, what_to_show, filter)
+        TreeWalker::new_with_filter(document, root_node, what_to_show, filter, CanGc::note())
     }
 }
 

--- a/components/script/dom/validitystate.rs
+++ b/components/script/dom/validitystate.rs
@@ -91,11 +91,11 @@ impl ValidityState {
         }
     }
 
-    pub(crate) fn new(window: &Window, element: &Element) -> DomRoot<ValidityState> {
+    pub(crate) fn new(window: &Window, element: &Element, can_gc: CanGc) -> DomRoot<ValidityState> {
         reflect_dom_object(
             Box::new(ValidityState::new_inherited(element)),
             window,
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/videotrack.rs
+++ b/components/script/dom/videotrack.rs
@@ -52,13 +52,14 @@ impl VideoTrack {
         label: DOMString,
         language: DOMString,
         track_list: Option<&VideoTrackList>,
+        can_gc: CanGc,
     ) -> DomRoot<VideoTrack> {
         reflect_dom_object(
             Box::new(VideoTrack::new_inherited(
                 id, kind, label, language, track_list,
             )),
             window,
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/videotracklist.rs
+++ b/components/script/dom/videotracklist.rs
@@ -40,11 +40,12 @@ impl VideoTrackList {
         window: &Window,
         tracks: &[&VideoTrack],
         media_element: Option<&HTMLMediaElement>,
+        can_gc: CanGc,
     ) -> DomRoot<VideoTrackList> {
         reflect_dom_object(
             Box::new(VideoTrackList::new_inherited(tracks, media_element)),
             window,
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/visibilitystateentry.rs
+++ b/components/script/dom/visibilitystateentry.rs
@@ -48,11 +48,12 @@ impl VisibilityStateEntry {
         global: &GlobalScope,
         state: DocumentVisibilityState,
         timestamp: CrossProcessInstant,
+        can_gc: CanGc,
     ) -> DomRoot<VisibilityStateEntry> {
         reflect_dom_object(
             Box::new(VisibilityStateEntry::new_inherited(state, timestamp)),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 }

--- a/components/script/dom/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl2renderingcontext.rs
@@ -3547,7 +3547,7 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.12>
     fn CreateQuery(&self) -> Option<DomRoot<WebGLQuery>> {
-        Some(WebGLQuery::new(&self.base))
+        Some(WebGLQuery::new(&self.base, CanGc::note()))
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.12>
@@ -3588,7 +3588,7 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.13>
     fn CreateSampler(&self) -> Option<DomRoot<WebGLSampler>> {
-        Some(WebGLSampler::new(&self.base))
+        Some(WebGLSampler::new(&self.base, CanGc::note()))
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.13>
@@ -3728,7 +3728,7 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
             return None;
         }
 
-        Some(WebGLSync::new(&self.base))
+        Some(WebGLSync::new(&self.base, CanGc::note()))
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.14>
@@ -3911,7 +3911,7 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.15>
     fn CreateTransformFeedback(&self) -> Option<DomRoot<WebGLTransformFeedback>> {
-        Some(WebGLTransformFeedback::new(&self.base))
+        Some(WebGLTransformFeedback::new(&self.base, CanGc::note()))
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.15>
@@ -4114,6 +4114,7 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
             size,
             ty,
             DOMString::from(name),
+            CanGc::note(),
         ))
     }
 

--- a/components/script/dom/webgl_extensions/ext/angleinstancedarrays.rs
+++ b/components/script/dom/webgl_extensions/ext/angleinstancedarrays.rs
@@ -32,11 +32,11 @@ impl ANGLEInstancedArrays {
 impl WebGLExtension for ANGLEInstancedArrays {
     type Extension = Self;
 
-    fn new(ctx: &WebGLRenderingContext) -> DomRoot<Self> {
+    fn new(ctx: &WebGLRenderingContext, can_gc: CanGc) -> DomRoot<Self> {
         reflect_dom_object(
             Box::new(ANGLEInstancedArrays::new_inherited(ctx)),
             &*ctx.global(),
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/webgl_extensions/ext/extblendminmax.rs
+++ b/components/script/dom/webgl_extensions/ext/extblendminmax.rs
@@ -27,12 +27,8 @@ impl EXTBlendMinmax {
 impl WebGLExtension for EXTBlendMinmax {
     type Extension = Self;
 
-    fn new(ctx: &WebGLRenderingContext) -> DomRoot<Self> {
-        reflect_dom_object(
-            Box::new(Self::new_inherited()),
-            &*ctx.global(),
-            CanGc::note(),
-        )
+    fn new(ctx: &WebGLRenderingContext, can_gc: CanGc) -> DomRoot<Self> {
+        reflect_dom_object(Box::new(Self::new_inherited()), &*ctx.global(), can_gc)
     }
 
     fn spec() -> WebGLExtensionSpec {

--- a/components/script/dom/webgl_extensions/ext/extcolorbufferhalffloat.rs
+++ b/components/script/dom/webgl_extensions/ext/extcolorbufferhalffloat.rs
@@ -27,11 +27,11 @@ impl EXTColorBufferHalfFloat {
 
 impl WebGLExtension for EXTColorBufferHalfFloat {
     type Extension = EXTColorBufferHalfFloat;
-    fn new(ctx: &WebGLRenderingContext) -> DomRoot<EXTColorBufferHalfFloat> {
+    fn new(ctx: &WebGLRenderingContext, can_gc: CanGc) -> DomRoot<EXTColorBufferHalfFloat> {
         reflect_dom_object(
             Box::new(EXTColorBufferHalfFloat::new_inherited()),
             &*ctx.global(),
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/webgl_extensions/ext/extfragdepth.rs
+++ b/components/script/dom/webgl_extensions/ext/extfragdepth.rs
@@ -27,12 +27,8 @@ impl EXTFragDepth {
 impl WebGLExtension for EXTFragDepth {
     type Extension = Self;
 
-    fn new(ctx: &WebGLRenderingContext) -> DomRoot<Self> {
-        reflect_dom_object(
-            Box::new(Self::new_inherited()),
-            &*ctx.global(),
-            CanGc::note(),
-        )
+    fn new(ctx: &WebGLRenderingContext, can_gc: CanGc) -> DomRoot<Self> {
+        reflect_dom_object(Box::new(Self::new_inherited()), &*ctx.global(), can_gc)
     }
 
     fn spec() -> WebGLExtensionSpec {

--- a/components/script/dom/webgl_extensions/ext/extshadertexturelod.rs
+++ b/components/script/dom/webgl_extensions/ext/extshadertexturelod.rs
@@ -27,12 +27,8 @@ impl EXTShaderTextureLod {
 impl WebGLExtension for EXTShaderTextureLod {
     type Extension = Self;
 
-    fn new(ctx: &WebGLRenderingContext) -> DomRoot<Self> {
-        reflect_dom_object(
-            Box::new(Self::new_inherited()),
-            &*ctx.global(),
-            CanGc::note(),
-        )
+    fn new(ctx: &WebGLRenderingContext, can_gc: CanGc) -> DomRoot<Self> {
+        reflect_dom_object(Box::new(Self::new_inherited()), &*ctx.global(), can_gc)
     }
 
     fn spec() -> WebGLExtensionSpec {

--- a/components/script/dom/webgl_extensions/ext/exttexturefilteranisotropic.rs
+++ b/components/script/dom/webgl_extensions/ext/exttexturefilteranisotropic.rs
@@ -28,12 +28,8 @@ impl EXTTextureFilterAnisotropic {
 impl WebGLExtension for EXTTextureFilterAnisotropic {
     type Extension = EXTTextureFilterAnisotropic;
 
-    fn new(ctx: &WebGLRenderingContext) -> DomRoot<Self> {
-        reflect_dom_object(
-            Box::new(Self::new_inherited()),
-            &*ctx.global(),
-            CanGc::note(),
-        )
+    fn new(ctx: &WebGLRenderingContext, can_gc: CanGc) -> DomRoot<Self> {
+        reflect_dom_object(Box::new(Self::new_inherited()), &*ctx.global(), can_gc)
     }
 
     fn spec() -> WebGLExtensionSpec {

--- a/components/script/dom/webgl_extensions/ext/oeselementindexuint.rs
+++ b/components/script/dom/webgl_extensions/ext/oeselementindexuint.rs
@@ -27,11 +27,11 @@ impl OESElementIndexUint {
 impl WebGLExtension for OESElementIndexUint {
     type Extension = Self;
 
-    fn new(ctx: &WebGLRenderingContext) -> DomRoot<Self> {
+    fn new(ctx: &WebGLRenderingContext, can_gc: CanGc) -> DomRoot<Self> {
         reflect_dom_object(
             Box::new(OESElementIndexUint::new_inherited()),
             &*ctx.global(),
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/webgl_extensions/ext/oesstandardderivatives.rs
+++ b/components/script/dom/webgl_extensions/ext/oesstandardderivatives.rs
@@ -27,11 +27,11 @@ impl OESStandardDerivatives {
 
 impl WebGLExtension for OESStandardDerivatives {
     type Extension = OESStandardDerivatives;
-    fn new(ctx: &WebGLRenderingContext) -> DomRoot<OESStandardDerivatives> {
+    fn new(ctx: &WebGLRenderingContext, can_gc: CanGc) -> DomRoot<OESStandardDerivatives> {
         reflect_dom_object(
             Box::new(OESStandardDerivatives::new_inherited()),
             &*ctx.global(),
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/webgl_extensions/ext/oestexturefloat.rs
+++ b/components/script/dom/webgl_extensions/ext/oestexturefloat.rs
@@ -26,11 +26,11 @@ impl OESTextureFloat {
 
 impl WebGLExtension for OESTextureFloat {
     type Extension = OESTextureFloat;
-    fn new(ctx: &WebGLRenderingContext) -> DomRoot<OESTextureFloat> {
+    fn new(ctx: &WebGLRenderingContext, can_gc: CanGc) -> DomRoot<OESTextureFloat> {
         reflect_dom_object(
             Box::new(OESTextureFloat::new_inherited()),
             &*ctx.global(),
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/webgl_extensions/ext/oestexturefloatlinear.rs
+++ b/components/script/dom/webgl_extensions/ext/oestexturefloatlinear.rs
@@ -25,11 +25,11 @@ impl OESTextureFloatLinear {
 
 impl WebGLExtension for OESTextureFloatLinear {
     type Extension = OESTextureFloatLinear;
-    fn new(ctx: &WebGLRenderingContext) -> DomRoot<OESTextureFloatLinear> {
+    fn new(ctx: &WebGLRenderingContext, can_gc: CanGc) -> DomRoot<OESTextureFloatLinear> {
         reflect_dom_object(
             Box::new(OESTextureFloatLinear::new_inherited()),
             &*ctx.global(),
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/webgl_extensions/ext/oestexturehalffloat.rs
+++ b/components/script/dom/webgl_extensions/ext/oestexturehalffloat.rs
@@ -27,11 +27,11 @@ impl OESTextureHalfFloat {
 
 impl WebGLExtension for OESTextureHalfFloat {
     type Extension = OESTextureHalfFloat;
-    fn new(ctx: &WebGLRenderingContext) -> DomRoot<OESTextureHalfFloat> {
+    fn new(ctx: &WebGLRenderingContext, can_gc: CanGc) -> DomRoot<OESTextureHalfFloat> {
         reflect_dom_object(
             Box::new(OESTextureHalfFloat::new_inherited()),
             &*ctx.global(),
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/webgl_extensions/ext/oestexturehalffloatlinear.rs
+++ b/components/script/dom/webgl_extensions/ext/oestexturehalffloatlinear.rs
@@ -26,11 +26,11 @@ impl OESTextureHalfFloatLinear {
 
 impl WebGLExtension for OESTextureHalfFloatLinear {
     type Extension = OESTextureHalfFloatLinear;
-    fn new(ctx: &WebGLRenderingContext) -> DomRoot<OESTextureHalfFloatLinear> {
+    fn new(ctx: &WebGLRenderingContext, can_gc: CanGc) -> DomRoot<OESTextureHalfFloatLinear> {
         reflect_dom_object(
             Box::new(OESTextureHalfFloatLinear::new_inherited()),
             &*ctx.global(),
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/webgl_extensions/ext/oesvertexarrayobject.rs
+++ b/components/script/dom/webgl_extensions/ext/oesvertexarrayobject.rs
@@ -54,11 +54,11 @@ impl OESVertexArrayObjectMethods<crate::DomTypeHolder> for OESVertexArrayObject 
 
 impl WebGLExtension for OESVertexArrayObject {
     type Extension = OESVertexArrayObject;
-    fn new(ctx: &WebGLRenderingContext) -> DomRoot<OESVertexArrayObject> {
+    fn new(ctx: &WebGLRenderingContext, can_gc: CanGc) -> DomRoot<OESVertexArrayObject> {
         reflect_dom_object(
             Box::new(OESVertexArrayObject::new_inherited(ctx)),
             &*ctx.global(),
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/webgl_extensions/ext/webglcolorbufferfloat.rs
+++ b/components/script/dom/webgl_extensions/ext/webglcolorbufferfloat.rs
@@ -27,11 +27,11 @@ impl WEBGLColorBufferFloat {
 
 impl WebGLExtension for WEBGLColorBufferFloat {
     type Extension = WEBGLColorBufferFloat;
-    fn new(ctx: &WebGLRenderingContext) -> DomRoot<WEBGLColorBufferFloat> {
+    fn new(ctx: &WebGLRenderingContext, can_gc: CanGc) -> DomRoot<WEBGLColorBufferFloat> {
         reflect_dom_object(
             Box::new(WEBGLColorBufferFloat::new_inherited()),
             &*ctx.global(),
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/webgl_extensions/ext/webglcompressedtextureetc1.rs
+++ b/components/script/dom/webgl_extensions/ext/webglcompressedtextureetc1.rs
@@ -27,11 +27,11 @@ impl WEBGLCompressedTextureETC1 {
 
 impl WebGLExtension for WEBGLCompressedTextureETC1 {
     type Extension = WEBGLCompressedTextureETC1;
-    fn new(ctx: &WebGLRenderingContext) -> DomRoot<WEBGLCompressedTextureETC1> {
+    fn new(ctx: &WebGLRenderingContext, can_gc: CanGc) -> DomRoot<WEBGLCompressedTextureETC1> {
         reflect_dom_object(
             Box::new(WEBGLCompressedTextureETC1::new_inherited()),
             &*ctx.global(),
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/webgl_extensions/ext/webglcompressedtextures3tc.rs
+++ b/components/script/dom/webgl_extensions/ext/webglcompressedtextures3tc.rs
@@ -27,11 +27,11 @@ impl WEBGLCompressedTextureS3TC {
 
 impl WebGLExtension for WEBGLCompressedTextureS3TC {
     type Extension = WEBGLCompressedTextureS3TC;
-    fn new(ctx: &WebGLRenderingContext) -> DomRoot<WEBGLCompressedTextureS3TC> {
+    fn new(ctx: &WebGLRenderingContext, can_gc: CanGc) -> DomRoot<WEBGLCompressedTextureS3TC> {
         reflect_dom_object(
             Box::new(WEBGLCompressedTextureS3TC::new_inherited()),
             &*ctx.global(),
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/webgl_extensions/extension.rs
+++ b/components/script/dom/webgl_extensions/extension.rs
@@ -9,6 +9,7 @@ use crate::dom::bindings::reflector::DomObject;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::trace::JSTraceable;
 use crate::dom::webglrenderingcontext::WebGLRenderingContext;
+use crate::script_runtime::CanGc;
 
 /// Trait implemented by WebGL extensions.
 pub(crate) trait WebGLExtension: Sized
@@ -19,7 +20,7 @@ where
     type Extension;
 
     /// Creates the DOM object of the WebGL extension.
-    fn new(ctx: &WebGLRenderingContext) -> DomRoot<Self::Extension>;
+    fn new(ctx: &WebGLRenderingContext, can_gc: CanGc) -> DomRoot<Self::Extension>;
 
     /// Returns which WebGL spec is this extension written against.
     fn spec() -> WebGLExtensionSpec;

--- a/components/script/dom/webgl_extensions/wrapper.rs
+++ b/components/script/dom/webgl_extensions/wrapper.rs
@@ -12,6 +12,7 @@ use crate::dom::bindings::reflector::DomObject;
 use crate::dom::bindings::root::MutNullableDom;
 use crate::dom::bindings::trace::JSTraceable;
 use crate::dom::webglrenderingcontext::WebGLRenderingContext;
+use crate::script_runtime::CanGc;
 
 /// Trait used internally by WebGLExtensions to store and
 /// handle the different WebGL extensions in a common list.
@@ -57,7 +58,7 @@ where
         let mut enabled = true;
         let extension = self.extension.or_init(|| {
             enabled = false;
-            T::new(ctx)
+            T::new(ctx, CanGc::note())
         });
         if !enabled {
             self.enable(ext);

--- a/components/script/dom/webglactiveinfo.rs
+++ b/components/script/dom/webglactiveinfo.rs
@@ -36,11 +36,12 @@ impl WebGLActiveInfo {
         size: i32,
         ty: u32,
         name: DOMString,
+        can_gc: CanGc,
     ) -> DomRoot<WebGLActiveInfo> {
         reflect_dom_object(
             Box::new(WebGLActiveInfo::new_inherited(size, ty, name)),
             window,
-            CanGc::note(),
+            can_gc,
         )
     }
 }

--- a/components/script/dom/webglbuffer.rs
+++ b/components/script/dom/webglbuffer.rs
@@ -56,14 +56,18 @@ impl WebGLBuffer {
         receiver
             .recv()
             .unwrap()
-            .map(|id| WebGLBuffer::new(context, id))
+            .map(|id| WebGLBuffer::new(context, id, CanGc::note()))
     }
 
-    pub(crate) fn new(context: &WebGLRenderingContext, id: WebGLBufferId) -> DomRoot<Self> {
+    pub(crate) fn new(
+        context: &WebGLRenderingContext,
+        id: WebGLBufferId,
+        can_gc: CanGc,
+    ) -> DomRoot<Self> {
         reflect_dom_object(
             Box::new(WebGLBuffer::new_inherited(context, id)),
             &*context.global(),
-            CanGc::note(),
+            can_gc,
         )
     }
 }

--- a/components/script/dom/webglframebuffer.rs
+++ b/components/script/dom/webglframebuffer.rs
@@ -143,7 +143,7 @@ impl WebGLFramebuffer {
         let (sender, receiver) = webgl_channel().unwrap();
         context.send_command(WebGLCommand::CreateFramebuffer(sender));
         let id = receiver.recv().unwrap()?;
-        let framebuffer = WebGLFramebuffer::new(context, id);
+        let framebuffer = WebGLFramebuffer::new(context, id, CanGc::note());
         Some(framebuffer)
     }
 
@@ -162,11 +162,15 @@ impl WebGLFramebuffer {
         Some(framebuffer)
     }
 
-    pub(crate) fn new(context: &WebGLRenderingContext, id: WebGLFramebufferId) -> DomRoot<Self> {
+    pub(crate) fn new(
+        context: &WebGLRenderingContext,
+        id: WebGLFramebufferId,
+        can_gc: CanGc,
+    ) -> DomRoot<Self> {
         reflect_dom_object(
             Box::new(WebGLFramebuffer::new_inherited(context, id)),
             &*context.global(),
-            CanGc::note(),
+            can_gc,
         )
     }
 }

--- a/components/script/dom/webglprogram.rs
+++ b/components/script/dom/webglprogram.rs
@@ -74,14 +74,18 @@ impl WebGLProgram {
         receiver
             .recv()
             .unwrap()
-            .map(|id| WebGLProgram::new(context, id))
+            .map(|id| WebGLProgram::new(context, id, CanGc::note()))
     }
 
-    pub(crate) fn new(context: &WebGLRenderingContext, id: WebGLProgramId) -> DomRoot<Self> {
+    pub(crate) fn new(
+        context: &WebGLRenderingContext,
+        id: WebGLProgramId,
+        can_gc: CanGc,
+    ) -> DomRoot<Self> {
         reflect_dom_object(
             Box::new(WebGLProgram::new_inherited(context, id)),
             &*context.global(),
-            CanGc::note(),
+            can_gc,
         )
     }
 }
@@ -328,6 +332,7 @@ impl WebGLProgram {
             data.size.unwrap_or(1),
             data.type_,
             data.name().into(),
+            CanGc::note(),
         ))
     }
 
@@ -345,6 +350,7 @@ impl WebGLProgram {
             data.size,
             data.type_,
             data.name.clone().into(),
+            CanGc::note(),
         ))
     }
 
@@ -451,6 +457,7 @@ impl WebGLProgram {
             self.link_generation.get(),
             size,
             type_,
+            CanGc::note(),
         )))
     }
 

--- a/components/script/dom/webglquery.rs
+++ b/components/script/dom/webglquery.rs
@@ -40,7 +40,7 @@ impl WebGLQuery {
         }
     }
 
-    pub(crate) fn new(context: &WebGLRenderingContext) -> DomRoot<Self> {
+    pub(crate) fn new(context: &WebGLRenderingContext, can_gc: CanGc) -> DomRoot<Self> {
         let (sender, receiver) = webgl_channel().unwrap();
         context.send_command(WebGLCommand::GenerateQuery(sender));
         let id = receiver.recv().unwrap();
@@ -48,7 +48,7 @@ impl WebGLQuery {
         reflect_dom_object(
             Box::new(Self::new_inherited(context, id)),
             &*context.global(),
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/webglrenderbuffer.rs
+++ b/components/script/dom/webglrenderbuffer.rs
@@ -55,14 +55,18 @@ impl WebGLRenderbuffer {
         receiver
             .recv()
             .unwrap()
-            .map(|id| WebGLRenderbuffer::new(context, id))
+            .map(|id| WebGLRenderbuffer::new(context, id, CanGc::note()))
     }
 
-    pub(crate) fn new(context: &WebGLRenderingContext, id: WebGLRenderbufferId) -> DomRoot<Self> {
+    pub(crate) fn new(
+        context: &WebGLRenderingContext,
+        id: WebGLRenderbufferId,
+        can_gc: CanGc,
+    ) -> DomRoot<Self> {
         reflect_dom_object(
             Box::new(WebGLRenderbuffer::new_inherited(context, id)),
             &*context.global(),
-            CanGc::note(),
+            can_gc,
         )
     }
 }

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -333,7 +333,7 @@ impl WebGLRenderingContext {
         self.current_vao.or_init(|| {
             DomRoot::from_ref(
                 self.default_vao
-                    .init_once(|| WebGLVertexArrayObjectOES::new(self, None)),
+                    .init_once(|| WebGLVertexArrayObjectOES::new(self, None, CanGc::note())),
             )
         })
     }
@@ -342,7 +342,7 @@ impl WebGLRenderingContext {
         self.current_vao_webgl2.or_init(|| {
             DomRoot::from_ref(
                 self.default_vao_webgl2
-                    .init_once(|| WebGLVertexArrayObject::new(self, None)),
+                    .init_once(|| WebGLVertexArrayObject::new(self, None, CanGc::note())),
             )
         })
     }
@@ -1189,7 +1189,7 @@ impl WebGLRenderingContext {
         receiver
             .recv()
             .unwrap()
-            .map(|id| WebGLVertexArrayObjectOES::new(self, Some(id)))
+            .map(|id| WebGLVertexArrayObjectOES::new(self, Some(id), CanGc::note()))
     }
 
     pub(crate) fn create_vertex_array_webgl2(&self) -> Option<DomRoot<WebGLVertexArrayObject>> {
@@ -1198,7 +1198,7 @@ impl WebGLRenderingContext {
         receiver
             .recv()
             .unwrap()
-            .map(|id| WebGLVertexArrayObject::new(self, Some(id)))
+            .map(|id| WebGLVertexArrayObject::new(self, Some(id), CanGc::note()))
     }
 
     pub(crate) fn delete_vertex_array(&self, vao: Option<&WebGLVertexArrayObjectOES>) {
@@ -3453,6 +3453,7 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
             range_min,
             range_max,
             precision,
+            CanGc::note(),
         ))
     }
 

--- a/components/script/dom/webglsampler.rs
+++ b/components/script/dom/webglsampler.rs
@@ -83,7 +83,7 @@ impl WebGLSampler {
         }
     }
 
-    pub(crate) fn new(context: &WebGLRenderingContext) -> DomRoot<Self> {
+    pub(crate) fn new(context: &WebGLRenderingContext, can_gc: CanGc) -> DomRoot<Self> {
         let (sender, receiver) = webgl_channel().unwrap();
         context.send_command(WebGLCommand::GenerateSampler(sender));
         let id = receiver.recv().unwrap();
@@ -91,7 +91,7 @@ impl WebGLSampler {
         reflect_dom_object(
             Box::new(Self::new_inherited(context, id)),
             &*context.global(),
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/webglshader.rs
+++ b/components/script/dom/webglshader.rs
@@ -73,18 +73,19 @@ impl WebGLShader {
         receiver
             .recv()
             .unwrap()
-            .map(|id| WebGLShader::new(context, id, shader_type))
+            .map(|id| WebGLShader::new(context, id, shader_type, CanGc::note()))
     }
 
     pub(crate) fn new(
         context: &WebGLRenderingContext,
         id: WebGLShaderId,
         shader_type: u32,
+        can_gc: CanGc,
     ) -> DomRoot<Self> {
         reflect_dom_object(
             Box::new(WebGLShader::new_inherited(context, id, shader_type)),
             &*context.global(),
-            CanGc::note(),
+            can_gc,
         )
     }
 }

--- a/components/script/dom/webglshaderprecisionformat.rs
+++ b/components/script/dom/webglshaderprecisionformat.rs
@@ -36,13 +36,14 @@ impl WebGLShaderPrecisionFormat {
         range_min: i32,
         range_max: i32,
         precision: i32,
+        can_gc: CanGc,
     ) -> DomRoot<WebGLShaderPrecisionFormat> {
         reflect_dom_object(
             Box::new(WebGLShaderPrecisionFormat::new_inherited(
                 range_min, range_max, precision,
             )),
             window,
-            CanGc::note(),
+            can_gc,
         )
     }
 }

--- a/components/script/dom/webglsync.rs
+++ b/components/script/dom/webglsync.rs
@@ -37,7 +37,7 @@ impl WebGLSync {
         }
     }
 
-    pub(crate) fn new(context: &WebGLRenderingContext) -> DomRoot<Self> {
+    pub(crate) fn new(context: &WebGLRenderingContext, can_gc: CanGc) -> DomRoot<Self> {
         let (sender, receiver) = webgl_channel().unwrap();
         context.send_command(WebGLCommand::FenceSync(sender));
         let sync_id = receiver.recv().unwrap();
@@ -45,7 +45,7 @@ impl WebGLSync {
         reflect_dom_object(
             Box::new(WebGLSync::new_inherited(context, sync_id)),
             &*context.global(),
-            CanGc::note(),
+            can_gc,
         )
     }
 }

--- a/components/script/dom/webgltexture.rs
+++ b/components/script/dom/webgltexture.rs
@@ -105,10 +105,14 @@ impl WebGLTexture {
         receiver
             .recv()
             .unwrap()
-            .map(|id| WebGLTexture::new(context, id))
+            .map(|id| WebGLTexture::new(context, id, CanGc::note()))
     }
 
-    pub(crate) fn new(context: &WebGLRenderingContext, id: WebGLTextureId) -> DomRoot<Self> {
+    pub(crate) fn new(
+        context: &WebGLRenderingContext,
+        id: WebGLTextureId,
+        can_gc: CanGc,
+    ) -> DomRoot<Self> {
         reflect_dom_object(
             Box::new(WebGLTexture::new_inherited(
                 context,
@@ -117,7 +121,7 @@ impl WebGLTexture {
                 None,
             )),
             &*context.global(),
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -126,11 +130,12 @@ impl WebGLTexture {
         context: &WebGLRenderingContext,
         id: WebGLTextureId,
         session: &XRSession,
+        can_gc: CanGc,
     ) -> DomRoot<Self> {
         reflect_dom_object(
             Box::new(WebGLTexture::new_inherited(context, id, Some(session))),
             &*context.global(),
-            CanGc::note(),
+            can_gc,
         )
     }
 }

--- a/components/script/dom/webgltransformfeedback.rs
+++ b/components/script/dom/webgltransformfeedback.rs
@@ -36,7 +36,7 @@ impl WebGLTransformFeedback {
         }
     }
 
-    pub(crate) fn new(context: &WebGLRenderingContext) -> DomRoot<Self> {
+    pub(crate) fn new(context: &WebGLRenderingContext, can_gc: CanGc) -> DomRoot<Self> {
         let (sender, receiver) = webgl_channel().unwrap();
         context.send_command(WebGLCommand::CreateTransformFeedback(sender));
         let id = receiver.recv().unwrap();
@@ -44,7 +44,7 @@ impl WebGLTransformFeedback {
         reflect_dom_object(
             Box::new(WebGLTransformFeedback::new_inherited(context, id)),
             &*context.global(),
-            CanGc::note(),
+            can_gc,
         )
     }
 }

--- a/components/script/dom/webgluniformlocation.rs
+++ b/components/script/dom/webgluniformlocation.rs
@@ -44,6 +44,7 @@ impl WebGLUniformLocation {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         window: &Window,
         id: i32,
@@ -52,6 +53,7 @@ impl WebGLUniformLocation {
         link_generation: u64,
         size: Option<i32>,
         type_: u32,
+        can_gc: CanGc,
     ) -> DomRoot<Self> {
         reflect_dom_object(
             Box::new(Self::new_inherited(
@@ -63,7 +65,7 @@ impl WebGLUniformLocation {
                 type_,
             )),
             window,
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/webglvertexarrayobject.rs
+++ b/components/script/dom/webglvertexarrayobject.rs
@@ -31,11 +31,12 @@ impl WebGLVertexArrayObject {
     pub(crate) fn new(
         context: &WebGLRenderingContext,
         id: Option<WebGLVertexArrayId>,
+        can_gc: CanGc,
     ) -> DomRoot<Self> {
         reflect_dom_object(
             Box::new(WebGLVertexArrayObject::new_inherited(context, id)),
             &*context.global(),
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/webglvertexarrayobjectoes.rs
+++ b/components/script/dom/webglvertexarrayobjectoes.rs
@@ -31,11 +31,12 @@ impl WebGLVertexArrayObjectOES {
     pub(crate) fn new(
         context: &WebGLRenderingContext,
         id: Option<WebGLVertexArrayId>,
+        can_gc: CanGc,
     ) -> DomRoot<Self> {
         reflect_dom_object(
             Box::new(WebGLVertexArrayObjectOES::new_inherited(context, id)),
             &*context.global(),
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/webgpu/gpu.rs
+++ b/components/script/dom/webgpu/gpu.rs
@@ -43,8 +43,8 @@ impl GPU {
         }
     }
 
-    pub(crate) fn new(global: &GlobalScope) -> DomRoot<GPU> {
-        reflect_dom_object(Box::new(GPU::new_inherited()), global, CanGc::note())
+    pub(crate) fn new(global: &GlobalScope, can_gc: CanGc) -> DomRoot<GPU> {
+        reflect_dom_object(Box::new(GPU::new_inherited()), global, can_gc)
     }
 }
 

--- a/components/script/dom/webgpu/gpuadapter.rs
+++ b/components/script/dom/webgpu/gpuadapter.rs
@@ -79,14 +79,14 @@ impl GPUAdapter {
         can_gc: CanGc,
     ) -> DomRoot<Self> {
         let features = GPUSupportedFeatures::Constructor(global, None, features, can_gc).unwrap();
-        let limits = GPUSupportedLimits::new(global, limits);
-        let info = GPUAdapterInfo::new(global, info);
+        let limits = GPUSupportedLimits::new(global, limits, can_gc);
+        let info = GPUAdapterInfo::new(global, info, can_gc);
         reflect_dom_object(
             Box::new(GPUAdapter::new_inherited(
                 channel, name, extensions, &features, &limits, &info, adapter,
             )),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 }

--- a/components/script/dom/webgpu/gpuadapterinfo.rs
+++ b/components/script/dom/webgpu/gpuadapterinfo.rs
@@ -28,8 +28,8 @@ impl GPUAdapterInfo {
         }
     }
 
-    pub(crate) fn new(global: &GlobalScope, info: AdapterInfo) -> DomRoot<Self> {
-        reflect_dom_object(Box::new(Self::new_inherited(info)), global, CanGc::note())
+    pub(crate) fn new(global: &GlobalScope, info: AdapterInfo, can_gc: CanGc) -> DomRoot<Self> {
+        reflect_dom_object(Box::new(Self::new_inherited(info)), global, can_gc)
     }
 }
 

--- a/components/script/dom/webgpu/gpubindgroup.rs
+++ b/components/script/dom/webgpu/gpubindgroup.rs
@@ -60,13 +60,14 @@ impl GPUBindGroup {
         device: WebGPUDevice,
         layout: &GPUBindGroupLayout,
         label: USVString,
+        can_gc: CanGc,
     ) -> DomRoot<Self> {
         reflect_dom_object(
             Box::new(GPUBindGroup::new_inherited(
                 channel, bind_group, device, layout, label,
             )),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 }
@@ -113,6 +114,7 @@ impl GPUBindGroup {
             device.id(),
             &descriptor.layout,
             descriptor.parent.label.clone(),
+            CanGc::note(),
         )
     }
 }

--- a/components/script/dom/webgpu/gpubindgrouplayout.rs
+++ b/components/script/dom/webgpu/gpubindgrouplayout.rs
@@ -52,6 +52,7 @@ impl GPUBindGroupLayout {
         channel: WebGPU,
         bind_group_layout: WebGPUBindGroupLayout,
         label: USVString,
+        can_gc: CanGc,
     ) -> DomRoot<Self> {
         reflect_dom_object(
             Box::new(GPUBindGroupLayout::new_inherited(
@@ -60,7 +61,7 @@ impl GPUBindGroupLayout {
                 label,
             )),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 }
@@ -110,6 +111,7 @@ impl GPUBindGroupLayout {
             device.channel().clone(),
             bgl,
             descriptor.parent.label.clone(),
+            CanGc::note(),
         ))
     }
 }

--- a/components/script/dom/webgpu/gpubuffer.rs
+++ b/components/script/dom/webgpu/gpubuffer.rs
@@ -116,13 +116,14 @@ impl GPUBuffer {
         usage: GPUFlagsConstant,
         mapping: Option<ActiveBufferMapping>,
         label: USVString,
+        can_gc: CanGc,
     ) -> DomRoot<Self> {
         reflect_dom_object(
             Box::new(GPUBuffer::new_inherited(
                 channel, buffer, device, size, usage, mapping, label,
             )),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 }
@@ -174,6 +175,7 @@ impl GPUBuffer {
             descriptor.usage,
             mapping,
             descriptor.parent.label.clone(),
+            CanGc::note(),
         ))
     }
 }

--- a/components/script/dom/webgpu/gpucanvascontext.rs
+++ b/components/script/dom/webgpu/gpucanvascontext.rs
@@ -144,6 +144,7 @@ impl GPUCanvasContext {
         global: &GlobalScope,
         canvas: &HTMLCanvasElement,
         channel: WebGPU,
+        can_gc: CanGc,
     ) -> DomRoot<Self> {
         let document = canvas.owner_document();
         let this = reflect_dom_object(
@@ -154,7 +155,7 @@ impl GPUCanvasContext {
                 document.webgpu_contexts(),
             )),
             global,
-            CanGc::note(),
+            can_gc,
         );
         this.webgpu_contexts
             .borrow_mut()

--- a/components/script/dom/webgpu/gpucommandbuffer.rs
+++ b/components/script/dom/webgpu/gpucommandbuffer.rs
@@ -43,6 +43,7 @@ impl GPUCommandBuffer {
         channel: WebGPU,
         command_buffer: WebGPUCommandBuffer,
         label: USVString,
+        can_gc: CanGc,
     ) -> DomRoot<Self> {
         reflect_dom_object(
             Box::new(GPUCommandBuffer::new_inherited(
@@ -51,7 +52,7 @@ impl GPUCommandBuffer {
                 label,
             )),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 }

--- a/components/script/dom/webgpu/gpucommandencoder.rs
+++ b/components/script/dom/webgpu/gpucommandencoder.rs
@@ -63,13 +63,14 @@ impl GPUCommandEncoder {
         device: &GPUDevice,
         encoder: WebGPUCommandEncoder,
         label: USVString,
+        can_gc: CanGc,
     ) -> DomRoot<Self> {
         reflect_dom_object(
             Box::new(GPUCommandEncoder::new_inherited(
                 channel, device, encoder, label,
             )),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 }
@@ -109,6 +110,7 @@ impl GPUCommandEncoder {
             device,
             encoder,
             descriptor.parent.label.clone(),
+            CanGc::note(),
         )
     }
 }
@@ -146,6 +148,7 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
             self,
             WebGPUComputePass(compute_pass_id),
             descriptor.parent.label.clone(),
+            CanGc::note(),
         )
     }
 
@@ -215,6 +218,7 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
             WebGPURenderPass(render_pass_id),
             self,
             descriptor.parent.label.clone(),
+            CanGc::note(),
         ))
     }
 
@@ -319,6 +323,7 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
             self.channel.clone(),
             buffer,
             descriptor.parent.label.clone(),
+            CanGc::note(),
         )
     }
 }

--- a/components/script/dom/webgpu/gpucompilationmessage.rs
+++ b/components/script/dom/webgpu/gpucompilationmessage.rs
@@ -48,6 +48,7 @@ impl GPUCompilationMessage {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         global: &GlobalScope,
         message: DOMString,
@@ -56,13 +57,14 @@ impl GPUCompilationMessage {
         line_pos: u64,
         offset: u64,
         length: u64,
+        can_gc: CanGc,
     ) -> DomRoot<Self> {
         reflect_dom_object(
             Box::new(Self::new_inherited(
                 message, mtype, line_num, line_pos, offset, length,
             )),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -75,6 +77,7 @@ impl GPUCompilationMessage {
             info.line_pos,
             info.offset,
             info.length,
+            CanGc::note(),
         )
     }
 }

--- a/components/script/dom/webgpu/gpucomputepassencoder.rs
+++ b/components/script/dom/webgpu/gpucomputepassencoder.rs
@@ -51,6 +51,7 @@ impl GPUComputePassEncoder {
         parent: &GPUCommandEncoder,
         compute_pass: WebGPUComputePass,
         label: USVString,
+        can_gc: CanGc,
     ) -> DomRoot<Self> {
         reflect_dom_object(
             Box::new(GPUComputePassEncoder::new_inherited(
@@ -60,7 +61,7 @@ impl GPUComputePassEncoder {
                 label,
             )),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 }

--- a/components/script/dom/webgpu/gpucomputepipeline.rs
+++ b/components/script/dom/webgpu/gpucomputepipeline.rs
@@ -53,6 +53,7 @@ impl GPUComputePipeline {
         compute_pipeline: WebGPUComputePipeline,
         label: USVString,
         device: &GPUDevice,
+        can_gc: CanGc,
     ) -> DomRoot<Self> {
         reflect_dom_object(
             Box::new(GPUComputePipeline::new_inherited(
@@ -61,7 +62,7 @@ impl GPUComputePipeline {
                 device,
             )),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 }
@@ -137,6 +138,7 @@ impl GPUComputePipelineMethods<crate::DomTypeHolder> for GPUComputePipeline {
             self.channel.clone(),
             WebGPUBindGroupLayout(id),
             USVString::default(),
+            CanGc::note(),
         ))
     }
 }

--- a/components/script/dom/webgpu/gpudevicelostinfo.rs
+++ b/components/script/dom/webgpu/gpudevicelostinfo.rs
@@ -35,11 +35,12 @@ impl GPUDeviceLostInfo {
         global: &GlobalScope,
         message: DOMString,
         reason: GPUDeviceLostReason,
+        can_gc: CanGc,
     ) -> DomRoot<Self> {
         reflect_dom_object(
             Box::new(GPUDeviceLostInfo::new_inherited(message, reason)),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 }

--- a/components/script/dom/webgpu/gpupipelinelayout.rs
+++ b/components/script/dom/webgpu/gpupipelinelayout.rs
@@ -55,6 +55,7 @@ impl GPUPipelineLayout {
         pipeline_layout: WebGPUPipelineLayout,
         label: USVString,
         bgls: Vec<WebGPUBindGroupLayout>,
+        can_gc: CanGc,
     ) -> DomRoot<Self> {
         reflect_dom_object(
             Box::new(GPUPipelineLayout::new_inherited(
@@ -64,7 +65,7 @@ impl GPUPipelineLayout {
                 bgls,
             )),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 }
@@ -113,6 +114,7 @@ impl GPUPipelineLayout {
             pipeline_layout,
             descriptor.parent.label.clone(),
             bgls,
+            CanGc::note(),
         )
     }
 }

--- a/components/script/dom/webgpu/gpuqueue.rs
+++ b/components/script/dom/webgpu/gpuqueue.rs
@@ -49,11 +49,16 @@ impl GPUQueue {
         }
     }
 
-    pub(crate) fn new(global: &GlobalScope, channel: WebGPU, queue: WebGPUQueue) -> DomRoot<Self> {
+    pub(crate) fn new(
+        global: &GlobalScope,
+        channel: WebGPU,
+        queue: WebGPUQueue,
+        can_gc: CanGc,
+    ) -> DomRoot<Self> {
         reflect_dom_object(
             Box::new(GPUQueue::new_inherited(channel, queue)),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 }

--- a/components/script/dom/webgpu/gpurenderbundle.rs
+++ b/components/script/dom/webgpu/gpurenderbundle.rs
@@ -48,6 +48,7 @@ impl GPURenderBundle {
         device: WebGPUDevice,
         channel: WebGPU,
         label: USVString,
+        can_gc: CanGc,
     ) -> DomRoot<Self> {
         reflect_dom_object(
             Box::new(GPURenderBundle::new_inherited(
@@ -57,7 +58,7 @@ impl GPURenderBundle {
                 label,
             )),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 }

--- a/components/script/dom/webgpu/gpurenderbundleencoder.rs
+++ b/components/script/dom/webgpu/gpurenderbundleencoder.rs
@@ -63,6 +63,7 @@ impl GPURenderBundleEncoder {
         device: &GPUDevice,
         channel: WebGPU,
         label: USVString,
+        can_gc: CanGc,
     ) -> DomRoot<Self> {
         reflect_dom_object(
             Box::new(GPURenderBundleEncoder::new_inherited(
@@ -72,7 +73,7 @@ impl GPURenderBundleEncoder {
                 label,
             )),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 }
@@ -123,6 +124,7 @@ impl GPURenderBundleEncoder {
             device,
             device.channel().clone(),
             descriptor.parent.parent.label.clone(),
+            CanGc::note(),
         ))
     }
 }
@@ -277,6 +279,7 @@ impl GPURenderBundleEncoderMethods<crate::DomTypeHolder> for GPURenderBundleEnco
             self.device.id(),
             self.channel.clone(),
             descriptor.parent.label.clone(),
+            CanGc::note(),
         )
     }
 }

--- a/components/script/dom/webgpu/gpurenderpassencoder.rs
+++ b/components/script/dom/webgpu/gpurenderpassencoder.rs
@@ -57,6 +57,7 @@ impl GPURenderPassEncoder {
         render_pass: WebGPURenderPass,
         parent: &GPUCommandEncoder,
         label: USVString,
+        can_gc: CanGc,
     ) -> DomRoot<Self> {
         reflect_dom_object(
             Box::new(GPURenderPassEncoder::new_inherited(
@@ -66,7 +67,7 @@ impl GPURenderPassEncoder {
                 label,
             )),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/webgpu/gpurenderpipeline.rs
+++ b/components/script/dom/webgpu/gpurenderpipeline.rs
@@ -50,6 +50,7 @@ impl GPURenderPipeline {
         render_pipeline: WebGPURenderPipeline,
         label: USVString,
         device: &GPUDevice,
+        can_gc: CanGc,
     ) -> DomRoot<Self> {
         reflect_dom_object(
             Box::new(GPURenderPipeline::new_inherited(
@@ -58,7 +59,7 @@ impl GPURenderPipeline {
                 device,
             )),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 }
@@ -126,6 +127,7 @@ impl GPURenderPipelineMethods<crate::DomTypeHolder> for GPURenderPipeline {
             self.channel.clone(),
             WebGPUBindGroupLayout(id),
             USVString::default(),
+            CanGc::note(),
         ))
     }
 }

--- a/components/script/dom/webgpu/gpusampler.rs
+++ b/components/script/dom/webgpu/gpusampler.rs
@@ -57,6 +57,7 @@ impl GPUSampler {
         compare_enable: bool,
         sampler: WebGPUSampler,
         label: USVString,
+        can_gc: CanGc,
     ) -> DomRoot<Self> {
         reflect_dom_object(
             Box::new(GPUSampler::new_inherited(
@@ -67,7 +68,7 @@ impl GPUSampler {
                 label,
             )),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 }
@@ -120,6 +121,7 @@ impl GPUSampler {
             compare_enable,
             sampler,
             descriptor.parent.label.clone(),
+            CanGc::note(),
         )
     }
 }

--- a/components/script/dom/webgpu/gpushadermodule.rs
+++ b/components/script/dom/webgpu/gpushadermodule.rs
@@ -59,6 +59,7 @@ impl GPUShaderModule {
         shader_module: WebGPUShaderModule,
         label: USVString,
         promise: Rc<Promise>,
+        can_gc: CanGc,
     ) -> DomRoot<Self> {
         reflect_dom_object(
             Box::new(GPUShaderModule::new_inherited(
@@ -68,7 +69,7 @@ impl GPUShaderModule {
                 promise,
             )),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 }
@@ -93,6 +94,7 @@ impl GPUShaderModule {
             WebGPUShaderModule(program_id),
             descriptor.parent.label.clone(),
             promise.clone(),
+            CanGc::note(),
         );
         let sender = response_async(&promise, &*shader_module);
         device

--- a/components/script/dom/webgpu/gpusupportedlimits.rs
+++ b/components/script/dom/webgpu/gpusupportedlimits.rs
@@ -29,8 +29,8 @@ impl GPUSupportedLimits {
         }
     }
 
-    pub(crate) fn new(global: &GlobalScope, limits: Limits) -> DomRoot<Self> {
-        reflect_dom_object(Box::new(Self::new_inherited(limits)), global, CanGc::note())
+    pub(crate) fn new(global: &GlobalScope, limits: Limits, can_gc: CanGc) -> DomRoot<Self> {
+        reflect_dom_object(Box::new(Self::new_inherited(limits)), global, can_gc)
     }
 }
 

--- a/components/script/dom/webgpu/gputexture.rs
+++ b/components/script/dom/webgpu/gputexture.rs
@@ -86,6 +86,7 @@ impl GPUTexture {
         format: GPUTextureFormat,
         texture_usage: u32,
         label: USVString,
+        can_gc: CanGc,
     ) -> DomRoot<Self> {
         reflect_dom_object(
             Box::new(GPUTexture::new_inherited(
@@ -101,7 +102,7 @@ impl GPUTexture {
                 label,
             )),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 }
@@ -159,6 +160,7 @@ impl GPUTexture {
             descriptor.format,
             descriptor.usage,
             descriptor.parent.label.clone(),
+            CanGc::note(),
         ))
     }
 }
@@ -230,6 +232,7 @@ impl GPUTextureMethods<crate::DomTypeHolder> for GPUTexture {
             texture_view,
             self,
             descriptor.parent.label.clone(),
+            CanGc::note(),
         ))
     }
 

--- a/components/script/dom/webgpu/gputextureview.rs
+++ b/components/script/dom/webgpu/gputextureview.rs
@@ -48,6 +48,7 @@ impl GPUTextureView {
         texture_view: WebGPUTextureView,
         texture: &GPUTexture,
         label: USVString,
+        can_gc: CanGc,
     ) -> DomRoot<GPUTextureView> {
         reflect_dom_object(
             Box::new(GPUTextureView::new_inherited(
@@ -57,7 +58,7 @@ impl GPUTextureView {
                 label,
             )),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 }

--- a/components/script/dom/webxr/fakexrdevice.rs
+++ b/components/script/dom/webxr/fakexrdevice.rs
@@ -59,11 +59,12 @@ impl FakeXRDevice {
     pub(crate) fn new(
         global: &GlobalScope,
         sender: IpcSender<MockDeviceMsg>,
+        can_gc: CanGc,
     ) -> DomRoot<FakeXRDevice> {
         reflect_dom_object(
             Box::new(FakeXRDevice::new_inherited(sender)),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -299,7 +300,8 @@ impl FakeXRDeviceMethods<crate::DomTypeHolder> for FakeXRDevice {
         let global = self.global();
         let _ = self.sender.send(MockDeviceMsg::AddInputSource(init));
 
-        let controller = FakeXRInputController::new(&global, self.sender.clone(), id);
+        let controller =
+            FakeXRInputController::new(&global, self.sender.clone(), id, CanGc::note());
 
         Ok(controller)
     }

--- a/components/script/dom/webxr/fakexrinputcontroller.rs
+++ b/components/script/dom/webxr/fakexrinputcontroller.rs
@@ -52,11 +52,12 @@ impl FakeXRInputController {
         global: &GlobalScope,
         sender: IpcSender<MockDeviceMsg>,
         id: InputId,
+        can_gc: CanGc,
     ) -> DomRoot<FakeXRInputController> {
         reflect_dom_object(
             Box::new(FakeXRInputController::new_inherited(sender, id)),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/webxr/xrboundedreferencespace.rs
+++ b/components/script/dom/webxr/xrboundedreferencespace.rs
@@ -45,7 +45,7 @@ impl XRBoundedReferenceSpace {
         can_gc: CanGc,
     ) -> DomRoot<XRBoundedReferenceSpace> {
         let offset = XRRigidTransform::identity(global, can_gc);
-        Self::new_offset(global, session, &offset)
+        Self::new_offset(global, session, &offset, can_gc)
     }
 
     #[allow(unused)]
@@ -53,11 +53,12 @@ impl XRBoundedReferenceSpace {
         global: &GlobalScope,
         session: &XRSession,
         offset: &XRRigidTransform,
+        can_gc: CanGc,
     ) -> DomRoot<XRBoundedReferenceSpace> {
         reflect_dom_object(
             Box::new(XRBoundedReferenceSpace::new_inherited(session, offset)),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/webxr/xrframe.rs
+++ b/components/script/dom/webxr/xrframe.rs
@@ -49,11 +49,16 @@ impl XRFrame {
         }
     }
 
-    pub(crate) fn new(global: &GlobalScope, session: &XRSession, data: Frame) -> DomRoot<XRFrame> {
+    pub(crate) fn new(
+        global: &GlobalScope,
+        session: &XRSession,
+        data: Frame,
+        can_gc: CanGc,
+    ) -> DomRoot<XRFrame> {
         reflect_dom_object(
             Box::new(XRFrame::new_inherited(session, data)),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -193,7 +198,7 @@ impl XRFrameMethods<crate::DomTypeHolder> for XRFrame {
             .hit_test_results
             .iter()
             .filter(|r| r.id == source.id())
-            .map(|r| XRHitTestResult::new(&self.global(), *r, self))
+            .map(|r| XRHitTestResult::new(&self.global(), *r, self, CanGc::note()))
             .collect()
     }
 

--- a/components/script/dom/webxr/xrhand.rs
+++ b/components/script/dom/webxr/xrhand.rs
@@ -127,6 +127,7 @@ impl XRHand {
         global: &GlobalScope,
         source: &XRInputSource,
         support: Hand<()>,
+        can_gc: CanGc,
     ) -> DomRoot<XRHand> {
         let id = source.id();
         let session = source.session();
@@ -136,12 +137,12 @@ impl XRHand {
                 .find(|&&(_, value)| value == joint)
                 .map(|&(hand_joint, _)| hand_joint)
                 .expect("Invalid joint name");
-            field.map(|_| XRJointSpace::new(global, session, id, joint, hand_joint))
+            field.map(|_| XRJointSpace::new(global, session, id, joint, hand_joint, CanGc::note()))
         });
         reflect_dom_object(
             Box::new(XRHand::new_inherited(source, &spaces)),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 }

--- a/components/script/dom/webxr/xrhittestresult.rs
+++ b/components/script/dom/webxr/xrhittestresult.rs
@@ -36,11 +36,12 @@ impl XRHitTestResult {
         global: &GlobalScope,
         result: HitTestResult,
         frame: &XRFrame,
+        can_gc: CanGc,
     ) -> DomRoot<XRHitTestResult> {
         reflect_dom_object(
             Box::new(XRHitTestResult::new_inherited(result, frame)),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 }

--- a/components/script/dom/webxr/xrhittestsource.rs
+++ b/components/script/dom/webxr/xrhittestsource.rs
@@ -34,11 +34,12 @@ impl XRHitTestSource {
         global: &GlobalScope,
         id: HitTestId,
         session: &XRSession,
+        can_gc: CanGc,
     ) -> DomRoot<XRHitTestSource> {
         reflect_dom_object(
             Box::new(XRHitTestSource::new_inherited(id, session)),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/webxr/xrinputsource.rs
+++ b/components/script/dom/webxr/xrinputsource.rs
@@ -145,7 +145,7 @@ impl XRInputSourceMethods<crate::DomTypeHolder> for XRInputSource {
     fn TargetRaySpace(&self) -> DomRoot<XRSpace> {
         self.target_ray_space.or_init(|| {
             let global = self.global();
-            XRSpace::new_inputspace(&global, &self.session, self, false)
+            XRSpace::new_inputspace(&global, &self.session, self, false, CanGc::note())
         })
     }
 
@@ -154,7 +154,7 @@ impl XRInputSourceMethods<crate::DomTypeHolder> for XRInputSource {
         if self.info.supports_grip {
             Some(self.grip_space.or_init(|| {
                 let global = self.global();
-                XRSpace::new_inputspace(&global, &self.session, self, true)
+                XRSpace::new_inputspace(&global, &self.session, self, true, CanGc::note())
             }))
         } else {
             None
@@ -181,7 +181,7 @@ impl XRInputSourceMethods<crate::DomTypeHolder> for XRInputSource {
     fn GetHand(&self) -> Option<DomRoot<XRHand>> {
         self.info.hand_support.as_ref().map(|hand| {
             self.hand
-                .or_init(|| XRHand::new(&self.global(), self, hand.clone()))
+                .or_init(|| XRHand::new(&self.global(), self, hand.clone(), CanGc::note()))
         })
     }
 }

--- a/components/script/dom/webxr/xrinputsourcearray.rs
+++ b/components/script/dom/webxr/xrinputsourcearray.rs
@@ -31,11 +31,11 @@ impl XRInputSourceArray {
         }
     }
 
-    pub(crate) fn new(global: &GlobalScope) -> DomRoot<XRInputSourceArray> {
+    pub(crate) fn new(global: &GlobalScope, can_gc: CanGc) -> DomRoot<XRInputSourceArray> {
         reflect_dom_object(
             Box::new(XRInputSourceArray::new_inherited()),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/webxr/xrjointspace.rs
+++ b/components/script/dom/webxr/xrjointspace.rs
@@ -49,11 +49,12 @@ impl XRJointSpace {
         input: InputId,
         joint: Joint,
         hand_joint: XRHandJoint,
+        can_gc: CanGc,
     ) -> DomRoot<XRJointSpace> {
         reflect_dom_object(
             Box::new(Self::new_inherited(session, input, joint, hand_joint)),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/webxr/xrpose.rs
+++ b/components/script/dom/webxr/xrpose.rs
@@ -34,11 +34,7 @@ impl XRPose {
         can_gc: CanGc,
     ) -> DomRoot<XRPose> {
         let transform = XRRigidTransform::new(global, transform, can_gc);
-        reflect_dom_object(
-            Box::new(XRPose::new_inherited(&transform)),
-            global,
-            CanGc::note(),
-        )
+        reflect_dom_object(Box::new(XRPose::new_inherited(&transform)), global, can_gc)
     }
 }
 

--- a/components/script/dom/webxr/xrreferencespace.rs
+++ b/components/script/dom/webxr/xrreferencespace.rs
@@ -46,7 +46,7 @@ impl XRReferenceSpace {
         can_gc: CanGc,
     ) -> DomRoot<XRReferenceSpace> {
         let offset = XRRigidTransform::identity(global, can_gc);
-        Self::new_offset(global, session, ty, &offset)
+        Self::new_offset(global, session, ty, &offset, can_gc)
     }
 
     #[allow(unused)]
@@ -55,11 +55,12 @@ impl XRReferenceSpace {
         session: &XRSession,
         ty: XRReferenceSpaceType,
         offset: &XRRigidTransform,
+        can_gc: CanGc,
     ) -> DomRoot<XRReferenceSpace> {
         reflect_dom_object(
             Box::new(XRReferenceSpace::new_inherited(session, offset, ty)),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -90,6 +91,7 @@ impl XRReferenceSpaceMethods<crate::DomTypeHolder> for XRReferenceSpace {
             self.upcast::<XRSpace>().session(),
             self.ty,
             &offset,
+            CanGc::note(),
         )
     }
 

--- a/components/script/dom/webxr/xrrenderstate.rs
+++ b/components/script/dom/webxr/xrrenderstate.rs
@@ -55,6 +55,7 @@ impl XRRenderState {
         inline_vertical_fov: Option<f64>,
         layer: Option<&XRWebGLLayer>,
         layers: Vec<&XRLayer>,
+        can_gc: CanGc,
     ) -> DomRoot<XRRenderState> {
         reflect_dom_object(
             Box::new(XRRenderState::new_inherited(
@@ -65,7 +66,7 @@ impl XRRenderState {
                 layers,
             )),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -77,6 +78,7 @@ impl XRRenderState {
             self.inline_vertical_fov.get(),
             self.base_layer.get().as_deref(),
             self.layers.borrow().iter().map(|x| &**x).collect(),
+            CanGc::note(),
         )
     }
 

--- a/components/script/dom/webxr/xrspace.rs
+++ b/components/script/dom/webxr/xrspace.rs
@@ -54,11 +54,12 @@ impl XRSpace {
         session: &XRSession,
         input: &XRInputSource,
         is_grip_space: bool,
+        can_gc: CanGc,
     ) -> DomRoot<XRSpace> {
         reflect_dom_object(
             Box::new(XRSpace::new_inputspace_inner(session, input, is_grip_space)),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/webxr/xrsystem.rs
+++ b/components/script/dom/webxr/xrsystem.rs
@@ -61,11 +61,11 @@ impl XRSystem {
         }
     }
 
-    pub(crate) fn new(window: &Window) -> DomRoot<XRSystem> {
+    pub(crate) fn new(window: &Window, can_gc: CanGc) -> DomRoot<XRSystem> {
         reflect_dom_object(
             Box::new(XRSystem::new_inherited(window.pipeline_id())),
             window,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -270,7 +270,8 @@ impl XRSystemMethods<crate::DomTypeHolder> for XRSystem {
 
     // https://github.com/immersive-web/webxr-test-api/blob/master/explainer.md
     fn Test(&self) -> DomRoot<XRTest> {
-        self.test.or_init(|| XRTest::new(&self.global()))
+        self.test
+            .or_init(|| XRTest::new(&self.global(), CanGc::note()))
     }
 }
 
@@ -293,7 +294,7 @@ impl XRSystem {
                 return;
             },
         };
-        let session = XRSession::new(&self.global(), session, mode, frame_receiver);
+        let session = XRSession::new(&self.global(), session, mode, frame_receiver, CanGc::note());
         if mode == XRSessionMode::Inline {
             self.active_inline_sessions
                 .borrow_mut()

--- a/components/script/dom/webxr/xrtest.rs
+++ b/components/script/dom/webxr/xrtest.rs
@@ -43,8 +43,8 @@ impl XRTest {
         }
     }
 
-    pub(crate) fn new(global: &GlobalScope) -> DomRoot<XRTest> {
-        reflect_dom_object(Box::new(XRTest::new_inherited()), global, CanGc::note())
+    pub(crate) fn new(global: &GlobalScope, can_gc: CanGc) -> DomRoot<XRTest> {
+        reflect_dom_object(Box::new(XRTest::new_inherited()), global, can_gc)
     }
 
     fn device_obtained(
@@ -54,7 +54,7 @@ impl XRTest {
     ) {
         let promise = trusted.root();
         if let Ok(sender) = response {
-            let device = FakeXRDevice::new(&self.global(), sender);
+            let device = FakeXRDevice::new(&self.global(), sender, CanGc::note());
             self.devices_connected
                 .borrow_mut()
                 .push(Dom::from_ref(&device));

--- a/components/script/dom/webxr/xrview.rs
+++ b/components/script/dom/webxr/xrview.rs
@@ -75,7 +75,7 @@ impl XRView {
                 view.cast_unit(),
             )),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/webxr/xrviewport.rs
+++ b/components/script/dom/webxr/xrviewport.rs
@@ -27,11 +27,15 @@ impl XRViewport {
         }
     }
 
-    pub(crate) fn new(global: &GlobalScope, viewport: Rect<i32, Viewport>) -> DomRoot<XRViewport> {
+    pub(crate) fn new(
+        global: &GlobalScope,
+        viewport: Rect<i32, Viewport>,
+        can_gc: CanGc,
+    ) -> DomRoot<XRViewport> {
         reflect_dom_object(
             Box::new(XRViewport::new_inherited(viewport)),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 }

--- a/components/script/dom/webxr/xrwebgllayer.rs
+++ b/components/script/dom/webxr/xrwebgllayer.rs
@@ -153,7 +153,8 @@ impl XRWebGLLayer {
         let session = self.session();
         // TODO: Cache this texture
         let color_texture_id = WebGLTextureId::new(sub_images.sub_image.as_ref()?.color_texture?);
-        let color_texture = WebGLTexture::new_webxr(context, color_texture_id, session);
+        let color_texture =
+            WebGLTexture::new_webxr(context, color_texture_id, session, CanGc::note());
         let target = self.texture_target();
 
         // Save the current bindings
@@ -188,7 +189,7 @@ impl XRWebGLLayer {
             // TODO: Cache this texture
             let depth_stencil_texture_id = WebGLTextureId::new(id);
             let depth_stencil_texture =
-                WebGLTexture::new_webxr(context, depth_stencil_texture_id, session);
+                WebGLTexture::new_webxr(context, depth_stencil_texture_id, session, CanGc::note());
             framebuffer
                 .texture2d_even_if_opaque(
                     constants::DEPTH_STENCIL_ATTACHMENT,
@@ -361,6 +362,6 @@ impl XRWebGLLayerMethods<crate::DomTypeHolder> for XRWebGLLayer {
         // don't seem to do this for stereoscopic immersive sessions.
         // Revisit if Servo gets support for handheld AR/VR via ARCore/ARKit
 
-        Some(XRViewport::new(&self.global(), viewport))
+        Some(XRViewport::new(&self.global(), viewport, CanGc::note()))
     }
 }

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -551,7 +551,7 @@ impl Window {
 
     fn new_paint_worklet(&self) -> DomRoot<Worklet> {
         debug!("Creating new paint worklet.");
-        Worklet::new(self, WorkletGlobalScopeType::Paint)
+        Worklet::new(self, WorkletGlobalScopeType::Paint, CanGc::note())
     }
 
     pub(crate) fn register_image_cache_listener(
@@ -908,30 +908,30 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
 
     // https://html.spec.whatwg.org/multipage/#dom-history
     fn History(&self) -> DomRoot<History> {
-        self.history.or_init(|| History::new(self))
+        self.history.or_init(|| History::new(self, CanGc::note()))
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-window-customelements
     fn CustomElements(&self) -> DomRoot<CustomElementRegistry> {
         self.custom_element_registry
-            .or_init(|| CustomElementRegistry::new(self))
+            .or_init(|| CustomElementRegistry::new(self, CanGc::note()))
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-location
     fn Location(&self) -> DomRoot<Location> {
-        self.location.or_init(|| Location::new(self))
+        self.location.or_init(|| Location::new(self, CanGc::note()))
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-sessionstorage
     fn SessionStorage(&self) -> DomRoot<Storage> {
         self.session_storage
-            .or_init(|| Storage::new(self, StorageType::Session))
+            .or_init(|| Storage::new(self, StorageType::Session, CanGc::note()))
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-localstorage
     fn LocalStorage(&self) -> DomRoot<Storage> {
         self.local_storage
-            .or_init(|| Storage::new(self, StorageType::Local))
+            .or_init(|| Storage::new(self, StorageType::Local, CanGc::note()))
     }
 
     // https://dvcs.w3.org/hg/webcrypto-api/raw-file/tip/spec/Overview.html#dfn-GlobalCrypto
@@ -965,7 +965,8 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
 
     // https://html.spec.whatwg.org/multipage/#dom-navigator
     fn Navigator(&self) -> DomRoot<Navigator> {
-        self.navigator.or_init(|| Navigator::new(self))
+        self.navigator
+            .or_init(|| Navigator::new(self, CanGc::note()))
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-windowtimers-settimeout
@@ -1081,8 +1082,13 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
     // https://dvcs.w3.org/hg/webperf/raw-file/tip/specs/
     // NavigationTiming/Overview.html#sec-window.performance-attribute
     fn Performance(&self) -> DomRoot<Performance> {
-        self.performance
-            .or_init(|| Performance::new(self.as_global_scope(), self.navigation_start.get()))
+        self.performance.or_init(|| {
+            Performance::new(
+                self.as_global_scope(),
+                self.navigation_start.get(),
+                CanGc::note(),
+            )
+        })
     }
 
     // https://html.spec.whatwg.org/multipage/#globaleventhandlers
@@ -1093,7 +1099,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
 
     // https://developer.mozilla.org/en-US/docs/Web/API/Window/screen
     fn Screen(&self) -> DomRoot<Screen> {
-        self.screen.or_init(|| Screen::new(self))
+        self.screen.or_init(|| Screen::new(self, CanGc::note()))
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-windowbase64-btoa
@@ -1240,6 +1246,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
             CSSStyleOwner::Element(Dom::from_ref(element)),
             pseudo,
             CSSModificationAccess::Readonly,
+            CanGc::note(),
         )
     }
 
@@ -1421,7 +1428,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
         );
         let media_query_list = media_queries::MediaList::parse(&context, &mut parser);
         let document = self.Document();
-        let mql = MediaQueryList::new(&document, media_query_list);
+        let mql = MediaQueryList::new(&document, media_query_list, CanGc::note());
         self.media_query_lists.track(&*mql);
         mql
     }
@@ -1439,7 +1446,8 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
 
     #[cfg(feature = "bluetooth")]
     fn TestRunner(&self) -> DomRoot<TestRunner> {
-        self.test_runner.or_init(|| TestRunner::new(self.upcast()))
+        self.test_runner
+            .or_init(|| TestRunner::new(self.upcast(), CanGc::note()))
     }
 
     fn RunningAnimationCount(&self) -> u32 {

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -267,7 +267,7 @@ impl WorkerGlobalScopeMethods<crate::DomTypeHolder> for WorkerGlobalScope {
     // https://html.spec.whatwg.org/multipage/#dom-workerglobalscope-location
     fn Location(&self) -> DomRoot<WorkerLocation> {
         self.location
-            .or_init(|| WorkerLocation::new(self, self.worker_url.borrow().clone()))
+            .or_init(|| WorkerLocation::new(self, self.worker_url.borrow().clone(), CanGc::note()))
     }
 
     // https://html.spec.whatwg.org/multipage/#handler-workerglobalscope-onerror
@@ -340,7 +340,8 @@ impl WorkerGlobalScopeMethods<crate::DomTypeHolder> for WorkerGlobalScope {
 
     // https://html.spec.whatwg.org/multipage/#dom-worker-navigator
     fn Navigator(&self) -> DomRoot<WorkerNavigator> {
-        self.navigator.or_init(|| WorkerNavigator::new(self))
+        self.navigator
+            .or_init(|| WorkerNavigator::new(self, CanGc::note()))
     }
 
     // https://html.spec.whatwg.org/multipage/#dfn-Crypto
@@ -444,7 +445,7 @@ impl WorkerGlobalScopeMethods<crate::DomTypeHolder> for WorkerGlobalScope {
     fn Performance(&self) -> DomRoot<Performance> {
         self.performance.or_init(|| {
             let global_scope = self.upcast::<GlobalScope>();
-            Performance::new(global_scope, self.navigation_start)
+            Performance::new(global_scope, self.navigation_start, CanGc::note())
         })
     }
 

--- a/components/script/dom/workerlocation.rs
+++ b/components/script/dom/workerlocation.rs
@@ -29,12 +29,12 @@ impl WorkerLocation {
         }
     }
 
-    pub(crate) fn new(global: &WorkerGlobalScope, url: ServoUrl) -> DomRoot<WorkerLocation> {
-        reflect_dom_object(
-            Box::new(WorkerLocation::new_inherited(url)),
-            global,
-            CanGc::note(),
-        )
+    pub(crate) fn new(
+        global: &WorkerGlobalScope,
+        url: ServoUrl,
+        can_gc: CanGc,
+    ) -> DomRoot<WorkerLocation> {
+        reflect_dom_object(Box::new(WorkerLocation::new_inherited(url)), global, can_gc)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-workerlocation-origin

--- a/components/script/dom/workernavigator.rs
+++ b/components/script/dom/workernavigator.rs
@@ -37,12 +37,8 @@ impl WorkerNavigator {
         }
     }
 
-    pub(crate) fn new(global: &WorkerGlobalScope) -> DomRoot<WorkerNavigator> {
-        reflect_dom_object(
-            Box::new(WorkerNavigator::new_inherited()),
-            global,
-            CanGc::note(),
-        )
+    pub(crate) fn new(global: &WorkerGlobalScope, can_gc: CanGc) -> DomRoot<WorkerNavigator> {
+        reflect_dom_object(Box::new(WorkerNavigator::new_inherited()), global, can_gc)
     }
 }
 
@@ -111,13 +107,13 @@ impl WorkerNavigatorMethods<crate::DomTypeHolder> for WorkerNavigator {
     // https://w3c.github.io/permissions/#navigator-and-workernavigator-extension
     fn Permissions(&self) -> DomRoot<Permissions> {
         self.permissions
-            .or_init(|| Permissions::new(&self.global()))
+            .or_init(|| Permissions::new(&self.global(), CanGc::note()))
     }
 
     // https://gpuweb.github.io/gpuweb/#dom-navigator-gpu
     #[cfg(feature = "webgpu")]
     fn Gpu(&self) -> DomRoot<GPU> {
-        self.gpu.or_init(|| GPU::new(&self.global()))
+        self.gpu.or_init(|| GPU::new(&self.global(), CanGc::note()))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-navigator-hardwareconcurrency>

--- a/components/script/dom/worklet.rs
+++ b/components/script/dom/worklet.rs
@@ -100,12 +100,16 @@ impl Worklet {
         }
     }
 
-    pub(crate) fn new(window: &Window, global_type: WorkletGlobalScopeType) -> DomRoot<Worklet> {
+    pub(crate) fn new(
+        window: &Window,
+        global_type: WorkletGlobalScopeType,
+        can_gc: CanGc,
+    ) -> DomRoot<Worklet> {
         debug!("Creating worklet {:?}.", global_type);
         reflect_dom_object(
             Box::new(Worklet::new_inherited(window, global_type)),
             window,
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/writablestream.rs
+++ b/components/script/dom/writablestream.rs
@@ -317,6 +317,7 @@ impl WritableStream {
                 global,
                 fulfillment_handler.take().map(|h| Box::new(h) as Box<_>),
                 rejection_handler.take().map(|h| Box::new(h) as Box<_>),
+                can_gc,
             );
             let realm = enter_realm(global);
             let comp = InRealm::Entered(&realm);

--- a/components/script/dom/writablestreamdefaultcontroller.rs
+++ b/components/script/dom/writablestreamdefaultcontroller.rs
@@ -412,6 +412,7 @@ impl WritableStreamDefaultController {
             global,
             fulfillment_handler.take().map(|h| Box::new(h) as Box<_>),
             rejection_handler.take().map(|h| Box::new(h) as Box<_>),
+            can_gc,
         );
         let realm = enter_realm(global);
         let comp = InRealm::Entered(&realm);
@@ -552,6 +553,7 @@ impl WritableStreamDefaultController {
             global,
             fulfillment_handler.take().map(|h| Box::new(h) as Box<_>),
             rejection_handler.take().map(|h| Box::new(h) as Box<_>),
+            can_gc,
         );
         let realm = enter_realm(global);
         let comp = InRealm::Entered(&realm);
@@ -650,6 +652,7 @@ impl WritableStreamDefaultController {
             global,
             fulfillment_handler.take().map(|h| Box::new(h) as Box<_>),
             rejection_handler.take().map(|h| Box::new(h) as Box<_>),
+            can_gc,
         );
         let realm = enter_realm(global);
         let comp = InRealm::Entered(&realm);

--- a/components/script/dom/xmldocument.rs
+++ b/components/script/dom/xmldocument.rs
@@ -78,6 +78,7 @@ impl XMLDocument {
         source: DocumentSource,
         doc_loader: DocumentLoader,
         inherited_insecure_requests_policy: Option<InsecureRequestsPolicy>,
+        can_gc: CanGc,
     ) -> DomRoot<XMLDocument> {
         let doc = reflect_dom_object(
             Box::new(XMLDocument::new_inherited(
@@ -94,7 +95,7 @@ impl XMLDocument {
                 inherited_insecure_requests_policy,
             )),
             window,
-            CanGc::note(),
+            can_gc,
         );
         {
             let node = doc.upcast::<Node>();

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -241,7 +241,7 @@ impl XMLHttpRequest {
             ready_state: Cell::new(XMLHttpRequestState::Unsent),
             timeout: Cell::new(Duration::ZERO),
             with_credentials: Cell::new(false),
-            upload: Dom::from_ref(&*XMLHttpRequestUpload::new(global)),
+            upload: Dom::from_ref(&*XMLHttpRequestUpload::new(global, CanGc::note())),
             response_url: DomRefCell::new(String::new()),
             status: DomRefCell::new(HttpStatus::new_error()),
             response: DomRefCell::new(vec![]),

--- a/components/script/dom/xmlhttprequestupload.rs
+++ b/components/script/dom/xmlhttprequestupload.rs
@@ -21,11 +21,11 @@ impl XMLHttpRequestUpload {
             eventtarget: XMLHttpRequestEventTarget::new_inherited(),
         }
     }
-    pub(crate) fn new(global: &GlobalScope) -> DomRoot<XMLHttpRequestUpload> {
+    pub(crate) fn new(global: &GlobalScope, can_gc: CanGc) -> DomRoot<XMLHttpRequestUpload> {
         reflect_dom_object(
             Box::new(XMLHttpRequestUpload::new_inherited()),
             global,
-            CanGc::note(),
+            can_gc,
         )
     }
 }

--- a/components/script/network_listener.rs
+++ b/components/script/network_listener.rs
@@ -66,7 +66,7 @@ pub(crate) fn submit_timing_data(
     can_gc: CanGc,
 ) {
     let performance_entry =
-        PerformanceResourceTiming::new(global, url, initiator_type, None, resource_timing);
+        PerformanceResourceTiming::new(global, url, initiator_type, None, resource_timing, can_gc);
     global
         .performance()
         .queue_entry(performance_entry.upcast::<PerformanceEntry>(), can_gc);

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -356,6 +356,7 @@ impl ModuleTree {
                 }),
             ))),
             None,
+            can_gc,
         );
 
         let realm = enter_realm(&*owner.global());
@@ -392,6 +393,7 @@ impl ModuleTree {
                 }),
             ))),
             None,
+            can_gc,
         );
 
         let realm = enter_realm(&*owner.global());
@@ -1440,6 +1442,7 @@ fn fetch_an_import_module_script_graph(
             global,
             promise.clone(),
             dynamic_module_id,
+            can_gc,
         ))),
     };
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3591,8 +3591,12 @@ impl ScriptThread {
     ) {
         let window = self.documents.borrow().find_window(pipeline_id);
         if let Some(window) = window {
-            let entry =
-                PerformancePaintTiming::new(window.as_global_scope(), metric_type, metric_value);
+            let entry = PerformancePaintTiming::new(
+                window.as_global_scope(),
+                metric_type,
+                metric_value,
+                can_gc,
+            );
             window
                 .Performance()
                 .queue_entry(entry.upcast::<PerformanceEntry>(), can_gc);


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Wherever we call `CanGc::note()` when calling `reflect_dom_object`, we pass a `CanGc` argument from the caller instead.

This change was mostly done automatically using a combination of search-and-replace tools (`ast-grep`, `sed`, etc.), and without a good idea of what the underlying code does.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #35504

<!-- Either: -->
- [x] These changes do not require tests because they are a refactor

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
