### PR TITLE
Remove `Servo::allow_navigation_request`

### DIFF
--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -33,7 +33,7 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 
 pub use base::id::TopLevelBrowsingContextId;
-use base::id::{PipelineId, PipelineNamespace, PipelineNamespaceId, WebViewId};
+use base::id::{PipelineNamespace, PipelineNamespaceId, WebViewId};
 #[cfg(feature = "bluetooth")]
 use bluetooth::BluetoothThreadFactory;
 #[cfg(feature = "bluetooth")]
@@ -691,16 +691,6 @@ impl Servo {
 
     pub fn start_shutting_down(&self) {
         self.compositor.borrow_mut().start_shutting_down();
-    }
-
-    pub fn allow_navigation_response(&self, pipeline_id: PipelineId, allow: bool) {
-        let msg = ConstellationMsg::AllowNavigationResponse(pipeline_id, allow);
-        if let Err(e) = self.constellation_proxy.try_send(msg) {
-            warn!(
-                "Sending allow navigation to constellation failed ({:?}).",
-                e
-            );
-        }
     }
 
     pub fn deinit(&self) {

--- a/components/servo/proxies.rs
+++ b/components/servo/proxies.rs
@@ -33,7 +33,7 @@ impl ConstellationProxy {
         }
     }
 
-    pub fn try_send(&self, msg: ConstellationMsg) -> Result<(), SendError<ConstellationMsg>> {
+    fn try_send(&self, msg: ConstellationMsg) -> Result<(), SendError<ConstellationMsg>> {
         if self.disconnected() {
             return Err(SendError(msg));
         }


### PR DESCRIPTION
This method is now unused in the new Servo API.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they just remove dead code.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
