### PR TITLE
fix touch event wrong coordinates. pageX, pageY, clientX, clientY etc.

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -2031,10 +2031,12 @@ impl Document {
         let target = DomRoot::upcast::<EventTarget>(el);
         let window = &*self.window;
 
-        let client_x = Finite::wrap(event.point.x as f64);
-        let client_y = Finite::wrap(event.point.y as f64);
-        let page_x = Finite::wrap(event.point.x as f64 + window.PageXOffset() as f64);
-        let page_y = Finite::wrap(event.point.y as f64 + window.PageYOffset() as f64);
+        let client_x = Finite::wrap(hit_test_result.point_in_viewport.x as f64);
+        let client_y = Finite::wrap(hit_test_result.point_in_viewport.y as f64);
+        let page_x =
+            Finite::wrap(hit_test_result.point_in_viewport.x as f64 + window.PageXOffset() as f64);
+        let page_y =
+            Finite::wrap(hit_test_result.point_in_viewport.y as f64 + window.PageYOffset() as f64);
 
         let touch = Touch::new(
             window, identifier, &target, client_x,


### PR DESCRIPTION
fix touch event wrong coordinates. pageX, pageY, clientX, clientY etc.
#35430 introduces the problem that the coordinates of the touch event are incorrect.
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #35549 

<!-- Either: -->

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
