### PR TITLE
dom: move node ranges to raredata

### DIFF
--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -1121,11 +1121,6 @@ impl Default for WeakRangeVec {
 
 #[allow(unsafe_code)]
 impl WeakRangeVec {
-    /// Create a new vector of weak references.
-    pub(crate) fn new() -> Self {
-        Self::default()
-    }
-
     /// Whether that vector of ranges is empty.
     pub(crate) fn is_empty(&self) -> bool {
         unsafe { (*self.cell.get()).is_empty() }

--- a/components/script/dom/raredata.rs
+++ b/components/script/dom/raredata.rs
@@ -16,6 +16,7 @@ use crate::dom::htmlslotelement::SlottableData;
 use crate::dom::intersectionobserver::IntersectionObserverRegistration;
 use crate::dom::mutationobserver::RegisteredObserver;
 use crate::dom::node::UniqueId;
+use crate::dom::range::WeakRangeVec;
 use crate::dom::shadowroot::ShadowRoot;
 use crate::dom::window::LayoutValue;
 
@@ -35,6 +36,12 @@ pub(crate) struct NodeRareData {
     pub(crate) unique_id: Option<UniqueId>,
 
     pub(crate) slottable_data: SlottableData,
+
+    /// A vector of weak references to Range instances of which the start
+    /// or end containers are this node. No range should ever be found
+    /// twice in this vector, even if both the start and end containers
+    /// are this node.
+    pub(crate) ranges: WeakRangeVec,
 }
 
 #[derive(Default, JSTraceable, MallocSizeOf)]

--- a/tests/unit/script/size_of.rs
+++ b/tests/unit/script/size_of.rs
@@ -30,10 +30,10 @@ macro_rules! sizeof_checker (
 
 // Update the sizes here
 sizeof_checker!(size_event_target, EventTarget, 48);
-sizeof_checker!(size_node, Node, 200);
-sizeof_checker!(size_element, Element, 376);
-sizeof_checker!(size_htmlelement, HTMLElement, 392);
-sizeof_checker!(size_div, HTMLDivElement, 392);
-sizeof_checker!(size_span, HTMLSpanElement, 392);
-sizeof_checker!(size_text, Text, 232);
-sizeof_checker!(size_characterdata, CharacterData, 232);
+sizeof_checker!(size_node, Node, 176);
+sizeof_checker!(size_element, Element, 352);
+sizeof_checker!(size_htmlelement, HTMLElement, 368);
+sizeof_checker!(size_div, HTMLDivElement, 368);
+sizeof_checker!(size_span, HTMLSpanElement, 368);
+sizeof_checker!(size_text, Text, 208);
+sizeof_checker!(size_characterdata, CharacterData, 208);


### PR DESCRIPTION
See the rationale in https://github.com/servo/servo/issues/35539

With this patch I see a reduction in memory use (all numbers are resident memory from memory reports) : 
- https://servo.org : 457.07 MiB -> 450.02 MiB
- https://dom.spec.whatwg.org/ : 862.61 MiB -> 852.44 MiB 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #35539 (GitHub issue number if applicable)
