### PR TITLE
Revert "build(deps): bump aws-lc-rs from 1.12.2 to 1.12.3"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,9 +343,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.12.3"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c6a895b664295a4ba0c2c0203c7075ea585dd75cd5c37a8efac829e13e460ef"
+checksum = "4c2b7ddaa2c56a367ad27a094ad8ef4faacf8a617c2575acb2ba88949df999ca"
 dependencies = [
  "aws-lc-sys",
  "paste",
@@ -354,9 +354,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.26.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9dd2e03ee80ca2822dd6ea431163d2ef259f2066a4d6ccaca6d9dcb386aa43"
+checksum = "54ac4f13dad353b209b34cbec082338202cbc01c8f00336b55c750c13ac91f8f"
 dependencies = [
  "bindgen 0.69.5",
  "cc",


### PR DESCRIPTION
Reverts servo/servo#35561

All recent tidy runs are failing with:
```
 | /home/runner/work/servo/servo/deny.toml:36: detected yanked crate (try `cargo update -p aws-lc-rs`): aws-lc-rs 1.12.3 registry+https://github.com/rust-lang/crates.io-index
```