### PR TITLE
Install fonts-noto-cjk for linux-wpt workflow

### DIFF
--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Bootstrap dependencies
         run: |
           sudo apt update
-          sudo apt install -qy --no-install-recommends mesa-vulkan-drivers
+          sudo apt install -qy --no-install-recommends mesa-vulkan-drivers fonts-noto-cjk
           ./mach bootstrap --skip-lints
       - name: Sync from upstream WPT
         if: ${{ inputs.wpt-sync-from-upstream }}

--- a/tests/wpt/meta/css/css-text/hanging-punctuation/hanging-punctuation-inline-001.html.ini
+++ b/tests/wpt/meta/css/css-text/hanging-punctuation/hanging-punctuation-inline-001.html.ini
@@ -1,0 +1,2 @@
+[hanging-punctuation-inline-001.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/line-break/line-break-normal-hyphens-001.html.ini
+++ b/tests/wpt/meta/css/css-text/line-break/line-break-normal-hyphens-001.html.ini
@@ -1,2 +1,0 @@
-[line-break-normal-hyphens-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/line-break/line-break-strict-hyphens-001.html.ini
+++ b/tests/wpt/meta/css/css-text/line-break/line-break-strict-hyphens-001.html.ini
@@ -1,2 +1,0 @@
-[line-break-strict-hyphens-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/line-breaking/segment-break-transformation-unremovable-1.html.ini
+++ b/tests/wpt/meta/css/css-text/line-breaking/segment-break-transformation-unremovable-1.html.ini
@@ -1,0 +1,2 @@
+[segment-break-transformation-unremovable-1.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/line-breaking/segment-break-transformation-unremovable-2.html.ini
+++ b/tests/wpt/meta/css/css-text/line-breaking/segment-break-transformation-unremovable-2.html.ini
@@ -1,0 +1,2 @@
+[segment-break-transformation-unremovable-2.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/line-breaking/segment-break-transformation-unremovable-3.html.ini
+++ b/tests/wpt/meta/css/css-text/line-breaking/segment-break-transformation-unremovable-3.html.ini
@@ -1,0 +1,2 @@
+[segment-break-transformation-unremovable-3.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/line-breaking/segment-break-transformation-unremovable-4.html.ini
+++ b/tests/wpt/meta/css/css-text/line-breaking/segment-break-transformation-unremovable-4.html.ini
@@ -1,0 +1,2 @@
+[segment-break-transformation-unremovable-4.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/text-transform/text-transform-full-size-kana-001.html.ini
+++ b/tests/wpt/meta/css/css-text/text-transform/text-transform-full-size-kana-001.html.ini
@@ -1,0 +1,2 @@
+[text-transform-full-size-kana-001.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/text-transform/text-transform-full-size-kana-002.html.ini
+++ b/tests/wpt/meta/css/css-text/text-transform/text-transform-full-size-kana-002.html.ini
@@ -1,0 +1,2 @@
+[text-transform-full-size-kana-002.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/text-transform/text-transform-full-size-kana-003.html.ini
+++ b/tests/wpt/meta/css/css-text/text-transform/text-transform-full-size-kana-003.html.ini
@@ -1,0 +1,2 @@
+[text-transform-full-size-kana-003.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/text-transform/text-transform-full-size-kana-004.html.ini
+++ b/tests/wpt/meta/css/css-text/text-transform/text-transform-full-size-kana-004.html.ini
@@ -1,0 +1,2 @@
+[text-transform-full-size-kana-004.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/text-transform/text-transform-full-size-kana-008.html.ini
+++ b/tests/wpt/meta/css/css-text/text-transform/text-transform-full-size-kana-008.html.ini
@@ -1,0 +1,2 @@
+[text-transform-full-size-kana-008.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/white-space/trailing-ideographic-space-003.html.ini
+++ b/tests/wpt/meta/css/css-text/white-space/trailing-ideographic-space-003.html.ini
@@ -1,0 +1,2 @@
+[trailing-ideographic-space-003.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/white-space/trailing-ideographic-space-006.html.ini
+++ b/tests/wpt/meta/css/css-text/white-space/trailing-ideographic-space-006.html.ini
@@ -1,0 +1,2 @@
+[trailing-ideographic-space-006.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/white-space/trailing-ideographic-space-008.html.ini
+++ b/tests/wpt/meta/css/css-text/white-space/trailing-ideographic-space-008.html.ini
@@ -1,0 +1,2 @@
+[trailing-ideographic-space-008.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/word-break/word-break-break-all-020.html.ini
+++ b/tests/wpt/meta/css/css-text/word-break/word-break-break-all-020.html.ini
@@ -1,2 +1,0 @@
-[word-break-break-all-020.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/word-break/word-break-break-all-032.html.ini
+++ b/tests/wpt/meta/css/css-text/word-break/word-break-break-all-032.html.ini
@@ -1,2 +1,0 @@
-[word-break-break-all-032.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/word-break/word-break-keep-all-006.html.ini
+++ b/tests/wpt/meta/css/css-text/word-break/word-break-keep-all-006.html.ini
@@ -1,2 +1,0 @@
-[word-break-keep-all-006.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta/css/font_fallback_01.html.ini
+++ b/tests/wpt/mozilla/meta/css/font_fallback_01.html.ini
@@ -1,2 +1,0 @@
-[font_fallback_01.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta/css/font_fallback_02.html.ini
+++ b/tests/wpt/mozilla/meta/css/font_fallback_02.html.ini
@@ -1,2 +1,0 @@
-[font_fallback_02.html]
-  expected: FAIL

--- a/tests/wpt/tests/css/css-fonts/size-adjust-unicode-range-system-fallback-ref.html
+++ b/tests/wpt/tests/css/css-fonts/size-adjust-unicode-range-system-fallback-ref.html
@@ -6,16 +6,17 @@
 @font-face {
   font-family: large-font;
   src: local(Ahem), url(/fonts/Ahem.ttf);
-  size-adjust: 1000%;
-  unicode-range: U+0020;
 }
 
 .space {
   font-family: large-font;
+  font-size: 1000%;
 }
 
 .ref {
   font-family: sans-serif;
+  position: relative;
+  left: -10em;
 }
 </style>
-<span class="space"> </span><span class="ref">あ</span>
+<span class="space">&nbsp;</span><span class="ref">あ</span>


### PR DESCRIPTION
Right now CJK-related tests are not running properly as the characters are rendered as tofu.

This PR installs fonts-noto-cjk to fix it. Also:
- `css/css-fonts/size-adjust-unicode-range-system-fallback.html` is a false pass, as the ref file depends on unsupported `size-adjust`. This PR removes the dependency to make it fail correctly
- It rebaselines the other affected tests
- It fixes #28758 by making the test failures stable.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #28758, and are required by #34770 

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
