### PR TITLE
fix(servoshell): blank view when close non focused tab

### DIFF
--- a/ports/servoshell/desktop/app_state.rs
+++ b/ports/servoshell/desktop/app_state.rs
@@ -240,8 +240,10 @@ impl RunningAppState {
 
         inner.webviews.retain(|&id, _| id != webview_id);
         inner.creation_order.retain(|&id| id != webview_id);
-        inner.focused_webview_id = None;
         inner.dialogs.remove(&webview_id);
+        if Some(webview_id) == inner.focused_webview_id {
+            inner.focused_webview_id = None;
+        }
 
         let last_created = inner
             .creation_order


### PR DESCRIPTION
`close_webview` removes the focused webview id whether it's the closed tab or not. It may unintentionally remove focus from the activated tab that is not being closed.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #35548

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
