### PR TITLE
Fix mach argument quoting on NixOS

### DIFF
--- a/mach
+++ b/mach
@@ -15,6 +15,14 @@
     run_in_nix_if_needed() {
         if { [ -f /etc/NIXOS ] || [ -n "${MACH_USE_NIX}" ]; } && [ -z "${IN_NIX_SHELL}" ]; then
             EXTRA_NIX_ARGS=${SERVO_ANDROID_BUILD:+'--arg buildAndroid true'}
+
+            # `nix-shell` needs the whole command passed as a single argument, so the arguments need
+            # to be shell-quoted. Rotate through the arguments, replacing them with quoted versions.
+            for arg in "$@"; do
+                set -- "$@" "$(printf \%q "$1")"
+                shift
+            done
+
             echo "NOTE: Entering nix-shell ${MACH_DIR}/shell.nix"
             exec nix-shell "${MACH_DIR}/shell.nix" $EXTRA_NIX_ARGS --run "$*"
         else


### PR DESCRIPTION
This patch makes mach shell-quote its arguments when rerunning itself with `nix-shell`, so that spaces and other special characters are handled correctly.

The test case in #35572 is handled as shown below (with `set -x`):

```
$ ./mach run -r 'data:text/html,<script>document.write(prompt())</script>'
NOTE: Entering nix-shell ./shell.nix
+ exec nix-shell ./shell.nix --run 'uv run python ./mach run -r data:text/html\,\<script\>document.write\(prompt\(\)\)\</script\>'
fetching path input 'path:/nix/store/kdynjy1mbgkdg4p196v9gx6ljpf7q4nk-source'
[servoshell runs correctly]
```

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #35572

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they only affect interactive use of mach on NixOS