### PR TITLE
fix(notification): add notification task source, run steps in parallel

### DIFF
--- a/components/profile/time.rs
+++ b/components/profile/time.rs
@@ -129,6 +129,7 @@ impl Formattable for ProfilerCategory {
             ProfilerCategory::ScriptWorkletEvent => "Script Worklet Event",
             ProfilerCategory::ScriptPerformanceEvent => "Script Performance Event",
             ProfilerCategory::ScriptWebGPUMsg => "Script WebGPU Message",
+            ProfilerCategory::ScriptNotificationEvent => "Script Notification Event",
             ProfilerCategory::TimeToFirstPaint => "Time To First Paint",
             ProfilerCategory::TimeToFirstContentfulPaint => "Time To First Contentful Paint",
             ProfilerCategory::TimeToInteractive => "Time to Interactive",

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -128,6 +128,7 @@ pub(crate) enum ScriptThreadEventCategory {
     PerformanceTimelineTask,
     #[cfg(feature = "webgpu")]
     WebGPUMsg,
+    NotificationEvent,
 }
 
 impl From<ScriptThreadEventCategory> for ProfilerCategory {
@@ -170,6 +171,9 @@ impl From<ScriptThreadEventCategory> for ProfilerCategory {
             ScriptThreadEventCategory::WorkletEvent => ProfilerCategory::ScriptWorkletEvent,
             #[cfg(feature = "webgpu")]
             ScriptThreadEventCategory::WebGPUMsg => ProfilerCategory::ScriptWebGPUMsg,
+            ScriptThreadEventCategory::NotificationEvent => {
+                ProfilerCategory::ScriptNotificationEvent
+            },
         }
     }
 }
@@ -214,6 +218,7 @@ impl From<ScriptThreadEventCategory> for ScriptHangAnnotation {
             ScriptThreadEventCategory::PortMessage => ScriptHangAnnotation::PortMessage,
             #[cfg(feature = "webgpu")]
             ScriptThreadEventCategory::WebGPUMsg => ScriptHangAnnotation::WebGPUMsg,
+            ScriptThreadEventCategory::NotificationEvent => ScriptHangAnnotation::NotificationEvent,
         }
     }
 }

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1704,6 +1704,14 @@ impl ScriptThread {
                 ScriptThreadEventCategory::WebGPUMsg => {
                     time_profile!(ProfilerCategory::ScriptWebGPUMsg, None, profiler_chan, f)
                 },
+                ScriptThreadEventCategory::NotificationEvent => {
+                    time_profile!(
+                        ProfilerCategory::ScriptNotificationEvent,
+                        None,
+                        profiler_chan,
+                        f
+                    )
+                },
             }
         } else {
             f()

--- a/components/script/task_manager.rs
+++ b/components/script/task_manager.rs
@@ -145,4 +145,5 @@ impl TaskManager {
     task_source_functions!(self, timer_task_source, Timer);
     task_source_functions!(self, user_interaction_task_source, UserInteraction);
     task_source_functions!(self, websocket_task_source, WebSocket);
+    task_source_functions!(self, notification_task_source, Notification);
 }

--- a/components/script/task_source.rs
+++ b/components/script/task_source.rs
@@ -42,6 +42,7 @@ pub(crate) enum TaskSourceName {
     Timer,
     /// <https://www.w3.org/TR/gamepad/#dfn-gamepad-task-source>
     Gamepad,
+    Notification,
 }
 
 impl From<TaskSourceName> for ScriptThreadEventCategory {
@@ -64,6 +65,7 @@ impl From<TaskSourceName> for ScriptThreadEventCategory {
             TaskSourceName::WebSocket => ScriptThreadEventCategory::WebSocketEvent,
             TaskSourceName::Timer => ScriptThreadEventCategory::TimerEvent,
             TaskSourceName::Gamepad => ScriptThreadEventCategory::InputEvent,
+            TaskSourceName::Notification => ScriptThreadEventCategory::NotificationEvent,
         }
     }
 }

--- a/components/shared/background_hang_monitor/lib.rs
+++ b/components/shared/background_hang_monitor/lib.rs
@@ -45,6 +45,7 @@ pub enum ScriptHangAnnotation {
     PerformanceTimelineTask,
     PortMessage,
     WebGPUMsg,
+    NotificationEvent,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]

--- a/components/shared/profile/time.rs
+++ b/components/shared/profile/time.rs
@@ -120,6 +120,7 @@ pub enum ProfilerCategory {
     ScriptHistoryEvent = 0x7d,
     ScriptPortMessage = 0x7e,
     ScriptWebGPUMsg = 0x7f,
+    ScriptNotificationEvent = 0x80,
 
     /// Web performance metrics.
     TimeToFirstPaint = 0x90,
@@ -176,6 +177,7 @@ impl ProfilerCategory {
             ProfilerCategory::ScriptHistoryEvent => "ScriptHistoryEvent",
             ProfilerCategory::ScriptPortMessage => "ScriptPortMessage",
             ProfilerCategory::ScriptWebGPUMsg => "ScriptWebGPUMsg",
+            ProfilerCategory::ScriptNotificationEvent => "ScriptNotificationEvent",
             ProfilerCategory::TimeToFirstPaint => "TimeToFirstPaint",
             ProfilerCategory::TimeToFirstContentfulPaint => "TimeToFirstContentfulPaint",
             ProfilerCategory::TimeToInteractive => "TimeToInteractive",


### PR DESCRIPTION
Fixes part of issue #34841 

- Add Notification task source in `TaskManager`
- Runs steps in tasks to follow the specification

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
