### PR TITLE
Move more bindings code to script_bindings

### DIFF
--- a/components/script/dom/bindings/conversions.rs
+++ b/components/script/dom/bindings/conversions.rs
@@ -194,7 +194,7 @@ where
     if !v.get().is_object() {
         return Err(());
     }
-    native_from_object(v.get().to_object(), cx)
+    unsafe { native_from_object(v.get().to_object(), cx) }
 }
 
 /// Get a `DomRoot<T>` for a DOM object accessible from a `HandleObject`.
@@ -205,7 +205,7 @@ pub(crate) fn root_from_handleobject<T>(
 where
     T: DomObject + IDLInterface,
 {
-    root_from_object(obj.get(), cx)
+    unsafe { root_from_object(obj.get(), cx) }
 }
 
 /// Returns whether `value` is an array-like object (Array, FileList,

--- a/components/script/dom/bindings/conversions.rs
+++ b/components/script/dom/bindings/conversions.rs
@@ -32,17 +32,17 @@
 //! | sequences               | `Vec<T>`        |                |
 //! | union types             | `T`             |                |
 
-use std::{ffi, ptr};
+use std::ffi;
 
 pub(crate) use js::conversions::{
     ConversionBehavior, ConversionResult, FromJSValConvertible, ToJSValConvertible,
 };
 use js::error::throw_type_error;
-use js::glue::{GetProxyReservedSlot, IsWrapper, JS_GetReservedSlot, UnwrapObjectDynamic};
+use js::glue::GetProxyReservedSlot;
 use js::jsapi::{Heap, IsWindowProxy, JSContext, JSObject, JS_IsExceptionPending};
 use js::jsval::UndefinedValue;
 use js::rust::wrappers::{IsArrayObject, JS_GetProperty, JS_HasProperty};
-use js::rust::{is_dom_object, HandleId, HandleObject, HandleValue, MutableHandleValue};
+use js::rust::{HandleId, HandleObject, HandleValue, MutableHandleValue};
 use num_traits::Float;
 pub(crate) use script_bindings::conversions::*;
 
@@ -91,21 +91,6 @@ impl<T: Float + FromJSValConvertible<Config = ()>> FromJSValConvertible for Fini
                 Err(())
             },
         }
-    }
-}
-
-impl<T: DomObject + IDLInterface> FromJSValConvertible for DomRoot<T> {
-    type Config = ();
-
-    unsafe fn from_jsval(
-        cx: *mut JSContext,
-        value: HandleValue,
-        _config: Self::Config,
-    ) -> Result<ConversionResult<DomRoot<T>>, ()> {
-        Ok(match root_from_handlevalue(value, cx) {
-            Ok(result) => ConversionResult::Success(result),
-            Err(()) => ConversionResult::Failure("value is not an object".into()),
-        })
     }
 }
 
@@ -158,79 +143,6 @@ pub(crate) unsafe fn jsid_to_string(cx: *mut JSContext, id: HandleId) -> Option<
 
 pub(crate) use script_bindings::conversions::is_dom_proxy;
 
-/// The index of the slot wherein a pointer to the reflected DOM object is
-/// stored for non-proxy bindings.
-// We use slot 0 for holding the raw object.  This is safe for both
-// globals and non-globals.
-pub(crate) const DOM_OBJECT_SLOT: u32 = 0;
-
-/// Get the private pointer of a DOM object from a given reflector.
-pub(crate) unsafe fn private_from_object(obj: *mut JSObject) -> *const libc::c_void {
-    let mut value = UndefinedValue();
-    if is_dom_object(obj) {
-        JS_GetReservedSlot(obj, DOM_OBJECT_SLOT, &mut value);
-    } else {
-        debug_assert!(is_dom_proxy(obj));
-        GetProxyReservedSlot(obj, 0, &mut value);
-    };
-    if value.is_undefined() {
-        ptr::null()
-    } else {
-        value.to_private()
-    }
-}
-
-pub(crate) enum PrototypeCheck {
-    Derive(fn(&'static DOMClass) -> bool),
-    Depth { depth: usize, proto_id: u16 },
-}
-
-/// Get a `*const libc::c_void` for the given DOM object, unwrapping any
-/// wrapper around it first, and checking if the object is of the correct type.
-///
-/// Returns Err(()) if `obj` is an opaque security wrapper or if the object is
-/// not an object for a DOM object of the given type (as defined by the
-/// proto_id and proto_depth).
-#[inline]
-pub(crate) unsafe fn private_from_proto_check(
-    mut obj: *mut JSObject,
-    cx: *mut JSContext,
-    proto_check: PrototypeCheck,
-) -> Result<*const libc::c_void, ()> {
-    let dom_class = get_dom_class(obj).or_else(|_| {
-        if IsWrapper(obj) {
-            trace!("found wrapper");
-            obj = UnwrapObjectDynamic(obj, cx, /* stopAtWindowProxy = */ false);
-            if obj.is_null() {
-                trace!("unwrapping security wrapper failed");
-                Err(())
-            } else {
-                assert!(!IsWrapper(obj));
-                trace!("unwrapped successfully");
-                get_dom_class(obj)
-            }
-        } else {
-            trace!("not a dom wrapper");
-            Err(())
-        }
-    })?;
-
-    let prototype_matches = match proto_check {
-        PrototypeCheck::Derive(f) => (f)(dom_class),
-        PrototypeCheck::Depth { depth, proto_id } => {
-            dom_class.interface_chain[depth] as u16 == proto_id
-        },
-    };
-
-    if prototype_matches {
-        trace!("good prototype");
-        Ok(private_from_object(obj))
-    } else {
-        trace!("bad prototype");
-        Err(())
-    }
-}
-
 /// Get a `*const libc::c_void` for the given DOM object, unless it is a DOM
 /// wrapper, and checking if the object is of the correct type.
 ///
@@ -251,17 +163,6 @@ unsafe fn private_from_proto_check_static(
     }
 }
 
-/// Get a `*const T` for a DOM object accessible from a `JSObject`.
-pub(crate) fn native_from_object<T>(obj: *mut JSObject, cx: *mut JSContext) -> Result<*const T, ()>
-where
-    T: DomObject + IDLInterface,
-{
-    unsafe {
-        private_from_proto_check(obj, cx, PrototypeCheck::Derive(T::derives))
-            .map(|ptr| ptr as *const T)
-    }
-}
-
 /// Get a `*const T` for a DOM object accessible from a `JSObject`, where the DOM object
 /// is guaranteed not to be a wrapper.
 pub(crate) fn native_from_object_static<T>(obj: *mut JSObject) -> Result<*const T, ()>
@@ -269,19 +170,6 @@ where
     T: DomObject + IDLInterface,
 {
     unsafe { private_from_proto_check_static(obj, T::derives).map(|ptr| ptr as *const T) }
-}
-
-/// Get a `DomRoot<T>` for the given DOM object, unwrapping any wrapper
-/// around it first, and checking if the object is of the correct type.
-///
-/// Returns Err(()) if `obj` is an opaque security wrapper or if the object is
-/// not a reflector for a DOM object of the given type (as defined by the
-/// proto_id and proto_depth).
-pub(crate) fn root_from_object<T>(obj: *mut JSObject, cx: *mut JSContext) -> Result<DomRoot<T>, ()>
-where
-    T: DomObject + IDLInterface,
-{
-    native_from_object(obj, cx).map(|ptr| unsafe { DomRoot::from_ref(&*ptr) })
 }
 
 /// Get a `DomRoot<T>` for the given DOM object, unwrapping any wrapper
@@ -309,18 +197,6 @@ where
     native_from_object(v.get().to_object(), cx)
 }
 
-/// Get a `DomRoot<T>` for a DOM object accessible from a `HandleValue`.
-/// Caller is responsible for throwing a JS exception if needed in case of error.
-pub(crate) fn root_from_handlevalue<T>(v: HandleValue, cx: *mut JSContext) -> Result<DomRoot<T>, ()>
-where
-    T: DomObject + IDLInterface,
-{
-    if !v.get().is_object() {
-        return Err(());
-    }
-    root_from_object(v.get().to_object(), cx)
-}
-
 /// Get a `DomRoot<T>` for a DOM object accessible from a `HandleObject`.
 pub(crate) fn root_from_handleobject<T>(
     obj: HandleObject,
@@ -330,12 +206,6 @@ where
     T: DomObject + IDLInterface,
 {
     root_from_object(obj.get(), cx)
-}
-
-impl<T: DomObject> ToJSValConvertible for DomRoot<T> {
-    unsafe fn to_jsval(&self, cx: *mut JSContext, rval: MutableHandleValue) {
-        self.reflector().to_jsval(cx, rval);
-    }
 }
 
 /// Returns whether `value` is an array-like object (Array, FileList,

--- a/components/script/dom/bindings/error.rs
+++ b/components/script/dom/bindings/error.rs
@@ -220,7 +220,7 @@ impl ErrorInfo {
     }
 
     fn from_dom_exception(object: HandleObject, cx: SafeJSContext) -> Option<ErrorInfo> {
-        let exception = match root_from_object::<DOMException>(object.get(), *cx) {
+        let exception = match unsafe { root_from_object::<DOMException>(object.get(), *cx) } {
             Ok(exception) => exception,
             Err(_) => return None,
         };

--- a/components/script/dom/bindings/import.rs
+++ b/components/script/dom/bindings/import.rs
@@ -96,6 +96,7 @@ pub(crate) mod module {
         jsapi, typedarray, JSCLASS_GLOBAL_SLOT_COUNT, JSCLASS_IS_DOMJSCLASS, JSCLASS_IS_GLOBAL,
         JSCLASS_RESERVED_SLOTS_MASK, JS_CALLEE,
     };
+    pub(crate) use script_bindings::constant::{ConstantSpec, ConstantVal};
     pub(crate) use servo_config::pref;
 
     pub(crate) use super::base::*;
@@ -108,7 +109,6 @@ pub(crate) mod module {
     pub(crate) use crate::dom::bindings::codegen::{
         InterfaceObjectMap, PrototypeList, RegisterBindings,
     };
-    pub(crate) use crate::dom::bindings::constant::{ConstantSpec, ConstantVal};
     pub(crate) use crate::dom::bindings::constructor::{
         call_default_constructor, call_html_constructor, pop_current_element_queue,
         push_new_element_queue,

--- a/components/script/dom/bindings/interface.rs
+++ b/components/script/dom/bindings/interface.rs
@@ -31,11 +31,11 @@ use js::rust::{
     define_methods, define_properties, get_object_class, is_dom_class, maybe_wrap_object,
     HandleObject, HandleValue, MutableHandleObject, RealmOptions,
 };
+use script_bindings::constant::{define_constants, ConstantSpec};
 use servo_url::MutableOrigin;
 
 use crate::dom::bindings::codegen::InterfaceObjectMap::Globals;
 use crate::dom::bindings::codegen::PrototypeList;
-use crate::dom::bindings::constant::{define_constants, ConstantSpec};
 use crate::dom::bindings::conversions::{get_dom_class, DOM_OBJECT_SLOT};
 use crate::dom::bindings::guard::Guard;
 use crate::dom::bindings::principals::ServoJSPrincipals;

--- a/components/script/dom/bindings/mod.rs
+++ b/components/script/dom/bindings/mod.rs
@@ -138,7 +138,6 @@ pub(crate) mod buffer_source;
 pub(crate) mod callback;
 #[allow(dead_code)]
 pub(crate) mod cell;
-pub(crate) mod constant;
 pub(crate) mod constructor;
 pub(crate) mod conversions;
 pub(crate) mod error;

--- a/components/script/dom/bindings/namespace.rs
+++ b/components/script/dom/bindings/namespace.rs
@@ -9,8 +9,8 @@ use std::ptr;
 
 use js::jsapi::{JSClass, JSFunctionSpec};
 use js::rust::{HandleObject, MutableHandleObject};
+use script_bindings::constant::ConstantSpec;
 
-use super::constant::ConstantSpec;
 use crate::dom::bindings::guard::Guard;
 use crate::dom::bindings::interface::{create_object, define_on_global_object};
 use crate::script_runtime::JSContext;

--- a/components/script/dom/bindings/root.rs
+++ b/components/script/dom/bindings/root.rs
@@ -32,6 +32,7 @@ use std::{mem, ptr};
 
 use js::jsapi::{JSObject, JSTracer};
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
+pub(crate) use script_bindings::root::*;
 use script_layout_interface::TrustedNodeAddress;
 use style::thread_state;
 
@@ -40,8 +41,6 @@ use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::DomObject;
 use crate::dom::bindings::trace::JSTraceable;
 use crate::dom::node::Node;
-
-pub(crate) use script_bindings::root::*;
 
 pub(crate) struct ThreadLocalStackRoots<'a>(PhantomData<&'a u32>);
 

--- a/components/script/dom/bindings/root.rs
+++ b/components/script/dom/bindings/root.rs
@@ -24,11 +24,10 @@
 //! originating `DomRoot<T>`.
 //!
 
-use std::cell::{Cell, OnceCell, UnsafeCell};
+use std::cell::{OnceCell, UnsafeCell};
 use std::default::Default;
 use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
-use std::ops::Deref;
 use std::{mem, ptr};
 
 use js::jsapi::{JSObject, JSTracer};
@@ -38,217 +37,11 @@ use style::thread_state;
 
 use crate::dom::bindings::conversions::DerivedFrom;
 use crate::dom::bindings::inheritance::Castable;
-use crate::dom::bindings::reflector::{DomObject, MutDomObject, Reflector};
-use crate::dom::bindings::trace::{trace_reflector, JSTraceable};
+use crate::dom::bindings::reflector::DomObject;
+use crate::dom::bindings::trace::JSTraceable;
 use crate::dom::node::Node;
 
-/// A rooted value.
-#[cfg_attr(crown, crown::unrooted_must_root_lint::allow_unrooted_interior)]
-pub(crate) struct Root<T: StableTraceObject> {
-    /// The value to root.
-    value: T,
-    /// List that ensures correct dynamic root ordering
-    root_list: *const RootCollection,
-}
-
-impl<T> Root<T>
-where
-    T: StableTraceObject + 'static,
-{
-    /// Create a new stack-bounded root for the provided value.
-    /// It cannot outlive its associated `RootCollection`, and it gives
-    /// out references which cannot outlive this new `Root`.
-    #[cfg_attr(crown, allow(crown::unrooted_must_root))]
-    pub(crate) unsafe fn new(value: T) -> Self {
-        unsafe fn add_to_root_list(object: *const dyn JSTraceable) -> *const RootCollection {
-            assert_in_script();
-            STACK_ROOTS.with(|root_list| {
-                let root_list = &*root_list.get().unwrap();
-                root_list.root(object);
-                root_list
-            })
-        }
-
-        let root_list = add_to_root_list(value.stable_trace_object());
-        Root { value, root_list }
-    }
-}
-
-/// `StableTraceObject` represents values that can be rooted through a stable address that will
-/// not change for their whole lifetime.
-/// It is an unsafe trait that requires implementors to ensure certain safety guarantees.
-///
-/// # Safety
-///
-/// Implementors of this trait must ensure that the `trace` method correctly accounts for all
-/// owned and referenced objects, so that the garbage collector can accurately determine which
-/// objects are still in use. Failing to adhere to this contract may result in undefined behavior,
-/// such as use-after-free errors.
-pub(crate) unsafe trait StableTraceObject {
-    /// Returns a stable trace object which address won't change for the whole
-    /// lifetime of the value.
-    fn stable_trace_object(&self) -> *const dyn JSTraceable;
-}
-
-unsafe impl<T> StableTraceObject for Dom<T>
-where
-    T: DomObject,
-{
-    fn stable_trace_object(&self) -> *const dyn JSTraceable {
-        // The JSTraceable impl for Reflector doesn't actually do anything,
-        // so we need this shenanigan to actually trace the reflector of the
-        // T pointer in Dom<T>.
-        #[cfg_attr(crown, allow(crown::unrooted_must_root))]
-        struct ReflectorStackRoot(Reflector);
-        unsafe impl JSTraceable for ReflectorStackRoot {
-            unsafe fn trace(&self, tracer: *mut JSTracer) {
-                trace_reflector(tracer, "on stack", &self.0);
-            }
-        }
-        unsafe { &*(self.reflector() as *const Reflector as *const ReflectorStackRoot) }
-    }
-}
-
-unsafe impl<T> StableTraceObject for MaybeUnreflectedDom<T>
-where
-    T: DomObject,
-{
-    fn stable_trace_object(&self) -> *const dyn JSTraceable {
-        // The JSTraceable impl for Reflector doesn't actually do anything,
-        // so we need this shenanigan to actually trace the reflector of the
-        // T pointer in Dom<T>.
-        #[cfg_attr(crown, allow(crown::unrooted_must_root))]
-        struct MaybeUnreflectedStackRoot<T>(T);
-        unsafe impl<T> JSTraceable for MaybeUnreflectedStackRoot<T>
-        where
-            T: DomObject,
-        {
-            unsafe fn trace(&self, tracer: *mut JSTracer) {
-                if self.0.reflector().get_jsobject().is_null() {
-                    self.0.trace(tracer);
-                } else {
-                    trace_reflector(tracer, "on stack", self.0.reflector());
-                }
-            }
-        }
-        unsafe { &*(self.ptr.as_ptr() as *const T as *const MaybeUnreflectedStackRoot<T>) }
-    }
-}
-
-impl<T> Deref for Root<T>
-where
-    T: Deref + StableTraceObject,
-{
-    type Target = <T as Deref>::Target;
-
-    fn deref(&self) -> &Self::Target {
-        assert_in_script();
-        &self.value
-    }
-}
-
-impl<T> Drop for Root<T>
-where
-    T: StableTraceObject,
-{
-    fn drop(&mut self) {
-        unsafe {
-            (*self.root_list).unroot(self.value.stable_trace_object());
-        }
-    }
-}
-
-/// A rooted reference to a DOM object.
-pub(crate) type DomRoot<T> = Root<Dom<T>>;
-
-impl<T: Castable> DomRoot<T> {
-    /// Cast a DOM object root upwards to one of the interfaces it derives from.
-    pub(crate) fn upcast<U>(root: DomRoot<T>) -> DomRoot<U>
-    where
-        U: Castable,
-        T: DerivedFrom<U>,
-    {
-        unsafe { mem::transmute::<DomRoot<T>, DomRoot<U>>(root) }
-    }
-
-    /// Cast a DOM object root downwards to one of the interfaces it might implement.
-    pub(crate) fn downcast<U>(root: DomRoot<T>) -> Option<DomRoot<U>>
-    where
-        U: DerivedFrom<T>,
-    {
-        if root.is::<U>() {
-            Some(unsafe { mem::transmute::<DomRoot<T>, DomRoot<U>>(root) })
-        } else {
-            None
-        }
-    }
-}
-
-impl<T: DomObject> DomRoot<T> {
-    /// Generate a new root from a reference
-    pub(crate) fn from_ref(unrooted: &T) -> DomRoot<T> {
-        unsafe { DomRoot::new(Dom::from_ref(unrooted)) }
-    }
-
-    /// Create a traced version of this rooted object.
-    ///
-    /// # Safety
-    ///
-    /// This should never be used to create on-stack values. Instead these values should always
-    /// end up as members of other DOM objects.
-    #[cfg_attr(crown, allow(crown::unrooted_must_root))]
-    pub(crate) fn as_traced(&self) -> Dom<T> {
-        Dom::from_ref(self)
-    }
-}
-
-impl<T> MallocSizeOf for DomRoot<T>
-where
-    T: DomObject + MallocSizeOf,
-{
-    fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
-        (**self).size_of(ops)
-    }
-}
-
-impl<T> PartialEq for DomRoot<T>
-where
-    T: DomObject,
-{
-    fn eq(&self, other: &Self) -> bool {
-        self.value == other.value
-    }
-}
-
-impl<T> Clone for DomRoot<T>
-where
-    T: DomObject,
-{
-    fn clone(&self) -> DomRoot<T> {
-        DomRoot::from_ref(self)
-    }
-}
-
-unsafe impl<T> JSTraceable for DomRoot<T>
-where
-    T: DomObject,
-{
-    unsafe fn trace(&self, _: *mut JSTracer) {
-        // Already traced.
-    }
-}
-
-/// A rooting mechanism for reflectors on the stack.
-/// LIFO is not required.
-///
-/// See also [*Exact Stack Rooting - Storing a GCPointer on the CStack*][cstack].
-///
-/// [cstack]: https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey/Internals/GC/Exact_Stack_Rooting
-pub(crate) struct RootCollection {
-    roots: UnsafeCell<Vec<*const dyn JSTraceable>>,
-}
-
-thread_local!(static STACK_ROOTS: Cell<Option<*const RootCollection>> = const { Cell::new(None) });
+pub(crate) use script_bindings::root::*;
 
 pub(crate) struct ThreadLocalStackRoots<'a>(PhantomData<&'a u32>);
 
@@ -263,48 +56,6 @@ impl Drop for ThreadLocalStackRoots<'_> {
     fn drop(&mut self) {
         STACK_ROOTS.with(|r| r.set(None));
     }
-}
-
-impl RootCollection {
-    /// Create an empty collection of roots
-    pub(crate) fn new() -> RootCollection {
-        assert_in_script();
-        RootCollection {
-            roots: UnsafeCell::new(vec![]),
-        }
-    }
-
-    /// Starts tracking a trace object.
-    unsafe fn root(&self, object: *const dyn JSTraceable) {
-        assert_in_script();
-        (*self.roots.get()).push(object);
-    }
-
-    /// Stops tracking a trace object, asserting if it isn't found.
-    unsafe fn unroot(&self, object: *const dyn JSTraceable) {
-        assert_in_script();
-        let roots = &mut *self.roots.get();
-        match roots
-            .iter()
-            .rposition(|r| std::ptr::addr_eq(*r as *const (), object as *const ()))
-        {
-            Some(idx) => {
-                roots.remove(idx);
-            },
-            None => panic!("Can't remove a root that was never rooted!"),
-        }
-    }
-}
-
-/// SM Callback that traces the rooted reflectors
-pub(crate) unsafe fn trace_roots(tracer: *mut JSTracer) {
-    trace!("tracing stack roots");
-    STACK_ROOTS.with(|collection| {
-        let collection = &*(*collection.get().unwrap()).roots.get();
-        for root in collection {
-            (**root).trace(tracer);
-        }
-    });
 }
 
 /// Get a slice of references to DOM objects.
@@ -327,118 +78,21 @@ where
     }
 }
 
-/// A traced reference to a DOM object
-///
-/// This type is critical to making garbage collection work with the DOM,
-/// but it is very dangerous; if garbage collection happens with a `Dom<T>`
-/// on the stack, the `Dom<T>` can point to freed memory.
-///
-/// This should only be used as a field in other DOM objects.
-#[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
-#[repr(transparent)]
-pub(crate) struct Dom<T> {
-    ptr: ptr::NonNull<T>,
-}
-
-// Dom<T> is similar to Rc<T>, in that it's not always clear how to avoid double-counting.
-// For now, we choose not to follow any such pointers.
-impl<T> MallocSizeOf for Dom<T> {
-    fn size_of(&self, _ops: &mut MallocSizeOfOps) -> usize {
-        0
-    }
-}
-
-impl<T> Dom<T> {
+pub(crate) trait ToLayout<T> {
     /// Returns `LayoutDom<T>` containing the same pointer.
     ///
     /// # Safety
     ///
     /// The `self` parameter to this method must meet all the requirements of [`ptr::NonNull::as_ref`].
-    pub(crate) unsafe fn to_layout(&self) -> LayoutDom<T> {
+    unsafe fn to_layout(&self) -> LayoutDom<T>;
+}
+
+impl<T: DomObject> ToLayout<T> for Dom<T> {
+    unsafe fn to_layout(&self) -> LayoutDom<T> {
         assert_in_layout();
         LayoutDom {
-            value: self.ptr.as_ref(),
+            value: self.as_ptr().as_ref().unwrap(),
         }
-    }
-}
-
-impl<T: DomObject> Dom<T> {
-    /// Create a `Dom<T>` from a `&T`
-    #[cfg_attr(crown, allow(crown::unrooted_must_root))]
-    pub(crate) fn from_ref(obj: &T) -> Dom<T> {
-        assert_in_script();
-        Dom {
-            ptr: ptr::NonNull::from(obj),
-        }
-    }
-
-    /// Return a rooted version of this DOM object ([`DomRoot<T>`]) suitable for use on the stack.
-    pub(crate) fn as_rooted(&self) -> DomRoot<T> {
-        DomRoot::from_ref(self)
-    }
-}
-
-impl<T: DomObject> Deref for Dom<T> {
-    type Target = T;
-
-    fn deref(&self) -> &T {
-        assert_in_script();
-        // We can only have &Dom<T> from a rooted thing, so it's safe to deref
-        // it to &T.
-        unsafe { &*self.ptr.as_ptr() }
-    }
-}
-
-unsafe impl<T: DomObject> JSTraceable for Dom<T> {
-    unsafe fn trace(&self, trc: *mut JSTracer) {
-        let trace_string;
-        let trace_info = if cfg!(debug_assertions) {
-            trace_string = format!("for {} on heap", ::std::any::type_name::<T>());
-            &trace_string[..]
-        } else {
-            "for DOM object on heap"
-        };
-        trace_reflector(trc, trace_info, (*self.ptr.as_ptr()).reflector());
-    }
-}
-
-/// A traced reference to a DOM object that may not be reflected yet.
-#[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
-pub(crate) struct MaybeUnreflectedDom<T> {
-    ptr: ptr::NonNull<T>,
-}
-
-impl<T> MaybeUnreflectedDom<T>
-where
-    T: DomObject,
-{
-    #[cfg_attr(crown, allow(crown::unrooted_must_root))]
-    pub(crate) unsafe fn from_box(value: Box<T>) -> Self {
-        Self {
-            ptr: Box::leak(value).into(),
-        }
-    }
-}
-
-impl<T> Root<MaybeUnreflectedDom<T>>
-where
-    T: DomObject,
-{
-    pub(crate) fn as_ptr(&self) -> *const T {
-        self.value.ptr.as_ptr()
-    }
-}
-
-impl<T> Root<MaybeUnreflectedDom<T>>
-where
-    T: MutDomObject,
-{
-    pub(crate) unsafe fn reflect_with(self, obj: *mut JSObject) -> DomRoot<T> {
-        let ptr = self.as_ptr();
-        drop(self);
-        let root = DomRoot::from_ref(&*ptr);
-        root.init_reflector(obj);
-        root
     }
 }
 
@@ -498,20 +152,6 @@ where
 
 impl<T> Copy for LayoutDom<'_, T> {}
 
-impl<T> PartialEq for Dom<T> {
-    fn eq(&self, other: &Dom<T>) -> bool {
-        self.ptr.as_ptr() == other.ptr.as_ptr()
-    }
-}
-
-impl<'a, T: DomObject> PartialEq<&'a T> for Dom<T> {
-    fn eq(&self, other: &&'a T) -> bool {
-        *self == Dom::from_ref(*other)
-    }
-}
-
-impl<T> Eq for Dom<T> {}
-
 impl<T> PartialEq for LayoutDom<'_, T> {
     fn eq(&self, other: &Self) -> bool {
         std::ptr::eq(self.value, other.value)
@@ -520,24 +160,9 @@ impl<T> PartialEq for LayoutDom<'_, T> {
 
 impl<T> Eq for LayoutDom<'_, T> {}
 
-impl<T> Hash for Dom<T> {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.ptr.as_ptr().hash(state)
-    }
-}
-
 impl<T> Hash for LayoutDom<'_, T> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         (self.value as *const T).hash(state)
-    }
-}
-
-impl<T> Clone for Dom<T> {
-    #[inline]
-    #[cfg_attr(crown, allow(crown::unrooted_must_root))]
-    fn clone(&self) -> Self {
-        assert_in_script();
-        Dom { ptr: self.ptr }
     }
 }
 
@@ -614,10 +239,6 @@ impl<T: DomObject + PartialEq> PartialEq<T> for MutDom<T> {
     fn eq(&self, other: &T) -> bool {
         unsafe { **self.val.get() == *other }
     }
-}
-
-pub(crate) fn assert_in_script() {
-    debug_assert!(thread_state::get().is_script());
 }
 
 pub(crate) fn assert_in_layout() {

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -48,6 +48,7 @@ use js::jsval::JSVal;
 use js::rust::{GCMethods, Handle};
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 use parking_lot::RwLock;
+pub(crate) use script_bindings::trace::*;
 use servo_arc::Arc as ServoArc;
 use smallvec::SmallVec;
 use style::author_styles::AuthorStyles;
@@ -68,8 +69,6 @@ use crate::dom::windowproxy::WindowProxyHandler;
 use crate::script_runtime::StreamConsumer;
 use crate::script_thread::IncompleteParserContexts;
 use crate::task::TaskBox;
-
-pub(crate) use script_bindings::trace::*;
 
 /// A trait to allow tracing only DOM sub-objects.
 ///

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -42,8 +42,8 @@ use indexmap::IndexMap;
 /// A trait to allow tracing (only) DOM objects.
 pub(crate) use js::gc::Traceable as JSTraceable;
 pub(crate) use js::gc::{RootableVec, RootedVec};
-use js::glue::{CallObjectTracer, CallScriptTracer, CallStringTracer, CallValueTracer};
-use js::jsapi::{GCTraceKindToAscii, Heap, JSObject, JSScript, JSString, JSTracer, TraceKind};
+use js::glue::{CallScriptTracer, CallStringTracer, CallValueTracer};
+use js::jsapi::{GCTraceKindToAscii, Heap, JSScript, JSString, JSTracer, TraceKind};
 use js::jsval::JSVal;
 use js::rust::{GCMethods, Handle};
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
@@ -61,13 +61,15 @@ use webxr_api::{Finger, Hand};
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::error::Error;
 use crate::dom::bindings::refcounted::{Trusted, TrustedPromise};
-use crate::dom::bindings::reflector::{DomObject, Reflector};
+use crate::dom::bindings::reflector::DomObject;
 use crate::dom::htmlimageelement::SourceSet;
 use crate::dom::htmlmediaelement::HTMLMediaElementFetchContext;
 use crate::dom::windowproxy::WindowProxyHandler;
 use crate::script_runtime::StreamConsumer;
 use crate::script_thread::IncompleteParserContexts;
 use crate::task::TaskBox;
+
+pub(crate) use script_bindings::trace::*;
 
 /// A trait to allow tracing only DOM sub-objects.
 ///
@@ -281,25 +283,6 @@ pub(crate) fn trace_jsval(tracer: *mut JSTracer, description: &str, val: &Heap<J
             tracer,
             val.ptr.get() as *mut _,
             GCTraceKindToAscii(val.get().trace_kind()),
-        );
-    }
-}
-
-/// Trace the `JSObject` held by `reflector`.
-#[cfg_attr(crown, allow(crown::unrooted_must_root))]
-pub(crate) fn trace_reflector(tracer: *mut JSTracer, description: &str, reflector: &Reflector) {
-    trace!("tracing reflector {}", description);
-    trace_object(tracer, description, reflector.rootable())
-}
-
-/// Trace a `JSObject`.
-pub(crate) fn trace_object(tracer: *mut JSTracer, description: &str, obj: &Heap<*mut JSObject>) {
-    unsafe {
-        trace!("tracing {}", description);
-        CallObjectTracer(
-            tracer,
-            obj.ptr.get() as *mut _,
-            GCTraceKindToAscii(TraceKind::Object),
         );
     }
 }

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -110,7 +110,7 @@ use crate::dom::bindings::inheritance::{Castable, ElementTypeId, HTMLElementType
 use crate::dom::bindings::num::Finite;
 use crate::dom::bindings::refcounted::{Trusted, TrustedPromise};
 use crate::dom::bindings::reflector::{reflect_dom_object_with_proto, DomGlobal};
-use crate::dom::bindings::root::{Dom, DomRoot, DomSlice, LayoutDom, MutNullableDom};
+use crate::dom::bindings::root::{Dom, DomRoot, DomSlice, LayoutDom, MutNullableDom, ToLayout};
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::bindings::trace::{HashMapTracedValues, NoTrace};
 #[cfg(feature = "webgpu")]

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -86,7 +86,7 @@ use crate::dom::bindings::error::{Error, ErrorResult, Fallible};
 use crate::dom::bindings::inheritance::{Castable, ElementTypeId, HTMLElementTypeId, NodeTypeId};
 use crate::dom::bindings::refcounted::{Trusted, TrustedPromise};
 use crate::dom::bindings::reflector::DomObject;
-use crate::dom::bindings::root::{Dom, DomRoot, LayoutDom, MutNullableDom};
+use crate::dom::bindings::root::{Dom, DomRoot, LayoutDom, MutNullableDom, ToLayout};
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::bindings::xmlname::{
     matches_name_production, namespace_from_domstring, validate_and_extract,
@@ -162,7 +162,7 @@ use crate::task::TaskOnce;
 
 /// <https://dom.spec.whatwg.org/#element>
 #[dom_struct]
-pub(crate) struct Element {
+pub struct Element {
     node: Node,
     #[no_trace]
     local_name: LocalName,
@@ -200,12 +200,6 @@ impl fmt::Debug for Element {
             write!(f, " id={}", id)?;
         }
         write!(f, ">")
-    }
-}
-
-impl fmt::Debug for DomRoot<Element> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        (**self).fmt(f)
     }
 }
 
@@ -3025,7 +3019,11 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         let quirks_mode = doc.quirks_mode();
         let element = DomRoot::from_ref(self);
 
-        Ok(dom_apis::element_matches(&element, &selectors, quirks_mode))
+        Ok(dom_apis::element_matches(
+            &SelectorWrapper::Borrowed(&element),
+            &selectors,
+            quirks_mode,
+        ))
     }
 
     // https://dom.spec.whatwg.org/#dom-element-webkitmatchesselector
@@ -3047,10 +3045,11 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
 
         let quirks_mode = doc.quirks_mode();
         Ok(dom_apis::element_closest(
-            DomRoot::from_ref(self),
+            SelectorWrapper::Owned(DomRoot::from_ref(self)),
             &selectors,
             quirks_mode,
-        ))
+        )
+           .map(SelectorWrapper::into_owned))
     }
 
     // https://dom.spec.whatwg.org/#dom-element-insertadjacentelement
@@ -3831,7 +3830,39 @@ impl VirtualMethods for Element {
     }
 }
 
-impl SelectorsElement for DomRoot<Element> {
+#[derive(Clone, PartialEq)]
+pub enum SelectorWrapper<'a> {
+    Borrowed(&'a DomRoot<Element>),
+    Owned(DomRoot<Element>),
+}
+
+impl<'a> fmt::Debug for SelectorWrapper<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.deref().fmt(f)
+    }
+}
+
+impl<'a> Deref for SelectorWrapper<'a> {
+    type Target = DomRoot<Element>;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            SelectorWrapper::Owned(r) => &r,
+            SelectorWrapper::Borrowed(r) => r,
+        }
+    }
+}
+
+impl<'a> SelectorWrapper<'a> {
+    fn into_owned(self) -> DomRoot<Element> {
+        match self {
+            SelectorWrapper::Owned(r) => r,
+            SelectorWrapper::Borrowed(r) => r.clone(),
+        }
+    }
+}
+
+impl<'a> SelectorsElement for SelectorWrapper<'a> {
     type Impl = SelectorImpl;
 
     #[allow(unsafe_code)]
@@ -3839,8 +3870,10 @@ impl SelectorsElement for DomRoot<Element> {
         ::selectors::OpaqueElement::new(unsafe { &*self.reflector().get_jsobject().get() })
     }
 
-    fn parent_element(&self) -> Option<DomRoot<Element>> {
-        self.upcast::<Node>().GetParentElement()
+    fn parent_element(&self) -> Option<Self> {
+        self.upcast::<Node>()
+            .GetParentElement()
+            .map(SelectorWrapper::Owned)
     }
 
     fn parent_node_is_shadow_root(&self) -> bool {
@@ -3853,6 +3886,7 @@ impl SelectorsElement for DomRoot<Element> {
     fn containing_shadow_host(&self) -> Option<Self> {
         self.containing_shadow_root()
             .map(|shadow_root| shadow_root.Host())
+            .map(SelectorWrapper::Owned)
     }
 
     fn is_pseudo_element(&self) -> bool {
@@ -3867,22 +3901,24 @@ impl SelectorsElement for DomRoot<Element> {
         false
     }
 
-    fn prev_sibling_element(&self) -> Option<DomRoot<Element>> {
+    fn prev_sibling_element(&self) -> Option<Self> {
         self.node
             .preceding_siblings()
             .filter_map(DomRoot::downcast)
             .next()
+            .map(SelectorWrapper::Owned)
     }
 
-    fn next_sibling_element(&self) -> Option<DomRoot<Element>> {
+    fn next_sibling_element(&self) -> Option<Self> {
         self.node
             .following_siblings()
             .filter_map(DomRoot::downcast)
             .next()
+            .map(SelectorWrapper::Owned)
     }
 
-    fn first_element_child(&self) -> Option<DomRoot<Element>> {
-        self.GetFirstElementChild()
+    fn first_element_child(&self) -> Option<Self> {
+        self.GetFirstElementChild().map(SelectorWrapper::Owned)
     }
 
     fn attr_matches(
@@ -3916,16 +3952,16 @@ impl SelectorsElement for DomRoot<Element> {
     }
 
     fn has_local_name(&self, local_name: &LocalName) -> bool {
-        Element::local_name(self) == local_name
+        Element::local_name(&self) == local_name
     }
 
     fn has_namespace(&self, ns: &Namespace) -> bool {
-        Element::namespace(self) == ns
+        Element::namespace(&self) == ns
     }
 
     fn is_same_type(&self, other: &Self) -> bool {
-        Element::local_name(self) == Element::local_name(other) &&
-            Element::namespace(self) == Element::namespace(other)
+        Element::local_name(&self) == Element::local_name(other) &&
+            Element::namespace(&self) == Element::namespace(other)
     }
 
     fn match_non_ts_pseudo_class(
@@ -3955,7 +3991,7 @@ impl SelectorsElement for DomRoot<Element> {
             NonTSPseudoClass::Lang(ref lang) => extended_filtering(&self.get_lang(), lang),
 
             NonTSPseudoClass::ReadOnly => {
-                !Element::state(self).contains(NonTSPseudoClass::ReadWrite.state_flag())
+                !Element::state(&self).contains(NonTSPseudoClass::ReadWrite.state_flag())
             },
 
             NonTSPseudoClass::Active |
@@ -3983,7 +4019,7 @@ impl SelectorsElement for DomRoot<Element> {
             NonTSPseudoClass::Target |
             NonTSPseudoClass::UserInvalid |
             NonTSPseudoClass::UserValid |
-            NonTSPseudoClass::Valid => Element::state(self).contains(pseudo_class.state_flag()),
+            NonTSPseudoClass::Valid => Element::state(&self).contains(pseudo_class.state_flag()),
         }
     }
 
@@ -4036,7 +4072,7 @@ impl SelectorsElement for DomRoot<Element> {
         if !self_flags.is_empty() {
             #[allow(unsafe_code)]
             unsafe {
-                Dom::from_ref(self.deref())
+                Dom::from_ref(&***self)
                     .to_layout()
                     .insert_selector_flags(self_flags);
             }
@@ -4048,7 +4084,7 @@ impl SelectorsElement for DomRoot<Element> {
             if let Some(p) = self.parent_element() {
                 #[allow(unsafe_code)]
                 unsafe {
-                    Dom::from_ref(p.deref())
+                    Dom::from_ref(&**p)
                         .to_layout()
                         .insert_selector_flags(parent_flags);
                 }

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -3831,6 +3831,10 @@ impl VirtualMethods for Element {
 }
 
 #[derive(Clone, PartialEq)]
+/// A type that wraps a DomRoot value so we can implement the SelectorsElement
+/// trait without violating the orphan rule. Since the trait assumes that the
+/// return type and self type of various methods is the same type that it is
+/// implemented against, we need to be able to represent multiple ownership styles.
 pub enum SelectorWrapper<'a> {
     Borrowed(&'a DomRoot<Element>),
     Owned(DomRoot<Element>),

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -3840,24 +3840,24 @@ pub enum SelectorWrapper<'a> {
     Owned(DomRoot<Element>),
 }
 
-impl<'a> fmt::Debug for SelectorWrapper<'a> {
+impl fmt::Debug for SelectorWrapper<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.deref().fmt(f)
     }
 }
 
-impl<'a> Deref for SelectorWrapper<'a> {
+impl Deref for SelectorWrapper<'_> {
     type Target = DomRoot<Element>;
 
     fn deref(&self) -> &Self::Target {
         match self {
-            SelectorWrapper::Owned(r) => &r,
+            SelectorWrapper::Owned(r) => r,
             SelectorWrapper::Borrowed(r) => r,
         }
     }
 }
 
-impl<'a> SelectorWrapper<'a> {
+impl SelectorWrapper<'_> {
     fn into_owned(self) -> DomRoot<Element> {
         match self {
             SelectorWrapper::Owned(r) => r,
@@ -3866,7 +3866,7 @@ impl<'a> SelectorWrapper<'a> {
     }
 }
 
-impl<'a> SelectorsElement for SelectorWrapper<'a> {
+impl SelectorsElement for SelectorWrapper<'_> {
     type Impl = SelectorImpl;
 
     #[allow(unsafe_code)]
@@ -3956,16 +3956,16 @@ impl<'a> SelectorsElement for SelectorWrapper<'a> {
     }
 
     fn has_local_name(&self, local_name: &LocalName) -> bool {
-        Element::local_name(&self) == local_name
+        Element::local_name(self) == local_name
     }
 
     fn has_namespace(&self, ns: &Namespace) -> bool {
-        Element::namespace(&self) == ns
+        Element::namespace(self) == ns
     }
 
     fn is_same_type(&self, other: &Self) -> bool {
-        Element::local_name(&self) == Element::local_name(other) &&
-            Element::namespace(&self) == Element::namespace(other)
+        Element::local_name(self) == Element::local_name(other) &&
+            Element::namespace(self) == Element::namespace(other)
     }
 
     fn match_non_ts_pseudo_class(
@@ -3995,7 +3995,7 @@ impl<'a> SelectorsElement for SelectorWrapper<'a> {
             NonTSPseudoClass::Lang(ref lang) => extended_filtering(&self.get_lang(), lang),
 
             NonTSPseudoClass::ReadOnly => {
-                !Element::state(&self).contains(NonTSPseudoClass::ReadWrite.state_flag())
+                !Element::state(self).contains(NonTSPseudoClass::ReadWrite.state_flag())
             },
 
             NonTSPseudoClass::Active |
@@ -4023,7 +4023,7 @@ impl<'a> SelectorsElement for SelectorWrapper<'a> {
             NonTSPseudoClass::Target |
             NonTSPseudoClass::UserInvalid |
             NonTSPseudoClass::UserValid |
-            NonTSPseudoClass::Valid => Element::state(&self).contains(pseudo_class.state_flag()),
+            NonTSPseudoClass::Valid => Element::state(self).contains(pseudo_class.state_flag()),
         }
     }
 

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -3049,7 +3049,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
             &selectors,
             quirks_mode,
         )
-           .map(SelectorWrapper::into_owned))
+        .map(SelectorWrapper::into_owned))
     }
 
     // https://dom.spec.whatwg.org/#dom-element-insertadjacentelement

--- a/components/script/dom/htmlcanvaselement.rs
+++ b/components/script/dom/htmlcanvaselement.rs
@@ -44,7 +44,7 @@ use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::num::Finite;
 use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::{DomGlobal, DomObject};
-use crate::dom::bindings::root::{Dom, DomRoot, LayoutDom};
+use crate::dom::bindings::root::{Dom, DomRoot, LayoutDom, ToLayout};
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::blob::Blob;
 use crate::dom::canvasrenderingcontext2d::{

--- a/components/script/dom/messageport.rs
+++ b/components/script/dom/messageport.rs
@@ -99,6 +99,7 @@ impl MessagePort {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#message-port-post-message-steps>
+    #[allow(unsafe_code)]
     fn post_message_impl(
         &self,
         cx: SafeJSContext,
@@ -118,7 +119,7 @@ impl MessagePort {
 
         let ports = transfer
             .iter()
-            .filter_map(|&obj| root_from_object::<MessagePort>(obj, *cx).ok());
+            .filter_map(|&obj| unsafe { root_from_object::<MessagePort>(obj, *cx).ok() });
         for port in ports {
             // Step 2
             if port.message_port_id() == self.message_port_id() {

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -76,7 +76,7 @@ use crate::dom::bindings::inheritance::{
 };
 use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::{reflect_dom_object_with_proto, DomObject, DomObjectWrap};
-use crate::dom::bindings::root::{Dom, DomRoot, DomSlice, LayoutDom, MutNullableDom};
+use crate::dom::bindings::root::{Dom, DomRoot, DomSlice, LayoutDom, MutNullableDom, ToLayout};
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::bindings::xmlname::namespace_from_domstring;
 use crate::dom::characterdata::{CharacterData, LayoutCharacterDataHelpers};
@@ -85,7 +85,7 @@ use crate::dom::customelementregistry::{try_upgrade_element, CallbackReaction};
 use crate::dom::document::{Document, DocumentSource, HasBrowsingContext, IsHTMLDocument};
 use crate::dom::documentfragment::DocumentFragment;
 use crate::dom::documenttype::DocumentType;
-use crate::dom::element::{CustomElementCreationMode, Element, ElementCreator};
+use crate::dom::element::{CustomElementCreationMode, Element, ElementCreator, SelectorWrapper};
 use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::htmlbodyelement::HTMLBodyElement;
@@ -184,12 +184,6 @@ impl fmt::Debug for Node {
         } else {
             write!(f, "[Node({:?})]", self.type_id())
         }
-    }
-}
-
-impl fmt::Debug for DomRoot<Node> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        (**self).fmt(f)
     }
 }
 
@@ -532,7 +526,11 @@ impl Iterator for QuerySelectorIterator {
                     MatchingForInvalidation::No,
                 );
                 if let Some(element) = DomRoot::downcast(node) {
-                    if matches_selector_list(selectors, &element, &mut ctx) {
+                    if matches_selector_list(
+                        selectors,
+                        &SelectorWrapper::Borrowed(&element),
+                        &mut ctx,
+                    ) {
                         return Some(DomRoot::upcast(element));
                     }
                 }
@@ -1044,9 +1042,9 @@ impl Node {
                 let mut descendants = self.traverse_preorder(ShadowIncluding::No);
                 // Skip the root of the tree.
                 assert!(&*descendants.next().unwrap() == self);
-                Ok(descendants
-                    .filter_map(DomRoot::downcast)
-                    .find(|element| matches_selector_list(&selectors, element, &mut ctx)))
+                Ok(descendants.filter_map(DomRoot::downcast).find(|element| {
+                    matches_selector_list(&selectors, &SelectorWrapper::Borrowed(element), &mut ctx)
+                }))
             },
         }
     }

--- a/components/script/dom/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl2renderingcontext.rs
@@ -39,7 +39,7 @@ use crate::dom::bindings::codegen::UnionTypes::{
 };
 use crate::dom::bindings::error::{ErrorResult, Fallible};
 use crate::dom::bindings::reflector::{reflect_dom_object, DomGlobal, Reflector};
-use crate::dom::bindings::root::{Dom, DomRoot, LayoutDom, MutNullableDom};
+use crate::dom::bindings::root::{Dom, DomRoot, LayoutDom, MutNullableDom, ToLayout};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::htmlcanvaselement::LayoutCanvasRenderingContextHelpers;

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -59,7 +59,7 @@ use crate::dom::workernavigator::WorkerNavigator;
 use crate::fetch;
 use crate::messaging::{CommonScriptMsg, ScriptEventLoopReceiver, ScriptEventLoopSender};
 use crate::realms::{enter_realm, InRealm};
-use crate::script_runtime::{CanGc, JSContext, Runtime};
+use crate::script_runtime::{CanGc, JSContext, JSContextHelper, Runtime};
 use crate::task::TaskCanceller;
 use crate::timers::{IsInterval, TimerCallback};
 

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -1154,18 +1154,4 @@ impl Runnable {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
-/// A compile-time marker that there are operations that could trigger a JS garbage collection
-/// operation within the current stack frame. It is trivially copyable, so it should be passed
-/// as a function argument and reused when calling other functions whenever possible. Since it
-/// is only meaningful within the current stack frame, it is impossible to move it to a different
-/// thread or into a task that will execute asynchronously.
-pub(crate) struct CanGc(std::marker::PhantomData<*mut ()>);
-
-impl CanGc {
-    /// Create a new CanGc value, representing that a GC operation is possible within the
-    /// current stack frame.
-    pub(crate) fn note() -> CanGc {
-        CanGc(std::marker::PhantomData)
-    }
-}
+pub(crate) use script_bindings::script_runtime::CanGc;

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -933,6 +933,8 @@ unsafe fn set_gc_zeal_options(_: *mut RawJSContext) {}
 
 pub(crate) use script_bindings::script_runtime::JSContext;
 
+/// Extra methods for the JSContext type defined in script_bindings, when
+/// the methods are only called by code in the script crate.
 pub(crate) trait JSContextHelper {
     fn get_reports(&self, path_seg: String) -> Vec<Report>;
 }

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -149,7 +149,7 @@ use crate::navigation::{InProgressLoad, NavigationListener};
 use crate::realms::enter_realm;
 use crate::script_module::ScriptFetchOptions;
 use crate::script_runtime::{
-    CanGc, JSContext, Runtime, ScriptThreadEventCategory, ThreadSafeJSContext,
+    CanGc, JSContext, JSContextHelper, Runtime, ScriptThreadEventCategory, ThreadSafeJSContext,
 };
 use crate::task_queue::TaskQueue;
 use crate::task_source::{SendableTaskSource, TaskSourceName};

--- a/components/script_bindings/constant.rs
+++ b/components/script_bindings/constant.rs
@@ -8,6 +8,7 @@ use std::ffi::CStr;
 
 use js::jsapi::{JSPROP_ENUMERATE, JSPROP_PERMANENT, JSPROP_READONLY};
 use js::jsval::{BooleanValue, DoubleValue, Int32Value, JSVal, NullValue, UInt32Value};
+use js::rooted;
 use js::rust::wrappers::JS_DefineProperty;
 use js::rust::HandleObject;
 
@@ -15,17 +16,17 @@ use crate::script_runtime::JSContext;
 
 /// Representation of an IDL constant.
 #[derive(Clone)]
-pub(crate) struct ConstantSpec {
+pub struct ConstantSpec {
     /// name of the constant.
-    pub(crate) name: &'static CStr,
+    pub name: &'static CStr,
     /// value of the constant.
-    pub(crate) value: ConstantVal,
+    pub value: ConstantVal,
 }
 
 /// Representation of an IDL constant value.
 #[derive(Clone)]
 #[allow(dead_code)]
-pub(crate) enum ConstantVal {
+pub enum ConstantVal {
     /// `long` constant.
     Int(i32),
     /// `unsigned long` constant.
@@ -40,7 +41,7 @@ pub(crate) enum ConstantVal {
 
 impl ConstantSpec {
     /// Returns a `JSVal` that represents the value of this `ConstantSpec`.
-    pub(crate) fn get_value(&self) -> JSVal {
+    pub fn get_value(&self) -> JSVal {
         match self.value {
             ConstantVal::Null => NullValue(),
             ConstantVal::Int(i) => Int32Value(i),
@@ -53,7 +54,7 @@ impl ConstantSpec {
 
 /// Defines constants on `obj`.
 /// Fails on JSAPI failure.
-pub(crate) fn define_constants(cx: JSContext, obj: HandleObject, constants: &[ConstantSpec]) {
+pub fn define_constants(cx: JSContext, obj: HandleObject, constants: &[ConstantSpec]) {
     for spec in constants {
         rooted!(in(*cx) let value = spec.get_value());
         unsafe {

--- a/components/script_bindings/conversions.rs
+++ b/components/script_bindings/conversions.rs
@@ -264,6 +264,9 @@ pub unsafe fn is_dom_proxy(obj: *mut JSObject) -> bool {
 pub const DOM_OBJECT_SLOT: u32 = 0;
 
 /// Get the private pointer of a DOM object from a given reflector.
+///
+/// # Safety
+/// obj must point to a valid non-null JS object.
 pub unsafe fn private_from_object(obj: *mut JSObject) -> *const libc::c_void {
     let mut value = UndefinedValue();
     if is_dom_object(obj) {
@@ -290,7 +293,12 @@ pub enum PrototypeCheck {
 /// Returns Err(()) if `obj` is an opaque security wrapper or if the object is
 /// not an object for a DOM object of the given type (as defined by the
 /// proto_id and proto_depth).
+///
+/// # Safety
+/// obj must point to a valid, non-null JS object.
+/// cx must point to a valid, non-null JS context.
 #[inline]
+#[allow(clippy::result_unit_err)]
 pub unsafe fn private_from_proto_check(
     mut obj: *mut JSObject,
     cx: *mut JSContext,
@@ -331,7 +339,12 @@ pub unsafe fn private_from_proto_check(
 }
 
 /// Get a `*const T` for a DOM object accessible from a `JSObject`.
-pub fn native_from_object<T>(obj: *mut JSObject, cx: *mut JSContext) -> Result<*const T, ()>
+///
+/// # Safety
+/// obj must point to a valid, non-null JS object.
+/// cx must point to a valid, non-null JS context.
+#[allow(clippy::result_unit_err)]
+pub unsafe fn native_from_object<T>(obj: *mut JSObject, cx: *mut JSContext) -> Result<*const T, ()>
 where
     T: DomObject + IDLInterface,
 {
@@ -347,7 +360,12 @@ where
 /// Returns Err(()) if `obj` is an opaque security wrapper or if the object is
 /// not a reflector for a DOM object of the given type (as defined by the
 /// proto_id and proto_depth).
-pub fn root_from_object<T>(obj: *mut JSObject, cx: *mut JSContext) -> Result<DomRoot<T>, ()>
+///
+/// # Safety
+/// obj must point to a valid, non-null JS object.
+/// cx must point to a valid, non-null JS context.
+#[allow(clippy::result_unit_err)]
+pub unsafe fn root_from_object<T>(obj: *mut JSObject, cx: *mut JSContext) -> Result<DomRoot<T>, ()>
 where
     T: DomObject + IDLInterface,
 {
@@ -356,7 +374,11 @@ where
 
 /// Get a `DomRoot<T>` for a DOM object accessible from a `HandleValue`.
 /// Caller is responsible for throwing a JS exception if needed in case of error.
-pub fn root_from_handlevalue<T>(v: HandleValue, cx: *mut JSContext) -> Result<DomRoot<T>, ()>
+///
+/// # Safety
+/// cx must point to a valid, non-null JS context.
+#[allow(clippy::result_unit_err)]
+pub unsafe fn root_from_handlevalue<T>(v: HandleValue, cx: *mut JSContext) -> Result<DomRoot<T>, ()>
 where
     T: DomObject + IDLInterface,
 {

--- a/components/script_bindings/conversions.rs
+++ b/components/script_bindings/conversions.rs
@@ -8,14 +8,18 @@ use js::conversions::{
     latin1_to_string, ConversionResult, FromJSValConvertible, ToJSValConvertible,
 };
 use js::error::throw_type_error;
-use js::glue::{GetProxyHandlerExtra, GetProxyReservedSlot, IsProxyHandlerFamily, IsWrapper, JS_GetReservedSlot, UnwrapObjectDynamic};
+use js::glue::{
+    GetProxyHandlerExtra, GetProxyReservedSlot, IsProxyHandlerFamily, IsWrapper,
+    JS_GetReservedSlot, UnwrapObjectDynamic,
+};
 use js::jsapi::{
     JSContext, JSObject, JSString, JS_DeprecatedStringHasLatin1Chars,
     JS_GetLatin1StringCharsAndLength, JS_GetTwoByteStringCharsAndLength, JS_NewStringCopyN,
 };
 use js::jsval::{ObjectValue, StringValue, UndefinedValue};
 use js::rust::{
-    get_object_class, is_dom_class, is_dom_object, maybe_wrap_value, HandleValue, MutableHandleValue, ToString,
+    get_object_class, is_dom_class, is_dom_object, maybe_wrap_value, HandleValue,
+    MutableHandleValue, ToString,
 };
 
 use crate::inheritance::Castable;

--- a/components/script_bindings/conversions.rs
+++ b/components/script_bindings/conversions.rs
@@ -8,18 +8,19 @@ use js::conversions::{
     latin1_to_string, ConversionResult, FromJSValConvertible, ToJSValConvertible,
 };
 use js::error::throw_type_error;
-use js::glue::{GetProxyHandlerExtra, IsProxyHandlerFamily};
+use js::glue::{GetProxyHandlerExtra, GetProxyReservedSlot, IsProxyHandlerFamily, IsWrapper, JS_GetReservedSlot, UnwrapObjectDynamic};
 use js::jsapi::{
     JSContext, JSObject, JSString, JS_DeprecatedStringHasLatin1Chars,
     JS_GetLatin1StringCharsAndLength, JS_GetTwoByteStringCharsAndLength, JS_NewStringCopyN,
 };
-use js::jsval::{ObjectValue, StringValue};
+use js::jsval::{ObjectValue, StringValue, UndefinedValue};
 use js::rust::{
-    get_object_class, is_dom_class, maybe_wrap_value, HandleValue, MutableHandleValue, ToString,
+    get_object_class, is_dom_class, is_dom_object, maybe_wrap_value, HandleValue, MutableHandleValue, ToString,
 };
 
 use crate::inheritance::Castable;
-use crate::reflector::Reflector;
+use crate::reflector::{DomObject, Reflector};
+use crate::root::DomRoot;
 use crate::str::{ByteString, DOMString, USVString};
 use crate::utils::{DOMClass, DOMJSClass};
 
@@ -199,6 +200,27 @@ impl ToJSValConvertible for Reflector {
     }
 }
 
+impl<T: DomObject + IDLInterface> FromJSValConvertible for DomRoot<T> {
+    type Config = ();
+
+    unsafe fn from_jsval(
+        cx: *mut JSContext,
+        value: HandleValue,
+        _config: Self::Config,
+    ) -> Result<ConversionResult<DomRoot<T>>, ()> {
+        Ok(match root_from_handlevalue(value, cx) {
+            Ok(result) => ConversionResult::Success(result),
+            Err(()) => ConversionResult::Failure("value is not an object".into()),
+        })
+    }
+}
+
+impl<T: DomObject> ToJSValConvertible for DomRoot<T> {
+    unsafe fn to_jsval(&self, cx: *mut JSContext, rval: MutableHandleValue) {
+        self.reflector().to_jsval(cx, rval);
+    }
+}
+
 /// Get the `DOMClass` from `obj`, or `Err(())` if `obj` is not a DOM object.
 ///
 /// # Safety
@@ -229,4 +251,113 @@ pub unsafe fn is_dom_proxy(obj: *mut JSObject) -> bool {
         let clasp = get_object_class(obj);
         ((*clasp).flags & js::JSCLASS_IS_PROXY) != 0 && IsProxyHandlerFamily(obj)
     }
+}
+
+/// The index of the slot wherein a pointer to the reflected DOM object is
+/// stored for non-proxy bindings.
+// We use slot 0 for holding the raw object.  This is safe for both
+// globals and non-globals.
+pub const DOM_OBJECT_SLOT: u32 = 0;
+
+/// Get the private pointer of a DOM object from a given reflector.
+pub unsafe fn private_from_object(obj: *mut JSObject) -> *const libc::c_void {
+    let mut value = UndefinedValue();
+    if is_dom_object(obj) {
+        JS_GetReservedSlot(obj, DOM_OBJECT_SLOT, &mut value);
+    } else {
+        debug_assert!(is_dom_proxy(obj));
+        GetProxyReservedSlot(obj, 0, &mut value);
+    };
+    if value.is_undefined() {
+        ptr::null()
+    } else {
+        value.to_private()
+    }
+}
+
+pub enum PrototypeCheck {
+    Derive(fn(&'static DOMClass) -> bool),
+    Depth { depth: usize, proto_id: u16 },
+}
+
+/// Get a `*const libc::c_void` for the given DOM object, unwrapping any
+/// wrapper around it first, and checking if the object is of the correct type.
+///
+/// Returns Err(()) if `obj` is an opaque security wrapper or if the object is
+/// not an object for a DOM object of the given type (as defined by the
+/// proto_id and proto_depth).
+#[inline]
+pub unsafe fn private_from_proto_check(
+    mut obj: *mut JSObject,
+    cx: *mut JSContext,
+    proto_check: PrototypeCheck,
+) -> Result<*const libc::c_void, ()> {
+    let dom_class = get_dom_class(obj).or_else(|_| {
+        if IsWrapper(obj) {
+            trace!("found wrapper");
+            obj = UnwrapObjectDynamic(obj, cx, /* stopAtWindowProxy = */ false);
+            if obj.is_null() {
+                trace!("unwrapping security wrapper failed");
+                Err(())
+            } else {
+                assert!(!IsWrapper(obj));
+                trace!("unwrapped successfully");
+                get_dom_class(obj)
+            }
+        } else {
+            trace!("not a dom wrapper");
+            Err(())
+        }
+    })?;
+
+    let prototype_matches = match proto_check {
+        PrototypeCheck::Derive(f) => (f)(dom_class),
+        PrototypeCheck::Depth { depth, proto_id } => {
+            dom_class.interface_chain[depth] as u16 == proto_id
+        },
+    };
+
+    if prototype_matches {
+        trace!("good prototype");
+        Ok(private_from_object(obj))
+    } else {
+        trace!("bad prototype");
+        Err(())
+    }
+}
+
+/// Get a `*const T` for a DOM object accessible from a `JSObject`.
+pub fn native_from_object<T>(obj: *mut JSObject, cx: *mut JSContext) -> Result<*const T, ()>
+where
+    T: DomObject + IDLInterface,
+{
+    unsafe {
+        private_from_proto_check(obj, cx, PrototypeCheck::Derive(T::derives))
+            .map(|ptr| ptr as *const T)
+    }
+}
+
+/// Get a `DomRoot<T>` for the given DOM object, unwrapping any wrapper
+/// around it first, and checking if the object is of the correct type.
+///
+/// Returns Err(()) if `obj` is an opaque security wrapper or if the object is
+/// not a reflector for a DOM object of the given type (as defined by the
+/// proto_id and proto_depth).
+pub fn root_from_object<T>(obj: *mut JSObject, cx: *mut JSContext) -> Result<DomRoot<T>, ()>
+where
+    T: DomObject + IDLInterface,
+{
+    native_from_object(obj, cx).map(|ptr| unsafe { DomRoot::from_ref(&*ptr) })
+}
+
+/// Get a `DomRoot<T>` for a DOM object accessible from a `HandleValue`.
+/// Caller is responsible for throwing a JS exception if needed in case of error.
+pub fn root_from_handlevalue<T>(v: HandleValue, cx: *mut JSContext) -> Result<DomRoot<T>, ()>
+where
+    T: DomObject + IDLInterface,
+{
+    if !v.get().is_object() {
+        return Err(());
+    }
+    root_from_object(v.get().to_object(), cx)
 }

--- a/components/script_bindings/lib.rs
+++ b/components/script_bindings/lib.rs
@@ -22,9 +22,10 @@ pub mod constant;
 pub mod conversions;
 pub mod inheritance;
 pub mod reflector;
+pub mod root;
 pub mod script_runtime;
 pub mod str;
-mod trace;
+pub mod trace;
 pub mod utils;
 
 #[allow(non_snake_case)]

--- a/components/script_bindings/lib.rs
+++ b/components/script_bindings/lib.rs
@@ -18,6 +18,7 @@ extern crate log;
 extern crate malloc_size_of_derive;
 
 pub mod callback;
+pub mod constant;
 pub mod conversions;
 pub mod inheritance;
 pub mod reflector;

--- a/components/script_bindings/root.rs
+++ b/components/script_bindings/root.rs
@@ -1,11 +1,10 @@
 use std::cell::{Cell, UnsafeCell};
-use std::fmt;
 use std::hash::{Hash, Hasher};
-use std::{mem, ptr};
 use std::ops::Deref;
+use std::{fmt, mem, ptr};
 
-use js::jsapi::{JSObject, JSTracer};
 use js::gc::Traceable as JSTraceable;
+use js::jsapi::{JSObject, JSTracer};
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 use style::thread_state;
 

--- a/components/script_bindings/root.rs
+++ b/components/script_bindings/root.rs
@@ -1,0 +1,415 @@
+use std::cell::{Cell, UnsafeCell};
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::{mem, ptr};
+use std::ops::Deref;
+
+use js::jsapi::{JSObject, JSTracer};
+use js::gc::Traceable as JSTraceable;
+use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
+use style::thread_state;
+
+use crate::conversions::DerivedFrom;
+use crate::inheritance::Castable;
+use crate::reflector::{DomObject, MutDomObject, Reflector};
+use crate::trace::trace_reflector;
+
+/// A rooted value.
+#[cfg_attr(crown, crown::unrooted_must_root_lint::allow_unrooted_interior)]
+pub struct Root<T: StableTraceObject> {
+    /// The value to root.
+    value: T,
+    /// List that ensures correct dynamic root ordering
+    root_list: *const RootCollection,
+}
+
+impl<T> Root<T>
+where
+    T: StableTraceObject + 'static,
+{
+    /// Create a new stack-bounded root for the provided value.
+    /// It cannot outlive its associated `RootCollection`, and it gives
+    /// out references which cannot outlive this new `Root`.
+    #[cfg_attr(crown, allow(crown::unrooted_must_root))]
+    pub unsafe fn new(value: T) -> Self {
+        unsafe fn add_to_root_list(object: *const dyn JSTraceable) -> *const RootCollection {
+            assert_in_script();
+            STACK_ROOTS.with(|root_list| {
+                let root_list = &*root_list.get().unwrap();
+                root_list.root(object);
+                root_list
+            })
+        }
+
+        let root_list = add_to_root_list(value.stable_trace_object());
+        Root { value, root_list }
+    }
+}
+
+/// `StableTraceObject` represents values that can be rooted through a stable address that will
+/// not change for their whole lifetime.
+/// It is an unsafe trait that requires implementors to ensure certain safety guarantees.
+///
+/// # Safety
+///
+/// Implementors of this trait must ensure that the `trace` method correctly accounts for all
+/// owned and referenced objects, so that the garbage collector can accurately determine which
+/// objects are still in use. Failing to adhere to this contract may result in undefined behavior,
+/// such as use-after-free errors.
+pub unsafe trait StableTraceObject {
+    /// Returns a stable trace object which address won't change for the whole
+    /// lifetime of the value.
+    fn stable_trace_object(&self) -> *const dyn JSTraceable;
+}
+
+unsafe impl<T> StableTraceObject for Dom<T>
+where
+    T: DomObject,
+{
+    fn stable_trace_object(&self) -> *const dyn JSTraceable {
+        // The JSTraceable impl for Reflector doesn't actually do anything,
+        // so we need this shenanigan to actually trace the reflector of the
+        // T pointer in Dom<T>.
+        #[cfg_attr(crown, allow(crown::unrooted_must_root))]
+        struct ReflectorStackRoot(Reflector);
+        unsafe impl JSTraceable for ReflectorStackRoot {
+            unsafe fn trace(&self, tracer: *mut JSTracer) {
+                trace_reflector(tracer, "on stack", &self.0);
+            }
+        }
+        unsafe { &*(self.reflector() as *const Reflector as *const ReflectorStackRoot) }
+    }
+}
+
+unsafe impl<T> StableTraceObject for MaybeUnreflectedDom<T>
+where
+    T: DomObject,
+{
+    fn stable_trace_object(&self) -> *const dyn JSTraceable {
+        // The JSTraceable impl for Reflector doesn't actually do anything,
+        // so we need this shenanigan to actually trace the reflector of the
+        // T pointer in Dom<T>.
+        #[cfg_attr(crown, allow(crown::unrooted_must_root))]
+        struct MaybeUnreflectedStackRoot<T>(T);
+        unsafe impl<T> JSTraceable for MaybeUnreflectedStackRoot<T>
+        where
+            T: DomObject,
+        {
+            unsafe fn trace(&self, tracer: *mut JSTracer) {
+                if self.0.reflector().get_jsobject().is_null() {
+                    self.0.trace(tracer);
+                } else {
+                    trace_reflector(tracer, "on stack", self.0.reflector());
+                }
+            }
+        }
+        unsafe { &*(self.ptr.as_ptr() as *const T as *const MaybeUnreflectedStackRoot<T>) }
+    }
+}
+
+impl<T> Deref for Root<T>
+where
+    T: Deref + StableTraceObject,
+{
+    type Target = <T as Deref>::Target;
+
+    fn deref(&self) -> &Self::Target {
+        assert_in_script();
+        &self.value
+    }
+}
+
+impl<T> Drop for Root<T>
+where
+    T: StableTraceObject,
+{
+    fn drop(&mut self) {
+        unsafe {
+            (*self.root_list).unroot(self.value.stable_trace_object());
+        }
+    }
+}
+
+impl<T: fmt::Debug + StableTraceObject> fmt::Debug for Root<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.value.fmt(f)
+    }
+}
+
+impl<T: fmt::Debug + DomObject> fmt::Debug for Dom<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        (**self).fmt(f)
+    }
+}
+
+/// A traced reference to a DOM object
+///
+/// This type is critical to making garbage collection work with the DOM,
+/// but it is very dangerous; if garbage collection happens with a `Dom<T>`
+/// on the stack, the `Dom<T>` can point to freed memory.
+///
+/// This should only be used as a field in other DOM objects.
+#[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
+#[repr(transparent)]
+pub struct Dom<T> {
+    ptr: ptr::NonNull<T>,
+}
+
+// Dom<T> is similar to Rc<T>, in that it's not always clear how to avoid double-counting.
+// For now, we choose not to follow any such pointers.
+impl<T> MallocSizeOf for Dom<T> {
+    fn size_of(&self, _ops: &mut MallocSizeOfOps) -> usize {
+        0
+    }
+}
+
+impl<T> PartialEq for Dom<T> {
+    fn eq(&self, other: &Dom<T>) -> bool {
+        self.ptr.as_ptr() == other.ptr.as_ptr()
+    }
+}
+
+impl<'a, T: DomObject> PartialEq<&'a T> for Dom<T> {
+    fn eq(&self, other: &&'a T) -> bool {
+        *self == Dom::from_ref(*other)
+    }
+}
+
+impl<T> Eq for Dom<T> {}
+
+impl<T> Hash for Dom<T> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.ptr.as_ptr().hash(state)
+    }
+}
+
+impl<T> Clone for Dom<T> {
+    #[inline]
+    #[cfg_attr(crown, allow(crown::unrooted_must_root))]
+    fn clone(&self) -> Self {
+        assert_in_script();
+        Dom { ptr: self.ptr }
+    }
+}
+
+impl<T: DomObject> Dom<T> {
+    /// Create a `Dom<T>` from a `&T`
+    #[cfg_attr(crown, allow(crown::unrooted_must_root))]
+    pub fn from_ref(obj: &T) -> Dom<T> {
+        assert_in_script();
+        Dom {
+            ptr: ptr::NonNull::from(obj),
+        }
+    }
+
+    /// Return a rooted version of this DOM object ([`DomRoot<T>`]) suitable for use on the stack.
+    pub fn as_rooted(&self) -> DomRoot<T> {
+        DomRoot::from_ref(self)
+    }
+
+    pub fn as_ptr(&self) -> *const T {
+        self.ptr.as_ptr()
+    }
+}
+
+impl<T: DomObject> Deref for Dom<T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        assert_in_script();
+        // We can only have &Dom<T> from a rooted thing, so it's safe to deref
+        // it to &T.
+        unsafe { &*self.ptr.as_ptr() }
+    }
+}
+
+unsafe impl<T: DomObject> JSTraceable for Dom<T> {
+    unsafe fn trace(&self, trc: *mut JSTracer) {
+        let trace_string;
+        let trace_info = if cfg!(debug_assertions) {
+            trace_string = format!("for {} on heap", ::std::any::type_name::<T>());
+            &trace_string[..]
+        } else {
+            "for DOM object on heap"
+        };
+        trace_reflector(trc, trace_info, (*self.ptr.as_ptr()).reflector());
+    }
+}
+
+/// A traced reference to a DOM object that may not be reflected yet.
+#[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
+pub struct MaybeUnreflectedDom<T> {
+    ptr: ptr::NonNull<T>,
+}
+
+impl<T> MaybeUnreflectedDom<T>
+where
+    T: DomObject,
+{
+    #[cfg_attr(crown, allow(crown::unrooted_must_root))]
+    pub unsafe fn from_box(value: Box<T>) -> Self {
+        Self {
+            ptr: Box::leak(value).into(),
+        }
+    }
+}
+
+impl<T> Root<MaybeUnreflectedDom<T>>
+where
+    T: DomObject,
+{
+    pub fn as_ptr(&self) -> *const T {
+        self.value.ptr.as_ptr()
+    }
+}
+
+impl<T> Root<MaybeUnreflectedDom<T>>
+where
+    T: MutDomObject,
+{
+    pub unsafe fn reflect_with(self, obj: *mut JSObject) -> DomRoot<T> {
+        let ptr = self.as_ptr();
+        drop(self);
+        let root = DomRoot::from_ref(&*ptr);
+        root.init_reflector(obj);
+        root
+    }
+}
+
+/// A rooted reference to a DOM object.
+pub type DomRoot<T> = Root<Dom<T>>;
+
+impl<T: Castable> DomRoot<T> {
+    /// Cast a DOM object root upwards to one of the interfaces it derives from.
+    pub fn upcast<U>(root: DomRoot<T>) -> DomRoot<U>
+    where
+        U: Castable,
+        T: DerivedFrom<U>,
+    {
+        unsafe { mem::transmute::<DomRoot<T>, DomRoot<U>>(root) }
+    }
+
+    /// Cast a DOM object root downwards to one of the interfaces it might implement.
+    pub fn downcast<U>(root: DomRoot<T>) -> Option<DomRoot<U>>
+    where
+        U: DerivedFrom<T>,
+    {
+        if root.is::<U>() {
+            Some(unsafe { mem::transmute::<DomRoot<T>, DomRoot<U>>(root) })
+        } else {
+            None
+        }
+    }
+}
+
+impl<T: DomObject> DomRoot<T> {
+    /// Generate a new root from a reference
+    pub fn from_ref(unrooted: &T) -> DomRoot<T> {
+        unsafe { DomRoot::new(Dom::from_ref(unrooted)) }
+    }
+
+    /// Create a traced version of this rooted object.
+    ///
+    /// # Safety
+    ///
+    /// This should never be used to create on-stack values. Instead these values should always
+    /// end up as members of other DOM objects.
+    #[cfg_attr(crown, allow(crown::unrooted_must_root))]
+    pub fn as_traced(&self) -> Dom<T> {
+        Dom::from_ref(self)
+    }
+}
+
+impl<T> MallocSizeOf for DomRoot<T>
+where
+    T: DomObject + MallocSizeOf,
+{
+    fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
+        (**self).size_of(ops)
+    }
+}
+
+impl<T> PartialEq for DomRoot<T>
+where
+    T: DomObject,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.value == other.value
+    }
+}
+
+impl<T> Clone for DomRoot<T>
+where
+    T: DomObject,
+{
+    fn clone(&self) -> DomRoot<T> {
+        DomRoot::from_ref(self)
+    }
+}
+
+unsafe impl<T> JSTraceable for DomRoot<T>
+where
+    T: DomObject,
+{
+    unsafe fn trace(&self, _: *mut JSTracer) {
+        // Already traced.
+    }
+}
+
+/// A rooting mechanism for reflectors on the stack.
+/// LIFO is not required.
+///
+/// See also [*Exact Stack Rooting - Storing a GCPointer on the CStack*][cstack].
+///
+/// [cstack]: https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey/Internals/GC/Exact_Stack_Rooting
+pub struct RootCollection {
+    roots: UnsafeCell<Vec<*const dyn JSTraceable>>,
+}
+
+impl RootCollection {
+    /// Create an empty collection of roots
+    pub fn new() -> RootCollection {
+        assert_in_script();
+        RootCollection {
+            roots: UnsafeCell::new(vec![]),
+        }
+    }
+
+    /// Starts tracking a trace object.
+    unsafe fn root(&self, object: *const dyn JSTraceable) {
+        assert_in_script();
+        (*self.roots.get()).push(object);
+    }
+
+    /// Stops tracking a trace object, asserting if it isn't found.
+    unsafe fn unroot(&self, object: *const dyn JSTraceable) {
+        assert_in_script();
+        let roots = &mut *self.roots.get();
+        match roots
+            .iter()
+            .rposition(|r| std::ptr::addr_eq(*r as *const (), object as *const ()))
+        {
+            Some(idx) => {
+                roots.remove(idx);
+            },
+            None => panic!("Can't remove a root that was never rooted!"),
+        }
+    }
+}
+
+thread_local!(pub static STACK_ROOTS: Cell<Option<*const RootCollection>> = const { Cell::new(None) });
+
+/// SM Callback that traces the rooted reflectors
+pub unsafe fn trace_roots(tracer: *mut JSTracer) {
+    trace!("tracing stack roots");
+    STACK_ROOTS.with(|collection| {
+        let collection = &*(*collection.get().unwrap()).roots.get();
+        for root in collection {
+            (**root).trace(tracer);
+        }
+    });
+}
+
+pub fn assert_in_script() {
+    debug_assert!(thread_state::get().is_script());
+}

--- a/components/script_bindings/script_runtime.rs
+++ b/components/script_bindings/script_runtime.rs
@@ -3,6 +3,34 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::cell::Cell;
+use std::ops::Deref;
+
+use js::jsapi::JSContext as RawJSContext;
+
+#[derive(Clone, Copy)]
+#[repr(transparent)]
+pub struct JSContext(*mut RawJSContext);
+
+#[allow(unsafe_code)]
+impl JSContext {
+    /// Create a new [`JSContext`] object from the given raw pointer.
+    ///
+    /// # Safety
+    ///
+    /// The `RawJSContext` argument must point to a valid `RawJSContext` in memory.
+    pub unsafe fn from_ptr(raw_js_context: *mut RawJSContext) -> Self {
+        JSContext(raw_js_context)
+    }
+}
+
+#[allow(unsafe_code)]
+impl Deref for JSContext {
+    type Target = *mut RawJSContext;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 thread_local!(
     static THREAD_ACTIVE: Cell<bool> = const { Cell::new(true) };

--- a/components/script_bindings/trace.rs
+++ b/components/script_bindings/trace.rs
@@ -9,14 +9,20 @@ use crate::reflector::Reflector;
 use crate::str::{DOMString, USVString};
 
 /// Trace the `JSObject` held by `reflector`.
+///
+/// # Safety
+/// tracer must point to a valid, non-null JS tracer.
 #[cfg_attr(crown, allow(crown::unrooted_must_root))]
-pub fn trace_reflector(tracer: *mut JSTracer, description: &str, reflector: &Reflector) {
+pub unsafe fn trace_reflector(tracer: *mut JSTracer, description: &str, reflector: &Reflector) {
     trace!("tracing reflector {}", description);
     trace_object(tracer, description, reflector.rootable())
 }
 
 /// Trace a `JSObject`.
-pub fn trace_object(tracer: *mut JSTracer, description: &str, obj: &Heap<*mut JSObject>) {
+///
+/// # Safety
+/// tracer must point to a valid, non-null JS tracer.
+pub unsafe fn trace_object(tracer: *mut JSTracer, description: &str, obj: &Heap<*mut JSObject>) {
     unsafe {
         trace!("tracing {}", description);
         CallObjectTracer(

--- a/components/script_bindings/trace.rs
+++ b/components/script_bindings/trace.rs
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use js::jsapi::{Heap, GCTraceKindToAscii, JSObject, JSTracer, TraceKind};
 use js::glue::CallObjectTracer;
+use js::jsapi::{GCTraceKindToAscii, Heap, JSObject, JSTracer, TraceKind};
 
 use crate::reflector::Reflector;
 use crate::str::{DOMString, USVString};

--- a/components/script_bindings/trace.rs
+++ b/components/script_bindings/trace.rs
@@ -2,7 +2,30 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use js::jsapi::{Heap, GCTraceKindToAscii, JSObject, JSTracer, TraceKind};
+use js::glue::CallObjectTracer;
+
+use crate::reflector::Reflector;
 use crate::str::{DOMString, USVString};
+
+/// Trace the `JSObject` held by `reflector`.
+#[cfg_attr(crown, allow(crown::unrooted_must_root))]
+pub fn trace_reflector(tracer: *mut JSTracer, description: &str, reflector: &Reflector) {
+    trace!("tracing reflector {}", description);
+    trace_object(tracer, description, reflector.rootable())
+}
+
+/// Trace a `JSObject`.
+pub fn trace_object(tracer: *mut JSTracer, description: &str, obj: &Heap<*mut JSObject>) {
+    unsafe {
+        trace!("tracing {}", description);
+        CallObjectTracer(
+            tracer,
+            obj.ptr.get() as *mut _,
+            GCTraceKindToAscii(TraceKind::Object),
+        );
+    }
+}
 
 /// For use on non-jsmanaged types
 /// Use #[derive(JSTraceable)] on JS managed types


### PR DESCRIPTION
The vast majority of these changes are moving code from one file to another. However, the Dom/Root changes expose some code that assumes it's in the same crate and requires additional surgery.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #1799
- [x] There are tests for these changes