### PR TITLE
libservo: Clean up interfaces for alert()/confirm()/prompt()

### DIFF
--- a/components/constellation/tracing.rs
+++ b/components/constellation/tracing.rs
@@ -201,7 +201,7 @@ mod from_script {
                 Self::ChangePageTitle(..) => target_variant!("ChangePageTitle"),
                 Self::MoveTo(..) => target_variant!("MoveTo"),
                 Self::ResizeTo(..) => target_variant!("ResizeTo"),
-                Self::Prompt(..) => target_variant!("Prompt"),
+                Self::ShowSimpleDialog(..) => target_variant!("ShowSimpleDialog"),
                 Self::RequestAuthentication(..) => target_variant!("RequestAuthentication"),
                 Self::ShowContextMenu(..) => target_variant!("ShowContextMenu"),
                 Self::AllowNavigationRequest(..) => target_variant!("AllowNavigationRequest"),

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -708,11 +708,11 @@ impl Servo {
                     webview.delegate().request_resize_to(webview, size);
                 }
             },
-            EmbedderMsg::Prompt(webview_id, prompt_definition, prompt_origin) => {
+            EmbedderMsg::ShowSimpleDialog(webview_id, prompt_definition) => {
                 if let Some(webview) = self.get_webview_handle(webview_id) {
                     webview
                         .delegate()
-                        .show_prompt(webview, prompt_definition, prompt_origin);
+                        .show_simple_dialog(webview, prompt_definition);
                 }
             },
             EmbedderMsg::ShowContextMenu(webview_id, ipc_sender, title, items) => {

--- a/ports/servoshell/egl/android/simpleservo.rs
+++ b/ports/servoshell/egl/android/simpleservo.rs
@@ -14,7 +14,7 @@ pub use servo::webrender_api::units::DeviceIntRect;
 /// and that perform_updates need to be called
 pub use servo::EventLoopWaker;
 use servo::{self, resources, Servo};
-pub use servo::{InputMethodType, MediaSessionPlaybackState, PromptResult, WindowRenderingContext};
+pub use servo::{InputMethodType, MediaSessionPlaybackState, WindowRenderingContext};
 
 use crate::egl::android::resources::ResourceReaderInstance;
 use crate::egl::app_state::{

--- a/ports/servoshell/egl/host_trait.rs
+++ b/ports/servoshell/egl/host_trait.rs
@@ -3,18 +3,22 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use servo::webrender_api::units::DeviceIntRect;
-use servo::{InputMethodType, LoadStatus, MediaSessionPlaybackState, PromptResult};
+use servo::{
+    InputMethodType, LoadStatus, MediaSessionPlaybackState, PermissionRequest, SimpleDialog,
+    WebView,
+};
 
-/// Callbacks. Implemented by embedder. Called by Servo.
+/// Callbacks implemented by embedder. Called by our RunningAppState, generally on behalf of Servo.
 pub trait HostTrait {
-    /// Show alert.
-    fn prompt_alert(&self, msg: String, trusted: bool);
-    /// Ask Yes/No question.
-    fn prompt_yes_no(&self, msg: String, trusted: bool) -> PromptResult;
-    /// Ask Ok/Cancel question.
-    fn prompt_ok_cancel(&self, msg: String, trusted: bool) -> PromptResult;
-    /// Ask for string
-    fn prompt_input(&self, msg: String, default: String, trusted: bool) -> Option<String>;
+    /// Content in a [`WebView`] is requesting permission to access a feature requiring
+    /// permission from the user. The embedder should allow or deny the request, either by
+    /// reading a cached value or querying the user for permission via the user interface.
+    fn request_permission(&self, _webview: WebView, _: PermissionRequest);
+    /// Show the user a [simple dialog](https://html.spec.whatwg.org/multipage/#simple-dialogs) (`alert()`, `confirm()`,
+    /// or `prompt()`). Since their messages are controlled by web content, they should be presented to the user in a
+    /// way that makes them impossible to mistake for browser UI.
+    /// TODO: This API needs to be reworked to match the new model of how responses are sent.
+    fn show_simple_dialog(&self, _webview: WebView, dialog: SimpleDialog);
     /// Show context menu
     fn show_context_menu(&self, title: Option<String>, items: Vec<String>);
     /// Notify that the load status of the page has changed.

--- a/ports/servoshell/egl/ohos.rs
+++ b/ports/servoshell/egl/ohos.rs
@@ -21,7 +21,10 @@ use napi_ohos::{Env, JsObject, JsString, NapiRaw};
 use ohos_ime::{AttachOptions, Ime, ImeProxy, RawTextEditorProxy};
 use ohos_ime_sys::types::InputMethod_EnterKeyType;
 use servo::style::Zero;
-use servo::{InputMethodType, LoadStatus, MediaSessionPlaybackState, PromptResult};
+use servo::{
+    AlertResponse, InputMethodType, LoadStatus, MediaSessionPlaybackState, PermissionRequest,
+    SimpleDialog, WebView,
+};
 use simpleservo::EventLoopWaker;
 use xcomponent_sys::{
     OH_NativeXComponent, OH_NativeXComponent_Callback, OH_NativeXComponent_GetKeyEvent,
@@ -671,6 +674,19 @@ impl HostCallbacks {
             ime_proxy: RefCell::new(None),
         }
     }
+
+    pub fn show_alert(&self, message: String) {
+        match PROMPT_TOAST.get() {
+            Some(prompt_fn) => {
+                let status = prompt_fn.call(message, ThreadsafeFunctionCallMode::NonBlocking);
+                if status != napi_ohos::Status::Ok {
+                    // Queue could be full.
+                    error!("show_alert failed with {status}");
+                }
+            },
+            None => error!("PROMPT_TOAST not set. Dropping message {message}"),
+        }
+    }
 }
 
 struct ServoIme {
@@ -698,33 +714,38 @@ impl Ime for ServoIme {
 
 #[allow(unused)]
 impl HostTrait for HostCallbacks {
-    fn prompt_alert(&self, msg: String, _trusted: bool) {
-        debug!("prompt_alert: {msg}");
-        match PROMPT_TOAST.get() {
-            Some(prompt_fn) => {
-                let status = prompt_fn.call(msg, ThreadsafeFunctionCallMode::NonBlocking);
-                if status != napi_ohos::Status::Ok {
-                    // Queue could be full.
-                    error!("prompt_alert failed with {status}");
-                }
+    fn request_permission(&self, _webview: WebView, request: PermissionRequest) {
+        warn!("Permissions prompt not implemented. Denied.");
+        request.deny();
+    }
+
+    fn show_simple_dialog(&self, _webview: WebView, dialog: SimpleDialog) {
+        let _ = match dialog {
+            SimpleDialog::Alert {
+                message,
+                response_sender,
+            } => {
+                debug!("SimpleDialog::Alert");
+                // TODO: Indicate that this message is untrusted, and what origin it came from.
+                self.show_alert(message);
+                response_sender.send(AlertResponse::Ok)
             },
-            None => error!("PROMPT_TOAST not set. Dropping msg {msg}"),
-        }
-    }
-
-    fn prompt_yes_no(&self, msg: String, trusted: bool) -> PromptResult {
-        warn!("Prompt not implemented. Cancelled. {}", msg);
-        PromptResult::Secondary
-    }
-
-    fn prompt_ok_cancel(&self, msg: String, trusted: bool) -> PromptResult {
-        warn!("Prompt not implemented. Cancelled. {}", msg);
-        PromptResult::Secondary
-    }
-
-    fn prompt_input(&self, msg: String, default: String, trusted: bool) -> Option<String> {
-        warn!("Input prompt not implemented. Cancelled. {}", msg);
-        Some(default)
+            SimpleDialog::Confirm {
+                message,
+                response_sender,
+            } => {
+                warn!("Confirm dialog not implemented. Cancelled. {}", message);
+                response_sender.send(Default::default())
+            },
+            SimpleDialog::Prompt {
+                message,
+                response_sender,
+                ..
+            } => {
+                warn!("Prompt dialog not implemented. Cancelled. {}", message);
+                response_sender.send(Default::default())
+            },
+        };
     }
 
     fn show_context_menu(&self, title: Option<String>, items: Vec<String>) {
@@ -740,7 +761,7 @@ impl HostTrait for HostCallbacks {
         if load_status == LoadStatus::Complete {
             #[cfg(feature = "tracing-hitrace")]
             let _scope = hitrace::ScopedTrace::start_trace(&c"PageLoadEndedPrompt");
-            self.prompt_alert("Page finished loading!".to_string(), true);
+            self.show_alert("Page finished loading!".to_string());
         }
     }
 
@@ -838,7 +859,7 @@ impl HostTrait for HostCallbacks {
         if let Some(bt) = backtrace {
             error!("Backtrace: {bt:?}")
         }
-        self.prompt_alert("Servo crashed!".to_string(), true);
-        self.prompt_alert(reason, true);
+        self.show_alert("Servo crashed!".to_string());
+        self.show_alert(reason);
     }
 }

--- a/tests/wpt/meta/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_block_modals-2.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_block_modals-2.html.ini
@@ -1,3 +1,0 @@
-[iframe_sandbox_block_modals-2.html]
-  [Frames without `allow-modals` should not be able to open modal dialogs]
-    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_block_modals-3.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_block_modals-3.html.ini
@@ -1,3 +1,0 @@
-[iframe_sandbox_block_modals-3.html]
-  [Frames without `allow-modals` should not be able to open modal dialogs]
-    expected: FAIL

--- a/tests/wpt/meta/html/webappapis/user-prompts/cannot-show-simple-dialogs/confirm-different-origin-frame.sub.html.ini
+++ b/tests/wpt/meta/html/webappapis/user-prompts/cannot-show-simple-dialogs/confirm-different-origin-frame.sub.html.ini
@@ -1,4 +1,0 @@
-[confirm-different-origin-frame.sub.html]
-  [confirm-different-origin-frame]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/webappapis/user-prompts/cannot-show-simple-dialogs/prompt-different-origin-frame.sub.html.ini
+++ b/tests/wpt/meta/html/webappapis/user-prompts/cannot-show-simple-dialogs/prompt-different-origin-frame.sub.html.ini
@@ -1,4 +1,0 @@
-[prompt-different-origin-frame.sub.html]
-  [prompt-different-origin-frame]
-    expected: FAIL
-


### PR DESCRIPTION
libservo has a generic “prompt” interface in the form of PromptDefinition (message, response sender, etc), PromptOrigin (whether the dialog is trusted or from untrusted web content), and PromptResult (positive, negative, or dismissed). While this flexibility was needed in the past, now the interface is only used for [alert()](https://html.spec.whatwg.org/multipage/#dom-alert), [confirm()](https://html.spec.whatwg.org/multipage/#dom-confirm), and [prompt()](https://html.spec.whatwg.org/multipage/#dom-prompt).

This patch replaces that interface with a very specific “dialog” or “script dialog” interface that is explicitly designed for those three kinds of dialogs and nothing else:

- show_prompt → show_dialog
- PromptResult → AlertResponse, ConfirmResponse, PromptResponse
- ConfirmResponse has no Dismissed (it was equivalent to Secondary in both spec and impl)
- PromptOrigin is gone (all of these dialogs are untrusted)

This allows us to encode the DOM-specified default values for when the user agent [**cannot show simple dialogs**](https://html.spec.whatwg.org/multipage/#cannot-show-simple-dialogs), and (in the future) add document origin details. We also fix the default values for servoshell desktop headless mode and egl unimplemented dialogs, which were incorrectly Ok for confirm() on desktop, and Ok(default) for prompt() on both.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] ~~These changes fix #___ (GitHub issue number if applicable)~~

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___