### PR TITLE
Allow resetting multiple flags at once in Element::set_state

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -4307,16 +4307,20 @@ impl Element {
 
     pub(crate) fn set_state(&self, which: ElementState, value: bool) {
         let mut state = self.state.get();
-        if state.contains(which) == value {
-            return;
-        }
-        let node = self.upcast::<Node>();
-        node.owner_doc().element_state_will_change(self);
+        let previous_state = state;
         if value {
             state.insert(which);
         } else {
             state.remove(which);
         }
+
+        if previous_state == state {
+            // Nothing to do
+            return;
+        }
+
+        let node = self.upcast::<Node>();
+        node.owner_doc().element_state_will_change(self);
         self.state.set(state);
     }
 


### PR DESCRIPTION
Previously, the code would incorrectly return without updating the flags if the caller tried to reset multiple flags at once and the not all of them were true.



---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any error
- [X] There are tests for these changes (covered by wpt and a meter test from https://github.com/servo/servo/pull/35524)


