### PR TITLE
servoshell: Read prefs.json from bundle on OHOS

### DIFF
--- a/ports/servoshell/egl/ohos/simpleservo.rs
+++ b/ports/servoshell/egl/ohos/simpleservo.rs
@@ -53,7 +53,7 @@ pub fn init(
     );
     debug!("Servo commandline args: {:?}", args);
 
-    let _ = crate::prefs::DEFAULT_PREFS_DIR
+    let _ = crate::prefs::DEFAULT_CONFIG_DIR
         .set(resource_dir)
         .inspect_err(|e| {
             warn!(

--- a/ports/servoshell/egl/ohos/simpleservo.rs
+++ b/ports/servoshell/egl/ohos/simpleservo.rs
@@ -40,7 +40,7 @@ pub fn init(
     info!("Entered simpleservo init function");
     crate::init_crypto();
     let resource_dir = PathBuf::from(&options.resource_dir).join("servo");
-    resources::set(Box::new(ResourceReaderInstance::new(resource_dir)));
+    resources::set(Box::new(ResourceReaderInstance::new(resource_dir.clone())));
 
     // It would be nice if `from_cmdline_args()` could accept str slices, to avoid allocations here.
     // Then again, this code could and maybe even should be disabled in production builds.
@@ -52,6 +52,13 @@ pub fn init(
             .map(|arg| arg.to_string()),
     );
     debug!("Servo commandline args: {:?}", args);
+
+    if crate::prefs::OVERRIDE_DEFAULT_PREFS_DIR
+        .set(resource_dir)
+        .is_err()
+    {
+        info!("Default Prefs Dir already previously filled");
+    };
 
     let (opts, preferences, servoshell_preferences) = match parse_command_line_arguments(args) {
         ArgumentParsingResult::ContentProcess(..) => {

--- a/ports/servoshell/egl/ohos/simpleservo.rs
+++ b/ports/servoshell/egl/ohos/simpleservo.rs
@@ -8,7 +8,7 @@ use std::ptr::NonNull;
 use std::rc::Rc;
 
 use dpi::PhysicalSize;
-use log::{debug, info};
+use log::{debug, info, warn};
 use raw_window_handle::{
     DisplayHandle, OhosDisplayHandle, OhosNdkWindowHandle, RawDisplayHandle, RawWindowHandle,
     WindowHandle,
@@ -53,12 +53,14 @@ pub fn init(
     );
     debug!("Servo commandline args: {:?}", args);
 
-    if crate::prefs::OVERRIDE_DEFAULT_PREFS_DIR
+    let _ = crate::prefs::DEFAULT_PREFS_DIR
         .set(resource_dir)
-        .is_err()
-    {
-        info!("Default Prefs Dir already previously filled");
-    };
+        .inspect_err(|e| {
+            warn!(
+                "Default Prefs Dir already previously filled. Got error {}",
+                e.display()
+            );
+        });
 
     let (opts, preferences, servoshell_preferences) = match parse_command_line_arguments(args) {
         ArgumentParsingResult::ContentProcess(..) => {

--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -6,6 +6,8 @@ use std::collections::HashMap;
 use std::fs::{read_to_string, File};
 use std::io::Read;
 use std::path::{Path, PathBuf};
+#[cfg(any(target_os = "android", target_env = "ohos"))]
+use std::sync::OnceLock;
 use std::{env, fs, process};
 
 use euclid::Size2D;
@@ -90,9 +92,12 @@ pub fn default_config_dir() -> Option<PathBuf> {
     Some(config_dir)
 }
 
+/// Overrides the default preference dir
+#[cfg(any(target_os = "android", target_env = "ohos"))]
+pub(crate) static OVERRIDE_DEFAULT_PREFS_DIR: OnceLock<PathBuf> = OnceLock::new();
 #[cfg(any(target_os = "android", target_env = "ohos"))]
 pub fn default_config_dir() -> Option<PathBuf> {
-    None
+    OVERRIDE_DEFAULT_PREFS_DIR.get().cloned()
 }
 
 #[cfg(target_os = "macos")]

--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -94,10 +94,10 @@ pub fn default_config_dir() -> Option<PathBuf> {
 
 /// Overrides the default preference dir
 #[cfg(any(target_os = "android", target_env = "ohos"))]
-pub(crate) static OVERRIDE_DEFAULT_PREFS_DIR: OnceLock<PathBuf> = OnceLock::new();
+pub(crate) static DEFAULT_PREFS_DIR: OnceLock<PathBuf> = OnceLock::new();
 #[cfg(any(target_os = "android", target_env = "ohos"))]
 pub fn default_config_dir() -> Option<PathBuf> {
-    OVERRIDE_DEFAULT_PREFS_DIR.get().cloned()
+    DEFAULT_PREFS_DIR.get().cloned()
 }
 
 #[cfg(target_os = "macos")]

--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -94,10 +94,10 @@ pub fn default_config_dir() -> Option<PathBuf> {
 
 /// Overrides the default preference dir
 #[cfg(any(target_os = "android", target_env = "ohos"))]
-pub(crate) static DEFAULT_PREFS_DIR: OnceLock<PathBuf> = OnceLock::new();
+pub(crate) static DEFAULT_CONFIG_DIR: OnceLock<PathBuf> = OnceLock::new();
 #[cfg(any(target_os = "android", target_env = "ohos"))]
 pub fn default_config_dir() -> Option<PathBuf> {
-    DEFAULT_PREFS_DIR.get().cloned()
+    DEFAULT_CONFIG_DIR.get().cloned()
 }
 
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
Allows to read the prefs.json from the hap bundle on OHOS.


<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #35455 (GitHub issue number if applicable)

It might require tests on android.

Signed-off-by: Narfinger <Narfinger@users.noreply.github.com>

