### PR TITLE
Add get_url() to GlobalScopeHelper

### DIFF
--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -3352,6 +3352,8 @@ pub(crate) trait GlobalScopeHelpers<D: crate::DomTypes> {
     fn incumbent() -> Option<DomRoot<D::GlobalScope>>;
 
     fn perform_a_microtask_checkpoint(&self, can_gc: CanGc);
+
+    fn get_url(&self) -> ServoUrl;
 }
 
 #[allow(unsafe_code)]
@@ -3386,5 +3388,9 @@ impl GlobalScopeHelpers<crate::DomTypeHolder> for GlobalScope {
 
     fn perform_a_microtask_checkpoint(&self, can_gc: CanGc) {
         GlobalScope::perform_a_microtask_checkpoint(self, can_gc)
+    }
+
+    fn get_url(&self) -> ServoUrl {
+        self.get_url()
     }
 }


### PR DESCRIPTION
This is needed to build with the tracing feature

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #35588 (GitHub issue number if applicable)

