### PR TITLE
build winit_minimal with bluetooth disabled

### DIFF
--- a/components/constellation/tracing.rs
+++ b/components/constellation/tracing.rs
@@ -233,7 +233,6 @@ mod from_script {
                     target_variant!("NotifyLoadStatusChanged(LoadStatus::Complete")
                 },
                 Self::Panic(..) => target_variant!("Panic"),
-                #[cfg(feature = "bluetooth")]
                 Self::GetSelectedBluetoothDevice(..) => {
                     target_variant!("GetSelectedBluetoothDevice")
                 },


### PR DESCRIPTION
The bluetooth feature is disabled by default when building winit_minimal, but there were a couple of places that did not take that into account.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
