### PR TITLE
dom: Move child_list to rare data

### DIFF
--- a/components/script/dom/raredata.rs
+++ b/components/script/dom/raredata.rs
@@ -7,7 +7,7 @@ use std::rc::Rc;
 use euclid::default::Rect;
 use servo_atoms::Atom;
 
-use crate::dom::bindings::root::Dom;
+use crate::dom::bindings::root::{Dom, MutNullableDom};
 use crate::dom::customelementregistry::{
     CustomElementDefinition, CustomElementReaction, CustomElementState,
 };
@@ -16,6 +16,7 @@ use crate::dom::htmlslotelement::SlottableData;
 use crate::dom::intersectionobserver::IntersectionObserverRegistration;
 use crate::dom::mutationobserver::RegisteredObserver;
 use crate::dom::node::UniqueId;
+use crate::dom::nodelist::NodeList;
 use crate::dom::range::WeakRangeVec;
 use crate::dom::shadowroot::ShadowRoot;
 use crate::dom::window::LayoutValue;
@@ -42,6 +43,9 @@ pub(crate) struct NodeRareData {
     /// twice in this vector, even if both the start and end containers
     /// are this node.
     pub(crate) ranges: WeakRangeVec,
+
+    /// The live list of children return by .childNodes.
+    pub(crate) child_list: MutNullableDom<NodeList>,
 }
 
 #[derive(Default, JSTraceable, MallocSizeOf)]

--- a/tests/unit/script/size_of.rs
+++ b/tests/unit/script/size_of.rs
@@ -30,10 +30,10 @@ macro_rules! sizeof_checker (
 
 // Update the sizes here
 sizeof_checker!(size_event_target, EventTarget, 48);
-sizeof_checker!(size_node, Node, 176);
-sizeof_checker!(size_element, Element, 352);
-sizeof_checker!(size_htmlelement, HTMLElement, 368);
-sizeof_checker!(size_div, HTMLDivElement, 368);
-sizeof_checker!(size_span, HTMLSpanElement, 368);
-sizeof_checker!(size_text, Text, 208);
-sizeof_checker!(size_characterdata, CharacterData, 208);
+sizeof_checker!(size_node, Node, 168);
+sizeof_checker!(size_element, Element, 344);
+sizeof_checker!(size_htmlelement, HTMLElement, 360);
+sizeof_checker!(size_div, HTMLDivElement, 360);
+sizeof_checker!(size_span, HTMLSpanElement, 360);
+sizeof_checker!(size_text, Text, 200);
+sizeof_checker!(size_characterdata, CharacterData, 200);


### PR DESCRIPTION
This is only created when calling the ChildNodes method. Gecko also stores it in their similar data structure at https://searchfox.org/mozilla-central/rev/155d514d72473453492a822e97dc1c68cf49d110/dom/base/nsINode.h#1464

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #___ (GitHub issue number if applicable)

