### PR TITLE
refactor: add CanGc as argument to extract_size_algorithm

### DIFF
--- a/components/script/dom/countqueuingstrategy.rs
+++ b/components/script/dom/countqueuingstrategy.rs
@@ -122,7 +122,10 @@ pub(crate) fn extract_high_water_mark(
 /// If the size algorithm is not set, return a fallback function which always returns 1.
 ///
 /// <https://streams.spec.whatwg.org/#make-size-algorithm-from-size-function>
-pub(crate) fn extract_size_algorithm(strategy: &QueuingStrategy) -> Rc<QueuingStrategySize> {
+pub(crate) fn extract_size_algorithm(
+    strategy: &QueuingStrategy,
+    _can_gc: CanGc,
+) -> Rc<QueuingStrategySize> {
     if strategy.size.is_none() {
         let cx = GlobalScope::get_cx();
         let fun_obj = native_raw_obj_fn!(cx, count_queuing_strategy_size, c"size", 0, 0);

--- a/components/script/dom/readablestream.rs
+++ b/components/script/dom/readablestream.rs
@@ -128,7 +128,7 @@ fn create_readable_stream(
     // If sizeAlgorithm was not passed, set it to an algorithm that returns 1.
     let size_algorithm = queuing_strategy
         .size
-        .unwrap_or(extract_size_algorithm(&QueuingStrategy::empty()));
+        .unwrap_or(extract_size_algorithm(&QueuingStrategy::empty(), can_gc));
 
     // Assert: ! IsNonNegativeNumber(highWaterMark) is true.
     assert!(high_water_mark >= 0.0);
@@ -274,7 +274,7 @@ impl ReadableStream {
             global,
             source,
             1.0,
-            extract_size_algorithm(&QueuingStrategy::empty()),
+            extract_size_algorithm(&QueuingStrategy::empty(), can_gc),
             can_gc,
         );
         controller.setup(stream.clone(), can_gc)?;
@@ -931,7 +931,7 @@ impl ReadableStreamMethods<crate::DomTypeHolder> for ReadableStream {
             let high_water_mark = extract_high_water_mark(strategy, 1.0)?;
 
             // Let sizeAlgorithm be ! ExtractSizeAlgorithm(strategy).
-            let size_algorithm = extract_size_algorithm(strategy);
+            let size_algorithm = extract_size_algorithm(strategy, can_gc);
 
             let controller = ReadableStreamDefaultController::new(
                 global,

--- a/components/script/dom/writablestream.rs
+++ b/components/script/dom/writablestream.rs
@@ -877,7 +877,7 @@ impl WritableStreamMethods<crate::DomTypeHolder> for WritableStream {
         let stream = WritableStream::new_with_proto(global, proto, can_gc);
 
         // Let sizeAlgorithm be ! ExtractSizeAlgorithm(strategy).
-        let size_algorithm = extract_size_algorithm(strategy);
+        let size_algorithm = extract_size_algorithm(strategy, can_gc);
 
         // Let highWaterMark be ? ExtractHighWaterMark(strategy, 1).
         let high_water_mark = extract_high_water_mark(strategy, 1.0)?;


### PR DESCRIPTION
Add CanGc as argument to extract_size_algorithm.

Addressed part of https://github.com/servo/servo/issues/34573

---

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they are a refactor.
