### PR TITLE
refactor: add CanGc as argument to ByteLengthQueuingStrategy::GetSize

### DIFF
--- a/components/script/dom/bytelengthqueuingstrategy.rs
+++ b/components/script/dom/bytelengthqueuingstrategy.rs
@@ -62,7 +62,7 @@ impl ByteLengthQueuingStrategyMethods<crate::DomTypeHolder> for ByteLengthQueuin
     }
 
     /// <https://streams.spec.whatwg.org/#blqs-size>
-    fn GetSize(&self) -> Fallible<Rc<Function>> {
+    fn GetSize(&self, _can_gc: CanGc) -> Fallible<Rc<Function>> {
         let global = self.global();
         // Return this's relevant global object's byte length queuing strategy
         // size function.

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -62,6 +62,10 @@ DOMInterfaces = {
     'canGc': ['GetCharacteristic', 'GetCharacteristics', 'GetIncludedService', 'GetIncludedServices'],
 },
 
+'ByteLengthQueuingStrategy': {
+    'canGc': ['GetSize'],
+},
+
 'CanvasGradient': {
     'canGc': ['AddColorStop'],
 },


### PR DESCRIPTION
Add CanGc as argument to `ByteLengthQueuingStrategy::GetSize`.

Addressed part of https://github.com/servo/servo/issues/34573

---

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they are a refactor.
