### PR TITLE
refactor: add CanGc as argument to CountQueuingStrategy::GetSize

### DIFF
--- a/components/script/dom/countqueuingstrategy.rs
+++ b/components/script/dom/countqueuingstrategy.rs
@@ -61,7 +61,7 @@ impl CountQueuingStrategyMethods<crate::DomTypeHolder> for CountQueuingStrategy 
     }
 
     /// <https://streams.spec.whatwg.org/#cqs-size>
-    fn GetSize(&self) -> Fallible<Rc<Function>> {
+    fn GetSize(&self, _can_gc: CanGc) -> Fallible<Rc<Function>> {
         let global = self.global();
         // Return this's relevant global object's count queuing strategy
         // size function.

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -74,6 +74,10 @@ DOMInterfaces = {
     'canGc': ['Before', 'After', 'ReplaceWith']
 },
 
+'CountQueuingStrategy': {
+    'canGc': ['GetSize'],
+},
+
 'CSSStyleDeclaration': {
     'canGc': ['RemoveProperty', 'SetCssText', 'GetPropertyValue', 'SetProperty', 'CssFloat', 'SetCssFloat']
 },


### PR DESCRIPTION
Add CanGc as argument to `CountQueuingStrategy::GetSize`.

Addressed part of https://github.com/servo/servo/issues/34573

---

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they are a refactor.
