### PR TITLE
refactor: add CanGc as argument to create_buffer_source_with_length

### DIFF
--- a/components/script/dom/bindings/buffer_source.rs
+++ b/components/script/dom/bindings/buffer_source.rs
@@ -28,7 +28,7 @@ use js::typedarray::{CreateWith, TypedArray, TypedArrayElement, TypedArrayElemen
 
 #[cfg(feature = "webgpu")]
 use crate::dom::globalscope::GlobalScope;
-use crate::script_runtime::JSContext;
+use crate::script_runtime::{CanGc, JSContext};
 
 // Represents a `BufferSource` as defined in the WebIDL specification.
 ///
@@ -52,6 +52,7 @@ pub(crate) enum BufferSource {
 
 pub(crate) fn new_initialized_heap_buffer_source<T>(
     init: HeapTypedArrayInit,
+    can_gc: CanGc,
 ) -> Result<HeapBufferSource<T>, ()>
 where
     T: TypedArrayElement + TypedArrayElementCreator,
@@ -65,7 +66,7 @@ where
         HeapTypedArrayInit::Info { len, cx } => {
             rooted!(in (*cx) let mut array = ptr::null_mut::<JSObject>());
             let typed_array_result =
-                create_buffer_source_with_length::<T>(cx, len as usize, array.handle_mut());
+                create_buffer_source_with_length::<T>(cx, len as usize, array.handle_mut(), can_gc);
             if typed_array_result.is_err() {
                 return Err(());
             }
@@ -364,6 +365,7 @@ fn create_buffer_source_with_length<T>(
     cx: JSContext,
     len: usize,
     dest: MutableHandleObject,
+    _can_gc: CanGc,
 ) -> Result<TypedArray<T, *mut JSObject>, ()>
 where
     T: TypedArrayElement + TypedArrayElementCreator,

--- a/components/script/dom/imagedata.rs
+++ b/components/script/dom/imagedata.rs
@@ -67,6 +67,7 @@ impl ImageData {
     ) -> Fallible<DomRoot<ImageData>> {
         let heap_typed_array = match new_initialized_heap_buffer_source::<ClampedU8>(
             HeapTypedArrayInit::Buffer(BufferSource::ArrayBufferView(Heap::boxed(jsobject))),
+            can_gc,
         ) {
             Ok(heap_typed_array) => heap_typed_array,
             Err(_) => return Err(Error::JSFailed),
@@ -121,14 +122,13 @@ impl ImageData {
         let cx = GlobalScope::get_cx();
         let len = width * height * 4;
 
-        let heap_typed_array =
-            match new_initialized_heap_buffer_source::<ClampedU8>(HeapTypedArrayInit::Info {
-                len,
-                cx,
-            }) {
-                Ok(heap_typed_array) => heap_typed_array,
-                Err(_) => return Err(Error::JSFailed),
-            };
+        let heap_typed_array = match new_initialized_heap_buffer_source::<ClampedU8>(
+            HeapTypedArrayInit::Info { len, cx },
+            can_gc,
+        ) {
+            Ok(heap_typed_array) => heap_typed_array,
+            Err(_) => return Err(Error::JSFailed),
+        };
         let imagedata = Box::new(ImageData {
             reflector_: Reflector::new(),
             width,


### PR DESCRIPTION
Add CanGc as argument to `create_buffer_source_with_length`.

Addressed part of https://github.com/servo/servo/issues/34573

---

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they are a refactor.
