### PR TITLE
refactor: add CanGc as argument to create_buffer_source

### DIFF
--- a/components/script/dom/blob.rs
+++ b/components/script/dom/blob.rs
@@ -281,7 +281,7 @@ impl BlobMethods<crate::DomTypeHolder> for Blob {
                 match bytes {
                     Ok(b) => {
                         let cx = GlobalScope::get_cx();
-                        let result = run_array_buffer_data_algorithm(cx, b);
+                        let result = run_array_buffer_data_algorithm(cx, b, CanGc::note());
 
                         match result {
                             Ok(FetchedData::ArrayBuffer(a)) => promise.resolve_native(&a),

--- a/components/script/dom/dommatrixreadonly.rs
+++ b/components/script/dom/dommatrixreadonly.rs
@@ -776,7 +776,7 @@ impl DOMMatrixReadOnlyMethods<crate::DomTypeHolder> for DOMMatrixReadOnly {
     }
 
     // https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-tofloat32array
-    fn ToFloat32Array(&self, cx: JSContext) -> Float32Array {
+    fn ToFloat32Array(&self, cx: JSContext, can_gc: CanGc) -> Float32Array {
         let vec: Vec<f32> = self
             .matrix
             .borrow()
@@ -785,15 +785,20 @@ impl DOMMatrixReadOnlyMethods<crate::DomTypeHolder> for DOMMatrixReadOnly {
             .map(|&x| x as f32)
             .collect();
         rooted!(in (*cx) let mut array = ptr::null_mut::<JSObject>());
-        create_buffer_source(cx, &vec, array.handle_mut())
+        create_buffer_source(cx, &vec, array.handle_mut(), can_gc)
             .expect("Converting matrix to float32 array should never fail")
     }
 
     // https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-tofloat64array
-    fn ToFloat64Array(&self, cx: JSContext) -> Float64Array {
+    fn ToFloat64Array(&self, cx: JSContext, can_gc: CanGc) -> Float64Array {
         rooted!(in (*cx) let mut array = ptr::null_mut::<JSObject>());
-        create_buffer_source(cx, &self.matrix.borrow().to_array(), array.handle_mut())
-            .expect("Converting matrix to float64 array should never fail")
+        create_buffer_source(
+            cx,
+            &self.matrix.borrow().to_array(),
+            array.handle_mut(),
+            can_gc,
+        )
+        .expect("Converting matrix to float64 array should never fail")
     }
 
     // https://drafts.fxtf.org/geometry/#dommatrixreadonly-stringification-behavior

--- a/components/script/dom/filereadersync.rs
+++ b/components/script/dom/filereadersync.rs
@@ -98,14 +98,19 @@ impl FileReaderSyncMethods<crate::DomTypeHolder> for FileReaderSync {
     }
 
     /// <https://w3c.github.io/FileAPI/#readAsArrayBufferSyncSection>
-    fn ReadAsArrayBuffer(&self, cx: JSContext, blob: &Blob) -> Fallible<ArrayBuffer> {
+    fn ReadAsArrayBuffer(
+        &self,
+        cx: JSContext,
+        blob: &Blob,
+        can_gc: CanGc,
+    ) -> Fallible<ArrayBuffer> {
         // step 1
         let blob_contents = FileReaderSync::get_blob_bytes(blob)?;
 
         // step 2
         rooted!(in(*cx) let mut array_buffer = ptr::null_mut::<JSObject>());
 
-        create_buffer_source::<ArrayBufferU8>(cx, &blob_contents, array_buffer.handle_mut())
+        create_buffer_source::<ArrayBufferU8>(cx, &blob_contents, array_buffer.handle_mut(), can_gc)
             .map_err(|_| Error::JSFailed)
     }
 }

--- a/components/script/dom/gamepad.rs
+++ b/components/script/dom/gamepad.rs
@@ -153,7 +153,7 @@ impl Gamepad {
             None,
             can_gc,
         );
-        gamepad.init_axes();
+        gamepad.init_axes(can_gc);
         gamepad
     }
 }
@@ -254,7 +254,7 @@ impl Gamepad {
 
     /// Initialize the number of axes in the "standard" gamepad mapping.
     /// <https://www.w3.org/TR/gamepad/#dfn-initializing-axes>
-    fn init_axes(&self) {
+    fn init_axes(&self, can_gc: CanGc) {
         let initial_axes: Vec<f64> = vec![
             0., // Horizontal axis for left stick (negative left/positive right)
             0., // Vertical axis for left stick (negative up/positive down)
@@ -262,7 +262,7 @@ impl Gamepad {
             0., // Vertical axis for right stick (negative up/positive down)
         ];
         self.axes
-            .set_data(GlobalScope::get_cx(), &initial_axes)
+            .set_data(GlobalScope::get_cx(), &initial_axes, can_gc)
             .expect("Failed to set axes data on gamepad.")
     }
 

--- a/components/script/dom/readablestream.rs
+++ b/components/script/dom/readablestream.rs
@@ -250,7 +250,7 @@ impl ReadableStream {
             UnderlyingSourceType::Memory(bytes.len()),
             can_gc,
         )?;
-        stream.enqueue_native(bytes);
+        stream.enqueue_native(bytes, can_gc);
         stream.controller_close_native();
         Ok(stream)
     }
@@ -375,12 +375,12 @@ impl ReadableStream {
 
     /// Endpoint to enqueue chunks directly from Rust.
     /// Note: in other use cases this call happens via the controller.
-    pub(crate) fn enqueue_native(&self, bytes: Vec<u8>) {
+    pub(crate) fn enqueue_native(&self, bytes: Vec<u8>, can_gc: CanGc) {
         match self.controller {
             ControllerType::Default(ref controller) => controller
                 .get()
                 .expect("Stream should have controller.")
-                .enqueue_native(bytes),
+                .enqueue_native(bytes, can_gc),
             _ => unreachable!(
                 "Enqueueing chunk to a stream from Rust on other than default controller"
             ),

--- a/components/script/dom/response.rs
+++ b/components/script/dom/response.rs
@@ -454,12 +454,12 @@ impl Response {
         *self.stream_consumer.borrow_mut() = sc;
     }
 
-    pub(crate) fn stream_chunk(&self, chunk: Vec<u8>) {
+    pub(crate) fn stream_chunk(&self, chunk: Vec<u8>, can_gc: CanGc) {
         // Note, are these two actually mutually exclusive?
         if let Some(stream_consumer) = self.stream_consumer.borrow().as_ref() {
             stream_consumer.consume_chunk(chunk.as_slice());
         } else if let Some(body) = self.body_stream.get() {
-            body.enqueue_native(chunk);
+            body.enqueue_native(chunk, can_gc);
         }
     }
 

--- a/components/script/dom/subtlecrypto.rs
+++ b/components/script/dom/subtlecrypto.rs
@@ -176,7 +176,8 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                 let cx = GlobalScope::get_cx();
                 rooted!(in(*cx) let mut array_buffer_ptr = ptr::null_mut::<JSObject>());
 
-                if let Err(e) = normalized_algorithm.encrypt(&subtle, &key, &data, cx, array_buffer_ptr.handle_mut()) {
+                if let Err(e) = normalized_algorithm.encrypt(&subtle, &key, &data, cx, array_buffer_ptr.handle_mut(),
+                    CanGc::note()) {
                     promise.reject_error(e);
                     return;
                 }
@@ -229,7 +230,8 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                     return;
                 }
 
-                if let Err(e) = normalized_algorithm.decrypt(&subtle, &key, &data, cx, array_buffer_ptr.handle_mut()) {
+                if let Err(e) = normalized_algorithm.decrypt(&subtle, &key, &data, cx, array_buffer_ptr.handle_mut(),
+                    CanGc::note()) {
                     promise.reject_error(e);
                     return;
                 }
@@ -314,7 +316,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                 };
 
                 rooted!(in(*cx) let mut array_buffer_ptr = ptr::null_mut::<JSObject>());
-                create_buffer_source::<ArrayBufferU8>(cx, &result, array_buffer_ptr.handle_mut())
+                create_buffer_source::<ArrayBufferU8>(cx, &result, array_buffer_ptr.handle_mut(), CanGc::note())
                     .expect("failed to create buffer source for exported key.");
 
                 // Step 9. Resolve promise with result.
@@ -466,7 +468,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
 
                 let cx = GlobalScope::get_cx();
                 rooted!(in(*cx) let mut array_buffer_ptr = ptr::null_mut::<JSObject>());
-                create_buffer_source::<ArrayBufferU8>(cx, digest.as_ref(), array_buffer_ptr.handle_mut())
+                create_buffer_source::<ArrayBufferU8>(cx, digest.as_ref(), array_buffer_ptr.handle_mut(), CanGc::note())
                     .expect("failed to create buffer source for exported key.");
 
 
@@ -708,7 +710,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                     }
                 };
 
-                create_buffer_source::<ArrayBufferU8>(cx, &result, array_buffer_ptr.handle_mut())
+                create_buffer_source::<ArrayBufferU8>(cx, &result, array_buffer_ptr.handle_mut(), CanGc::note())
                     .expect("failed to create buffer source for derived bits.");
 
                 // Step 10. Resolve promise with result.
@@ -821,7 +823,8 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                             AesExportedKey::Raw(k) => {
                                 let cx = GlobalScope::get_cx();
                                 rooted!(in(*cx) let mut array_buffer_ptr = ptr::null_mut::<JSObject>());
-                                create_buffer_source::<ArrayBufferU8>(cx, &k, array_buffer_ptr.handle_mut())
+                                create_buffer_source::<ArrayBufferU8>(cx, &k, array_buffer_ptr.handle_mut(),
+                                    CanGc::note())
                                     .expect("failed to create buffer source for exported key.");
                                 promise.resolve_native(&array_buffer_ptr.get())
                             },
@@ -933,19 +936,20 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
 
                 let result = match normalized_algorithm {
                     KeyWrapAlgorithm::AesKw => {
-                        subtle.wrap_key_aes_kw(&wrapping_key, &bytes, cx, array_buffer_ptr.handle_mut())
+                        subtle.wrap_key_aes_kw(&wrapping_key, &bytes, cx, array_buffer_ptr.handle_mut(), CanGc::note())
                     },
                     KeyWrapAlgorithm::AesCbc(params) => {
-                        subtle.encrypt_aes_cbc(&params, &wrapping_key, &bytes, cx, array_buffer_ptr.handle_mut())
+                        subtle.encrypt_aes_cbc(&params, &wrapping_key, &bytes, cx, array_buffer_ptr.handle_mut(),
+                            CanGc::note())
                     },
                     KeyWrapAlgorithm::AesCtr(params) => {
                         subtle.encrypt_decrypt_aes_ctr(
-                            &params, &wrapping_key, &bytes, cx, array_buffer_ptr.handle_mut()
+                            &params, &wrapping_key, &bytes, cx, array_buffer_ptr.handle_mut(), CanGc::note()
                         )
                     },
                     KeyWrapAlgorithm::AesGcm(params) => {
                         subtle.encrypt_aes_gcm(
-                            &params, &wrapping_key, &bytes, cx, array_buffer_ptr.handle_mut()
+                            &params, &wrapping_key, &bytes, cx, array_buffer_ptr.handle_mut(), CanGc::note()
                         )
                     },
                 };
@@ -1016,21 +1020,25 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
 
                 let result = match normalized_algorithm {
                     KeyWrapAlgorithm::AesKw => {
-                        subtle.unwrap_key_aes_kw(&unwrapping_key, &wrapped_key_bytes, cx, array_buffer_ptr.handle_mut())
+                        subtle.unwrap_key_aes_kw(&unwrapping_key, &wrapped_key_bytes, cx, array_buffer_ptr.handle_mut(),
+                            CanGc::note())
                     },
                     KeyWrapAlgorithm::AesCbc(params) => {
                         subtle.decrypt_aes_cbc(
-                            &params, &unwrapping_key, &wrapped_key_bytes, cx, array_buffer_ptr.handle_mut()
+                            &params, &unwrapping_key, &wrapped_key_bytes, cx, array_buffer_ptr.handle_mut(),
+                            CanGc::note()
                         )
                     },
                     KeyWrapAlgorithm::AesCtr(params) => {
                         subtle.encrypt_decrypt_aes_ctr(
-                            &params, &unwrapping_key, &wrapped_key_bytes, cx, array_buffer_ptr.handle_mut()
+                            &params, &unwrapping_key, &wrapped_key_bytes, cx, array_buffer_ptr.handle_mut(),
+                            CanGc::note()
                         )
                     },
                     KeyWrapAlgorithm::AesGcm(params) => {
                         subtle.decrypt_aes_gcm(
-                            &params, &unwrapping_key, &wrapped_key_bytes, cx, array_buffer_ptr.handle_mut()
+                            &params, &unwrapping_key, &wrapped_key_bytes, cx, array_buffer_ptr.handle_mut(),
+                            CanGc::note()
                         )
                     },
                 };
@@ -1648,6 +1656,7 @@ impl SubtleCrypto {
         data: &[u8],
         cx: JSContext,
         handle: MutableHandleObject,
+        can_gc: CanGc,
     ) -> Result<Vec<u8>, Error> {
         if params.iv.len() != 16 {
             return Err(Error::Operation);
@@ -1672,7 +1681,7 @@ impl SubtleCrypto {
             _ => return Err(Error::Data),
         };
 
-        create_buffer_source::<ArrayBufferU8>(cx, &ct, handle)
+        create_buffer_source::<ArrayBufferU8>(cx, &ct, handle, can_gc)
             .expect("failed to create buffer source for exported key.");
 
         Ok(ct)
@@ -1686,6 +1695,7 @@ impl SubtleCrypto {
         data: &[u8],
         cx: JSContext,
         handle: MutableHandleObject,
+        can_gc: CanGc,
     ) -> Result<Vec<u8>, Error> {
         if params.iv.len() != 16 {
             return Err(Error::Operation);
@@ -1716,7 +1726,7 @@ impl SubtleCrypto {
             _ => return Err(Error::Data),
         };
 
-        create_buffer_source::<ArrayBufferU8>(cx, plaintext, handle)
+        create_buffer_source::<ArrayBufferU8>(cx, plaintext, handle, can_gc)
             .expect("failed to create buffer source for exported key.");
 
         Ok(plaintext.to_vec())
@@ -1730,6 +1740,7 @@ impl SubtleCrypto {
         data: &[u8],
         cx: JSContext,
         handle: MutableHandleObject,
+        can_gc: CanGc,
     ) -> Result<Vec<u8>, Error> {
         if params.counter.len() != 16 || params.length == 0 || params.length > 128 {
             return Err(Error::Operation);
@@ -1754,7 +1765,7 @@ impl SubtleCrypto {
             _ => return Err(Error::Data),
         };
 
-        create_buffer_source::<ArrayBufferU8>(cx, &ciphertext, handle)
+        create_buffer_source::<ArrayBufferU8>(cx, &ciphertext, handle, can_gc)
             .expect("failed to create buffer source for exported key.");
 
         Ok(ciphertext)
@@ -1768,6 +1779,7 @@ impl SubtleCrypto {
         plaintext: &[u8],
         cx: JSContext,
         handle: MutableHandleObject,
+        can_gc: CanGc,
     ) -> Result<Vec<u8>, Error> {
         // Step 1. If plaintext has a length greater than 2^39 - 256 bytes, then throw an OperationError.
         if plaintext.len() as u64 > (2 << 39) - 256 {
@@ -1874,7 +1886,7 @@ impl SubtleCrypto {
         ciphertext.extend_from_slice(&tag.unwrap()[..tag_length as usize / 8]);
 
         // Step 8. Return the result of creating an ArrayBuffer containing ciphertext.
-        create_buffer_source::<ArrayBufferU8>(cx, &ciphertext, handle)
+        create_buffer_source::<ArrayBufferU8>(cx, &ciphertext, handle, can_gc)
             .expect("failed to create buffer source for encrypted ciphertext");
 
         Ok(ciphertext)
@@ -1888,6 +1900,7 @@ impl SubtleCrypto {
         ciphertext: &[u8],
         cx: JSContext,
         handle: MutableHandleObject,
+        can_gc: CanGc,
     ) -> Result<Vec<u8>, Error> {
         // Step 1.
         // FIXME: aes_gcm uses a fixed tag length
@@ -1998,7 +2011,7 @@ impl SubtleCrypto {
         // Let plaintext be the output P of the Authenticated Decryption Function.
 
         // Step 9. Return the result of creating an ArrayBuffer containing plaintext.
-        create_buffer_source::<ArrayBufferU8>(cx, &plaintext, handle)
+        create_buffer_source::<ArrayBufferU8>(cx, &plaintext, handle, can_gc)
             .expect("failed to create buffer source for decrypted plaintext");
 
         Ok(plaintext)
@@ -2431,6 +2444,7 @@ impl SubtleCrypto {
         bytes: &[u8],
         cx: JSContext,
         handle: MutableHandleObject,
+        can_gc: CanGc,
     ) -> Result<Vec<u8>, Error> {
         // Step 1. If plaintext is not a multiple of 64 bits in length, then throw an OperationError.
         if bytes.len() % 8 != 0 {
@@ -2468,7 +2482,7 @@ impl SubtleCrypto {
             _ => return Err(Error::Operation),
         };
 
-        create_buffer_source::<ArrayBufferU8>(cx, &wrapped_key, handle)
+        create_buffer_source::<ArrayBufferU8>(cx, &wrapped_key, handle, can_gc)
             .expect("failed to create buffer source for wrapped key.");
 
         // 3. Return ciphertext.
@@ -2482,6 +2496,7 @@ impl SubtleCrypto {
         bytes: &[u8],
         cx: JSContext,
         handle: MutableHandleObject,
+        can_gc: CanGc,
     ) -> Result<Vec<u8>, Error> {
         // Step 1. Let plaintext be the result of performing the Key Unwrap operation described in Section 2.2.2
         //         of [RFC3394] with ciphertext as the input ciphertext and using the default Initial Value defined
@@ -2515,7 +2530,7 @@ impl SubtleCrypto {
             _ => return Err(Error::Operation),
         };
 
-        create_buffer_source::<ArrayBufferU8>(cx, &unwrapped_key, handle)
+        create_buffer_source::<ArrayBufferU8>(cx, &unwrapped_key, handle, can_gc)
             .expect("failed to create buffer source for unwrapped key.");
 
         // 3. Return plaintext.
@@ -2853,11 +2868,14 @@ impl EncryptionAlgorithm {
         data: &[u8],
         cx: JSContext,
         result: MutableHandleObject,
+        can_gc: CanGc,
     ) -> Result<Vec<u8>, Error> {
         match self {
-            Self::AesCbc(params) => subtle.encrypt_aes_cbc(params, key, data, cx, result),
-            Self::AesCtr(params) => subtle.encrypt_decrypt_aes_ctr(params, key, data, cx, result),
-            Self::AesGcm(params) => subtle.encrypt_aes_gcm(params, key, data, cx, result),
+            Self::AesCbc(params) => subtle.encrypt_aes_cbc(params, key, data, cx, result, can_gc),
+            Self::AesCtr(params) => {
+                subtle.encrypt_decrypt_aes_ctr(params, key, data, cx, result, can_gc)
+            },
+            Self::AesGcm(params) => subtle.encrypt_aes_gcm(params, key, data, cx, result, can_gc),
         }
     }
 
@@ -2869,11 +2887,14 @@ impl EncryptionAlgorithm {
         data: &[u8],
         cx: JSContext,
         result: MutableHandleObject,
+        can_gc: CanGc,
     ) -> Result<Vec<u8>, Error> {
         match self {
-            Self::AesCbc(params) => subtle.decrypt_aes_cbc(params, key, data, cx, result),
-            Self::AesCtr(params) => subtle.encrypt_decrypt_aes_ctr(params, key, data, cx, result),
-            Self::AesGcm(params) => subtle.decrypt_aes_gcm(params, key, data, cx, result),
+            Self::AesCbc(params) => subtle.decrypt_aes_cbc(params, key, data, cx, result, can_gc),
+            Self::AesCtr(params) => {
+                subtle.encrypt_decrypt_aes_ctr(params, key, data, cx, result, can_gc)
+            },
+            Self::AesGcm(params) => subtle.decrypt_aes_gcm(params, key, data, cx, result, can_gc),
         }
     }
 }

--- a/components/script/dom/testbinding.rs
+++ b/components/script/dom/testbinding.rs
@@ -226,7 +226,7 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
         let data: [u8; 16] = [0; 16];
 
         rooted!(in (*cx) let mut array = ptr::null_mut::<JSObject>());
-        create_buffer_source(cx, &data, array.handle_mut())
+        create_buffer_source(cx, &data, array.handle_mut(), CanGc::note())
             .expect("Creating ClampedU8 array should never fail")
     }
     fn AnyAttribute(&self, _: SafeJSContext, _: MutableHandleValue) {}

--- a/components/script/dom/textencoder.rs
+++ b/components/script/dom/textencoder.rs
@@ -64,11 +64,11 @@ impl TextEncoderMethods<crate::DomTypeHolder> for TextEncoder {
     }
 
     /// <https://encoding.spec.whatwg.org/#dom-textencoder-encode>
-    fn Encode(&self, cx: JSContext, input: USVString) -> Uint8Array {
+    fn Encode(&self, cx: JSContext, input: USVString, can_gc: CanGc) -> Uint8Array {
         let encoded = input.0.as_bytes();
 
         rooted!(in(*cx) let mut js_object = ptr::null_mut::<JSObject>());
-        create_buffer_source(cx, encoded, js_object.handle_mut())
+        create_buffer_source(cx, encoded, js_object.handle_mut(), can_gc)
             .expect("Converting input to uint8 array should never fail")
     }
 

--- a/components/script/dom/webxr/xrray.rs
+++ b/components/script/dom/webxr/xrray.rs
@@ -136,7 +136,7 @@ impl XRRayMethods<crate::DomTypeHolder> for XRRay {
     }
 
     /// <https://immersive-web.github.io/hit-test/#dom-xrray-matrix>
-    fn Matrix(&self, _cx: JSContext) -> Float32Array {
+    fn Matrix(&self, _cx: JSContext, can_gc: CanGc) -> Float32Array {
         // https://immersive-web.github.io/hit-test/#xrray-obtain-the-matrix
         if !self.matrix.is_initialized() {
             // Step 1
@@ -163,7 +163,7 @@ impl XRRayMethods<crate::DomTypeHolder> for XRRay {
                 .to_transform()
                 .to_array();
             self.matrix
-                .set_data(_cx, &arr)
+                .set_data(_cx, &arr, can_gc)
                 .expect("Failed to set matrix data on XRRAy.")
         }
 

--- a/components/script/dom/webxr/xrrigidtransform.rs
+++ b/components/script/dom/webxr/xrrigidtransform.rs
@@ -167,10 +167,10 @@ impl XRRigidTransformMethods<crate::DomTypeHolder> for XRRigidTransform {
         })
     }
     // https://immersive-web.github.io/webxr/#dom-xrrigidtransform-matrix
-    fn Matrix(&self, _cx: JSContext) -> Float32Array {
+    fn Matrix(&self, _cx: JSContext, can_gc: CanGc) -> Float32Array {
         if !self.matrix.is_initialized() {
             self.matrix
-                .set_data(_cx, &self.transform.to_transform().to_array())
+                .set_data(_cx, &self.transform.to_transform().to_array(), can_gc)
                 .expect("Failed to set on data on transform's internal matrix.")
         }
 

--- a/components/script/dom/webxr/xrsession.rs
+++ b/components/script/dom/webxr/xrsession.rs
@@ -993,7 +993,7 @@ impl XRSessionMethods<crate::DomTypeHolder> for XRSession {
     }
 
     /// <https://www.w3.org/TR/webxr/#dom-xrsession-supportedframerates>
-    fn GetSupportedFrameRates(&self, cx: JSContext) -> Option<Float32Array> {
+    fn GetSupportedFrameRates(&self, cx: JSContext, can_gc: CanGc) -> Option<Float32Array> {
         let session = self.session.borrow();
         if self.mode == XRSessionMode::Inline || session.supported_frame_rates().is_empty() {
             None
@@ -1001,7 +1001,7 @@ impl XRSessionMethods<crate::DomTypeHolder> for XRSession {
             let framerates = session.supported_frame_rates();
             rooted!(in (*cx) let mut array = ptr::null_mut::<JSObject>());
             Some(
-                create_buffer_source(cx, framerates, array.handle_mut())
+                create_buffer_source(cx, framerates, array.handle_mut(), can_gc)
                     .expect("Failed to construct supported frame rates array"),
             )
         }

--- a/components/script/dom/webxr/xrview.rs
+++ b/components/script/dom/webxr/xrview.rs
@@ -95,13 +95,13 @@ impl XRViewMethods<crate::DomTypeHolder> for XRView {
     }
 
     /// <https://immersive-web.github.io/webxr/#dom-xrview-projectionmatrix>
-    fn ProjectionMatrix(&self, _cx: JSContext) -> Float32Array {
+    fn ProjectionMatrix(&self, _cx: JSContext, can_gc: CanGc) -> Float32Array {
         if !self.proj.is_initialized() {
             let cx = GlobalScope::get_cx();
             // row_major since euclid uses row vectors
             let proj = self.view.projection.to_array();
             self.proj
-                .set_data(cx, &proj)
+                .set_data(cx, &proj, can_gc)
                 .expect("Failed to set projection matrix.")
         }
         self.proj

--- a/components/script/dom/writablestreamdefaultcontroller.rs
+++ b/components/script/dom/writablestreamdefaultcontroller.rs
@@ -164,7 +164,7 @@ impl Callback for WriteAlgorithmFulfillmentHandler {
         {
             rooted!(in(*cx) let mut rval = UndefinedValue());
             let mut queue = controller.queue.borrow_mut();
-            queue.dequeue_value(cx, Some(rval.handle_mut()));
+            queue.dequeue_value(cx, Some(rval.handle_mut()), can_gc);
         }
 
         let global = GlobalScope::from_safe_context(cx, realm);
@@ -526,7 +526,7 @@ impl WritableStreamDefaultController {
         // Perform ! DequeueValue(controller).
         {
             let mut queue = self.queue.borrow_mut();
-            queue.dequeue_value(cx, None);
+            queue.dequeue_value(cx, None, can_gc);
         }
 
         // Assert: controller.[[queue]] is empty.
@@ -600,7 +600,7 @@ impl WritableStreamDefaultController {
             if queue.is_empty() {
                 return;
             }
-            queue.peek_queue_value(cx, value.handle_mut())
+            queue.peek_queue_value(cx, value.handle_mut(), can_gc)
         };
 
         if is_closed {

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -272,7 +272,7 @@ impl FetchResponseListener for FetchContext {
 
     fn process_response_chunk(&mut self, _: RequestId, chunk: Vec<u8>) {
         let response = self.response_object.root();
-        response.stream_chunk(chunk);
+        response.stream_chunk(chunk, CanGc::note());
     }
 
     fn process_response_eof(

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -18,6 +18,10 @@ DOMInterfaces = {
     'weakReferenceable': True,
 },
 
+'AudioBuffer': {
+    'canGc':['CopyToChannel', 'GetChannelData'],
+},
+
 'AudioContext': {
     'inRealms': ['Close', 'Suspend'],
     'canGc':['CreateMediaStreamDestination', 'CreateMediaElementSource', 'CreateMediaStreamSource', 'CreateMediaStreamTrackSource', 'Suspend', 'Close'],
@@ -117,7 +121,7 @@ DOMInterfaces = {
 },
 
 'DOMMatrixReadOnly': {
-    'canGc': ['Multiply', 'Inverse', 'Scale', 'Translate', 'Rotate', 'RotateFromVector','FlipY', 'ScaleNonUniform', 'Scale3d', 'RotateAxisAngle', 'SkewX', 'SkewY', 'FlipX', 'TransformPoint', 'FromFloat32Array', 'FromFloat64Array','FromMatrix'],
+    'canGc': ['Multiply', 'Inverse', 'Scale', 'Translate', 'Rotate', 'RotateFromVector','FlipY', 'ScaleNonUniform', 'Scale3d', 'RotateAxisAngle', 'SkewX', 'SkewY', 'FlipX', 'TransformPoint', 'FromFloat32Array', 'FromFloat64Array', 'FromMatrix', 'ToFloat32Array', 'ToFloat64Array'],
 },
 
 'DOMParser': {
@@ -174,6 +178,10 @@ DOMInterfaces = {
 
 'FileReader': {
     'canGc': ['Abort'],
+},
+
+'FileReaderSync': {
+    'canGc': ['ReadAsArrayBuffer'],
 },
 
 'FontFaceSet': {
@@ -481,6 +489,10 @@ DOMInterfaces = {
     'canGc': ['SplitText']
 },
 
+'TextEncoder': {
+    'canGc': ['Encode']
+},
+
 'URL': {
     'weakReferenceable': True,
     'canGc': ['Parse', 'SearchParams'],
@@ -539,7 +551,7 @@ DOMInterfaces = {
 },
 
 'XRRay': {
-    'canGc': ['Origin', 'Direction'],
+    'canGc': ['Origin', 'Direction', 'Matrix'],
 },
 
 'XRReferenceSpace': {
@@ -547,12 +559,12 @@ DOMInterfaces = {
 },
 
 'XRRigidTransform': {
-    'canGc': ['Position', 'Orientation', 'Inverse'],
+    'canGc': ['Position', 'Orientation', 'Inverse', 'Matrix'],
 },
 
 'XRSession': {
     'inRealms': ['RequestReferenceSpace', 'UpdateRenderState', 'UpdateTargetFrameRate'],
-    'canGc': ['End', 'RequestReferenceSpace', 'UpdateTargetFrameRate', 'RequestHitTestSource'],
+    'canGc': ['End', 'RequestReferenceSpace', 'UpdateTargetFrameRate', 'RequestHitTestSource', 'GetSupportedFrameRates'],
 },
 
 'XRSystem': {
@@ -562,6 +574,10 @@ DOMInterfaces = {
 
 'XRTest': {
     'canGc': ['SimulateDeviceConnection', 'DisconnectAllDevices'],
+},
+
+'XRView': {
+    'canGc': ['ProjectionMatrix'],
 },
 
 'ReadableStream': {


### PR DESCRIPTION
Add CanGc as argument to `create_buffer_source`.

Addressed part of https://github.com/servo/servo/issues/34573

---

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they are a refactor.
