### PR TITLE
refactor: add CanGc as argument to SubtleCrypto::import_key_{pbkdf2, aes, hkdf, hmac}

### DIFF
--- a/components/script/dom/subtlecrypto.rs
+++ b/components/script/dom/subtlecrypto.rs
@@ -2189,6 +2189,7 @@ impl SubtleCrypto {
         extractable: bool,
         usages: Vec<KeyUsage>,
         alg_name: &str,
+        can_gc: CanGc,
     ) -> Result<DomRoot<CryptoKey>, Error> {
         if usages.iter().any(|usage| {
             !matches!(
@@ -2231,7 +2232,7 @@ impl SubtleCrypto {
             algorithm_object.handle(),
             usages,
             handle,
-            CanGc::note(),
+            can_gc,
         );
 
         Ok(crypto_key)
@@ -2299,6 +2300,7 @@ impl SubtleCrypto {
         data: &[u8],
         extractable: bool,
         usages: Vec<KeyUsage>,
+        can_gc: CanGc,
     ) -> Result<DomRoot<CryptoKey>, Error> {
         // Step 1. Let keyData be the key data to be imported.
         // Step 2.  If format is "raw":
@@ -2336,7 +2338,7 @@ impl SubtleCrypto {
                 algorithm_object.handle(),
                 usages,
                 Handle::Hkdf(data.to_vec()),
-                CanGc::note(),
+                can_gc,
             );
 
             // Step 8. Return key.
@@ -2356,6 +2358,7 @@ impl SubtleCrypto {
         key_data: &[u8],
         extractable: bool,
         usages: Vec<KeyUsage>,
+        can_gc: CanGc,
     ) -> Result<DomRoot<CryptoKey>, Error> {
         // Step 1. Let keyData be the key data to be imported.
         // Step 2. If usages contains an entry which is not "sign" or "verify", then throw a SyntaxError.
@@ -2434,7 +2437,7 @@ impl SubtleCrypto {
             algorithm_object.handle(),
             usages,
             Handle::Hmac(truncated_data),
-            CanGc::note(),
+            can_gc,
         );
 
         // Step 15. Return key.
@@ -2827,24 +2830,24 @@ impl ImportKeyAlgorithm {
     ) -> Result<DomRoot<CryptoKey>, Error> {
         match self {
             Self::AesCbc => {
-                subtle.import_key_aes(format, secret, extractable, key_usages, ALG_AES_CBC)
+                subtle.import_key_aes(format, secret, extractable, key_usages, ALG_AES_CBC, can_gc)
             },
             Self::AesCtr => {
-                subtle.import_key_aes(format, secret, extractable, key_usages, ALG_AES_CTR)
+                subtle.import_key_aes(format, secret, extractable, key_usages, ALG_AES_CTR, can_gc)
             },
             Self::AesKw => {
-                subtle.import_key_aes(format, secret, extractable, key_usages, ALG_AES_KW)
+                subtle.import_key_aes(format, secret, extractable, key_usages, ALG_AES_KW, can_gc)
             },
             Self::AesGcm => {
-                subtle.import_key_aes(format, secret, extractable, key_usages, ALG_AES_GCM)
+                subtle.import_key_aes(format, secret, extractable, key_usages, ALG_AES_GCM, can_gc)
             },
             Self::Hmac(params) => {
-                subtle.import_key_hmac(params, format, secret, extractable, key_usages)
+                subtle.import_key_hmac(params, format, secret, extractable, key_usages, can_gc)
             },
             Self::Pbkdf2 => {
                 subtle.import_key_pbkdf2(format, secret, extractable, key_usages, can_gc)
             },
-            Self::Hkdf => subtle.import_key_hkdf(format, secret, extractable, key_usages),
+            Self::Hkdf => subtle.import_key_hkdf(format, secret, extractable, key_usages, can_gc),
         }
     }
 }


### PR DESCRIPTION
Add CanGc as argument to `SubtleCrypto::import_key_{pbkdf2, aes, hkdf, hmac}`.

Addressed part of https://github.com/servo/servo/issues/34573

---

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they are a refactor.
