### PR TITLE
libservo: Move WebDriver messages to the `embedder` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1852,6 +1852,7 @@ version = "0.0.1"
 dependencies = [
  "base",
  "cfg-if",
+ "cookie 0.18.1",
  "crossbeam-channel",
  "euclid",
  "http 1.2.0",
@@ -1862,10 +1863,13 @@ dependencies = [
  "malloc_size_of_derive",
  "num-derive",
  "num-traits",
+ "pixels",
  "serde",
  "servo_malloc_size_of",
  "servo_url",
+ "style_traits",
  "url",
+ "webdriver",
  "webrender_api",
  "webxr-api",
 ]

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -25,7 +25,10 @@ use crossbeam_channel::{unbounded, Sender};
 use cssparser::{Parser, ParserInput, SourceLocation};
 use devtools_traits::{ScriptToDevtoolsControlMsg, TimelineMarker, TimelineMarkerType};
 use dom_struct::dom_struct;
-use embedder_traits::{EmbedderMsg, PromptDefinition, PromptOrigin, PromptResult, Theme};
+use embedder_traits::{
+    EmbedderMsg, PromptDefinition, PromptOrigin, PromptResult, Theme, WebDriverJSError,
+    WebDriverJSResult,
+};
 use euclid::default::{Point2D as UntypedPoint2D, Rect as UntypedRect};
 use euclid::{Point2D, Rect, Scale, Size2D, Vector2D};
 use fonts::FontContext;
@@ -56,7 +59,6 @@ use script_layout_interface::{
     combine_id_with_fragment_type, FragmentType, Layout, PendingImageState, QueryMsg, Reflow,
     ReflowGoal, ReflowRequest, TrustedNodeAddress,
 };
-use script_traits::webdriver_msg::{WebDriverJSError, WebDriverJSResult};
 use script_traits::{
     DocumentState, LoadData, LoadOrigin, NavigationHistoryBehavior, ScriptMsg, ScriptThreadMessage,
     ScriptToConstellationChan, ScrollState, StructuredSerializedData, WindowSizeData,

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -45,7 +45,9 @@ use devtools_traits::{
     CSSError, DevtoolScriptControlMsg, DevtoolsPageInfo, NavigationState,
     ScriptToDevtoolsControlMsg, WorkerId,
 };
-use embedder_traits::{EmbedderMsg, InputEvent, MediaSessionActionType, Theme};
+use embedder_traits::{
+    EmbedderMsg, InputEvent, MediaSessionActionType, Theme, WebDriverScriptCommand,
+};
 use euclid::default::Rect;
 use fonts::{FontContext, SystemFontServiceProxy};
 use headers::{HeaderMapExt, LastModified, ReferrerPolicy as ReferrerPolicyHeader};
@@ -77,7 +79,6 @@ use profile_traits::time_profile;
 use script_layout_interface::{
     node_id_from_scroll_id, LayoutConfig, LayoutFactory, ReflowGoal, ScriptThreadFactory,
 };
-use script_traits::webdriver_msg::WebDriverScriptCommand;
 use script_traits::{
     ConstellationInputEvent, DiscardBrowsingContext, DocumentActivity, EventResult,
     InitialScriptState, JsEvalResult, LoadData, LoadOrigin, NavigationHistoryBehavior,

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -8,6 +8,9 @@ use std::ffi::CString;
 
 use base::id::{BrowsingContextId, PipelineId};
 use cookie::Cookie;
+use embedder_traits::{
+    WebDriverCookieError, WebDriverFrameId, WebDriverJSError, WebDriverJSResult, WebDriverJSValue,
+};
 use euclid::default::{Point2D, Rect, Size2D};
 use hyper_serde::Serde;
 use ipc_channel::ipc::{self, IpcSender};
@@ -21,9 +24,6 @@ use js::rust::{HandleObject, HandleValue, IdVector};
 use net_traits::CookieSource::{NonHTTP, HTTP};
 use net_traits::CoreResourceMsg::{DeleteCookies, GetCookiesDataForUrl, SetCookieForUrl};
 use net_traits::IpcSend;
-use script_traits::webdriver_msg::{
-    WebDriverCookieError, WebDriverFrameId, WebDriverJSError, WebDriverJSResult, WebDriverJSValue,
-};
 use servo_url::ServoUrl;
 use webdriver::common::{WebElement, WebFrame, WebWindow};
 use webdriver::error::ErrorStatus;

--- a/components/shared/compositing/constellation_msg.rs
+++ b/components/shared/compositing/constellation_msg.rs
@@ -8,11 +8,11 @@ use std::time::Duration;
 
 use base::id::{BrowsingContextId, PipelineId, TopLevelBrowsingContextId, WebViewId};
 use base::Epoch;
-use embedder_traits::{Cursor, InputEvent, MediaSessionActionType, Theme, TraversalDirection};
-use ipc_channel::ipc::IpcSender;
-use script_traits::{
-    AnimationTickType, LogEntry, WebDriverCommandMsg, WindowSizeData, WindowSizeType,
+use embedder_traits::{
+    Cursor, InputEvent, MediaSessionActionType, Theme, TraversalDirection, WebDriverCommandMsg,
 };
+use ipc_channel::ipc::IpcSender;
+use script_traits::{AnimationTickType, LogEntry, WindowSizeData, WindowSizeType};
 use servo_url::ServoUrl;
 use webrender_traits::CompositorHitTestResult;
 

--- a/components/shared/embedder/Cargo.toml
+++ b/components/shared/embedder/Cargo.toml
@@ -17,6 +17,7 @@ webxr = ["dep:webxr-api"]
 [dependencies]
 base = { workspace = true }
 cfg-if = { workspace = true }
+cookie = { workspace = true }
 crossbeam-channel = { workspace = true }
 euclid = { workspace = true }
 http = { workspace = true }
@@ -28,8 +29,11 @@ num-derive = "0.4"
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
 num-traits = { workspace = true }
+pixels = { path = "../../pixels" }
 serde = { workspace = true }
 servo_url = { path = "../../url" }
+style_traits = { workspace = true }
 url = { workspace = true }
+webdriver = { workspace = true }
 webrender_api = { workspace = true }
 webxr-api = { workspace = true, features = ["ipc"], optional = true }

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -4,6 +4,7 @@
 
 pub mod input_events;
 pub mod resources;
+mod webdriver;
 
 use std::fmt::{Debug, Error, Formatter};
 use std::path::PathBuf;
@@ -22,6 +23,7 @@ use url::Url;
 use webrender_api::units::{DeviceIntPoint, DeviceIntRect, DeviceIntSize};
 
 pub use crate::input_events::*;
+pub use crate::webdriver::*;
 
 /// Tracks whether Servo isn't shutting down, is in the process of shutting down,
 /// or has finished shutting down.

--- a/components/webdriver_server/actions.rs
+++ b/components/webdriver_server/actions.rs
@@ -7,11 +7,9 @@ use std::time::{Duration, Instant};
 use std::{cmp, thread};
 
 use compositing_traits::ConstellationMsg;
-use embedder_traits::MouseButtonAction;
+use embedder_traits::{MouseButtonAction, WebDriverCommandMsg, WebDriverScriptCommand};
 use ipc_channel::ipc;
 use keyboard_types::webdriver::KeyInputState;
-use script_traits::webdriver_msg::WebDriverScriptCommand;
-use script_traits::WebDriverCommandMsg;
 use webdriver::actions::{
     ActionSequence, ActionsType, GeneralAction, KeyAction, KeyActionItem, KeyDownAction,
     KeyUpAction, NullActionItem, PointerAction, PointerActionItem, PointerActionParameters,
@@ -398,8 +396,8 @@ impl Handler {
             .unwrap();
 
         // Steps 7 - 8
-        let viewport = receiver.recv().unwrap().initial_viewport;
-        if x < 0 || x as f32 > viewport.width || y < 0 || y as f32 > viewport.height {
+        let viewport_size = receiver.recv().unwrap();
+        if x < 0 || x as f32 > viewport_size.width || y < 0 || y as f32 > viewport_size.height {
             return Err(ErrorStatus::MoveTargetOutOfBounds);
         }
 


### PR DESCRIPTION
This is the first step toward moving the WebDriver implementation to
servoshell. This move will make it possible to start testing the
embedding API with WebDriver. See [this zulip thread][a] for more details.

While WebDriver will be able to use a lot of API commands to do what it
is doing now, there will still need to be some "cheat codes" for more
gnarly access to `ScriptThread` details. That's why we likely won't be
able to remove all WebDriver-specific messages from the API -- but maybe
they will be useful for embedders somehow.

A couple messages have to change as they depended on `script_traits`
types, particularly those that used `WindowSizeData` and `LoadData`. I
think this helps to encapsulate the WebDriver commands a bit more
though.

[a]: https://servo.zulipchat.com/#narrow/channel/437943-embedding/topic/webdriver.20as.20embedding.20api.20playgound

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they just move some types to a new crate.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
