### PR TITLE
refactor: propagate CanGc arguments through callers, part 3/n

### DIFF
--- a/components/script/dom/readablestreamdefaultcontroller.rs
+++ b/components/script/dom/readablestreamdefaultcontroller.rs
@@ -715,7 +715,7 @@ impl ReadableStreamDefaultController {
                     // First, throw the exception.
                     // Note: this must be done manually here,
                     // because `enqueue_value_with_size` does not call into JS.
-                    throw_dom_exception(cx, &self.global(), error, CanGc::note());
+                    throw_dom_exception(cx, &self.global(), error, can_gc);
 
                     // Then, get a handle to the JS val for the exception,
                     // and use that to error the stream.

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -352,7 +352,7 @@ impl ModuleTree {
             &owner.global(),
             Some(ModuleHandler::new_boxed(Box::new(
                 task!(fetched_resolve: move || {
-                    this.notify_owner_to_finish(identity, options,CanGc::note());
+                    this.notify_owner_to_finish(identity, options, CanGc::note());
                 }),
             ))),
             None,


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Addresses part of #34573 

Of note, these functions from #34573 are now equipped with a `can_gc` argument:
- `SubtleCrypto::generate_key_aes`
- `SubtleCrypto::generate_key_hmac`

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [x] These changes do not require tests because they are a refactor

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
