### PR TITLE
script: add `CanGc` argument to `Promise::new_resolved` and `Promise::new_rejected`

### DIFF
--- a/components/script/dom/defaultteeunderlyingsource.rs
+++ b/components/script/dom/defaultteeunderlyingsource.rs
@@ -115,7 +115,7 @@ impl DefaultTeeUnderlyingSource {
             // Return a promise resolved with undefined.
             let cx = GlobalScope::get_cx();
             rooted!(in(*cx) let mut rval = UndefinedValue());
-            return Promise::new_resolved(&self.stream.global(), cx, rval.handle());
+            return Promise::new_resolved(&self.stream.global(), cx, rval.handle(), can_gc);
         }
 
         // Set reading to true.
@@ -147,7 +147,12 @@ impl DefaultTeeUnderlyingSource {
         // Return a promise resolved with undefined.
         let cx = GlobalScope::get_cx();
         rooted!(in(*cx) let mut rval = UndefinedValue());
-        Promise::new_resolved(&self.stream.global(), GlobalScope::get_cx(), rval.handle())
+        Promise::new_resolved(
+            &self.stream.global(),
+            GlobalScope::get_cx(),
+            rval.handle(),
+            can_gc,
+        )
     }
 
     /// <https://streams.spec.whatwg.org/#abstract-opdef-readablestreamdefaulttee>

--- a/components/script/dom/promise.rs
+++ b/components/script/dom/promise.rs
@@ -153,6 +153,7 @@ impl Promise {
         global: &GlobalScope,
         cx: SafeJSContext,
         value: impl ToJSValConvertible,
+        _can_gc: CanGc,
     ) -> Rc<Promise> {
         let _ac = JSAutoRealm::new(*cx, global.reflector().get_jsobject().get());
         unsafe {
@@ -400,6 +401,6 @@ impl PromiseHelpers<crate::DomTypeHolder> for Promise {
         cx: SafeJSContext,
         value: impl ToJSValConvertible,
     ) -> Rc<Promise> {
-        Promise::new_resolved(global, cx, value)
+        Promise::new_resolved(global, cx, value, CanGc::note())
     }
 }

--- a/components/script/dom/promise.rs
+++ b/components/script/dom/promise.rs
@@ -171,6 +171,7 @@ impl Promise {
         global: &GlobalScope,
         cx: SafeJSContext,
         value: impl ToJSValConvertible,
+        _can_gc: CanGc,
     ) -> Rc<Promise> {
         let _ac = JSAutoRealm::new(*cx, global.reflector().get_jsobject().get());
         unsafe {

--- a/components/script/dom/readablestream.rs
+++ b/components/script/dom/readablestream.rs
@@ -666,9 +666,7 @@ impl ReadableStream {
 
         // If stream.[[state]] is "closed", return a promise resolved with undefined.
         if self.is_closed() {
-            let promise = Promise::new(&self.global(), can_gc);
-            promise.resolve_native(&());
-            return promise;
+            return Promise::new_resolved(&self.global(), GlobalScope::get_cx(), (), can_gc);
         }
         // If stream.[[state]] is "errored", return a promise rejected with stream.[[storedError]].
         if self.is_errored() {

--- a/components/script/dom/readablestreamdefaultreader.rs
+++ b/components/script/dom/readablestreamdefaultreader.rs
@@ -371,7 +371,7 @@ impl ReadableStreamDefaultReaderMethods<crate::DomTypeHolder> for ReadableStream
                 &self.global(),
                 error.handle_mut(),
             );
-            return Promise::new_rejected(&self.global(), cx, error.handle());
+            return Promise::new_rejected(&self.global(), cx, error.handle(), can_gc);
         }
         // Let promise be a new promise.
         let promise = Promise::new(&self.global(), can_gc);

--- a/components/script/dom/readablestreamgenericreader.rs
+++ b/components/script/dom/readablestreamgenericreader.rs
@@ -54,7 +54,7 @@ pub(crate) trait ReadableStreamGenericReader {
             let cx = GlobalScope::get_cx();
             rooted!(in(*cx) let mut error = UndefinedValue());
             stream.get_stored_error(error.handle_mut());
-            self.set_closed_promise(Promise::new_rejected(global, cx, error.handle()));
+            self.set_closed_promise(Promise::new_rejected(global, cx, error.handle(), can_gc));
 
             // Set reader.[[closedPromise]].[[PromiseIsHandled]] to true
             self.get_closed_promise().set_promise_is_handled();
@@ -104,6 +104,7 @@ pub(crate) trait ReadableStreamGenericReader {
                     &stream.global(),
                     cx,
                     error.handle(),
+                    CanGc::note(),
                 ));
             }
             // Set reader.[[closedPromise]].[[PromiseIsHandled]] to true.

--- a/components/script/dom/readablestreamgenericreader.rs
+++ b/components/script/dom/readablestreamgenericreader.rs
@@ -45,7 +45,7 @@ pub(crate) trait ReadableStreamGenericReader {
             // Otherwise, if stream.[[state]] is "closed",
             // Set reader.[[closedPromise]] to a promise resolved with undefined.
             let cx = GlobalScope::get_cx();
-            self.set_closed_promise(Promise::new_resolved(global, cx, ()));
+            self.set_closed_promise(Promise::new_resolved(global, cx, (), can_gc));
         } else {
             // Assert: stream.[[state]] is "errored"
             assert!(stream.is_errored());

--- a/components/script/dom/testbinding.rs
+++ b/components/script/dom/testbinding.rs
@@ -977,7 +977,7 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
 
     #[cfg_attr(crown, allow(crown::unrooted_must_root))]
     fn ReturnRejectedPromise(&self, cx: SafeJSContext, v: HandleValue) -> Rc<Promise> {
-        Promise::new_rejected(&self.global(), cx, v)
+        Promise::new_rejected(&self.global(), cx, v, CanGc::note())
     }
 
     fn PromiseResolveNative(&self, cx: SafeJSContext, p: &Promise, v: HandleValue) {

--- a/components/script/dom/testbinding.rs
+++ b/components/script/dom/testbinding.rs
@@ -972,7 +972,7 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
 
     #[cfg_attr(crown, allow(crown::unrooted_must_root))]
     fn ReturnResolvedPromise(&self, cx: SafeJSContext, v: HandleValue) -> Rc<Promise> {
-        Promise::new_resolved(&self.global(), cx, v)
+        Promise::new_resolved(&self.global(), cx, v, CanGc::note())
     }
 
     #[cfg_attr(crown, allow(crown::unrooted_must_root))]

--- a/components/script/dom/writablestream.rs
+++ b/components/script/dom/writablestream.rs
@@ -650,9 +650,7 @@ impl WritableStream {
         // If stream.[[state]] is "closed" or "errored",
         if self.is_closed() || self.is_errored() {
             // return a promise resolved with undefined.
-            let promise = Promise::new(global, can_gc);
-            promise.resolve_native(&());
-            return promise;
+            return Promise::new_resolved(global, cx, (), can_gc);
         }
 
         // TODO: Signal abort on stream.[[controller]].[[abortController]] with reason.

--- a/components/script/dom/writablestreamdefaultcontroller.rs
+++ b/components/script/dom/writablestreamdefaultcontroller.rs
@@ -386,14 +386,10 @@ impl WritableStreamDefaultController {
                 let promise = Promise::new_with_js_promise(result_object.handle(), cx);
                 promise
             } else {
-                let promise = Promise::new(global, can_gc);
-                promise.resolve_native(&result.get());
-                promise
+                Promise::new_resolved(global, cx, result.get(), can_gc)
             }
         } else {
-            let promise = Promise::new(global, can_gc);
-            promise.resolve_native(&());
-            promise
+            Promise::new_resolved(global, cx, (), can_gc)
         };
 
         let rooted_default_controller = DomRoot::from_ref(self);
@@ -451,9 +447,7 @@ impl WritableStreamDefaultController {
                 ExceptionHandling::Rethrow,
             )
         } else {
-            let promise = Promise::new(global, can_gc);
-            promise.resolve_native(&());
-            Ok(promise)
+            Ok(Promise::new_resolved(global, cx, (), can_gc))
         };
         result.unwrap_or_else(|e| {
             let promise = Promise::new(global, can_gc);
@@ -479,9 +473,7 @@ impl WritableStreamDefaultController {
                 ExceptionHandling::Rethrow,
             )
         } else {
-            let promise = Promise::new(global, can_gc);
-            promise.resolve_native(&());
-            Ok(promise)
+            Ok(Promise::new_resolved(global, cx, (), can_gc))
         };
         result.unwrap_or_else(|e| {
             let promise = Promise::new(global, can_gc);
@@ -502,9 +494,7 @@ impl WritableStreamDefaultController {
         let result = if let Some(algo) = algo {
             algo.Call_(&this_object.handle(), ExceptionHandling::Rethrow)
         } else {
-            let promise = Promise::new(global, can_gc);
-            promise.resolve_native(&());
-            Ok(promise)
+            Ok(Promise::new_resolved(global, cx, (), can_gc))
         };
         result.unwrap_or_else(|e| {
             let promise = Promise::new(global, can_gc);


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Partial fix of #34573

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [X] These changes do not require tests

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
