### PR TITLE
Don't tell stylo about stylesheets that are not in a browsing context

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -4404,12 +4404,12 @@ impl Document {
             })
             .cloned();
 
-        let cloned_stylesheet = sheet.clone();
-        let insertion_point2 = insertion_point.clone();
-        self.window.layout_mut().add_stylesheet(
-            cloned_stylesheet,
-            insertion_point2.as_ref().map(|s| s.sheet.clone()),
-        );
+        if self.has_browsing_context() {
+            self.window.layout_mut().add_stylesheet(
+                sheet.clone(),
+                insertion_point.as_ref().map(|s| s.sheet.clone()),
+            );
+        }
 
         DocumentOrShadowRoot::add_stylesheet(
             owner,
@@ -4430,10 +4430,11 @@ impl Document {
     /// Remove a stylesheet owned by `owner` from the list of document sheets.
     #[cfg_attr(crown, allow(crown::unrooted_must_root))] // Owner needs to be rooted already necessarily.
     pub(crate) fn remove_stylesheet(&self, owner: &Element, stylesheet: &Arc<Stylesheet>) {
-        let cloned_stylesheet = stylesheet.clone();
-        self.window
-            .layout_mut()
-            .remove_stylesheet(cloned_stylesheet);
+        if self.has_browsing_context() {
+            self.window
+                .layout_mut()
+                .remove_stylesheet(stylesheet.clone());
+        }
 
         DocumentOrShadowRoot::remove_stylesheet(
             owner,

--- a/tests/wpt/meta/html/rendering/non-replaced-elements/flow-content-0/slot-element-focusable.tentative.html.ini
+++ b/tests/wpt/meta/html/rendering/non-replaced-elements/flow-content-0/slot-element-focusable.tentative.html.ini
@@ -1,5 +1,4 @@
 [slot-element-focusable.tentative.html]
-  expected: CRASH
   [slot element with display: block should be focusable]
     expected: FAIL
 

--- a/tests/wpt/meta/shadow-dom/MouseEvent-prototype-offsetX-offsetY.html.ini
+++ b/tests/wpt/meta/shadow-dom/MouseEvent-prototype-offsetX-offsetY.html.ini
@@ -1,4 +1,9 @@
 [MouseEvent-prototype-offsetX-offsetY.html]
-  expected: CRASH
   [MouseEvent's offsetX and offsetY attributes must be relative to the target.]
+    expected: FAIL
+
+  [MouseEvent's offsetX and offsetY attributes must be relative to the shadow host when an event is dispatched inside its shadow tree.]
+    expected: FAIL
+
+  [MouseEvent's offsetX and offsetY attributes must be relative to the target when an event is dispatched on a slotted content.]
     expected: FAIL

--- a/tests/wpt/meta/shadow-dom/ShadowRoot-interface.html.ini
+++ b/tests/wpt/meta/shadow-dom/ShadowRoot-interface.html.ini
@@ -1,25 +1,6 @@
 [ShadowRoot-interface.html]
-  expected: CRASH
   [ShadowRoot.activeElement must return the focused element of the context object when shadow root is open.]
     expected: FAIL
 
   [ShadowRoot.activeElement must return the focused element of the context object when shadow root is closed.]
-    expected: FAIL
-
-  [ShadowRoot.innerHTML must return the result of the HTML fragment serialization algorithm when shadow root is open.]
-    expected: FAIL
-
-  [ShadowRoot.innerHTML must return the result of the HTML fragment serialization algorithm when shadow root is closed.]
-    expected: FAIL
-
-  [ShadowRoot.innerHTML must replace all with the result of invoking the fragment parsing algorithm when shadow root is open.]
-    expected: FAIL
-
-  [ShadowRoot.innerHTML must replace all with the result of invoking the fragment parsing algorithm when shadow root is closed.]
-    expected: FAIL
-
-  [ShadowRoot.styleSheets must return a StyleSheetList sequence containing the shadow root style sheets when shadow root is open.]
-    expected: FAIL
-
-  [ShadowRoot.styleSheets must return a StyleSheetList sequence containing the shadow root style sheets when shadow root is closed.]
     expected: FAIL


### PR DESCRIPTION
There can be multiple documents per window (meaning, multiple documents per `Stylist`) and because stylo doesn't seem to track which stylesheet is registered in which document, things get out of sync. That causes crashes as seen in https://github.com/servo/servo/issues/35184.

With this change, we don't register stylesheets from documents that don't have browsing context. I'm not sure this is the right fix, but it does fix the crash and a few tests. Please review carefully.

For reference, one situation where there are multiple documents for the same window occurs when assigning to an element's `innerHTML`, which parses the right hand side in a temporary document and then moves all nodes over to the actual doc. The temporary document uses the same window (which might be wrong?)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix https://github.com/servo/servo/issues/35184
- [X] There are tests for these changes 

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
