### PR TITLE
Remove the traversal for DomRoot values when collection memory usage

### DIFF
--- a/components/script_bindings/root.rs
+++ b/components/script_bindings/root.rs
@@ -337,8 +337,8 @@ impl<T> MallocSizeOf for DomRoot<T>
 where
     T: DomObject + MallocSizeOf,
 {
-    fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
-        (**self).size_of(ops)
+    fn size_of(&self, _ops: &mut MallocSizeOfOps) -> usize {
+        0
     }
 }
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

See the discussion in https://github.com/servo/servo/issues/35600
---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #35600 (GitHub issue number if applicable)
