### PR TITLE
refactor: add CanGc as argument to WindowProxy::set_window

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -693,7 +693,7 @@ impl Document {
         self.activity.get() != DocumentActivity::Inactive
     }
 
-    pub(crate) fn set_activity(&self, activity: DocumentActivity) {
+    pub(crate) fn set_activity(&self, activity: DocumentActivity, can_gc: CanGc) {
         // This function should only be called on documents with a browsing context
         assert!(self.has_browsing_context);
         if activity == self.activity.get() {
@@ -708,14 +708,14 @@ impl Document {
             ClientContextId::build(pipeline_id.namespace_id.0, pipeline_id.index.0.get());
 
         if activity != DocumentActivity::FullyActive {
-            self.window().suspend();
+            self.window().suspend(can_gc);
             media.suspend(&client_context_id);
             return;
         }
 
         self.title_changed();
         self.dirty_all_nodes();
-        self.window().resume();
+        self.window().resume(can_gc);
         media.resume(&client_context_id);
 
         if self.ready_state.get() != DocumentReadyState::Complete {

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2541,13 +2541,13 @@ impl Window {
         had_clip_rect
     }
 
-    pub(crate) fn suspend(&self) {
+    pub(crate) fn suspend(&self, can_gc: CanGc) {
         // Suspend timer events.
         self.as_global_scope().suspend();
 
         // Set the window proxy to be a cross-origin window.
         if self.window_proxy().currently_active() == Some(self.global().pipeline_id()) {
-            self.window_proxy().unset_currently_active();
+            self.window_proxy().unset_currently_active(can_gc);
         }
 
         // A hint to the JS runtime that now would be a good time to
@@ -2557,12 +2557,12 @@ impl Window {
         self.Gc();
     }
 
-    pub(crate) fn resume(&self) {
+    pub(crate) fn resume(&self, can_gc: CanGc) {
         // Resume timer events.
         self.as_global_scope().resume();
 
         // Set the window proxy to be this object.
-        self.window_proxy().set_currently_active(self);
+        self.window_proxy().set_currently_active(self, can_gc);
 
         // Push the document title to the compositor since we are
         // activating this document due to a navigation.

--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -625,7 +625,7 @@ impl WindowProxy {
     /// Change the Window that this WindowProxy resolves to.
     // TODO: support setting the window proxy to a dummy value,
     // to handle the case when the active document is in another script thread.
-    fn set_window(&self, window: &GlobalScope, handler: &WindowProxyHandler) {
+    fn set_window(&self, window: &GlobalScope, handler: &WindowProxyHandler, _can_gc: CanGc) {
         unsafe {
             debug!("Setting window of {:p}.", self);
 
@@ -675,7 +675,7 @@ impl WindowProxy {
         }
     }
 
-    pub(crate) fn set_currently_active(&self, window: &Window) {
+    pub(crate) fn set_currently_active(&self, window: &Window, can_gc: CanGc) {
         if let Some(pipeline_id) = self.currently_active() {
             if pipeline_id == window.pipeline_id() {
                 return debug!(
@@ -685,11 +685,11 @@ impl WindowProxy {
         }
 
         let global_scope = window.as_global_scope();
-        self.set_window(global_scope, WindowProxyHandler::proxy_handler());
+        self.set_window(global_scope, WindowProxyHandler::proxy_handler(), can_gc);
         self.currently_active.set(Some(global_scope.pipeline_id()));
     }
 
-    pub(crate) fn unset_currently_active(&self) {
+    pub(crate) fn unset_currently_active(&self, can_gc: CanGc) {
         if self.currently_active().is_none() {
             return debug!("Attempt to unset the currently active window on a windowproxy that does not have one.");
         }
@@ -698,6 +698,7 @@ impl WindowProxy {
         self.set_window(
             window.upcast(),
             WindowProxyHandler::x_origin_proxy_handler(),
+            can_gc,
         );
         self.currently_active.set(None);
     }


### PR DESCRIPTION
Add CanGc as argument to `WindowProxy::set_window`.

Addressed part of https://github.com/servo/servo/issues/34573

---

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they are a refactor.
