### PR TITLE
refactor: add CanGc as argument to DataBlock::view

### DIFF
--- a/components/script/dom/bindings/buffer_source.rs
+++ b/components/script/dom/bindings/buffer_source.rs
@@ -429,7 +429,7 @@ impl DataBlock {
     }
 
     /// Returns error if requested range is already mapped
-    pub(crate) fn view(&mut self, range: Range<usize>) -> Result<&DataView, ()> {
+    pub(crate) fn view(&mut self, range: Range<usize>, _can_gc: CanGc) -> Result<&DataView, ()> {
         if self
             .data_views
             .iter()

--- a/components/script/dom/webgpu/gpubuffer.rs
+++ b/components/script/dom/webgpu/gpubuffer.rs
@@ -296,6 +296,7 @@ impl GPUBufferMethods<crate::DomTypeHolder> for GPUBuffer {
         _cx: JSContext,
         offset: GPUSize64,
         size: Option<GPUSize64>,
+        can_gc: CanGc,
     ) -> Fallible<ArrayBuffer> {
         let range_size = if let Some(s) = size {
             s
@@ -320,7 +321,7 @@ impl GPUBufferMethods<crate::DomTypeHolder> for GPUBuffer {
         let rebased_offset = (offset - mapping.range.start) as usize;
         mapping
             .data
-            .view(rebased_offset..rebased_offset + range_size as usize)
+            .view(rebased_offset..rebased_offset + range_size as usize, can_gc)
             .map(|view| view.array_buffer())
             .map_err(|()| Error::Operation)
     }

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -217,7 +217,7 @@ DOMInterfaces = {
 
 'GPUBuffer': {
     'inRealms': ['MapAsync'],
-    'canGc': ['MapAsync'],
+    'canGc': ['GetMappedRange', 'MapAsync'],
 },
 
 'GPUCanvasContext': {


### PR DESCRIPTION
Add CanGc as argument to `DataBlock::view`.

Addressed part of https://github.com/servo/servo/issues/34573

---

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they are a refactor.
