### PR TITLE
refactor: add CanGc as argument to Promise::new_rejected

### DIFF
--- a/components/script/dom/promise.rs
+++ b/components/script/dom/promise.rs
@@ -170,6 +170,7 @@ impl Promise {
         global: &GlobalScope,
         cx: SafeJSContext,
         value: impl ToJSValConvertible,
+        _can_gc: CanGc,
     ) -> Rc<Promise> {
         let _ac = JSAutoRealm::new(*cx, global.reflector().get_jsobject().get());
         unsafe {

--- a/components/script/dom/readablestream.rs
+++ b/components/script/dom/readablestream.rs
@@ -536,13 +536,13 @@ impl ReadableStream {
     /// must be done after `start_reading`.
     /// Native call to
     /// <https://streams.spec.whatwg.org/#abstract-opdef-readablestreamdefaultreaderrelease>
-    pub(crate) fn stop_reading(&self) {
+    pub(crate) fn stop_reading(&self, can_gc: CanGc) {
         match self.reader {
             ReaderType::Default(ref reader) => {
                 let Some(reader) = reader.get() else {
                     unreachable!("Attempt to stop reading without having first acquired a reader.");
                 };
-                reader.release().expect("Reader release cannot fail.");
+                reader.release(can_gc).expect("Reader release cannot fail.");
             },
             ReaderType::BYOB(_) => {
                 unreachable!("Native stop reading can only be done with a default reader.")

--- a/components/script/dom/readablestreambyobreader.rs
+++ b/components/script/dom/readablestreambyobreader.rs
@@ -153,9 +153,9 @@ impl ReadableStreamBYOBReader {
     }
 
     /// <https://streams.spec.whatwg.org/#abstract-opdef-readablestreambyobreaderrelease>
-    pub(crate) fn release(&self) -> Fallible<()> {
+    pub(crate) fn release(&self, can_gc: CanGc) -> Fallible<()> {
         // Perform ! ReadableStreamReaderGenericRelease(reader).
-        self.generic_release()?;
+        self.generic_release(can_gc)?;
         // Let e be a new TypeError exception.
         let cx = GlobalScope::get_cx();
         rooted!(in(*cx) let mut error = UndefinedValue());
@@ -336,14 +336,14 @@ impl ReadableStreamBYOBReaderMethods<crate::DomTypeHolder> for ReadableStreamBYO
     }
 
     /// <https://streams.spec.whatwg.org/#byob-reader-release-lock>
-    fn ReleaseLock(&self) -> Fallible<()> {
+    fn ReleaseLock(&self, can_gc: CanGc) -> Fallible<()> {
         if self.stream.get().is_none() {
             // If this.[[stream]] is undefined, return.
             return Ok(());
         }
 
         // Perform !ReadableStreamBYOBReaderRelease(this).
-        self.release()
+        self.release(can_gc)
     }
 
     /// <https://streams.spec.whatwg.org/#generic-reader-closed>

--- a/components/script/dom/readablestreamdefaultreader.rs
+++ b/components/script/dom/readablestreamdefaultreader.rs
@@ -245,9 +245,9 @@ impl ReadableStreamDefaultReader {
     }
 
     /// <https://streams.spec.whatwg.org/#abstract-opdef-readablestreamdefaultreaderrelease>
-    pub(crate) fn release(&self) -> Fallible<()> {
+    pub(crate) fn release(&self, can_gc: CanGc) -> Fallible<()> {
         // Perform ! ReadableStreamReaderGenericRelease(reader).
-        self.generic_release()?;
+        self.generic_release(can_gc)?;
         // Let e be a new TypeError exception.
         let cx = GlobalScope::get_cx();
         rooted!(in(*cx) let mut error = UndefinedValue());
@@ -371,7 +371,7 @@ impl ReadableStreamDefaultReaderMethods<crate::DomTypeHolder> for ReadableStream
                 &self.global(),
                 error.handle_mut(),
             );
-            return Promise::new_rejected(&self.global(), cx, error.handle());
+            return Promise::new_rejected(&self.global(), cx, error.handle(), can_gc);
         }
         // Let promise be a new promise.
         let promise = Promise::new(&self.global(), can_gc);
@@ -399,14 +399,14 @@ impl ReadableStreamDefaultReaderMethods<crate::DomTypeHolder> for ReadableStream
     }
 
     /// <https://streams.spec.whatwg.org/#default-reader-release-lock>
-    fn ReleaseLock(&self) -> Fallible<()> {
+    fn ReleaseLock(&self, can_gc: CanGc) -> Fallible<()> {
         if self.stream.get().is_none() {
             // Step 1: If this.[[stream]] is undefined, return.
             return Ok(());
         }
 
         // Step 2: Perform !ReadableStreamDefaultReaderRelease(this).
-        self.release()
+        self.release(can_gc)
     }
 
     /// <https://streams.spec.whatwg.org/#generic-reader-closed>

--- a/components/script/dom/readablestreamgenericreader.rs
+++ b/components/script/dom/readablestreamgenericreader.rs
@@ -54,7 +54,7 @@ pub(crate) trait ReadableStreamGenericReader {
             let cx = GlobalScope::get_cx();
             rooted!(in(*cx) let mut error = UndefinedValue());
             stream.get_stored_error(error.handle_mut());
-            self.set_closed_promise(Promise::new_rejected(global, cx, error.handle()));
+            self.set_closed_promise(Promise::new_rejected(global, cx, error.handle(), can_gc));
 
             // Set reader.[[closedPromise]].[[PromiseIsHandled]] to true
             self.get_closed_promise().set_promise_is_handled();
@@ -76,7 +76,7 @@ pub(crate) trait ReadableStreamGenericReader {
 
     /// <https://streams.spec.whatwg.org/#readable-stream-reader-generic-release>
     #[allow(unsafe_code)]
-    fn generic_release(&self) -> Fallible<()> {
+    fn generic_release(&self, can_gc: CanGc) -> Fallible<()> {
         // Let stream be reader.[[stream]].
 
         // Assert: stream is not undefined.
@@ -104,6 +104,7 @@ pub(crate) trait ReadableStreamGenericReader {
                     &stream.global(),
                     cx,
                     error.handle(),
+                    can_gc,
                 ));
             }
             // Set reader.[[closedPromise]].[[PromiseIsHandled]] to true.

--- a/components/script/dom/testbinding.rs
+++ b/components/script/dom/testbinding.rs
@@ -976,8 +976,13 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
     }
 
     #[cfg_attr(crown, allow(crown::unrooted_must_root))]
-    fn ReturnRejectedPromise(&self, cx: SafeJSContext, v: HandleValue) -> Rc<Promise> {
-        Promise::new_rejected(&self.global(), cx, v)
+    fn ReturnRejectedPromise(
+        &self,
+        cx: SafeJSContext,
+        v: HandleValue,
+        can_gc: CanGc,
+    ) -> Rc<Promise> {
+        Promise::new_rejected(&self.global(), cx, v, can_gc)
     }
 
     fn PromiseResolveNative(&self, cx: SafeJSContext, p: &Promise, v: HandleValue) {

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -485,7 +485,7 @@ DOMInterfaces = {
 #FIXME(jdm): This should be 'register': False, but then we don't generate enum types
 'TestBinding': {
     'inRealms': ['PromiseAttribute', 'PromiseNativeHandler'],
-    'canGc': ['InterfaceAttribute', 'GetInterfaceAttributeNullable', 'ReceiveInterface', 'ReceiveInterfaceSequence', 'ReceiveNullableInterface', 'PromiseAttribute', 'PromiseNativeHandler'],
+    'canGc': ['InterfaceAttribute', 'GetInterfaceAttributeNullable', 'ReceiveInterface', 'ReceiveInterfaceSequence', 'ReceiveNullableInterface', 'PromiseAttribute', 'PromiseNativeHandler', 'ReturnRejectedPromise'],
 },
 
 'TestWorklet': {
@@ -597,11 +597,11 @@ DOMInterfaces = {
 },
 
 "ReadableStreamBYOBReader": {
-    "canGc": ["Read", "Cancel"]
+    "canGc": ["Cancel", "Read", "ReleaseLock"]
 },
 
 "ReadableStreamDefaultReader": {
-    "canGc": ["Read", "Cancel"]
+    "canGc": ["Cancel", "Read", "ReleaseLock"]
 },
 
 'WritableStream': {


### PR DESCRIPTION
Add CanGc as argument to `Promise::new_rejected`.

Addressed part of https://github.com/servo/servo/issues/34573

---

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they are a refactor.
