### PR TITLE
chore: silence unused import warning in app_state.rs

### DIFF
--- a/ports/servoshell/desktop/app_state.rs
+++ b/ports/servoshell/desktop/app_state.rs
@@ -6,7 +6,6 @@ use std::cell::{Ref, RefCell, RefMut};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::rc::Rc;
-use std::thread;
 
 use euclid::Vector2D;
 use image::DynamicImage;
@@ -598,7 +597,7 @@ impl WebViewDelegate for RunningAppState {
 
 #[cfg(target_os = "linux")]
 fn platform_get_selected_devices(devices: Vec<String>) -> Option<String> {
-    thread::Builder::new()
+    std::thread::Builder::new()
         .name("DevicePicker".to_owned())
         .spawn(move || {
             let dialog_rows: Vec<&str> = devices.iter().map(|s| s.as_ref()).collect();


### PR DESCRIPTION
Silence unused import warning in `ports/servoshell/desktop/app_state.rs`.

Without this change on non-Linux platforms you will get:
```
warning: unused import: `std::thread`
 --> ports/servoshell/desktop/app_state.rs:9:5
  |
9 | use std::thread;
  |     ^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default
```

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

- [x] These changes do not require tests because they don't change functionality.
