### PR TITLE
refactor: add CanGc as argument to Promise::resolve

### DIFF
--- a/components/script/body.rs
+++ b/components/script/body.rs
@@ -632,12 +632,14 @@ impl ConsumeBodyPromiseHandler {
         match pkg_data_results {
             Ok(results) => {
                 match results {
-                    FetchedData::Text(s) => self.result_promise.resolve_native(&USVString(s)),
-                    FetchedData::Json(j) => self.result_promise.resolve_native(&j),
-                    FetchedData::BlobData(b) => self.result_promise.resolve_native(&b),
-                    FetchedData::FormData(f) => self.result_promise.resolve_native(&f),
-                    FetchedData::Bytes(b) => self.result_promise.resolve_native(&b),
-                    FetchedData::ArrayBuffer(a) => self.result_promise.resolve_native(&a),
+                    FetchedData::Text(s) => {
+                        self.result_promise.resolve_native(&USVString(s), can_gc)
+                    },
+                    FetchedData::Json(j) => self.result_promise.resolve_native(&j, can_gc),
+                    FetchedData::BlobData(b) => self.result_promise.resolve_native(&b, can_gc),
+                    FetchedData::FormData(f) => self.result_promise.resolve_native(&f, can_gc),
+                    FetchedData::Bytes(b) => self.result_promise.resolve_native(&b, can_gc),
+                    FetchedData::ArrayBuffer(a) => self.result_promise.resolve_native(&a, can_gc),
                     FetchedData::JSException(e) => self.result_promise.reject_native(&e.handle()),
                 };
             },

--- a/components/script/dom/audiocontext.rs
+++ b/components/script/dom/audiocontext.rs
@@ -152,7 +152,7 @@ impl AudioContextMethods<crate::DomTypeHolder> for AudioContext {
 
         // Step 3.
         if self.context.State() == AudioContextState::Suspended {
-            promise.resolve_native(&());
+            promise.resolve_native(&(), can_gc);
             return promise;
         }
 
@@ -167,7 +167,7 @@ impl AudioContextMethods<crate::DomTypeHolder> for AudioContext {
                         let base_context = base_context.root();
                         let context = context.root();
                         let promise = trusted_promise.root();
-                        promise.resolve_native(&());
+                        promise.resolve_native(&(), CanGc::note());
                         if base_context.State() != AudioContextState::Suspended {
                             base_context.set_state_attribute(AudioContextState::Suspended);
                             context.global().task_manager().dom_manipulation_task_source().queue_simple_event(
@@ -208,7 +208,7 @@ impl AudioContextMethods<crate::DomTypeHolder> for AudioContext {
 
         // Step 3.
         if self.context.State() == AudioContextState::Closed {
-            promise.resolve_native(&());
+            promise.resolve_native(&(), can_gc);
             return promise;
         }
 
@@ -223,7 +223,7 @@ impl AudioContextMethods<crate::DomTypeHolder> for AudioContext {
                         let base_context = base_context.root();
                         let context = context.root();
                         let promise = trusted_promise.root();
-                        promise.resolve_native(&());
+                        promise.resolve_native(&(), CanGc::note());
                         if base_context.State() != AudioContextState::Closed {
                             base_context.set_state_attribute(AudioContextState::Closed);
                             context.global().task_manager().dom_manipulation_task_source().queue_simple_event(

--- a/components/script/dom/baseaudiocontext.rs
+++ b/components/script/dom/baseaudiocontext.rs
@@ -211,7 +211,7 @@ impl BaseAudioContext {
         f();
         for promise in &*promises {
             match result {
-                Ok(ref value) => promise.resolve_native(value),
+                Ok(ref value) => promise.resolve_native(value, CanGc::note()),
                 Err(ref error) => promise.reject_error(error.clone()),
             }
         }
@@ -298,7 +298,7 @@ impl BaseAudioContextMethods<crate::DomTypeHolder> for BaseAudioContext {
 
         // Step 3.
         if self.state.get() == AudioContextState::Running {
-            promise.resolve_native(&());
+            promise.resolve_native(&(), can_gc);
             return promise;
         }
 
@@ -549,7 +549,7 @@ impl BaseAudioContextMethods<crate::DomTypeHolder> for BaseAudioContext {
                         if let Some(callback) = resolver.success_callback {
                             let _ = callback.Call__(&buffer, ExceptionHandling::Report);
                         }
-                        resolver.promise.resolve_native(&buffer);
+                        resolver.promise.resolve_native(&buffer, CanGc::note());
                     }));
                 })
                 .error(move |error| {

--- a/components/script/dom/bindings/refcounted.rs
+++ b/components/script/dom/bindings/refcounted.rs
@@ -31,6 +31,7 @@ use std::rc::Rc;
 use std::sync::{Arc, Weak};
 
 use js::jsapi::JSTracer;
+use script_bindings::script_runtime::CanGc;
 
 use crate::dom::bindings::conversions::ToJSValConvertible;
 use crate::dom::bindings::error::Error;
@@ -151,7 +152,7 @@ impl TrustedPromise {
         let this = self;
         task!(resolve_promise: move || {
             debug!("Resolving promise.");
-            this.root().resolve_native(&value);
+            this.root().resolve_native(&value, CanGc::note());
         })
     }
 }

--- a/components/script/dom/blob.rs
+++ b/components/script/dom/blob.rs
@@ -256,7 +256,7 @@ impl BlobMethods<crate::DomTypeHolder> for Blob {
                 Ok(b) => {
                     let (text, _, _) = UTF_8.decode(&b);
                     let text = DOMString::from(text);
-                    promise.resolve_native(&text);
+                    promise.resolve_native(&text, CanGc::note());
                 },
                 Err(e) => {
                     promise.reject_error(e);
@@ -284,7 +284,9 @@ impl BlobMethods<crate::DomTypeHolder> for Blob {
                         let result = run_array_buffer_data_algorithm(cx, b, CanGc::note());
 
                         match result {
-                            Ok(FetchedData::ArrayBuffer(a)) => promise.resolve_native(&a),
+                            Ok(FetchedData::ArrayBuffer(a)) => {
+                                promise.resolve_native(&a, CanGc::note())
+                            },
                             Err(e) => promise.reject_error(e),
                             _ => panic!("Unexpected result from run_array_buffer_data_algorithm"),
                         }

--- a/components/script/dom/bluetooth/bluetooth.rs
+++ b/components/script/dom/bluetooth/bluetooth.rs
@@ -589,7 +589,7 @@ impl AsyncBluetoothListener for Bluetooth {
             BluetoothResponse::RequestDevice(device) => {
                 let mut device_instance_map = self.device_instance_map.borrow_mut();
                 if let Some(existing_device) = device_instance_map.get(&device.id.clone()) {
-                    return promise.resolve_native(&**existing_device);
+                    return promise.resolve_native(&**existing_device, can_gc);
                 }
                 let bt_device = BluetoothDevice::new(
                     &self.global(),
@@ -609,12 +609,12 @@ impl AsyncBluetoothListener for Bluetooth {
                     });
                 // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetooth-requestdevice
                 // Step 5.
-                promise.resolve_native(&bt_device);
+                promise.resolve_native(&bt_device, can_gc);
             },
             // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetooth-getavailability
             // Step 2 - 3.
             BluetoothResponse::GetAvailability(is_available) => {
-                promise.resolve_native(&is_available);
+                promise.resolve_native(&is_available, can_gc);
             },
             _ => promise.reject_error(Error::Type("Something went wrong...".to_owned())),
         }
@@ -655,7 +655,7 @@ impl PermissionAlgorithm for Bluetooth {
         // Step 3.
         if let PermissionState::Denied = status.get_state() {
             status.set_devices(Vec::new());
-            return promise.resolve_native(status);
+            return promise.resolve_native(status, CanGc::note());
         }
 
         // Step 4.
@@ -727,7 +727,7 @@ impl PermissionAlgorithm for Bluetooth {
 
         // https://w3c.github.io/permissions/#dom-permissions-query
         // Step 7.
-        promise.resolve_native(status);
+        promise.resolve_native(status, CanGc::note());
     }
 
     // https://webbluetoothcg.github.io/web-bluetooth/#request-the-bluetooth-permission

--- a/components/script/dom/bluetooth/bluetoothdevice.rs
+++ b/components/script/dom/bluetooth/bluetoothdevice.rs
@@ -327,14 +327,14 @@ impl BluetoothDeviceMethods<crate::DomTypeHolder> for BluetoothDevice {
 }
 
 impl AsyncBluetoothListener for BluetoothDevice {
-    fn handle_response(&self, response: BluetoothResponse, promise: &Rc<Promise>, _can_gc: CanGc) {
+    fn handle_response(&self, response: BluetoothResponse, promise: &Rc<Promise>, can_gc: CanGc) {
         match response {
             // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothdevice-unwatchadvertisements
             BluetoothResponse::WatchAdvertisements(_result) => {
                 // Step 3.1.
                 self.watching_advertisements.set(true);
                 // Step 3.2.
-                promise.resolve_native(&());
+                promise.resolve_native(&(), can_gc);
             },
             _ => promise.reject_error(Error::Type("Something went wrong...".to_owned())),
         }

--- a/components/script/dom/bluetooth/bluetoothpermissionresult.rs
+++ b/components/script/dom/bluetooth/bluetoothpermissionresult.rs
@@ -112,7 +112,7 @@ impl AsyncBluetoothListener for BluetoothPermissionResult {
 
                     // https://w3c.github.io/permissions/#dom-permissions-request
                     // Step 8.
-                    return promise.resolve_native(self);
+                    return promise.resolve_native(self, can_gc);
                 }
                 let bt_device = BluetoothDevice::new(
                     &self.global(),
@@ -135,7 +135,7 @@ impl AsyncBluetoothListener for BluetoothPermissionResult {
 
                 // https://w3c.github.io/permissions/#dom-permissions-request
                 // Step 8.
-                promise.resolve_native(self);
+                promise.resolve_native(self, can_gc);
             },
             _ => promise.reject_error(Error::Type("Something went wrong...".to_owned())),
         }

--- a/components/script/dom/bluetooth/bluetoothremotegattcharacteristic.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattcharacteristic.rs
@@ -309,11 +309,10 @@ impl AsyncBluetoothListener for BluetoothRemoteGATTCharacteristic {
             // Step 7.
             BluetoothResponse::GetDescriptors(descriptors_vec, single) => {
                 if single {
-                    promise.resolve_native(&device.get_or_create_descriptor(
-                        &descriptors_vec[0],
-                        self,
+                    promise.resolve_native(
+                        &device.get_or_create_descriptor(&descriptors_vec[0], self, can_gc),
                         can_gc,
-                    ));
+                    );
                     return;
                 }
                 let mut descriptors = vec![];
@@ -321,7 +320,7 @@ impl AsyncBluetoothListener for BluetoothRemoteGATTCharacteristic {
                     let bt_descriptor = device.get_or_create_descriptor(&descriptor, self, can_gc);
                     descriptors.push(bt_descriptor);
                 }
-                promise.resolve_native(&descriptors);
+                promise.resolve_native(&descriptors, can_gc);
             },
             // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattcharacteristic-readvalue
             BluetoothResponse::ReadValue(result) => {
@@ -337,7 +336,7 @@ impl AsyncBluetoothListener for BluetoothRemoteGATTCharacteristic {
                     .fire_bubbling_event(atom!("characteristicvaluechanged"), can_gc);
 
                 // Step 5.5.4.
-                promise.resolve_native(&value);
+                promise.resolve_native(&value, can_gc);
             },
             // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattcharacteristic-writevalue
             BluetoothResponse::WriteValue(result) => {
@@ -348,7 +347,7 @@ impl AsyncBluetoothListener for BluetoothRemoteGATTCharacteristic {
                 *self.value.borrow_mut() = Some(ByteString::new(result));
 
                 // Step 7.5.3.
-                promise.resolve_native(&());
+                promise.resolve_native(&(), can_gc);
             },
             // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattcharacteristic-startnotifications
             // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattcharacteristic-stopnotifications
@@ -358,7 +357,7 @@ impl AsyncBluetoothListener for BluetoothRemoteGATTCharacteristic {
 
                 // (StartNotification) Step 11.
                 // (StopNotification)  Step 5.
-                promise.resolve_native(self);
+                promise.resolve_native(self, can_gc);
             },
             _ => promise.reject_error(Error::Type("Something went wrong...".to_owned())),
         }

--- a/components/script/dom/bluetooth/bluetoothremotegattdescriptor.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattdescriptor.rs
@@ -181,7 +181,7 @@ impl BluetoothRemoteGATTDescriptorMethods<crate::DomTypeHolder> for BluetoothRem
 }
 
 impl AsyncBluetoothListener for BluetoothRemoteGATTDescriptor {
-    fn handle_response(&self, response: BluetoothResponse, promise: &Rc<Promise>, _can_gc: CanGc) {
+    fn handle_response(&self, response: BluetoothResponse, promise: &Rc<Promise>, can_gc: CanGc) {
         match response {
             // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattdescriptor-readvalue
             BluetoothResponse::ReadValue(result) => {
@@ -193,7 +193,7 @@ impl AsyncBluetoothListener for BluetoothRemoteGATTDescriptor {
                 *self.value.borrow_mut() = Some(value.clone());
 
                 // Step 5.4.3.
-                promise.resolve_native(&value);
+                promise.resolve_native(&value, can_gc);
             },
             // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattdescriptor-writevalue
             BluetoothResponse::WriteValue(result) => {
@@ -205,7 +205,7 @@ impl AsyncBluetoothListener for BluetoothRemoteGATTDescriptor {
 
                 // Step 7.4.3.
                 // TODO: Resolve promise with undefined instead of a value.
-                promise.resolve_native(&());
+                promise.resolve_native(&(), can_gc);
             },
             _ => promise.reject_error(Error::Type("Something went wrong...".to_owned())),
         }

--- a/components/script/dom/bluetooth/bluetoothremotegattserver.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattserver.rs
@@ -164,18 +164,17 @@ impl AsyncBluetoothListener for BluetoothRemoteGATTServer {
                 self.connected.set(connected);
 
                 // Step 5.2.5.
-                promise.resolve_native(self);
+                promise.resolve_native(self, can_gc);
             },
             // https://webbluetoothcg.github.io/web-bluetooth/#getgattchildren
             // Step 7.
             BluetoothResponse::GetPrimaryServices(services_vec, single) => {
                 let device = self.Device();
                 if single {
-                    promise.resolve_native(&device.get_or_create_service(
-                        &services_vec[0],
-                        self,
+                    promise.resolve_native(
+                        &device.get_or_create_service(&services_vec[0], self, can_gc),
                         can_gc,
-                    ));
+                    );
                     return;
                 }
                 let mut services = vec![];
@@ -183,7 +182,7 @@ impl AsyncBluetoothListener for BluetoothRemoteGATTServer {
                     let bt_service = device.get_or_create_service(&service, self, can_gc);
                     services.push(bt_service);
                 }
-                promise.resolve_native(&services);
+                promise.resolve_native(&services, can_gc);
             },
             _ => promise.reject_error(Error::Type("Something went wrong...".to_owned())),
         }

--- a/components/script/dom/bluetooth/bluetoothremotegattservice.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattservice.rs
@@ -172,11 +172,10 @@ impl AsyncBluetoothListener for BluetoothRemoteGATTService {
             // Step 7.
             BluetoothResponse::GetCharacteristics(characteristics_vec, single) => {
                 if single {
-                    promise.resolve_native(&device.get_or_create_characteristic(
-                        &characteristics_vec[0],
-                        self,
+                    promise.resolve_native(
+                        &device.get_or_create_characteristic(&characteristics_vec[0], self, can_gc),
                         can_gc,
-                    ));
+                    );
                     return;
                 }
                 let mut characteristics = vec![];
@@ -185,17 +184,16 @@ impl AsyncBluetoothListener for BluetoothRemoteGATTService {
                         device.get_or_create_characteristic(&characteristic, self, can_gc);
                     characteristics.push(bt_characteristic);
                 }
-                promise.resolve_native(&characteristics);
+                promise.resolve_native(&characteristics, can_gc);
             },
             // https://webbluetoothcg.github.io/web-bluetooth/#getgattchildren
             // Step 7.
             BluetoothResponse::GetIncludedServices(services_vec, single) => {
                 if single {
-                    return promise.resolve_native(&device.get_or_create_service(
-                        &services_vec[0],
-                        &device.get_gatt(),
+                    return promise.resolve_native(
+                        &device.get_or_create_service(&services_vec[0], &device.get_gatt(), can_gc),
                         can_gc,
-                    ));
+                    );
                 }
                 let mut services = vec![];
                 for service in services_vec {
@@ -203,7 +201,7 @@ impl AsyncBluetoothListener for BluetoothRemoteGATTService {
                         device.get_or_create_service(&service, &device.get_gatt(), can_gc);
                     services.push(bt_service);
                 }
-                promise.resolve_native(&services);
+                promise.resolve_native(&services, can_gc);
             },
             _ => promise.reject_error(Error::Type("Something went wrong...".to_owned())),
         }

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -343,6 +343,7 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
         name: DOMString,
         constructor_: Rc<CustomElementConstructor>,
         options: &ElementDefinitionOptions,
+        can_gc: CanGc,
     ) -> ErrorResult {
         let cx = GlobalScope::get_cx();
         rooted!(in(*cx) let constructor = constructor_.callback());
@@ -543,7 +544,7 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
                 definition
                     .constructor
                     .to_jsval(*cx, constructor.handle_mut());
-                promise.resolve_native(&constructor.get());
+                promise.resolve_native(&constructor.get(), can_gc);
             }
         }
         Ok(())
@@ -595,7 +596,7 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
                     .constructor
                     .to_jsval(*cx, constructor.handle_mut());
                 let promise = Promise::new_in_current_realm(comp, can_gc);
-                promise.resolve_native(&constructor.get());
+                promise.resolve_native(&constructor.get(), can_gc);
                 return promise;
             }
         }

--- a/components/script/dom/defaultteereadrequest.rs
+++ b/components/script/dom/defaultteereadrequest.rs
@@ -178,20 +178,20 @@ impl DefaultTeeReadRequest {
         }
     }
     /// <https://streams.spec.whatwg.org/#read-request-close-steps>
-    pub(crate) fn close_steps(&self) {
+    pub(crate) fn close_steps(&self, can_gc: CanGc) {
         // Set reading to false.
         self.reading.set(false);
         // If canceled_1 is false, perform ! ReadableStreamDefaultControllerClose(branch_1.[[controller]]).
         if !self.canceled_1.get() {
-            self.readable_stream_default_controller_close(&self.branch_1);
+            self.readable_stream_default_controller_close(&self.branch_1, can_gc);
         }
         // If canceled_2 is false, perform ! ReadableStreamDefaultControllerClose(branch_2.[[controller]]).
         if !self.canceled_2.get() {
-            self.readable_stream_default_controller_close(&self.branch_2);
+            self.readable_stream_default_controller_close(&self.branch_2, can_gc);
         }
         // If canceled_1 is false or canceled_2 is false, resolve cancelPromise with undefined.
         if !self.canceled_1.get() || !self.canceled_2.get() {
-            self.cancel_promise.resolve_native(&());
+            self.cancel_promise.resolve_native(&(), can_gc);
         }
     }
     /// <https://streams.spec.whatwg.org/#read-request-error-steps>
@@ -215,8 +215,8 @@ impl DefaultTeeReadRequest {
 
     /// Call into close of the default controller of a stream,
     /// <https://streams.spec.whatwg.org/#readable-stream-default-controller-close>
-    fn readable_stream_default_controller_close(&self, stream: &ReadableStream) {
-        stream.get_default_controller().close();
+    fn readable_stream_default_controller_close(&self, stream: &ReadableStream, can_gc: CanGc) {
+        stream.get_default_controller().close(can_gc);
     }
 
     /// Call into error of the default controller of stream,

--- a/components/script/dom/defaultteeunderlyingsource.rs
+++ b/components/script/dom/defaultteeunderlyingsource.rs
@@ -213,6 +213,6 @@ impl DefaultTeeUnderlyingSource {
         let cancel_result = self.stream.cancel(reasons_value.handle(), can_gc);
 
         // Resolve cancelPromise with cancelResult.
-        self.cancel_promise.resolve_native(&cancel_result);
+        self.cancel_promise.resolve_native(&cancel_result, can_gc);
     }
 }

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -4625,7 +4625,7 @@ impl TaskOnce for ElementPerformFullscreenEnter {
             .fire_event(atom!("fullscreenchange"), CanGc::note());
 
         // Step 7.7
-        promise.resolve_native(&());
+        promise.resolve_native(&(), CanGc::note());
     }
 }
 
@@ -4659,7 +4659,7 @@ impl TaskOnce for ElementPerformFullscreenExit {
             .fire_event(atom!("fullscreenchange"), CanGc::note());
 
         // Step 9.10
-        self.promise.root().resolve_native(&());
+        self.promise.root().resolve_native(&(), CanGc::note());
     }
 }
 

--- a/components/script/dom/fontface.rs
+++ b/components/script/dom/fontface.rs
@@ -514,7 +514,7 @@ impl FontFaceMethods<crate::DomTypeHolder> for FontFace {
                             font_face.status.set(FontFaceLoadStatus::Loaded);
                             let old_template = font_face.template.borrow_mut().replace((family_name, template));
                             debug_assert!(old_template.is_none(), "FontFace's template must be intialized only once");
-                            font_face.font_status_promise.resolve_native(&font_face);
+                            font_face.font_status_promise.resolve_native(&font_face, CanGc::note());
                         }
                     }
 

--- a/components/script/dom/fontfaceset.rs
+++ b/components/script/dom/fontfaceset.rs
@@ -69,9 +69,9 @@ impl FontFaceSet {
         }
     }
 
-    pub(crate) fn fulfill_ready_promise_if_needed(&self) {
+    pub(crate) fn fulfill_ready_promise_if_needed(&self, can_gc: CanGc) {
         if !self.promise.is_fulfilled() {
-            self.promise.resolve_native(self);
+            self.promise.resolve_native(self, can_gc);
         }
     }
 }
@@ -114,7 +114,7 @@ impl FontFaceSetMethods<crate::DomTypeHolder> for FontFaceSet {
                 // TODO: Step 4.2. Resolve promise with the result of waiting for all of the
                 // [[FontStatusPromise]]s of each font face in the font face list, in order.
                 let matched_fonts = Vec::<&FontFace>::new();
-                promise.resolve_native(&matched_fonts);
+                promise.resolve_native(&matched_fonts, CanGc::note());
             }));
 
         // Step 2. Return promise. Complete the rest of these steps asynchronously.

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -591,8 +591,8 @@ fn stream_handle_incoming(stream: &ReadableStream, bytes: Fallible<Vec<u8>>, can
 }
 
 /// Callback used to close streams as part of FileListener.
-fn stream_handle_eof(stream: &ReadableStream) {
-    stream.controller_close_native();
+fn stream_handle_eof(stream: &ReadableStream, can_gc: CanGc) {
+    stream.controller_close_native(can_gc);
 }
 
 impl FileListener {
@@ -657,7 +657,7 @@ impl FileListener {
 
                         let task = task!(enqueue_stream_chunk: move || {
                             let stream = trusted.root();
-                            stream_handle_eof(&stream);
+                            stream_handle_eof(&stream, CanGc::note());
                         });
 
                         self.task_source.queue(task);
@@ -2729,7 +2729,7 @@ impl GlobalScope {
 
                     image_bitmap.set_bitmap_data(data);
                     image_bitmap.set_origin_clean(canvas.origin_is_clean());
-                    p.resolve_native(&(image_bitmap));
+                    p.resolve_native(&(image_bitmap), can_gc);
                 }
                 p
             },
@@ -2749,7 +2749,7 @@ impl GlobalScope {
                         ImageBitmap::new(self, size.width, size.height, can_gc).unwrap();
                     image_bitmap.set_bitmap_data(data);
                     image_bitmap.set_origin_clean(canvas.origin_is_clean());
-                    p.resolve_native(&(image_bitmap));
+                    p.resolve_native(&(image_bitmap), can_gc);
                 }
                 p
             },

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -450,7 +450,7 @@ impl HTMLImageElement {
         LoadBlocker::terminate(&self.current_request.borrow().blocker, can_gc);
         // Mark the node dirty
         self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
-        self.resolve_image_decode_promises();
+        self.resolve_image_decode_promises(can_gc);
     }
 
     /// Step 24 of <https://html.spec.whatwg.org/multipage/#update-the-image-data>
@@ -559,7 +559,7 @@ impl HTMLImageElement {
         if matches!(state, State::Broken) {
             self.reject_image_decode_promises(can_gc);
         } else if matches!(state, State::CompletelyAvailable) {
-            self.resolve_image_decode_promises();
+            self.resolve_image_decode_promises(can_gc);
         }
     }
 
@@ -1186,7 +1186,7 @@ impl HTMLImageElement {
             State::CompletelyAvailable
         ) {
             // this doesn't follow the spec, but it's been discussed in <https://github.com/whatwg/html/issues/4217>
-            promise.resolve_native(&());
+            promise.resolve_native(&(), can_gc);
         } else {
             self.image_decode_promises
                 .borrow_mut()
@@ -1194,9 +1194,9 @@ impl HTMLImageElement {
         }
     }
 
-    fn resolve_image_decode_promises(&self) {
+    fn resolve_image_decode_promises(&self, can_gc: CanGc) {
         for promise in self.image_decode_promises.borrow().iter() {
-            promise.resolve_native(&());
+            promise.resolve_native(&(), can_gc);
         }
         self.image_decode_promises.borrow_mut().clear();
     }

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -1219,7 +1219,7 @@ impl HTMLMediaElement {
         f();
         for promise in &*promises {
             match result {
-                Ok(ref value) => promise.resolve_native(value),
+                Ok(ref value) => promise.resolve_native(value, CanGc::note()),
                 Err(ref error) => promise.reject_error(error.clone()),
             }
         }

--- a/components/script/dom/mediadevices.rs
+++ b/components/script/dom/mediadevices.rs
@@ -72,7 +72,7 @@ impl MediaDevicesMethods<crate::DomTypeHolder> for MediaDevices {
             }
         }
 
-        p.resolve_native(&stream);
+        p.resolve_native(&stream, can_gc);
         p
     }
 
@@ -107,7 +107,7 @@ impl MediaDevicesMethods<crate::DomTypeHolder> for MediaDevices {
             Err(_) => Vec::new(),
         };
 
-        p.resolve_native(&result_list);
+        p.resolve_native(&result_list, can_gc);
 
         // Step 3.
         p

--- a/components/script/dom/navigationpreloadmanager.rs
+++ b/components/script/dom/navigationpreloadmanager.rs
@@ -63,7 +63,7 @@ impl NavigationPreloadManagerMethods<crate::DomTypeHolder> for NavigationPreload
                 .set_navigation_preload_enabled(true);
 
             // 4.
-            promise.resolve_native(&UndefinedValue());
+            promise.resolve_native(&UndefinedValue(), can_gc);
         }
 
         promise
@@ -86,7 +86,7 @@ impl NavigationPreloadManagerMethods<crate::DomTypeHolder> for NavigationPreload
                 .set_navigation_preload_enabled(false);
 
             // 4.
-            promise.resolve_native(&UndefinedValue());
+            promise.resolve_native(&UndefinedValue(), can_gc);
         }
 
         promise
@@ -109,7 +109,7 @@ impl NavigationPreloadManagerMethods<crate::DomTypeHolder> for NavigationPreload
                 .set_navigation_preload_header_value(value);
 
             // 4.
-            promise.resolve_native(&UndefinedValue());
+            promise.resolve_native(&UndefinedValue(), can_gc);
         }
 
         promise
@@ -135,7 +135,7 @@ impl NavigationPreloadManagerMethods<crate::DomTypeHolder> for NavigationPreload
             .get_navigation_preload_header_value();
 
         // 5.
-        promise.resolve_native(&state);
+        promise.resolve_native(&state, can_gc);
 
         promise
     }

--- a/components/script/dom/notification.rs
+++ b/components/script/dom/notification.rs
@@ -295,7 +295,7 @@ impl NotificationMethods<crate::DomTypeHolder> for Notification {
                 }
 
                 // Step 3.2.2: Resolve promise with permissionState.
-                promise.resolve_native(&notification_permission);
+                promise.resolve_native(&notification_permission, CanGc::note());
             }),
         );
 

--- a/components/script/dom/offlineaudiocontext.rs
+++ b/components/script/dom/offlineaudiocontext.rs
@@ -179,36 +179,37 @@ impl OfflineAudioContextMethods<crate::DomTypeHolder> for OfflineAudioContext {
             .name("OfflineACResolver".to_owned())
             .spawn(move || {
                 let _ = receiver.recv();
-                task_source.queue(
-                    task!(resolve: move || {
-                        let this = this.root();
-                        let processed_audio = processed_audio.lock().unwrap();
-                        let mut processed_audio: Vec<_> = processed_audio
-                            .chunks(this.length as usize)
-                            .map(|channel| channel.to_vec())
-                            .collect();
-                        // it can end up being empty if the task failed
-                        if processed_audio.len() != this.length as usize {
-                            processed_audio.resize(this.length as usize, Vec::new())
-                        }
-                        let buffer = AudioBuffer::new(
-                            this.global().as_window(),
-                            this.channel_count,
-                            this.length,
-                            *this.context.SampleRate(),
-                            Some(processed_audio.as_slice()),
-                            CanGc::note());
-                        (*this.pending_rendering_promise.borrow_mut()).take().unwrap().resolve_native(&buffer);
-                        let global = &this.global();
-                        let window = global.as_window();
-                        let event = OfflineAudioCompletionEvent::new(window,
-                                                                     atom!("complete"),
-                                                                     EventBubbles::DoesNotBubble,
-                                                                     EventCancelable::NotCancelable,
-                                                                     &buffer, CanGc::note());
-                        event.upcast::<Event>().fire(this.upcast(), CanGc::note());
-                    })
-                );
+                task_source.queue(task!(resolve: move || {
+                    let this = this.root();
+                    let processed_audio = processed_audio.lock().unwrap();
+                    let mut processed_audio: Vec<_> = processed_audio
+                        .chunks(this.length as usize)
+                        .map(|channel| channel.to_vec())
+                        .collect();
+                    // it can end up being empty if the task failed
+                    if processed_audio.len() != this.length as usize {
+                        processed_audio.resize(this.length as usize, Vec::new())
+                    }
+                    let buffer = AudioBuffer::new(
+                        this.global().as_window(),
+                        this.channel_count,
+                        this.length,
+                        *this.context.SampleRate(),
+                        Some(processed_audio.as_slice()),
+                        CanGc::note());
+                    (*this.pending_rendering_promise.borrow_mut())
+                        .take()
+                        .unwrap()
+                        .resolve_native(&buffer, CanGc::note());
+                    let global = &this.global();
+                    let window = global.as_window();
+                    let event = OfflineAudioCompletionEvent::new(window,
+                                                                 atom!("complete"),
+                                                                 EventBubbles::DoesNotBubble,
+                                                                 EventCancelable::NotCancelable,
+                                                                 &buffer, CanGc::note());
+                    event.upcast::<Event>().fire(this.upcast(), CanGc::note());
+                }));
             })
             .unwrap();
 

--- a/components/script/dom/permissions.rs
+++ b/components/script/dom/permissions.rs
@@ -160,14 +160,14 @@ impl Permissions {
                         // (Request) Step 7. The default algorithm always resolve
 
                         // (Request) Step 8.
-                        p.resolve_native(&status);
+                        p.resolve_native(&status, can_gc);
                     },
                     Operation::Query => {
                         // (Query) Step 6.
                         Permissions::permission_query(cx, &p, &root_desc, &status);
 
                         // (Query) Step 7.
-                        p.resolve_native(&status);
+                        p.resolve_native(&status, can_gc);
                     },
 
                     Operation::Revoke => {

--- a/components/script/dom/promise.rs
+++ b/components/script/dom/promise.rs
@@ -184,7 +184,7 @@ impl Promise {
     }
 
     #[allow(unsafe_code)]
-    pub(crate) fn resolve_native<T>(&self, val: &T)
+    pub(crate) fn resolve_native<T>(&self, val: &T, can_gc: CanGc)
     where
         T: ToJSValConvertible,
     {
@@ -194,12 +194,12 @@ impl Promise {
         unsafe {
             val.to_jsval(*cx, v.handle_mut());
         }
-        self.resolve(cx, v.handle());
+        self.resolve(cx, v.handle(), can_gc);
     }
 
     #[allow(unsafe_code)]
     #[cfg_attr(crown, allow(crown::unrooted_must_root))]
-    pub(crate) fn resolve(&self, cx: SafeJSContext, value: HandleValue) {
+    pub(crate) fn resolve(&self, cx: SafeJSContext, value: HandleValue, _can_gc: CanGc) {
         unsafe {
             if !ResolvePromise(*cx, self.promise_obj(), value) {
                 JS_ClearPendingException(*cx);

--- a/components/script/dom/response.rs
+++ b/components/script/dom/response.rs
@@ -464,9 +464,9 @@ impl Response {
     }
 
     #[cfg_attr(crown, allow(crown::unrooted_must_root))]
-    pub(crate) fn finish(&self) {
+    pub(crate) fn finish(&self, can_gc: CanGc) {
         if let Some(body) = self.body_stream.get() {
-            body.controller_close_native();
+            body.controller_close_native(can_gc);
         }
         let stream_consumer = self.stream_consumer.borrow_mut().take();
         if let Some(stream_consumer) = stream_consumer {

--- a/components/script/dom/rtcpeerconnection.rs
+++ b/components/script/dom/rtcpeerconnection.rs
@@ -457,7 +457,7 @@ impl RTCPeerConnection {
                     } else {
                         let init: RTCSessionDescriptionInit = desc.convert();
                         for promise in this.offer_promises.borrow_mut().drain(..) {
-                            promise.resolve_native(&init);
+                            promise.resolve_native(&init, CanGc::note());
                         }
                     }
                 }));
@@ -486,7 +486,7 @@ impl RTCPeerConnection {
                     } else {
                         let init: RTCSessionDescriptionInit = desc.convert();
                         for promise in this.answer_promises.borrow_mut().drain(..) {
-                            promise.resolve_native(&init);
+                            promise.resolve_native(&init, CanGc::note());
                         }
                     }
                 }));
@@ -583,7 +583,7 @@ impl RTCPeerConnectionMethods<crate::DomTypeHolder> for RTCPeerConnection {
             });
 
         // XXXManishearth add_ice_candidate should have a callback
-        p.resolve_native(&());
+        p.resolve_native(&(), can_gc);
         p
     }
 
@@ -662,7 +662,7 @@ impl RTCPeerConnectionMethods<crate::DomTypeHolder> for RTCPeerConnection {
                             &desc,
                         ).unwrap();
                         this.local_description.set(Some(&desc));
-                        trusted_promise.root().resolve_native(&())
+                        trusted_promise.root().resolve_native(&(), CanGc::note())
                     }));
                 }),
             );
@@ -705,7 +705,7 @@ impl RTCPeerConnectionMethods<crate::DomTypeHolder> for RTCPeerConnection {
                             &desc,
                         ).unwrap();
                         this.remote_description.set(Some(&desc));
-                        trusted_promise.root().resolve_native(&())
+                        trusted_promise.root().resolve_native(&(), CanGc::note())
                     }));
                 }),
             );

--- a/components/script/dom/rtcrtpsender.rs
+++ b/components/script/dom/rtcrtpsender.rs
@@ -53,7 +53,7 @@ impl RTCRtpSenderMethods<crate::DomTypeHolder> for RTCRtpSender {
     // https://w3c.github.io/webrtc-pc/#dom-rtcrtpsender-setparameters
     fn SetParameters(&self, _parameters: &RTCRtpSendParameters, can_gc: CanGc) -> Rc<Promise> {
         let promise = Promise::new(&self.global(), can_gc);
-        promise.resolve_native(&());
+        promise.resolve_native(&(), can_gc);
         promise
     }
 }

--- a/components/script/dom/serviceworkercontainer.rs
+++ b/components/script/dom/serviceworkercontainer.rs
@@ -248,7 +248,7 @@ impl RegisterJobResultHandler {
                     );
 
                     // Step 1.4
-                    promise.resolve_native(&*registration);
+                    promise.resolve_native(&*registration, CanGc::note());
                 }));
 
                 // TODO: step 2, handle equivalent jobs.

--- a/components/script/dom/subtlecrypto.rs
+++ b/components/script/dom/subtlecrypto.rs
@@ -181,7 +181,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                     promise.reject_error(e);
                     return;
                 }
-                promise.resolve_native(&*array_buffer_ptr.handle());
+                promise.resolve_native(&*array_buffer_ptr.handle(), CanGc::note());
             })
         );
 
@@ -236,7 +236,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                     return;
                 }
 
-                promise.resolve_native(&*array_buffer_ptr.handle());
+                promise.resolve_native(&*array_buffer_ptr.handle(), CanGc::note());
             })
         );
 
@@ -320,7 +320,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                     .expect("failed to create buffer source for exported key.");
 
                 // Step 9. Resolve promise with result.
-                promise.resolve_native(&*array_buffer_ptr);
+                promise.resolve_native(&*array_buffer_ptr, CanGc::note());
             }));
 
         promise
@@ -408,7 +408,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                 };
 
                 // Step 9. Resolve promise with result.
-                promise.resolve_native(&result);
+                promise.resolve_native(&result, CanGc::note());
             }));
 
         promise
@@ -473,7 +473,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
 
 
                 // Step 9. Resolve promise with result.
-                promise.resolve_native(&*array_buffer_ptr);
+                promise.resolve_native(&*array_buffer_ptr, CanGc::note());
             })
         );
 
@@ -510,7 +510,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                 let key = normalized_algorithm.generate_key(&subtle, key_usages, extractable);
 
                 match key {
-                    Ok(key) => promise.resolve_native(&key),
+                    Ok(key) => promise.resolve_native(&key, CanGc::note()),
                     Err(e) => promise.reject_error(e),
                 }
             }));
@@ -641,7 +641,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                 }
 
                 // Step 17. Resolve promise with result.
-                promise.resolve_native(&*result);
+                promise.resolve_native(&*result, CanGc::note());
             }),
         );
 
@@ -715,7 +715,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                     .expect("failed to create buffer source for derived bits.");
 
                 // Step 10. Resolve promise with result.
-                promise.resolve_native(&*array_buffer_ptr);
+                promise.resolve_native(&*array_buffer_ptr, CanGc::note());
             }));
 
         promise
@@ -779,7 +779,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                 let imported_key = normalized_algorithm.import_key(&subtle,
                     format, &data, extractable, key_usages, CanGc::note());
                 match imported_key {
-                    Ok(k) => promise.resolve_native(&k),
+                    Ok(k) => promise.resolve_native(&k, CanGc::note()),
                     Err(e) => promise.reject_error(e),
                 };
             }));
@@ -829,10 +829,10 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                                 create_buffer_source::<ArrayBufferU8>(cx, &k, array_buffer_ptr.handle_mut(),
                                     CanGc::note())
                                     .expect("failed to create buffer source for exported key.");
-                                promise.resolve_native(&array_buffer_ptr.get())
+                                promise.resolve_native(&array_buffer_ptr.get(), CanGc::note())
                             },
                             AesExportedKey::Jwk(k) => {
-                                promise.resolve_native(&k)
+                                promise.resolve_native(&k, CanGc::note())
                             },
                         }
                     },
@@ -958,7 +958,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                 };
 
                 match result {
-                    Ok(_) => promise.resolve_native(&*array_buffer_ptr),
+                    Ok(_) => promise.resolve_native(&*array_buffer_ptr, CanGc::note()),
                     Err(e) => promise.reject_error(e),
                 }
             }),
@@ -1068,7 +1068,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                 };
                 match normalized_key_algorithm.import_key(&subtle, format, &import_key_bytes,
                     extractable, key_usages, CanGc::note()) {
-                    Ok(imported_key) => promise.resolve_native(&imported_key),
+                    Ok(imported_key) => promise.resolve_native(&imported_key, CanGc::note()),
                     Err(e) => promise.reject_error(e),
                 }
             }),

--- a/components/script/dom/testbinding.rs
+++ b/components/script/dom/testbinding.rs
@@ -980,8 +980,8 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
         Promise::new_rejected(&self.global(), cx, v, CanGc::note())
     }
 
-    fn PromiseResolveNative(&self, cx: SafeJSContext, p: &Promise, v: HandleValue) {
-        p.resolve(cx, v);
+    fn PromiseResolveNative(&self, cx: SafeJSContext, p: &Promise, v: HandleValue, can_gc: CanGc) {
+        p.resolve(cx, v, can_gc);
     }
 
     fn PromiseRejectNative(&self, cx: SafeJSContext, p: &Promise, v: HandleValue) {
@@ -1163,6 +1163,8 @@ pub(crate) struct TestBindingCallback {
 impl TestBindingCallback {
     #[cfg_attr(crown, allow(crown::unrooted_must_root))]
     pub(crate) fn invoke(self) {
-        self.promise.root().resolve_native(&self.value);
+        self.promise
+            .root()
+            .resolve_native(&self.value, CanGc::note());
     }
 }

--- a/components/script/dom/underlyingsourcecontainer.rs
+++ b/components/script/dom/underlyingsourcecontainer.rs
@@ -203,7 +203,7 @@ impl UnderlyingSourceContainer {
                         promise
                     } else {
                         let promise = Promise::new(&self.global(), can_gc);
-                        promise.resolve_native(&result.get());
+                        promise.resolve_native(&result.get(), can_gc);
                         promise
                     };
                     return Some(Ok(promise));

--- a/components/script/dom/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl2renderingcontext.rs
@@ -4691,7 +4691,7 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
     fn MakeXRCompatible(&self, can_gc: CanGc) -> Rc<Promise> {
         // XXXManishearth Fill in with compatibility checks when rust-webxr supports this
         let p = Promise::new(&self.global(), can_gc);
-        p.resolve_native(&());
+        p.resolve_native(&(), can_gc);
         p
     }
 }

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -4818,7 +4818,7 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
     fn MakeXRCompatible(&self, can_gc: CanGc) -> Rc<Promise> {
         // XXXManishearth Fill in with compatibility checks when rust-webxr supports this
         let p = Promise::new(&self.global(), can_gc);
-        p.resolve_native(&());
+        p.resolve_native(&(), can_gc);
         p
     }
 }

--- a/components/script/dom/webgpu/gpu.rs
+++ b/components/script/dom/webgpu/gpu.rs
@@ -168,15 +168,15 @@ impl AsyncWGPUListener for GPU {
                     adapter.adapter_id,
                     can_gc,
                 );
-                promise.resolve_native(&adapter);
+                promise.resolve_native(&adapter, can_gc);
             },
             WebGPUResponse::Adapter(Err(e)) => {
                 warn!("Could not get GPUAdapter ({:?})", e);
-                promise.resolve_native(&None::<GPUAdapter>);
+                promise.resolve_native(&None::<GPUAdapter>, can_gc);
             },
             WebGPUResponse::None => {
                 warn!("Couldn't get a response, because WebGPU is disabled");
-                promise.resolve_native(&None::<GPUAdapter>);
+                promise.resolve_native(&None::<GPUAdapter>, can_gc);
             },
             _ => unreachable!("GPU received wrong WebGPUResponse"),
         }

--- a/components/script/dom/webgpu/gpuadapter.rs
+++ b/components/script/dom/webgpu/gpuadapter.rs
@@ -189,7 +189,7 @@ impl GPUAdapterMethods<crate::DomTypeHolder> for GPUAdapter {
         if !unmask_hints.is_empty() {
             todo!("unmaskHints on RequestAdapterInfo");
         }
-        promise.resolve_native(&*self.info);
+        promise.resolve_native(&*self.info, can_gc);
         // Step 5
         promise
     }
@@ -222,7 +222,7 @@ impl AsyncWGPUListener for GPUAdapter {
                     can_gc,
                 );
                 self.global().add_gpu_device(&device);
-                promise.resolve_native(&device);
+                promise.resolve_native(&device, can_gc);
             },
             WebGPUResponse::Device((_, _, Err(RequestDeviceError::UnsupportedFeature(f)))) => {
                 promise.reject_error(Error::Type(
@@ -246,7 +246,7 @@ impl AsyncWGPUListener for GPUAdapter {
                     can_gc,
                 );
                 device.lose(GPUDeviceLostReason::Unknown, e.to_string(), can_gc);
-                promise.resolve_native(&device);
+                promise.resolve_native(&device, can_gc);
             },
             WebGPUResponse::None => unreachable!("Failed to get a response for RequestDevice"),
             _ => unreachable!("GPUAdapter received wrong WebGPUResponse"),

--- a/components/script/dom/webgpu/gpuqueue.rs
+++ b/components/script/dom/webgpu/gpuqueue.rs
@@ -220,11 +220,11 @@ impl AsyncWGPUListener for GPUQueue {
         &self,
         response: webgpu::WebGPUResponse,
         promise: &Rc<Promise>,
-        _can_gc: CanGc,
+        can_gc: CanGc,
     ) {
         match response {
             WebGPUResponse::SubmittedWorkDone => {
-                promise.resolve_native(&());
+                promise.resolve_native(&(), can_gc);
             },
             _ => {
                 warn!("GPUQueue received wrong WebGPUResponse");

--- a/components/script/dom/webgpu/gpushadermodule.rs
+++ b/components/script/dom/webgpu/gpushadermodule.rs
@@ -134,7 +134,7 @@ impl AsyncWGPUListener for GPUShaderModule {
         match response {
             WebGPUResponse::CompilationInfo(info) => {
                 let info = GPUCompilationInfo::from(&self.global(), info, can_gc);
-                promise.resolve_native(&info);
+                promise.resolve_native(&info, can_gc);
             },
             _ => unreachable!("Wrong response received on AsyncWGPUListener for GPUShaderModule"),
         }

--- a/components/script/dom/webxr/xrsystem.rs
+++ b/components/script/dom/webxr/xrsystem.rs
@@ -258,7 +258,7 @@ impl XRSystemMethods<crate::DomTypeHolder> for XRSystem {
                     return;
                 };
                 task_source.queue(task!(request_session: move || {
-                    this.root().session_obtained(message, trusted.root(), mode, frame_receiver);
+                    this.root().session_obtained(message, trusted.root(), mode, frame_receiver, CanGc::note());
                 }));
             }),
         );
@@ -282,6 +282,7 @@ impl XRSystem {
         promise: Rc<Promise>,
         mode: XRSessionMode,
         frame_receiver: IpcReceiver<Frame>,
+        can_gc: CanGc,
     ) {
         let session = match response {
             Ok(session) => session,
@@ -302,7 +303,7 @@ impl XRSystem {
         } else {
             self.set_active_immersive_session(&session);
         }
-        promise.resolve_native(&session);
+        promise.resolve_native(&session, can_gc);
         // https://github.com/immersive-web/webxr/issues/961
         // This must be called _after_ the promise is resolved
         session.setup_initial_inputs();

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2058,7 +2058,7 @@ impl Window {
         // a "rendering opportunity" in `ScriptThread::handle_web_font_loaded, which should also
         // make sure a microtask checkpoint happens, triggering the promise callback.
         if !waiting_for_web_fonts_to_load && is_ready_state_complete {
-            font_face_set.fulfill_ready_promise_if_needed();
+            font_face_set.fulfill_ready_promise_if_needed(can_gc);
         }
 
         // If writing a screenshot, check if the script has reached a state

--- a/components/script/dom/writablestreamdefaultcontroller.rs
+++ b/components/script/dom/writablestreamdefaultcontroller.rs
@@ -40,11 +40,11 @@ struct CloseAlgorithmFulfillmentHandler {
 }
 
 impl Callback for CloseAlgorithmFulfillmentHandler {
-    fn callback(&self, cx: SafeJSContext, _v: SafeHandleValue, _realm: InRealm, _can_gc: CanGc) {
+    fn callback(&self, cx: SafeJSContext, _v: SafeHandleValue, _realm: InRealm, can_gc: CanGc) {
         let stream = self.stream.as_rooted();
 
         // Perform ! WritableStreamFinishInFlightClose(stream).
-        stream.finish_in_flight_close(cx);
+        stream.finish_in_flight_close(cx, can_gc);
     }
 }
 
@@ -154,7 +154,7 @@ impl Callback for WriteAlgorithmFulfillmentHandler {
             .expect("Controller should have a stream.");
 
         // Perform ! WritableStreamFinishInFlightWrite(stream).
-        stream.finish_in_flight_write();
+        stream.finish_in_flight_write(can_gc);
 
         // Let state be stream.[[state]].
         // Assert: state is "writable" or "erroring".

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -266,7 +266,7 @@ impl FetchResponseListener for FetchContext {
         }
 
         // Step 4.3
-        promise.resolve_native(&self.response_object.root());
+        promise.resolve_native(&self.response_object.root(), CanGc::note());
         self.fetch_promise = Some(TrustedPromise::new(promise));
     }
 
@@ -282,7 +282,7 @@ impl FetchResponseListener for FetchContext {
     ) {
         let response = self.response_object.root();
         let _ac = enter_realm(&*response);
-        response.finish();
+        response.finish(CanGc::note());
         // TODO
         // ... trailerObject is not supported in Servo yet.
     }

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -92,7 +92,7 @@ DOMInterfaces = {
 
 'CustomElementRegistry': {
     'inRealms': ['WhenDefined'],
-    'canGc': ['WhenDefined'],
+    'canGc': ['Define', 'WhenDefined'],
 },
 
 'DataTransfer': {
@@ -485,7 +485,7 @@ DOMInterfaces = {
 #FIXME(jdm): This should be 'register': False, but then we don't generate enum types
 'TestBinding': {
     'inRealms': ['PromiseAttribute', 'PromiseNativeHandler'],
-    'canGc': ['InterfaceAttribute', 'GetInterfaceAttributeNullable', 'ReceiveInterface', 'ReceiveInterfaceSequence', 'ReceiveNullableInterface', 'PromiseAttribute', 'PromiseNativeHandler'],
+    'canGc': ['InterfaceAttribute', 'GetInterfaceAttributeNullable', 'ReceiveInterface', 'ReceiveInterfaceSequence', 'ReceiveNullableInterface', 'PromiseAttribute', 'PromiseNativeHandler', 'PromiseResolveNative'],
 },
 
 'TestWorklet': {
@@ -593,7 +593,7 @@ DOMInterfaces = {
 },
 
 "ReadableStreamDefaultController": {
-    "canGc": ["Enqueue"]
+    "canGc": ["Close", "Enqueue"]
 },
 
 "ReadableStreamBYOBReader": {


### PR DESCRIPTION
Add CanGc as argument to `Promise::resolve`.

Addressed part of https://github.com/servo/servo/issues/34573

---

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they are a refactor.
