### PR TITLE
refactor RTCError::new_inherited

### DIFF
--- a/components/script/dom/rtcerror.rs
+++ b/components/script/dom/rtcerror.rs
@@ -9,16 +9,16 @@ use crate::dom::bindings::codegen::Bindings::RTCErrorBinding::{
     RTCErrorDetailType, RTCErrorInit, RTCErrorMethods,
 };
 use crate::dom::bindings::reflector::{reflect_dom_object_with_proto, DomGlobal};
-use crate::dom::bindings::root::{Dom, DomRoot};
+use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
-use crate::dom::domexception::{DOMErrorName, DOMException};
+use crate::dom::domexception::DOMException;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::window::Window;
 use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct RTCError {
-    exception: Dom<DOMException>,
+    exception: DOMException,
     error_detail: RTCErrorDetailType,
     sdp_line_number: Option<i32>,
     http_request_status_code: Option<i32>,
@@ -28,18 +28,9 @@ pub(crate) struct RTCError {
 }
 
 impl RTCError {
-    fn new_inherited(
-        global: &GlobalScope,
-        init: &RTCErrorInit,
-        message: DOMString,
-        can_gc: CanGc,
-    ) -> RTCError {
+    fn new_inherited(init: &RTCErrorInit, message: DOMString) -> RTCError {
         RTCError {
-            exception: Dom::from_ref(&*DOMException::new(
-                global,
-                DOMErrorName::from(&message).unwrap(),
-                can_gc,
-            )),
+            exception: DOMException::new_inherited(message, "OperationError".into()),
             error_detail: init.errorDetail,
             sdp_line_number: init.sdpLineNumber,
             http_request_status_code: init.httpRequestStatusCode,
@@ -66,7 +57,7 @@ impl RTCError {
         can_gc: CanGc,
     ) -> DomRoot<RTCError> {
         reflect_dom_object_with_proto(
-            Box::new(RTCError::new_inherited(global, init, message, can_gc)),
+            Box::new(RTCError::new_inherited(init, message)),
             global,
             proto,
             can_gc,


### PR DESCRIPTION
Refactor `RTCError::new_inherited` as suggested by @jdm in https://github.com/servo/servo/issues/35615.
I used `GPUPipelineError` as inspiration.

---

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #35615

- [x] These changes do not require tests because it's a refactor.
