### PR TITLE
Improve scheduling of the memory profiler.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5811,6 +5811,7 @@ dependencies = [
  "base",
  "ipc-channel",
  "libc",
+ "parking_lot",
  "profile_traits",
  "regex",
  "serde",

--- a/components/profile/Cargo.toml
+++ b/components/profile/Cargo.toml
@@ -14,6 +14,7 @@ path = "lib.rs"
 [dependencies]
 base = { workspace = true }
 ipc-channel = { workspace = true }
+parking_lot = { workspace = true }
 profile_traits = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
Switch the delay to be used between the end of a previous run and the next, instead of the start of consecutive runs. That ensure that we don't enqueue messages when processing is slower than the delay.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #35613 (GitHub issue number if applicable)

