### PR TITLE
Unify `(Offscreen)CanvasRenderingContext2d` and make `PaintRenderingContext2D` standalone

### DIFF
--- a/components/script/canvas_context.rs
+++ b/components/script/canvas_context.rs
@@ -11,6 +11,7 @@ use script_layout_interface::{HTMLCanvasData, HTMLCanvasDataSource};
 
 use crate::dom::bindings::codegen::UnionTypes::HTMLCanvasElementOrOffscreenCanvas;
 use crate::dom::bindings::inheritance::Castable;
+use crate::dom::htmlcanvaselement::HTMLCanvasElement;
 use crate::dom::node::{Node, NodeDamage};
 
 pub(crate) trait LayoutCanvasRenderingContextHelpers {
@@ -72,6 +73,13 @@ impl HTMLCanvasElementOrOffscreenCanvas {
                 canvas.get_size().cast()
             },
             HTMLCanvasElementOrOffscreenCanvas::OffscreenCanvas(canvas) => canvas.get_size(),
+        }
+    }
+
+    pub(crate) fn canvas(&self) -> Option<&HTMLCanvasElement> {
+        match self {
+            HTMLCanvasElementOrOffscreenCanvas::HTMLCanvasElement(canvas) => Some(canvas),
+            HTMLCanvasElementOrOffscreenCanvas::OffscreenCanvas(canvas) => canvas.placeholder(),
         }
     }
 }

--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -23,7 +23,7 @@ use crate::dom::bindings::codegen::UnionTypes::{
 use crate::dom::bindings::error::{ErrorResult, Fallible};
 use crate::dom::bindings::num::Finite;
 use crate::dom::bindings::reflector::{reflect_dom_object, DomGlobal, Reflector};
-use crate::dom::bindings::root::{Dom, DomRoot, LayoutDom};
+use crate::dom::bindings::root::{DomRoot, LayoutDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::canvasgradient::CanvasGradient;
 use crate::dom::canvaspattern::CanvasPattern;
@@ -38,21 +38,19 @@ use crate::script_runtime::CanGc;
 #[dom_struct]
 pub(crate) struct CanvasRenderingContext2D {
     reflector_: Reflector,
-    /// For rendering contexts created by an HTML canvas element, this is Some,
-    /// for ones created by a paint worklet, this is None.
-    canvas: Option<Dom<HTMLCanvasElement>>,
+    canvas: HTMLCanvasElementOrOffscreenCanvas,
     canvas_state: CanvasState,
 }
 
 impl CanvasRenderingContext2D {
     pub(crate) fn new_inherited(
         global: &GlobalScope,
-        canvas: Option<&HTMLCanvasElement>,
+        canvas: HTMLCanvasElementOrOffscreenCanvas,
         size: Size2D<u32>,
     ) -> CanvasRenderingContext2D {
         CanvasRenderingContext2D {
             reflector_: Reflector::new(),
-            canvas: canvas.map(Dom::from_ref),
+            canvas,
             canvas_state: CanvasState::new(
                 global,
                 Size2D::new(size.width as u64, size.height as u64),
@@ -68,7 +66,7 @@ impl CanvasRenderingContext2D {
     ) -> DomRoot<CanvasRenderingContext2D> {
         let boxed = Box::new(CanvasRenderingContext2D::new_inherited(
             global,
-            Some(canvas),
+            HTMLCanvasElementOrOffscreenCanvas::HTMLCanvasElement(DomRoot::from_ref(canvas)),
             size,
         ));
         reflect_dom_object(boxed, global, can_gc)
@@ -112,17 +110,16 @@ impl CanvasRenderingContext2D {
             Point2D::new(rect.origin.x as u64, rect.origin.y as u64),
             Size2D::new(rect.size.width as u64, rect.size.height as u64),
         );
-        self.canvas_state.get_rect(
-            self.canvas
-                .as_ref()
-                .map_or(Size2D::zero(), |c| c.get_size().to_u64()),
-            rect,
-        )
+        self.canvas_state.get_rect(self.canvas.size(), rect)
     }
 
     pub(crate) fn send_data(&self, sender: IpcSender<CanvasImageData>) {
         let msg = CanvasMsg::FromLayout(FromLayoutMsg::SendData(sender), self.get_canvas_id());
         let _ = self.canvas_state.get_ipc_renderer().send(msg);
+    }
+
+    pub(crate) fn get_ipc_renderer(&self) -> IpcSender<CanvasMsg> {
+        self.canvas_state.get_ipc_renderer().clone()
     }
 }
 
@@ -153,11 +150,7 @@ impl CanvasContext for CanvasRenderingContext2D {
     }
 
     fn canvas(&self) -> HTMLCanvasElementOrOffscreenCanvas {
-        if let Some(ref canvas) = self.canvas {
-            HTMLCanvasElementOrOffscreenCanvas::HTMLCanvasElement(canvas.as_rooted())
-        } else {
-            unimplemented!()
-        }
+        self.canvas.clone()
     }
 
     fn resize(&self) {
@@ -181,14 +174,7 @@ impl CanvasContext for CanvasRenderingContext2D {
     }
 
     fn mark_as_dirty(&self) {
-        self.canvas_state.mark_as_dirty(self.canvas.as_deref())
-    }
-
-    fn size(&self) -> Size2D<u64> {
-        self.canvas
-            .as_ref()
-            .map(|c| c.get_size().cast())
-            .unwrap_or(Size2D::zero())
+        self.canvas_state.mark_as_dirty(self.canvas.canvas())
     }
 }
 
@@ -204,9 +190,10 @@ impl CanvasContext for CanvasRenderingContext2D {
 impl CanvasRenderingContext2DMethods<crate::DomTypeHolder> for CanvasRenderingContext2D {
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-canvas
     fn Canvas(&self) -> DomRoot<HTMLCanvasElement> {
-        // This method is not called from a paint worklet rendering context,
-        // so it's OK to panic if self.canvas is None.
-        DomRoot::from_ref(self.canvas.as_ref().expect("No canvas."))
+        match &self.canvas {
+            HTMLCanvasElementOrOffscreenCanvas::HTMLCanvasElement(canvas) => canvas.clone(),
+            _ => panic!("Should not be called from offscreen canvas"),
+        }
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-save
@@ -334,14 +321,14 @@ impl CanvasRenderingContext2DMethods<crate::DomTypeHolder> for CanvasRenderingCo
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-filltext
     fn FillText(&self, text: DOMString, x: f64, y: f64, max_width: Option<f64>, can_gc: CanGc) {
         self.canvas_state
-            .fill_text(self.canvas.as_deref(), text, x, y, max_width, can_gc);
+            .fill_text(self.canvas.canvas(), text, x, y, max_width, can_gc);
         self.mark_as_dirty();
     }
 
     // https://html.spec.whatwg.org/multipage/#textmetrics
     fn MeasureText(&self, text: DOMString, can_gc: CanGc) -> DomRoot<TextMetrics> {
         self.canvas_state
-            .measure_text(&self.global(), self.canvas.as_deref(), text, can_gc)
+            .measure_text(&self.global(), self.canvas.canvas(), text, can_gc)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-font
@@ -352,7 +339,7 @@ impl CanvasRenderingContext2DMethods<crate::DomTypeHolder> for CanvasRenderingCo
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-font
     fn SetFont(&self, value: DOMString, can_gc: CanGc) {
         self.canvas_state
-            .set_font(self.canvas.as_deref(), value, can_gc)
+            .set_font(self.canvas.canvas(), value, can_gc)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-textalign
@@ -388,7 +375,7 @@ impl CanvasRenderingContext2DMethods<crate::DomTypeHolder> for CanvasRenderingCo
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-drawimage
     fn DrawImage(&self, image: CanvasImageSource, dx: f64, dy: f64) -> ErrorResult {
         self.canvas_state
-            .draw_image(self.canvas.as_deref(), image, dx, dy)
+            .draw_image(self.canvas.canvas(), image, dx, dy)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-drawimage
@@ -401,7 +388,7 @@ impl CanvasRenderingContext2DMethods<crate::DomTypeHolder> for CanvasRenderingCo
         dh: f64,
     ) -> ErrorResult {
         self.canvas_state
-            .draw_image_(self.canvas.as_deref(), image, dx, dy, dw, dh)
+            .draw_image_(self.canvas.canvas(), image, dx, dy, dw, dh)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-drawimage
@@ -417,18 +404,8 @@ impl CanvasRenderingContext2DMethods<crate::DomTypeHolder> for CanvasRenderingCo
         dw: f64,
         dh: f64,
     ) -> ErrorResult {
-        self.canvas_state.draw_image__(
-            self.canvas.as_deref(),
-            image,
-            sx,
-            sy,
-            sw,
-            sh,
-            dx,
-            dy,
-            dw,
-            dh,
-        )
+        self.canvas_state
+            .draw_image__(self.canvas.canvas(), image, sx, sy, sw, sh, dx, dy, dw, dh)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-moveto
@@ -501,7 +478,7 @@ impl CanvasRenderingContext2DMethods<crate::DomTypeHolder> for CanvasRenderingCo
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-strokestyle
     fn SetStrokeStyle(&self, value: StringOrCanvasGradientOrCanvasPattern, can_gc: CanGc) {
         self.canvas_state
-            .set_stroke_style(self.canvas.as_deref(), value, can_gc)
+            .set_stroke_style(self.canvas.canvas(), value, can_gc)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-strokestyle
@@ -512,7 +489,7 @@ impl CanvasRenderingContext2DMethods<crate::DomTypeHolder> for CanvasRenderingCo
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-strokestyle
     fn SetFillStyle(&self, value: StringOrCanvasGradientOrCanvasPattern, can_gc: CanGc) {
         self.canvas_state
-            .set_fill_style(self.canvas.as_deref(), value, can_gc)
+            .set_fill_style(self.canvas.canvas(), value, can_gc)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-createimagedata
@@ -540,29 +517,14 @@ impl CanvasRenderingContext2DMethods<crate::DomTypeHolder> for CanvasRenderingCo
         sh: i32,
         can_gc: CanGc,
     ) -> Fallible<DomRoot<ImageData>> {
-        self.canvas_state.get_image_data(
-            self.canvas
-                .as_ref()
-                .map_or(Size2D::zero(), |c| c.get_size().to_u64()),
-            &self.global(),
-            sx,
-            sy,
-            sw,
-            sh,
-            can_gc,
-        )
+        self.canvas_state
+            .get_image_data(self.canvas.size(), &self.global(), sx, sy, sw, sh, can_gc)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-putimagedata
     fn PutImageData(&self, imagedata: &ImageData, dx: i32, dy: i32) {
-        self.canvas_state.put_image_data(
-            self.canvas
-                .as_ref()
-                .map_or(Size2D::zero(), |c| c.get_size().to_u64()),
-            imagedata,
-            dx,
-            dy,
-        )
+        self.canvas_state
+            .put_image_data(self.canvas.size(), imagedata, dx, dy)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-putimagedata
@@ -578,9 +540,7 @@ impl CanvasRenderingContext2DMethods<crate::DomTypeHolder> for CanvasRenderingCo
         dirty_height: i32,
     ) {
         self.canvas_state.put_image_data_(
-            self.canvas
-                .as_ref()
-                .map_or(Size2D::zero(), |c| c.get_size().to_u64()),
+            self.canvas.size(),
             imagedata,
             dx,
             dy,
@@ -714,7 +674,7 @@ impl CanvasRenderingContext2DMethods<crate::DomTypeHolder> for CanvasRenderingCo
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-shadowcolor
     fn SetShadowColor(&self, value: DOMString, can_gc: CanGc) {
         self.canvas_state
-            .set_shadow_color(self.canvas.as_deref(), value, can_gc)
+            .set_shadow_color(self.canvas.canvas(), value, can_gc)
     }
 }
 

--- a/components/script/dom/offscreencanvas.rs
+++ b/components/script/dom/offscreencanvas.rs
@@ -123,12 +123,7 @@ impl OffscreenCanvas {
                 OffscreenCanvasContext::OffscreenContext2d(ref ctx) => Some(DomRoot::from_ref(ctx)),
             };
         }
-        let context = OffscreenCanvasRenderingContext2D::new(
-            &self.global(),
-            self,
-            self.placeholder.as_deref(),
-            CanGc::note(),
-        );
+        let context = OffscreenCanvasRenderingContext2D::new(&self.global(), self, CanGc::note());
         *self.context.borrow_mut() = Some(OffscreenCanvasContext::OffscreenContext2d(
             Dom::from_ref(&*context),
         ));
@@ -137,6 +132,10 @@ impl OffscreenCanvas {
 
     pub(crate) fn is_valid(&self) -> bool {
         self.Width() != 0 && self.Height() != 0
+    }
+
+    pub(crate) fn placeholder(&self) -> Option<&HTMLCanvasElement> {
+        self.placeholder.as_deref()
     }
 }
 

--- a/components/script/dom/paintrenderingcontext2d.rs
+++ b/components/script/dom/paintrenderingcontext2d.rs
@@ -4,17 +4,19 @@
 
 use std::cell::Cell;
 
-use canvas_traits::canvas::CanvasImageData;
+use canvas_traits::canvas::{CanvasId, CanvasImageData, CanvasMsg, FromLayoutMsg};
 use dom_struct::dom_struct;
 use euclid::{Scale, Size2D};
 use ipc_channel::ipc::IpcSender;
+use script_bindings::reflector::Reflector;
 use servo_url::ServoUrl;
 use style_traits::CSSPixel;
 use webrender_api::units::DevicePixel;
 
+use super::bindings::reflector::DomGlobal as _;
+use crate::canvas_state::CanvasState;
 use crate::dom::bindings::codegen::Bindings::CanvasRenderingContext2DBinding::{
     CanvasFillRule, CanvasImageSource, CanvasLineCap, CanvasLineJoin,
-    CanvasRenderingContext2DMethods,
 };
 use crate::dom::bindings::codegen::Bindings::PaintRenderingContext2DBinding::PaintRenderingContext2DMethods;
 use crate::dom::bindings::codegen::UnionTypes::StringOrCanvasGradientOrCanvasPattern;
@@ -26,23 +28,23 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::canvasgradient::CanvasGradient;
 use crate::dom::canvaspattern::CanvasPattern;
-use crate::dom::canvasrenderingcontext2d::CanvasRenderingContext2D;
 use crate::dom::dommatrix::DOMMatrix;
 use crate::dom::paintworkletglobalscope::PaintWorkletGlobalScope;
 use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct PaintRenderingContext2D {
-    context: CanvasRenderingContext2D,
+    reflector_: Reflector,
+    canvas_state: CanvasState,
     #[no_trace]
     device_pixel_ratio: Cell<Scale<f32, CSSPixel, DevicePixel>>,
 }
 
 impl PaintRenderingContext2D {
     fn new_inherited(global: &PaintWorkletGlobalScope) -> PaintRenderingContext2D {
-        let size = Size2D::zero();
         PaintRenderingContext2D {
-            context: CanvasRenderingContext2D::new_inherited(global.upcast(), None, size),
+            reflector_: Reflector::new(),
+            canvas_state: CanvasState::new(global.upcast(), Size2D::zero()),
             device_pixel_ratio: Cell::new(Scale::new(1.0)),
         }
     }
@@ -58,12 +60,17 @@ impl PaintRenderingContext2D {
         )
     }
 
+    pub(crate) fn get_canvas_id(&self) -> CanvasId {
+        self.canvas_state.get_canvas_id()
+    }
+
     pub(crate) fn send_data(&self, sender: IpcSender<CanvasImageData>) {
-        self.context.send_data(sender);
+        let msg = CanvasMsg::FromLayout(FromLayoutMsg::SendData(sender), self.get_canvas_id());
+        let _ = self.canvas_state.get_ipc_renderer().send(msg);
     }
 
     pub(crate) fn take_missing_image_urls(&self) -> Vec<ServoUrl> {
-        self.context.take_missing_image_urls()
+        std::mem::take(&mut self.canvas_state.get_missing_image_urls().borrow_mut())
     }
 
     pub(crate) fn set_bitmap_dimensions(
@@ -73,8 +80,8 @@ impl PaintRenderingContext2D {
     ) {
         let size = size * device_pixel_ratio;
         self.device_pixel_ratio.set(device_pixel_ratio);
-        self.context
-            .set_canvas_bitmap_dimensions(size.to_untyped().to_u64());
+        self.canvas_state
+            .set_bitmap_dimensions(size.to_untyped().to_u64());
         self.scale_by_device_pixel_ratio();
     }
 
@@ -89,124 +96,125 @@ impl PaintRenderingContext2D {
 impl PaintRenderingContext2DMethods<crate::DomTypeHolder> for PaintRenderingContext2D {
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-save
     fn Save(&self) {
-        self.context.Save()
+        self.canvas_state.save()
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-restore
     fn Restore(&self) {
-        self.context.Restore()
+        self.canvas_state.restore()
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-context-2d-reset>
     fn Reset(&self) {
-        self.context.Reset()
+        self.canvas_state.reset()
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-scale
     fn Scale(&self, x: f64, y: f64) {
-        self.context.Scale(x, y)
+        self.canvas_state.scale(x, y)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-rotate
     fn Rotate(&self, angle: f64) {
-        self.context.Rotate(angle)
+        self.canvas_state.rotate(angle)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-translate
     fn Translate(&self, x: f64, y: f64) {
-        self.context.Translate(x, y)
+        self.canvas_state.translate(x, y)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-transform
     fn Transform(&self, a: f64, b: f64, c: f64, d: f64, e: f64, f: f64) {
-        self.context.Transform(a, b, c, d, e, f)
+        self.canvas_state.transform(a, b, c, d, e, f)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-gettransform
     fn GetTransform(&self, can_gc: CanGc) -> DomRoot<DOMMatrix> {
-        self.context.GetTransform(can_gc)
+        self.canvas_state.get_transform(&self.global(), can_gc)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-settransform
     fn SetTransform(&self, a: f64, b: f64, c: f64, d: f64, e: f64, f: f64) {
-        self.context.SetTransform(a, b, c, d, e, f);
+        self.canvas_state.set_transform(a, b, c, d, e, f);
         self.scale_by_device_pixel_ratio();
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-resettransform
     fn ResetTransform(&self) {
-        self.context.ResetTransform();
+        self.canvas_state.reset_transform();
         self.scale_by_device_pixel_ratio();
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-globalalpha
     fn GlobalAlpha(&self) -> f64 {
-        self.context.GlobalAlpha()
+        self.canvas_state.global_alpha()
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-globalalpha
     fn SetGlobalAlpha(&self, alpha: f64) {
-        self.context.SetGlobalAlpha(alpha)
+        self.canvas_state.set_global_alpha(alpha)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-globalcompositeoperation
     fn GlobalCompositeOperation(&self) -> DOMString {
-        self.context.GlobalCompositeOperation()
+        self.canvas_state.global_composite_operation()
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-globalcompositeoperation
     fn SetGlobalCompositeOperation(&self, op_str: DOMString) {
-        self.context.SetGlobalCompositeOperation(op_str)
+        self.canvas_state.set_global_composite_operation(op_str)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-fillrect
     fn FillRect(&self, x: f64, y: f64, width: f64, height: f64) {
-        self.context.FillRect(x, y, width, height)
+        self.canvas_state.fill_rect(x, y, width, height)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-clearrect
     fn ClearRect(&self, x: f64, y: f64, width: f64, height: f64) {
-        self.context.ClearRect(x, y, width, height)
+        self.canvas_state.clear_rect(x, y, width, height)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-strokerect
     fn StrokeRect(&self, x: f64, y: f64, width: f64, height: f64) {
-        self.context.StrokeRect(x, y, width, height)
+        self.canvas_state.stroke_rect(x, y, width, height)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-beginpath
     fn BeginPath(&self) {
-        self.context.BeginPath()
+        self.canvas_state.begin_path()
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-closepath
     fn ClosePath(&self) {
-        self.context.ClosePath()
+        self.canvas_state.close_path()
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-fill
     fn Fill(&self, fill_rule: CanvasFillRule) {
-        self.context.Fill(fill_rule)
+        self.canvas_state.fill(fill_rule)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-stroke
     fn Stroke(&self) {
-        self.context.Stroke()
+        self.canvas_state.stroke()
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-clip
     fn Clip(&self, fill_rule: CanvasFillRule) {
-        self.context.Clip(fill_rule)
+        self.canvas_state.clip(fill_rule)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-ispointinpath
     fn IsPointInPath(&self, x: f64, y: f64, fill_rule: CanvasFillRule) -> bool {
-        self.context.IsPointInPath(x, y, fill_rule)
+        self.canvas_state
+            .is_point_in_path(&self.global(), x, y, fill_rule)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-drawimage
     fn DrawImage(&self, image: CanvasImageSource, dx: f64, dy: f64) -> ErrorResult {
-        self.context.DrawImage(image, dx, dy)
+        self.canvas_state.draw_image(None, image, dx, dy)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-drawimage
@@ -218,7 +226,7 @@ impl PaintRenderingContext2DMethods<crate::DomTypeHolder> for PaintRenderingCont
         dw: f64,
         dh: f64,
     ) -> ErrorResult {
-        self.context.DrawImage_(image, dx, dy, dw, dh)
+        self.canvas_state.draw_image_(None, image, dx, dy, dw, dh)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-drawimage
@@ -234,43 +242,44 @@ impl PaintRenderingContext2DMethods<crate::DomTypeHolder> for PaintRenderingCont
         dw: f64,
         dh: f64,
     ) -> ErrorResult {
-        self.context
-            .DrawImage__(image, sx, sy, sw, sh, dx, dy, dw, dh)
+        self.canvas_state
+            .draw_image__(None, image, sx, sy, sw, sh, dx, dy, dw, dh)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-moveto
     fn MoveTo(&self, x: f64, y: f64) {
-        self.context.MoveTo(x, y)
+        self.canvas_state.move_to(x, y)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-lineto
     fn LineTo(&self, x: f64, y: f64) {
-        self.context.LineTo(x, y)
+        self.canvas_state.line_to(x, y)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-rect
     fn Rect(&self, x: f64, y: f64, width: f64, height: f64) {
-        self.context.Rect(x, y, width, height)
+        self.canvas_state.rect(x, y, width, height)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-quadraticcurveto
     fn QuadraticCurveTo(&self, cpx: f64, cpy: f64, x: f64, y: f64) {
-        self.context.QuadraticCurveTo(cpx, cpy, x, y)
+        self.canvas_state.quadratic_curve_to(cpx, cpy, x, y)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-beziercurveto
     fn BezierCurveTo(&self, cp1x: f64, cp1y: f64, cp2x: f64, cp2y: f64, x: f64, y: f64) {
-        self.context.BezierCurveTo(cp1x, cp1y, cp2x, cp2y, x, y)
+        self.canvas_state
+            .bezier_curve_to(cp1x, cp1y, cp2x, cp2y, x, y)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-arc
     fn Arc(&self, x: f64, y: f64, r: f64, start: f64, end: f64, ccw: bool) -> ErrorResult {
-        self.context.Arc(x, y, r, start, end, ccw)
+        self.canvas_state.arc(x, y, r, start, end, ccw)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-arcto
     fn ArcTo(&self, cp1x: f64, cp1y: f64, cp2x: f64, cp2y: f64, r: f64) -> ErrorResult {
-        self.context.ArcTo(cp1x, cp1y, cp2x, cp2y, r)
+        self.canvas_state.arc_to(cp1x, cp1y, cp2x, cp2y, r)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-ellipse
@@ -285,38 +294,38 @@ impl PaintRenderingContext2DMethods<crate::DomTypeHolder> for PaintRenderingCont
         end: f64,
         ccw: bool,
     ) -> ErrorResult {
-        self.context
-            .Ellipse(x, y, rx, ry, rotation, start, end, ccw)
+        self.canvas_state
+            .ellipse(x, y, rx, ry, rotation, start, end, ccw)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-imagesmoothingenabled
     fn ImageSmoothingEnabled(&self) -> bool {
-        self.context.ImageSmoothingEnabled()
+        self.canvas_state.image_smoothing_enabled()
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-imagesmoothingenabled
     fn SetImageSmoothingEnabled(&self, value: bool) {
-        self.context.SetImageSmoothingEnabled(value)
+        self.canvas_state.set_image_smoothing_enabled(value)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-strokestyle
     fn StrokeStyle(&self) -> StringOrCanvasGradientOrCanvasPattern {
-        self.context.StrokeStyle()
+        self.canvas_state.stroke_style()
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-strokestyle
     fn SetStrokeStyle(&self, value: StringOrCanvasGradientOrCanvasPattern, can_gc: CanGc) {
-        self.context.SetStrokeStyle(value, can_gc)
+        self.canvas_state.set_stroke_style(None, value, can_gc)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-strokestyle
     fn FillStyle(&self) -> StringOrCanvasGradientOrCanvasPattern {
-        self.context.FillStyle()
+        self.canvas_state.fill_style()
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-strokestyle
     fn SetFillStyle(&self, value: StringOrCanvasGradientOrCanvasPattern, can_gc: CanGc) {
-        self.context.SetFillStyle(value, can_gc)
+        self.canvas_state.set_fill_style(None, value, can_gc)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-createlineargradient
@@ -327,7 +336,8 @@ impl PaintRenderingContext2DMethods<crate::DomTypeHolder> for PaintRenderingCont
         x1: Finite<f64>,
         y1: Finite<f64>,
     ) -> DomRoot<CanvasGradient> {
-        self.context.CreateLinearGradient(x0, y0, x1, y1)
+        self.canvas_state
+            .create_linear_gradient(&self.global(), x0, y0, x1, y1, CanGc::note())
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-createradialgradient
@@ -340,7 +350,16 @@ impl PaintRenderingContext2DMethods<crate::DomTypeHolder> for PaintRenderingCont
         y1: Finite<f64>,
         r1: Finite<f64>,
     ) -> Fallible<DomRoot<CanvasGradient>> {
-        self.context.CreateRadialGradient(x0, y0, r0, x1, y1, r1)
+        self.canvas_state.create_radial_gradient(
+            &self.global(),
+            x0,
+            y0,
+            r0,
+            x1,
+            y1,
+            r1,
+            CanGc::note(),
+        )
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-createpattern
@@ -349,86 +368,87 @@ impl PaintRenderingContext2DMethods<crate::DomTypeHolder> for PaintRenderingCont
         image: CanvasImageSource,
         repetition: DOMString,
     ) -> Fallible<Option<DomRoot<CanvasPattern>>> {
-        self.context.CreatePattern(image, repetition)
+        self.canvas_state
+            .create_pattern(&self.global(), image, repetition, CanGc::note())
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-linewidth
     fn LineWidth(&self) -> f64 {
-        self.context.LineWidth()
+        self.canvas_state.line_width()
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-linewidth
     fn SetLineWidth(&self, width: f64) {
-        self.context.SetLineWidth(width)
+        self.canvas_state.set_line_width(width)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-linecap
     fn LineCap(&self) -> CanvasLineCap {
-        self.context.LineCap()
+        self.canvas_state.line_cap()
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-linecap
     fn SetLineCap(&self, cap: CanvasLineCap) {
-        self.context.SetLineCap(cap)
+        self.canvas_state.set_line_cap(cap)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-linejoin
     fn LineJoin(&self) -> CanvasLineJoin {
-        self.context.LineJoin()
+        self.canvas_state.line_join()
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-linejoin
     fn SetLineJoin(&self, join: CanvasLineJoin) {
-        self.context.SetLineJoin(join)
+        self.canvas_state.set_line_join(join)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-miterlimit
     fn MiterLimit(&self) -> f64 {
-        self.context.MiterLimit()
+        self.canvas_state.miter_limit()
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-miterlimit
     fn SetMiterLimit(&self, limit: f64) {
-        self.context.SetMiterLimit(limit)
+        self.canvas_state.set_miter_limit(limit)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-shadowoffsetx
     fn ShadowOffsetX(&self) -> f64 {
-        self.context.ShadowOffsetX()
+        self.canvas_state.shadow_offset_x()
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-shadowoffsetx
     fn SetShadowOffsetX(&self, value: f64) {
-        self.context.SetShadowOffsetX(value)
+        self.canvas_state.set_shadow_offset_x(value)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-shadowoffsety
     fn ShadowOffsetY(&self) -> f64 {
-        self.context.ShadowOffsetY()
+        self.canvas_state.shadow_offset_y()
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-shadowoffsety
     fn SetShadowOffsetY(&self, value: f64) {
-        self.context.SetShadowOffsetY(value)
+        self.canvas_state.set_shadow_offset_y(value)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-shadowblur
     fn ShadowBlur(&self) -> f64 {
-        self.context.ShadowBlur()
+        self.canvas_state.shadow_blur()
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-shadowblur
     fn SetShadowBlur(&self, value: f64) {
-        self.context.SetShadowBlur(value)
+        self.canvas_state.set_shadow_blur(value)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-shadowcolor
     fn ShadowColor(&self) -> DOMString {
-        self.context.ShadowColor()
+        self.canvas_state.shadow_color()
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-shadowcolor
     fn SetShadowColor(&self, value: DOMString, can_gc: CanGc) {
-        self.context.SetShadowColor(value, can_gc)
+        self.canvas_state.set_shadow_color(None, value, can_gc)
     }
 }

--- a/components/script_bindings/codegen/CodegenRust.py
+++ b/components/script_bindings/codegen/CodegenRust.py
@@ -2462,8 +2462,8 @@ class CGAssertInheritance(CGThing):
 
         selfName = self.descriptor.interface.identifier.name
 
-        if selfName == "PaintRenderingContext2D":
-            # PaintRenderingContext2D embeds a CanvasRenderingContext2D
+        if selfName == "OffscreenCanvasRenderingContext2D":
+            # OffscreenCanvasRenderingContext2D embeds a CanvasRenderingContext2D
             # instead of a Reflector as an optimization,
             # but this is fine since CanvasRenderingContext2D
             # also has a reflector


### PR DESCRIPTION
Before `PaintRenderingContext2D` included `CanvasRenderingContext2d` and `OffscreenCanvasRenderingContext2D` was standalone, but `CanvasRenderingContext2d` and `OffscreenCanvasRenderingContext2D` share more logic than `PaintRenderingContext2D` and each CanvasContext needs handles both on/off screen so it makes more sense to have them unified in 2d too.

This PR basically just switches `OffscreenCanvasRenderingContext2D` to include `CanvasRenderingContext2d` instead of `CanvasState` and `PaintRenderingContext2D` to use `CanvasState` instead of `CanvasRenderingContext2d` (thus making it standalone). Add/remove ration is good, because we are able to simplify `CanvasRenderingContext2d` when it does not need to handle `PaintRenderingContext2D` cases.

try run: https://github.com/sagudev/servo/actions/runs/13481834718

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #35500
- [x] There are tests for these changes in WPT

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
