### PR TITLE
refactor: add CanGc as argument to Promise::reject

### DIFF
--- a/components/script/body.rs
+++ b/components/script/body.rs
@@ -600,8 +600,8 @@ impl Callback for ConsumeBodyPromiseRejectionHandler {
     /// Continuing Step 4 of <https://fetch.spec.whatwg.org/#concept-body-consume-body>
     /// Step 3 of <https://fetch.spec.whatwg.org/#concept-read-all-bytes-from-readablestream>,
     // the rejection steps.
-    fn callback(&self, cx: JSContext, v: HandleValue, _realm: InRealm, _can_gc: CanGc) {
-        self.result_promise.reject(cx, v);
+    fn callback(&self, cx: JSContext, v: HandleValue, _realm: InRealm, can_gc: CanGc) {
+        self.result_promise.reject(cx, v, can_gc);
     }
 }
 

--- a/components/script/dom/promise.rs
+++ b/components/script/dom/promise.rs
@@ -218,7 +218,7 @@ impl Promise {
         unsafe {
             val.to_jsval(*cx, v.handle_mut());
         }
-        self.reject(cx, v.handle());
+        self.reject(cx, v.handle(), CanGc::note());
     }
 
     pub(crate) fn reject_error(&self, error: Error) {
@@ -226,12 +226,12 @@ impl Promise {
         let _ac = enter_realm(self);
         rooted!(in(*cx) let mut v = UndefinedValue());
         error.to_jsval(cx, &self.global(), v.handle_mut());
-        self.reject(cx, v.handle());
+        self.reject(cx, v.handle(), CanGc::note());
     }
 
     #[allow(unsafe_code)]
     #[cfg_attr(crown, allow(crown::unrooted_must_root))]
-    pub(crate) fn reject(&self, cx: SafeJSContext, value: HandleValue) {
+    pub(crate) fn reject(&self, cx: SafeJSContext, value: HandleValue, _can_gc: CanGc) {
         unsafe {
             if !RejectPromise(*cx, self.promise_obj(), value) {
                 JS_ClearPendingException(*cx);

--- a/components/script/dom/testbinding.rs
+++ b/components/script/dom/testbinding.rs
@@ -984,8 +984,8 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
         p.resolve(cx, v, can_gc);
     }
 
-    fn PromiseRejectNative(&self, cx: SafeJSContext, p: &Promise, v: HandleValue) {
-        p.reject(cx, v);
+    fn PromiseRejectNative(&self, cx: SafeJSContext, p: &Promise, v: HandleValue, can_gc: CanGc) {
+        p.reject(cx, v, can_gc);
     }
 
     fn PromiseRejectWithTypeError(&self, p: &Promise, s: USVString) {

--- a/components/script/dom/writablestream.rs
+++ b/components/script/dom/writablestream.rs
@@ -263,7 +263,7 @@ impl WritableStream {
         let write_requests = mem::take(&mut *self.write_requests.borrow_mut());
         for request in write_requests {
             // Reject writeRequest with storedError.
-            request.reject(cx, stored_error.handle());
+            request.reject(cx, stored_error.handle(), can_gc);
         }
 
         // Set stream.[[writeRequests]] to an empty list.
@@ -287,7 +287,7 @@ impl WritableStream {
                 // Reject abortRequest’s promise with storedError.
                 pending_abort_request
                     .promise
-                    .reject(cx, stored_error.handle());
+                    .reject(cx, stored_error.handle(), can_gc);
 
                 // Perform ! WritableStreamRejectCloseAndClosedPromiseIfNeeded(stream).
                 self.reject_close_and_closed_promise_if_needed(cx);

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -485,7 +485,7 @@ DOMInterfaces = {
 #FIXME(jdm): This should be 'register': False, but then we don't generate enum types
 'TestBinding': {
     'inRealms': ['PromiseAttribute', 'PromiseNativeHandler'],
-    'canGc': ['InterfaceAttribute', 'GetInterfaceAttributeNullable', 'ReceiveInterface', 'ReceiveInterfaceSequence', 'ReceiveNullableInterface', 'PromiseAttribute', 'PromiseNativeHandler', 'PromiseResolveNative'],
+    'canGc': ['InterfaceAttribute', 'GetInterfaceAttributeNullable', 'ReceiveInterface', 'ReceiveInterfaceSequence', 'ReceiveNullableInterface', 'PromiseAttribute', 'PromiseNativeHandler', 'PromiseResolveNative', 'PromiseRejectNative'],
 },
 
 'TestWorklet': {


### PR DESCRIPTION
Add CanGc as argument to `Promise::reject`.

Addressed part of https://github.com/servo/servo/issues/34573.

Changes to `Promise::reject_native` and `Promise::reject_error` will be done in separate PRs in order to keep the PR size manageable.

---

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they are a refactor.
