### PR TITLE
feat: support IME cursor area

### DIFF
--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -10,6 +10,7 @@ use std::env;
 use std::rc::Rc;
 use std::time::Duration;
 
+use dpi::LogicalPosition;
 use euclid::{Angle, Length, Point2D, Rotation3D, Scale, Size2D, UnknownUnit, Vector2D, Vector3D};
 use keyboard_types::{Modifiers, ShortcutMatcher};
 use log::{debug, info};
@@ -707,9 +708,19 @@ impl WindowPortsMethods for Window {
         _input_type: servo::InputMethodType,
         _text: Option<(String, i32)>,
         _multiline: bool,
-        _position: servo::webrender_api::units::DeviceIntRect,
+        position: servo::webrender_api::units::DeviceIntRect,
     ) {
         self.winit_window.set_ime_allowed(true);
+        self.winit_window.set_ime_cursor_area(
+            LogicalPosition::new(
+                position.min.x,
+                position.min.y + (self.toolbar_height.get().0 as i32),
+            ),
+            LogicalSize::new(
+                position.max.x - position.min.x,
+                position.max.y - position.min.y,
+            ),
+        );
     }
 
     fn hide_ime(&self) {

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -30,7 +30,7 @@ use servo::{
 };
 use surfman::{Context, Device};
 use url::Url;
-use winit::dpi::{LogicalSize, LogicalPosition, PhysicalPosition, PhysicalSize};
+use winit::dpi::{LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize};
 use winit::event::{
     ElementState, KeyEvent, MouseButton, MouseScrollDelta, TouchPhase, WindowEvent,
 };

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -10,7 +10,6 @@ use std::env;
 use std::rc::Rc;
 use std::time::Duration;
 
-use dpi::LogicalPosition;
 use euclid::{Angle, Length, Point2D, Rotation3D, Scale, Size2D, UnknownUnit, Vector2D, Vector3D};
 use keyboard_types::{Modifiers, ShortcutMatcher};
 use log::{debug, info};
@@ -31,7 +30,7 @@ use servo::{
 };
 use surfman::{Context, Device};
 use url::Url;
-use winit::dpi::{LogicalSize, PhysicalPosition, PhysicalSize};
+use winit::dpi::{LogicalSize, LogicalPosition, PhysicalPosition, PhysicalSize};
 use winit::event::{
     ElementState, KeyEvent, MouseButton, MouseScrollDelta, TouchPhase, WindowEvent,
 };


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

A small Servoshell improvement followup to #35535 to perform `set_ime_cursor_area` when showing IME. This will allow the OS to prevent IME window to obscure the text area while showing the window at where text input happens.

This currently is ignored on X11 and will always be shown at the bottom left of the window:

- https://github.com/rust-windowing/winit/blob/master/src/platform_impl/linux/x11/ime/context.rs#L358-L360
- https://github.com/rust-windowing/winit/issues/3092

**Working Examples**

macOS:

![image](https://github.com/user-attachments/assets/42b520b9-0c23-4922-8534-68cac42572fa)

Windows:

![image](https://github.com/user-attachments/assets/21dde0fa-a1b4-4f0f-8488-aaa4e70a6b0a)

Wayland:

<img width="843" alt="截圖 2025-02-24 上午10 54 37" src="https://github.com/user-attachments/assets/f6a0b85f-ccc7-4a95-b574-039d2f080144" />


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [x] These changes do not require tests because this is an update to servoshell's ime setup

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
