### PR TITLE
Remove `get_ipc_sender` from `OffscreenCanvasRenderingContext2D`

### DIFF
--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -117,10 +117,6 @@ impl CanvasRenderingContext2D {
         let msg = CanvasMsg::FromLayout(FromLayoutMsg::SendData(sender), self.get_canvas_id());
         let _ = self.canvas_state.get_ipc_renderer().send(msg);
     }
-
-    pub(crate) fn get_ipc_renderer(&self) -> IpcSender<CanvasMsg> {
-        self.canvas_state.get_ipc_renderer().clone()
-    }
 }
 
 pub(crate) trait LayoutCanvasRenderingContext2DHelpers {

--- a/components/script/dom/htmlcanvaselement.rs
+++ b/components/script/dom/htmlcanvaselement.rs
@@ -6,7 +6,7 @@ use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::rc::Rc;
 
-use canvas_traits::canvas::{CanvasId, CanvasMsg, FromScriptMsg};
+use canvas_traits::canvas::CanvasId;
 use canvas_traits::webgl::{GLContextAttributes, WebGLVersion};
 use dom_struct::dom_struct;
 use euclid::default::Size2D;
@@ -20,7 +20,6 @@ use ipc_channel::ipc::IpcSharedMemory;
 use ipc_channel::ipc::{self as ipcchan};
 use js::error::throw_type_error;
 use js::rust::{HandleObject, HandleValue};
-use profile_traits::ipc;
 use script_layout_interface::{HTMLCanvasData, HTMLCanvasDataSource};
 use script_traits::serializable::BlobImpl;
 #[cfg(feature = "webgpu")]
@@ -401,17 +400,7 @@ impl HTMLCanvasElement {
             },
             #[cfg(feature = "webgpu")]
             Some(CanvasContext::WebGPU(context)) => context.get_image_data_as_shared_memory(),
-            Some(CanvasContext::Placeholder(context)) => {
-                let (sender, receiver) =
-                    ipc::channel(self.global().time_profiler_chan().clone()).unwrap();
-                let msg = CanvasMsg::FromScript(
-                    FromScriptMsg::SendPixels(sender),
-                    context.get_canvas_id(),
-                );
-                context.get_ipc_renderer().send(msg).unwrap();
-
-                Some(receiver.recv().unwrap())
-            },
+            Some(CanvasContext::Placeholder(context)) => context.get_image_data_as_shared_memory(),
             None => None,
         };
 

--- a/components/script/dom/offscreencanvas.rs
+++ b/components/script/dom/offscreencanvas.rs
@@ -4,12 +4,10 @@
 
 use std::cell::Cell;
 
-use canvas_traits::canvas::{CanvasMsg, FromScriptMsg};
 use dom_struct::dom_struct;
 use euclid::default::Size2D;
 use ipc_channel::ipc::IpcSharedMemory;
 use js::rust::{HandleObject, HandleValue};
-use profile_traits::ipc;
 
 use crate::dom::bindings::cell::{ref_filter_map, DomRefCell, Ref};
 use crate::dom::bindings::codegen::Bindings::OffscreenCanvasBinding::{
@@ -99,15 +97,7 @@ impl OffscreenCanvas {
 
         let data = match self.context.borrow().as_ref() {
             Some(OffscreenCanvasContext::OffscreenContext2d(context)) => {
-                let (sender, receiver) =
-                    ipc::channel(self.global().time_profiler_chan().clone()).unwrap();
-                let msg = CanvasMsg::FromScript(
-                    FromScriptMsg::SendPixels(sender),
-                    context.get_canvas_id(),
-                );
-                context.get_ipc_renderer().send(msg).unwrap();
-
-                Some(receiver.recv().unwrap())
+                context.get_image_data_as_shared_memory()
             },
             None => None,
         };

--- a/components/script/dom/offscreencanvasrenderingcontext2d.rs
+++ b/components/script/dom/offscreencanvasrenderingcontext2d.rs
@@ -5,10 +5,10 @@
 use crate::dom::bindings::codegen::GenericBindings::CanvasRenderingContext2DBinding::CanvasRenderingContext2D_Binding::CanvasRenderingContext2DMethods;
 use crate::canvas_context::CanvasContext as _;
 use crate::dom::bindings::codegen::UnionTypes::HTMLCanvasElementOrOffscreenCanvas;
-use canvas_traits::canvas::{Canvas2dMsg, CanvasId, CanvasMsg};
+use canvas_traits::canvas::Canvas2dMsg;
 use dom_struct::dom_struct;
 use euclid::default::Size2D;
-use ipc_channel::ipc::IpcSender;
+use ipc_channel::ipc::IpcSharedMemory;
 
 use crate::dom::bindings::codegen::Bindings::CanvasRenderingContext2DBinding::{
     CanvasDirection, CanvasFillRule, CanvasImageSource, CanvasLineCap, CanvasLineJoin,
@@ -75,12 +75,8 @@ impl OffscreenCanvasRenderingContext2D {
         self.context.origin_is_clean()
     }
 
-    pub(crate) fn get_canvas_id(&self) -> CanvasId {
-        self.context.get_canvas_id()
-    }
-
-    pub(crate) fn get_ipc_renderer(&self) -> IpcSender<CanvasMsg> {
-        self.context.get_ipc_renderer()
+    pub(crate) fn get_image_data_as_shared_memory(&self) -> Option<IpcSharedMemory> {
+        self.context.get_image_data_as_shared_memory()
     }
 }
 


### PR DESCRIPTION
Makes `(Offscreen)CanvasRenderingContext2D` less leaky of it's internals. Continuation of https://github.com/servo/servo/pull/35285


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes in WPT

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
