### PR TITLE
Fix typo in function name and remove unused import

### DIFF
--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1059,7 +1059,7 @@ impl ScriptThread {
     }
 
     /// Process compositor events as part of a "update the rendering task".
-    fn proces_pending_input_events(&self, pipeline_id: PipelineId, can_gc: CanGc) {
+    fn process_pending_input_events(&self, pipeline_id: PipelineId, can_gc: CanGc) {
         let Some(document) = self.documents.borrow().find_document(pipeline_id) else {
             warn!("Processing pending compositor events for closed pipeline {pipeline_id}.");
             return;
@@ -1198,13 +1198,13 @@ impl ScriptThread {
                 continue;
             }
 
-            // TODO(#31581): The steps in the "Revealing the document" section need to be implemente
-            // `proces_pending_input_events` handles the focusing steps as well as other events
+            // TODO(#31581): The steps in the "Revealing the document" section need to be implemented
+            // `process_pending_input_events` handles the focusing steps as well as other events
             // from the compositor.
 
             // TODO: Should this be broken and to match the specification more closely? For instance see
             // https://html.spec.whatwg.org/multipage/#flush-autofocus-candidates.
-            self.proces_pending_input_events(*pipeline_id, can_gc);
+            self.process_pending_input_events(*pipeline_id, can_gc);
 
             // TODO(#31665): Implement the "run the scroll steps" from
             // https://drafts.csswg.org/cssom-view/#document-run-the-scroll-steps.

--- a/components/webxr/openxr/mod.rs
+++ b/components/webxr/openxr/mod.rs
@@ -8,7 +8,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use std::{mem, thread};
 
-use euclid::{Box2D, Point2D, Rect, RigidTransform3D, Rotation3D, Size2D, Transform3D, Vector3D};
+use euclid::{Point2D, Rect, RigidTransform3D, Rotation3D, Size2D, Transform3D, Vector3D};
 use glow::{self as gl, HasContext, PixelUnpackData};
 use interaction_profiles::{get_profiles_from_path, get_supported_interaction_profiles};
 use log::{error, warn};


### PR DESCRIPTION
As titled.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
