### PR TITLE
Update to rust 1.85

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,8 +37,7 @@ jobs:
         uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-deny
-          # Version 0.18 requires rustc 1.85, but we are still using rustc 1.83.
-          version: 0.17
+          version: 0.18
           locked: true
       - name: Bootstrap dependencies
         run: |

--- a/components/canvas/canvas_data.rs
+++ b/components/canvas/canvas_data.rs
@@ -216,10 +216,7 @@ impl PathBuilderRef<'_> {
     }
 
     fn current_point(&mut self) -> Option<Point2D<f32>> {
-        let inverse = match self.transform.inverse() {
-            Some(i) => i,
-            None => return None,
-        };
+        let inverse = self.transform.inverse()?;
         self.builder
             .get_current_point()
             .map(|point| inverse.transform_point(Point2D::new(point.x, point.y)))
@@ -1404,7 +1401,7 @@ impl<'a> CanvasData<'a> {
         let canvas_rect = Rect::from_size(canvas_size);
         if canvas_rect
             .intersection(&read_rect)
-            .map_or(true, |rect| rect.is_empty())
+            .is_none_or(|rect| rect.is_empty())
         {
             return vec![];
         }

--- a/components/canvas/webgl_thread.rs
+++ b/components/canvas/webgl_thread.rs
@@ -2881,10 +2881,10 @@ fn image_to_tex_image_data(
             for i in 0..pixel_count {
                 let p = {
                     let rgba = &pixels[i * 4..i * 4 + 4];
-                    (rgba[0] as u16 & 0xf0) << 8 |
-                        (rgba[1] as u16 & 0xf0) << 4 |
+                    ((rgba[0] as u16 & 0xf0) << 8) |
+                        ((rgba[1] as u16 & 0xf0) << 4) |
                         (rgba[2] as u16 & 0xf0) |
-                        (rgba[3] as u16 & 0xf0) >> 4
+                        ((rgba[3] as u16 & 0xf0) >> 4)
                 };
                 NativeEndian::write_u16(&mut pixels[i * 2..i * 2 + 2], p);
             }
@@ -2895,10 +2895,10 @@ fn image_to_tex_image_data(
             for i in 0..pixel_count {
                 let p = {
                     let rgba = &pixels[i * 4..i * 4 + 4];
-                    (rgba[0] as u16 & 0xf8) << 8 |
-                        (rgba[1] as u16 & 0xf8) << 3 |
-                        (rgba[2] as u16 & 0xf8) >> 2 |
-                        (rgba[3] as u16) >> 7
+                    ((rgba[0] as u16 & 0xf8) << 8) |
+                        ((rgba[1] as u16 & 0xf8) << 3) |
+                        ((rgba[2] as u16 & 0xf8) >> 2) |
+                        ((rgba[3] as u16) >> 7)
                 };
                 NativeEndian::write_u16(&mut pixels[i * 2..i * 2 + 2], p);
             }
@@ -2909,9 +2909,9 @@ fn image_to_tex_image_data(
             for i in 0..pixel_count {
                 let p = {
                     let rgb = &pixels[i * 4..i * 4 + 3];
-                    (rgb[0] as u16 & 0xf8) << 8 |
-                        (rgb[1] as u16 & 0xfc) << 3 |
-                        (rgb[2] as u16 & 0xf8) >> 3
+                    ((rgb[0] as u16 & 0xf8) << 8) |
+                        ((rgb[1] as u16 & 0xfc) << 3) |
+                        ((rgb[2] as u16 & 0xf8) >> 3)
                 };
                 NativeEndian::write_u16(&mut pixels[i * 2..i * 2 + 2], p);
             }
@@ -3057,15 +3057,15 @@ fn premultiply_inplace(format: TexFormat, data_type: TexDataType, pixels: &mut [
         (TexFormat::RGBA, TexDataType::UnsignedShort4444) => {
             for rgba in pixels.chunks_mut(2) {
                 let pix = NativeEndian::read_u16(rgba);
-                let extend_to_8_bits = |val| (val | val << 4) as u8;
-                let r = extend_to_8_bits(pix >> 12 & 0x0f);
-                let g = extend_to_8_bits(pix >> 8 & 0x0f);
-                let b = extend_to_8_bits(pix >> 4 & 0x0f);
+                let extend_to_8_bits = |val| (val | (val << 4)) as u8;
+                let r = extend_to_8_bits((pix >> 12) & 0x0f);
+                let g = extend_to_8_bits((pix >> 8) & 0x0f);
+                let b = extend_to_8_bits((pix >> 4) & 0x0f);
                 let a = extend_to_8_bits(pix & 0x0f);
                 NativeEndian::write_u16(
                     rgba,
-                    ((pixels::multiply_u8_color(r, a) & 0xf0) as u16) << 8 |
-                        ((pixels::multiply_u8_color(g, a) & 0xf0) as u16) << 4 |
+                    (((pixels::multiply_u8_color(r, a) & 0xf0) as u16) << 8) |
+                        (((pixels::multiply_u8_color(g, a) & 0xf0) as u16) << 4) |
                         ((pixels::multiply_u8_color(b, a) & 0xf0) as u16) |
                         ((a & 0x0f) as u16),
                 );

--- a/components/fonts/font_template.rs
+++ b/components/fonts/font_template.rs
@@ -230,9 +230,7 @@ impl FontTemplateRefMethods for FontTemplateRef {
             .descriptor
             .unicode_range
             .as_ref()
-            .map_or(true, |ranges| {
-                ranges.iter().any(|range| range.contains(&character))
-            })
+            .is_none_or(|ranges| ranges.iter().any(|range| range.contains(&character)))
     }
 }
 

--- a/components/layout_2020/display_list/stacking_context.rs
+++ b/components/layout_2020/display_list/stacking_context.rs
@@ -98,7 +98,7 @@ impl DisplayList {
     /// but has to be unique to the entire scene.
     fn get_next_spatial_tree_item_key(&mut self) -> SpatialTreeItemKey {
         self.spatial_tree_count += 1;
-        let pipeline_tag = (self.wr.pipeline_id.0 as u64) << 32 | self.wr.pipeline_id.1 as u64;
+        let pipeline_tag = ((self.wr.pipeline_id.0 as u64) << 32) | self.wr.pipeline_id.1 as u64;
         SpatialTreeItemKey::new(pipeline_tag, self.spatial_tree_count)
     }
 

--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -2072,7 +2072,7 @@ impl FlexItem<'_> {
                     (flex_axis == FlexAxis::Row && self.stretches());
 
                 let has_child_which_depends_on_block_constraints = fragments.iter().any(|fragment| {
-                        fragment.base().map_or(false,|base|
+                        fragment.base().is_some_and(|base|
                                 base.flags.contains(
                                     FragmentFlags::SIZE_DEPENDS_ON_BLOCK_CONSTRAINTS_AND_CAN_BE_CHILD_OF_FLEX_ITEM))
                 });

--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -302,7 +302,7 @@ impl PositioningContext {
             .is_empty() &&
             self.for_nearest_positioned_ancestor
                 .as_ref()
-                .map_or(true, |vector| vector.is_empty())
+                .is_none_or(|vector| vector.is_empty())
     }
 
     pub(crate) fn append(&mut self, other: Self) {

--- a/components/layout_2020/table/mod.rs
+++ b/components/layout_2020/table/mod.rs
@@ -176,11 +176,7 @@ impl Table {
     }
 
     fn resolve_first_cell(&self, coords: TableSlotCoordinates) -> Option<&TableSlotCell> {
-        let resolved_coords = match self.resolve_first_cell_coords(coords) {
-            Some(coords) => coords,
-            None => return None,
-        };
-
+        let resolved_coords = self.resolve_first_cell_coords(coords)?;
         let slot = self.get_slot(resolved_coords);
         match slot {
             Some(TableSlot::Cell(cell)) => Some(cell),

--- a/components/net/cookie.rs
+++ b/components/net/cookie.rs
@@ -183,7 +183,7 @@ impl ServoCookie {
         let has_case_insensitive_prefix = |value: &str, prefix: &str| {
             value
                 .get(..prefix.len())
-                .map_or(false, |p| p.eq_ignore_ascii_case(prefix))
+                .is_some_and(|p| p.eq_ignore_ascii_case(prefix))
         };
         if has_case_insensitive_prefix(cookie.name(), "__Secure-") &&
             !cookie.secure().unwrap_or(false)

--- a/components/net/cookie_storage.rs
+++ b/components/net/cookie_storage.rs
@@ -261,9 +261,7 @@ fn get_oldest_accessed(
         if (c.cookie.secure().unwrap_or(false) == is_secure_cookie) &&
             oldest_accessed
                 .as_ref()
-                .map_or(true, |(_, current_oldest_time)| {
-                    c.last_access < *current_oldest_time
-                })
+                .is_none_or(|(_, current_oldest_time)| c.last_access < *current_oldest_time)
         {
             oldest_accessed = Some((i, c.last_access));
         }

--- a/components/net/decoder.rs
+++ b/components/net/decoder.rs
@@ -275,14 +275,12 @@ impl Stream for BodyStream {
                 //
                 // The error can be safely ignored if we known that all content was received or is explicitly
                 // set in preferences.
-                let all_content_read = self
-                    .content_length
-                    .map_or(false, |c| c.0 == self.total_read);
+                let all_content_read = self.content_length.is_some_and(|c| c.0 == self.total_read);
                 if self.is_secure_scheme && all_content_read {
                     let source = err.source();
                     let is_unexpected_eof = source
                         .and_then(|e| e.downcast_ref::<io::Error>())
-                        .map_or(false, |e| e.kind() == io::ErrorKind::UnexpectedEof);
+                        .is_some_and(|e| e.kind() == io::ErrorKind::UnexpectedEof);
                     if is_unexpected_eof {
                         return Poll::Ready(None);
                     }

--- a/components/net/mime_classifier.rs
+++ b/components/net/mime_classifier.rs
@@ -392,9 +392,9 @@ impl Mp4Matcher {
             return false;
         }
 
-        let box_size = ((data[0] as u32) << 24 |
-            (data[1] as u32) << 16 |
-            (data[2] as u32) << 8 |
+        let box_size = (((data[0] as u32) << 24) |
+            ((data[1] as u32) << 16) |
+            ((data[2] as u32) << 8) |
             (data[3] as u32)) as usize;
         if (data.len() < box_size) || (box_size % 4 != 0) {
             return false;

--- a/components/net/storage_thread.rs
+++ b/components/net/storage_thread.rs
@@ -185,11 +185,11 @@ impl StorageManager {
         let message = data
             .get_mut(&origin)
             .map(|&mut (ref mut total, ref mut entry)| {
-                let mut new_total_size = this_storage_size + value.as_bytes().len();
+                let mut new_total_size = this_storage_size + value.len();
                 if let Some(old_value) = entry.get(&name) {
-                    new_total_size -= old_value.as_bytes().len();
+                    new_total_size -= old_value.len();
                 } else {
-                    new_total_size += name.as_bytes().len();
+                    new_total_size += name.len();
                 }
 
                 if (new_total_size + other_storage_size) > QUOTA_SIZE_LIMIT {
@@ -245,7 +245,7 @@ impl StorageManager {
             .get_mut(&origin)
             .and_then(|&mut (ref mut total, ref mut entry)| {
                 entry.remove(&name).inspect(|old| {
-                    *total -= name.as_bytes().len() + old.as_bytes().len();
+                    *total -= name.len() + old.len();
                 })
             });
         sender.send(old_value).unwrap();

--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -144,9 +144,7 @@ pub(crate) fn handle_get_children(
         Some(parent) => {
             let is_whitespace = |node: &NodeInfo| {
                 node.node_type == NodeConstants::TEXT_NODE &&
-                    node.node_value
-                        .as_ref()
-                        .map_or(true, |v| v.trim().is_empty())
+                    node.node_value.as_ref().is_none_or(|v| v.trim().is_empty())
             };
 
             let inline: Vec<_> = parent

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -1114,7 +1114,7 @@ impl Document {
         if implicit_transaction {
             self.begin_focus_transaction();
         }
-        if elem.map_or(true, |e| e.is_focusable_area()) {
+        if elem.is_none_or(|e| e.is_focusable_area()) {
             *self.focus_transaction.borrow_mut() =
                 FocusTransaction::InTransaction(elem.map(Dom::from_ref));
         }
@@ -1795,7 +1795,7 @@ impl Document {
         let target_has_changed = prev_mouse_over_target
             .get()
             .as_ref()
-            .map_or(true, |old_target| old_target != &new_target);
+            .is_none_or(|old_target| old_target != &new_target);
 
         // Here we know the target has changed, so we must update the state,
         // dispatch mouseout to the previous one, mouseover to the new one.

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -1639,7 +1639,7 @@ pub(crate) trait FormControl: DomObject {
         let has_form_attr = elem.has_attribute(&local_name!("form"));
         let same_subtree = self
             .form_owner()
-            .map_or(true, |form| elem.is_in_same_home_subtree(&*form));
+            .is_none_or(|form| elem.is_in_same_home_subtree(&*form));
 
         self.unregister_if_necessary();
 

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -837,10 +837,7 @@ impl HTMLInputElement {
             },
             // https://html.spec.whatwg.org/multipage/#file-upload-state-(type%3Dfile)%3Asuffering-from-being-missing
             InputType::File => {
-                self.Required() &&
-                    self.filelist
-                        .get()
-                        .map_or(true, |files| files.Length() == 0)
+                self.Required() && self.filelist.get().is_none_or(|files| files.Length() == 0)
             },
             // https://html.spec.whatwg.org/multipage/#the-required-attribute%3Asuffering-from-being-missing
             _ => {

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -1317,7 +1317,7 @@ impl Node {
     }
 
     pub(crate) fn is_display_none(&self) -> bool {
-        self.style_data.borrow().as_ref().map_or(true, |data| {
+        self.style_data.borrow().as_ref().is_none_or(|data| {
             data.element_data
                 .borrow()
                 .styles
@@ -2184,8 +2184,7 @@ impl Node {
     ) {
         node.owner_doc().add_script_and_layout_blocker();
         debug_assert!(*node.owner_doc() == *parent.owner_doc());
-        debug_assert!(child.map_or(true, |child| Some(parent) ==
-            child.GetParentNode().as_deref()));
+        debug_assert!(child.is_none_or(|child| Some(parent) == child.GetParentNode().as_deref()));
 
         // Step 1.
         let count = if node.is::<DocumentFragment>() {

--- a/components/script/dom/performance.rs
+++ b/components/script/dom/performance.rs
@@ -78,10 +78,10 @@ impl PerformanceEntryList {
             .entries
             .iter()
             .filter(|e| {
-                name.as_ref().map_or(true, |name_| *e.name() == *name_) &&
+                name.as_ref().is_none_or(|name_| *e.name() == *name_) &&
                     entry_type
                         .as_ref()
-                        .map_or(true, |type_| *e.entry_type() == *type_)
+                        .is_none_or(|type_| *e.entry_type() == *type_)
             })
             .cloned()
             .collect::<Vec<DomRoot<PerformanceEntry>>>();

--- a/components/script/dom/webglprogram.rs
+++ b/components/script/dom/webglprogram.rs
@@ -432,7 +432,7 @@ impl WebGLProgram {
 
         let (size, type_) = {
             let (base_name, array_index) = match parse_uniform_name(&name) {
-                Some((name, index)) if index.map_or(true, |i| i >= 0) => (name, index),
+                Some((name, index)) if index.is_none_or(|i| i >= 0) => (name, index),
                 _ => return Ok(None),
             };
 

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -670,7 +670,7 @@ impl WebGLRenderingContext {
         // or UNSIGNED_SHORT_5_5_5_1, a Uint16Array must be supplied.
         // or FLOAT, a Float32Array must be supplied.
         // If the types do not match, an INVALID_OPERATION error is generated.
-        let data_type_matches = data.as_ref().map_or(true, |buffer| {
+        let data_type_matches = data.as_ref().is_none_or(|buffer| {
             Some(data_type.sized_data_type()) ==
                 array_buffer_type_to_sized_type(buffer.get_array_type()) &&
                 data_type.required_webgl_version() <= self.webgl_version()

--- a/components/script/dom/websocket.rs
+++ b/components/script/dom/websocket.rs
@@ -349,7 +349,7 @@ impl WebSocketMethods<crate::DomTypeHolder> for WebSocket {
 
     // https://html.spec.whatwg.org/multipage/#dom-websocket-send
     fn Send(&self, data: USVString) -> ErrorResult {
-        let data_byte_len = data.0.as_bytes().len() as u64;
+        let data_byte_len = data.0.len() as u64;
         let send_data = self.send_impl(data_byte_len)?;
 
         if send_data {
@@ -417,7 +417,7 @@ impl WebSocketMethods<crate::DomTypeHolder> for WebSocket {
             }
         }
         if let Some(ref reason) = reason {
-            if reason.0.as_bytes().len() > 123 {
+            if reason.0.len() > 123 {
                 //reason cannot be larger than 123 bytes
                 return Err(Error::Syntax);
             }

--- a/components/script/dom/writablestreamdefaultwriter.rs
+++ b/components/script/dom/writablestreamdefaultwriter.rs
@@ -286,7 +286,7 @@ impl WritableStreamDefaultWriter {
         if !self
             .stream
             .get()
-            .map_or(false, |current_stream| current_stream == stream)
+            .is_some_and(|current_stream| current_stream == stream)
         {
             let promise = Promise::new(global, can_gc);
             promise.reject_error(Error::Type(

--- a/components/script/stylesheet_loader.rs
+++ b/components/script/stylesheet_loader.rs
@@ -188,7 +188,7 @@ impl FetchResponseListener for StylesheetContext {
                     // else we risk applying the wrong stylesheet when responses come out-of-order.
                     let is_stylesheet_load_applicable = self
                         .request_generation_id
-                        .map_or(true, |gen| gen == link.get_request_generation_id());
+                        .is_none_or(|gen| gen == link.get_request_generation_id());
                     if is_stylesheet_load_applicable {
                         let shared_lock = document.style_shared_lock().clone();
                         let sheet = Arc::new(Stylesheet::from_bytes(
@@ -375,7 +375,7 @@ impl StyleStylesheetLoader for StylesheetLoader<'_> {
         layer: ImportLayer,
     ) -> Arc<Locked<ImportRule>> {
         // Ensure the supports conditions for this @import are true, if not, refuse to load
-        if !supports.as_ref().map_or(true, |s| s.enabled) {
+        if !supports.as_ref().is_none_or(|s| s.enabled) {
             return Arc::new(lock.wrap(ImportRule {
                 url,
                 stylesheet: ImportSheet::new_refused(),

--- a/components/script/textinput.rs
+++ b/components/script/textinput.rs
@@ -1001,7 +1001,7 @@ impl<T: ClipboardProvider> TextInput<T> {
 
     /// Whether the content is empty.
     pub(crate) fn is_empty(&self) -> bool {
-        self.lines.len() <= 1 && self.lines.first().map_or(true, |line| line.is_empty())
+        self.lines.len() <= 1 && self.lines.first().is_none_or(|line| line.is_empty())
     }
 
     /// The length of the content in bytes.

--- a/components/script/xpath/parser.rs
+++ b/components/script/xpath/parser.rs
@@ -352,7 +352,7 @@ impl CoreFunction {
         let min = self.min_args();
         let max = self.max_args();
 
-        num_args >= min && max.map_or(true, |max| num_args <= max)
+        num_args >= min && max.is_none_or(|max| num_args <= max)
     }
 }
 

--- a/components/shared/net/http_status.rs
+++ b/components/shared/net/http_status.rs
@@ -72,7 +72,7 @@ impl HttpStatus {
 
     /// Helper that relays is_success() from the underlying code.
     pub fn is_success(&self) -> bool {
-        StatusCode::from_u16(self.code).map_or(false, |s| s.is_success())
+        StatusCode::from_u16(self.code).is_ok_and(|s| s.is_success())
     }
 
     /// True when the object was created with `new_error`.

--- a/components/shared/net/request.rs
+++ b/components/shared/net/request.rs
@@ -787,9 +787,9 @@ fn validate_range_header(value: &str) -> bool {
         if let Some(start) = start {
             if let Ok(start_num) = start.parse::<u64>() {
                 return match end {
-                    Some(e) if !e.is_empty() => e
-                        .parse::<u64>()
-                        .map_or(false, |end_num| start_num <= end_num),
+                    Some(e) if !e.is_empty() => {
+                        e.parse::<u64>().is_ok_and(|end_num| start_num <= end_num)
+                    },
                     _ => true,
                 };
             }

--- a/ports/servoshell/desktop/dialog.rs
+++ b/ports/servoshell/desktop/dialog.rs
@@ -55,7 +55,7 @@ impl Dialog {
                     Arc::new(move |path: &Path| {
                         path.extension()
                             .and_then(|e| e.to_str())
-                            .map_or(false, |ext| {
+                            .is_some_and(|ext| {
                                 let ext = ext.to_lowercase();
                                 patterns.iter().any(|pattern| ext == pattern.0)
                             })

--- a/ports/servoshell/desktop/minibrowser.rs
+++ b/ports/servoshell/desktop/minibrowser.rs
@@ -126,7 +126,7 @@ impl Minibrowser {
                 self.last_mouse_position =
                     Some(winit_position_to_euclid_point(*position).to_f32() / scale);
                 self.last_mouse_position
-                    .map_or(false, |p| self.is_in_browser_rect(p))
+                    .is_some_and(|p| self.is_in_browser_rect(p))
             },
             WindowEvent::MouseInput {
                 state: ElementState::Pressed,
@@ -148,7 +148,7 @@ impl Minibrowser {
             },
             WindowEvent::MouseWheel { .. } | WindowEvent::MouseInput { .. } => self
                 .last_mouse_position
-                .map_or(false, |p| self.is_in_browser_rect(p)),
+                .is_some_and(|p| self.is_in_browser_rect(p)),
             _ => true,
         };
         result

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 # Be sure to update shell.nix and support/crown/rust-toolchain.toml when bumping this!
-channel = "1.83.0"
+channel = "1.85.0"
 
 components = [
     # For support/crown

--- a/support/crown/rust-toolchain.toml
+++ b/support/crown/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.83.0"
+channel = "1.85.0"
 
 components = [
     "clippy",

--- a/support/crown/src/main.rs
+++ b/support/crown/src/main.rs
@@ -23,7 +23,6 @@ extern crate rustc_trait_selection;
 extern crate rustc_type_ir;
 
 use std::path::Path;
-use std::process::ExitCode;
 
 use rustc_driver::Callbacks;
 use rustc_interface::interface::Config;
@@ -61,7 +60,7 @@ impl Callbacks for MyCallbacks {
     }
 }
 
-fn main() -> ExitCode {
+fn main() {
     let handler =
         rustc_session::EarlyDiagCtxt::new(rustc_session::config::ErrorOutputType::default());
     rustc_driver::init_logger(&handler, rustc_log::LoggerConfig::from_env("CROWN_LOG"));
@@ -76,8 +75,5 @@ fn main() -> ExitCode {
     // Pass cfg(crown) to rustc
     args.extend(["--cfg".to_owned(), "crown".to_owned()]);
 
-    match rustc_driver::RunCompiler::new(&args, &mut MyCallbacks).run() {
-        Ok(_) => ExitCode::SUCCESS,
-        Err(_) => ExitCode::FAILURE,
-    }
+    rustc_driver::RunCompiler::new(&args, &mut MyCallbacks).run()
 }

--- a/support/crown/src/unrooted_must_root.rs
+++ b/support/crown/src/unrooted_must_root.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use rustc_hir::{self as hir, intravisit as visit, ExprKind};
-use rustc_lint::{LateContext, LateLintPass, LintContext, LintPass, LintStore};
+use rustc_lint::{LateContext, LateLintPass, Lint, LintContext, LintPass, LintStore};
 use rustc_middle::ty;
 use rustc_session::declare_tool_lint;
 use rustc_span::def_id::{DefId, LocalDefId};
@@ -216,6 +216,10 @@ fn is_unrooted_ty<'tcx>(
 impl LintPass for UnrootedPass {
     fn name(&self) -> &'static str {
         "ServoUnrootedPass"
+    }
+
+    fn get_lints(&self) -> Vec<&'static Lint> {
+        vec![UNROOTED_MUST_ROOT]
     }
 }
 


### PR DESCRIPTION
This is needed for cargo-deny (https://github.com/servo/servo/actions/runs/13494896983/job/37699886214?pr=35627)

The main relevant change to  `rustc_driver` is in https://github.com/rust-lang/rust/commit/f51ec110a714fea09105586b26c7f8e6a2a57018#diff-e87ad0ff8989aa16265a0075eaf27a5ec821aeb929c73b28774d609c890715f2, which is part of a transition from `ParamEnv` to `TypingEnv` within rustc.




---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
