### PR TITLE
Do not assume `OffscreenCanvasContext` to be 2d

### DIFF
--- a/components/script/canvas_state.rs
+++ b/components/script/canvas_state.rs
@@ -524,13 +524,19 @@ impl CanvasState {
                     ));
                 },
                 CanvasContext::Placeholder(ref context) => {
-                    context.send_canvas_2d_msg(Canvas2dMsg::DrawImageInOther(
-                        self.get_canvas_id(),
-                        image_size,
-                        dest_rect,
-                        source_rect,
-                        smoothing_enabled,
-                    ));
+                    let Some(context) = context.context() else {
+                        return Err(Error::InvalidState);
+                    };
+                    match *context {
+                        OffscreenCanvasContext::OffscreenContext2d(ref context) => context
+                            .send_canvas_2d_msg(Canvas2dMsg::DrawImageInOther(
+                                self.get_canvas_id(),
+                                image_size,
+                                dest_rect,
+                                source_rect,
+                                smoothing_enabled,
+                            )),
+                    }
                 },
                 _ => return Err(Error::InvalidState),
             }

--- a/components/script/dom/offscreencanvas.rs
+++ b/components/script/dom/offscreencanvas.rs
@@ -127,6 +127,19 @@ impl OffscreenCanvas {
     pub(crate) fn placeholder(&self) -> Option<&HTMLCanvasElement> {
         self.placeholder.as_deref()
     }
+
+    pub(crate) fn resize(&self, size: Size2D<u64>) {
+        self.width.set(size.width);
+        self.height.set(size.height);
+
+        if let Some(canvas_context) = self.context() {
+            match &*canvas_context {
+                OffscreenCanvasContext::OffscreenContext2d(rendering_context) => {
+                    rendering_context.set_canvas_bitmap_dimensions(self.get_size());
+                },
+            }
+        }
+    }
 }
 
 impl OffscreenCanvasMethods<crate::DomTypeHolder> for OffscreenCanvas {


### PR DESCRIPTION
`HTMLCanvasElement` assumed `OffscreenCanvasContext` to be 2d, but in the future this might not be the case.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes in WPT

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
