### PR TITLE
Prevent lint job from trying to use incompatible cargo-deny version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,6 +37,8 @@ jobs:
         uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-deny
+          # Version 0.18 requires rustc 1.85, but we are still using rustc 1.83.
+          version: 0.17
           locked: true
       - name: Bootstrap dependencies
         run: |


### PR DESCRIPTION
Lint jobs were failing because they would try to install the latest version of cargo-deny (0.18.0), which requries rustc 1.85.0 or newer, while the currently active rustc version is 1.83.0.

Therefore this makes it install version 0.17 instead.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #35631
- [X] These changes do not require tests because it's a fix for a CI bustage

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
