### PR TITLE
libservo: Stop double-buffering `OffscreenRenderingContext`

### DIFF
--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -304,7 +304,7 @@ impl Servo {
         };
 
         // Get GL bindings
-        let webrender_gl = rendering_context.gl_api();
+        let webrender_gl = rendering_context.gleam_gl_api();
 
         // Make sure the gl context is made current.
         if let Err(err) = rendering_context.make_current() {

--- a/ports/servoshell/desktop/minibrowser.rs
+++ b/ports/servoshell/desktop/minibrowser.rs
@@ -80,15 +80,9 @@ impl Minibrowser {
         event_loop: &ActiveEventLoop,
         initial_url: ServoUrl,
     ) -> Self {
-        let gl = unsafe {
-            glow::Context::from_loader_function(|s| {
-                rendering_context.parent_context().get_proc_address(s)
-            })
-        };
-
         // Adapted from https://github.com/emilk/egui/blob/9478e50d012c5138551c38cbee16b07bc1fcf283/crates/egui_glow/examples/pure_glow.rs
         #[allow(clippy::arc_with_non_send_sync)]
-        let context = EguiGlow::new(event_loop, Arc::new(gl), None);
+        let context = EguiGlow::new(event_loop, rendering_context.glow_gl_api(), None);
 
         // Disable the builtin egui handlers for the Ctrl+Plus, Ctrl+Minus and Ctrl+0
         // shortcuts as they don't work well with servoshell's `device-pixel-ratio` CLI argument.


### PR DESCRIPTION
The `OffscreenRenderingContext` does not need to be double-buffered.
Instead, when resizing the framebuffer, create a new one and blit the
old contents onto the new surface. This allows immediately displaying
the contents without having to render paint the WebRender scene one more
time. In addition to speeding up the rendering pipeline, the goal here
is to reduce flickering during resizes (though there is more work to
do).

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they just modify some internal details of the offscreen rendering context.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
