### PR TITLE
chore: Update wgpu

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4743,7 +4743,7 @@ checksum = "956787520e75e9bd233246045d19f42fb73242759cc57fba9611d940ae96d4b0"
 [[package]]
 name = "naga"
 version = "24.0.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=d8833d079833c62b4fd00325d0ba08ec0c8bc309#d8833d079833c62b4fd00325d0ba08ec0c8bc309"
+source = "git+https://github.com/gfx-rs/wgpu?rev=2f255edc60e9669c8c737464c59af10d59a31126#2f255edc60e9669c8c737464c59af10d59a31126"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -8654,7 +8654,7 @@ checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
 [[package]]
 name = "wgpu-core"
 version = "24.0.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=d8833d079833c62b4fd00325d0ba08ec0c8bc309#d8833d079833c62b4fd00325d0ba08ec0c8bc309"
+source = "git+https://github.com/gfx-rs/wgpu?rev=2f255edc60e9669c8c737464c59af10d59a31126#2f255edc60e9669c8c737464c59af10d59a31126"
 dependencies = [
  "arrayvec",
  "bit-vec",
@@ -8672,14 +8672,41 @@ dependencies = [
  "serde",
  "smallvec",
  "thiserror 2.0.9",
+ "wgpu-core-deps-apple",
+ "wgpu-core-deps-emscripten",
+ "wgpu-core-deps-windows-linux-android",
  "wgpu-hal",
  "wgpu-types",
 ]
 
 [[package]]
+name = "wgpu-core-deps-apple"
+version = "24.0.0"
+source = "git+https://github.com/gfx-rs/wgpu?rev=2f255edc60e9669c8c737464c59af10d59a31126#2f255edc60e9669c8c737464c59af10d59a31126"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-emscripten"
+version = "24.0.0"
+source = "git+https://github.com/gfx-rs/wgpu?rev=2f255edc60e9669c8c737464c59af10d59a31126#2f255edc60e9669c8c737464c59af10d59a31126"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-windows-linux-android"
+version = "24.0.0"
+source = "git+https://github.com/gfx-rs/wgpu?rev=2f255edc60e9669c8c737464c59af10d59a31126#2f255edc60e9669c8c737464c59af10d59a31126"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
 name = "wgpu-hal"
 version = "24.0.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=d8833d079833c62b4fd00325d0ba08ec0c8bc309#d8833d079833c62b4fd00325d0ba08ec0c8bc309"
+source = "git+https://github.com/gfx-rs/wgpu?rev=2f255edc60e9669c8c737464c59af10d59a31126#2f255edc60e9669c8c737464c59af10d59a31126"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -8711,7 +8738,6 @@ dependencies = [
  "profiling",
  "range-alloc",
  "raw-window-handle",
- "rustc-hash 1.1.0",
  "smallvec",
  "thiserror 2.0.9",
  "wasm-bindgen",
@@ -8724,7 +8750,7 @@ dependencies = [
 [[package]]
 name = "wgpu-types"
 version = "24.0.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=d8833d079833c62b4fd00325d0ba08ec0c8bc309#d8833d079833c62b4fd00325d0ba08ec0c8bc309"
+source = "git+https://github.com/gfx-rs/wgpu?rev=2f255edc60e9669c8c737464c59af10d59a31126#2f255edc60e9669c8c737464c59af10d59a31126"
 dependencies = [
  "bitflags 2.8.0",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,8 +164,8 @@ webrender = { git = "https://github.com/servo/webrender", branch = "0.66", featu
 webrender_api = { git = "https://github.com/servo/webrender", branch = "0.66" }
 webrender_traits = { path = "components/shared/webrender" }
 webxr-api = { path = "components/shared/webxr" }
-wgpu-core = { git = "https://github.com/gfx-rs/wgpu", rev = "d8833d079833c62b4fd00325d0ba08ec0c8bc309" }
-wgpu-types = { git = "https://github.com/gfx-rs/wgpu", rev = "d8833d079833c62b4fd00325d0ba08ec0c8bc309" }
+wgpu-core = { git = "https://github.com/gfx-rs/wgpu", rev = "2f255edc60e9669c8c737464c59af10d59a31126" }
+wgpu-types = { git = "https://github.com/gfx-rs/wgpu", rev = "2f255edc60e9669c8c737464c59af10d59a31126" }
 winapi = "0.3"
 windows-sys = "0.59"
 wio = "0.2"

--- a/components/webgpu/wgpu_thread.rs
+++ b/components/webgpu/wgpu_thread.rs
@@ -754,7 +754,7 @@ impl WGPU {
                         device_id: _device_id,
                     } => {
                         let global = &self.global;
-                        let (pass, error) = global.command_encoder_create_compute_pass(
+                        let (pass, error) = global.command_encoder_begin_compute_pass(
                             command_encoder_id,
                             &ComputePassDescriptor {
                                 label,
@@ -908,7 +908,7 @@ impl WGPU {
                             occlusion_query_set: None,
                         };
                         let (pass, error) =
-                            global.command_encoder_create_render_pass(command_encoder_id, desc);
+                            global.command_encoder_begin_render_pass(command_encoder_id, desc);
                         assert!(
                             self.render_passes
                                 .insert(render_pass_id, Pass::new(pass, error.is_none()))


### PR DESCRIPTION
Notable changes in wgpu:
- `command_encoder_create_*_pass` renamed to `command_encoder_begin_*_pass`
- more validation
- more stuff supported in naga

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes in WebGPU CTS

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
