### PR TITLE
refactor: add CanGc as argument to Promise::reject_native

### DIFF
--- a/components/script/body.rs
+++ b/components/script/body.rs
@@ -281,14 +281,14 @@ struct TransmitBodyPromiseHandler {
 
 impl Callback for TransmitBodyPromiseHandler {
     /// Step 5 of <https://fetch.spec.whatwg.org/#concept-request-transmit-body>
-    fn callback(&self, cx: JSContext, v: HandleValue, _realm: InRealm, _can_gc: CanGc) {
+    fn callback(&self, cx: JSContext, v: HandleValue, _realm: InRealm, can_gc: CanGc) {
         let is_done = match get_read_promise_done(cx, &v) {
             Ok(is_done) => is_done,
             Err(_) => {
                 // Step 5.5, the "otherwise" steps.
                 // TODO: terminate fetch.
                 let _ = self.control_sender.send(BodyChunkRequest::Done);
-                return self.stream.stop_reading();
+                return self.stream.stop_reading(can_gc);
             },
         };
 
@@ -296,7 +296,7 @@ impl Callback for TransmitBodyPromiseHandler {
             // Step 5.3, the "done" steps.
             // TODO: queue a fetch task on request to process request end-of-body.
             let _ = self.control_sender.send(BodyChunkRequest::Done);
-            return self.stream.stop_reading();
+            return self.stream.stop_reading(can_gc);
         }
 
         let chunk = match get_read_promise_bytes(cx, &v) {
@@ -304,7 +304,7 @@ impl Callback for TransmitBodyPromiseHandler {
             Err(_) => {
                 // Step 5.5, the "otherwise" steps.
                 let _ = self.control_sender.send(BodyChunkRequest::Error);
-                return self.stream.stop_reading();
+                return self.stream.stop_reading(can_gc);
             },
         };
 
@@ -330,10 +330,10 @@ struct TransmitBodyPromiseRejectionHandler {
 
 impl Callback for TransmitBodyPromiseRejectionHandler {
     /// <https://fetch.spec.whatwg.org/#concept-request-transmit-body>
-    fn callback(&self, _cx: JSContext, _v: HandleValue, _realm: InRealm, _can_gc: CanGc) {
+    fn callback(&self, _cx: JSContext, _v: HandleValue, _realm: InRealm, can_gc: CanGc) {
         // Step 5.4, the "rejection" steps.
         let _ = self.control_sender.send(BodyChunkRequest::Error);
-        self.stream.stop_reading();
+        self.stream.stop_reading(can_gc);
     }
 }
 
@@ -640,7 +640,9 @@ impl ConsumeBodyPromiseHandler {
                     FetchedData::FormData(f) => self.result_promise.resolve_native(&f, can_gc),
                     FetchedData::Bytes(b) => self.result_promise.resolve_native(&b, can_gc),
                     FetchedData::ArrayBuffer(a) => self.result_promise.resolve_native(&a, can_gc),
-                    FetchedData::JSException(e) => self.result_promise.reject_native(&e.handle()),
+                    FetchedData::JSException(e) => {
+                        self.result_promise.reject_native(&e.handle(), can_gc)
+                    },
                 };
             },
             Err(err) => self.result_promise.reject_error(err),
@@ -661,7 +663,7 @@ impl Callback for ConsumeBodyPromiseHandler {
         let is_done = match get_read_promise_done(cx, &v) {
             Ok(is_done) => is_done,
             Err(err) => {
-                stream.stop_reading();
+                stream.stop_reading(can_gc);
                 // When read is fulfilled with a value that doesn't matches with neither of the above patterns.
                 return self.result_promise.reject_error(err);
             },
@@ -674,7 +676,7 @@ impl Callback for ConsumeBodyPromiseHandler {
             let chunk = match get_read_promise_bytes(cx, &v) {
                 Ok(chunk) => chunk,
                 Err(err) => {
-                    stream.stop_reading();
+                    stream.stop_reading(can_gc);
                     // When read is fulfilled with a value that matches with neither of the above patterns
                     return self.result_promise.reject_error(err);
                 },

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -579,11 +579,14 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
         // Step 1
         if !is_valid_custom_element_name(&name) {
             let promise = Promise::new_in_current_realm(comp, can_gc);
-            promise.reject_native(&DOMException::new(
-                self.window.as_global_scope(),
-                DOMErrorName::SyntaxError,
+            promise.reject_native(
+                &DOMException::new(
+                    self.window.as_global_scope(),
+                    DOMErrorName::SyntaxError,
+                    can_gc,
+                ),
                 can_gc,
-            ));
+            );
             return promise;
         }
 

--- a/components/script/dom/defaultteereadrequest.rs
+++ b/components/script/dom/defaultteereadrequest.rs
@@ -138,12 +138,14 @@ impl DefaultTeeReadRequest {
                 self.readable_stream_default_controller_error(
                     &self.branch_1,
                     clone_result.handle(),
+                    can_gc,
                 );
 
                 // Perform ! ReadableStreamDefaultControllerError(branch_2.[[controller]], cloneResult.[[Value]]).
                 self.readable_stream_default_controller_error(
                     &self.branch_2,
                     clone_result.handle(),
+                    can_gc,
                 );
                 // Resolve cancelPromise with ! ReadableStreamCancel(stream, cloneResult.[[Value]]).
                 self.stream_cancel(clone_result.handle(), can_gc);
@@ -225,8 +227,9 @@ impl DefaultTeeReadRequest {
         &self,
         stream: &ReadableStream,
         error: SafeHandleValue,
+        can_gc: CanGc,
     ) {
-        stream.get_default_controller().error(error);
+        stream.get_default_controller().error(error, can_gc);
     }
 
     pub(crate) fn pull_algorithm(&self, can_gc: CanGc) {

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -585,7 +585,7 @@ fn stream_handle_incoming(stream: &ReadableStream, bytes: Fallible<Vec<u8>>, can
             stream.enqueue_native(b, can_gc);
         },
         Err(e) => {
-            stream.error_native(e);
+            stream.error_native(e, can_gc);
         },
     }
 }

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -1176,11 +1176,10 @@ impl HTMLImageElement {
         if !document.is_fully_active() ||
             matches!(self.current_request.borrow().state, State::Broken)
         {
-            promise.reject_native(&DOMException::new(
-                &document.global(),
-                DOMErrorName::EncodingError,
+            promise.reject_native(
+                &DOMException::new(&document.global(), DOMErrorName::EncodingError, can_gc),
                 can_gc,
-            ));
+            );
         } else if matches!(
             self.current_request.borrow().state,
             State::CompletelyAvailable
@@ -1204,11 +1203,10 @@ impl HTMLImageElement {
     fn reject_image_decode_promises(&self, can_gc: CanGc) {
         let document = self.owner_document();
         for promise in self.image_decode_promises.borrow().iter() {
-            promise.reject_native(&DOMException::new(
-                &document.global(),
-                DOMErrorName::EncodingError,
+            promise.reject_native(
+                &DOMException::new(&document.global(), DOMErrorName::EncodingError, can_gc),
                 can_gc,
-            ));
+            );
         }
         self.image_decode_promises.borrow_mut().clear();
     }

--- a/components/script/dom/navigationpreloadmanager.rs
+++ b/components/script/dom/navigationpreloadmanager.rs
@@ -52,11 +52,10 @@ impl NavigationPreloadManagerMethods<crate::DomTypeHolder> for NavigationPreload
 
         // 2.
         if self.serviceworker_registration.is_active() {
-            promise.reject_native(&DOMException::new(
-                &self.global(),
-                DOMErrorName::InvalidStateError,
+            promise.reject_native(
+                &DOMException::new(&self.global(), DOMErrorName::InvalidStateError, can_gc),
                 can_gc,
-            ));
+            );
         } else {
             // 3.
             self.serviceworker_registration
@@ -75,11 +74,10 @@ impl NavigationPreloadManagerMethods<crate::DomTypeHolder> for NavigationPreload
 
         // 2.
         if self.serviceworker_registration.is_active() {
-            promise.reject_native(&DOMException::new(
-                &self.global(),
-                DOMErrorName::InvalidStateError,
+            promise.reject_native(
+                &DOMException::new(&self.global(), DOMErrorName::InvalidStateError, can_gc),
                 can_gc,
-            ));
+            );
         } else {
             // 3.
             self.serviceworker_registration
@@ -98,11 +96,10 @@ impl NavigationPreloadManagerMethods<crate::DomTypeHolder> for NavigationPreload
 
         // 2.
         if self.serviceworker_registration.is_active() {
-            promise.reject_native(&DOMException::new(
-                &self.global(),
-                DOMErrorName::InvalidStateError,
+            promise.reject_native(
+                &DOMException::new(&self.global(), DOMErrorName::InvalidStateError, can_gc),
                 can_gc,
-            ));
+            );
         } else {
             // 3.
             self.serviceworker_registration

--- a/components/script/dom/promise.rs
+++ b/components/script/dom/promise.rs
@@ -208,7 +208,7 @@ impl Promise {
     }
 
     #[allow(unsafe_code)]
-    pub(crate) fn reject_native<T>(&self, val: &T)
+    pub(crate) fn reject_native<T>(&self, val: &T, can_gc: CanGc)
     where
         T: ToJSValConvertible,
     {
@@ -218,7 +218,7 @@ impl Promise {
         unsafe {
             val.to_jsval(*cx, v.handle_mut());
         }
-        self.reject(cx, v.handle(), CanGc::note());
+        self.reject(cx, v.handle(), can_gc);
     }
 
     pub(crate) fn reject_error(&self, error: Error) {

--- a/components/script/dom/response.rs
+++ b/components/script/dom/response.rs
@@ -90,9 +90,9 @@ impl Response {
         )
     }
 
-    pub(crate) fn error_stream(&self, error: Error) {
+    pub(crate) fn error_stream(&self, error: Error, can_gc: CanGc) {
         if let Some(body) = self.body_stream.get() {
-            body.error_native(error);
+            body.error_native(error, can_gc);
         }
     }
 }

--- a/components/script/dom/webgpu/gpudevice.rs
+++ b/components/script/dom/webgpu/gpudevice.rs
@@ -605,21 +605,25 @@ impl AsyncWGPUListener for GPUDevice {
                     ),
                     can_gc,
                 ),
-                Err(webgpu::Error::Validation(msg)) => {
-                    promise.reject_native(&GPUPipelineError::new(
+                Err(webgpu::Error::Validation(msg)) => promise.reject_native(
+                    &GPUPipelineError::new(
                         &self.global(),
                         msg.into(),
                         GPUPipelineErrorReason::Validation,
                         can_gc,
-                    ))
-                },
+                    ),
+                    can_gc,
+                ),
                 Err(webgpu::Error::OutOfMemory(msg) | webgpu::Error::Internal(msg)) => promise
-                    .reject_native(&GPUPipelineError::new(
-                        &self.global(),
-                        msg.into(),
-                        GPUPipelineErrorReason::Internal,
+                    .reject_native(
+                        &GPUPipelineError::new(
+                            &self.global(),
+                            msg.into(),
+                            GPUPipelineErrorReason::Internal,
+                            can_gc,
+                        ),
                         can_gc,
-                    )),
+                    ),
             },
             WebGPUResponse::RenderPipeline(result) => match result {
                 Ok(pipeline) => promise.resolve_native(
@@ -632,21 +636,25 @@ impl AsyncWGPUListener for GPUDevice {
                     ),
                     can_gc,
                 ),
-                Err(webgpu::Error::Validation(msg)) => {
-                    promise.reject_native(&GPUPipelineError::new(
+                Err(webgpu::Error::Validation(msg)) => promise.reject_native(
+                    &GPUPipelineError::new(
                         &self.global(),
                         msg.into(),
                         GPUPipelineErrorReason::Validation,
                         can_gc,
-                    ))
-                },
+                    ),
+                    can_gc,
+                ),
                 Err(webgpu::Error::OutOfMemory(msg) | webgpu::Error::Internal(msg)) => promise
-                    .reject_native(&GPUPipelineError::new(
-                        &self.global(),
-                        msg.into(),
-                        GPUPipelineErrorReason::Internal,
+                    .reject_native(
+                        &GPUPipelineError::new(
+                            &self.global(),
+                            msg.into(),
+                            GPUPipelineErrorReason::Internal,
+                            can_gc,
+                        ),
                         can_gc,
-                    )),
+                    ),
             },
             _ => unreachable!("Wrong response received on AsyncWGPUListener for GPUDevice"),
         }

--- a/components/script/dom/webxr/xrtest.rs
+++ b/components/script/dom/webxr/xrtest.rs
@@ -61,7 +61,7 @@ impl XRTest {
                 .push(Dom::from_ref(&device));
             promise.resolve_native(&device, can_gc);
         } else {
-            promise.reject_native(&());
+            promise.reject_native(&(), can_gc);
         }
     }
 }

--- a/components/script/dom/writablestreamdefaultwriter.rs
+++ b/components/script/dom/writablestreamdefaultwriter.rs
@@ -109,7 +109,7 @@ impl WritableStreamDefaultWriter {
             // Set writer.[[readyPromise]].[[PromiseIsHandled]] to true.
             // Note: new promise created in `new_inherited`.
             let ready_promise = self.ready_promise.borrow();
-            ready_promise.reject_native(&error.handle());
+            ready_promise.reject_native(&error.handle(), can_gc);
             ready_promise.set_promise_is_handled();
 
             // Set writer.[[closedPromise]] to a new promise.
@@ -141,21 +141,25 @@ impl WritableStreamDefaultWriter {
         // Set writer.[[readyPromise]].[[PromiseIsHandled]] to true.
         // Note: new promise created in `new_inherited`.
         let ready_promise = self.ready_promise.borrow();
-        ready_promise.reject_native(&error.handle());
+        ready_promise.reject_native(&error.handle(), can_gc);
         ready_promise.set_promise_is_handled();
 
         // Set writer.[[closedPromise]] to a promise rejected with storedError.
         // Set writer.[[closedPromise]].[[PromiseIsHandled]] to true.
         // Note: new promise created in `new_inherited`.
         let ready_promise = self.closed_promise.borrow();
-        ready_promise.reject_native(&error.handle());
+        ready_promise.reject_native(&error.handle(), can_gc);
         ready_promise.set_promise_is_handled();
 
         Ok(())
     }
 
-    pub(crate) fn reject_closed_promise_with_stored_error(&self, error: &SafeHandleValue) {
-        self.closed_promise.borrow().reject_native(error);
+    pub(crate) fn reject_closed_promise_with_stored_error(
+        &self,
+        error: &SafeHandleValue,
+        can_gc: CanGc,
+    ) {
+        self.closed_promise.borrow().reject_native(error, can_gc);
     }
 
     pub(crate) fn set_close_promise_is_handled(&self) {
@@ -186,14 +190,14 @@ impl WritableStreamDefaultWriter {
         // If writer.[[readyPromise]].[[PromiseState]] is "pending",
         if ready_promise.is_pending() {
             // reject writer.[[readyPromise]] with error.
-            ready_promise.reject_native(&error);
+            ready_promise.reject_native(&error, can_gc);
 
             // Set writer.[[readyPromise]].[[PromiseIsHandled]] to true.
             ready_promise.set_promise_is_handled();
         } else {
             // Otherwise, set writer.[[readyPromise]] to a promise rejected with error.
             let promise = Promise::new(global, can_gc);
-            promise.reject_native(&error);
+            promise.reject_native(&error, can_gc);
 
             // Set writer.[[readyPromise]].[[PromiseIsHandled]] to true.
             promise.set_promise_is_handled();
@@ -213,14 +217,14 @@ impl WritableStreamDefaultWriter {
         // If writer.[[closedPromise]].[[PromiseState]] is "pending",
         if closed_promise.is_pending() {
             // reject writer.[[closedPromise]] with error.
-            closed_promise.reject_native(&error);
+            closed_promise.reject_native(&error, can_gc);
 
             // Set writer.[[closedPromise]].[[PromiseIsHandled]] to true.
             closed_promise.set_promise_is_handled();
         } else {
             // Otherwise, set writer.[[closedPromise]] to a promise rejected with error.
             let promise = Promise::new(global, can_gc);
-            promise.reject_native(&error);
+            promise.reject_native(&error, can_gc);
 
             // Set writer.[[closedPromise]].[[PromiseIsHandled]] to true.
             promise.set_promise_is_handled();
@@ -302,7 +306,7 @@ impl WritableStreamDefaultWriter {
             rooted!(in(*cx) let mut error = UndefinedValue());
             stream.get_stored_error(error.handle_mut());
             let promise = Promise::new(global, can_gc);
-            promise.reject_native(&error.handle());
+            promise.reject_native(&error.handle(), can_gc);
             return promise;
         }
 
@@ -324,7 +328,7 @@ impl WritableStreamDefaultWriter {
             rooted!(in(*cx) let mut error = UndefinedValue());
             stream.get_stored_error(error.handle_mut());
             let promise = Promise::new(global, can_gc);
-            promise.reject_native(&error.handle());
+            promise.reject_native(&error.handle(), can_gc);
             return promise;
         }
 

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -150,7 +150,7 @@ pub(crate) fn Fetch(
     //         with input and init as arguments. If this throws an exception, reject p with it and return p.
     let request = match Request::Constructor(global, None, can_gc, input, init) {
         Err(e) => {
-            response.error_stream(e.clone());
+            response.error_stream(e.clone(), can_gc);
             promise.reject_error(e);
             return promise;
         },
@@ -227,7 +227,10 @@ impl FetchResponseListener for FetchContext {
                 self.fetch_promise = Some(TrustedPromise::new(promise));
                 let response = self.response_object.root();
                 response.set_type(DOMResponseType::Error, CanGc::note());
-                response.error_stream(Error::Type("Network error occurred".to_string()));
+                response.error_stream(
+                    Error::Type("Network error occurred".to_string()),
+                    CanGc::note(),
+                );
                 return;
             },
             // Step 4.2

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -593,15 +593,15 @@ DOMInterfaces = {
 },
 
 "ReadableStreamDefaultController": {
-    "canGc": ["Close", "Enqueue"]
+    "canGc": ["Close", "Enqueue", "Error"]
 },
 
 "ReadableStreamBYOBReader": {
-    "canGc": ["Read", "Cancel"]
+    "canGc": ["Cancel", "Read", "ReleaseLock"]
 },
 
 "ReadableStreamDefaultReader": {
-    "canGc": ["Read", "Cancel"]
+    "canGc": ["Cancel", "Read", "ReleaseLock"]
 },
 
 'WritableStream': {


### PR DESCRIPTION
Add CanGc as argument to `Promise::reject_native`.

Addressed part of https://github.com/servo/servo/issues/34573.

---

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they are a refactor.
