### PR TITLE
Avoid "OSError: [Errno 39] Directory not empty" when running tests

### DIFF
--- a/tests/wpt/tests/tools/wptrunner/wptrunner/executors/executorservo.py
+++ b/tests/wpt/tests/tools/wptrunner/wptrunner/executors/executorservo.py
@@ -3,6 +3,7 @@
 import base64
 import json
 import os
+import shutil
 import subprocess
 import tempfile
 import threading
@@ -221,7 +222,7 @@ class ServoRefTestExecutor(ServoExecutor):
         self.implementation.reset()
 
     def teardown(self):
-        os.rmdir(self.tempdir)
+        shutil.rmtree(self.tempdir)
         ServoExecutor.teardown(self)
 
     def screenshot(self, test, viewport_size, dpi, page_ranges):


### PR DESCRIPTION
Since #35538, when executorservo.py tries to remove the temporary directories after running tests, an error is produced because these directories aren't empty.

Therefore, this changes `os.rmdir` into `shutil.rmtree`, in order to remove the directories and their contents.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #35635
- [X] These changes do not require tests because this is just a fix about running tests

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
