### PR TITLE
Bump channel in shell.nix to support rustc 1.85.

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,7 @@
 [toolchain]
-# Be sure to update shell.nix and support/crown/rust-toolchain.toml when bumping this!
+# Be sure to update the 'rust-overlay' module's url in shell.nix to point to a
+# commit which supports the required rustc version and also update the version
+# in support/crown/rust-toolchain.toml when bumping this!
 channel = "1.85.0"
 
 components = [

--- a/shell.nix
+++ b/shell.nix
@@ -10,7 +10,7 @@ with import (builtins.fetchTarball {
   overlays = [
     (import (builtins.fetchTarball {
       # Bumped the channel in rust-toolchain.toml? Bump this commit too!
-      url = "https://github.com/oxalica/rust-overlay/archive/10faa81b4c0135a04716cbd1649260d82b2890cd.tar.gz";
+      url = "https://github.com/oxalica/rust-overlay/archive/7c5892ad87b90d72668964975eebd4e174ff6204.tar.gz";
     }))
   ];
   config = {


### PR DESCRIPTION
PR #35628 bumped the rustc version to 1.85, but this broke nix-based systems as these also require bumping the channel for the 'rust-overlay' module to a commit that includes support for that version of rustc.

---

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because the PR modifies only shell.nix
