### PR TITLE
refactor: add CanGc as argument to exception_to_promise

### DIFF
--- a/components/script_bindings/codegen/CodegenRust.py
+++ b/components/script_bindings/codegen/CodegenRust.py
@@ -4249,7 +4249,7 @@ class CGMethodPromiseWrapper(CGAbstractExternMethod):
             if ok {
               return true;
             }
-            return exception_to_promise(cx, (*args).rval());
+            return exception_to_promise(cx, (*args).rval(), CanGc::note());
             """,
             methodName=self.method.identifier.name,
             args=", ".join(arg.name for arg in self.args),
@@ -4284,7 +4284,7 @@ class CGGetterPromiseWrapper(CGAbstractExternMethod):
             if ok {
               return true;
             }
-            return exception_to_promise(cx, args.rval());
+            return exception_to_promise(cx, args.rval(), CanGc::note());
             """,
             methodName=self.method_call,
             args=", ".join(arg.name for arg in self.args),


### PR DESCRIPTION
Add CanGc as argument to `exception_to_promise`.

Addressed part of https://github.com/servo/servo/issues/34573.

---

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they are a refactor.
