### PR TITLE
servoshell: Fall back to PNG format when outputting an image

### DIFF
--- a/ports/servoshell/desktop/app_state.rs
+++ b/ports/servoshell/desktop/app_state.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 use std::rc::Rc;
 
 use euclid::Vector2D;
-use image::DynamicImage;
+use image::{DynamicImage, ImageFormat};
 use keyboard_types::{Key, KeyboardEvent, Modifiers, ShortcutMatcher};
 use log::{error, info};
 use servo::base::id::WebViewId;
@@ -146,7 +146,10 @@ impl RunningAppState {
             return;
         };
 
-        if let Err(error) = DynamicImage::ImageRgba8(image).save(output_path) {
+        let image_format = ImageFormat::from_path(output_path).unwrap_or(ImageFormat::Png);
+        if let Err(error) =
+            DynamicImage::ImageRgba8(image).save_with_format(output_path, image_format)
+        {
             error!("Failed to save {output_path}: {error}.");
         }
     }

--- a/tests/wpt/tests/tools/wptrunner/wptrunner/executors/executorservo.py
+++ b/tests/wpt/tests/tools/wptrunner/wptrunner/executors/executorservo.py
@@ -226,7 +226,6 @@ class ServoRefTestExecutor(ServoExecutor):
 
     def screenshot(self, test, viewport_size, dpi, page_ranges):
         with TempFilename(self.tempdir) as output_path:
-            output_path = f"{output_path}.png"
             extra_args = ["--exit",
                           "--output=%s" % output_path,
                           "--window-size", viewport_size or "800x600"]


### PR DESCRIPTION
A recent change, #35538 added the ability to dump different output image
formats. Unfortunately, this necessitated adding a file extension to the
output image for WPT tests. This had two problems:

1. The original change never landed properly in WPT for unknown reasons.
2. It interfered with the way that temporary files were cleaned up
   during WPT runs.

This change modifies the image dumping code to fall back to PNG format
when there is no valid file extension on the output image and reverts
the change made to the WPT runner.

Fixes #35635.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes. Literally the WPT tests.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
