### PR TITLE
layout: Support `stretch` cross size for automatic min size in flexbox

### DIFF
--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -2530,14 +2530,16 @@ impl FlexItemBox {
             Direction::Block
         };
 
+        let cross_stretch_size = containing_block_size
+            .cross
+            .map(|v| v - pbm_auto_is_zero.cross);
         let cross_size = SizeConstraint::new(
             if content_box_size.cross.is_initial() && auto_cross_size_stretches_to_container_size {
-                containing_block_size
-                    .cross
-                    .map(|v| v - pbm_auto_is_zero.cross)
+                cross_stretch_size
             } else {
-                // TODO(#32853): handle size keywords.
-                content_box_size.cross.to_numeric()
+                content_box_size
+                    .cross
+                    .maybe_resolve_extrinsic(cross_stretch_size)
             },
             min_size.cross.auto_is(Au::zero),
             max_size.cross,

--- a/tests/wpt/tests/css/css-sizing/stretch/flexbox-auto-minimum-001.html
+++ b/tests/wpt/tests/css/css-sizing/stretch/flexbox-auto-minimum-001.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Automatic minimum size of flex item with stretch cross size</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#stretch-fit-sizing">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#min-size-auto">
+<link rel="match" href="../../reference/ref-filled-green-200px-square.html">
+<meta assert="A definite `stretch` cross size can be transferred through the
+  aspect ratio when computing the automatic minimum size of a flex item.">
+
+<style>
+div {
+  display: flex;
+  flex-direction: column;
+  height: 200px;
+  width: 200px;
+  background: red;
+}
+canvas {
+  width: stretch;
+  align-self: start;
+  flex-basis: 0;
+  background: green;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div class="flex">
+  <canvas width="100" height="100"></canvas>
+</div>

--- a/tests/wpt/tests/css/css-sizing/stretch/flexbox-auto-minimum-002.html
+++ b/tests/wpt/tests/css/css-sizing/stretch/flexbox-auto-minimum-002.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Automatic minimum size of flex item with stretch cross size</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#stretch-fit-sizing">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#min-size-auto">
+<link rel="match" href="../../reference/ref-filled-green-200px-square.html">
+<meta assert="A definite `stretch` cross size can be transferred through the
+  aspect ratio when computing the automatic minimum size of a flex item.">
+
+<style>
+div {
+  display: flex;
+  flex-direction: row;
+  height: 200px;
+  width: 200px;
+  background: red;
+}
+canvas {
+  height: stretch;
+  align-self: start;
+  flex-basis: 0;
+  background: green;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div class="flex">
+  <canvas width="100" height="100"></canvas>
+</div>


### PR DESCRIPTION
The computation of the automatic minimum size may involve transferring a definite cross size into the main axis through the aspect ratio. We were only considering numeric sizes as definite, but `stretch` can also be definite.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #32853
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
