### PR TITLE
layout: Change the `IndefiniteContainingBlock` sizes to `Option<Au>`

### DIFF
--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -2389,7 +2389,7 @@ impl FlexItemBox {
             layout_context,
             config
                 .flex_axis
-                .vec2_to_flex_relative(containing_block.size.map(|v| v.non_auto())),
+                .vec2_to_flex_relative(containing_block.size),
             cross_axis_is_item_block_axis,
             content_box_size,
             content_min_size_no_auto,
@@ -2498,7 +2498,7 @@ impl FlexItemBox {
     fn automatic_min_size(
         &self,
         layout_context: &LayoutContext,
-        containing_block_size: FlexRelativeVec2<AuOrAuto>,
+        containing_block_size: FlexRelativeVec2<Option<Au>>,
         cross_axis_is_item_block_axis: bool,
         content_box_size: FlexRelativeVec2<Size<Au>>,
         min_size: FlexRelativeVec2<GenericLengthPercentageOrAuto<Au>>,
@@ -2520,7 +2520,6 @@ impl FlexItemBox {
         let specified_size_suggestion = content_box_size.main.maybe_resolve_extrinsic(
             containing_block_size
                 .main
-                .non_auto()
                 .map(|v| v - pbm_auto_is_zero.main),
         );
 
@@ -2535,7 +2534,6 @@ impl FlexItemBox {
             if content_box_size.cross.is_initial() && auto_cross_size_stretches_to_container_size {
                 containing_block_size
                     .cross
-                    .non_auto()
                     .map(|v| v - pbm_auto_is_zero.cross)
             } else {
                 // TODO(#32853): handle size keywords.

--- a/components/layout_2020/geom.rs
+++ b/components/layout_2020/geom.rs
@@ -898,19 +898,11 @@ impl SizeConstraint {
             _ => None,
         }
     }
-
-    #[inline]
-    pub(crate) fn to_auto_or(self) -> AutoOr<Au> {
-        self.to_definite()
-            .map_or(AutoOr::Auto, AutoOr::LengthPercentage)
-    }
 }
 
-impl From<AuOrAuto> for SizeConstraint {
-    fn from(size: AuOrAuto) -> Self {
-        size.non_auto()
-            .map(SizeConstraint::Definite)
-            .unwrap_or_default()
+impl From<Option<Au>> for SizeConstraint {
+    fn from(size: Option<Au>) -> Self {
+        size.map(SizeConstraint::Definite).unwrap_or_default()
     }
 }
 

--- a/components/layout_2020/sizing.rs
+++ b/components/layout_2020/sizing.rs
@@ -142,7 +142,6 @@ pub(crate) fn outer_inline(
             let available_block_size = containing_block
                 .size
                 .block
-                .non_auto()
                 .map(|v| Au::zero().max(v - pbm_sums.block));
             let automatic_size = if content_box_sizes.block.preferred.is_initial() &&
                 auto_block_size_stretches_to_containing_block

--- a/components/layout_2020/style_ext.rs
+++ b/components/layout_2020/style_ext.rs
@@ -840,13 +840,12 @@ impl LayoutStyle<'_> {
         // indefinite percentages, we treat the entire value as the initial value of the property.
         // However, for min size properties, as well as for margins and paddings,
         // we instead resolve indefinite percentages against zero.
-        let containing_block_size = containing_block.size.map(|value| value.non_auto());
-        let containing_block_size_auto_is_zero =
-            containing_block_size.map(|value| value.unwrap_or_else(Au::zero));
+        let containing_block_size_or_zero =
+            containing_block.size.map(|value| value.unwrap_or_default());
         let writing_mode = containing_block.writing_mode;
         let pbm = self.padding_border_margin_with_writing_mode_and_containing_block_inline_size(
             writing_mode,
-            containing_block.size.inline.auto_is(Au::zero),
+            containing_block_size_or_zero.inline,
         );
         let style = self.style();
         let box_size = style.box_size(writing_mode);
@@ -872,15 +871,15 @@ impl LayoutStyle<'_> {
             depends_on_block_constraints(&max_size.block) ||
             style.depends_on_block_constraints_due_to_relative_positioning(writing_mode);
 
-        let box_size = box_size.maybe_percentages_relative_to_basis(&containing_block_size);
+        let box_size = box_size.maybe_percentages_relative_to_basis(&containing_block.size);
         let content_box_size = style
             .content_box_size_for_box_size(box_size, &pbm)
             .map(|v| v.map(Au::from));
-        let min_size = min_size.percentages_relative_to_basis(&containing_block_size_auto_is_zero);
+        let min_size = min_size.percentages_relative_to_basis(&containing_block_size_or_zero);
         let content_min_box_size = style
             .content_min_box_size_for_min_size(min_size, &pbm)
             .map(|v| v.map(Au::from));
-        let max_size = max_size.maybe_percentages_relative_to_basis(&containing_block_size);
+        let max_size = max_size.maybe_percentages_relative_to_basis(&containing_block.size);
         let content_max_box_size = style
             .content_max_box_size_for_max_size(max_size, &pbm)
             .map(|v| v.map(Au::from));

--- a/components/layout_2020/table/layout.rs
+++ b/components/layout_2020/table/layout.rs
@@ -35,7 +35,7 @@ use crate::fragment_tree::{
     PositioningFragment, SpecificLayoutInfo,
 };
 use crate::geom::{
-    AuOrAuto, LogicalRect, LogicalSides, LogicalVec2, PhysicalPoint, PhysicalRect, PhysicalSides,
+    LogicalRect, LogicalSides, LogicalVec2, PhysicalPoint, PhysicalRect, PhysicalSides,
     PhysicalVec, Size, SizeConstraint, ToLogical, ToLogicalWithContainingBlock,
 };
 use crate::positioned::{relative_adjustement, PositioningContext, PositioningContextLength};
@@ -704,10 +704,7 @@ impl<'a> TableLayout<'a> {
     /// Compute CAPMIN: <https://drafts.csswg.org/css-tables/#capmin>
     fn compute_caption_minimum_inline_size(&self, layout_context: &LayoutContext) -> Au {
         let containing_block = IndefiniteContainingBlock {
-            size: LogicalVec2 {
-                inline: AuOrAuto::Auto,
-                block: AuOrAuto::Auto,
-            },
+            size: LogicalVec2::default(),
             writing_mode: self.table.style.writing_mode,
         };
         self.table


### PR DESCRIPTION
Thus avoiding the need to convert to/from `AuOrAuto`.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because there is no behavior change

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
