### PR TITLE
libservo: Notify delegates of send errors in request objects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4341,6 +4341,7 @@ dependencies = [
  "gaol",
  "gleam",
  "gstreamer",
+ "http 1.3.1",
  "ipc-channel",
  "keyboard-types",
  "layout_thread_2020",

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -124,6 +124,7 @@ gaol = "0.2.1"
 webxr = { path = "../webxr", features = ["ipc", "glwindow", "headless", "openxr-api"] }
 
 [dev-dependencies]
+http = { workspace = true }
 libservo = { path = ".", features = ["tracing"] }
 rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs"] }
 tracing = { workspace = true }

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -119,7 +119,7 @@ pub use {
 pub use {bluetooth, bluetooth_traits};
 
 use crate::proxies::ConstellationProxy;
-use crate::servo_delegate::ServoErrorChannel;
+use crate::responders::ServoErrorChannel;
 pub use crate::servo_delegate::{ServoDelegate, ServoError};
 pub use crate::webview::WebView;
 pub use crate::webview_delegate::{

--- a/components/servo/responders.rs
+++ b/components/servo/responders.rs
@@ -16,7 +16,7 @@ pub(crate) struct ServoErrorSender {
 
 impl ServoErrorSender {
     pub(crate) fn raise_response_send_error(&self, error: bincode::Error) {
-        if let Err(error) = self.sender.send(ServoError::ResponseSend(error)) {
+        if let Err(error) = self.sender.send(ServoError::ResponseFailedToSend(error)) {
             warn!("Failed to send Servo error: {error:?}");
         }
     }
@@ -43,6 +43,7 @@ impl ServoErrorChannel {
             sender: self.sender.clone(),
         }
     }
+
     pub(crate) fn try_recv(&self) -> Option<ServoError> {
         match self.receiver.try_recv() {
             Ok(result) => Some(result),

--- a/components/servo/responders.rs
+++ b/components/servo/responders.rs
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/// Sender for errors raised by delegate request objects.
+///
+/// This allows errors to be raised asynchronously.
+pub(crate) trait DelegateErrorSender {
+    fn raise_response_send_error(&self, error: bincode::Error);
+}

--- a/components/servo/responders.rs
+++ b/components/servo/responders.rs
@@ -2,9 +2,54 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use crossbeam_channel::{Receiver, Sender, TryRecvError, unbounded};
+use log::warn;
+
+use crate::ServoError;
+
 /// Sender for errors raised by delegate request objects.
 ///
 /// This allows errors to be raised asynchronously.
-pub(crate) trait DelegateErrorSender {
-    fn raise_response_send_error(&self, error: bincode::Error);
+pub(crate) struct ServoErrorSender {
+    sender: Sender<ServoError>,
+}
+
+impl ServoErrorSender {
+    pub(crate) fn raise_response_send_error(&self, error: bincode::Error) {
+        if let Err(error) = self.sender.send(ServoError::ResponseSend(error)) {
+            warn!("Failed to send Servo error: {error:?}");
+        }
+    }
+}
+
+/// Channel for errors raised by [`WebViewDelegate`] request objects.
+///
+/// This allows errors to be raised asynchronously.
+pub(crate) struct ServoErrorChannel {
+    sender: Sender<ServoError>,
+    receiver: Receiver<ServoError>,
+}
+
+impl Default for ServoErrorChannel {
+    fn default() -> Self {
+        let (sender, receiver) = unbounded();
+        Self { sender, receiver }
+    }
+}
+
+impl ServoErrorChannel {
+    pub(crate) fn sender(&self) -> ServoErrorSender {
+        ServoErrorSender {
+            sender: self.sender.clone(),
+        }
+    }
+    pub(crate) fn try_recv(&self) -> Option<ServoError> {
+        match self.receiver.try_recv() {
+            Ok(result) => Some(result),
+            Err(error) => {
+                debug_assert_eq!(error, TryRecvError::Empty);
+                None
+            },
+        }
+    }
 }

--- a/components/servo/servo_delegate.rs
+++ b/components/servo/servo_delegate.rs
@@ -2,10 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use crossbeam_channel::{Receiver, Sender, TryRecvError, unbounded};
+use log::warn;
+
 use crate::Servo;
+use crate::responders::DelegateErrorSender;
 use crate::webview_delegate::{AllowOrDenyRequest, WebResourceLoad};
 
-#[derive(Clone, Copy, Debug, Hash, PartialEq)]
+#[derive(Debug)]
 pub enum ServoError {
     /// The channel to the off-the-main-thread web engine has been lost. No further
     /// attempts to communicate will happen. This is an unrecoverable error in Servo.
@@ -13,6 +17,53 @@ pub enum ServoError {
     /// The devtools server, used to expose pages to remote web inspectors has failed
     /// to start.
     DevtoolsFailedToStart,
+    /// Failed to send response to delegate request.
+    ResponseSend(bincode::Error),
+}
+
+/// Channel for errors raised by [`WebViewDelegate`] request objects.
+///
+/// This allows errors to be raised asynchronously.
+pub(crate) struct ServoErrorChannel {
+    sender: Sender<ServoError>,
+    receiver: Receiver<ServoError>,
+}
+
+impl Default for ServoErrorChannel {
+    fn default() -> Self {
+        let (sender, receiver) = unbounded();
+        Self { sender, receiver }
+    }
+}
+
+impl ServoErrorChannel {
+    pub(crate) fn sender(&self) -> ServoErrorSender {
+        ServoErrorSender {
+            sender: self.sender.clone(),
+        }
+    }
+    pub(crate) fn try_recv(&self) -> Option<ServoError> {
+        match self.receiver.try_recv() {
+            Ok(result) => Some(result),
+            Err(error) => {
+                debug_assert_eq!(error, TryRecvError::Empty);
+                None
+            },
+        }
+    }
+}
+
+/// Sender for [`ServoError`] that identifies the [`WebView`] in question.
+pub(crate) struct ServoErrorSender {
+    sender: Sender<ServoError>,
+}
+
+impl DelegateErrorSender for ServoErrorSender {
+    fn raise_response_send_error(&self, error: bincode::Error) {
+        if let Err(error) = self.sender.send(ServoError::ResponseSend(error)) {
+            warn!("Failed to send Servo error: {error:?}");
+        }
+    }
 }
 
 pub trait ServoDelegate {

--- a/components/servo/servo_delegate.rs
+++ b/components/servo/servo_delegate.rs
@@ -14,7 +14,7 @@ pub enum ServoError {
     /// to start.
     DevtoolsFailedToStart,
     /// Failed to send response to delegate request.
-    ResponseSend(bincode::Error),
+    ResponseFailedToSend(bincode::Error),
 }
 
 pub trait ServoDelegate {

--- a/components/servo/webview_delegate.rs
+++ b/components/servo/webview_delegate.rs
@@ -17,8 +17,7 @@ use serde::Serialize;
 use url::Url;
 use webrender_api::units::{DeviceIntPoint, DeviceIntRect, DeviceIntSize};
 
-use crate::responders::DelegateErrorSender;
-use crate::servo_delegate::ServoErrorSender;
+use crate::responders::ServoErrorSender;
 use crate::{ConstellationProxy, WebView};
 
 /// A request to navigate a [`WebView`] or one of its inner frames. This can be handled

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -150,7 +150,7 @@ pub enum SimpleDialog {
     },
 }
 
-#[derive(Debug, Default, Deserialize, Serialize)]
+#[derive(Debug, Default, Deserialize, PartialEq, Serialize)]
 pub struct AuthenticationResponse {
     /// Username for http request authentication
     pub username: String,
@@ -208,7 +208,7 @@ impl Default for PromptResponse {
 }
 
 /// A response to a request to allow or deny an action.
-#[derive(Clone, Copy, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub enum AllowOrDeny {
     Allow,
     Deny,

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -165,6 +165,7 @@ class MachCommands(CommandBase):
             "fonts",
             "hyper_serde",
             "layout_2020",
+            "libservo",
             "net",
             "net_traits",
             "pixels",


### PR DESCRIPTION
This patch centralises IPC error handling for delegate request objects by adding a new ServoError variant that gets passed to ServoDelegate::notify_error(). These errors come from request objects via an internal crossbeam channel.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] ~~These changes fix #___ (GitHub issue number if applicable)~~

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___