### PR TITLE
CI: Fail on winit_minimal example build errors

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -165,6 +165,12 @@ jobs:
       - name: Install crown
         run: cargo install --path support/crown
 
+      - name: Build libservo with examples (${{ inputs.profile }})
+        if: ${{ inputs.build-libservo }}
+        run: cargo build -p libservo --all-targets --${{ inputs.profile }} --target-dir target/libservo
+      - name: Clean libservo build to save disk space
+        if: ${{ inputs.build-libservo }}
+        run: rm -Rf target/libservo
       - name: Build (${{ inputs.profile }})
         run: |
           ./mach build --use-crown --locked --${{ inputs.profile }} --features "layout_2013"
@@ -180,10 +186,6 @@ jobs:
           timeout_minutes: 20
           max_attempts: 2 # https://github.com/servo/servo/issues/30683
           command: ./mach test-unit --${{ inputs.profile }}
-      - name: Build libservo with examples
-        if: ${{ inputs.build-libservo }}
-        continue-on-error: true
-        run: cargo build -p libservo --all-targets
       - name: Archive build timing
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -145,6 +145,12 @@ jobs:
         run: |
           ./mach bootstrap --skip-lints
           brew install gnu-tar
+      - name: Build libservo with examples (${{ inputs.profile }})
+        if: ${{ inputs.build-libservo }}
+        run: cargo build -p libservo --all-targets --${{ inputs.profile }} --target-dir target/libservo
+      - name: Clean libservo build to save disk space
+        if: ${{ inputs.build-libservo }}
+        run: rm -Rf target/libservo
       - name: Build (${{ inputs.profile }})
         run: |
           ./mach build --use-crown --locked --${{ inputs.profile }}
@@ -164,10 +170,6 @@ jobs:
           timeout_minutes: 40 # https://github.com/servo/servo/issues/30275
           max_attempts: 3 # https://github.com/servo/servo/issues/30683
           command: ./mach test-unit --${{ inputs.profile }}
-      - name: Build libservo with examples
-        if: ${{ inputs.build-libservo }}
-        continue-on-error: true
-        run: cargo build -p libservo --all-targets
       - name: Build mach package
         run: ./mach package --${{ inputs.profile }}
       - name: Run DMG smoketest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           {
             echo 'result<<EOF'
-            python ./python/servo/try_parser.py ${{ github.event_name == 'pull_request' && 'linux-unit-tests lint' || github.event_name == 'push' && 'fail-fast full bencher production-bencher' || 'fail-fast full' }}
+            python ./python/servo/try_parser.py ${{ github.event_name == 'pull_request' && 'linux-unit-tests linux-build-libservo lint' || github.event_name == 'push' && 'fail-fast full bencher production-bencher' || 'fail-fast full' }}
             echo EOF
            } >> $GITHUB_OUTPUT
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -159,6 +159,12 @@ jobs:
           echo "`$env:LIBCLANG_PATH now = $env:LIBCLANG_PATH"
           echo "`$env:PATH now = $env:PATH"
 
+      - name: Build libservo with examples (${{ inputs.profile }})
+        if: ${{ inputs.build-libservo }}
+        run: cargo build -p libservo --all-targets --${{ inputs.profile }} --target-dir target\libservo
+      - name: Clean libservo build to save disk space
+        if: ${{ inputs.build-libservo }}
+        run: Remove-Item -Recurse -Force target\libservo
       - name: Build (${{ inputs.profile }})
         run: |
           .\mach build --use-crown --locked --${{ inputs.profile }}
@@ -176,10 +182,6 @@ jobs:
           timeout_minutes: 30
           max_attempts: 3 # https://github.com/servo/servo/issues/30683
           command: .\mach test-unit --${{ inputs.profile }} -- -- --test-threads=1
-      - name: Build libservo with examples
-        if: ${{ inputs.build-libservo }}
-        continue-on-error: true
-        run: cargo build -p libservo --all-targets
       - name: Archive build timing
         uses: actions/upload-artifact@v4
         with:

--- a/python/servo/try_parser.py
+++ b/python/servo/try_parser.py
@@ -181,8 +181,11 @@ class Config(object):
                 self.fail_fast = True
                 continue  # skip over keyword
             if word == "full":
-                words.extend(["linux-unit-tests", "linux-wpt-2020", "linux-bencher"])
-                words.extend(["macos-unit-tests", "windows-unit-tests", "android", "ohos", "lint"])
+                words.extend(["linux-unit-tests", "linux-build-libservo", "linux-wpt-2020", "linux-bencher"])
+                words.extend([
+                    "macos-unit-tests", "macos-build-libservo", "windows-unit-tests", "windows-build-libservo",
+                    "android", "ohos", "lint",
+                ])
                 continue  # skip over keyword
             if word == "bencher":
                 words.extend(["linux-bencher", "macos-bencher", "windows-bencher", "android-bencher", "ohos-bencher"])
@@ -237,32 +240,32 @@ class TestParser(unittest.TestCase):
         self.assertDictEqual(json.loads(Config("").to_json()),
                              {"fail_fast": False, "matrix": [
                               {
-                                  "name": "Linux (Unit Tests, WPT, Bencher)",
+                                  "name": "Linux (Unit Tests, Build libservo, WPT, Bencher)",
                                   "workflow": "linux",
                                   "wpt_layout": "2020",
                                   "profile": "release",
                                   "unit_tests": True,
-                                  'build_libservo': False,
+                                  'build_libservo': True,
                                   'bencher': True,
                                   "wpt_args": ""
                               },
                               {
-                                  "name": "MacOS (Unit Tests)",
+                                  "name": "MacOS (Unit Tests, Build libservo)",
                                   "workflow": "macos",
                                   "wpt_layout": "none",
                                   "profile": "release",
                                   "unit_tests": True,
-                                  'build_libservo': False,
+                                  'build_libservo': True,
                                   'bencher': False,
                                   "wpt_args": ""
                               },
                               {
-                                  "name": "Windows (Unit Tests)",
+                                  "name": "Windows (Unit Tests, Build libservo)",
                                   "workflow": "windows",
                                   "wpt_layout": "none",
                                   "profile": "release",
                                   "unit_tests": True,
-                                  'build_libservo': False,
+                                  'build_libservo': True,
                                   'bencher': False,
                                   "wpt_args": ""
                               },


### PR DESCRIPTION
This patch enables the libservo and winit_minimal builds by default for pull requests and mach try full, reverting #35180. It supersedes #35182 by freeing space taken by the libservo build before building servoshell.

- [ ] Rerun test builds with [prebuilt libservo and winit_minimal](https://github.com/servo/ci-runners/commit/cc1295d66ffd7743095e36523c05d7c015dfe13a)
- [ ] Remove from pull_request and maybe full, but keep in merge queue?

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] ~~These changes fix #___ (GitHub issue number if applicable)~~

<!-- Either: -->
- [ ] CI test plan
  - [x] [self-hosted mach try linux-build-libservo](https://github.com/servo/servo/actions/runs/13561148225)
  - [x] [GitHub-hosted mach try linux-build-libservo](https://github.com/servo/servo/actions/runs/13562674575)
  - [x] [self-hosted mach try full](https://github.com/servo/servo/actions/runs/13561135206)
  - [x] [GitHub-hosted mach try full](https://github.com/servo/servo/actions/runs/13562683508)