### PR TITLE
layout: Merge `BoxFragment::used_overflow` into `ComputedValuesExt::effective_overflow`

### DIFF
--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -2510,7 +2510,7 @@ impl FlexItemBox {
     ) -> Au {
         // FIXME(stshine): Consider more situations when auto min size is not needed.
         let style = &self.independent_formatting_context.style();
-        if style.establishes_scroll_container() {
+        if style.establishes_scroll_container(self.base_fragment_info().flags) {
             return Au::zero();
         }
 

--- a/components/layout_2020/flow/construct.rs
+++ b/components/layout_2020/flow/construct.rs
@@ -25,6 +25,7 @@ use crate::dom_traversal::{
 use crate::flow::float::FloatBox;
 use crate::flow::{BlockContainer, BlockFormattingContext, BlockLevelBox};
 use crate::formatting_contexts::IndependentFormattingContext;
+use crate::fragment_tree::FragmentFlags;
 use crate::layout_box_base::LayoutBoxBase;
 use crate::positioned::AbsolutelyPositionedBox;
 use crate::style_ext::{ComputedValuesExt, DisplayGeneratingBox, DisplayInside, DisplayOutside};
@@ -493,7 +494,11 @@ where
         let kind = match contents {
             Contents::NonReplaced(contents) => match display_inside {
                 DisplayInside::Flow { is_list_item }
-                    if !info.style.establishes_block_formatting_context() =>
+                    // Fragment flags are just used to indicate that the element is not replaced, so empty
+                    // flags are okay here.
+                    if !info.style.establishes_block_formatting_context(
+                        FragmentFlags::empty()
+                    ) =>
                 {
                     BlockLevelCreator::SameFormattingContextBlock(
                         IntermediateBlockContainer::Deferred {

--- a/components/layout_2020/fragment_tree/box_fragment.rs
+++ b/components/layout_2020/fragment_tree/box_fragment.rs
@@ -154,7 +154,7 @@ impl BoxFragment {
         //
         // This applies even if there is no baseline set, so we unconditionally set the value here
         // and ignore anything that is set via [`Self::with_baselines`].
-        if self.style.establishes_scroll_container() {
+        if self.style.establishes_scroll_container(self.base.flags) {
             let content_rect_size = self.content_rect.size.to_logical(writing_mode);
             let padding = self.padding.to_logical(writing_mode);
             let border = self.border.to_logical(writing_mode);
@@ -228,7 +228,7 @@ impl BoxFragment {
             self.clearance,
             self.scrollable_overflow(),
             self.baselines,
-            self.style.effective_overflow(),
+            self.style.effective_overflow(self.base.flags),
         ));
 
         for child in &self.children {
@@ -239,7 +239,7 @@ impl BoxFragment {
 
     pub fn scrollable_overflow_for_parent(&self) -> PhysicalRect<Au> {
         let mut overflow = self.border_rect();
-        if self.style.establishes_scroll_container() {
+        if self.style.establishes_scroll_container(self.base.flags) {
             return overflow;
         }
 
@@ -251,7 +251,7 @@ impl BoxFragment {
             overflow.max_y().max(scrollable_overflow.max_y()),
         );
 
-        let overflow_style = self.style.effective_overflow();
+        let overflow_style = self.style.effective_overflow(self.base.flags);
         if overflow_style.y == ComputedOverflow::Visible {
             overflow.origin.y = overflow.origin.y.min(scrollable_overflow.origin.y);
             overflow.size.height = bottom_right.y - overflow.origin.y;

--- a/tests/wpt/meta/css/css-overflow/overflow-img-display-table.html.ini
+++ b/tests/wpt/meta/css/css-overflow/overflow-img-display-table.html.ini
@@ -1,2 +1,0 @@
-[overflow-img-display-table.html]
-  expected: FAIL


### PR DESCRIPTION
1. Merge `used_overflow` to `effective_overflow`
2. Remove duplicate call
3. Add link to spec, as the Overflow handling for replaced element is different in: 
 

- [Level 4](https://www.w3.org/TR/css-overflow-4/#overflow-control): On [replaced elements](https://www.w3.org/TR/css-display-3/#replaced-element), the [used values](https://www.w3.org/TR/CSS21/cascade.html#used-value) of all computed values other than [visible](https://www.w3.org/TR/css-overflow-3/#valdef-overflow-visible) is [clip](https://www.w3.org/TR/css-overflow-3/#valdef-overflow-clip).
- [Level 3 Draft](https://drafts.csswg.org/css-overflow-3/#overflow-control): On [replaced elements](https://drafts.csswg.org/css-display-4/#replaced-element), a [computed](https://drafts.csswg.org/css-cascade-5/#computed-value) 'hidden' value further resolves to a [used value](https://drafts.csswg.org/css-cascade-5/#used-value) of 'clip'.
- [Level 3](https://www.w3.org/TR/css-overflow-3/#overflow-control): No special handling for replaced element

Our implementation conforms to the Level 4.

4. Add comment that was missing before, to cite that viewport overflow must be interpreted as scrollable.

cc @xiaochengh 
 
---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] This is a follow up of #35103 

<!-- Either: -->
- [x] These changes require [tests here](https://github.com/yezhizhen/servo/actions/runs/13612930918)
`/css/css-overflow/overflow-img-display-table.html` is now passing. (Border radius clipped the image)

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
