### PR TITLE
Blocks all background webview interactions when a dialog is open

### DIFF
--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -364,7 +364,7 @@ impl ApplicationHandler<WakerEvent> for App {
                 },
                 ref event => {
                     let response =
-                        minibrowser.on_window_event(window.winit_window().unwrap(), event);
+                        minibrowser.on_window_event(window.winit_window().unwrap(), state, event);
                     // Update minibrowser if there's resize event to sync up with window.
                     if let WindowEvent::Resized(_) = event {
                         minibrowser.update(

--- a/ports/servoshell/desktop/app_state.rs
+++ b/ports/servoshell/desktop/app_state.rs
@@ -292,15 +292,22 @@ impl RunningAppState {
         inner_mut.need_update = true;
     }
 
-    fn has_active_dialog(&self) -> bool {
-        let Some(webview) = self.focused_webview() else {
+    pub(crate) fn has_active_dialog(&self) -> bool {
+        let last_created_webview_id = self.inner().creation_order.last().cloned();
+        let Some(webview_id) = self
+            .focused_webview()
+            .as_ref()
+            .map(WebView::id)
+            .or(last_created_webview_id)
+        else {
             return false;
         };
+
         let inner = self.inner();
-        let Some(dialogs) = inner.dialogs.get(&webview.id()) else {
-            return false;
-        };
-        !dialogs.is_empty()
+        inner
+            .dialogs
+            .get(&webview_id)
+            .is_some_and(|dialogs| !dialogs.is_empty())
     }
 
     pub(crate) fn get_focused_webview_index(&self) -> Option<usize> {

--- a/ports/servoshell/desktop/minibrowser.rs
+++ b/ports/servoshell/desktop/minibrowser.rs
@@ -117,8 +117,19 @@ impl Minibrowser {
     /// Preprocess the given [winit::event::WindowEvent], returning unconsumed for mouse events in
     /// the Servo browser rect. This is needed because the CentralPanel we create for our webview
     /// would otherwise make egui report events in that area as consumed.
-    pub fn on_window_event(&mut self, window: &Window, event: &WindowEvent) -> EventResponse {
+    pub fn on_window_event(
+        &mut self,
+        window: &Window,
+        app_state: &RunningAppState,
+        event: &WindowEvent,
+    ) -> EventResponse {
         let mut result = self.context.on_window_event(window, event);
+
+        if app_state.has_active_dialog() {
+            result.consumed = true;
+            return result;
+        }
+
         result.consumed &= match event {
             WindowEvent::CursorMoved { position, .. } => {
                 let scale = Scale::<_, DeviceIndependentPixel, _>::new(


### PR DESCRIPTION
Prevents interaction with the current webview elements when an attached dialog is open.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
