### PR TITLE
Make auxiliary webviews exist in the constellation immediately

### DIFF
--- a/components/constellation/tracing.rs
+++ b/components/constellation/tracing.rs
@@ -167,7 +167,7 @@ mod from_script {
                 Self::SetThrottledComplete(..) => target!("SetThrottledComplete"),
                 Self::ScriptLoadedURLInIFrame(..) => target!("ScriptLoadedURLInIFrame"),
                 Self::ScriptNewIFrame(..) => target!("ScriptNewIFrame"),
-                Self::ScriptNewAuxiliary(..) => target!("ScriptNewAuxiliary"),
+                Self::CreateAuxiliaryWebView(..) => target!("ScriptNewAuxiliary"),
                 Self::ActivateDocument => target!("ActivateDocument"),
                 Self::SetDocumentState(..) => target!("SetDocumentState"),
                 Self::SetLayoutEpoch(..) => target!("SetLayoutEpoch"),

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -22,7 +22,7 @@ use background_hang_monitor_api::BackgroundHangMonitorRegister;
 use base::cross_process_instant::CrossProcessInstant;
 use base::id::{
     BlobId, BrowsingContextId, HistoryStateId, MessagePortId, PipelineId, PipelineNamespaceId,
-    TopLevelBrowsingContextId,
+    TopLevelBrowsingContextId, WebViewId,
 };
 use base::Epoch;
 use bitflags::bitflags;
@@ -561,16 +561,23 @@ pub enum IFrameSandboxState {
 
 /// Specifies the information required to load an auxiliary browsing context.
 #[derive(Debug, Deserialize, Serialize)]
-pub struct AuxiliaryBrowsingContextLoadInfo {
+pub struct AuxiliaryWebViewCreationRequest {
     /// Load data containing the url to load
     pub load_data: LoadData,
+    /// The webview that caused this request.
+    pub opener_webview_id: WebViewId,
     /// The pipeline opener browsing context.
     pub opener_pipeline_id: PipelineId,
-    /// The new top-level ID for the auxiliary.
-    pub new_top_level_browsing_context_id: TopLevelBrowsingContextId,
-    /// The new browsing context ID.
-    pub new_browsing_context_id: BrowsingContextId,
-    /// The new pipeline ID for the auxiliary.
+    /// Sender for the constellation’s response to our request.
+    pub response_sender: IpcSender<Option<AuxiliaryWebViewCreationResponse>>,
+}
+
+/// Constellation’s response to auxiliary browsing context creation requests.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct AuxiliaryWebViewCreationResponse {
+    /// The new webview ID.
+    pub new_webview_id: WebViewId,
+    /// The new pipeline ID.
     pub new_pipeline_id: PipelineId,
 }
 

--- a/components/shared/script/script_msg.rs
+++ b/components/shared/script/script_msg.rs
@@ -28,7 +28,7 @@ use style_traits::CSSPixel;
 use webgpu::{wgc, WebGPU, WebGPUResponse};
 
 use crate::{
-    AnimationState, AuxiliaryBrowsingContextLoadInfo, BroadcastMsg, DocumentState,
+    AnimationState, AuxiliaryWebViewCreationRequest, BroadcastMsg, DocumentState,
     IFrameLoadInfoWithData, LoadData, MessagePortMsg, NavigationHistoryBehavior, PortMessageTask,
     StructuredSerializedData, WindowSizeType, WorkerGlobalScopeInit, WorkerScriptLoadOrigin,
 };
@@ -207,7 +207,7 @@ pub enum ScriptMsg {
     /// A load of the initial `about:blank` has been completed in an IFrame.
     ScriptNewIFrame(IFrameLoadInfoWithData),
     /// Script has opened a new auxiliary browsing context.
-    ScriptNewAuxiliary(AuxiliaryBrowsingContextLoadInfo),
+    CreateAuxiliaryWebView(AuxiliaryWebViewCreationRequest),
     /// Mark a new document as active
     ActivateDocument,
     /// Set the document state for a pipeline (used by screenshot / reftests)
@@ -289,7 +289,7 @@ impl fmt::Debug for ScriptMsg {
             SetThrottledComplete(..) => "SetThrottledComplete",
             ScriptLoadedURLInIFrame(..) => "ScriptLoadedURLInIFrame",
             ScriptNewIFrame(..) => "ScriptNewIFrame",
-            ScriptNewAuxiliary(..) => "ScriptNewAuxiliary",
+            CreateAuxiliaryWebView(..) => "ScriptNewAuxiliary",
             ActivateDocument => "ActivateDocument",
             SetDocumentState(..) => "SetDocumentState",
             SetLayoutEpoch(..) => "SetLayoutEpoch",


### PR DESCRIPTION
To allow embedders to interact with webviews as soon as they are created, we need to ensure that they exist in both the compositor and the constellation before those interactions happen. #35662 does this for the compositor, while this patch does this for the constellation.

When a webview opens another webview (via &lt;a target>, &lt;form target>, window.open(), etc), the embedder creates an “auxiliary” webview, which previously went as follows:

- script create_auxiliary_browsing_context
- libservo AllowOpeningWebView
- embedder request_open_auxiliary_webview (→ constellation FocusWebView)
- script create_auxiliary_browsing_context
- constellation ScriptNewAuxiliary

In that model, the constellation may receive FocusWebView before it receives ScriptNewAuxiliary. Now they are created as follows:

- script create_auxiliary_browsing_context
- constellation CreateAuxiliaryWebView
- libservo AllowOpeningWebView
- embedder request_open_auxiliary_webview (→ constellation FocusWebView)
- constellation CreateAuxiliaryWebView
- script create_auxiliary_browsing_context

Since these messages are all synchronous and the constellation will have set up the webview before handling any new messages, the webview will always exist by the time we handle the embedder’s FocusWebView.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] ~~These changes fix #___ (GitHub issue number if applicable)~~

<!-- Either: -->
- [x] These changes are covered by tests that open auxiliary webviews
- [ ] These changes do not require tests because ___