### PR TITLE
Remove `tinyfiledialogs` dependency from `Cargo.toml`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6928,7 +6928,6 @@ dependencies = [
  "shellwords",
  "sig",
  "surfman",
- "tinyfiledialogs",
  "tokio",
  "tracing",
  "tracing-perfetto",
@@ -7679,16 +7678,6 @@ dependencies = [
  "arrayref",
  "bytemuck",
  "strict-num",
-]
-
-[[package]]
-name = "tinyfiledialogs"
-version = "3.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "848eb50d6d21430349d82418c2244f611b1ad3e1c52c675320338b3102d06554"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]

--- a/deny.toml
+++ b/deny.toml
@@ -39,7 +39,6 @@ allow = [
     "Ubuntu-font-1.0",
     "Unicode-3.0",
     "Zlib",
-    "zlib-acknowledgement",
 ]
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -123,7 +123,6 @@ net_traits = { workspace = true }
 serde_json = { workspace = true }
 shellwords = "1.0.0"
 surfman = { workspace = true, features = ["sm-x11", "sm-raw-window-handle-06"] }
-tinyfiledialogs = "3.0"
 egui-file-dialog = "0.9.0"
 winit = "0.30.9"
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

- removed `zlib-acknowledgement` license as well since only `tinyfiledialogs` required it,
---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
