### PR TITLE
Fix /_mozilla/css/text_transform_uppercase_a.html to not be intermittent

### DIFF
--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -6552,7 +6552,7 @@
      ]
     ],
     "text_transform_uppercase_a.html": [
-     "fe96b8ad64530a0e30085c1ec61820b9c79493e1",
+     "0fb0122a403803d712fbca97f93bd6ddd0abb6d9",
      [
       null,
       [
@@ -10087,7 +10087,7 @@
      []
     ],
     "text_transform_uppercase_ref.html": [
-     "97d2f366ea32246c55b7a8c01a89c1df86c3378c",
+     "9b21f2d40a957eeb690eb4919925659e0cc23c71",
      []
     ],
     "textarea_space_calculation-ref.html": [

--- a/tests/wpt/mozilla/tests/css/text_transform_uppercase_a.html
+++ b/tests/wpt/mozilla/tests/css/text_transform_uppercase_a.html
@@ -1,9 +1,14 @@
 <!DOCTYPE html>
-<html>
+<html class="reftest-wait">
 <link rel='match' href='text_transform_uppercase_ref.html'>
 <!-- Tests that `text-transform: uppercase` works. -->
 <body>
 <h1 style='text-transform: uppercase; font-family: Hiragino Maru Gothic Pro'>You çan do anything at ゾムボ.com</h1>
+<script>
+document.fonts.ready.then(() => {
+  document.documentElement.className = "";
+});
+</script>
 </body>
 </html>
 

--- a/tests/wpt/mozilla/tests/css/text_transform_uppercase_ref.html
+++ b/tests/wpt/mozilla/tests/css/text_transform_uppercase_ref.html
@@ -1,8 +1,13 @@
 <!DOCTYPE html>
-<html>
+<html class="reftest-wait">
 <!-- Tests that `text-transform: uppercase` works. -->
 <body>
 <h1 style='font-family: Hiragino Maru Gothic Pro'>YOU ÇAN DO ANYTHING AT ゾムボ.COM</h1>
+<script>
+document.fonts.ready.then(() => {
+  document.documentElement.className = "";
+});
+</script>
 </body>
 </html>
 


### PR DESCRIPTION
It was sometimes failing because it uses the `Hiragino Maru Gothic Pro` font, but wasn't waiting for it to be ready. Failure example: https://github.com/servo/servo/actions/runs/13527551465/job/37802996305

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #35679
- [X] These changes do not require tests because this is purely a test change

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
