### PR TITLE
Allow webdriver screenshots to occur immediately upon request.

### DIFF
--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -583,7 +583,7 @@ pub(crate) fn parse_command_line_arguments(args: Vec<String>) -> ArgumentParsing
     }
 
     let exit_after_load = opt_match.opt_present("x") || output_image_path.is_some();
-    let wait_for_stable_image = exit_after_load || webdriver_port.is_some();
+    let wait_for_stable_image = exit_after_load;
     let servoshell_preferences = ServoShellPreferences {
         user_agent: opt_match.opt_str("u"),
         url,


### PR DESCRIPTION
This fixes a regression from #35538 that made servodriver unusable. There's no reason that screenshots initiated from webdriver need to occur in the stable state—it's not part of the [specification](https://w3c.github.io/webdriver/#take-screenshot), and it's not required for passing conformance tests. Any pageload synchronization should be the responsibility of the webdriver client, instead.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #35667
- [x] These changes do not require tests because we don't run our webdriver harness in CI yet