### PR TITLE
servoshell: Use sRGB colorspace on macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6930,6 +6930,8 @@ dependencies = [
  "net",
  "net_traits",
  "nix",
+ "objc2-app-kit",
+ "objc2-foundation",
  "ohos-ime",
  "ohos-ime-sys",
  "ohos-vsync",

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -131,3 +131,16 @@ sig = "1.0"
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { workspace = true, features = ["Win32_Graphics_Gdi"] }
 libservo = { path = "../../components/servo", features = ["no-wgl"] }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2 = "0.5.2"
+objc2-app-kit = { version = "0.2.2", default-features = false, features = [
+    "std",
+    "NSColorSpace",
+    "NSResponder",
+    "NSView",
+    "NSWindow",
+] }
+objc2-foundation = { version = "0.2.2", default-features = false, features = [
+    "std",
+] }

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -133,7 +133,6 @@ windows-sys = { workspace = true, features = ["Win32_Graphics_Gdi"] }
 libservo = { path = "../../components/servo", features = ["no-wgl"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-objc2 = "0.5.2"
 objc2-app-kit = { version = "0.2.2", default-features = false, features = [
     "std",
     "NSColorSpace",

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -13,7 +13,7 @@ use std::time::Duration;
 use euclid::{Angle, Length, Point2D, Rotation3D, Scale, Size2D, UnknownUnit, Vector2D, Vector3D};
 use keyboard_types::{Modifiers, ShortcutMatcher};
 use log::{debug, info};
-use raw_window_handle::{HasDisplayHandle, HasWindowHandle, RawWindowHandle};
+use raw_window_handle::{HasDisplayHandle, HasWindowHandle};
 use servo::compositing::windowing::{
     AnimationState, EmbedderCoordinates, WebRenderDebugOption, WindowMethods,
 };
@@ -41,6 +41,7 @@ use winit::window::Icon;
 use {
     objc2_app_kit::{NSColorSpace, NSView},
     objc2_foundation::MainThreadMarker,
+    raw_window_handle::RawWindowHandle,
 };
 
 use super::app_state::RunningAppState;

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -13,7 +13,7 @@ use std::time::Duration;
 use euclid::{Angle, Length, Point2D, Rotation3D, Scale, Size2D, UnknownUnit, Vector2D, Vector3D};
 use keyboard_types::{Modifiers, ShortcutMatcher};
 use log::{debug, info};
-use raw_window_handle::{HasDisplayHandle, HasWindowHandle};
+use raw_window_handle::{HasDisplayHandle, HasWindowHandle, RawWindowHandle};
 use servo::compositing::windowing::{
     AnimationState, EmbedderCoordinates, WebRenderDebugOption, WindowMethods,
 };
@@ -41,7 +41,6 @@ use winit::window::Icon;
 use {
     objc2_app_kit::{NSColorSpace, NSView},
     objc2_foundation::MainThreadMarker,
-    raw_window_handle::RawWindowHandle,
 };
 
 use super::app_state::RunningAppState;
@@ -432,8 +431,7 @@ impl Window {
     fn force_srgb_color_space(window_handle: RawWindowHandle) {
         #[cfg(target_os = "macos")]
         {
-            if let RawWindowHandle::AppKit(handle) = window_handle
-            {
+            if let RawWindowHandle::AppKit(handle) = window_handle {
                 assert!(MainThreadMarker::new().is_some());
                 unsafe {
                     let view = handle.ns_view.cast::<NSView>().as_ref();

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -109,19 +109,15 @@ impl Window {
 
         #[cfg(target_os = "macos")]
         {
-            let view = match winit_window.window_handle().unwrap().as_raw() {
-                RawWindowHandle::AppKit(handle) => {
-                    assert!(MainThreadMarker::new().is_some());
-                    unsafe { Some(handle.ns_view.cast::<NSView>().as_ref()) }
-                },
-                _ => None,
-            };
-
-            unsafe {
-                view.unwrap()
-                    .window()
-                    .unwrap()
-                    .setColorSpace(Some(&NSColorSpace::sRGBColorSpace()));
+            if let RawWindowHandle::AppKit(handle) = winit_window.window_handle().unwrap().as_raw()
+            {
+                assert!(MainThreadMarker::new().is_some());
+                unsafe {
+                    let view = handle.ns_view.cast::<NSView>().as_ref();
+                    view.window()
+                        .unwrap()
+                        .setColorSpace(Some(&NSColorSpace::sRGBColorSpace()));
+                }
             }
         }
 

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -107,19 +107,7 @@ impl Window {
             winit_window.set_window_icon(Some(load_icon(icon_bytes)));
         }
 
-        #[cfg(target_os = "macos")]
-        {
-            if let RawWindowHandle::AppKit(handle) = winit_window.window_handle().unwrap().as_raw()
-            {
-                assert!(MainThreadMarker::new().is_some());
-                unsafe {
-                    let view = handle.ns_view.cast::<NSView>().as_ref();
-                    view.window()
-                        .unwrap()
-                        .setColorSpace(Some(&NSColorSpace::sRGBColorSpace()));
-                }
-            }
-        }
+        Window::force_srgb_color_space(winit_window.window_handle().unwrap().as_raw());
 
         let monitor = winit_window
             .current_monitor()
@@ -439,6 +427,22 @@ impl Window {
 
     pub(crate) fn offscreen_rendering_context(&self) -> Rc<OffscreenRenderingContext> {
         self.rendering_context.clone()
+    }
+
+    fn force_srgb_color_space(window_handle: RawWindowHandle) {
+        #[cfg(target_os = "macos")]
+        {
+            if let RawWindowHandle::AppKit(handle) = window_handle
+            {
+                assert!(MainThreadMarker::new().is_some());
+                unsafe {
+                    let view = handle.ns_view.cast::<NSView>().as_ref();
+                    view.window()
+                        .unwrap()
+                        .setColorSpace(Some(&NSColorSpace::sRGBColorSpace()));
+                }
+            }
+        }
     }
 }
 

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -428,6 +428,7 @@ impl Window {
         self.rendering_context.clone()
     }
 
+    #[allow(unused_variables)]
     fn force_srgb_color_space(window_handle: RawWindowHandle) {
         #[cfg(target_os = "macos")]
         {


### PR DESCRIPTION
By default, macOS will use a `NSWindow` in Display P3, in the case of Servo, which lacks proper color space management, this results in sRGB colors becoming oversaturated and bright as they are improperly displayed. To resolve this, we can force macOS to use an sRGB `NSWindow`.

This will of course need to be changed/removed if and when Servo gains proper wide color gamut support.

This change does not fix the improper clipping of wide color gamut values observed in the original issue.

Before:
<img width="300" alt="Screenshot 2025-02-26 at 12 15 27" src="https://github.com/user-attachments/assets/e2755762-528e-479c-a6d2-f8d1e7fa3285" />

After:
<img width="300" alt="Screenshot 2025-02-26 at 12 14 26" src="https://github.com/user-attachments/assets/77667e4c-ae79-4d69-a131-6ab7c7f9c024" />


---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes improve, but don't fix #33676,  #33356
- [X] These changes do not require tests because they only affect servoshell presentation