### PR TITLE
Support single-value `<select>` elements

### DIFF
--- a/components/constellation/tracing.rs
+++ b/components/constellation/tracing.rs
@@ -236,6 +236,7 @@ mod from_script {
                 Self::StopGamepadHapticEffect(..) => target_variant!("StopGamepadHapticEffect"),
                 Self::ShutdownComplete => target_variant!("ShutdownComplete"),
                 Self::ShowNotification(..) => target_variant!("ShowNotification"),
+                Self::ShowSelectElementMenu(..) => target_variant!("ShowSelectElementMenu"),
             }
         }
     }

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -1387,7 +1387,7 @@ impl Document {
 
         let node = unsafe { node::from_untrusted_compositor_node_address(hit_test_result.node) };
         let Some(el) = node
-            .inclusive_ancestors(ShadowIncluding::No)
+            .inclusive_ancestors(ShadowIncluding::Yes)
             .filter_map(DomRoot::downcast::<Element>)
             .next()
         else {

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -1291,6 +1291,10 @@ impl Document {
             return None;
         };
 
+        if response.is_some() && response != selected_index {
+            select_element.selection_changed(can_gc);
+        }
+
         response
     }
 

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -4379,6 +4379,12 @@ impl Element {
                 let element = self.downcast::<HTMLLabelElement>().unwrap();
                 Some(element as &dyn Activatable)
             },
+            NodeTypeId::Element(ElementTypeId::HTMLElement(
+                HTMLElementTypeId::HTMLSelectElement,
+            )) => {
+                let element = self.downcast::<HTMLSelectElement>().unwrap();
+                Some(element as &dyn Activatable)
+            },
             NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLElement)) => {
                 let element = self.downcast::<HTMLElement>().unwrap();
                 Some(element as &dyn Activatable)

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -514,7 +514,6 @@ impl Element {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn attach_shadow(
         &self,
-        // TODO: remove is_ua_widget argument
         is_ua_widget: IsUserAgentWidget,
         mode: ShadowRootMode,
         clonable: bool,

--- a/components/script/dom/htmloptionelement.rs
+++ b/components/script/dom/htmloptionelement.rs
@@ -175,7 +175,7 @@ fn collect_text(element: &Element, value: &mut String) {
 }
 
 impl HTMLOptionElementMethods<crate::DomTypeHolder> for HTMLOptionElement {
-    // https://html.spec.whatwg.org/multipage/#dom-option
+    /// <https://html.spec.whatwg.org/multipage/#dom-option>
     fn Option(
         window: &Window,
         proto: Option<HandleObject>,
@@ -217,19 +217,19 @@ impl HTMLOptionElementMethods<crate::DomTypeHolder> for HTMLOptionElement {
     // https://html.spec.whatwg.org/multipage/#dom-option-disabled
     make_bool_setter!(SetDisabled, "disabled");
 
-    // https://html.spec.whatwg.org/multipage/#dom-option-text
+    /// <https://html.spec.whatwg.org/multipage/#dom-option-text>
     fn Text(&self) -> DOMString {
         let mut content = String::new();
         collect_text(self.upcast(), &mut content);
         DOMString::from(str_join(split_html_space_chars(&content), " "))
     }
 
-    // https://html.spec.whatwg.org/multipage/#dom-option-text
+    /// <https://html.spec.whatwg.org/multipage/#dom-option-text>
     fn SetText(&self, value: DOMString, can_gc: CanGc) {
         self.upcast::<Node>().SetTextContent(Some(value), can_gc)
     }
 
-    // https://html.spec.whatwg.org/multipage/#dom-option-form
+    /// <https://html.spec.whatwg.org/multipage/#dom-option-form>
     fn GetForm(&self) -> Option<DomRoot<HTMLFormElement>> {
         let parent = self.upcast::<Node>().GetParentNode().and_then(|p| {
             if p.is::<HTMLOptGroupElement>() {
@@ -242,7 +242,7 @@ impl HTMLOptionElementMethods<crate::DomTypeHolder> for HTMLOptionElement {
         parent.and_then(|p| p.downcast::<HTMLSelectElement>().and_then(|s| s.GetForm()))
     }
 
-    // https://html.spec.whatwg.org/multipage/#attr-option-value
+    /// <https://html.spec.whatwg.org/multipage/#attr-option-value>
     fn Value(&self) -> DOMString {
         let element = self.upcast::<Element>();
         let attr = &local_name!("value");
@@ -256,7 +256,7 @@ impl HTMLOptionElementMethods<crate::DomTypeHolder> for HTMLOptionElement {
     // https://html.spec.whatwg.org/multipage/#attr-option-value
     make_setter!(SetValue, "value");
 
-    // https://html.spec.whatwg.org/multipage/#attr-option-label
+    /// <https://html.spec.whatwg.org/multipage/#attr-option-label>
     fn Label(&self) -> DOMString {
         let element = self.upcast::<Element>();
         let attr = &local_name!("label");
@@ -276,12 +276,12 @@ impl HTMLOptionElementMethods<crate::DomTypeHolder> for HTMLOptionElement {
     // https://html.spec.whatwg.org/multipage/#dom-option-defaultselected
     make_bool_setter!(SetDefaultSelected, "selected");
 
-    // https://html.spec.whatwg.org/multipage/#dom-option-selected
+    /// <https://html.spec.whatwg.org/multipage/#dom-option-selected>
     fn Selected(&self) -> bool {
         self.selectedness.get()
     }
 
-    // https://html.spec.whatwg.org/multipage/#dom-option-selected
+    /// <https://html.spec.whatwg.org/multipage/#dom-option-selected>
     fn SetSelected(&self, selected: bool) {
         self.dirtiness.set(true);
         self.selectedness.set(selected);
@@ -289,7 +289,7 @@ impl HTMLOptionElementMethods<crate::DomTypeHolder> for HTMLOptionElement {
         self.update_select_validity(CanGc::note());
     }
 
-    // https://html.spec.whatwg.org/multipage/#dom-option-index
+    /// <https://html.spec.whatwg.org/multipage/#dom-option-index>
     fn Index(&self) -> i32 {
         self.index()
     }

--- a/components/script/dom/htmloptionelement.rs
+++ b/components/script/dom/htmloptionelement.rs
@@ -146,6 +146,23 @@ impl HTMLOptionElement {
                 .perform_validation_and_update(ValidationFlags::all(), can_gc);
         }
     }
+
+    /// <https://html.spec.whatwg.org/multipage/#concept-option-label>
+    ///
+    /// Note that this is not equivalent to <https://html.spec.whatwg.org/multipage/#dom-option-label>.
+    pub(crate) fn displayed_label(&self) -> DOMString {
+        // > The label of an option element is the value of the label content attribute, if there is one
+        // > and its value is not the empty string, or, otherwise, the value of the element's text IDL attribute.
+        let label = self
+            .upcast::<Element>()
+            .get_string_attribute(&local_name!("label"));
+
+        if label.is_empty() {
+            return self.Text();
+        }
+
+        label
+    }
 }
 
 // FIXME(ajeffrey): Provide a way of buffering DOMStrings other than using Strings

--- a/components/script/dom/htmloptionscollection.rs
+++ b/components/script/dom/htmloptionscollection.rs
@@ -240,11 +240,11 @@ impl HTMLOptionsCollectionMethods<crate::DomTypeHolder> for HTMLOptionsCollectio
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-htmloptionscollection-selectedindex>
-    fn SetSelectedIndex(&self, index: i32) {
+    fn SetSelectedIndex(&self, index: i32, can_gc: CanGc) {
         self.upcast()
             .root_node()
             .downcast::<HTMLSelectElement>()
             .expect("HTMLOptionsCollection not rooted on a HTMLSelectElement")
-            .SetSelectedIndex(index)
+            .SetSelectedIndex(index, can_gc)
     }
 }

--- a/components/script/dom/htmlselectelement.rs
+++ b/components/script/dom/htmlselectelement.rs
@@ -330,10 +330,27 @@ impl HTMLSelectElement {
             .or_else(|| self.list_of_options().next())
             .map(|option| option.Label())
             .unwrap_or_default();
+
+        // Replace newlines with whitespace, then collapse and trim whitespace
+        let mut displayed_text = String::with_capacity(selected_option_text.len());
+        let mut last_was_whitespace = false;
+        for c in selected_option_text.chars() {
+            if c.is_whitespace() || matches!(c, '\n' | '\r') {
+                if !last_was_whitespace {
+                    displayed_text.push(' ');
+                } else {
+                    last_was_whitespace = true;
+                }
+            } else {
+                displayed_text.push(c);
+                last_was_whitespace = false;
+            }
+        }
+
         shadow_tree
             .selected_option
             .upcast::<CharacterData>()
-            .SetData(selected_option_text);
+            .SetData(displayed_text.trim().into());
     }
 
     pub(crate) fn selection_changed(&self, can_gc: CanGc) {

--- a/components/script/dom/htmlselectelement.rs
+++ b/components/script/dom/htmlselectelement.rs
@@ -328,7 +328,7 @@ impl HTMLSelectElement {
         let selected_option_text = self
             .selected_option()
             .or_else(|| self.list_of_options().next())
-            .map(|option| option.Label())
+            .map(|option| option.displayed_label())
             .unwrap_or_default();
 
         // Replace newlines with whitespace, then collapse and trim whitespace

--- a/components/script/dom/htmlselectelement.rs
+++ b/components/script/dom/htmlselectelement.rs
@@ -366,7 +366,7 @@ impl HTMLSelectElement {
 }
 
 impl HTMLSelectElementMethods<crate::DomTypeHolder> for HTMLSelectElement {
-    // https://html.spec.whatwg.org/multipage/#dom-select-add
+    /// <https://html.spec.whatwg.org/multipage/#dom-select-add>
     fn Add(
         &self,
         element: HTMLOptionElementOrHTMLOptGroupElement,
@@ -381,7 +381,7 @@ impl HTMLSelectElementMethods<crate::DomTypeHolder> for HTMLSelectElement {
     // https://html.spec.whatwg.org/multipage/#dom-fe-disabled
     make_bool_setter!(SetDisabled, "disabled");
 
-    // https://html.spec.whatwg.org/multipage/#dom-fae-form
+    /// <https://html.spec.whatwg.org/multipage/#dom-fae-form>
     fn GetForm(&self) -> Option<DomRoot<HTMLFormElement>> {
         self.form_owner()
     }
@@ -410,7 +410,7 @@ impl HTMLSelectElementMethods<crate::DomTypeHolder> for HTMLSelectElement {
     // https://html.spec.whatwg.org/multipage/#dom-select-size
     make_uint_setter!(SetSize, "size", DEFAULT_SELECT_SIZE);
 
-    // https://html.spec.whatwg.org/multipage/#dom-select-type
+    /// <https://html.spec.whatwg.org/multipage/#dom-select-type>
     fn Type(&self) -> DOMString {
         DOMString::from(if self.Multiple() {
             "select-multiple"
@@ -422,7 +422,7 @@ impl HTMLSelectElementMethods<crate::DomTypeHolder> for HTMLSelectElement {
     // https://html.spec.whatwg.org/multipage/#dom-lfe-labels
     make_labels_getter!(Labels, labels_node_list);
 
-    // https://html.spec.whatwg.org/multipage/#dom-select-options
+    /// <https://html.spec.whatwg.org/multipage/#dom-select-options>
     fn Options(&self) -> DomRoot<HTMLOptionsCollection> {
         self.options.or_init(|| {
             let window = self.owner_window();
@@ -430,27 +430,27 @@ impl HTMLSelectElementMethods<crate::DomTypeHolder> for HTMLSelectElement {
         })
     }
 
-    // https://html.spec.whatwg.org/multipage/#dom-select-length
+    /// <https://html.spec.whatwg.org/multipage/#dom-select-length>
     fn Length(&self) -> u32 {
         self.Options().Length()
     }
 
-    // https://html.spec.whatwg.org/multipage/#dom-select-length
+    /// <https://html.spec.whatwg.org/multipage/#dom-select-length>
     fn SetLength(&self, length: u32, can_gc: CanGc) {
         self.Options().SetLength(length, can_gc)
     }
 
-    // https://html.spec.whatwg.org/multipage/#dom-select-item
+    /// <https://html.spec.whatwg.org/multipage/#dom-select-item>
     fn Item(&self, index: u32) -> Option<DomRoot<Element>> {
         self.Options().upcast().Item(index)
     }
 
-    // https://html.spec.whatwg.org/multipage/#dom-select-item
+    /// <https://html.spec.whatwg.org/multipage/#dom-select-item>
     fn IndexedGetter(&self, index: u32) -> Option<DomRoot<Element>> {
         self.Options().IndexedGetter(index)
     }
 
-    // https://html.spec.whatwg.org/multipage/#dom-select-setter
+    /// <https://html.spec.whatwg.org/multipage/#dom-select-setter>
     fn IndexedSetter(
         &self,
         index: u32,
@@ -460,31 +460,31 @@ impl HTMLSelectElementMethods<crate::DomTypeHolder> for HTMLSelectElement {
         self.Options().IndexedSetter(index, value, can_gc)
     }
 
-    // https://html.spec.whatwg.org/multipage/#dom-select-nameditem
+    /// <https://html.spec.whatwg.org/multipage/#dom-select-nameditem>
     fn NamedItem(&self, name: DOMString) -> Option<DomRoot<HTMLOptionElement>> {
         self.Options()
             .NamedGetter(name)
             .and_then(DomRoot::downcast::<HTMLOptionElement>)
     }
 
-    // https://html.spec.whatwg.org/multipage/#dom-select-remove
+    /// <https://html.spec.whatwg.org/multipage/#dom-select-remove>
     fn Remove_(&self, index: i32) {
         self.Options().Remove(index)
     }
 
-    // https://html.spec.whatwg.org/multipage/#dom-select-remove
+    /// <https://html.spec.whatwg.org/multipage/#dom-select-remove>
     fn Remove(&self) {
         self.upcast::<Element>().Remove()
     }
 
-    // https://html.spec.whatwg.org/multipage/#dom-select-value
+    /// <https://html.spec.whatwg.org/multipage/#dom-select-value>
     fn Value(&self) -> DOMString {
         self.selected_option()
             .map(|opt_elem| opt_elem.Value())
             .unwrap_or_default()
     }
 
-    // https://html.spec.whatwg.org/multipage/#dom-select-value
+    /// <https://html.spec.whatwg.org/multipage/#dom-select-value>
     fn SetValue(&self, value: DOMString) {
         let mut opt_iter = self.list_of_options();
         // Reset until we find an <option> with a matching value
@@ -505,7 +505,7 @@ impl HTMLSelectElementMethods<crate::DomTypeHolder> for HTMLSelectElement {
             .perform_validation_and_update(ValidationFlags::VALUE_MISSING, CanGc::note());
     }
 
-    // https://html.spec.whatwg.org/multipage/#dom-select-selectedindex
+    /// <https://html.spec.whatwg.org/multipage/#dom-select-selectedindex>
     fn SelectedIndex(&self) -> i32 {
         self.list_of_options()
             .enumerate()
@@ -515,7 +515,7 @@ impl HTMLSelectElementMethods<crate::DomTypeHolder> for HTMLSelectElement {
             .unwrap_or(-1)
     }
 
-    // https://html.spec.whatwg.org/multipage/#dom-select-selectedindex
+    /// <https://html.spec.whatwg.org/multipage/#dom-select-selectedindex>
     fn SetSelectedIndex(&self, index: i32, can_gc: CanGc) {
         let mut opt_iter = self.list_of_options();
         for opt in opt_iter.by_ref().take(index as usize) {
@@ -534,32 +534,32 @@ impl HTMLSelectElementMethods<crate::DomTypeHolder> for HTMLSelectElement {
         self.update_shadow_tree(can_gc);
     }
 
-    // https://html.spec.whatwg.org/multipage/#dom-cva-willvalidate
+    /// <https://html.spec.whatwg.org/multipage/#dom-cva-willvalidate>
     fn WillValidate(&self) -> bool {
         self.is_instance_validatable()
     }
 
-    // https://html.spec.whatwg.org/multipage/#dom-cva-validity
+    /// <https://html.spec.whatwg.org/multipage/#dom-cva-validity>
     fn Validity(&self) -> DomRoot<ValidityState> {
         self.validity_state()
     }
 
-    // https://html.spec.whatwg.org/multipage/#dom-cva-checkvalidity
+    /// <https://html.spec.whatwg.org/multipage/#dom-cva-checkvalidity>
     fn CheckValidity(&self, can_gc: CanGc) -> bool {
         self.check_validity(can_gc)
     }
 
-    // https://html.spec.whatwg.org/multipage/#dom-cva-reportvalidity
+    /// <https://html.spec.whatwg.org/multipage/#dom-cva-reportvalidity>
     fn ReportValidity(&self, can_gc: CanGc) -> bool {
         self.report_validity(can_gc)
     }
 
-    // https://html.spec.whatwg.org/multipage/#dom-cva-validationmessage
+    /// <https://html.spec.whatwg.org/multipage/#dom-cva-validationmessage>
     fn ValidationMessage(&self) -> DOMString {
         self.validation_message()
     }
 
-    // https://html.spec.whatwg.org/multipage/#dom-cva-setcustomvalidity
+    /// <https://html.spec.whatwg.org/multipage/#dom-cva-setcustomvalidity>
     fn SetCustomValidity(&self, error: DOMString) {
         self.validity_state().set_custom_error_message(error);
     }

--- a/components/script/dom/htmlselectelement.rs
+++ b/components/script/dom/htmlselectelement.rs
@@ -322,7 +322,7 @@ impl HTMLSelectElement {
             .expect("UA shadow tree was not created")
     }
 
-    fn update_shadow_tree(&self, can_gc: CanGc) {
+    pub(crate) fn update_shadow_tree(&self, can_gc: CanGc) {
         let shadow_tree = self.shadow_tree(can_gc);
 
         let selected_option_text = self

--- a/components/script/dom/validitystate.rs
+++ b/components/script/dom/validitystate.rs
@@ -24,7 +24,7 @@ use crate::dom::node::Node;
 use crate::dom::window::Window;
 use crate::script_runtime::CanGc;
 
-// https://html.spec.whatwg.org/multipage/#validity-states
+/// <https://html.spec.whatwg.org/multipage/#validity-states>
 #[derive(Clone, Copy, JSTraceable, MallocSizeOf)]
 pub(crate) struct ValidationFlags(u32);
 

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -360,7 +360,7 @@ DOMInterfaces = {
 },
 
 'HTMLOptionsCollection': {
-    'canGc': ['IndexedSetter', 'SetLength']
+    'canGc': ['IndexedSetter', 'SetLength', 'SetSelectedIndex']
 },
 
 'HTMLOutputElement': {
@@ -376,7 +376,7 @@ DOMInterfaces = {
 },
 
 'HTMLSelectElement': {
-    'canGc': ['ReportValidity', 'SetLength', 'IndexedSetter', 'CheckValidity'],
+    'canGc': ['ReportValidity', 'SetLength', 'IndexedSetter', 'CheckValidity', 'SetSelectedIndex'],
 },
 
 'HTMLTableElement': {

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -125,7 +125,7 @@ pub use crate::servo_delegate::{ServoDelegate, ServoError};
 pub use crate::webview::WebView;
 pub use crate::webview_delegate::{
     AllowOrDenyRequest, AuthenticationRequest, NavigationRequest, PermissionRequest,
-    WebResourceLoad, WebViewDelegate,
+    SelectElementPrompt, WebResourceLoad, WebViewDelegate,
 };
 
 #[cfg(feature = "webdriver")]
@@ -969,6 +969,21 @@ impl Servo {
                 match webview_id.and_then(|webview_id| self.get_webview_handle(webview_id)) {
                     Some(webview) => webview.delegate().show_notification(webview, notification),
                     None => self.delegate().show_notification(notification),
+                }
+            },
+            EmbedderMsg::ShowSelectElementMenu(
+                webview_id,
+                options,
+                selected_option,
+                position,
+                ipc_sender,
+            ) => {
+                if let Some(webview) = self.get_webview_handle(webview_id) {
+                    let prompt =
+                        SelectElementPrompt::new(options, selected_option, position, ipc_sender);
+                    webview
+                        .delegate()
+                        .show_select_element_prompt(webview, prompt);
                 }
             },
         }

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -124,7 +124,7 @@ use crate::responders::ServoErrorChannel;
 pub use crate::servo_delegate::{ServoDelegate, ServoError};
 pub use crate::webview::WebView;
 pub use crate::webview_delegate::{
-    AllowOrDenyRequest, AuthenticationRequest, NavigationRequest, PermissionRequest,
+    AllowOrDenyRequest, AuthenticationRequest, FormControl, NavigationRequest, PermissionRequest,
     SelectElementPrompt, WebResourceLoad, WebViewDelegate,
 };
 
@@ -983,7 +983,7 @@ impl Servo {
                         SelectElementPrompt::new(options, selected_option, position, ipc_sender);
                     webview
                         .delegate()
-                        .show_select_element_prompt(webview, prompt);
+                        .show_form_control(webview, FormControl::SelectElement(prompt));
                 }
             },
         }

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -125,7 +125,7 @@ pub use crate::servo_delegate::{ServoDelegate, ServoError};
 pub use crate::webview::WebView;
 pub use crate::webview_delegate::{
     AllowOrDenyRequest, AuthenticationRequest, FormControl, NavigationRequest, PermissionRequest,
-    SelectElementPrompt, WebResourceLoad, WebViewDelegate,
+    SelectElement, WebResourceLoad, WebViewDelegate,
 };
 
 #[cfg(feature = "webdriver")]
@@ -979,8 +979,7 @@ impl Servo {
                 ipc_sender,
             ) => {
                 if let Some(webview) = self.get_webview_handle(webview_id) {
-                    let prompt =
-                        SelectElementPrompt::new(options, selected_option, position, ipc_sender);
+                    let prompt = SelectElement::new(options, selected_option, position, ipc_sender);
                     webview
                         .delegate()
                         .show_form_control(webview, FormControl::SelectElement(prompt));

--- a/components/servo/webview_delegate.rs
+++ b/components/servo/webview_delegate.rs
@@ -9,8 +9,8 @@ use constellation_traits::ConstellationMsg;
 use embedder_traits::{
     AllowOrDeny, AuthenticationResponse, ContextMenuResult, Cursor, FilterPattern,
     GamepadHapticEffectType, InputMethodType, LoadStatus, MediaSessionEvent, Notification,
-    PermissionFeature, ScreenGeometry, SelectElementOptionOrOptgroup, SimpleDialog, WebResourceRequest,
-    WebResourceResponse, WebResourceResponseMsg,
+    PermissionFeature, ScreenGeometry, SelectElementOptionOrOptgroup, SimpleDialog,
+    WebResourceRequest, WebResourceResponse, WebResourceResponseMsg,
 };
 use ipc_channel::ipc::IpcSender;
 use keyboard_types::KeyboardEvent;
@@ -299,18 +299,18 @@ impl Drop for InterceptedWebResourceLoad {
 /// The controls of an interactive form element.
 pub enum FormControl {
     /// The picker of a `<select>` element.
-    SelectElement(SelectElementPrompt),
+    SelectElement(SelectElement),
 }
 
 /// Represents a dialog triggered by clicking a `<select>` element.
-pub struct SelectElementPrompt {
+pub struct SelectElement {
     pub(crate) options: Vec<SelectElementOptionOrOptgroup>,
     pub(crate) selected_option: Option<usize>,
     pub(crate) position: DeviceIntRect,
     pub(crate) responder: IpcResponder<Option<usize>>,
 }
 
-impl SelectElementPrompt {
+impl SelectElement {
     pub(crate) fn new(
         options: Vec<SelectElementOptionOrOptgroup>,
         selected_option: Option<usize>,
@@ -509,6 +509,10 @@ pub trait WebViewDelegate {
     /// Request to hide the IME when the editable element is blurred.
     fn hide_ime(&self, _webview: WebView) {}
 
+    /// Request that the embedder show UI elements for form controls that are not integrated
+    /// into page content, such as dropdowns for `<select>` elements.
+    fn show_form_control(&self, _webview: WebView, _form_control: FormControl) {}
+
     /// Request to play a haptic effect on a connected gamepad.
     fn play_gamepad_haptic_effect(
         &self,
@@ -520,8 +524,6 @@ pub trait WebViewDelegate {
     }
     /// Request to stop a haptic effect on a connected gamepad.
     fn stop_gamepad_haptic_effect(&self, _webview: WebView, _: usize, _: IpcSender<bool>) {}
-
-    fn show_form_control(&self, _webview: WebView, _form_control: FormControl) {}
 
     /// Triggered when this [`WebView`] will load a web (HTTP/HTTPS) resource. The load may be
     /// intercepted and alternate contents can be loaded by the client by calling

--- a/components/servo/webview_delegate.rs
+++ b/components/servo/webview_delegate.rs
@@ -296,6 +296,12 @@ impl Drop for InterceptedWebResourceLoad {
     }
 }
 
+/// The controls of an interactive form element.
+pub enum FormControl {
+    /// The picker of a `<select>` element.
+    SelectElement(SelectElementPrompt),
+}
+
 /// Represents a dialog triggered by clicking a `<select>` element.
 pub struct SelectElementPrompt {
     pub(crate) options: Vec<SelectElementOptionOrOptgroup>,
@@ -515,13 +521,7 @@ pub trait WebViewDelegate {
     /// Request to stop a haptic effect on a connected gamepad.
     fn stop_gamepad_haptic_effect(&self, _webview: WebView, _: usize, _: IpcSender<bool>) {}
 
-    fn show_select_element_prompt(
-        &self,
-        _webview: WebView,
-        select_element_prompt: SelectElementPrompt,
-    ) {
-        select_element_prompt.submit();
-    }
+    fn show_form_control(&self, _webview: WebView, _form_control: FormControl) {}
 
     /// Triggered when this [`WebView`] will load a web (HTTP/HTTPS) resource. The load may be
     /// intercepted and alternate contents can be loaded by the client by calling

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -223,6 +223,27 @@ pub enum AllowOrDeny {
     Deny,
 }
 
+#[derive(Clone, Debug, Deserialize, Serialize)]
+
+pub struct SelectElementOption {
+    /// A unique identifier for the option that can be used to select it.
+    pub id: usize,
+    /// The label that should be used to display the option to the user.
+    pub label: String,
+    /// Whether or not the option is selectable
+    pub is_disabled: bool,
+}
+
+/// Represents the contents of either an `<option>` or an `<optgroup>` element
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum SelectElementOptionOrOptgroup {
+    Option(SelectElementOption),
+    Optgroup {
+        label: String,
+        options: Vec<SelectElementOption>,
+    },
+}
+
 #[derive(Deserialize, IntoStaticStr, Serialize)]
 pub enum EmbedderMsg {
     /// A status message to be displayed by the browser chrome.
@@ -331,6 +352,16 @@ pub enum EmbedderMsg {
     ShutdownComplete,
     /// Request to display a notification.
     ShowNotification(Option<WebViewId>, Notification),
+    /// Indicates that the user has activated a `<select>` element.
+    ///
+    /// The embedder should respond with the new state of the `<select>` element.
+    ShowSelectElementMenu(
+        WebViewId,
+        Vec<SelectElementOptionOrOptgroup>,
+        Option<usize>,
+        DeviceIntRect,
+        IpcSender<Option<usize>>,
+    ),
 }
 
 impl Debug for EmbedderMsg {
@@ -654,4 +685,10 @@ pub struct ScreenGeometry {
     /// and `window.screenTop` APIs. This will be converted to CSS pixels based on the pixel scaling
     /// of the `WebView`.
     pub offset: DeviceIntPoint,
+}
+
+impl From<SelectElementOption> for SelectElementOptionOrOptgroup {
+    fn from(value: SelectElementOption) -> Self {
+        Self::Option(value)
+    }
 }

--- a/ports/servoshell/desktop/app_state.rs
+++ b/ports/servoshell/desktop/app_state.rs
@@ -18,8 +18,8 @@ use servo::webrender_api::ScrollLocation;
 use servo::webrender_api::units::{DeviceIntPoint, DeviceIntRect, DeviceIntSize};
 use servo::{
     AllowOrDenyRequest, AuthenticationRequest, FilterPattern, GamepadHapticEffectType, LoadStatus,
-    PermissionRequest, Servo, ServoDelegate, ServoError, SimpleDialog, TouchEventType, WebView,
-    WebViewDelegate,
+    PermissionRequest, SelectElementPrompt, Servo, ServoDelegate, ServoError, SimpleDialog,
+    TouchEventType, WebView, WebViewDelegate,
 };
 use url::Url;
 
@@ -582,5 +582,16 @@ impl WebViewDelegate for RunningAppState {
 
     fn hide_ime(&self, _webview: WebView) {
         self.inner().window.hide_ime();
+    }
+
+    fn show_select_element_prompt(&self, webview: WebView, prompt: SelectElementPrompt) {
+        if self.servoshell_preferences.headless {
+            return;
+        }
+
+        // FIXME: Reading the toolbar height is needed here to properly position the select dialog.
+        // But if the toolbar height changes while the dialog is open then the position won't be updated
+        let offset = self.inner().window.toolbar_height();
+        self.add_dialog(webview, Dialog::new_select_element_dialog(prompt, offset));
     }
 }

--- a/ports/servoshell/desktop/app_state.rs
+++ b/ports/servoshell/desktop/app_state.rs
@@ -17,9 +17,9 @@ use servo::ipc_channel::ipc::IpcSender;
 use servo::webrender_api::ScrollLocation;
 use servo::webrender_api::units::{DeviceIntPoint, DeviceIntRect, DeviceIntSize};
 use servo::{
-    AllowOrDenyRequest, AuthenticationRequest, FilterPattern, GamepadHapticEffectType, LoadStatus,
-    PermissionRequest, SelectElementPrompt, Servo, ServoDelegate, ServoError, SimpleDialog,
-    TouchEventType, WebView, WebViewDelegate,
+    AllowOrDenyRequest, AuthenticationRequest, FilterPattern, FormControl, GamepadHapticEffectType,
+    LoadStatus, PermissionRequest, Servo, ServoDelegate, ServoError, SimpleDialog, TouchEventType,
+    WebView, WebViewDelegate,
 };
 use url::Url;
 
@@ -584,14 +584,18 @@ impl WebViewDelegate for RunningAppState {
         self.inner().window.hide_ime();
     }
 
-    fn show_select_element_prompt(&self, webview: WebView, prompt: SelectElementPrompt) {
+    fn show_form_control(&self, webview: WebView, form_control: FormControl) {
         if self.servoshell_preferences.headless {
             return;
         }
 
-        // FIXME: Reading the toolbar height is needed here to properly position the select dialog.
-        // But if the toolbar height changes while the dialog is open then the position won't be updated
-        let offset = self.inner().window.toolbar_height();
-        self.add_dialog(webview, Dialog::new_select_element_dialog(prompt, offset));
+        match form_control {
+            FormControl::SelectElement(prompt) => {
+                // FIXME: Reading the toolbar height is needed here to properly position the select dialog.
+                // But if the toolbar height changes while the dialog is open then the position won't be updated
+                let offset = self.inner().window.toolbar_height();
+                self.add_dialog(webview, Dialog::new_select_element_dialog(prompt, offset));
+            },
+        }
     }
 }

--- a/ports/servoshell/desktop/dialog.rs
+++ b/ports/servoshell/desktop/dialog.rs
@@ -7,11 +7,14 @@ use std::sync::Arc;
 
 use egui::Modal;
 use egui_file_dialog::{DialogState, FileDialog as EguiFileDialog};
+use euclid::Length;
 use log::warn;
 use servo::ipc_channel::ipc::IpcSender;
+use servo::servo_geometry::DeviceIndependentPixel;
 use servo::{
     AlertResponse, AuthenticationRequest, ConfirmResponse, FilterPattern, PermissionRequest,
-    PromptResponse, SimpleDialog,
+    PromptResponse, SelectElementOption, SelectElementOptionOrOptgroup, SelectElementPrompt,
+    SimpleDialog,
 };
 
 pub enum Dialog {
@@ -35,6 +38,10 @@ pub enum Dialog {
         devices: Vec<String>,
         selected_device_index: usize,
         response_sender: IpcSender<Option<String>>,
+    },
+    SelectElement {
+        maybe_prompt: Option<SelectElementPrompt>,
+        toolbar_offset: Length<f32, DeviceIndependentPixel>,
     },
 }
 
@@ -99,6 +106,16 @@ impl Dialog {
             devices,
             selected_device_index: 0,
             response_sender,
+        }
+    }
+
+    pub fn new_select_element_dialog(
+        prompt: SelectElementPrompt,
+        toolbar_offset: Length<f32, DeviceIndependentPixel>,
+    ) -> Self {
+        Dialog::SelectElement {
+            maybe_prompt: Some(prompt),
+            toolbar_offset,
         }
     }
 
@@ -371,6 +388,101 @@ impl Dialog {
                         },
                     );
                 });
+                is_open
+            },
+            Dialog::SelectElement {
+                maybe_prompt,
+                toolbar_offset,
+            } => {
+                let Some(prompt) = maybe_prompt else {
+                    // Prompt was dismissed, so the dialog should be closed too
+                    return false;
+                };
+                let mut is_open = true;
+
+                let mut position = prompt.position();
+                position.min.y += toolbar_offset.0 as i32;
+                position.max.y += toolbar_offset.0 as i32;
+                let area = egui::Area::new(egui::Id::new("select-window"))
+                    .fixed_pos(egui::pos2(position.min.x as f32, position.max.y as f32));
+
+                let mut selected_option = prompt.selected_option();
+
+                fn display_option(
+                    ui: &mut egui::Ui,
+                    option: &SelectElementOption,
+                    selected_option: &mut Option<usize>,
+                    is_open: &mut bool,
+                    in_group: bool,
+                ) {
+                    let is_checked =
+                        selected_option.is_some_and(|selected_index| selected_index == option.id);
+
+                    // TODO: Surely there's a better way to align text in a selectable label in egui
+                    let label_text = if in_group {
+                        format!("   {}", option.label)
+                    } else {
+                        option.label.to_owned()
+                    };
+                    let label = if option.is_disabled {
+                        egui::RichText::new(&label_text).strikethrough()
+                    } else {
+                        egui::RichText::new(&label_text)
+                    };
+                    let clickable_area = ui
+                        .allocate_ui_with_layout(
+                            [ui.available_width(), 0.0].into(),
+                            egui::Layout::top_down_justified(egui::Align::LEFT),
+                            |ui| ui.selectable_label(is_checked, label),
+                        )
+                        .inner;
+
+                    if clickable_area.clicked() && !option.is_disabled {
+                        *selected_option = Some(option.id);
+                        *is_open = false;
+                    }
+
+                    if clickable_area.hovered() && option.is_disabled {
+                        ui.ctx().set_cursor_icon(egui::CursorIcon::NotAllowed);
+                    }
+                }
+
+                let modal = Modal::new("select_element_picker".into()).area(area);
+                modal.show(ctx, |ui| {
+                    for option_or_optgroup in prompt.options() {
+                        match &option_or_optgroup {
+                            SelectElementOptionOrOptgroup::Option(option) => {
+                                display_option(
+                                    ui,
+                                    option,
+                                    &mut selected_option,
+                                    &mut is_open,
+                                    false,
+                                );
+                            },
+                            SelectElementOptionOrOptgroup::Optgroup { label, options } => {
+                                ui.label(egui::RichText::new(label).strong());
+
+                                for option in options {
+                                    display_option(
+                                        ui,
+                                        option,
+                                        &mut selected_option,
+                                        &mut is_open,
+                                        true,
+                                    );
+                                }
+                            },
+                        }
+                    }
+                });
+
+                prompt.select(selected_option);
+
+                if !is_open {
+                    maybe_prompt.take().unwrap().submit();
+                }
+
                 is_open
             },
         }

--- a/ports/servoshell/desktop/dialog.rs
+++ b/ports/servoshell/desktop/dialog.rs
@@ -13,7 +13,7 @@ use servo::ipc_channel::ipc::IpcSender;
 use servo::servo_geometry::DeviceIndependentPixel;
 use servo::{
     AlertResponse, AuthenticationRequest, ConfirmResponse, FilterPattern, PermissionRequest,
-    PromptResponse, SelectElementOption, SelectElementOptionOrOptgroup, SelectElementPrompt,
+    PromptResponse, SelectElement, SelectElementOption, SelectElementOptionOrOptgroup,
     SimpleDialog,
 };
 
@@ -40,7 +40,7 @@ pub enum Dialog {
         response_sender: IpcSender<Option<String>>,
     },
     SelectElement {
-        maybe_prompt: Option<SelectElementPrompt>,
+        maybe_prompt: Option<SelectElement>,
         toolbar_offset: Length<f32, DeviceIndependentPixel>,
     },
 }
@@ -110,7 +110,7 @@ impl Dialog {
     }
 
     pub fn new_select_element_dialog(
-        prompt: SelectElementPrompt,
+        prompt: SelectElement,
         toolbar_offset: Length<f32, DeviceIndependentPixel>,
     ) -> Self {
         Dialog::SelectElement {
@@ -395,7 +395,7 @@ impl Dialog {
                 toolbar_offset,
             } => {
                 let Some(prompt) = maybe_prompt else {
-                    // Prompt was dismissed, so the dialog should be closed too
+                    // Prompt was dismissed, so the dialog should be closed too.
                     return false;
                 };
                 let mut is_open = true;
@@ -418,7 +418,7 @@ impl Dialog {
                     let is_checked =
                         selected_option.is_some_and(|selected_index| selected_index == option.id);
 
-                    // TODO: Surely there's a better way to align text in a selectable label in egui
+                    // TODO: Surely there's a better way to align text in a selectable label in egui.
                     let label_text = if in_group {
                         format!("   {}", option.label)
                     } else {

--- a/resources/servo.css
+++ b/resources/servo.css
@@ -87,30 +87,6 @@ input[type="file"] {
   border-style: none;
 }
 
-select {
-  border-style: solid;
-  border-width: 1px;
-  background: white;
-}
-
-select[multiple]              { padding: 0em 0.25em; }
-select:not([multiple])        { padding: 0.25em 0.5em; border-radius: 6px; }
-
-select:not([multiple])::after {
-  content: "";
-  display: inline-block;
-  border-width: 5.2px 3px 0 3px;
-  border-style: solid;
-  border-color: currentcolor transparent transparent transparent;
-  margin-left: 0.5em;
-}
-
-select:not([multiple]) option           { display: none !important; }
-select:not([multiple]) option[selected] { display: inline !important; }
-select[multiple] option                 { display: block !important; }
-select[multiple] option[selected]       { background-color: grey; color: white; }
-select[multiple]:focus option[selected] { background-color: darkblue; }
-
 td[align="left"]    { text-align: left; }
 td[align="center"]  { text-align: center; }
 td[align="right"]   { text-align: right; }
@@ -357,4 +333,13 @@ progress #-servo-progress-bar {
   display: block;
   height: 100%;
   background-color: #7a3;
+}
+
+select {
+  background-color: lightgrey;
+  border-radius: 5px;
+  border: 1px solid gray;
+  padding: 0 0.25em;
+  /* Don't show a text cursor when hovering selected option */
+  cursor: default;
 }

--- a/tests/wpt/meta/css/css-content/content-none-option.html.ini
+++ b/tests/wpt/meta/css/css-content/content-none-option.html.ini
@@ -1,0 +1,2 @@
+[content-none-option.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-content/content-none-select-1.html.ini
+++ b/tests/wpt/meta/css/css-content/content-none-select-1.html.ini
@@ -1,0 +1,2 @@
+[content-none-select-1.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-content/content-none-select-2.html.ini
+++ b/tests/wpt/meta/css/css-content/content-none-select-2.html.ini
@@ -1,0 +1,2 @@
+[content-none-select-2.html]
+  expected: FAIL

--- a/tests/wpt/meta/html/dom/elements/the-innertext-and-outertext-properties/getter.html.ini
+++ b/tests/wpt/meta/html/dom/elements/the-innertext-and-outertext-properties/getter.html.ini
@@ -28,3 +28,24 @@
 
   [opened <details> content shown ("<div><details open><summary>abc</summary>123")]
     expected: FAIL
+
+  [<select size='1'> contents of options preserved ("<select size='1'><option>abc</option><option>def")]
+    expected: FAIL
+
+  [<select size='2'> contents of options preserved ("<select size='2'><option>abc</option><option>def")]
+    expected: FAIL
+
+  [empty <optgroup> in <select> ("<div>a<select><optgroup></select>bc")]
+    expected: FAIL
+
+  [empty <option> in <select> ("<div>a<select><option></select>bc")]
+    expected: FAIL
+
+  [<optgroup> containing <option> ("<select><optgroup><option>abc</select>")]
+    expected: FAIL
+
+  [<select size='1'> contents of options preserved ("<div><select size='1'><option>abc</option><option>def")]
+    expected: FAIL
+
+  [<select size='2'> contents of options preserved ("<div><select size='2'><option>abc</option><option>def")]
+    expected: FAIL

--- a/tests/wpt/meta/html/rendering/replaced-elements/the-option-element/option-label-whitespace.html.ini
+++ b/tests/wpt/meta/html/rendering/replaced-elements/the-option-element/option-label-whitespace.html.ini
@@ -1,2 +1,0 @@
-[option-label-whitespace.html]
-  expected: FAIL

--- a/tests/wpt/meta/html/rendering/replaced-elements/the-option-element/option-with-br.html.ini
+++ b/tests/wpt/meta/html/rendering/replaced-elements/the-option-element/option-with-br.html.ini
@@ -1,2 +1,0 @@
-[option-with-br.html]
-  expected: FAIL

--- a/tests/wpt/meta/html/rendering/replaced-elements/the-select-element/select-1-block-size-001.html.ini
+++ b/tests/wpt/meta/html/rendering/replaced-elements/the-select-element/select-1-block-size-001.html.ini
@@ -1,0 +1,2 @@
+[select-1-block-size-001.html]
+  expected: FAIL

--- a/tests/wpt/meta/html/rendering/replaced-elements/the-select-element/select-button-min-height-001.html.ini
+++ b/tests/wpt/meta/html/rendering/replaced-elements/the-select-element/select-button-min-height-001.html.ini
@@ -1,0 +1,2 @@
+[select-button-min-height-001.html]
+  expected: FAIL

--- a/tests/wpt/meta/html/rendering/replaced-elements/the-select-element/select-empty.html.ini
+++ b/tests/wpt/meta/html/rendering/replaced-elements/the-select-element/select-empty.html.ini
@@ -1,0 +1,2 @@
+[select-empty.html]
+  expected: FAIL

--- a/tests/wpt/meta/html/rendering/replaced-elements/the-select-element/select-multiple-re-add-option-via-document-fragment.html.ini
+++ b/tests/wpt/meta/html/rendering/replaced-elements/the-select-element/select-multiple-re-add-option-via-document-fragment.html.ini
@@ -1,0 +1,2 @@
+[select-multiple-re-add-option-via-document-fragment.html]
+  expected: FAIL

--- a/tests/wpt/meta/html/rendering/widgets/select-wrap-no-spill.optional.html.ini
+++ b/tests/wpt/meta/html/rendering/widgets/select-wrap-no-spill.optional.html.ini
@@ -1,4 +1,0 @@
-[select-wrap-no-spill.optional.html]
-  [Selected OPTION label with white-space:pre-wrap should not spill out.]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/rendering/widgets/the-select-element/option-add-label-quirks.html.ini
+++ b/tests/wpt/meta/html/rendering/widgets/the-select-element/option-add-label-quirks.html.ini
@@ -1,2 +1,0 @@
-[option-add-label-quirks.html]
-  expected: FAIL

--- a/tests/wpt/meta/html/rendering/widgets/the-select-element/option-checked-styling.html.ini
+++ b/tests/wpt/meta/html/rendering/widgets/the-select-element/option-checked-styling.html.ini
@@ -1,2 +1,0 @@
-[option-checked-styling.html]
-  expected: FAIL

--- a/tests/wpt/meta/html/semantics/forms/the-label-element/clicking-interactive-content.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-label-element/clicking-interactive-content.html.ini
@@ -5,13 +5,7 @@
   [interactive content <input> as first child of <label>]
     expected: FAIL
 
-  [interactive content <select></select> as second child under <label>]
-    expected: FAIL
-
   [interactive content <iframe></iframe> as second child under <label>]
-    expected: FAIL
-
-  [interactive content <select></select> as first child of <label>]
     expected: FAIL
 
   [interactive content <video tabindex=""></video> as second child under <label>]
@@ -30,9 +24,6 @@
     expected: FAIL
 
   [interactive content <object usemap=""></object> as second child under <label>]
-    expected: FAIL
-
-  [interactive content <select></select> deeply nested under <label>]
     expected: FAIL
 
   [interactive content <textarea></textarea> as first child of <label>]
@@ -67,4 +58,3 @@
 
   [interactive content <textarea></textarea> as second child under <label>]
     expected: FAIL
-

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/closed-listbox-rendering.tentative.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/closed-listbox-rendering.tentative.html.ini
@@ -1,2 +1,0 @@
-[closed-listbox-rendering.tentative.html]
-  expected: FAIL

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/select-marker-end-aligned.tentative.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/select-marker-end-aligned.tentative.html.ini
@@ -1,2 +1,0 @@
-[select-marker-end-aligned.tentative.html]
-  expected: FAIL

--- a/tests/wpt/tests/html/rendering/widgets/the-select-element/option-add-label-quirks.html
+++ b/tests/wpt/tests/html/rendering/widgets/the-select-element/option-add-label-quirks.html
@@ -2,7 +2,7 @@
 <title>OPTION's label attribute in SELECT -- Adding a label (quirks)</title>
 <link rel="help" href="https://html.spec.whatwg.org/multipage/rendering.html#the-select-element-2">
 <link rel="match" href="option-label-ref.html">
-<meta name="assert" content="An option element is expected to be rendered by displaying the element's label.">
+<meta name="assert" content="An option element is expected to be rendered by displaying the element's label when the document is in quirks mode">
 
 <select>
   <option>Element Text</option>


### PR DESCRIPTION
https://github.com/user-attachments/assets/9aba75ff-4190-4a85-89ed-d3f3aa53d3b0



Among other things this adds a new `EmbedderMsg::ShowSelectElementMenu` to tell the embedder to display a select popup at the given location.

This is a draft because some small style adjustments need to be made:
* the select element should always have the width of the largest option
* the border should be part of the shadow tree

Apart from that, it's mostly ready for review.

<details><summary>HTML for demo video</summary>

```html
<html>

<body>
<select id="c" name="choice">
  <option value="first">First Value</option>
  <option value="second">Second Value</option>
  <option value="third">Third Value</option>
</select>
</body>
</html>
```
</details>

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] Part of https://github.com/servo/servo/issues/3551
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
