### PR TITLE
winit_mininal: support proper window resizing

### DIFF
--- a/components/servo/examples/winit_minimal.rs
+++ b/components/servo/examples/winit_minimal.rs
@@ -184,6 +184,16 @@ impl ApplicationHandler<WakerEvent> for App {
                     }
                 }
             },
+            WindowEvent::Resized(new_size) => {
+                if let Self::Running(state) = self {
+                    if let Some(webview) = state.webviews.borrow().last() {
+                        let mut rect = webview.rect();
+                        rect.set_size(winit_size_to_euclid_size(new_size).to_f32());
+                        webview.move_resize(rect);
+                        webview.resize(new_size);
+                    }
+                }
+            },
             _ => (),
         }
     }


### PR DESCRIPTION
Hooks up the winit resize event with the webview API. I'm not sure why we have to call both `webview.move_resize()` and `webview.resize()`, this is a bit odd.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
