### PR TITLE
script: Avoid double borrow crash in `DataTransferItem`

### DIFF
--- a/components/script/dom/datatransferitem.rs
+++ b/components/script/dom/datatransferitem.rs
@@ -123,7 +123,8 @@ impl DataTransferItemMethods<crate::DomTypeHolder> for DataTransferItem {
                 .task_manager()
                 .dom_manipulation_task_source()
                 .queue(task!(invoke_callback: move || {
-                    if let Some(index) = this.root().pending_callbacks.borrow().iter().position(|val| val.id == id) {
+                    let maybe_index = this.root().pending_callbacks.borrow().iter().position(|val| val.id == id);
+                    if let Some(index) = maybe_index {
                         let callback = this.root().pending_callbacks.borrow_mut().swap_remove(index).callback;
                         let _ = callback.Call__(DOMString::from(string), ExceptionHandling::Report);
                     }

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -9,6 +9,13 @@
       {}
      ]
     ],
+    "datatransferitem-crash.html": [
+     "d11355ab38c1e99e0ba3e10d7dfed18bf26af60b",
+     [
+      null,
+      {}
+     ]
+    ],
     "test-wait-crash.html": [
      "2419da6af0c278a17b9ff974d4418f9e386ef3e0",
      [

--- a/tests/wpt/mozilla/tests/mozilla/datatransferitem-crash.html
+++ b/tests/wpt/mozilla/tests/mozilla/datatransferitem-crash.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<meta charset="utf-8">
+<meta name="assert" content="GetAsString shouldn't crash.">
+
+<script>
+  const dt = new DataTransfer();
+
+  dt.items.add("data", "text/plain");
+  let item = dt.items[0];
+
+  item.getAsString(str => {
+    console.log(`Calling getAsString on a item shouldn't crash`);
+  });
+</script>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [ ] These changes do not require tests because

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
