### PR TITLE
compositor: Make `PipelineDetails` and pending paint metrics per-WebView

### DIFF
--- a/components/constellation/pipeline.rs
+++ b/components/constellation/pipeline.rs
@@ -386,8 +386,11 @@ impl Pipeline {
         // It's OK for the constellation to block on the compositor,
         // since the compositor never blocks on the constellation.
         if let Ok((sender, receiver)) = ipc::channel() {
-            self.compositor_proxy
-                .send(CompositorMsg::PipelineExited(self.id, sender));
+            self.compositor_proxy.send(CompositorMsg::PipelineExited(
+                self.top_level_browsing_context_id,
+                self.id,
+                sender,
+            ));
             if let Err(e) = receiver.recv() {
                 warn!("Sending exit message failed ({:?}).", e);
             }
@@ -455,7 +458,8 @@ impl Pipeline {
     /// running timers at a heavily limited rate.
     pub fn set_throttled(&self, throttled: bool) {
         let script_msg = ScriptThreadMessage::SetThrottled(self.id, throttled);
-        let compositor_msg = CompositorMsg::SetThrottled(self.id, throttled);
+        let compositor_msg =
+            CompositorMsg::SetThrottled(self.top_level_browsing_context_id, self.id, throttled);
         let err = self.event_loop.send(script_msg);
         if let Err(e) = err {
             warn!("Sending SetThrottled to script failed ({}).", e);

--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -794,8 +794,11 @@ impl LayoutThread {
                 self.paint_time_metrics
                     .maybe_observe_paint_time(self, epoch, is_contentful.0);
 
-                self.compositor_api
-                    .send_display_list(compositor_info, builder.end().1);
+                self.compositor_api.send_display_list(
+                    self.webview_id,
+                    compositor_info,
+                    builder.end().1,
+                );
 
                 let (keys, instance_keys) = self
                     .font_context
@@ -1040,6 +1043,7 @@ impl LayoutThread {
 
         let point = Point2D::new(-state.scroll_offset.x, -state.scroll_offset.y);
         self.compositor_api.send_scroll_node(
+            self.webview_id,
             self.id.into(),
             units::LayoutPoint::from_untyped(point),
             state.scroll_id,

--- a/components/layout_thread_2020/lib.rs
+++ b/components/layout_thread_2020/lib.rs
@@ -820,6 +820,7 @@ impl LayoutThread {
             .insert(state.scroll_id, state.scroll_offset);
         let point = Point2D::new(-state.scroll_offset.x, -state.scroll_offset.y);
         self.compositor_api.send_scroll_node(
+            self.webview_id,
             self.id.into(),
             units::LayoutPoint::from_untyped(point),
             state.scroll_id,
@@ -890,8 +891,11 @@ impl LayoutThread {
             .maybe_observe_paint_time(self, epoch, is_contentful);
 
         if reflow_goal.needs_display() {
-            self.compositor_api
-                .send_display_list(display_list.compositor_info, display_list.wr.end().1);
+            self.compositor_api.send_display_list(
+                self.webview_id,
+                display_list.compositor_info,
+                display_list.wr.end().1,
+            );
 
             let (keys, instance_keys) = self
                 .font_context

--- a/components/metrics/lib.rs
+++ b/components/metrics/lib.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 
 use base::Epoch;
 use base::cross_process_instant::CrossProcessInstant;
-use base::id::PipelineId;
+use base::id::{PipelineId, WebViewId};
 use ipc_channel::ipc::IpcSender;
 use log::warn;
 use malloc_size_of_derive::MallocSizeOf;
@@ -255,6 +255,7 @@ pub struct PaintTimeMetrics {
     navigation_start: CrossProcessInstant,
     first_paint: Cell<Option<CrossProcessInstant>>,
     first_contentful_paint: Cell<Option<CrossProcessInstant>>,
+    webview_id: WebViewId,
     pipeline_id: PipelineId,
     time_profiler_chan: ProfilerChan,
     constellation_chan: IpcSender<LayoutMsg>,
@@ -264,6 +265,7 @@ pub struct PaintTimeMetrics {
 
 impl PaintTimeMetrics {
     pub fn new(
+        webview_id: WebViewId,
         pipeline_id: PipelineId,
         time_profiler_chan: ProfilerChan,
         constellation_chan: IpcSender<LayoutMsg>,
@@ -276,6 +278,7 @@ impl PaintTimeMetrics {
             navigation_start,
             first_paint: Cell::new(None),
             first_contentful_paint: Cell::new(None),
+            webview_id,
             pipeline_id,
             time_profiler_chan,
             constellation_chan,
@@ -308,7 +311,7 @@ impl PaintTimeMetrics {
         // Send the pending metric information to the compositor thread.
         // The compositor will record the current time after painting the
         // frame with the given ID and will send the metric back to us.
-        let msg = LayoutMsg::PendingPaintMetric(self.pipeline_id, epoch);
+        let msg = LayoutMsg::PendingPaintMetric(self.webview_id, self.pipeline_id, epoch);
         if let Err(e) = self.constellation_chan.send(msg) {
             warn!("Failed to send PendingPaintMetric {:?}", e);
         }

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3051,6 +3051,7 @@ impl ScriptThread {
         };
 
         let paint_time_metrics = PaintTimeMetrics::new(
+            incomplete.top_level_browsing_context_id,
             incomplete.pipeline_id,
             self.senders.time_profiler_sender.clone(),
             self.senders.layout_to_constellation_ipc_sender.clone(),

--- a/components/shared/compositing/lib.rs
+++ b/components/shared/compositing/lib.rs
@@ -9,7 +9,7 @@ mod constellation_msg;
 use std::fmt::{Debug, Error, Formatter};
 
 use base::Epoch;
-use base::id::{PipelineId, TopLevelBrowsingContextId};
+use base::id::{PipelineId, TopLevelBrowsingContextId, WebViewId};
 pub use constellation_msg::ConstellationMsg;
 use crossbeam_channel::{Receiver, Sender};
 use embedder_traits::{EventLoopWaker, MouseButton, MouseButtonAction};
@@ -59,7 +59,7 @@ impl CompositorReceiver {
 /// Messages from (or via) the constellation thread to the compositor.
 pub enum CompositorMsg {
     /// Alerts the compositor that the given pipeline has changed whether it is running animations.
-    ChangeRunningAnimationsState(PipelineId, AnimationState),
+    ChangeRunningAnimationsState(WebViewId, PipelineId, AnimationState),
     /// Create or update a webview, given its frame tree.
     CreateOrUpdateWebView(SendableFrameTree),
     /// Remove a webview.
@@ -71,7 +71,7 @@ pub enum CompositorMsg {
     /// A reply to the compositor asking if the output image is stable.
     IsReadyToSaveImageReply(bool),
     /// Set whether to use less resources by stopping animations.
-    SetThrottled(PipelineId, bool),
+    SetThrottled(WebViewId, PipelineId, bool),
     /// WebRender has produced a new frame. This message informs the compositor that
     /// the frame is ready. It contains a bool to indicate if it needs to composite and the
     /// `DocumentId` of the new frame.
@@ -81,11 +81,11 @@ pub enum CompositorMsg {
     // when it shuts down a pipeline, to the compositor; when the compositor
     // sends a reply on the IpcSender, the constellation knows it's safe to
     // tear down the other threads associated with this pipeline.
-    PipelineExited(PipelineId, IpcSender<()>),
+    PipelineExited(WebViewId, PipelineId, IpcSender<()>),
     /// Indicates to the compositor that it needs to record the time when the frame with
     /// the given ID (epoch) is painted and report it to the layout of the given
-    /// pipeline ID.
-    PendingPaintMetric(PipelineId, Epoch),
+    /// WebViewId and PipelienId.
+    PendingPaintMetric(WebViewId, PipelineId, Epoch),
     /// The load of a page has completed
     LoadComplete(TopLevelBrowsingContextId),
     /// WebDriver mouse button event
@@ -114,7 +114,7 @@ pub struct CompositionPipeline {
 impl Debug for CompositorMsg {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
         match *self {
-            CompositorMsg::ChangeRunningAnimationsState(_, state) => {
+            CompositorMsg::ChangeRunningAnimationsState(_, _, state) => {
                 write!(f, "ChangeRunningAnimationsState({:?})", state)
             },
             CompositorMsg::CreateOrUpdateWebView(..) => write!(f, "CreateOrUpdateWebView"),

--- a/components/shared/script/script_msg.rs
+++ b/components/shared/script/script_msg.rs
@@ -9,7 +9,7 @@ use base::Epoch;
 use base::id::{
     BroadcastChannelRouterId, BrowsingContextId, HistoryStateId, MessagePortId,
     MessagePortRouterId, PipelineId, ServiceWorkerId, ServiceWorkerRegistrationId,
-    TopLevelBrowsingContextId,
+    TopLevelBrowsingContextId, WebViewId,
 };
 use canvas_traits::canvas::{CanvasId, CanvasMsg};
 use devtools_traits::{ScriptToDevtoolsControlMsg, WorkerId};
@@ -49,7 +49,7 @@ pub struct IFrameSizeMsg {
 pub enum LayoutMsg {
     /// Requests that the constellation inform the compositor that it needs to record
     /// the time when the frame with the given ID (epoch) is painted.
-    PendingPaintMetric(PipelineId, Epoch),
+    PendingPaintMetric(WebViewId, PipelineId, Epoch),
 }
 
 impl fmt::Debug for LayoutMsg {

--- a/components/webdriver_server/actions.rs
+++ b/components/webdriver_server/actions.rs
@@ -431,14 +431,8 @@ impl Handler {
         target_y: i64,
         tick_start: Instant,
     ) {
-        let pointer_input_state = match self
-            .session
-            .as_mut()
-            .unwrap()
-            .input_state_table
-            .get_mut(source_id)
-            .unwrap()
-        {
+        let session = self.session.as_mut().unwrap();
+        let pointer_input_state = match session.input_state_table.get_mut(source_id).unwrap() {
             InputSourceState::Null => unreachable!(),
             InputSourceState::Key(_) => unreachable!(),
             InputSourceState::Pointer(pointer_input_state) => pointer_input_state,

--- a/tests/unit/metrics/paint_time.rs
+++ b/tests/unit/metrics/paint_time.rs
@@ -4,7 +4,7 @@
 
 use base::Epoch;
 use base::cross_process_instant::CrossProcessInstant;
-use base::id::TEST_PIPELINE_ID;
+use base::id::{TEST_PIPELINE_ID, TEST_WEBVIEW_ID};
 use ipc_channel::ipc;
 use metrics::{PaintTimeMetrics, ProfilerMetadataFactory, ProgressiveWebMetric};
 use profile_traits::time::{ProfilerChan, TimerMetadata};
@@ -25,6 +25,7 @@ fn test_paint_metrics_construction() {
     let (script_sender, _) = ipc::channel().unwrap();
     let start_time = CrossProcessInstant::now();
     let paint_time_metrics = PaintTimeMetrics::new(
+        TEST_WEBVIEW_ID,
         TEST_PIPELINE_ID,
         profiler_chan,
         layout_sender,
@@ -56,6 +57,7 @@ fn test_common(display_list_is_contentful: bool, epoch: Epoch) -> PaintTimeMetri
     let (script_sender, _) = ipc::channel().unwrap();
     let start_time = CrossProcessInstant::now();
     let mut paint_time_metrics = PaintTimeMetrics::new(
+        TEST_WEBVIEW_ID,
         TEST_PIPELINE_ID,
         profiler_chan,
         layout_sender,


### PR DESCRIPTION
This is one of the first big steps toward making the compositor work
per-WebView. It moves the collection of pipelines into the per-WebView
data structure in the compositor as well as the pending paint metrics.

This means that more messages need to carry information about the
WebView they apply to. Note that there are still a few places that we
need to map from `PipelineId` to `WebViewId`, so this also includes a
shared mapping which tracks this. The mapping can be removed once event
handling is fully per-WebView.

Co-authored-by: Delan Azabani <dazabani@igalia.com>
Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are covered by existing tests.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
