### PR TITLE
clippy: Fix a couple clippy warnings on macOS

### DIFF
--- a/components/fonts/platform/macos/font.rs
+++ b/components/fonts/platform/macos/font.rs
@@ -141,7 +141,7 @@ impl CachedKernTable {
     fn binary_search(&self, first_glyph: GlyphId, second_glyph: GlyphId) -> Option<i16> {
         let pairs = &self.font_table.buffer()[self.pair_data_range.clone()];
 
-        let query = first_glyph << 16 | second_glyph;
+        let query = (first_glyph << 16) | second_glyph;
         let (mut start, mut end) = (0, pairs.len() / KERN_PAIR_LEN);
         while start < end {
             let i = (start + end) / 2;

--- a/components/layout/display_list/webrender_helpers.rs
+++ b/components/layout/display_list/webrender_helpers.rs
@@ -190,7 +190,7 @@ impl DisplayItem {
         builder: &DisplayListBuilder,
         node_index: usize,
     ) -> SpatialTreeItemKey {
-        let pipeline_tag = (builder.pipeline_id.0 as u64) << 32 | builder.pipeline_id.1 as u64;
+        let pipeline_tag = ((builder.pipeline_id.0 as u64) << 32) | builder.pipeline_id.1 as u64;
         SpatialTreeItemKey::new(pipeline_tag, node_index as u64)
     }
 


### PR DESCRIPTION
The new version of rust has more checks trying to prevent mistakes
around order of operations and shifts.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes do not require tests because they just fix some clippy warnings.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
