### PR TITLE
fonts: Remove the per-FontGroup cached fallback font

### DIFF
--- a/components/canvas/canvas_data.rs
+++ b/components/canvas/canvas_data.rs
@@ -710,7 +710,7 @@ impl<'a> CanvasData<'a> {
             // TODO: This should ultimately handle emoji variation selectors, but raqote does not yet
             // have support for color glyphs.
             let script = Script::from(character);
-            let font = font_group.find_by_codepoint(&self.font_context, character, None);
+            let font = font_group.find_by_codepoint(&self.font_context, character, None, None);
 
             if !current_text_run.script_and_font_compatible(script, &font) {
                 let previous_text_run = mem::replace(

--- a/components/fonts/tests/font_context.rs
+++ b/components/fonts/tests/font_context.rs
@@ -276,7 +276,7 @@ mod font_context {
 
         let font = group
             .write()
-            .find_by_codepoint(&mut context.context, 'a', None)
+            .find_by_codepoint(&mut context.context, 'a', None, None)
             .unwrap();
         assert_eq!(&font_face_name(&font.identifier()), "csstest-ascii");
         assert_eq!(
@@ -290,7 +290,7 @@ mod font_context {
 
         let font = group
             .write()
-            .find_by_codepoint(&mut context.context, 'a', None)
+            .find_by_codepoint(&mut context.context, 'a', None, None)
             .unwrap();
         assert_eq!(&font_face_name(&font.identifier()), "csstest-ascii");
         assert_eq!(
@@ -304,7 +304,7 @@ mod font_context {
 
         let font = group
             .write()
-            .find_by_codepoint(&mut context.context, 'á', None)
+            .find_by_codepoint(&mut context.context, 'á', None, None)
             .unwrap();
         assert_eq!(&font_face_name(&font.identifier()), "csstest-basic-regular");
         assert_eq!(
@@ -328,7 +328,7 @@ mod font_context {
 
         let font = group
             .write()
-            .find_by_codepoint(&mut context.context, 'a', None)
+            .find_by_codepoint(&mut context.context, 'a', None, None)
             .unwrap();
         assert_eq!(
             &font_face_name(&font.identifier()),
@@ -338,7 +338,7 @@ mod font_context {
 
         let font = group
             .write()
-            .find_by_codepoint(&mut context.context, 'á', None)
+            .find_by_codepoint(&mut context.context, 'á', None, None)
             .unwrap();
         assert_eq!(
             &font_face_name(&font.identifier()),

--- a/components/layout/text.rs
+++ b/components/layout/text.rs
@@ -210,7 +210,7 @@ impl TextRunScanner {
                     .unwrap_or_else(|| {
                         let space_width = font_group
                             .write()
-                            .find_by_codepoint(font_context, ' ', None)
+                            .find_by_codepoint(font_context, ' ', None, None)
                             .and_then(|font| {
                                 font.glyph_index(' ')
                                     .map(|glyph_id| font.glyph_h_advance(glyph_id))
@@ -252,10 +252,12 @@ impl TextRunScanner {
                 let (mut start_position, mut end_position) = (0, 0);
                 for (byte_index, character) in text.char_indices() {
                     if !character.is_control() {
-                        let font =
-                            font_group
-                                .write()
-                                .find_by_codepoint(font_context, character, None);
+                        let font = font_group.write().find_by_codepoint(
+                            font_context,
+                            character,
+                            None,
+                            None,
+                        );
 
                         let bidi_level = match bidi_levels {
                             Some(levels) => levels[*paragraph_bytes_processed],

--- a/components/layout_thread_2020/lib.rs
+++ b/components/layout_thread_2020/lib.rs
@@ -1162,7 +1162,7 @@ impl FontMetricsProvider for LayoutFontMetricsProvider {
             .or_else(|| {
                 font_group
                     .write()
-                    .find_by_codepoint(font_context, '0', None)?
+                    .find_by_codepoint(font_context, '0', None, None)?
                     .metrics
                     .zero_horizontal_advance
             })
@@ -1173,7 +1173,7 @@ impl FontMetricsProvider for LayoutFontMetricsProvider {
             .or_else(|| {
                 font_group
                     .write()
-                    .find_by_codepoint(font_context, '\u{6C34}', None)?
+                    .find_by_codepoint(font_context, '\u{6C34}', None, None)?
                     .metrics
                     .ic_horizontal_advance
             })

--- a/tests/wpt/meta/css/CSS2/bidi-text/bidi-breaking-001.xht.ini
+++ b/tests/wpt/meta/css/CSS2/bidi-text/bidi-breaking-001.xht.ini
@@ -1,0 +1,2 @@
+[bidi-breaking-001.xht]
+  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/bidi-text/bidi-breaking-002.xht.ini
+++ b/tests/wpt/meta/css/CSS2/bidi-text/bidi-breaking-002.xht.ini
@@ -1,0 +1,2 @@
+[bidi-breaking-002.xht]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-content/quotes-016.html.ini
+++ b/tests/wpt/meta/css/css-content/quotes-016.html.ini
@@ -1,2 +1,0 @@
-[quotes-016.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-content/quotes-026.html.ini
+++ b/tests/wpt/meta/css/css-content/quotes-026.html.ini
@@ -1,2 +1,0 @@
-[quotes-026.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/word-break/word-break-keep-all-005.html.ini
+++ b/tests/wpt/meta/css/css-text/word-break/word-break-keep-all-005.html.ini
@@ -1,2 +1,0 @@
-[word-break-keep-all-005.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/word-break/word-break-keep-all-007.html.ini
+++ b/tests/wpt/meta/css/css-text/word-break/word-break-keep-all-007.html.ini
@@ -1,2 +1,0 @@
-[word-break-keep-all-007.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/word-break/word-break-keep-all-008.html.ini
+++ b/tests/wpt/meta/css/css-text/word-break/word-break-keep-all-008.html.ini
@@ -1,2 +1,0 @@
-[word-break-keep-all-008.html]
-  expected: FAIL


### PR DESCRIPTION
Instead of keeping a per-FontGroup cache of the previously used fallback
font, cache this value in the caller of `FontGroup::find_by_codepoint`.
The problem with caching this value in the `FontGroup` is that it can
make one layout different from the next.

Still, it is important to cache the value somewhere so that, for
instance, Chinese character don't have to continuously walk through the
entire fallback list when laying out. The heuristic here is to try to
last used font first if the `Script`s match. At the very least this
should make one layout consistent with the next.

Fixes #35704.
Fixes #35689.
Fixes #35679.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
