### PR TITLE
add `cancelable` property to the `TouchEvent`

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -1406,7 +1406,7 @@ impl IOCompositor {
                 .move_allowed(self.touch_handler.current_sequence_id)
             {
                 // https://w3c.github.io/touch-events/#cancelability
-                event.cancelable = false;
+                event.disable_cancelable();
                 match action {
                     TouchMoveAction::Scroll(delta, point) => self.on_scroll_window_event(
                         ScrollLocation::Delta(LayoutVector2D::from_untyped(delta.to_untyped())),

--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -1396,7 +1396,7 @@ impl IOCompositor {
         self.send_touch_event(event);
     }
 
-    fn on_touch_move(&mut self, event: TouchEvent) {
+    fn on_touch_move(&mut self, mut event: TouchEvent) {
         let action: TouchMoveAction = self.touch_handler.on_touch_move(event.id, event.point);
         if TouchMoveAction::NoAction != action {
             // if first move processed and allowed, we directly process the move event,
@@ -1405,6 +1405,8 @@ impl IOCompositor {
                 .touch_handler
                 .move_allowed(self.touch_handler.current_sequence_id)
             {
+                // https://w3c.github.io/touch-events/#cancelability
+                event.cancelable = false;
                 match action {
                     TouchMoveAction::Scroll(delta, point) => self.on_scroll_window_event(
                         ScrollLocation::Delta(LayoutVector2D::from_untyped(delta.to_untyped())),

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -2086,11 +2086,16 @@ impl Document {
             TouchList::new(window, touches.r(), can_gc)
         };
 
+        let cancelable = if event.cancelable {
+            EventCancelable::Cancelable
+        } else {
+            EventCancelable::NotCancelable
+        };
         let event = DomTouchEvent::new(
             window,
             DOMString::from(event_name),
             EventBubbles::Bubbles,
-            EventCancelable::Cancelable,
+            cancelable,
             Some(window),
             0i32,
             &touches,

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -2086,16 +2086,11 @@ impl Document {
             TouchList::new(window, touches.r(), can_gc)
         };
 
-        let cancelable = if event.cancelable {
-            EventCancelable::Cancelable
-        } else {
-            EventCancelable::NotCancelable
-        };
         let event = DomTouchEvent::new(
             window,
             DOMString::from(event_name),
             EventBubbles::Bubbles,
-            cancelable,
+            EventCancelable::from(event.is_cancelable()),
             Some(window),
             0i32,
             &touches,

--- a/components/shared/embedder/input_events.rs
+++ b/components/shared/embedder/input_events.rs
@@ -147,6 +147,7 @@ pub struct TouchEvent {
     pub event_type: TouchEventType,
     pub id: TouchId,
     pub point: DevicePoint,
+    pub cancelable: bool,
     /// The sequence_id will be set by servo's touch handler.
     sequence_id: Option<TouchSequenceId>,
 }
@@ -158,6 +159,7 @@ impl TouchEvent {
             id,
             point,
             sequence_id: None,
+            cancelable: true,
         }
     }
     /// Embedders should ignore this.

--- a/components/shared/embedder/input_events.rs
+++ b/components/shared/embedder/input_events.rs
@@ -147,7 +147,8 @@ pub struct TouchEvent {
     pub event_type: TouchEventType,
     pub id: TouchId,
     pub point: DevicePoint,
-    pub cancelable: bool,
+    /// cancelable default value is true, once the first move has been processed by script disable it.
+    cancelable: bool,
     /// The sequence_id will be set by servo's touch handler.
     sequence_id: Option<TouchSequenceId>,
 }
@@ -176,6 +177,16 @@ impl TouchEvent {
     #[doc(hidden)]
     pub fn expect_sequence_id(&self) -> TouchSequenceId {
         self.sequence_id.expect("Sequence ID not initialized")
+    }
+
+    #[doc(hidden)]
+    pub fn disable_cancelable(&mut self) {
+        self.cancelable = false;
+    }
+
+    #[doc(hidden)]
+    pub fn is_cancelable(&self) -> bool {
+        self.cancelable
     }
 }
 


### PR DESCRIPTION

<!-- Please describe your changes on the following line: -->
add `cancelable` property to the `TouchEvent`
set `cancellable = false` when sending move events to script, if the first touch_move event did not cancel it

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix a part of #35436 

<!-- Either: -->

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
