### PR TITLE
servoshell: Rename `Minibrowser::is_in_browser_rect` to `Minibrowser::is_in_egui_toolbar_rect`

### DIFF
--- a/ports/servoshell/desktop/minibrowser.rs
+++ b/ports/servoshell/desktop/minibrowser.rs
@@ -138,7 +138,7 @@ impl Minibrowser {
                 self.last_mouse_position =
                     Some(winit_position_to_euclid_point(*position).to_f32() / scale);
                 self.last_mouse_position
-                    .is_some_and(|p| self.is_in_browser_rect(p))
+                    .is_some_and(|p| self.is_in_egui_toolbar_rect(p))
             },
             WindowEvent::MouseInput {
                 state: ElementState::Pressed,
@@ -160,14 +160,14 @@ impl Minibrowser {
             },
             WindowEvent::MouseWheel { .. } | WindowEvent::MouseInput { .. } => self
                 .last_mouse_position
-                .is_some_and(|p| self.is_in_browser_rect(p)),
+                .is_some_and(|p| self.is_in_egui_toolbar_rect(p)),
             _ => true,
         };
         result
     }
 
-    /// Return true iff the given position is in the Servo browser rect.
-    fn is_in_browser_rect(&self, position: Point2D<f32, DeviceIndependentPixel>) -> bool {
+    /// Return true iff the given position is over the egui toolbar.
+    fn is_in_egui_toolbar_rect(&self, position: Point2D<f32, DeviceIndependentPixel>) -> bool {
         position.y < self.toolbar_height.get()
     }
 


### PR DESCRIPTION
"browser rect" is a bit of a misnomer as the browser is the entire
window, but this function is trying to determine if a point is on the
non-WebView toolbar portion of the GUI.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
