### PR TITLE
canvas: Do not update `ImageKey` during canvas layout

### DIFF
--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -338,7 +338,7 @@ impl InlineAbsoluteFragmentInfo {
 #[derive(Clone)]
 pub enum CanvasFragmentSource {
     WebGL(ImageKey),
-    Image(Arc<Mutex<IpcSender<CanvasMsg>>>),
+    Image((ImageKey, CanvasId, Arc<Mutex<IpcSender<CanvasMsg>>>)),
     WebGPU(ImageKey),
     /// Transparent black
     Empty,
@@ -349,15 +349,18 @@ pub struct CanvasFragmentInfo {
     pub source: CanvasFragmentSource,
     pub dom_width: Au,
     pub dom_height: Au,
-    pub canvas_id: CanvasId,
 }
 
 impl CanvasFragmentInfo {
     pub fn new(data: HTMLCanvasData) -> CanvasFragmentInfo {
         let source = match data.source {
             HTMLCanvasDataSource::WebGL(texture_id) => CanvasFragmentSource::WebGL(texture_id),
-            HTMLCanvasDataSource::Image(ipc_sender) => {
-                CanvasFragmentSource::Image(Arc::new(Mutex::new(ipc_sender)))
+            HTMLCanvasDataSource::Image((image_key, canvas_id, ipc_sender)) => {
+                CanvasFragmentSource::Image((
+                    image_key,
+                    canvas_id,
+                    Arc::new(Mutex::new(ipc_sender)),
+                ))
             },
             HTMLCanvasDataSource::WebGPU(image_key) => CanvasFragmentSource::WebGPU(image_key),
             HTMLCanvasDataSource::Empty => CanvasFragmentSource::Empty,
@@ -367,7 +370,6 @@ impl CanvasFragmentInfo {
             source,
             dom_width: Au::from_px(data.width as i32),
             dom_height: Au::from_px(data.height as i32),
-            canvas_id: data.canvas_id,
         }
     }
 }

--- a/components/layout_2020/dom.rs
+++ b/components/layout_2020/dom.rs
@@ -155,17 +155,14 @@ where
         let canvas_data = node.canvas_data()?;
         let source = match canvas_data.source {
             HTMLCanvasDataSource::WebGL(texture_id) => CanvasSource::WebGL(texture_id),
-            HTMLCanvasDataSource::Image(ipc_sender) => {
-                CanvasSource::Image(Arc::new(Mutex::new(ipc_sender)))
+            HTMLCanvasDataSource::Image((image_key, canvas_id, ipc_sender)) => {
+                CanvasSource::Image((image_key, canvas_id, Arc::new(Mutex::new(ipc_sender))))
             },
             HTMLCanvasDataSource::WebGPU(image_key) => CanvasSource::WebGPU(image_key),
             HTMLCanvasDataSource::Empty => CanvasSource::Empty,
         };
         Some((
-            CanvasInfo {
-                source,
-                canvas_id: canvas_data.canvas_id,
-            },
+            CanvasInfo { source },
             PhysicalSize::new(canvas_data.width.into(), canvas_data.height.into()),
         ))
     }

--- a/components/script/canvas_context.rs
+++ b/components/script/canvas_context.rs
@@ -4,7 +4,6 @@
 
 //! Common interfaces for Canvas Contexts
 
-use canvas_traits::canvas::CanvasId;
 use euclid::default::Size2D;
 use ipc_channel::ipc::IpcSharedMemory;
 use script_layout_interface::{HTMLCanvasData, HTMLCanvasDataSource};
@@ -20,7 +19,6 @@ pub(crate) trait LayoutCanvasRenderingContextHelpers {
 
 pub(crate) trait LayoutHTMLCanvasElementHelpers {
     fn data(self) -> HTMLCanvasData;
-    fn get_canvas_id_for_layout(self) -> CanvasId;
 }
 
 pub(crate) trait CanvasContext {

--- a/components/script/canvas_state.rs
+++ b/components/script/canvas_state.rs
@@ -34,6 +34,7 @@ use style::values::specified::color::Color;
 use style_traits::values::ToCss;
 use style_traits::{CssWriter, ParsingMode};
 use url::Url;
+use webrender_api::ImageKey;
 
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::CanvasRenderingContext2DBinding::{
@@ -145,6 +146,8 @@ pub(crate) struct CanvasState {
     ipc_renderer: IpcSender<CanvasMsg>,
     #[no_trace]
     canvas_id: CanvasId,
+    #[no_trace]
+    image_key: ImageKey,
     state: DomRefCell<CanvasContextState>,
     origin_clean: Cell<bool>,
     #[ignore_malloc_size_of = "Arc"]
@@ -172,7 +175,7 @@ impl CanvasState {
         script_to_constellation_chan
             .send(ScriptMsg::CreateCanvasPaintThread(size, sender))
             .unwrap();
-        let (ipc_renderer, canvas_id) = receiver.recv().unwrap();
+        let (ipc_renderer, canvas_id, image_key) = receiver.recv().unwrap();
         debug!("Done.");
         // Worklets always receive a unique origin. This messes with fetching
         // cached images in the case of paint worklets, since the image cache
@@ -191,12 +194,17 @@ impl CanvasState {
             base_url: global.api_base_url(),
             missing_image_urls: DomRefCell::new(Vec::new()),
             saved_states: DomRefCell::new(Vec::new()),
+            image_key,
             origin,
         }
     }
 
     pub(crate) fn get_ipc_renderer(&self) -> &IpcSender<CanvasMsg> {
         &self.ipc_renderer
+    }
+
+    pub(crate) fn image_key(&self) -> ImageKey {
+        self.image_key
     }
 
     pub(crate) fn get_missing_image_urls(&self) -> &DomRefCell<Vec<ServoUrl>> {

--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -2,16 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use canvas_traits::canvas::{
-    Canvas2dMsg, CanvasId, CanvasImageData, CanvasMsg, FromLayoutMsg, FromScriptMsg,
-};
+use canvas_traits::canvas::{Canvas2dMsg, CanvasId, CanvasMsg, FromScriptMsg};
 use dom_struct::dom_struct;
 use euclid::default::{Point2D, Rect, Size2D};
-use ipc_channel::ipc::{IpcSender, IpcSharedMemory};
+use ipc_channel::ipc::IpcSharedMemory;
 use profile_traits::ipc;
+use script_layout_interface::HTMLCanvasDataSource;
 use servo_url::ServoUrl;
 
-use crate::canvas_context::CanvasContext;
+use crate::canvas_context::{CanvasContext, LayoutCanvasRenderingContextHelpers};
 use crate::canvas_state::CanvasState;
 use crate::dom::bindings::codegen::Bindings::CanvasRenderingContext2DBinding::{
     CanvasDirection, CanvasFillRule, CanvasImageSource, CanvasLineCap, CanvasLineJoin,
@@ -112,28 +111,16 @@ impl CanvasRenderingContext2D {
         );
         self.canvas_state.get_rect(self.canvas.size(), rect)
     }
-
-    pub(crate) fn send_data(&self, sender: IpcSender<CanvasImageData>) {
-        let msg = CanvasMsg::FromLayout(FromLayoutMsg::SendData(sender), self.get_canvas_id());
-        let _ = self.canvas_state.get_ipc_renderer().send(msg);
-    }
 }
 
-pub(crate) trait LayoutCanvasRenderingContext2DHelpers {
-    fn get_ipc_renderer(self) -> IpcSender<CanvasMsg>;
-    fn get_canvas_id(self) -> CanvasId;
-}
-
-impl LayoutCanvasRenderingContext2DHelpers for LayoutDom<'_, CanvasRenderingContext2D> {
-    fn get_ipc_renderer(self) -> IpcSender<CanvasMsg> {
-        (self.unsafe_get()).canvas_state.get_ipc_renderer().clone()
-    }
-
-    fn get_canvas_id(self) -> CanvasId {
-        // FIXME(nox): This relies on the fact that CanvasState::get_canvas_id
-        // does nothing fancy but it would be easier to trust a
-        // LayoutDom<_>-like type that would wrap the &CanvasState.
-        self.unsafe_get().canvas_state.get_canvas_id()
+impl LayoutCanvasRenderingContextHelpers for LayoutDom<'_, CanvasRenderingContext2D> {
+    fn canvas_data_source(self) -> HTMLCanvasDataSource {
+        let canvas_state = &self.unsafe_get().canvas_state;
+        HTMLCanvasDataSource::Image((
+            canvas_state.image_key(),
+            canvas_state.get_canvas_id(),
+            canvas_state.get_ipc_renderer().clone(),
+        ))
     }
 }
 

--- a/components/script/dom/htmlcanvaselement.rs
+++ b/components/script/dom/htmlcanvaselement.rs
@@ -6,7 +6,6 @@ use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::rc::Rc;
 
-use canvas_traits::canvas::CanvasId;
 use canvas_traits::webgl::{GLContextAttributes, WebGLVersion};
 use dom_struct::dom_struct;
 use euclid::default::Size2D;
@@ -48,9 +47,7 @@ use crate::dom::bindings::reflector::{DomGlobal, DomObject};
 use crate::dom::bindings::root::{Dom, DomRoot, LayoutDom, ToLayout};
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::blob::Blob;
-use crate::dom::canvasrenderingcontext2d::{
-    CanvasRenderingContext2D, LayoutCanvasRenderingContext2DHelpers,
-};
+use crate::dom::canvasrenderingcontext2d::CanvasRenderingContext2D;
 use crate::dom::document::Document;
 use crate::dom::element::{AttributeMutation, Element, LayoutElementHelpers};
 #[cfg(not(feature = "webgpu"))]
@@ -208,9 +205,7 @@ impl LayoutHTMLCanvasElementHelpers for LayoutDom<'_, HTMLCanvasElement> {
     fn data(self) -> HTMLCanvasData {
         let source = unsafe {
             match self.unsafe_get().context.borrow_for_layout().as_ref() {
-                Some(CanvasContext::Context2d(context)) => {
-                    HTMLCanvasDataSource::Image(context.to_layout().get_ipc_renderer())
-                },
+                Some(CanvasContext::Context2d(context)) => context.to_layout().canvas_data_source(),
                 Some(CanvasContext::WebGL(context)) => context.to_layout().canvas_data_source(),
                 Some(CanvasContext::WebGL2(context)) => context.to_layout().canvas_data_source(),
                 #[cfg(feature = "webgpu")]
@@ -229,20 +224,6 @@ impl LayoutHTMLCanvasElementHelpers for LayoutDom<'_, HTMLCanvasElement> {
             source,
             width: width_attr.map_or(DEFAULT_WIDTH, |val| val.as_uint()),
             height: height_attr.map_or(DEFAULT_HEIGHT, |val| val.as_uint()),
-            canvas_id: self.get_canvas_id_for_layout(),
-        }
-    }
-
-    #[allow(unsafe_code)]
-    fn get_canvas_id_for_layout(self) -> CanvasId {
-        let canvas = self.unsafe_get();
-        unsafe {
-            if let &Some(CanvasContext::Context2d(ref context)) = canvas.context.borrow_for_layout()
-            {
-                context.to_layout().get_canvas_id()
-            } else {
-                CanvasId(0)
-            }
         }
     }
 }

--- a/components/script/dom/paintworkletglobalscope.rs
+++ b/components/script/dom/paintworkletglobalscope.rs
@@ -23,7 +23,6 @@ use js::rust::wrappers::{Call, Construct1};
 use js::rust::{HandleValue, Runtime};
 use net_traits::image_cache::ImageCache;
 use pixels::PixelFormat;
-use profile_traits::ipc;
 use script_traits::{DrawAPaintImageResult, PaintWorkletError, Painter};
 use servo_config::pref;
 use servo_url::ServoUrl;
@@ -40,7 +39,7 @@ use crate::dom::bindings::codegen::Bindings::VoidFunctionBinding::VoidFunction;
 use crate::dom::bindings::conversions::{get_property, get_property_jsval};
 use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::inheritance::Castable;
-use crate::dom::bindings::reflector::{DomGlobal, DomObject};
+use crate::dom::bindings::reflector::DomObject;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::cssstylevalue::CSSStyleValue;
@@ -354,19 +353,13 @@ impl PaintWorkletGlobalScope {
             return self.invalid_image(size_in_dpx, missing_image_urls);
         }
 
-        let (sender, receiver) = ipc::channel(self.global().time_profiler_chan().clone())
-            .expect("IPC channel creation.");
-        rendering_context.send_data(sender);
-        let image_key = match receiver.recv() {
-            Ok(data) => Some(data.image_key),
-            _ => None,
-        };
+        let image_key = rendering_context.image_key();
 
         DrawAPaintImageResult {
             width: size_in_dpx.width,
             height: size_in_dpx.height,
             format: PixelFormat::BGRA8,
-            image_key,
+            image_key: Some(image_key),
             missing_image_urls,
         }
     }

--- a/components/shared/canvas/canvas.rs
+++ b/components/shared/canvas/canvas.rs
@@ -12,7 +12,6 @@ use serde::{Deserialize, Serialize};
 use serde_bytes::ByteBuf;
 use style::color::AbsoluteColor;
 use style::properties::style_structs::Font as FontStyleStruct;
-use webrender_api::ImageKey;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum FillRule {
@@ -30,11 +29,6 @@ pub enum CanvasMsg {
     FromScript(FromScriptMsg, CanvasId),
     Recreate(Option<Size2D<u64>>, CanvasId),
     Close(CanvasId),
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct CanvasImageData {
-    pub image_key: ImageKey,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -84,7 +78,7 @@ pub enum Canvas2dMsg {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum FromLayoutMsg {
-    SendData(IpcSender<CanvasImageData>),
+    UpdateImage(IpcSender<()>),
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/components/shared/canvas/lib.rs
+++ b/components/shared/canvas/lib.rs
@@ -8,6 +8,7 @@
 
 use crossbeam_channel::Sender;
 use euclid::default::Size2D;
+use webrender_api::ImageKey;
 
 use crate::canvas::CanvasId;
 
@@ -17,7 +18,7 @@ pub mod webgl;
 
 pub enum ConstellationCanvasMsg {
     Create {
-        id_sender: Sender<CanvasId>,
+        sender: Sender<(CanvasId, ImageKey)>,
         size: Size2D<u64>,
     },
     Exit,

--- a/components/shared/script/script_msg.rs
+++ b/components/shared/script/script_msg.rs
@@ -25,6 +25,7 @@ use servo_url::{ImmutableOrigin, ServoUrl};
 use style_traits::CSSPixel;
 #[cfg(feature = "webgpu")]
 use webgpu::{WebGPU, WebGPUResponse, wgc};
+use webrender_api::ImageKey;
 
 use crate::mem::MemoryReportResult;
 use crate::{
@@ -144,7 +145,7 @@ pub enum ScriptMsg {
     /// 2D canvases may use the GPU and we don't want to give untrusted content access to the GPU.)
     CreateCanvasPaintThread(
         UntypedSize2D<u64>,
-        IpcSender<(IpcSender<CanvasMsg>, CanvasId)>,
+        IpcSender<(IpcSender<CanvasMsg>, CanvasId, ImageKey)>,
     ),
     /// Notifies the constellation that this frame has received focus.
     Focus,

--- a/components/shared/script_layout/lib.rs
+++ b/components/shared/script_layout/lib.rs
@@ -120,7 +120,7 @@ pub enum LayoutElementType {
 
 pub enum HTMLCanvasDataSource {
     WebGL(ImageKey),
-    Image(IpcSender<CanvasMsg>),
+    Image((ImageKey, CanvasId, IpcSender<CanvasMsg>)),
     WebGPU(ImageKey),
     /// transparent black
     Empty,
@@ -130,7 +130,6 @@ pub struct HTMLCanvasData {
     pub source: HTMLCanvasDataSource,
     pub width: u32,
     pub height: u32,
-    pub canvas_id: CanvasId,
 }
 
 pub struct SVGSVGData {


### PR DESCRIPTION
https://github.com/servo/servo/pull/35695 made 2d canvas reuse one ImageKey, so we can simply send it on 2d canvas creation. This avoids receiving image key from paint thread on every layout and brings 2d canvas context closer to other canvas ctxs. This also brings in a lot of simplifications.

Currently we still send ipc message (to update wr image) on layouting and await that update image cmd is sent to WR (or else we get problems, because we can built/send display list before update image is sent to WR), but I plan to tackle this in followup PR.

PR is reviewable per commits.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes in WPT

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
