### PR TITLE
Sync cargo-deny version in python/servo/platform/base.py

### DIFF
--- a/python/servo/platform/base.py
+++ b/python/servo/platform/base.py
@@ -82,11 +82,11 @@ class Base:
         def cargo_deny_installed():
             if force or not shutil.which("cargo-deny"):
                 return False
-            # Tidy needs at least version 0.16.3 installed.
+            # Tidy needs at least version 0.18.1 installed.
             result = subprocess.run(["cargo-deny", "--version"],
                                     encoding='utf-8', capture_output=True)
             (major, minor, micro) = result.stdout.strip().split(" ")[1].split(".", 2)
-            return (int(major), int(minor), int(micro)) >= (0, 16, 3)
+            return (int(major), int(minor), int(micro)) >= (0, 18, 1)
 
         if cargo_deny_installed():
             return False


### PR DESCRIPTION
Sync cargo-deny version in `python/servo/platform/base.py` to the version specified in CI (`.github/workflows/lint.yml`). CI now requires 0.18.* after changes in https://github.com/servo/servo/pull/35628.

Previously I had cargo-deny version 0.16.3 installed on my machine. After pulling the latest changes on `main`, I started to get the following errors:
```
 ➤  Running `cargo-deny` checks...
  | /Users/yerke/dev/servo/deny.toml:30: unable to check for yanked crates: async-compression 0.4.20 registry+https://github.com/rust-lang/crates.io-index
  | /Users/yerke/dev/servo/deny.toml:71: unable to check for yanked crates: calendrical_calculations 0.1.3 registry+https://github.com/rust-lang/crates.io-index
  | /Users/yerke/dev/servo/deny.toml:78: unable to check for yanked crates: cc 1.2.16 registry+https://github.com/rust-lang/crates.io-index
  | /Users/yerke/dev/servo/deny.toml:85: unable to check for yanked crates: chrono 0.4.40 registry+https://github.com/rust-lang/crates.io-index
  | /Users/yerke/dev/servo/deny.toml:91: unable to check for yanked crates: clap 4.5.31 registry+https://github.com/rust-lang/crates.io-index
  | /Users/yerke/dev/servo/deny.toml:92: unable to check for yanked crates: clap_builder 4.5.31 registry+https://github.com/rust-lang/crates.io-index
  | /Users/yerke/dev/servo/deny.toml:173: unable to check for yanked crates: either 1.14.0 registry+https://github.com/rust-lang/crates.io-index
  | /Users/yerke/dev/servo/deny.toml:195: unable to check for yanked crates: flate2 1.1.0 registry+https://github.com/rust-lang/crates.io-index
  | /Users/yerke/dev/servo/deny.toml:374: unable to check for yanked crates: libc 0.2.170 registry+https://github.com/rust-lang/crates.io-index
  | /Users/yerke/dev/servo/deny.toml:384: unable to check for yanked crates: litemap 0.7.5 registry+https://github.com/rust-lang/crates.io-index
  | /Users/yerke/dev/servo/deny.toml:634: unable to check for yanked crates: tar 0.4.44 registry+https://github.com/rust-lang/crates.io-index
  | /Users/yerke/dev/servo/deny.toml:764: unable to check for yanked crates: windows-link 0.1.0 registry+https://github.com/rust-lang/crates.io-index
  | /Users/yerke/dev/servo/deny.toml:822: unable to check for yanked crates: zerofrom 0.1.6 registry+https://github.com/rust-lang/crates.io-index
  | /Users/yerke/dev/servo/deny.toml:823: unable to check for yanked crates: zerofrom-derive 0.1.6 registry+https://github.com/rust-lang/crates.io-index
```

Updating cargo-deny to version 0.18.1 (which the latest in 0.18.*) resolved the issue.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

- [x] These changes do not require tests because I am just updating the cargo-deny version to match the version we use in CI.
