### PR TITLE
refactor: add CanGc as argument to methods in CanvasRenderingContext2D and OffscreenCanvasRenderingContext2D

### DIFF
--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -555,9 +555,10 @@ impl CanvasRenderingContext2DMethods<crate::DomTypeHolder> for CanvasRenderingCo
         y0: Finite<f64>,
         x1: Finite<f64>,
         y1: Finite<f64>,
+        can_gc: CanGc,
     ) -> DomRoot<CanvasGradient> {
         self.canvas_state
-            .create_linear_gradient(&self.global(), x0, y0, x1, y1, CanGc::note())
+            .create_linear_gradient(&self.global(), x0, y0, x1, y1, can_gc)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-createradialgradient
@@ -569,17 +570,10 @@ impl CanvasRenderingContext2DMethods<crate::DomTypeHolder> for CanvasRenderingCo
         x1: Finite<f64>,
         y1: Finite<f64>,
         r1: Finite<f64>,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<CanvasGradient>> {
-        self.canvas_state.create_radial_gradient(
-            &self.global(),
-            x0,
-            y0,
-            r0,
-            x1,
-            y1,
-            r1,
-            CanGc::note(),
-        )
+        self.canvas_state
+            .create_radial_gradient(&self.global(), x0, y0, r0, x1, y1, r1, can_gc)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-createpattern
@@ -587,9 +581,10 @@ impl CanvasRenderingContext2DMethods<crate::DomTypeHolder> for CanvasRenderingCo
         &self,
         image: CanvasImageSource,
         repetition: DOMString,
+        can_gc: CanGc,
     ) -> Fallible<Option<DomRoot<CanvasPattern>>> {
         self.canvas_state
-            .create_pattern(&self.global(), image, repetition, CanGc::note())
+            .create_pattern(&self.global(), image, repetition, can_gc)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-linewidth

--- a/components/script/dom/offscreencanvasrenderingcontext2d.rs
+++ b/components/script/dom/offscreencanvasrenderingcontext2d.rs
@@ -173,8 +173,9 @@ impl OffscreenCanvasRenderingContext2DMethods<crate::DomTypeHolder>
         y0: Finite<f64>,
         x1: Finite<f64>,
         y1: Finite<f64>,
+        can_gc: CanGc,
     ) -> DomRoot<CanvasGradient> {
-        self.context.CreateLinearGradient(x0, y0, x1, y1)
+        self.context.CreateLinearGradient(x0, y0, x1, y1, can_gc)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-createradialgradient
@@ -186,8 +187,10 @@ impl OffscreenCanvasRenderingContext2DMethods<crate::DomTypeHolder>
         x1: Finite<f64>,
         y1: Finite<f64>,
         r1: Finite<f64>,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<CanvasGradient>> {
-        self.context.CreateRadialGradient(x0, y0, r0, x1, y1, r1)
+        self.context
+            .CreateRadialGradient(x0, y0, r0, x1, y1, r1, can_gc)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-createpattern
@@ -195,8 +198,9 @@ impl OffscreenCanvasRenderingContext2DMethods<crate::DomTypeHolder>
         &self,
         image: CanvasImageSource,
         repetition: DOMString,
+        can_gc: CanGc,
     ) -> Fallible<Option<DomRoot<CanvasPattern>>> {
-        self.context.CreatePattern(image, repetition)
+        self.context.CreatePattern(image, repetition, can_gc)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-save

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -76,7 +76,7 @@ DOMInterfaces = {
 },
 
 'CanvasRenderingContext2D': {
-    'canGc': ['GetTransform','GetImageData', 'CreateImageData', 'CreateImageData_', 'SetFont', 'FillText', 'MeasureText', 'SetStrokeStyle', 'SetFillStyle', 'SetShadowColor'],
+    'canGc': ['GetTransform','GetImageData', 'CreateImageData', 'CreateImageData_', 'SetFont', 'FillText', 'MeasureText', 'SetStrokeStyle', 'SetFillStyle', 'SetShadowColor', 'CreateLinearGradient', 'CreatePattern', 'CreateRadialGradient'],
 },
 
 'CharacterData': {
@@ -419,7 +419,7 @@ DOMInterfaces = {
 },
 
 'OffscreenCanvasRenderingContext2D': {
-    'canGc': ['CreateImageData', 'CreateImageData_', 'GetImageData', 'GetTransform', 'SetFont', 'FillText', 'MeasureText', 'SetStrokeStyle', 'SetFillStyle', 'SetShadowColor'],
+    'canGc': ['CreateImageData', 'CreateImageData_', 'GetImageData', 'GetTransform', 'SetFont', 'FillText', 'MeasureText', 'SetStrokeStyle', 'SetFillStyle', 'SetShadowColor', 'CreateLinearGradient', 'CreatePattern', 'CreateRadialGradient'],
 },
 
 'PaintRenderingContext2D': {


### PR DESCRIPTION
Add CanGc as argument to methods in `CanvasRenderingContext2D` and `OffscreenCanvasRenderingContext2D`.

Addressed part of https://github.com/servo/servo/issues/34573.

---

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they are a refactor.
