### PR TITLE
Various fixes for webdriver conformance tests

### DIFF
--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -43,7 +43,8 @@ use crate::dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
 use crate::dom::bindings::codegen::Bindings::XMLSerializerBinding::XMLSerializerMethods;
 use crate::dom::bindings::conversions::{
     ConversionBehavior, ConversionResult, FromJSValConvertible, StringificationBehavior,
-    get_property, get_property_jsval, is_array_like, jsid_to_string, jsstring_to_str, root_from_object,
+    get_property, get_property_jsval, is_array_like, jsid_to_string, jsstring_to_str,
+    root_from_object,
 };
 use crate::dom::bindings::error::{Error, throw_dom_exception};
 use crate::dom::bindings::inheritance::Castable;

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -176,8 +176,7 @@ unsafe fn is_arguments_object(cx: *mut JSContext, value: HandleValue) -> bool {
     let Some(class_name) = NonNull::new(class_name.get()) else {
         return false;
     };
-    let class_name = jsstring_to_str(cx, class_name).replace("[object ", "");
-    class_name.starts_with("Arguments")
+    jsstring_to_str(cx, class_name) == "[object Arguments]"
 }
 
 #[allow(unsafe_code)]

--- a/components/webdriver_server/actions.rs
+++ b/components/webdriver_server/actions.rs
@@ -378,13 +378,10 @@ impl Handler {
                 ))
                 .unwrap();
 
-                match receiver.recv().unwrap() {
-                    Ok(point) => match point {
-                        Some(point) => point,
-                        None => return Err(ErrorStatus::UnknownError),
-                    },
-                    Err(_) => return Err(ErrorStatus::UnknownError),
-                }
+                let Some(point) = receiver.recv().unwrap()? else {
+                    return Err(ErrorStatus::UnknownError);
+                };
+                point
             },
         };
 

--- a/components/webdriver_server/actions.rs
+++ b/components/webdriver_server/actions.rs
@@ -372,10 +372,9 @@ impl Handler {
             PointerOrigin::Pointer => (start_x + x_offset, start_y + y_offset),
             PointerOrigin::Element(ref x) => {
                 let (sender, receiver) = ipc::channel().unwrap();
-                self.browsing_context_script_command(WebDriverScriptCommand::GetElementInViewCenterPoint(
-                    x.to_string(),
-                    sender,
-                ))
+                self.browsing_context_script_command(
+                    WebDriverScriptCommand::GetElementInViewCenterPoint(x.to_string(), sender),
+                )
                 .unwrap();
 
                 let Some(point) = receiver.recv().unwrap()? else {

--- a/components/webdriver_server/actions.rs
+++ b/components/webdriver_server/actions.rs
@@ -372,7 +372,7 @@ impl Handler {
             PointerOrigin::Pointer => (start_x + x_offset, start_y + y_offset),
             PointerOrigin::Element(ref x) => {
                 let (sender, receiver) = ipc::channel().unwrap();
-                self.top_level_script_command(WebDriverScriptCommand::GetElementInViewCenterPoint(
+                self.browsing_context_script_command(WebDriverScriptCommand::GetElementInViewCenterPoint(
                     x.to_string(),
                     sender,
                 ))

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -897,14 +897,8 @@ impl Handler {
                 .unwrap();
         }
 
-        let webview_id = self.focus_webview_id()?;
-        let browsing_context_id = BrowsingContextId::from(webview_id);
-        let session = self.session_mut().unwrap();
-        session.webview_id = webview_id;
-        session.browsing_context_id = browsing_context_id;
-
         Ok(WebDriverResponse::CloseWindow(CloseWindowResponse(
-            session.window_handles.values().cloned().collect(),
+            self.session().unwrap().window_handles.values().cloned().collect(),
         )))
     }
 

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -1468,7 +1468,7 @@ impl Handler {
         let (sender, receiver) = ipc::channel().unwrap();
         let command = WebDriverScriptCommand::ExecuteScript(script, sender);
         self.browsing_context_script_command(command)?;
-        let result = receiver.recv().unwrap();
+        let result = receiver.recv().unwrap_or(Err(WebDriverJSError::BrowsingContextNotFound));
         self.postprocess_js_result(result)
     }
 
@@ -1502,7 +1502,7 @@ impl Handler {
         let (sender, receiver) = ipc::channel().unwrap();
         let command = WebDriverScriptCommand::ExecuteAsyncScript(script, sender);
         self.browsing_context_script_command(command)?;
-        let result = receiver.recv().unwrap();
+        let result = receiver.recv().unwrap_or(Err(WebDriverJSError::BrowsingContextNotFound));
         self.postprocess_js_result(result)
     }
 
@@ -1515,7 +1515,7 @@ impl Handler {
                 serde_json::to_value(SendableWebDriverJSValue(value))?,
             ))),
             Err(WebDriverJSError::BrowsingContextNotFound) => Err(WebDriverError::new(
-                ErrorStatus::JavascriptError,
+                ErrorStatus::NoSuchWindow,
                 "Pipeline id not found in browsing context",
             )),
             Err(WebDriverJSError::JSError) => Err(WebDriverError::new(

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -924,17 +924,18 @@ impl Handler {
             .send(ConstellationMsg::WebDriverCommand(cmd_msg))
             .unwrap();
 
+        let mut handle = self.session.as_ref().unwrap().id.to_string();
         if let Ok(new_webview_id) = receiver.recv() {
             let session = self.session_mut().unwrap();
             session.webview_id = new_webview_id;
             session.browsing_context_id = BrowsingContextId::from(new_webview_id);
             let new_handle = Uuid::new_v4().to_string();
+            handle = new_handle.clone();
             session.window_handles.insert(new_webview_id, new_handle);
         }
 
         let _ = self.wait_for_load();
 
-        let handle = self.session.as_ref().unwrap().id.to_string();
         Ok(WebDriverResponse::NewWindow(NewWindowResponse {
             handle,
             typ: "tab".to_string(),

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -1458,7 +1458,7 @@ impl Handler {
         // new Function() and then takes the resulting function and executes
         // it with a vec of arguments.
         let script = format!(
-            "(function() {{ {} }})({})",
+            "(function() {{ {}\n }})({})",
             func_body,
             args_string.join(", ")
         );
@@ -1491,7 +1491,7 @@ impl Handler {
             "".into()
         };
         let script = format!(
-            "{} (function() {{ {} }})({})",
+            "{} (function() {{ {}\n }})({})",
             timeout_script,
             func_body,
             args_string.join(", "),

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -898,7 +898,12 @@ impl Handler {
         }
 
         Ok(WebDriverResponse::CloseWindow(CloseWindowResponse(
-            self.session().unwrap().window_handles.values().cloned().collect(),
+            self.session()
+                .unwrap()
+                .window_handles
+                .values()
+                .cloned()
+                .collect(),
         )))
     }
 
@@ -1462,7 +1467,9 @@ impl Handler {
         let (sender, receiver) = ipc::channel().unwrap();
         let command = WebDriverScriptCommand::ExecuteScript(script, sender);
         self.browsing_context_script_command(command)?;
-        let result = receiver.recv().unwrap_or(Err(WebDriverJSError::BrowsingContextNotFound));
+        let result = receiver
+            .recv()
+            .unwrap_or(Err(WebDriverJSError::BrowsingContextNotFound));
         self.postprocess_js_result(result)
     }
 
@@ -1496,7 +1503,9 @@ impl Handler {
         let (sender, receiver) = ipc::channel().unwrap();
         let command = WebDriverScriptCommand::ExecuteAsyncScript(script, sender);
         self.browsing_context_script_command(command)?;
-        let result = receiver.recv().unwrap_or(Err(WebDriverJSError::BrowsingContextNotFound));
+        let result = receiver
+            .recv()
+            .unwrap_or(Err(WebDriverJSError::BrowsingContextNotFound));
         self.postprocess_js_result(result)
     }
 

--- a/tests/wpt/tests/tools/wptrunner/wptrunner/browsers/servodriver.py
+++ b/tests/wpt/tests/tools/wptrunner/wptrunner/browsers/servodriver.py
@@ -48,11 +48,13 @@ def browser_kwargs(logger, test_type, run_info_data, config, **kwargs):
         "server_config": config,
         "user_stylesheets": kwargs.get("user_stylesheets"),
         "headless": kwargs.get("headless"),
+        "capabilities": kwargs.get("capabilities"),
     }
 
 
 def executor_kwargs(logger, test_type, test_environment, run_info_data, **kwargs):
     rv = base_executor_kwargs(test_type, test_environment, run_info_data, **kwargs)
+    rv['capabilities'] = {}
     return rv
 
 

--- a/tests/wpt/tests/tools/wptrunner/wptrunner/executors/executorservodriver.py
+++ b/tests/wpt/tests/tools/wptrunner/wptrunner/executors/executorservodriver.py
@@ -78,7 +78,7 @@ class ServoWebDriverTestharnessExecutor(WebDriverTestharnessExecutor):
     protocol_cls = ServoWebDriverProtocol
 
     def __init__(self, logger, browser, server_config, timeout_multiplier=1,
-                 close_after_done=True, capabilities={}, debug_info=None,
+                 close_after_done=True, capabilities=None, debug_info=None,
                  **kwargs):
         WebDriverTestharnessExecutor.__init__(self, logger, browser, server_config,
                                               timeout_multiplier, capabilities=capabilities,
@@ -96,7 +96,7 @@ class ServoWebDriverRefTestExecutor(WebDriverRefTestExecutor):
     protocol_cls = ServoWebDriverProtocol
 
     def __init__(self, logger, browser, server_config, timeout_multiplier=1,
-                 screenshot_cache=None, capabilities={}, debug_info=None,
+                 screenshot_cache=None, capabilities=None, debug_info=None,
                  **kwargs):
         WebDriverRefTestExecutor.__init__(self, logger, browser, server_config,
                                           timeout_multiplier, screenshot_cache,
@@ -114,7 +114,7 @@ class ServoWebDriverCrashtestExecutor(WebDriverCrashtestExecutor):
     protocol_cls = ServoWebDriverProtocol
 
     def __init__(self, logger, browser, server_config, timeout_multiplier=1,
-                 screenshot_cache=None, capabilities={}, debug_info=None,
+                 screenshot_cache=None, capabilities=None, debug_info=None,
                  **kwargs):
         WebDriverCrashtestExecutor.__init__(self, logger, browser, server_config,
                                             timeout_multiplier, screenshot_cache,


### PR DESCRIPTION
I'm working through test failures under tests/wpt/tests/webdriver/tests/classic/execute_script/execute.py, and these changes allow many of the tests in that file to pass.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #34683 
- [x] There are tests for these changes (but they don't run in CI yet)