### PR TITLE
Check for existence of 'sudo' on Linux in ./mach bootstrap

### DIFF
--- a/python/servo/platform/linux.py
+++ b/python/servo/platform/linux.py
@@ -207,7 +207,7 @@ class Linux(Base):
         def check_sudo():
             if os.geteuid() != 0:
                 if shutil.which('sudo') is None:
-                    return False;
+                    return False
             return True
 
         def run_as_root(command, force=False):


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Update linux.py bootstrap script to check for the existence of the 'sudo' command before attempting to call it. If it does not find 'sudo', then it will gracefully notify the user, wait for a prompt, and then continue on with the bootstrap process, exactly as is done when bootstrap does not recognize the distro.

Note that while this addresses the ugly stack trace mentioned in issue #35736, it does not address the desire for an "opt-in" to sudo. In other words, mach bootstrap will still automatically try to call sudo when not running as root.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #35736 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because there are no existing tests for current behavior. I tested manually for the case where sudo exists, and where it does not exist. I also ran as root and verified it does not check for sudo.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
