### PR TITLE
Set a valid default value for the --userscripts command line option

### DIFF
--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -612,7 +612,7 @@ pub(crate) fn parse_command_line_arguments(args: Vec<String>) -> ArgumentParsing
         time_profiler_trace_path: opt_match.opt_str("profiler-trace-path"),
         mem_profiler_period,
         nonincremental_layout,
-        userscripts: opt_match.opt_default("userscripts", ""),
+        userscripts: opt_match.opt_default("userscripts", "resources/user-agent-js"),
         user_stylesheets,
         hard_fail: opt_match.opt_present("f") && !opt_match.opt_present("F"),
         webdriver_port,


### PR DESCRIPTION
This prevents a crash when not specifying the path and matches the help message for that option.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
