### PR TITLE
script: Avoid double borrow crash on iframe focus

### DIFF
--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -16,6 +16,13 @@
       {}
      ]
     ],
+    "iframe_focus-crash.html": [
+     "f991b1a563f3cc44870640ab194708fa239ad89d",
+     [
+      null,
+      {}
+     ]
+    ],
     "test-wait-crash.html": [
      "2419da6af0c278a17b9ff974d4418f9e386ef3e0",
      [

--- a/tests/wpt/mozilla/tests/mozilla/iframe_focus-crash.html
+++ b/tests/wpt/mozilla/tests/mozilla/iframe_focus-crash.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<meta charset="utf-8">
+<meta name="assert" content="focusing an iframe with onfocus event shouldn't crash">
+
+<iframe id="f" srcdoc="<iframe></iframe><script>document.querySelector('iframe').focus();</script>"></iframe>
+<script>
+    document.querySelector('iframe').onfocus = () => f;
+</script>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
When an iframe with an `onfocus` event is focused, servo will crash due to attempting a mutable borrow on an already-borrowed `RefCell`. Avoid this by providing a new root for the needed `Element` borrow.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #35543

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
