### PR TITLE
refactor: add CanGc as argument to methods in CSSGroupingRule, CSSKeyframesRule, Crypto

### DIFF
--- a/components/script/dom/crypto.rs
+++ b/components/script/dom/crypto.rs
@@ -44,9 +44,9 @@ impl Crypto {
 
 impl CryptoMethods<crate::DomTypeHolder> for Crypto {
     /// <https://w3c.github.io/webcrypto/#dfn-Crypto-attribute-subtle>
-    fn Subtle(&self) -> DomRoot<SubtleCrypto> {
+    fn Subtle(&self, can_gc: CanGc) -> DomRoot<SubtleCrypto> {
         self.subtle
-            .or_init(|| SubtleCrypto::new(&self.global(), CanGc::note()))
+            .or_init(|| SubtleCrypto::new(&self.global(), can_gc))
     }
 
     #[allow(unsafe_code)]

--- a/components/script/dom/cssgroupingrule.rs
+++ b/components/script/dom/cssgroupingrule.rs
@@ -39,14 +39,14 @@ impl CSSGroupingRule {
         }
     }
 
-    fn rulelist(&self) -> DomRoot<CSSRuleList> {
+    fn rulelist(&self, can_gc: CanGc) -> DomRoot<CSSRuleList> {
         let parent_stylesheet = self.upcast::<CSSRule>().parent_stylesheet();
         self.rulelist.or_init(|| {
             CSSRuleList::new(
                 self.global().as_window(),
                 parent_stylesheet,
                 RulesSource::Rules(self.rules.clone()),
-                CanGc::note(),
+                can_gc,
             )
         })
     }
@@ -62,13 +62,13 @@ impl CSSGroupingRule {
 
 impl CSSGroupingRuleMethods<crate::DomTypeHolder> for CSSGroupingRule {
     // https://drafts.csswg.org/cssom/#dom-cssgroupingrule-cssrules
-    fn CssRules(&self) -> DomRoot<CSSRuleList> {
+    fn CssRules(&self, can_gc: CanGc) -> DomRoot<CSSRuleList> {
         // XXXManishearth check origin clean flag
-        self.rulelist()
+        self.rulelist(can_gc)
     }
 
     // https://drafts.csswg.org/cssom/#dom-cssgroupingrule-insertrule
-    fn InsertRule(&self, rule: DOMString, index: u32) -> Fallible<u32> {
+    fn InsertRule(&self, rule: DOMString, index: u32, can_gc: CanGc) -> Fallible<u32> {
         // TODO: this should accumulate the rule types of all ancestors.
         let rule_type = self.cssrule.as_specific().ty();
         let containing_rule_types = CssRuleTypes::from(rule_type);
@@ -76,17 +76,17 @@ impl CSSGroupingRuleMethods<crate::DomTypeHolder> for CSSGroupingRule {
             CssRuleType::Style | CssRuleType::Scope => Some(rule_type),
             _ => None,
         };
-        self.rulelist().insert_rule(
+        self.rulelist(can_gc).insert_rule(
             &rule,
             index,
             containing_rule_types,
             parse_relative_rule_type,
-            CanGc::note(),
+            can_gc,
         )
     }
 
     // https://drafts.csswg.org/cssom/#dom-cssgroupingrule-deleterule
-    fn DeleteRule(&self, index: u32) -> ErrorResult {
-        self.rulelist().remove_rule(index)
+    fn DeleteRule(&self, index: u32, can_gc: CanGc) -> ErrorResult {
+        self.rulelist(can_gc).remove_rule(index)
     }
 }

--- a/components/script/dom/csskeyframesrule.rs
+++ b/components/script/dom/csskeyframesrule.rs
@@ -61,14 +61,14 @@ impl CSSKeyframesRule {
         )
     }
 
-    fn rulelist(&self) -> DomRoot<CSSRuleList> {
+    fn rulelist(&self, can_gc: CanGc) -> DomRoot<CSSRuleList> {
         self.rulelist.or_init(|| {
             let parent_stylesheet = &self.upcast::<CSSRule>().parent_stylesheet();
             CSSRuleList::new(
                 self.global().as_window(),
                 parent_stylesheet,
                 RulesSource::Keyframes(self.keyframesrule.clone()),
-                CanGc::note(),
+                can_gc,
             )
         })
     }
@@ -94,12 +94,12 @@ impl CSSKeyframesRule {
 
 impl CSSKeyframesRuleMethods<crate::DomTypeHolder> for CSSKeyframesRule {
     // https://drafts.csswg.org/css-animations/#dom-csskeyframesrule-cssrules
-    fn CssRules(&self) -> DomRoot<CSSRuleList> {
-        self.rulelist()
+    fn CssRules(&self, can_gc: CanGc) -> DomRoot<CSSRuleList> {
+        self.rulelist(can_gc)
     }
 
     // https://drafts.csswg.org/css-animations/#dom-csskeyframesrule-appendrule
-    fn AppendRule(&self, rule: DOMString) {
+    fn AppendRule(&self, rule: DOMString, can_gc: CanGc) {
         let style_stylesheet = self.cssrule.parent_stylesheet().style_stylesheet();
         let rule = Keyframe::parse(
             &rule,
@@ -113,21 +113,21 @@ impl CSSKeyframesRuleMethods<crate::DomTypeHolder> for CSSKeyframesRule {
                 .write_with(&mut guard)
                 .keyframes
                 .push(rule);
-            self.rulelist().append_lazy_dom_rule();
+            self.rulelist(can_gc).append_lazy_dom_rule();
         }
     }
 
     // https://drafts.csswg.org/css-animations/#dom-csskeyframesrule-deleterule
-    fn DeleteRule(&self, selector: DOMString) {
+    fn DeleteRule(&self, selector: DOMString, can_gc: CanGc) {
         if let Some(idx) = self.find_rule(&selector) {
-            let _ = self.rulelist().remove_rule(idx as u32);
+            let _ = self.rulelist(can_gc).remove_rule(idx as u32);
         }
     }
 
     // https://drafts.csswg.org/css-animations/#dom-csskeyframesrule-findrule
-    fn FindRule(&self, selector: DOMString) -> Option<DomRoot<CSSKeyframeRule>> {
+    fn FindRule(&self, selector: DOMString, can_gc: CanGc) -> Option<DomRoot<CSSKeyframeRule>> {
         self.find_rule(&selector)
-            .and_then(|idx| self.rulelist().item(idx as u32))
+            .and_then(|idx| self.rulelist(can_gc).item(idx as u32))
             .and_then(DomRoot::downcast)
     }
 

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -87,6 +87,18 @@ DOMInterfaces = {
     'canGc': ['GetSize'],
 },
 
+'CSSGroupingRule': {
+    'canGc': ['CssRules', 'DeleteRule', 'InsertRule'],
+},
+
+'CSSKeyframesRule': {
+    'canGc': ['AppendRule', 'CssRules', 'DeleteRule', 'FindRule'],
+},
+
+'Crypto': {
+    'canGc': ['Subtle'],
+},
+
 'CSSStyleDeclaration': {
     'canGc': ['RemoveProperty', 'SetCssText', 'GetPropertyValue', 'SetProperty', 'CssFloat', 'SetCssFloat']
 },


### PR DESCRIPTION
Add CanGc as argument to methods in `CSSGroupingRule`, `CSSKeyframesRule`, `Crypto`.

Addressed part of https://github.com/servo/servo/issues/34573.

---

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they are a refactor.
