### PR TITLE
Respond to the `connect` message from a devtools client

### DIFF
--- a/components/devtools/actor.rs
+++ b/components/devtools/actor.rs
@@ -10,7 +10,7 @@ use std::net::TcpStream;
 use std::sync::{Arc, Mutex};
 
 use base::cross_process_instant::CrossProcessInstant;
-use log::{debug, warn};
+use log::debug;
 use serde_json::{Map, Value};
 
 /// General actor system infrastructure.
@@ -175,21 +175,22 @@ impl ActorRegistry {
         let to = match msg.get("to") {
             Some(to) => to.as_str().unwrap(),
             None => {
-                warn!("Received unexpected message: {:?}", msg);
+                log::warn!("Received unexpected message: {:?}", msg);
                 return Err(());
             },
         };
 
         match self.actors.get(to) {
-            None => debug!("message received for unknown actor \"{}\"", to),
+            None => log::warn!("message received for unknown actor \"{}\"", to),
             Some(actor) => {
                 let msg_type = msg.get("type").unwrap().as_str().unwrap();
                 if actor.handle_message(self, msg_type, msg, stream, id)? !=
                     ActorMessageStatus::Processed
                 {
-                    debug!(
+                    log::warn!(
                         "unexpected message type \"{}\" found for actor \"{}\"",
-                        msg_type, to
+                        msg_type,
+                        to
                     );
                 }
             },

--- a/components/devtools/actors/root.rs
+++ b/components/devtools/actors/root.rs
@@ -12,7 +12,7 @@
 use std::net::TcpStream;
 
 use serde::Serialize;
-use serde_json::{Map, Value};
+use serde_json::{json, Map, Value};
 
 use crate::actor::{Actor, ActorMessageStatus, ActorRegistry};
 use crate::actors::device::DeviceActor;
@@ -145,6 +145,13 @@ impl Actor for RootActor {
         _id: StreamId,
     ) -> Result<ActorMessageStatus, ()> {
         Ok(match msg_type {
+            "connect" => {
+                let message = json!({
+                    "from": "root",
+                });
+                let _ = stream.write_json_packet(&message);
+                ActorMessageStatus::Processed
+            },
             "listAddons" => {
                 let actor = ListAddonsReply {
                     from: "root".to_owned(),

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -28,7 +28,7 @@ use devtools_traits::{
 };
 use embedder_traits::{AllowOrDeny, EmbedderMsg, EmbedderProxy};
 use ipc_channel::ipc::{self, IpcSender};
-use log::{debug, trace, warn};
+use log::trace;
 use serde::Serialize;
 use servo_rand::RngCore;
 
@@ -650,10 +650,10 @@ fn allow_devtools_client(stream: &mut TcpStream, embedder: &EmbedderProxy, token
 
 /// Process the input from a single devtools client until EOF.
 fn handle_client(actors: Arc<Mutex<ActorRegistry>>, mut stream: TcpStream, id: StreamId) {
-    debug!("connection established to {}", stream.peer_addr().unwrap());
+    log::info!("Connection established to {}", stream.peer_addr().unwrap());
     let msg = actors.lock().unwrap().find::<RootActor>("root").encodable();
     if let Err(e) = stream.write_json_packet(&msg) {
-        warn!("Error writing response: {:?}", e);
+        log::warn!("Error writing response: {:?}", e);
         return;
     }
 
@@ -665,17 +665,17 @@ fn handle_client(actors: Arc<Mutex<ActorRegistry>>, mut stream: TcpStream, id: S
                     &mut stream,
                     id,
                 ) {
-                    debug!("error: devtools actor stopped responding");
+                    log::error!("Devtools actor stopped responding");
                     let _ = stream.shutdown(Shutdown::Both);
                     break;
                 }
             },
             Ok(None) => {
-                debug!("error: EOF");
+                log::info!("Devtools connection closed");
                 break;
             },
             Err(err_msg) => {
-                debug!("error: {}", err_msg);
+                log::error!("Failed to read message from devtools client: {}", err_msg);
                 break;
             },
         }


### PR DESCRIPTION
The `connect` message is sent to the root actor when a client connection is established and tells it about the frontend version of the client. While we don't really need that information yet, we shouldn't ignore the message, otherwise we trigger warnings about unimplemented functionality.

I also bumped the log level of some log messages in the devtools server. Previously almost everything was `log::debug`, which buries important warnings in spam (for example, all messages that are sent/received by the server are also logged at that level). Additionally, seeing a `log::debug("error: [..]")` physically hurts me.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] There are no tests for these changes, we don't have devtools tests.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
