### PR TITLE
script: Make `Blob.ArrayBuffer()` more specification-compliant

### DIFF
--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -39,7 +39,7 @@ DOMInterfaces = {
 'Blob': {
     'weakReferenceable': True,
     'canGc': ['Slice', 'Text', 'ArrayBuffer', 'Stream', 'Bytes'],
-    'inRealms': ['Bytes'],
+    'inRealms': ['Bytes', 'ArrayBuffer'],
 },
 
 'Bluetooth': {


### PR DESCRIPTION
I have modified the Blob.ArrayBuffer implementation to comply with the specification part of #25209.
See also: #35151.

Testing: This does not seem to affect tested behavior, so no new tests.