### PR TITLE
Migrate to the 2024 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,9 @@ exclude = [".cargo", "support/crown"]
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
 license = "MPL-2.0"
-edition = "2021"
+edition = "2024"
 publish = false
-rust-version = "1.83.0"
+rust-version = "1.85.0"
 
 [workspace.dependencies]
 accountable-refcell = "0.2.0"

--- a/components/allocator/Cargo.toml
+++ b/components/allocator/Cargo.toml
@@ -23,3 +23,6 @@ windows-sys = { workspace = true, features = ["Win32_System_Memory"] }
 
 [target.'cfg(target_env = "ohos")'.dependencies]
 libc = { workspace = true }
+
+[lints.rust]
+unsafe_op_in_unsafe_fn = { level = "allow" }

--- a/components/allocator/lib.rs
+++ b/components/allocator/lib.rs
@@ -21,7 +21,7 @@ mod platform {
     ///
     /// Passing a non-heap allocated pointer to this function results in undefined behavior.
     pub unsafe extern "C" fn usable_size(ptr: *const c_void) -> usize {
-        tikv_jemallocator::usable_size(ptr)
+        unsafe { tikv_jemallocator::usable_size(ptr) }
     }
 
     /// Memory allocation APIs compatible with libc

--- a/components/background_hang_monitor/Cargo.toml
+++ b/components/background_hang_monitor/Cargo.toml
@@ -32,3 +32,6 @@ mach2 = { version = "0.4", optional = true }
 [target.'cfg(all(target_os = "linux", not(any(target_arch = "arm", target_arch = "aarch64", target_env = "ohos", target_env = "musl"))))'.dependencies]
 nix = { workspace = true, features = ["signal"], optional = true }
 unwind-sys = { version = "0.1.4", optional = true }
+
+[lints.rust]
+unsafe_op_in_unsafe_fn = { level = "allow" }

--- a/components/bluetooth/lib.rs
+++ b/components/bluetooth/lib.rs
@@ -430,7 +430,7 @@ impl BluetoothManager {
         let mut device_id;
         let mut rng = servo_rand::thread_rng();
         loop {
-            device_id = rng.gen::<u32>().to_string();
+            device_id = rng.r#gen::<u32>().to_string();
             if !self.cached_devices.contains_key(&device_id) {
                 break;
             }

--- a/components/canvas/canvas_data.rs
+++ b/components/canvas/canvas_data.rs
@@ -986,7 +986,7 @@ impl<'a> CanvasData<'a> {
     ) {
         self.ensure_path();
         let result = match self.path_state.as_ref() {
-            Some(PathState::UserSpacePath(ref path, ref transform)) => {
+            Some(PathState::UserSpacePath(path, transform)) => {
                 let target_transform = self.drawtarget.get_transform();
                 let path_transform = transform.as_ref().unwrap_or(&target_transform);
                 path.contains_point(x, y, path_transform)
@@ -1227,8 +1227,8 @@ impl<'a> CanvasData<'a> {
         // to move between device and user space.
         match self.path_state.as_mut() {
             None | Some(PathState::DeviceSpacePathBuilder(..)) => (),
-            Some(PathState::UserSpacePathBuilder(_, ref mut transform)) |
-            Some(PathState::UserSpacePath(_, ref mut transform)) => {
+            Some(PathState::UserSpacePathBuilder(_, transform)) |
+            Some(PathState::UserSpacePath(_, transform)) => {
                 if transform.is_none() {
                     *transform = Some(self.drawtarget.get_transform());
                 }

--- a/components/compositing/touch.rs
+++ b/components/compositing/touch.rs
@@ -347,11 +347,7 @@ impl TouchHandler {
     pub fn on_vsync(&mut self) -> Option<FlingAction> {
         let touch_sequence = self.touch_sequence_map.get_mut(&self.current_sequence_id)?;
 
-        let Flinging {
-            velocity,
-            ref cursor,
-        } = &mut touch_sequence.state
-        else {
+        let Flinging { velocity, cursor } = &mut touch_sequence.state else {
             return None;
         };
         if velocity.length().abs() < FLING_MIN_SCREEN_PX {

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -5490,7 +5490,7 @@ where
     fn maybe_close_random_pipeline(&mut self) {
         match self.random_pipeline_closure {
             Some((ref mut rng, probability)) => {
-                if probability <= rng.gen::<f32>() {
+                if probability <= rng.r#gen::<f32>() {
                     return;
                 }
             },
@@ -5506,7 +5506,7 @@ where
                         .pending_changes
                         .iter()
                         .any(|change| change.new_pipeline_id == pipeline.id) &&
-                        probability <= rng.gen::<f32>()
+                        probability <= rng.r#gen::<f32>()
                     {
                         // We tend not to close pending pipelines, as that almost always
                         // results in pipelines being closed early in their lifecycle,

--- a/components/constellation/session_history.rs
+++ b/components/constellation/session_history.rs
@@ -58,8 +58,8 @@ impl JointSessionHistory {
         url: ServoUrl,
     ) {
         if let Some(SessionHistoryDiff::Pipeline {
-            ref mut new_history_state_id,
-            ref mut new_url,
+            new_history_state_id,
+            new_url,
             ..
         }) = self.past.iter_mut().find(|diff| match diff {
             SessionHistoryDiff::Pipeline {
@@ -73,8 +73,8 @@ impl JointSessionHistory {
         }
 
         if let Some(SessionHistoryDiff::Pipeline {
-            ref mut old_history_state_id,
-            ref mut old_url,
+            old_history_state_id,
+            old_url,
             ..
         }) = self.future.iter_mut().find(|diff| match diff {
             SessionHistoryDiff::Pipeline {

--- a/components/fonts/font_context.rs
+++ b/components/fonts/font_context.rs
@@ -347,8 +347,8 @@ impl FontContext {
     }
 
     pub fn is_supported_web_font_source(source: &&Source) -> bool {
-        let url_source = match source {
-            Source::Url(ref url_source) => url_source,
+        let url_source = match &source {
+            Source::Url(url_source) => url_source,
             Source::Local(_) => return true,
         };
         let format_hint = match url_source.format_hint {

--- a/components/fonts/glyph.rs
+++ b/components/fonts/glyph.rs
@@ -606,7 +606,7 @@ impl GlyphStore {
     pub fn iter_glyphs_for_byte_range(
         &self,
         range: &Range<ByteIndex>,
-    ) -> impl Iterator<Item = GlyphInfo> {
+    ) -> impl Iterator<Item = GlyphInfo> + use<'_> {
         if range.begin() >= self.len() {
             panic!("iter_glyphs_for_range: range.begin beyond length!");
         }

--- a/components/fonts/platform/freetype/font.rs
+++ b/components/fonts/platform/freetype/font.rs
@@ -573,7 +573,7 @@ struct TtHeader {
     glyph_data_format: FT_Short,
 }
 
-extern "C" {
+unsafe extern "C" {
     fn FT_Load_Sfnt_Table(
         face: FT_Face,
         tag: FT_ULong,

--- a/components/fonts/platform/freetype/font_list.rs
+++ b/components/fonts/platform/freetype/font_list.rs
@@ -293,7 +293,6 @@ fn font_weight_from_fontconfig_pattern(pattern: *mut FcPattern) -> Option<FontWe
 /// Creates a String from the given null-terminated buffer.
 /// Panics if the buffer does not contain UTF-8.
 unsafe fn c_str_to_string(s: *const c_char) -> String {
-    std::str::from_utf8(CStr::from_ptr(s).to_bytes())
-        .unwrap()
-        .to_owned()
+    let c_str = unsafe { CStr::from_ptr(s) };
+    std::str::from_utf8(c_str.to_bytes()).unwrap().to_owned()
 }

--- a/components/fonts/shaper.rs
+++ b/components/fonts/shaper.rs
@@ -59,10 +59,10 @@ impl ShapedGlyphData {
     /// Passing an invalid buffer pointer to this function results in undefined behavior.
     pub unsafe fn new(buffer: *mut hb_buffer_t) -> ShapedGlyphData {
         let mut glyph_count = 0;
-        let glyph_infos = hb_buffer_get_glyph_infos(buffer, &mut glyph_count);
+        let glyph_infos = unsafe { hb_buffer_get_glyph_infos(buffer, &mut glyph_count) };
         assert!(!glyph_infos.is_null());
         let mut pos_count = 0;
-        let pos_infos = hb_buffer_get_glyph_positions(buffer, &mut pos_count);
+        let pos_infos = unsafe { hb_buffer_get_glyph_positions(buffer, &mut pos_count) };
         assert!(!pos_infos.is_null());
         assert_eq!(glyph_count, pos_count);
 

--- a/components/layout_2020/display_list/gradient.rs
+++ b/components/layout_2020/display_list/gradient.rs
@@ -33,10 +33,10 @@ pub(super) fn build(
 ) -> WebRenderGradient {
     match gradient {
         Gradient::Linear {
-            ref items,
-            ref direction,
-            ref color_interpolation_method,
-            ref flags,
+            items,
+            direction,
+            color_interpolation_method,
+            flags,
             compat_mode: _,
         } => build_linear(
             style,
@@ -48,11 +48,11 @@ pub(super) fn build(
             builder,
         ),
         Gradient::Radial {
-            ref shape,
-            ref position,
-            ref color_interpolation_method,
-            ref items,
-            ref flags,
+            shape,
+            position,
+            color_interpolation_method,
+            items,
+            flags,
             compat_mode: _,
         } => build_radial(
             style,

--- a/components/layout_2020/display_list/mod.rs
+++ b/components/layout_2020/display_list/mod.rs
@@ -780,7 +780,7 @@ impl<'a> BuilderForBoxFragment<'a> {
         for (index, image) in b.background_image.0.iter().enumerate().rev() {
             match image {
                 Image::None => {},
-                Image::Gradient(ref gradient) => {
+                Image::Gradient(gradient) => {
                     let intrinsic = NaturalSizes::empty();
                     let Some(layer) =
                         &background::layout_layer(self, painter, builder, index, intrinsic)
@@ -816,7 +816,7 @@ impl<'a> BuilderForBoxFragment<'a> {
                         },
                     }
                 },
-                Image::Url(ref image_url) => {
+                Image::Url(image_url) => {
                     // FIXME: images won’t always have in intrinsic width or
                     // height when support for SVG is added, or a WebRender
                     // `ImageKey`, for that matter.

--- a/components/layout_2020/dom_traversal.rs
+++ b/components/layout_2020/dom_traversal.rs
@@ -417,7 +417,7 @@ where
     Node: NodeExt<'dom>,
 {
     match &pseudo_element_style.get_counters().content {
-        Content::Items(ref items) => {
+        Content::Items(items) => {
             let mut vec = vec![];
             for item in items.items.iter() {
                 match item {

--- a/components/layout_2020/flow/inline/line.rs
+++ b/components/layout_2020/flow/inline/line.rs
@@ -740,7 +740,7 @@ impl LineItem {
         match self {
             LineItem::InlineStartBoxPaddingBorderMargin(_) => true,
             LineItem::InlineEndBoxPaddingBorderMargin(_) => true,
-            LineItem::TextRun(_, ref mut item) => item.trim_whitespace_at_end(whitespace_trimmed),
+            LineItem::TextRun(_, item) => item.trim_whitespace_at_end(whitespace_trimmed),
             LineItem::Atomic(..) => false,
             LineItem::AbsolutelyPositioned(..) => true,
             LineItem::Float(..) => true,
@@ -751,7 +751,7 @@ impl LineItem {
         match self {
             LineItem::InlineStartBoxPaddingBorderMargin(_) => true,
             LineItem::InlineEndBoxPaddingBorderMargin(_) => true,
-            LineItem::TextRun(_, ref mut item) => item.trim_whitespace_at_start(whitespace_trimmed),
+            LineItem::TextRun(_, item) => item.trim_whitespace_at_start(whitespace_trimmed),
             LineItem::Atomic(..) => false,
             LineItem::AbsolutelyPositioned(..) => true,
             LineItem::Float(..) => true,

--- a/components/layout_2020/flow/inline/mod.rs
+++ b/components/layout_2020/flow/inline/mod.rs
@@ -1534,7 +1534,7 @@ impl InlineFormattingContext {
         let mut new_linebreaker = LineBreaker::new(text_content.as_str());
         for item in builder.inline_items.iter() {
             match &mut *item.borrow_mut() {
-                InlineItem::TextRun(ref mut text_run) => {
+                InlineItem::TextRun(text_run) => {
                     text_run.borrow_mut().segment_and_shape(
                         &text_content,
                         &layout_context.font_context,
@@ -1683,7 +1683,7 @@ impl InlineFormattingContext {
                         },
                     ));
                 },
-                InlineItem::OutOfFlowFloatBox(ref float_box) => {
+                InlineItem::OutOfFlowFloatBox(float_box) => {
                     float_box.layout_into_line_items(&mut layout);
                 },
             }

--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -113,7 +113,7 @@ impl BlockLevelBox {
             BlockLevelBox::OutOfFlowAbsolutelyPositionedBox(_) |
             BlockLevelBox::OutOfFlowFloatBox(_) => return true,
             BlockLevelBox::OutsideMarker(_) => return false,
-            BlockLevelBox::Independent(ref context) => {
+            BlockLevelBox::Independent(context) => {
                 // FIXME: If the element doesn't fit next to floats, it will get clearance.
                 // In that case this should be returning false.
                 context.layout_style()
@@ -135,7 +135,7 @@ impl BlockLevelBox {
         collected_margin.adjoin_assign(&CollapsedMargin::new(margin.block_start));
 
         let child_boxes = match self {
-            BlockLevelBox::SameFormattingContextBlock { ref contents, .. } => match contents {
+            BlockLevelBox::SameFormattingContextBlock { contents, .. } => match contents {
                 BlockContainer::BlockLevelBoxes(boxes) => boxes,
                 BlockContainer::InlineFormattingContext(_) => return false,
             },
@@ -427,7 +427,7 @@ fn compute_inline_content_sizes_for_block_level_boxes(
         match &*box_.borrow() {
             BlockLevelBox::OutOfFlowAbsolutelyPositionedBox(_) |
             BlockLevelBox::OutsideMarker { .. } => None,
-            BlockLevelBox::OutOfFlowFloatBox(ref float_box) => {
+            BlockLevelBox::OutOfFlowFloatBox(float_box) => {
                 let inline_content_sizes_result = float_box.contents.outer_inline_content_sizes(
                     layout_context,
                     containing_block,
@@ -465,7 +465,7 @@ fn compute_inline_content_sizes_for_block_level_boxes(
                 // Instead, we treat it like an independent block with 'clear: both'.
                 Some((inline_content_sizes_result, None, Clear::Both))
             },
-            BlockLevelBox::Independent(ref independent) => {
+            BlockLevelBox::Independent(independent) => {
                 let inline_content_sizes_result = independent.outer_inline_content_sizes(
                     layout_context,
                     containing_block,
@@ -2149,7 +2149,7 @@ fn block_size_is_zero_or_intrinsic(size: &StyleSize, containing_block: &Containi
         StyleSize::MaxContent |
         StyleSize::FitContent |
         StyleSize::Stretch => true,
-        StyleSize::LengthPercentage(ref lp) => {
+        StyleSize::LengthPercentage(lp) => {
             // TODO: Should this resolve definite percentages? Blink does it, Gecko and WebKit don't.
             lp.is_definitely_zero() ||
                 (lp.0.has_percentage() && !containing_block.size.block.is_definite())

--- a/components/layout_2020/query.rs
+++ b/components/layout_2020/query.rs
@@ -191,7 +191,7 @@ pub fn process_resolved_style_request<'dom>(
             }
 
             let (content_rect, margins, padding, specific_layout_info) = match fragment {
-                Fragment::Box(ref box_fragment) | Fragment::Float(ref box_fragment) => {
+                Fragment::Box(box_fragment) | Fragment::Float(box_fragment) => {
                     let box_fragment = box_fragment.borrow();
                     if style.get_box().position != Position::Static {
                         let resolved_insets = || {

--- a/components/layout_2020/style_ext.rs
+++ b/components/layout_2020/style_ext.rs
@@ -338,7 +338,7 @@ impl ComputedValuesExt for ComputedValues {
     fn physical_box_offsets(&self) -> PhysicalSides<LengthPercentageOrAuto<'_>> {
         fn convert(inset: &Inset) -> LengthPercentageOrAuto<'_> {
             match inset {
-                Inset::LengthPercentage(ref v) => LengthPercentageOrAuto::LengthPercentage(v),
+                Inset::LengthPercentage(v) => LengthPercentageOrAuto::LengthPercentage(v),
                 Inset::Auto => LengthPercentageOrAuto::Auto,
                 Inset::AnchorFunction(_) => unreachable!("anchor() should be disabled"),
                 Inset::AnchorSizeFunction(_) => unreachable!("anchor-size() should be disabled"),
@@ -460,7 +460,7 @@ impl ComputedValuesExt for ComputedValues {
     fn physical_margin(&self) -> PhysicalSides<LengthPercentageOrAuto<'_>> {
         fn convert(inset: &Margin) -> LengthPercentageOrAuto<'_> {
             match inset {
-                Margin::LengthPercentage(ref v) => LengthPercentageOrAuto::LengthPercentage(v),
+                Margin::LengthPercentage(v) => LengthPercentageOrAuto::LengthPercentage(v),
                 Margin::Auto => LengthPercentageOrAuto::Auto,
                 Margin::AnchorSizeFunction(_) => unreachable!("anchor-size() should be disabled"),
             }

--- a/components/layout_2020/table/construct.rs
+++ b/components/layout_2020/table/construct.rs
@@ -63,7 +63,7 @@ impl<Node> AnonymousTableContent<'_, Node> {
     fn is_whitespace_only(&self) -> bool {
         match self {
             Self::Element { .. } => false,
-            Self::Text(_, ref text) => text.chars().all(char_is_whitespace),
+            Self::Text(_, text) => text.chars().all(char_is_whitespace),
         }
     }
 
@@ -170,7 +170,7 @@ impl Table {
         let slot = self.get_slot(coords);
         match slot {
             Some(TableSlot::Cell(cell)) => vec![ResolvedSlotAndLocation { cell, coords }],
-            Some(TableSlot::Spanned(ref offsets)) => offsets
+            Some(TableSlot::Spanned(offsets)) => offsets
                 .iter()
                 .flat_map(|offset| self.resolve_slot_at(coords - *offset))
                 .collect(),
@@ -434,7 +434,7 @@ impl TableBuilder {
         for row_index in 0..self.table.size.height {
             let last_row_index_in_group = self.last_row_index_in_row_group_at_row_n(row_index);
             for cell in self.table.slots[row_index].iter_mut() {
-                if let TableSlot::Cell(ref mut cell) = cell {
+                if let TableSlot::Cell(cell) = cell {
                     if cell.rowspan == 1 {
                         continue;
                     }

--- a/components/layout_2020/table/layout.rs
+++ b/components/layout_2020/table/layout.rs
@@ -1093,7 +1093,7 @@ impl<'a> TableLayout<'a> {
                     .par_iter()
                     .enumerate()
                     .map(|(column_index, slot)| {
-                        let TableSlot::Cell(ref cell) = slot else {
+                        let TableSlot::Cell(cell) = slot else {
                             return None;
                         };
 
@@ -2303,19 +2303,18 @@ impl<'a> RowFragmentLayout<'a> {
                 relative_adjustement(&self.row.style, containing_block_for_children);
         }
 
-        let (inline_size, block_size) =
-            if let Some(ref row_group_layout) = row_group_fragment_layout {
-                self.rect.start_corner -= row_group_layout.rect.start_corner;
-                (
-                    row_group_layout.rect.size.inline,
-                    SizeConstraint::Definite(row_group_layout.rect.size.block),
-                )
-            } else {
-                (
-                    containing_block_for_logical_conversion.size.inline,
-                    containing_block_for_logical_conversion.size.block,
-                )
-            };
+        let (inline_size, block_size) = if let Some(row_group_layout) = row_group_fragment_layout {
+            self.rect.start_corner -= row_group_layout.rect.start_corner;
+            (
+                row_group_layout.rect.size.inline,
+                SizeConstraint::Definite(row_group_layout.rect.size.block),
+            )
+        } else {
+            (
+                containing_block_for_logical_conversion.size.inline,
+                containing_block_for_logical_conversion.size.block,
+            )
+        };
 
         let row_group_containing_block = ContainingBlock {
             size: ContainingBlockSize {

--- a/components/layout_2020/taffy/layout.rs
+++ b/components/layout_2020/taffy/layout.rs
@@ -52,8 +52,8 @@ fn with_independant_formatting_context<T>(
     cb: impl FnOnce(&IndependentFormattingContext) -> T,
 ) -> T {
     match item {
-        TaffyItemBoxInner::InFlowBox(ref mut context) => cb(context),
-        TaffyItemBoxInner::OutOfFlowAbsolutelyPositionedBox(ref abspos_box) => {
+        TaffyItemBoxInner::InFlowBox(context) => cb(context),
+        TaffyItemBoxInner::OutOfFlowAbsolutelyPositionedBox(abspos_box) => {
             cb(&AtomicRefCell::borrow(abspos_box).context)
         },
     }

--- a/components/layout_2020/tests/floats.rs
+++ b/components/layout_2020/tests/floats.rs
@@ -302,7 +302,7 @@ fn test_tree_range_setting() {
     quickcheck::quickcheck(f);
     fn check(bands: Vec<FloatBandWrapper>, ranges: Vec<FloatRangeInput>) {
         let mut tree = FloatBandTree::new();
-        for FloatBandWrapper(ref band) in &bands {
+        for FloatBandWrapper(band) in &bands {
             tree = tree.insert(*band);
         }
 

--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -140,8 +140,8 @@ macro_rules! malloc_size_of_is_0(
 
 impl MallocSizeOf for keyboard_types::Key {
     fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
-        match self {
-            keyboard_types::Key::Character(ref string) => {
+        match &self {
+            keyboard_types::Key::Character(string) => {
                 <String as MallocSizeOf>::size_of(string, ops)
             },
             _ => 0,

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -473,13 +473,13 @@ enum BodySink {
 impl BodySink {
     fn transmit_bytes(&self, bytes: Vec<u8>) {
         match self {
-            BodySink::Chunked(ref sender) => {
+            BodySink::Chunked(sender) => {
                 let sender = sender.clone();
                 HANDLE.lock().unwrap().as_mut().unwrap().spawn(async move {
                     let _ = sender.send(Ok(Frame::data(bytes.into()))).await;
                 });
             },
-            BodySink::Buffered(ref sender) => {
+            BodySink::Buffered(sender) => {
                 let _ = sender.send(BodyChunk::Chunk(bytes));
             },
         }
@@ -488,7 +488,7 @@ impl BodySink {
     fn close(&self) {
         match self {
             BodySink::Chunked(_) => { /* no need to close sender */ },
-            BodySink::Buffered(ref sender) => {
+            BodySink::Buffered(sender) => {
                 let _ = sender.send(BodyChunk::Done);
             },
         }

--- a/components/profile/mem.rs
+++ b/components/profile/mem.rs
@@ -191,7 +191,7 @@ mod system_reporter {
     }
 
     #[cfg(all(target_os = "linux", target_env = "gnu"))]
-    extern "C" {
+    unsafe extern "C" {
         fn mallinfo() -> struct_mallinfo;
     }
 

--- a/components/rand/lib.rs
+++ b/components/rand/lib.rs
@@ -185,7 +185,7 @@ pub fn random<T>() -> T
 where
     Standard: Distribution<T>,
 {
-    thread_rng().gen()
+    thread_rng().r#gen()
 }
 
 // TODO(eijebong): Replace calls to this by random once `uuid::Uuid` implements `rand::Rand` again.

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -27,6 +27,7 @@ webgpu = ["script_bindings/webgpu", "script_traits/webgpu"]
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(crown)'] }
+unsafe_op_in_unsafe_fn = { level = "allow" }
 
 [dependencies]
 aes = { workspace = true }

--- a/components/script/body.rs
+++ b/components/script/body.rs
@@ -438,11 +438,11 @@ impl Extractable for BodyInit {
     // https://fetch.spec.whatwg.org/#concept-bodyinit-extract
     fn extract(&self, global: &GlobalScope, can_gc: CanGc) -> Fallible<ExtractedBody> {
         match self {
-            BodyInit::String(ref s) => s.extract(global, can_gc),
-            BodyInit::URLSearchParams(ref usp) => usp.extract(global, can_gc),
-            BodyInit::Blob(ref b) => b.extract(global, can_gc),
-            BodyInit::FormData(ref formdata) => formdata.extract(global, can_gc),
-            BodyInit::ArrayBuffer(ref typedarray) => {
+            BodyInit::String(s) => s.extract(global, can_gc),
+            BodyInit::URLSearchParams(usp) => usp.extract(global, can_gc),
+            BodyInit::Blob(b) => b.extract(global, can_gc),
+            BodyInit::FormData(formdata) => formdata.extract(global, can_gc),
+            BodyInit::ArrayBuffer(typedarray) => {
                 let bytes = typedarray.to_vec();
                 let total_bytes = bytes.len();
                 let stream = ReadableStream::new_from_bytes(global, bytes, can_gc)?;
@@ -453,7 +453,7 @@ impl Extractable for BodyInit {
                     source: BodySource::Object,
                 })
             },
-            BodyInit::ArrayBufferView(ref typedarray) => {
+            BodyInit::ArrayBufferView(typedarray) => {
                 let bytes = typedarray.to_vec();
                 let total_bytes = bytes.len();
                 let stream = ReadableStream::new_from_bytes(global, bytes, can_gc)?;

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -114,7 +114,7 @@ impl QueuedTaskConversion for DedicatedWorkerScriptMsg {
             _ => return None,
         };
         let script_msg = match common_worker_msg {
-            WorkerScriptMsg::Common(ref script_msg) => script_msg,
+            WorkerScriptMsg::Common(script_msg) => script_msg,
             _ => return None,
         };
         match script_msg {

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -1618,7 +1618,7 @@ impl Element {
             if *name == local_name!("id") || *name == local_name!("name") {
                 match maybe_attr {
                     None => true,
-                    Some(ref attr) => matches!(*attr.value(), AttrValue::Atom(_)),
+                    Some(attr) => matches!(*attr.value(), AttrValue::Atom(_)),
                 }
             } else {
                 true

--- a/components/script/dom/filereader.rs
+++ b/components/script/dom/filereader.rs
@@ -149,8 +149,8 @@ impl FileReaderSharedFunctionality {
             let resultmime = blob_type.parse::<Mime>().ok();
             resultmime.and_then(|mime| {
                 mime.params()
-                    .find(|(ref k, _)| &mime::CHARSET == k)
-                    .and_then(|(_, ref v)| Encoding::for_label(v.as_ref().as_bytes()))
+                    .find(|(k, _)| &mime::CHARSET == k)
+                    .and_then(|(_, v)| Encoding::for_label(v.as_ref().as_bytes()))
             })
         });
 

--- a/components/script/dom/fontface.rs
+++ b/components/script/dom/fontface.rs
@@ -95,16 +95,16 @@ fn parse_font_face_descriptors(
     );
 
     let FontFaceDescriptors {
-        ref ascentOverride,
-        ref descentOverride,
-        ref display,
-        ref featureSettings,
-        ref lineGapOverride,
-        ref stretch,
-        ref style,
-        ref unicodeRange,
-        ref variationSettings,
-        ref weight,
+        ascentOverride,
+        descentOverride,
+        display,
+        featureSettings,
+        lineGapOverride,
+        stretch,
+        style,
+        unicodeRange,
+        variationSettings,
+        weight,
     } = input_descriptors;
 
     let _ = variationSettings; // TODO: Stylo doesn't parse font-variation-settings yet.

--- a/components/script/dom/formdata.rs
+++ b/components/script/dom/formdata.rs
@@ -181,10 +181,8 @@ impl FormDataMethods<crate::DomTypeHolder> for FormData {
             .iter()
             .find(|(datum_name, _)| datum_name.0 == name.0)
             .map(|(_, datum)| match &datum.value {
-                FormDatumValue::String(ref s) => {
-                    FileOrUSVString::USVString(USVString(s.to_string()))
-                },
-                FormDatumValue::File(ref b) => FileOrUSVString::File(DomRoot::from_ref(b)),
+                FormDatumValue::String(s) => FileOrUSVString::USVString(USVString(s.to_string())),
+                FormDatumValue::File(b) => FileOrUSVString::File(DomRoot::from_ref(b)),
             })
     }
 
@@ -199,10 +197,10 @@ impl FormDataMethods<crate::DomTypeHolder> for FormData {
                 }
 
                 Some(match &datum.value {
-                    FormDatumValue::String(ref s) => {
+                    FormDatumValue::String(s) => {
                         FileOrUSVString::USVString(USVString(s.to_string()))
                     },
-                    FormDatumValue::File(ref b) => FileOrUSVString::File(DomRoot::from_ref(b)),
+                    FormDatumValue::File(b) => FileOrUSVString::File(DomRoot::from_ref(b)),
                 })
             })
             .collect()
@@ -308,8 +306,8 @@ impl Iterable for FormData {
         let data = self.data.borrow();
         let datum = &data.get(n as usize).unwrap().1;
         match &datum.value {
-            FormDatumValue::String(ref s) => FileOrUSVString::USVString(USVString(s.to_string())),
-            FormDatumValue::File(ref b) => FileOrUSVString::File(DomRoot::from_ref(b)),
+            FormDatumValue::String(s) => FileOrUSVString::USVString(USVString(s.to_string())),
+            FormDatumValue::File(b) => FileOrUSVString::File(DomRoot::from_ref(b)),
         }
     }
 

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -1338,7 +1338,7 @@ impl GlobalScope {
     /// TODO: Also remove them if they do not have an event-listener.
     /// see <https://github.com/servo/servo/issues/25772>
     pub(crate) fn perform_a_broadcast_channel_garbage_collection_checkpoint(&self) {
-        let is_empty = if let BroadcastChannelState::Managed(router_id, ref mut channels) =
+        let is_empty = if let BroadcastChannelState::Managed(router_id, channels) =
             &mut *self.broadcast_channel_state.borrow_mut()
         {
             channels.retain(|name, ref mut channels| {
@@ -1552,7 +1552,7 @@ impl GlobalScope {
                 BlobTracker::Blob(weak) => weak.root().is_none(),
             };
             if garbage_collected && !blob_info.has_url {
-                if let BlobData::File(ref f) = blob_info.blob_impl.blob_data() {
+                if let BlobData::File(f) = blob_info.blob_impl.blob_data() {
                     self.decrement_file_ref(f.get_id());
                 }
                 false
@@ -1569,7 +1569,7 @@ impl GlobalScope {
             .borrow_mut()
             .drain()
             .for_each(|(_id, blob_info)| {
-                if let BlobData::File(ref f) = blob_info.blob_impl.blob_data() {
+                if let BlobData::File(f) = blob_info.blob_impl.blob_data() {
                     self.decrement_file_ref(f.get_id());
                 }
             });
@@ -1594,7 +1594,7 @@ impl GlobalScope {
                 .get(blob_id)
                 .expect("get_blob_bytes for an unknown blob.");
             match blob_info.blob_impl.blob_data() {
-                BlobData::Sliced(ref parent, ref rel_pos) => Some((*parent, rel_pos.clone())),
+                BlobData::Sliced(parent, rel_pos) => Some((*parent, rel_pos.clone())),
                 _ => None,
             }
         };
@@ -1615,7 +1615,7 @@ impl GlobalScope {
             .get(blob_id)
             .expect("get_blob_bytes_non_sliced called for a unknown blob.");
         match blob_info.blob_impl.blob_data() {
-            BlobData::File(ref f) => {
+            BlobData::File(f) => {
                 let (buffer, is_new_buffer) = match f.get_cache() {
                     Some(bytes) => (bytes, false),
                     None => {
@@ -1631,7 +1631,7 @@ impl GlobalScope {
 
                 Ok(buffer)
             },
-            BlobData::Memory(ref s) => Ok(s.clone()),
+            BlobData::Memory(s) => Ok(s.clone()),
             BlobData::Sliced(_, _) => panic!("This blob doesn't have a parent."),
         }
     }
@@ -1649,7 +1649,7 @@ impl GlobalScope {
                 .get(blob_id)
                 .expect("get_blob_bytes_or_file_id for an unknown blob.");
             match blob_info.blob_impl.blob_data() {
-                BlobData::Sliced(ref parent, ref rel_pos) => Some((*parent, rel_pos.clone())),
+                BlobData::Sliced(parent, rel_pos) => Some((*parent, rel_pos.clone())),
                 _ => None,
             }
         };
@@ -1679,11 +1679,11 @@ impl GlobalScope {
             .get(blob_id)
             .expect("get_blob_bytes_non_sliced_or_file_id called for a unknown blob.");
         match blob_info.blob_impl.blob_data() {
-            BlobData::File(ref f) => match f.get_cache() {
+            BlobData::File(f) => match f.get_cache() {
                 Some(bytes) => BlobResult::Bytes(bytes.clone()),
                 None => BlobResult::File(f.get_id(), f.get_size() as usize),
             },
-            BlobData::Memory(ref s) => BlobResult::Bytes(s.clone()),
+            BlobData::Memory(s) => BlobResult::Bytes(s.clone()),
             BlobData::Sliced(_, _) => panic!("This blob doesn't have a parent."),
         }
     }
@@ -1705,7 +1705,7 @@ impl GlobalScope {
                 .get(blob_id)
                 .expect("get_blob_size called for a unknown blob.");
             match blob_info.blob_impl.blob_data() {
-                BlobData::Sliced(ref parent, ref rel_pos) => Some((*parent, rel_pos.clone())),
+                BlobData::Sliced(parent, rel_pos) => Some((*parent, rel_pos.clone())),
                 _ => None,
             }
         };
@@ -1715,8 +1715,8 @@ impl GlobalScope {
                     .get(&parent_id)
                     .expect("Parent of blob whose size is unknown.");
                 let parent_size = match parent_info.blob_impl.blob_data() {
-                    BlobData::File(ref f) => f.get_size(),
-                    BlobData::Memory(ref v) => v.len() as u64,
+                    BlobData::File(f) => f.get_size(),
+                    BlobData::Memory(v) => v.len() as u64,
                     BlobData::Sliced(_, _) => panic!("Blob ancestry should be only one level."),
                 };
                 rel_pos.to_abs_range(parent_size as usize).len() as u64
@@ -1726,8 +1726,8 @@ impl GlobalScope {
                     .get(blob_id)
                     .expect("Blob whose size is unknown.");
                 match blob_info.blob_impl.blob_data() {
-                    BlobData::File(ref f) => f.get_size(),
-                    BlobData::Memory(ref v) => v.len() as u64,
+                    BlobData::File(f) => f.get_size(),
+                    BlobData::Memory(v) => v.len() as u64,
                     BlobData::Sliced(_, _) => {
                         panic!("It was previously checked that this blob does not have a parent.")
                     },
@@ -1747,7 +1747,7 @@ impl GlobalScope {
             blob_info.has_url = true;
 
             match blob_info.blob_impl.blob_data() {
-                BlobData::Sliced(ref parent, ref rel_pos) => Some((*parent, rel_pos.clone())),
+                BlobData::Sliced(parent, rel_pos) => Some((*parent, rel_pos.clone())),
                 _ => None,
             }
         };
@@ -1758,8 +1758,8 @@ impl GlobalScope {
                     .expect("Parent of blob whose url is requested is unknown.");
                 let parent_file_id = self.promote(parent_info, /* set_valid is */ false);
                 let parent_size = match parent_info.blob_impl.blob_data() {
-                    BlobData::File(ref f) => f.get_size(),
-                    BlobData::Memory(ref v) => v.len() as u64,
+                    BlobData::File(f) => f.get_size(),
+                    BlobData::Memory(v) => v.len() as u64,
                     BlobData::Sliced(_, _) => panic!("Blob ancestry should be only one level."),
                 };
                 let parent_size = rel_pos.to_abs_range(parent_size as usize).len() as u64;
@@ -1827,7 +1827,7 @@ impl GlobalScope {
             BlobData::Sliced(_, _) => {
                 panic!("Sliced blobs should use create_sliced_url_id instead of promote.");
             },
-            BlobData::File(ref f) => {
+            BlobData::File(f) => {
                 if set_valid {
                     let origin = get_blob_origin(&global_url);
                     let (tx, rx) = profile_ipc::channel(self.time_profiler_chan().clone()).unwrap();
@@ -1845,7 +1845,7 @@ impl GlobalScope {
                     return f.get_id();
                 }
             },
-            BlobData::Memory(ref mut bytes_in) => mem::swap(bytes_in, &mut bytes),
+            BlobData::Memory(bytes_in) => mem::swap(bytes_in, &mut bytes),
         };
 
         let origin = get_blob_origin(&global_url);

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -213,7 +213,7 @@ impl VideoFrameRenderer for MediaFrameRenderer {
         );
 
         match &mut self.current_frame {
-            Some(ref mut current_frame)
+            Some(current_frame)
                 if current_frame.width == frame.get_width() &&
                     current_frame.height == frame.get_height() =>
             {
@@ -233,7 +233,7 @@ impl VideoFrameRenderer for MediaFrameRenderer {
                     updates.push(ImageUpdate::DeleteImage(old_image_key));
                 }
             },
-            Some(ref mut current_frame) => {
+            Some(current_frame) => {
                 self.old_frame = Some(current_frame.image_key);
 
                 let Some(new_image_key) = self.compositor_api.generate_image_key() else {
@@ -971,7 +971,7 @@ impl HTMLMediaElement {
                                 Some(ServoUrl::parse(&blob_url).expect("infallible"));
                             self.fetch_request(None, None);
                         },
-                        SrcObject::MediaStream(ref stream) => {
+                        SrcObject::MediaStream(stream) => {
                             let tracks = &*stream.get_tracks();
                             for (pos, track) in tracks.iter().enumerate() {
                                 if self
@@ -1788,7 +1788,7 @@ impl HTMLMediaElement {
                 // fetching where we left.
                 if let Some(ref current_fetch_context) = *self.current_fetch_context.borrow() {
                     match current_fetch_context.cancel_reason() {
-                        Some(ref reason) if *reason == CancelReason::Backoff => {
+                        Some(reason) if *reason == CancelReason::Backoff => {
                             // XXX(ferjm) Ideally we should just create a fetch request from
                             // where we left. But keeping track of the exact next byte that the
                             // media backend expects is not the easiest task, so I'm simply

--- a/components/script/dom/htmlselectelement.rs
+++ b/components/script/dom/htmlselectelement.rs
@@ -114,7 +114,9 @@ impl HTMLSelectElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#concept-select-option-list
-    pub(crate) fn list_of_options(&self) -> impl Iterator<Item = DomRoot<HTMLOptionElement>> {
+    pub(crate) fn list_of_options(
+        &self,
+    ) -> impl Iterator<Item = DomRoot<HTMLOptionElement>> + use<'_> {
         self.upcast::<Node>().children().flat_map(|node| {
             if node.is::<HTMLOptionElement>() {
                 let node = DomRoot::downcast::<HTMLOptionElement>(node).unwrap();

--- a/components/script/dom/mediadevices.rs
+++ b/components/script/dom/mediadevices.rs
@@ -118,22 +118,20 @@ fn convert_constraints(js: &BooleanOrMediaTrackConstraints) -> Option<MediaTrack
     match js {
         BooleanOrMediaTrackConstraints::Boolean(false) => None,
         BooleanOrMediaTrackConstraints::Boolean(true) => Some(Default::default()),
-        BooleanOrMediaTrackConstraints::MediaTrackConstraints(ref c) => {
-            Some(MediaTrackConstraintSet {
-                height: c.parent.height.as_ref().and_then(convert_culong),
-                width: c.parent.width.as_ref().and_then(convert_culong),
-                aspect: c.parent.aspectRatio.as_ref().and_then(convert_cdouble),
-                frame_rate: c.parent.frameRate.as_ref().and_then(convert_cdouble),
-                sample_rate: c.parent.sampleRate.as_ref().and_then(convert_culong),
-            })
-        },
+        BooleanOrMediaTrackConstraints::MediaTrackConstraints(c) => Some(MediaTrackConstraintSet {
+            height: c.parent.height.as_ref().and_then(convert_culong),
+            width: c.parent.width.as_ref().and_then(convert_culong),
+            aspect: c.parent.aspectRatio.as_ref().and_then(convert_cdouble),
+            frame_rate: c.parent.frameRate.as_ref().and_then(convert_cdouble),
+            sample_rate: c.parent.sampleRate.as_ref().and_then(convert_culong),
+        }),
     }
 }
 
 fn convert_culong(js: &ConstrainULong) -> Option<Constrain<u32>> {
     match js {
         ConstrainULong::ClampedUnsignedLong(val) => Some(Constrain::Value(*val)),
-        ConstrainULong::ConstrainULongRange(ref range) => {
+        ConstrainULong::ConstrainULongRange(range) => {
             if range.parent.min.is_some() || range.parent.max.is_some() {
                 Some(Constrain::Range(ConstrainRange {
                     min: range.parent.min,
@@ -150,7 +148,7 @@ fn convert_culong(js: &ConstrainULong) -> Option<Constrain<u32>> {
 fn convert_cdouble(js: &ConstrainDouble) -> Option<Constrain<f64>> {
     match js {
         ConstrainDouble::Double(val) => Some(Constrain::Value(**val)),
-        ConstrainDouble::ConstrainDoubleRange(ref range) => {
+        ConstrainDouble::ConstrainDoubleRange(range) => {
             if range.parent.min.is_some() || range.parent.max.is_some() {
                 Some(Constrain::Range(ConstrainRange {
                     min: range.parent.min.map(|x| *x),

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -752,14 +752,18 @@ impl Node {
         TreeIterator::new(self, shadow_including)
     }
 
-    pub(crate) fn inclusively_following_siblings(&self) -> impl Iterator<Item = DomRoot<Node>> {
+    pub(crate) fn inclusively_following_siblings(
+        &self,
+    ) -> impl Iterator<Item = DomRoot<Node>> + use<> {
         SimpleNodeIterator {
             current: Some(DomRoot::from_ref(self)),
             next_node: |n| n.GetNextSibling(),
         }
     }
 
-    pub(crate) fn inclusively_preceding_siblings(&self) -> impl Iterator<Item = DomRoot<Node>> {
+    pub(crate) fn inclusively_preceding_siblings(
+        &self,
+    ) -> impl Iterator<Item = DomRoot<Node>> + use<> {
         SimpleNodeIterator {
             current: Some(DomRoot::from_ref(self)),
             next_node: |n| n.GetPreviousSibling(),
@@ -799,14 +803,14 @@ impl Node {
             .any(|ancestor| &*ancestor == self)
     }
 
-    pub(crate) fn following_siblings(&self) -> impl Iterator<Item = DomRoot<Node>> {
+    pub(crate) fn following_siblings(&self) -> impl Iterator<Item = DomRoot<Node>> + use<> {
         SimpleNodeIterator {
             current: self.GetNextSibling(),
             next_node: |n| n.GetNextSibling(),
         }
     }
 
-    pub(crate) fn preceding_siblings(&self) -> impl Iterator<Item = DomRoot<Node>> {
+    pub(crate) fn preceding_siblings(&self) -> impl Iterator<Item = DomRoot<Node>> + use<> {
         SimpleNodeIterator {
             current: self.GetPreviousSibling(),
             next_node: |n| n.GetPreviousSibling(),
@@ -827,7 +831,7 @@ impl Node {
         }
     }
 
-    pub(crate) fn descending_last_children(&self) -> impl Iterator<Item = DomRoot<Node>> {
+    pub(crate) fn descending_last_children(&self) -> impl Iterator<Item = DomRoot<Node>> + use<> {
         SimpleNodeIterator {
             current: self.GetLastChild(),
             next_node: |n| n.GetLastChild(),
@@ -1090,7 +1094,7 @@ impl Node {
         Ok(NodeList::new_simple_list(&window, iter, CanGc::note()))
     }
 
-    pub(crate) fn ancestors(&self) -> impl Iterator<Item = DomRoot<Node>> {
+    pub(crate) fn ancestors(&self) -> impl Iterator<Item = DomRoot<Node>> + use<> {
         SimpleNodeIterator {
             current: self.GetParentNode(),
             next_node: |n| n.GetParentNode(),
@@ -1101,7 +1105,7 @@ impl Node {
     pub(crate) fn inclusive_ancestors(
         &self,
         shadow_including: ShadowIncluding,
-    ) -> impl Iterator<Item = DomRoot<Node>> {
+    ) -> impl Iterator<Item = DomRoot<Node>> + use<> {
         SimpleNodeIterator {
             current: Some(DomRoot::from_ref(self)),
             next_node: move |n| {
@@ -1143,21 +1147,21 @@ impl Node {
         self.is_connected() && self.owner_doc().browsing_context().is_some()
     }
 
-    pub(crate) fn children(&self) -> impl Iterator<Item = DomRoot<Node>> {
+    pub(crate) fn children(&self) -> impl Iterator<Item = DomRoot<Node>> + use<> {
         SimpleNodeIterator {
             current: self.GetFirstChild(),
             next_node: |n| n.GetNextSibling(),
         }
     }
 
-    pub(crate) fn rev_children(&self) -> impl Iterator<Item = DomRoot<Node>> {
+    pub(crate) fn rev_children(&self) -> impl Iterator<Item = DomRoot<Node>> + use<> {
         SimpleNodeIterator {
             current: self.GetLastChild(),
             next_node: |n| n.GetPreviousSibling(),
         }
     }
 
-    pub(crate) fn child_elements(&self) -> impl Iterator<Item = DomRoot<Element>> {
+    pub(crate) fn child_elements(&self) -> impl Iterator<Item = DomRoot<Element>> + use<> {
         self.children()
             .filter_map(DomRoot::downcast as fn(_) -> _)
             .peekable()

--- a/components/script/dom/readablestream.rs
+++ b/components/script/dom/readablestream.rs
@@ -281,13 +281,13 @@ impl ReadableStream {
     /// Call into the release steps of the controller,
     pub(crate) fn perform_release_steps(&self) -> Fallible<()> {
         match self.controller.borrow().as_ref() {
-            Some(ControllerType::Default(ref controller)) => {
+            Some(ControllerType::Default(controller)) => {
                 let controller = controller
                     .get()
                     .ok_or_else(|| Error::Type("Stream should have controller.".to_string()))?;
                 controller.perform_release_steps()
             },
-            Some(ControllerType::Byte(ref controller)) => {
+            Some(ControllerType::Byte(controller)) => {
                 let controller = controller
                     .get()
                     .ok_or_else(|| Error::Type("Stream should have controller.".to_string()))?;
@@ -307,11 +307,11 @@ impl ReadableStream {
         can_gc: CanGc,
     ) {
         match self.controller.borrow().as_ref() {
-            Some(ControllerType::Default(ref controller)) => controller
+            Some(ControllerType::Default(controller)) => controller
                 .get()
                 .expect("Stream should have controller.")
                 .perform_pull_steps(read_request, can_gc),
-            Some(ControllerType::Byte(ref controller)) => controller
+            Some(ControllerType::Byte(controller)) => controller
                 .get()
                 .expect("Stream should have controller.")
                 .perform_pull_steps(cx, read_request, can_gc),
@@ -333,7 +333,7 @@ impl ReadableStream {
         can_gc: CanGc,
     ) {
         match self.controller.borrow().as_ref() {
-            Some(ControllerType::Byte(ref controller)) => controller
+            Some(ControllerType::Byte(controller)) => controller
                 .get()
                 .expect("Stream should have controller.")
                 .perform_pull_into(cx, read_into_request, view, options, can_gc),
@@ -348,7 +348,7 @@ impl ReadableStream {
     /// <https://streams.spec.whatwg.org/#readable-stream-add-read-request>
     pub(crate) fn add_read_request(&self, read_request: &ReadRequest) {
         match self.reader.borrow().as_ref() {
-            Some(ReaderType::Default(ref reader)) => {
+            Some(ReaderType::Default(reader)) => {
                 let Some(reader) = reader.get() else {
                     panic!("Attempt to add a read request without having first acquired a reader.");
                 };
@@ -369,7 +369,7 @@ impl ReadableStream {
     pub(crate) fn add_read_into_request(&self, read_request: &ReadIntoRequest) {
         match self.reader.borrow().as_ref() {
             // Assert: stream.[[reader]] implements ReadableStreamBYOBReader.
-            Some(ReaderType::BYOB(ref reader)) => {
+            Some(ReaderType::BYOB(reader)) => {
                 let Some(reader) = reader.get() else {
                     unreachable!(
                         "Attempt to add a read into request without having first acquired a reader."
@@ -392,7 +392,7 @@ impl ReadableStream {
     /// Note: in other use cases this call happens via the controller.
     pub(crate) fn enqueue_native(&self, bytes: Vec<u8>, can_gc: CanGc) {
         match self.controller.borrow().as_ref() {
-            Some(ControllerType::Default(ref controller)) => controller
+            Some(ControllerType::Default(controller)) => controller
                 .get()
                 .expect("Stream should have controller.")
                 .enqueue_native(bytes, can_gc),
@@ -418,7 +418,7 @@ impl ReadableStream {
         // Let reader be stream.[[reader]].
 
         match self.reader.borrow().as_ref() {
-            Some(ReaderType::Default(ref reader)) => {
+            Some(ReaderType::Default(reader)) => {
                 let Some(reader) = reader.get() else {
                     // If reader is undefined, return.
                     return;
@@ -427,7 +427,7 @@ impl ReadableStream {
                 // Perform ! ReadableStreamDefaultReaderErrorReadRequests(reader, e).
                 reader.error(e, can_gc);
             },
-            Some(ReaderType::BYOB(ref reader)) => {
+            Some(ReaderType::BYOB(reader)) => {
                 let Some(reader) = reader.get() else {
                     // If reader is undefined, return.
                     return;
@@ -460,7 +460,7 @@ impl ReadableStream {
     /// <https://streams.spec.whatwg.org/#readable-stream-default-controller-close>
     pub(crate) fn controller_close_native(&self, can_gc: CanGc) {
         match self.controller.borrow().as_ref() {
-            Some(ControllerType::Default(ref controller)) => {
+            Some(ControllerType::Default(controller)) => {
                 let _ = controller
                     .get()
                     .expect("Stream should have controller.")
@@ -476,7 +476,7 @@ impl ReadableStream {
     /// Useful for native source integration only.
     pub(crate) fn in_memory(&self) -> bool {
         match self.controller.borrow().as_ref() {
-            Some(ControllerType::Default(ref controller)) => controller
+            Some(ControllerType::Default(controller)) => controller
                 .get()
                 .expect("Stream should have controller.")
                 .in_memory(),
@@ -492,7 +492,7 @@ impl ReadableStream {
     /// Useful for native source integration only.
     pub(crate) fn get_in_memory_bytes(&self) -> Option<Vec<u8>> {
         match self.controller.borrow().as_ref() {
-            Some(ControllerType::Default(ref controller)) => controller
+            Some(ControllerType::Default(controller)) => controller
                 .get()
                 .expect("Stream should have controller.")
                 .get_in_memory_bytes(),
@@ -536,7 +536,7 @@ impl ReadableStream {
 
     pub(crate) fn get_default_controller(&self) -> DomRoot<ReadableStreamDefaultController> {
         match self.controller.borrow().as_ref() {
-            Some(ControllerType::Default(ref controller)) => {
+            Some(ControllerType::Default(controller)) => {
                 controller.get().expect("Stream should have controller.")
             },
             _ => {
@@ -549,9 +549,7 @@ impl ReadableStream {
 
     pub(crate) fn get_default_reader(&self) -> DomRoot<ReadableStreamDefaultReader> {
         match self.reader.borrow().as_ref() {
-            Some(ReaderType::Default(ref reader)) => {
-                reader.get().expect("Stream should have reader.")
-            },
+            Some(ReaderType::Default(reader)) => reader.get().expect("Stream should have reader."),
             _ => {
                 unreachable!("Getting default reader for a stream with a non-default reader")
             },
@@ -565,7 +563,7 @@ impl ReadableStream {
     /// <https://streams.spec.whatwg.org/#readable-stream-default-reader-read>
     pub(crate) fn read_a_chunk(&self, can_gc: CanGc) -> Rc<Promise> {
         match self.reader.borrow().as_ref() {
-            Some(ReaderType::Default(ref reader)) => {
+            Some(ReaderType::Default(reader)) => {
                 let Some(reader) = reader.get() else {
                     unreachable!(
                         "Attempt to read stream chunk without having first acquired a reader."
@@ -587,7 +585,7 @@ impl ReadableStream {
         let reader_ref = self.reader.borrow();
 
         match reader_ref.as_ref() {
-            Some(ReaderType::Default(ref reader)) => {
+            Some(ReaderType::Default(reader)) => {
                 let Some(reader) = reader.get() else {
                     unreachable!("Attempt to stop reading without having first acquired a reader.");
                 };
@@ -604,8 +602,8 @@ impl ReadableStream {
     /// <https://streams.spec.whatwg.org/#is-readable-stream-locked>
     pub(crate) fn is_locked(&self) -> bool {
         match self.reader.borrow().as_ref() {
-            Some(ReaderType::Default(ref reader)) => reader.get().is_some(),
-            Some(ReaderType::BYOB(ref reader)) => reader.get().is_some(),
+            Some(ReaderType::Default(reader)) => reader.get().is_some(),
+            Some(ReaderType::BYOB(reader)) => reader.get().is_some(),
             None => false,
         }
     }
@@ -632,21 +630,21 @@ impl ReadableStream {
 
     pub(crate) fn has_default_reader(&self) -> bool {
         match self.reader.borrow().as_ref() {
-            Some(ReaderType::Default(ref reader)) => reader.get().is_some(),
+            Some(ReaderType::Default(reader)) => reader.get().is_some(),
             _ => false,
         }
     }
 
     pub(crate) fn has_byob_reader(&self) -> bool {
         match self.reader.borrow().as_ref() {
-            Some(ReaderType::BYOB(ref reader)) => reader.get().is_some(),
+            Some(ReaderType::BYOB(reader)) => reader.get().is_some(),
             _ => false,
         }
     }
 
     pub(crate) fn has_byte_controller(&self) -> bool {
         match self.controller.borrow().as_ref() {
-            Some(ControllerType::Byte(ref controller)) => controller.get().is_some(),
+            Some(ControllerType::Byte(controller)) => controller.get().is_some(),
             _ => false,
         }
     }
@@ -654,7 +652,7 @@ impl ReadableStream {
     /// <https://streams.spec.whatwg.org/#readable-stream-get-num-read-requests>
     pub(crate) fn get_num_read_requests(&self) -> usize {
         match self.reader.borrow().as_ref() {
-            Some(ReaderType::Default(ref reader)) => {
+            Some(ReaderType::Default(reader)) => {
                 let reader = reader
                     .get()
                     .expect("Stream must have a reader when getting the number of read requests.");
@@ -671,7 +669,7 @@ impl ReadableStream {
         assert!(self.has_byob_reader());
 
         match self.reader.borrow().as_ref() {
-            Some(ReaderType::BYOB(ref reader)) => {
+            Some(ReaderType::BYOB(reader)) => {
                 let Some(reader) = reader.get() else {
                     unreachable!(
                         "Stream must have a reader when get num read into requests is called into."
@@ -694,7 +692,7 @@ impl ReadableStream {
         assert!(self.has_default_reader());
 
         match self.reader.borrow().as_ref() {
-            Some(ReaderType::Default(ref reader)) => {
+            Some(ReaderType::Default(reader)) => {
                 // step 2 - Let reader be stream.[[reader]].
                 let reader = reader
                     .get()
@@ -735,7 +733,7 @@ impl ReadableStream {
 
         // Let reader be stream.[[reader]].
         match self.reader.borrow().as_ref() {
-            Some(ReaderType::BYOB(ref reader)) => {
+            Some(ReaderType::BYOB(reader)) => {
                 let Some(reader) = reader.get() else {
                     unreachable!(
                         "Stream must have a reader when a read into request is fulfilled."
@@ -776,7 +774,7 @@ impl ReadableStream {
         self.state.set(ReadableStreamState::Closed);
         // Let reader be stream.[[reader]].
         match self.reader.borrow().as_ref() {
-            Some(ReaderType::Default(ref reader)) => {
+            Some(ReaderType::Default(reader)) => {
                 let Some(reader) = reader.get() else {
                     // If reader is undefined, return.
                     return;
@@ -784,7 +782,7 @@ impl ReadableStream {
                 // step 5 & 6
                 reader.close(can_gc);
             },
-            Some(ReaderType::BYOB(ref reader)) => {
+            Some(ReaderType::BYOB(reader)) => {
                 let Some(reader) = reader.get() else {
                     // If reader is undefined, return.
                     return;
@@ -823,7 +821,7 @@ impl ReadableStream {
         self.close(can_gc);
 
         // If reader is not undefined and reader implements ReadableStreamBYOBReader,
-        if let Some(ReaderType::BYOB(ref reader)) = self.reader.borrow().as_ref() {
+        if let Some(ReaderType::BYOB(reader)) = self.reader.borrow().as_ref() {
             if let Some(reader) = reader.get() {
                 // step 6.1, 6.2 & 6.3 of https://streams.spec.whatwg.org/#readable-stream-cancel
                 reader.cancel(can_gc);
@@ -833,11 +831,11 @@ impl ReadableStream {
         // Let sourceCancelPromise be ! stream.[[controller]].[[CancelSteps]](reason).
 
         let source_cancel_promise = match self.controller.borrow().as_ref() {
-            Some(ControllerType::Default(ref controller)) => controller
+            Some(ControllerType::Default(controller)) => controller
                 .get()
                 .expect("Stream should have controller.")
                 .perform_cancel_steps(reason, can_gc),
-            Some(ControllerType::Byte(ref controller)) => controller
+            Some(ControllerType::Byte(controller)) => controller
                 .get()
                 .expect("Stream should have controller.")
                 .perform_cancel_steps(reason, can_gc),

--- a/components/script/dom/servoparser/html.rs
+++ b/components/script/dom/servoparser/html.rs
@@ -159,7 +159,7 @@ struct SerializationIterator {
     stack: Vec<SerializationCommand>,
 }
 
-fn rev_children_iter(n: &Node, can_gc: CanGc) -> impl Iterator<Item = DomRoot<Node>> {
+fn rev_children_iter(n: &Node, can_gc: CanGc) -> impl Iterator<Item = DomRoot<Node>> + use<'_> {
     if n.downcast::<Element>().is_some_and(|e| e.is_void()) {
         return Node::new_document_node().rev_children();
     }

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -192,7 +192,7 @@ impl ServoParser {
         context: &Element,
         input: DOMString,
         can_gc: CanGc,
-    ) -> impl Iterator<Item = DomRoot<Node>> {
+    ) -> impl Iterator<Item = DomRoot<Node>> + use<'_> {
         let context_node = context.upcast::<Node>();
         let context_document = context_node.owner_doc();
         let window = context_document.window();

--- a/components/script/dom/webglframebuffer.rs
+++ b/components/script/dom/webglframebuffer.rs
@@ -65,11 +65,11 @@ impl WebGLFramebufferAttachment {
     }
 
     fn root(&self) -> WebGLFramebufferAttachmentRoot {
-        match *self {
-            WebGLFramebufferAttachment::Renderbuffer(ref rb) => {
+        match self {
+            WebGLFramebufferAttachment::Renderbuffer(rb) => {
                 WebGLFramebufferAttachmentRoot::Renderbuffer(DomRoot::from_ref(rb))
             },
-            WebGLFramebufferAttachment::Texture { ref texture, .. } => {
+            WebGLFramebufferAttachment::Texture { texture, .. } => {
                 WebGLFramebufferAttachmentRoot::Texture(DomRoot::from_ref(texture))
             },
         }
@@ -78,7 +78,7 @@ impl WebGLFramebufferAttachment {
     fn detach(&self) {
         match self {
             WebGLFramebufferAttachment::Renderbuffer(rb) => rb.detach_from_framebuffer(),
-            WebGLFramebufferAttachment::Texture { ref texture, .. } => {
+            WebGLFramebufferAttachment::Texture { texture, .. } => {
                 texture.detach_from_framebuffer()
             },
         }
@@ -271,11 +271,11 @@ impl WebGLFramebuffer {
     ) -> Result<(), u32> {
         // Get the size of this attachment.
         let (format, size) = match attachment {
-            Some(WebGLFramebufferAttachment::Renderbuffer(ref att_rb)) => {
+            Some(WebGLFramebufferAttachment::Renderbuffer(att_rb)) => {
                 (Some(att_rb.internal_format()), att_rb.size())
             },
             Some(WebGLFramebufferAttachment::Texture {
-                texture: ref att_tex,
+                texture: att_tex,
                 level,
             }) => match att_tex.image_info_at_face(0, *level as u32) {
                 Some(info) => (

--- a/components/script/dom/webgpu/gpudevice.rs
+++ b/components/script/dom/webgpu/gpudevice.rs
@@ -239,7 +239,7 @@ impl GPUDevice {
         &self,
         layout: &GPUPipelineLayoutOrGPUAutoLayoutMode,
     ) -> PipelineLayout {
-        if let GPUPipelineLayoutOrGPUAutoLayoutMode::GPUPipelineLayout(ref layout) = layout {
+        if let GPUPipelineLayoutOrGPUAutoLayoutMode::GPUPipelineLayout(layout) = layout {
             PipelineLayout::Explicit(layout.id().0)
         } else {
             let layout_id = self.global().wgpu_id_hub().create_pipeline_layout_id();

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -3097,8 +3097,10 @@ fn is_named_element_with_id_attribute(elem: &Element) -> bool {
 }
 
 #[allow(unsafe_code)]
-#[no_mangle]
+#[unsafe(no_mangle)]
 /// Helper for interactive debugging sessions in lldb/gdb.
 unsafe extern "C" fn dump_js_stack(cx: *mut RawJSContext) {
-    DumpJSStack(cx, true, false, false);
+    unsafe {
+        DumpJSStack(cx, true, false, false);
+    }
 }

--- a/components/script/messaging.rs
+++ b/components/script/messaging.rs
@@ -48,56 +48,56 @@ pub(crate) enum MixedMessage {
 impl MixedMessage {
     pub(crate) fn pipeline_id(&self) -> Option<PipelineId> {
         match self {
-            MixedMessage::FromConstellation(ref inner_msg) => match *inner_msg {
-                ScriptThreadMessage::StopDelayingLoadEventsMode(id) => Some(id),
-                ScriptThreadMessage::AttachLayout(ref new_layout_info) => new_layout_info
+            MixedMessage::FromConstellation(inner_msg) => match inner_msg {
+                ScriptThreadMessage::StopDelayingLoadEventsMode(id) => Some(*id),
+                ScriptThreadMessage::AttachLayout(new_layout_info) => new_layout_info
                     .parent_info
                     .or(Some(new_layout_info.new_pipeline_id)),
-                ScriptThreadMessage::Resize(id, ..) => Some(id),
-                ScriptThreadMessage::ThemeChange(id, ..) => Some(id),
-                ScriptThreadMessage::ResizeInactive(id, ..) => Some(id),
-                ScriptThreadMessage::UnloadDocument(id) => Some(id),
-                ScriptThreadMessage::ExitPipeline(id, ..) => Some(id),
+                ScriptThreadMessage::Resize(id, ..) => Some(*id),
+                ScriptThreadMessage::ThemeChange(id, ..) => Some(*id),
+                ScriptThreadMessage::ResizeInactive(id, ..) => Some(*id),
+                ScriptThreadMessage::UnloadDocument(id) => Some(*id),
+                ScriptThreadMessage::ExitPipeline(id, ..) => Some(*id),
                 ScriptThreadMessage::ExitScriptThread => None,
-                ScriptThreadMessage::SendInputEvent(id, ..) => Some(id),
-                ScriptThreadMessage::Viewport(id, ..) => Some(id),
-                ScriptThreadMessage::GetTitle(id) => Some(id),
-                ScriptThreadMessage::SetDocumentActivity(id, ..) => Some(id),
-                ScriptThreadMessage::SetThrottled(id, ..) => Some(id),
-                ScriptThreadMessage::SetThrottledInContainingIframe(id, ..) => Some(id),
-                ScriptThreadMessage::NavigateIframe(id, ..) => Some(id),
-                ScriptThreadMessage::PostMessage { target: id, .. } => Some(id),
-                ScriptThreadMessage::UpdatePipelineId(_, _, _, id, _) => Some(id),
-                ScriptThreadMessage::UpdateHistoryState(id, ..) => Some(id),
-                ScriptThreadMessage::RemoveHistoryStates(id, ..) => Some(id),
-                ScriptThreadMessage::FocusIFrame(id, ..) => Some(id),
-                ScriptThreadMessage::WebDriverScriptCommand(id, ..) => Some(id),
-                ScriptThreadMessage::TickAllAnimations(id, ..) => Some(id),
-                ScriptThreadMessage::WebFontLoaded(id, ..) => Some(id),
+                ScriptThreadMessage::SendInputEvent(id, ..) => Some(*id),
+                ScriptThreadMessage::Viewport(id, ..) => Some(*id),
+                ScriptThreadMessage::GetTitle(id) => Some(*id),
+                ScriptThreadMessage::SetDocumentActivity(id, ..) => Some(*id),
+                ScriptThreadMessage::SetThrottled(id, ..) => Some(*id),
+                ScriptThreadMessage::SetThrottledInContainingIframe(id, ..) => Some(*id),
+                ScriptThreadMessage::NavigateIframe(id, ..) => Some(*id),
+                ScriptThreadMessage::PostMessage { target: id, .. } => Some(*id),
+                ScriptThreadMessage::UpdatePipelineId(_, _, _, id, _) => Some(*id),
+                ScriptThreadMessage::UpdateHistoryState(id, ..) => Some(*id),
+                ScriptThreadMessage::RemoveHistoryStates(id, ..) => Some(*id),
+                ScriptThreadMessage::FocusIFrame(id, ..) => Some(*id),
+                ScriptThreadMessage::WebDriverScriptCommand(id, ..) => Some(*id),
+                ScriptThreadMessage::TickAllAnimations(id, ..) => Some(*id),
+                ScriptThreadMessage::WebFontLoaded(id, ..) => Some(*id),
                 ScriptThreadMessage::DispatchIFrameLoadEvent {
                     target: _,
                     parent: id,
                     child: _,
-                } => Some(id),
-                ScriptThreadMessage::DispatchStorageEvent(id, ..) => Some(id),
-                ScriptThreadMessage::ReportCSSError(id, ..) => Some(id),
-                ScriptThreadMessage::Reload(id, ..) => Some(id),
-                ScriptThreadMessage::PaintMetric(id, ..) => Some(id),
-                ScriptThreadMessage::ExitFullScreen(id, ..) => Some(id),
+                } => Some(*id),
+                ScriptThreadMessage::DispatchStorageEvent(id, ..) => Some(*id),
+                ScriptThreadMessage::ReportCSSError(id, ..) => Some(*id),
+                ScriptThreadMessage::Reload(id, ..) => Some(*id),
+                ScriptThreadMessage::PaintMetric(id, ..) => Some(*id),
+                ScriptThreadMessage::ExitFullScreen(id, ..) => Some(*id),
                 ScriptThreadMessage::MediaSessionAction(..) => None,
                 #[cfg(feature = "webgpu")]
                 ScriptThreadMessage::SetWebGPUPort(..) => None,
-                ScriptThreadMessage::SetScrollStates(id, ..) => Some(id),
-                ScriptThreadMessage::SetEpochPaintTime(id, ..) => Some(id),
+                ScriptThreadMessage::SetScrollStates(id, ..) => Some(*id),
+                ScriptThreadMessage::SetEpochPaintTime(id, ..) => Some(*id),
             },
-            MixedMessage::FromScript(ref inner_msg) => match *inner_msg {
+            MixedMessage::FromScript(inner_msg) => match inner_msg {
                 MainThreadScriptMsg::Common(CommonScriptMsg::Task(_, _, pipeline_id, _)) => {
-                    pipeline_id
+                    *pipeline_id
                 },
                 MainThreadScriptMsg::Common(CommonScriptMsg::CollectReports(_)) => None,
-                MainThreadScriptMsg::NavigationResponse { pipeline_id, .. } => Some(pipeline_id),
-                MainThreadScriptMsg::WorkletLoaded(pipeline_id) => Some(pipeline_id),
-                MainThreadScriptMsg::RegisterPaintWorklet { pipeline_id, .. } => Some(pipeline_id),
+                MainThreadScriptMsg::NavigationResponse { pipeline_id, .. } => Some(*pipeline_id),
+                MainThreadScriptMsg::WorkletLoaded(pipeline_id) => Some(*pipeline_id),
+                MainThreadScriptMsg::RegisterPaintWorklet { pipeline_id, .. } => Some(*pipeline_id),
                 MainThreadScriptMsg::Inactive => None,
                 MainThreadScriptMsg::WakeUp => None,
             },
@@ -396,7 +396,7 @@ impl ScriptThreadReceivers {
                 }
                 #[cfg(not(feature = "webgpu"))]
                 {
-                    &crossbeam_channel::never::<()>()
+                    crossbeam_channel::never::<()>()
                 }
             }) -> msg => {
                 #[cfg(feature = "webgpu")]

--- a/components/script/navigation.rs
+++ b/components/script/navigation.rs
@@ -97,7 +97,7 @@ impl NavigationListener {
     }
 
     pub(crate) fn http_redirect_metadata(message: &FetchResponseMsg) -> Option<&Metadata> {
-        let FetchResponseMsg::ProcessResponse(_, Ok(ref metadata)) = message else {
+        let FetchResponseMsg::ProcessResponse(_, Ok(metadata)) = message else {
             return None;
         };
 

--- a/components/script/stylesheet_loader.rs
+++ b/components/script/stylesheet_loader.rs
@@ -188,7 +188,7 @@ impl FetchResponseListener for StylesheetContext {
                     // else we risk applying the wrong stylesheet when responses come out-of-order.
                     let is_stylesheet_load_applicable = self
                         .request_generation_id
-                        .is_none_or(|gen| gen == link.get_request_generation_id());
+                        .is_none_or(|generation| generation == link.get_request_generation_id());
                     if is_stylesheet_load_applicable {
                         let shared_lock = document.style_shared_lock().clone();
                         let sheet = Arc::new(Stylesheet::from_bytes(
@@ -314,7 +314,7 @@ impl StylesheetLoader<'_> {
             .elem
             .containing_shadow_root()
             .map(|sr| Trusted::new(&*sr));
-        let gen = self
+        let generation = self
             .elem
             .downcast::<HTMLLinkElement>()
             .map(HTMLLinkElement::get_request_generation_id);
@@ -327,7 +327,7 @@ impl StylesheetLoader<'_> {
             document: Trusted::new(&*document),
             shadow_root,
             origin_clean: true,
-            request_generation_id: gen,
+            request_generation_id: generation,
             resource_timing: ResourceFetchTiming::new(ResourceTimingType::Resource),
         };
 

--- a/components/script/task.rs
+++ b/components/script/task.rs
@@ -75,7 +75,10 @@ pub(crate) struct TaskCanceller {
 
 impl TaskCanceller {
     /// Returns a wrapped `task` that will be cancelled if the `TaskCanceller` says so.
-    pub(crate) fn wrap_task(&self, task: impl TaskOnce) -> impl TaskOnce {
+    pub(crate) fn wrap_task<T>(&self, task: T) -> impl TaskOnce + use<T>
+    where
+        T: TaskOnce,
+    {
         CancellableTask {
             canceller: self.clone(),
             inner: task,

--- a/components/script/window_named_properties.rs
+++ b/components/script/window_named_properties.rs
@@ -85,7 +85,7 @@ unsafe extern "C" fn get_own_property_descriptor(
     desc: MutableHandle<PropertyDescriptor>,
     is_none: *mut bool,
 ) -> bool {
-    let cx = SafeJSContext::from_ptr(cx);
+    let cx = unsafe { SafeJSContext::from_ptr(cx) };
 
     if id.is_symbol() {
         if id.get().asBits_ == SymbolId(GetWellKnownSymbol(*cx, SymbolCode::toStringTag)).asBits_ {
@@ -95,7 +95,7 @@ unsafe extern "C" fn get_own_property_descriptor(
                 RustMutableHandle::from_raw(desc),
                 rval.handle(),
                 JSPROP_READONLY.into(),
-                &mut *is_none,
+                unsafe { &mut *is_none },
             );
         }
         return true;
@@ -115,7 +115,7 @@ unsafe extern "C" fn get_own_property_descriptor(
     }
 
     let s = if id.is_string() {
-        jsstr_to_string(*cx, id.to_string())
+        unsafe { jsstr_to_string(*cx, id.to_string()) }
     } else if id.is_int() {
         // If the property key is an integer index, convert it to a String too.
         // For indexed access on the window object, which may shadow this, see
@@ -131,16 +131,16 @@ unsafe extern "C" fn get_own_property_descriptor(
         return true;
     }
 
-    let window = Root::downcast::<Window>(GlobalScope::from_object(proxy.get()))
+    let window = Root::downcast::<Window>(unsafe { GlobalScope::from_object(proxy.get()) })
         .expect("global is not a window");
     if let Some(obj) = window.NamedGetter(s.into()) {
         rooted!(in(*cx) let mut rval = UndefinedValue());
         obj.to_jsval(*cx, rval.handle_mut());
         set_property_descriptor(
-            RustMutableHandle::from_raw(desc),
+            unsafe { RustMutableHandle::from_raw(desc) },
             rval.handle(),
             0,
-            &mut *is_none,
+            unsafe { &mut *is_none },
         );
     }
     true
@@ -155,8 +155,10 @@ unsafe extern "C" fn own_property_keys(
     // TODO is this all we need to return? compare with gecko:
     // https://searchfox.org/mozilla-central/rev/af78418c4b5f2c8721d1a06486cf4cf0b33e1e8d/dom/base/WindowNamedPropertiesHandler.cpp#175-232
     // see also https://github.com/whatwg/html/issues/9068
-    rooted!(in(cx) let mut rooted = SymbolId(GetWellKnownSymbol(cx, SymbolCode::toStringTag)));
-    AppendToIdVector(props, rooted.handle().into());
+    unsafe {
+        rooted!(in(cx) let mut rooted = SymbolId(GetWellKnownSymbol(cx, SymbolCode::toStringTag)));
+        AppendToIdVector(props, rooted.handle().into());
+    }
     true
 }
 
@@ -168,7 +170,9 @@ unsafe extern "C" fn define_property(
     _desc: Handle<PropertyDescriptor>,
     result: *mut ObjectOpResult,
 ) -> bool {
-    (*result).code_ = JSErrNum::JSMSG_CANT_DEFINE_WINDOW_NAMED_PROPERTY as usize;
+    unsafe {
+        (*result).code_ = JSErrNum::JSMSG_CANT_DEFINE_WINDOW_NAMED_PROPERTY as usize;
+    }
     true
 }
 
@@ -179,7 +183,9 @@ unsafe extern "C" fn delete(
     _id: HandleId,
     result: *mut ObjectOpResult,
 ) -> bool {
-    (*result).code_ = JSErrNum::JSMSG_CANT_DELETE_WINDOW_NAMED_PROPERTY as usize;
+    unsafe {
+        (*result).code_ = JSErrNum::JSMSG_CANT_DELETE_WINDOW_NAMED_PROPERTY as usize;
+    }
     true
 }
 
@@ -190,8 +196,10 @@ unsafe extern "C" fn get_prototype_if_ordinary(
     is_ordinary: *mut bool,
     proto: MutableHandleObject,
 ) -> bool {
-    *is_ordinary = true;
-    proto.set(js::jsapi::GetStaticPrototype(proxy.get()));
+    unsafe {
+        *is_ordinary = true;
+        proto.set(js::jsapi::GetStaticPrototype(proxy.get()));
+    }
     true
 }
 
@@ -201,7 +209,9 @@ unsafe extern "C" fn prevent_extensions(
     _proxy: HandleObject,
     result: *mut ObjectOpResult,
 ) -> bool {
-    (*result).code_ = JSErrNum::JSMSG_CANT_PREVENT_EXTENSIONS as usize;
+    unsafe {
+        (*result).code_ = JSErrNum::JSMSG_CANT_PREVENT_EXTENSIONS as usize;
+    }
     true
 }
 
@@ -211,7 +221,9 @@ unsafe extern "C" fn is_extensible(
     _proxy: HandleObject,
     extensible: *mut bool,
 ) -> bool {
-    *extensible = true;
+    unsafe {
+        *extensible = true;
+    }
     true
 }
 

--- a/components/script_bindings/Cargo.toml
+++ b/components/script_bindings/Cargo.toml
@@ -43,3 +43,4 @@ webxr = []
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(crown)'] }
+unsafe_op_in_unsafe_fn = { level = "allow" }

--- a/components/script_bindings/codegen/CodegenRust.py
+++ b/components/script_bindings/codegen/CodegenRust.py
@@ -5162,7 +5162,7 @@ class CGUnionStruct(CGThing):
         return False
 
     def manualImplClone(self, templateVars):
-        arms = [f"            {self.type}::{v['name']}(ref inner) => "
+        arms = [f"            {self.type}::{v['name']}(inner) => "
                 f"{self.type}::{v['name']}(inner.clone()),"
                 for (v, _) in templateVars]
         arms = "\n".join(arms)

--- a/components/script_bindings/root.rs
+++ b/components/script_bindings/root.rs
@@ -428,9 +428,11 @@ thread_local!(pub static STACK_ROOTS: Cell<Option<*const RootCollection>> = cons
 pub unsafe fn trace_roots(tracer: *mut JSTracer) {
     trace!("tracing stack roots");
     STACK_ROOTS.with(|collection| {
-        let collection = &*(*collection.get().unwrap()).roots.get();
+        let collection = unsafe { &*(*collection.get().unwrap()).roots.get() };
         for root in collection {
-            (**root).trace(tracer);
+            unsafe {
+                (**root).trace(tracer);
+            }
         }
     });
 }

--- a/components/script_bindings/trace.rs
+++ b/components/script_bindings/trace.rs
@@ -16,7 +16,7 @@ use crate::str::{DOMString, USVString};
 #[cfg_attr(crown, allow(crown::unrooted_must_root))]
 pub unsafe fn trace_reflector(tracer: *mut JSTracer, description: &str, reflector: &Reflector) {
     trace!("tracing reflector {}", description);
-    trace_object(tracer, description, reflector.rootable())
+    unsafe { trace_object(tracer, description, reflector.rootable()) }
 }
 
 /// Trace a `JSObject`.

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -787,7 +787,7 @@ impl StructuredSerializedData {
             for (original_id, blob) in blobs.iter() {
                 let type_string = blob.type_string();
 
-                if let BlobData::Memory(ref bytes) = blob.blob_data() {
+                if let BlobData::Memory(bytes) = blob.blob_data() {
                     let blob_clone = BlobImpl::new_from_bytes(bytes.clone(), type_string);
 
                     // Note: we insert the blob at the original id,

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -1882,7 +1882,7 @@ impl WebDriverHandler<ServoExtensionRoute> for Handler {
 
 fn webdriver_value_to_js_argument(v: &Value) -> String {
     match v {
-        Value::String(ref s) => format!("\"{}\"", s),
+        Value::String(s) => format!("\"{}\"", s),
         Value::Null => "null".to_string(),
         Value::Bool(b) => b.to_string(),
         Value::Number(n) => n.to_string(),

--- a/components/webgpu/wgpu_thread.rs
+++ b/components/webgpu/wgpu_thread.rs
@@ -1293,7 +1293,7 @@ impl WGPU {
         encoder_id: id::CommandEncoderId,
         result: &Result<U, T>,
     ) {
-        if let Err(ref e) = result {
+        if let Err(e) = result {
             self.error_command_encoders
                 .entry(encoder_id)
                 .or_insert_with(|| format!("{:?}", e));

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -131,3 +131,6 @@ sig = "1.0"
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { workspace = true, features = ["Win32_Graphics_Gdi"] }
 libservo = { path = "../../components/servo", features = ["no-wgl"] }
+
+[lints.rust]
+unsafe_op_in_unsafe_fn = { level = "allow" }

--- a/ports/servoshell/desktop/dialog.rs
+++ b/ports/servoshell/desktop/dialog.rs
@@ -238,14 +238,14 @@ impl Dialog {
             Dialog::Authentication {
                 username,
                 password,
-                ref mut request,
+                request,
             } => {
                 let mut is_open = true;
                 Modal::new("authentication".into()).show(ctx, |ui| {
                     let mut frame = egui::Frame::default().inner_margin(10.0).begin(ui);
                     frame.content_ui.set_min_width(150.0);
 
-                    if let Some(ref request) = request {
+                    if let Some(request) = request {
                         let url =
                             egui::RichText::new(request.url().origin().unicode_serialization());
                         frame.content_ui.heading(url);

--- a/ports/servoshell/egl/android.rs
+++ b/ports/servoshell/egl/android.rs
@@ -34,11 +34,11 @@ struct HostCallbacks {
     jvm: JavaVM,
 }
 
-extern "C" {
+unsafe extern "C" {
     fn ANativeWindow_fromSurface(env: *mut jni::sys::JNIEnv, surface: jobject) -> *mut c_void;
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn android_main() {
     // FIXME(mukilan): this android_main is only present to stop
     // the java side 'System.loadLibrary('servoshell') call from
@@ -57,7 +57,7 @@ where
     });
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_servo_servoview_JNIServo_version<'local>(
     env: JNIEnv<'local>,
     _class: JClass<'local>,
@@ -67,7 +67,7 @@ pub extern "C" fn Java_org_servo_servoview_JNIServo_version<'local>(
         .unwrap_or_else(|_str| JObject::null().into())
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_servo_servoview_JNIServo_init<'local>(
     mut env: JNIEnv<'local>,
     _: JClass<'local>,
@@ -147,7 +147,7 @@ pub extern "C" fn Java_org_servo_servoview_JNIServo_init<'local>(
     };
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_servo_servoview_JNIServo_requestShutdown<'local>(
     mut env: JNIEnv<'local>,
     _class: JClass<'local>,
@@ -156,7 +156,7 @@ pub extern "C" fn Java_org_servo_servoview_JNIServo_requestShutdown<'local>(
     call(&mut env, |s| s.request_shutdown());
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_servo_servoview_JNIServo_deinit<'local>(
     _env: JNIEnv<'local>,
     _class: JClass<'local>,
@@ -165,7 +165,7 @@ pub extern "C" fn Java_org_servo_servoview_JNIServo_deinit<'local>(
     simpleservo::deinit();
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_servo_servoview_JNIServo_resize<'local>(
     mut env: JNIEnv<'local>,
     _: JClass<'local>,
@@ -179,7 +179,7 @@ pub extern "C" fn Java_org_servo_servoview_JNIServo_resize<'local>(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_servo_servoview_JNIServo_performUpdates<'local>(
     mut env: JNIEnv<'local>,
     _class: JClass<'local>,
@@ -191,7 +191,7 @@ pub extern "C" fn Java_org_servo_servoview_JNIServo_performUpdates<'local>(
     });
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_servo_servoview_JNIServo_loadUri<'local>(
     mut env: JNIEnv<'local>,
     _class: JClass<'local>,
@@ -209,7 +209,7 @@ pub extern "C" fn Java_org_servo_servoview_JNIServo_loadUri<'local>(
     };
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_servo_servoview_JNIServo_reload<'local>(
     mut env: JNIEnv<'local>,
     _class: JClass<'local>,
@@ -218,7 +218,7 @@ pub extern "C" fn Java_org_servo_servoview_JNIServo_reload<'local>(
     call(&mut env, |s| s.reload());
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_servo_servoview_JNIServo_stop<'local>(
     mut env: JNIEnv<'local>,
     _class: JClass<'local>,
@@ -227,7 +227,7 @@ pub extern "C" fn Java_org_servo_servoview_JNIServo_stop<'local>(
     call(&mut env, |s| s.stop());
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_servo_servoview_JNIServo_goBack<'local>(
     mut env: JNIEnv<'local>,
     _class: JClass<'local>,
@@ -236,7 +236,7 @@ pub extern "C" fn Java_org_servo_servoview_JNIServo_goBack<'local>(
     call(&mut env, |s| s.go_back());
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_servo_servoview_JNIServo_goForward<'local>(
     mut env: JNIEnv<'local>,
     _class: JClass<'local>,
@@ -245,7 +245,7 @@ pub extern "C" fn Java_org_servo_servoview_JNIServo_goForward<'local>(
     call(&mut env, |s| s.go_forward());
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_servo_servoview_JNIServo_scrollStart<'local>(
     mut env: JNIEnv<'local>,
     _: JClass<'local>,
@@ -258,7 +258,7 @@ pub extern "C" fn Java_org_servo_servoview_JNIServo_scrollStart<'local>(
     call(&mut env, |s| s.scroll_start(dx as f32, dy as f32, x, y));
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_servo_servoview_JNIServo_scrollEnd<'local>(
     mut env: JNIEnv<'local>,
     _: JClass<'local>,
@@ -271,7 +271,7 @@ pub extern "C" fn Java_org_servo_servoview_JNIServo_scrollEnd<'local>(
     call(&mut env, |s| s.scroll_end(dx as f32, dy as f32, x, y));
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_servo_servoview_JNIServo_scroll<'local>(
     mut env: JNIEnv<'local>,
     _: JClass<'local>,
@@ -284,7 +284,7 @@ pub extern "C" fn Java_org_servo_servoview_JNIServo_scroll<'local>(
     call(&mut env, |s| s.scroll(dx as f32, dy as f32, x, y));
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_servo_servoview_JNIServo_touchDown<'local>(
     mut env: JNIEnv<'local>,
     _: JClass<'local>,
@@ -296,7 +296,7 @@ pub extern "C" fn Java_org_servo_servoview_JNIServo_touchDown<'local>(
     call(&mut env, |s| s.touch_down(x, y, pointer_id));
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_servo_servoview_JNIServo_touchUp<'local>(
     mut env: JNIEnv<'local>,
     _: JClass<'local>,
@@ -308,7 +308,7 @@ pub extern "C" fn Java_org_servo_servoview_JNIServo_touchUp<'local>(
     call(&mut env, |s| s.touch_up(x, y, pointer_id));
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_servo_servoview_JNIServo_touchMove<'local>(
     mut env: JNIEnv<'local>,
     _: JClass<'local>,
@@ -320,7 +320,7 @@ pub extern "C" fn Java_org_servo_servoview_JNIServo_touchMove<'local>(
     call(&mut env, |s| s.touch_move(x, y, pointer_id));
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_servo_servoview_JNIServo_touchCancel<'local>(
     mut env: JNIEnv<'local>,
     _: JClass<'local>,
@@ -332,7 +332,7 @@ pub extern "C" fn Java_org_servo_servoview_JNIServo_touchCancel<'local>(
     call(&mut env, |s| s.touch_cancel(x, y, pointer_id));
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_servo_servoview_JNIServo_pinchZoomStart<'local>(
     mut env: JNIEnv<'local>,
     _: JClass<'local>,
@@ -344,7 +344,7 @@ pub extern "C" fn Java_org_servo_servoview_JNIServo_pinchZoomStart<'local>(
     call(&mut env, |s| s.pinchzoom_start(factor, x as u32, y as u32));
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_servo_servoview_JNIServo_pinchZoom<'local>(
     mut env: JNIEnv<'local>,
     _: JClass<'local>,
@@ -356,7 +356,7 @@ pub extern "C" fn Java_org_servo_servoview_JNIServo_pinchZoom<'local>(
     call(&mut env, |s| s.pinchzoom(factor, x as u32, y as u32));
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_servo_servoview_JNIServo_pinchZoomEnd<'local>(
     mut env: JNIEnv<'local>,
     _: JClass<'local>,
@@ -368,7 +368,7 @@ pub extern "C" fn Java_org_servo_servoview_JNIServo_pinchZoomEnd<'local>(
     call(&mut env, |s| s.pinchzoom_end(factor, x as u32, y as u32));
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_servo_servoview_JNIServo_click(
     mut env: JNIEnv,
     _: JClass,
@@ -379,7 +379,7 @@ pub extern "C" fn Java_org_servo_servoview_JNIServo_click(
     call(&mut env, |s| s.click(x, y));
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_servo_servoview_JNIServo_pauseCompositor(
     mut env: JNIEnv,
     _: JClass<'_>,
@@ -388,7 +388,7 @@ pub extern "C" fn Java_org_servo_servoview_JNIServo_pauseCompositor(
     call(&mut env, |s| s.pause_compositor());
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_servo_servoview_JNIServo_resumeCompositor<'local>(
     mut env: JNIEnv<'local>,
     _: JClass<'local>,
@@ -407,7 +407,7 @@ pub extern "C" fn Java_org_servo_servoview_JNIServo_resumeCompositor<'local>(
     });
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_servo_servoview_JNIServo_mediaSessionAction<'local>(
     mut env: JNIEnv<'local>,
     _: JClass<'local>,
@@ -689,7 +689,7 @@ impl HostTrait for HostCallbacks {
     fn on_panic(&self, _reason: String, _backtrace: Option<String>) {}
 }
 
-extern "C" {
+unsafe extern "C" {
     pub fn __android_log_write(prio: c_int, tag: *const c_char, text: *const c_char) -> c_int;
 }
 

--- a/ports/servoshell/egl/ohos.rs
+++ b/ports/servoshell/egl/ohos.rs
@@ -213,7 +213,7 @@ unsafe extern "C" fn on_vsync_cb(
 
 static SERVO_CHANNEL: OnceLock<Sender<ServoAction>> = OnceLock::new();
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 extern "C" fn on_surface_created_cb(xcomponent: *mut OH_NativeXComponent, window: *mut c_void) {
     info!("on_surface_created_cb");
 

--- a/ports/servoshell/platform/macos/mod.rs
+++ b/ports/servoshell/platform/macos/mod.rs
@@ -35,11 +35,11 @@ pub fn deinit(clean_shutdown: bool) {
     }
 }
 
-#[link_section = "__TEXT,__info_plist"]
-#[no_mangle]
+#[unsafe(link_section = "__TEXT,__info_plist")]
+#[unsafe(no_mangle)]
 pub static INFO_PLIST: [u8; 619] = *include_bytes!("Info.plist");
 
 #[link(name = "count_threads")]
-extern "C" {
+unsafe extern "C" {
     fn macos_count_running_threads() -> i32;
 }

--- a/support/rust-task_info/src/task_basic_info.rs
+++ b/support/rust-task_info/src/task_basic_info.rs
@@ -37,7 +37,7 @@ pub fn resident_size() -> Option<usize> {
     }
 }
 
-extern "C" {
+unsafe extern "C" {
     fn TaskBasicInfoVirtualSize(virtual_size: *mut size_t) -> c_int;
     fn TaskBasicInfoResidentSize(resident_size: *mut size_t) -> c_int;
 }


### PR DESCRIPTION
Now that we use rustc `1.85` we might as well migrate to the latest edition.

The main changes are the following:

* Added appropriate `+ use<>` bounds to `impl Trait` in return types to indicate the generic parameters that the returned type may use
* Removed binding modifiers where they're not needed (`let Some(ref r) = &f` -> `let Some(r) = &f`)
* Removed any `gen` identifiers, which are now reserved, or used `r#gen` if that's not possible
* mark `extern` blocks as `unsafe`

I have set the default lint level for the `unsafe_op_in_unsafe_fn` lint to "allow" (the same as it was by default in the 2021 edition). In 2024 edition it triggers a warning by default, but the lint is incredibly noisy for servo, causing around 60.000 warnings. 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes (covered by our test suites, most changes should also "just work" once they compile)

