### PR TITLE
Allow domain-like as URL location input

### DIFF
--- a/ports/servoshell/parser.rs
+++ b/ports/servoshell/parser.rs
@@ -66,10 +66,16 @@ pub(crate) fn location_bar_input_to_url(request: &str, searchpage: &str) -> Opti
     ServoUrl::parse(request).ok().or_else(|| {
         if request.starts_with('/') {
             ServoUrl::parse(&format!("file://{}", request)).ok()
-        } else if request.contains('/') || is_reg_domain(request) {
+        } else if !request.contains(' ') && is_reg_domain(request) || is_domain_like(request) {
             ServoUrl::parse(&format!("https://{}", request)).ok()
         } else {
             ServoUrl::parse(&searchpage.replace("%s", request)).ok()
         }
     })
+}
+
+/// Check if string is domain-like based on ad hoc heuristics.
+fn is_domain_like(s: &str) -> bool {
+    !s.starts_with('/') && s.contains('/') ||
+        (!s.contains(' ') && !s.starts_with('.') && s.split('.').count() > 1)
 }


### PR DESCRIPTION
Before this patch, domain with subdomain (e.g. book.servo.org) won't be treated as URL location.

This patch retifies that by adding Firefox's location bar behavior:

  - book.servo.org is URL location
  - book.servo.org. is URL location
  - .book.servo.org is not URL location

Fixes #35754.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #35754 (GitHub issue number if applicable)

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
