### PR TITLE
Create `config_dir` if none exist for caching

### DIFF
--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -20,7 +20,7 @@ use devtools_traits::DevtoolsControlMsg;
 use embedder_traits::EmbedderProxy;
 use hyper_serde::Serde;
 use ipc_channel::ipc::{self, IpcReceiver, IpcReceiverSet, IpcSender};
-use log::{debug, warn};
+use log::{debug, trace, warn};
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 use net_traits::blob_url_store::parse_blob_url;
 use net_traits::filemanager_thread::FileTokenCheck;
@@ -496,7 +496,7 @@ where
     let mut string_buffer: String = String::new();
     match file.read_to_string(&mut string_buffer) {
         Err(why) => panic!("couldn't read from {}: {}", display, why),
-        Ok(_) => debug!("successfully read from {}", display),
+        Ok(_) => trace!("successfully read from {}", display),
     }
 
     match serde_json::from_str(&string_buffer) {
@@ -523,7 +523,7 @@ where
 
     match file.write_all(json_encoded.as_bytes()) {
         Err(why) => panic!("couldn't write to {}: {}", display, why),
-        Ok(_) => debug!("successfully wrote to {}", display),
+        Ok(_) => trace!("successfully wrote to {}", display),
     }
 }
 

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -496,7 +496,7 @@ where
     let mut string_buffer: String = String::new();
     match file.read_to_string(&mut string_buffer) {
         Err(why) => panic!("couldn't read from {}: {}", display, why),
-        Ok(_) => println!("successfully read from {}", display),
+        Ok(_) => debug!("successfully read from {}", display),
     }
 
     match serde_json::from_str(&string_buffer) {
@@ -523,7 +523,7 @@ where
 
     match file.write_all(json_encoded.as_bytes()) {
         Err(why) => panic!("couldn't write to {}: {}", display, why),
-        Ok(_) => println!("successfully wrote to {}", display),
+        Ok(_) => debug!("successfully wrote to {}", display),
     }
 }
 

--- a/ports/servoshell/egl/ohos.rs
+++ b/ports/servoshell/egl/ohos.rs
@@ -49,6 +49,7 @@ pub struct InitOpts {
     pub os_full_name: String,
     /// Path to application data bundled with the servo app, e.g. web-pages.
     pub resource_dir: String,
+    pub cache_dir: String,
     pub display_density: f64,
     pub commandline_args: String,
 }

--- a/ports/servoshell/egl/ohos/simpleservo.rs
+++ b/ports/servoshell/egl/ohos/simpleservo.rs
@@ -40,6 +40,7 @@ pub fn init(
     info!("Entered simpleservo init function");
     crate::init_crypto();
     let resource_dir = PathBuf::from(&options.resource_dir).join("servo");
+    debug!("Resources are located at: {:?}", resource_dir);
     resources::set(Box::new(ResourceReaderInstance::new(resource_dir.clone())));
 
     // It would be nice if `from_cmdline_args()` could accept str slices, to avoid allocations here.
@@ -53,14 +54,20 @@ pub fn init(
     );
     debug!("Servo commandline args: {:?}", args);
 
+    let config_dir = PathBuf::from(&options.cache_dir).join("servo");
+    debug!("Configs are located at: {:?}", config_dir);
     let _ = crate::prefs::DEFAULT_CONFIG_DIR
-        .set(resource_dir)
+        .set(config_dir)
         .inspect_err(|e| {
             warn!(
                 "Default Prefs Dir already previously filled. Got error {}",
                 e.display()
             );
         });
+
+    // Used to locate `prefs.json`
+    args.push("--resource-dir".to_string());
+    args.push(resource_dir.to_str().unwrap().to_string());
 
     let (opts, preferences, servoshell_preferences) = match parse_command_line_arguments(args) {
         ArgumentParsingResult::ContentProcess(..) => {

--- a/ports/servoshell/egl/ohos/simpleservo.rs
+++ b/ports/servoshell/egl/ohos/simpleservo.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 use std::cell::RefCell;
+use std::fs;
 use std::os::raw::c_void;
 use std::path::PathBuf;
 use std::ptr::NonNull;
@@ -57,7 +58,7 @@ pub fn init(
     let config_dir = PathBuf::from(&options.cache_dir).join("servo");
     debug!("Configs are located at: {:?}", config_dir);
     let _ = crate::prefs::DEFAULT_CONFIG_DIR
-        .set(config_dir)
+        .set(config_dir.clone())
         .inspect_err(|e| {
             warn!(
                 "Default Prefs Dir already previously filled. Got error {}",
@@ -65,9 +66,17 @@ pub fn init(
             );
         });
 
-    // Used to locate `prefs.json`
-    args.push("--resource-dir".to_string());
-    args.push(resource_dir.to_str().unwrap().to_string());
+    // Try copy `prefs.json` from {this.context.resource_prefsDir}/servo/
+    // to `config_dir` if none exist
+    let source_prefs = resource_dir.join("prefs.json");
+    let target_prefs = config_dir.join("prefs.json");
+    if !target_prefs.exists() && source_prefs.exists() {
+        debug!("Copy {:?} to {:?}", source_prefs, target_prefs);
+        fs::copy(&source_prefs, &target_prefs).unwrap_or_else(|e| {
+            debug!("Copy failed! {:?}", e);
+            0
+        });
+    }
 
     let (opts, preferences, servoshell_preferences) = match parse_command_line_arguments(args) {
         ArgumentParsingResult::ContentProcess(..) => {

--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -119,14 +119,14 @@ pub fn default_config_dir() -> Option<PathBuf> {
 /// Get a Servo [`Preferences`] to use when initializing Servo by first reading the user
 /// preferences file and then overriding these preferences with the ones from the `--prefs-file`
 /// command-line argument, if given.
-fn get_preferences(opts_matches: &Matches, pref_dir: &Option<PathBuf>) -> Preferences {
+fn get_preferences(opts_matches: &Matches, config_dir: &Option<PathBuf>) -> Preferences {
     // Do not read any preferences files from the disk when testing as we do not want it
     // to throw off test results.
     if cfg!(test) {
         return Preferences::default();
     }
 
-    let user_prefs_path = pref_dir
+    let user_prefs_path = config_dir
         .clone()
         .map(|path| path.join("prefs.json"))
         .filter(|path| path.exists());
@@ -366,13 +366,6 @@ pub(crate) fn parse_command_line_arguments(args: Vec<String>) -> ArgumentParsing
         "/path/to/prefs.json",
     );
 
-    opts.optopt(
-        "",
-        "resource-dir",
-        "Path to resource directory (ohos only)",
-        "",
-    );
-
     let opt_match = match opts.parse(args) {
         Ok(m) => m,
         Err(f) => args_fail(&f.to_string()),
@@ -394,19 +387,13 @@ pub(crate) fn parse_command_line_arguments(args: Vec<String>) -> ArgumentParsing
         .or_else(default_config_dir)
         .inspect(|path| {
             if !path.exists() {
-                fs::create_dir_all(path).expect("Failed to create config directory")
+                fs::create_dir_all(path).unwrap_or_else(|e| {
+                    error!("Failed to create config directory at {:?}: {:?}", path, e)
+                })
             }
         });
 
-    #[cfg(target_env = "ohos")]
-    // For now, prefs.json in ohos is always in {this.context.resourceDir}/servo/
-    let pref_dir = &opt_match.opt_str("resource-dir").map(Into::into);
-
-    #[cfg(not(target_env = "ohos"))]
-    let pref_dir = &config_dir;
-
-    //for ohos, pref_dir is resource_dir
-    let mut preferences = get_preferences(&opt_match, pref_dir);
+    let mut preferences = get_preferences(&opt_match, &config_dir);
 
     // If this is the content process, we'll receive the real options over IPC. So just fill in
     // some dummy options for now.

--- a/support/openharmony/entry/src/main/ets/pages/Index.ets
+++ b/support/openharmony/entry/src/main/ets/pages/Index.ets
@@ -17,6 +17,7 @@ interface InitOpts {
   deviceType: string,
   osFullName: string,
   resourceDir: string,
+  cacheDir: string,
   displayDensity: number,
   commandlineArgs: string,
 }
@@ -109,13 +110,16 @@ struct Index {
         .onLoad((xComponentContext) => {
           this.xComponentContext = xComponentContext as ServoXComponentInterface;
           let resource_dir: string = this.context.resourceDir;
-          console.debug("Resources are located at %{public}s", resource_dir);
+          let cache_dir: string = this.context.cacheDir;
+          console.debug("resourceDir: ", resource_dir);
+          console.debug("cacheDir: ", cache_dir);
           let init_options: InitOpts = {
             url: this.urlToLoad,
             deviceType: get_device_type(),
             osFullName: deviceInfo.osFullName,
             displayDensity: get_density(),
             resourceDir: resource_dir,
+            cacheDir: cache_dir,
             commandlineArgs: this.CommandlineArgs
           }
           this.xComponentContext.initServo(init_options)

--- a/tests/wpt/meta/webstorage/storage_local_setitem_quotaexceedederr.window.js.ini
+++ b/tests/wpt/meta/webstorage/storage_local_setitem_quotaexceedederr.window.js.ini
@@ -1,0 +1,2 @@
+[storage_local_setitem_quotaexceedederr.window.html]
+    expected: TIMEOUT


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
1. Print like `println!("successfully read from {}", display)` changed to debug, to not [TIMEOUT] wpt-test 
2. Create `config_dir` and use default `fn default_config_dir` if none exists
3. For OHOS, pass `this.context.cacheDir` as a new field in `InitOpts` interface during the NAPI integration. It is used as `config_dir`.

`auth_cache.json`, `cookie_jar.json`, `local_data.json` etc. can now be saved in device storage in default setting, to be reused when relaunching the app.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #35758 

<!-- Either: -->

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
cc @xiaochengh 