### PR TITLE
Fix the problem that touchmove crashes occasionally. Fix crash when multiple touch cancels occur

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -1528,13 +1528,6 @@ impl IOCompositor {
                         // actions, and try to remove the touch sequence.
                         self.touch_handler
                             .remove_pending_touch_move_action(sequence_id);
-                        // Todo: Perhaps we need to check how many fingers are still active.
-                        if let Some(touch_sequence) =
-                            self.touch_handler.get_touch_sequence_mut(sequence_id)
-                        {
-                            touch_sequence.state = TouchSequenceState::Finished;
-                        }
-                        // Cancel should be the last event for a given sequence_id.
                         self.touch_handler.try_remove_touch_sequence(sequence_id);
                     },
                 }

--- a/components/compositing/touch.rs
+++ b/components/compositing/touch.rs
@@ -26,7 +26,7 @@ const FLING_MAX_SCREEN_PX: f32 = 4000.0;
 pub struct TouchHandler {
     pub current_sequence_id: TouchSequenceId,
     // todo: VecDeque + modulo arithmetic would be more efficient.
-    pub touch_sequence_map: HashMap<TouchSequenceId, TouchSequenceInfo>,
+    touch_sequence_map: HashMap<TouchSequenceId, TouchSequenceInfo>,
 }
 
 /// Whether the default move action is allowed or not.
@@ -213,41 +213,39 @@ impl TouchHandler {
     }
 
     pub(crate) fn set_handling_touch_move(&mut self, sequence_id: TouchSequenceId, flag: bool) {
-        self.touch_sequence_map
-            .get_mut(&sequence_id)
-            .unwrap()
-            .handling_touch_move = flag;
+        if let Some(sequence) = self.touch_sequence_map.get_mut(&sequence_id) {
+            sequence.handling_touch_move = flag;
+        }
     }
 
     pub(crate) fn is_handling_touch_move(&self, sequence_id: TouchSequenceId) -> bool {
-        self.touch_sequence_map
-            .get(&sequence_id)
-            .unwrap()
-            .handling_touch_move
+        if let Some(sequence) = self.touch_sequence_map.get(&sequence_id) {
+            sequence.handling_touch_move
+        } else {
+            false
+        }
     }
 
     pub(crate) fn prevent_click(&mut self, sequence_id: TouchSequenceId) {
-        self.touch_sequence_map
-            .get_mut(&sequence_id)
-            .unwrap()
-            .prevent_click = true;
+        if let Some(sequence) = self.touch_sequence_map.get_mut(&sequence_id) {
+            sequence.prevent_click = true;
+        }
     }
 
     pub(crate) fn prevent_move(&mut self, sequence_id: TouchSequenceId) {
-        self.touch_sequence_map
-            .get_mut(&sequence_id)
-            .unwrap()
-            .prevent_move = TouchMoveAllowed::Prevented;
+        if let Some(sequence) = self.touch_sequence_map.get_mut(&sequence_id) {
+            sequence.prevent_move = TouchMoveAllowed::Prevented;
+        }
     }
 
     /// Returns true if default move actions are allowed, false if prevented or the result
     /// is still pending.,
     pub(crate) fn move_allowed(&mut self, sequence_id: TouchSequenceId) -> bool {
-        self.touch_sequence_map
-            .get(&sequence_id)
-            .unwrap()
-            .prevent_move ==
-            TouchMoveAllowed::Allowed
+        if let Some(sequence) = self.touch_sequence_map.get_mut(&sequence_id) {
+            sequence.prevent_move == TouchMoveAllowed::Allowed
+        } else {
+            true
+        }
     }
 
     pub(crate) fn pending_touch_move_action(
@@ -294,10 +292,8 @@ impl TouchHandler {
     pub(crate) fn get_touch_sequence_mut(
         &mut self,
         sequence_id: TouchSequenceId,
-    ) -> &mut TouchSequenceInfo {
-        self.touch_sequence_map
-            .get_mut(&sequence_id)
-            .expect("Touch sequence not found.")
+    ) -> Option<&mut TouchSequenceInfo> {
+        self.touch_sequence_map.get_mut(&sequence_id)
     }
 
     pub fn on_touch_down(&mut self, id: TouchId, point: Point2D<f32, DevicePixel>) {
@@ -377,7 +373,7 @@ impl TouchHandler {
         id: TouchId,
         point: Point2D<f32, DevicePixel>,
     ) -> TouchMoveAction {
-        let touch_sequence = self.get_touch_sequence_mut(self.current_sequence_id);
+        let touch_sequence = self.get_current_touch_sequence_mut();
         let idx = match touch_sequence
             .active_touch_points
             .iter_mut()
@@ -454,7 +450,7 @@ impl TouchHandler {
     }
 
     pub fn on_touch_up(&mut self, id: TouchId, point: Point2D<f32, DevicePixel>) {
-        let touch_sequence = self.get_touch_sequence_mut(self.current_sequence_id);
+        let touch_sequence = self.get_current_touch_sequence_mut();
         let old = match touch_sequence
             .active_touch_points
             .iter()
@@ -531,7 +527,7 @@ impl TouchHandler {
     }
 
     pub fn on_touch_cancel(&mut self, id: TouchId, _point: Point2D<f32, DevicePixel>) {
-        let touch_sequence = self.get_touch_sequence_mut(self.current_sequence_id);
+        let touch_sequence = self.get_current_touch_sequence_mut();
         match touch_sequence
             .active_touch_points
             .iter()
@@ -545,6 +541,8 @@ impl TouchHandler {
                 return;
             },
         }
-        touch_sequence.state = Finished;
+        if touch_sequence.active_touch_points.is_empty() {
+            touch_sequence.state = Finished;
+        }
     }
 }


### PR DESCRIPTION

reason: During vsync message processing, the touchsequenceInfo is deleted if the last Fling is performed. Then, the touchmove processed message is received. However, the touchsequenceInfo has been deleted at this time. Therefore, the touchsequenceInfo cannot be obtained, causing a crash.
resolution: Check whether touchSequenceInfo exists when touch_sequence_map is modified in on_touch_event_processed.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #35760 and fix #35762 

<!-- Either: -->

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
