### PR TITLE
Reduce allocations in layout_block_level_children_in_parallel

### DIFF
--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -7,7 +7,7 @@
 
 use app_units::{Au, MAX_AU};
 use inline::InlineFormattingContext;
-use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
+use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
 use servo_arc::Arc;
 use style::Zero;
 use style::computed_values::clear::T as StyleClear;
@@ -662,7 +662,10 @@ fn layout_block_level_children_in_parallel(
 ) -> Vec<Fragment> {
     let collects_for_nearest_positioned_ancestor =
         positioning_context.collects_for_nearest_positioned_ancestor();
-    let layout_results: Vec<(Fragment, PositioningContext)> = child_boxes
+    let mut layout_results: Vec<(Fragment, PositioningContext)> =
+        Vec::with_capacity(child_boxes.len());
+
+    child_boxes
         .par_iter()
         .map(|child_box| {
             let mut child_positioning_context =
@@ -676,7 +679,7 @@ fn layout_block_level_children_in_parallel(
             );
             (fragment, child_positioning_context)
         })
-        .collect();
+        .collect_into_vec(&mut layout_results);
 
     layout_results
         .into_iter()


### PR DESCRIPTION
This function showed up as a top producer of allocations (around 10% of all allocations).
Allocating the vector once upfront and using
`collect_into_vec` removes any intermediate allocations. This approach is also recommended by the rayon documentation: https://docs.rs/rayon/1.10.0/rayon/iter/trait.ParallelIterator.html#method.collect


---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes reduce intermediate allocations
