### PR TITLE
Optimize IPC for non-cancelable touch events

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -1438,7 +1438,8 @@ impl IOCompositor {
             if !self
                 .touch_handler
                 .is_handling_touch_move(self.touch_handler.current_sequence_id) &&
-                self.send_touch_event(event)
+                self.send_touch_event(event) &&
+                event.is_cancelable()
             {
                 self.touch_handler
                     .set_handling_touch_move(self.touch_handler.current_sequence_id, true);

--- a/components/compositing/touch.rs
+++ b/components/compositing/touch.rs
@@ -229,12 +229,16 @@ impl TouchHandler {
     pub(crate) fn prevent_click(&mut self, sequence_id: TouchSequenceId) {
         if let Some(sequence) = self.touch_sequence_map.get_mut(&sequence_id) {
             sequence.prevent_click = true;
+        } else {
+            warn!("TouchSequenceInfo corresponding to the sequence number has been deleted.");
         }
     }
 
     pub(crate) fn prevent_move(&mut self, sequence_id: TouchSequenceId) {
         if let Some(sequence) = self.touch_sequence_map.get_mut(&sequence_id) {
             sequence.prevent_move = TouchMoveAllowed::Prevented;
+        } else {
+            warn!("TouchSequenceInfo corresponding to the sequence number has been deleted.");
         }
     }
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1095,27 +1095,26 @@ impl ScriptThread {
                 InputEvent::Touch(touch_event) => {
                     let touch_result =
                         document.handle_touch_event(touch_event, event.hit_test_result, can_gc);
-                    match (touch_result, touch_event.is_cancelable()) {
-                        (TouchEventResult::Processed(handled), true) => {
-                            let sequence_id = touch_event.expect_sequence_id();
-                            let result = if handled {
-                                script_traits::TouchEventResult::DefaultAllowed(
-                                    sequence_id,
-                                    touch_event.event_type,
-                                )
-                            } else {
-                                script_traits::TouchEventResult::DefaultPrevented(
-                                    sequence_id,
-                                    touch_event.event_type,
-                                )
-                            };
-                            let message = ScriptMsg::TouchEventProcessed(result);
-                            self.senders
-                                .pipeline_to_constellation_sender
-                                .send((pipeline_id, message))
-                                .unwrap();
-                        },
-                        _ => {},
+                    if let (TouchEventResult::Processed(handled), true) =
+                        (touch_result, touch_event.is_cancelable())
+                    {
+                        let sequence_id = touch_event.expect_sequence_id();
+                        let result = if handled {
+                            script_traits::TouchEventResult::DefaultAllowed(
+                                sequence_id,
+                                touch_event.event_type,
+                            )
+                        } else {
+                            script_traits::TouchEventResult::DefaultPrevented(
+                                sequence_id,
+                                touch_event.event_type,
+                            )
+                        };
+                        let message = ScriptMsg::TouchEventProcessed(result);
+                        self.senders
+                            .pipeline_to_constellation_sender
+                            .send((pipeline_id, message))
+                            .unwrap();
                     }
                 },
                 InputEvent::Wheel(wheel_event) => {


### PR DESCRIPTION
Reduce needless IPC with non-cancelable touch events. If a touch event is not cancellable, no message is sent back to the Compositor, since no action would be required anyway.

Add a warning log when prevent TouchsequenceInfo cannot be found.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix a part of #35436,  Optimization for #35713

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
