### PR TITLE
feat: Support the displaying of selected filename/file count for File Input

### DIFF
--- a/components/script/dom/filelist.rs
+++ b/components/script/dom/filelist.rs
@@ -6,6 +6,7 @@ use std::slice::Iter;
 
 use dom_struct::dom_struct;
 
+use super::bindings::root::{LayoutDom, ToLayout};
 use crate::dom::bindings::codegen::Bindings::FileListBinding::FileListMethods;
 use crate::dom::bindings::reflector::{Reflector, reflect_dom_object};
 use crate::dom::bindings::root::{Dom, DomRoot};
@@ -67,5 +68,25 @@ impl FileListMethods<crate::DomTypeHolder> for FileList {
     // check-tidy: no specs after this line
     fn IndexedGetter(&self, index: u32) -> Option<DomRoot<File>> {
         self.Item(index)
+    }
+}
+
+pub(crate) trait LayoutFileListHelpers<'dom> {
+    fn file_for_layout(&self, index: u32) -> Option<&File>;
+    fn len(&self) -> usize;
+}
+
+#[allow(unsafe_code)]
+impl<'dom> LayoutFileListHelpers<'dom> for LayoutDom<'dom, FileList> {
+    fn len(&self) -> usize {
+        self.unsafe_get().list.len()
+    }
+    fn file_for_layout(&self, index: u32) -> Option<&File> {
+        let list = &self.unsafe_get().list;
+        if (index as usize) < list.len() {
+            Some(unsafe { list[index as usize].to_layout().unsafe_get() })
+        } else {
+            None
+        }
     }
 }

--- a/resources/servo.css
+++ b/resources/servo.css
@@ -74,13 +74,17 @@ input[type="radio"]:checked::before { content: "●"; line-height: 1em; }
 
 input[type="file"]::before {
   content: "Choose File";
+  background: lightgrey;
+  border-top: solid 1px #EEEEEE;
+  border-left: solid 1px #CCCCCC;
+  border-right: solid 1px #999999;
+  border-bottom: solid 1px #999999;
 }
 
 input[type="file"] {
-  background: lightgrey;
   text-align: center;
-  vertical-align: middle;
   color: black;
+  border-style: none;
 }
 
 select {


### PR DESCRIPTION
This PR allows the display of selected file count for `htmlinputelement` with `file` type.

**Working Example**

https://github.com/user-attachments/assets/8f4eff54-cf0a-45a8-a2b4-22f06333ce7a

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #35633

<!-- Either: -->
- [x] These changes do not require tests because no functionality change has been introduced

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
