### PR TITLE
Rename ohos app bundle

### DIFF
--- a/support/openharmony/AppScope/app.json5
+++ b/support/openharmony/AppScope/app.json5
@@ -1,6 +1,6 @@
 {
   "app": {
-    "bundleName": "org.servo.servoshell",
+    "bundleName": "org.servo.servo",
     "vendor": "example",
     "versionCode": 1000000,
     "versionName": "1.0.0",


### PR DESCRIPTION
The `shell` suffix causes issues with the startup profiling tools on OpenHarmony. The profiler fails to detect the start of the app. This is fixed by renaming the app. I tried various different variations and identified the `shell`
suffix to be the culprit.
E.g. `org.servo.shell` has the same issue, so it's not a length issue.

This does require users to regenerate signatures for the new app bundle name, which will lead to the HarmonyOS CI test job temporarily failing (but it doesn't block the merge queue).

Edit: This would also break the OHOS nightly build, unless the signature file is updated too.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes allow profiling the startup performance of the servoshell app on OpenHarmony.
- [x] These changes do not require tests because this just changes the app bundle name
