### PR TITLE
Devtools: Update targeted Firefox version

### DIFF
--- a/components/devtools/actors/device.rs
+++ b/components/devtools/actors/device.rs
@@ -60,7 +60,7 @@ impl Actor for DeviceActor {
                         apptype: "servo".to_string(),
                         version: env!("CARGO_PKG_VERSION").to_string(),
                         appbuildid: BUILD_ID.to_string(),
-                        platformversion: "130.0".to_string(),
+                        platformversion: "133.0".to_string(),
                         brand_name: "Servo".to_string(),
                     },
                 };


### PR DESCRIPTION
Current version is old(130.0) and that is an unsupported setup and it can cause the DevTools to fail. The minimum supported version is (133.0a1)

Signedoff-by: atbrakhi <atbrakhi@igalia.com>

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)
