### PR TITLE
servoshell: Minor fixes to cli help.

### DIFF
--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -359,7 +359,7 @@ pub(crate) fn parse_command_line_arguments(args: Vec<String>) -> ArgumentParsing
         "",
         "pref",
         "A preference to set to enable",
-        "dom.bluetooth.enabled",
+        "dom_bluetooth_enabled",
     );
     opts.optmulti(
         "",
@@ -371,7 +371,7 @@ pub(crate) fn parse_command_line_arguments(args: Vec<String>) -> ArgumentParsing
         "",
         "prefs-file",
         "Load in additional prefs from a file.",
-        "--prefs-file /path/to/prefs.json",
+        "/path/to/prefs.json",
     );
 
     let opt_match = match opts.parse(args) {


### PR DESCRIPTION
Fixes the `--pref` enable hint to use `_` instead of dots. Remove `--prefs-file` from the hint, since the hint is placed directly after the long option. (The help line displayed as `--prefs-file --prefs-file /path/to/prefs.json` before).


---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes improve the cli help output
- [x] These changes do not require tests because: they adjust the cli help output.