### PR TITLE
mach: Install Rust toolchain during bootstrap if needed

### DIFF
--- a/python/servo/platform/base.py
+++ b/python/servo/platform/base.py
@@ -60,6 +60,7 @@ class Base:
         installed_something = False
         if not skip_platform:
             installed_something |= self._platform_bootstrap(force)
+        self.install_rust_toolchain()
         if not skip_lints:
             installed_something |= self.install_taplo(force)
             installed_something |= self.install_cargo_deny(force)
@@ -67,6 +68,14 @@ class Base:
 
         if not installed_something:
             print("Dependencies were already installed!")
+
+    def install_rust_toolchain(self):
+        # rustup 1.28.0, and rustup 1.28.1+ with RUSTUP_AUTO_INSTALL=0, require us to explicitly
+        # install the Rust toolchain before trying to use it.
+        print(" * Installing Rust toolchain...")
+        if subprocess.call(["rustup", "show", "active-toolchain"]) != 0:
+            if subprocess.call(["rustup", "toolchain", "install"]) != 0:
+                raise EnvironmentError("Installation of Rust toolchain failed.")
 
     def install_taplo(self, force: bool) -> bool:
         if not force and shutil.which("taplo") is not None:


### PR DESCRIPTION
In servo/ci-runners#27, we found that mach bootstrap was busted due to a “toolchain not installed” error. This was because rustup 1.28.0 (as well as the upcoming rustup 1.28.1 with RUSTUP_AUTO_INSTALL=0) no longer installs the Rust toolchain when you try to use it for the first time (see rust-lang/rustup#3985, rust-lang/rustup#4211).

This patch explicitly installs the Rust toolchain during mach bootstrap. Users that prefer RUSTUP_AUTO_INSTALL=0 will need to rerun mach bootstrap whenever we bump our Rust version (rust-toolchain.toml).

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] ~~These changes fix #___ (GitHub issue number if applicable)~~

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because testing mach’s handling of this edge case would be impractical, and the failure mode is relatively simple