### PR TITLE
refactor: add CanGc as argument to methods in CSSKeyframeRule, CSSMediaRule, CSSRule

### DIFF
--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -239,7 +239,7 @@ pub(crate) fn handle_get_stylesheet_style(
 
         let styles = (0..list.Length())
             .filter_map(move |i| {
-                let rule = list.Item(i)?;
+                let rule = list.Item(i, can_gc)?;
                 let style = rule.downcast::<CSSStyleRule>()?;
                 if *selector != *style.SelectorText() {
                     return None;
@@ -270,6 +270,7 @@ pub(crate) fn handle_get_selectors(
     pipeline: PipelineId,
     node_id: String,
     reply: IpcSender<Option<Vec<(String, usize)>>>,
+    can_gc: CanGc,
 ) {
     let msg = (|| {
         let node = find_node_by_unique_id(documents, pipeline, &node_id)?;
@@ -285,7 +286,7 @@ pub(crate) fn handle_get_selectors(
                 let elem = node.downcast::<Element>()?;
 
                 Some((0..list.Length()).filter_map(move |j| {
-                    let rule = list.Item(j)?;
+                    let rule = list.Item(j, can_gc)?;
                     let style = rule.downcast::<CSSStyleRule>()?;
                     let selector = style.SelectorText();
                     elem.Matches(selector.clone()).ok()?.then_some(())?;

--- a/components/script/dom/csskeyframerule.rs
+++ b/components/script/dom/csskeyframerule.rs
@@ -60,7 +60,7 @@ impl CSSKeyframeRule {
 
 impl CSSKeyframeRuleMethods<crate::DomTypeHolder> for CSSKeyframeRule {
     // https://drafts.csswg.org/css-animations/#dom-csskeyframerule-style
-    fn Style(&self) -> DomRoot<CSSStyleDeclaration> {
+    fn Style(&self, can_gc: CanGc) -> DomRoot<CSSStyleDeclaration> {
         self.style_decl.or_init(|| {
             let guard = self.cssrule.shared_lock().read();
             CSSStyleDeclaration::new(
@@ -71,7 +71,7 @@ impl CSSKeyframeRuleMethods<crate::DomTypeHolder> for CSSKeyframeRule {
                 ),
                 None,
                 CSSModificationAccess::ReadWrite,
-                CanGc::note(),
+                can_gc,
             )
         })
     }

--- a/components/script/dom/csskeyframesrule.rs
+++ b/components/script/dom/csskeyframesrule.rs
@@ -127,7 +127,7 @@ impl CSSKeyframesRuleMethods<crate::DomTypeHolder> for CSSKeyframesRule {
     // https://drafts.csswg.org/css-animations/#dom-csskeyframesrule-findrule
     fn FindRule(&self, selector: DOMString, can_gc: CanGc) -> Option<DomRoot<CSSKeyframeRule>> {
         self.find_rule(&selector)
-            .and_then(|idx| self.rulelist(can_gc).item(idx as u32))
+            .and_then(|idx| self.rulelist(can_gc).item(idx as u32, can_gc))
             .and_then(DomRoot::downcast)
     }
 

--- a/components/script/dom/cssmediarule.rs
+++ b/components/script/dom/cssmediarule.rs
@@ -52,13 +52,13 @@ impl CSSMediaRule {
         )
     }
 
-    fn medialist(&self) -> DomRoot<MediaList> {
+    fn medialist(&self, can_gc: CanGc) -> DomRoot<MediaList> {
         self.medialist.or_init(|| {
             MediaList::new(
                 self.global().as_window(),
                 self.cssconditionrule.parent_stylesheet(),
                 self.mediarule.media_queries.clone(),
-                CanGc::note(),
+                can_gc,
             )
         })
     }
@@ -84,7 +84,7 @@ impl SpecificCSSRule for CSSMediaRule {
 
 impl CSSMediaRuleMethods<crate::DomTypeHolder> for CSSMediaRule {
     // https://drafts.csswg.org/cssom/#dom-cssgroupingrule-media
-    fn Media(&self) -> DomRoot<MediaList> {
-        self.medialist()
+    fn Media(&self, can_gc: CanGc) -> DomRoot<MediaList> {
+        self.medialist(can_gc)
     }
 }

--- a/components/script/dom/cssrulelist.rs
+++ b/components/script/dom/cssrulelist.rs
@@ -186,7 +186,7 @@ impl CSSRuleList {
         }
     }
 
-    pub(crate) fn item(&self, idx: u32) -> Option<DomRoot<CSSRule>> {
+    pub(crate) fn item(&self, idx: u32, can_gc: CanGc) -> Option<DomRoot<CSSRule>> {
         self.dom_rules.borrow().get(idx as usize).map(|rule| {
             rule.or_init(|| {
                 let parent_stylesheet = &self.parent_stylesheet;
@@ -196,13 +196,13 @@ impl CSSRuleList {
                         self.global().as_window(),
                         parent_stylesheet,
                         rules.read_with(&guard).0[idx as usize].clone(),
-                        CanGc::note(),
+                        can_gc,
                     ),
                     RulesSource::Keyframes(ref rules) => DomRoot::upcast(CSSKeyframeRule::new(
                         self.global().as_window(),
                         parent_stylesheet,
                         rules.read_with(&guard).keyframes[idx as usize].clone(),
-                        CanGc::note(),
+                        can_gc,
                     )),
                 }
             })
@@ -224,8 +224,8 @@ impl CSSRuleList {
 
 impl CSSRuleListMethods<crate::DomTypeHolder> for CSSRuleList {
     // https://drafts.csswg.org/cssom/#ref-for-dom-cssrulelist-item-1
-    fn Item(&self, idx: u32) -> Option<DomRoot<CSSRule>> {
-        self.item(idx)
+    fn Item(&self, idx: u32, can_gc: CanGc) -> Option<DomRoot<CSSRule>> {
+        self.item(idx, can_gc)
     }
 
     // https://drafts.csswg.org/cssom/#dom-cssrulelist-length
@@ -234,7 +234,7 @@ impl CSSRuleListMethods<crate::DomTypeHolder> for CSSRuleList {
     }
 
     // check-tidy: no specs after this line
-    fn IndexedGetter(&self, index: u32) -> Option<DomRoot<CSSRule>> {
-        self.Item(index)
+    fn IndexedGetter(&self, index: u32, can_gc: CanGc) -> Option<DomRoot<CSSRule>> {
+        self.Item(index, can_gc)
     }
 }

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2030,7 +2030,7 @@ impl ScriptThread {
                 &documents, id, node_id, selector, stylesheet, reply, can_gc,
             ),
             DevtoolScriptControlMsg::GetSelectors(id, node_id, reply) => {
-                devtools::handle_get_selectors(&documents, id, node_id, reply)
+                devtools::handle_get_selectors(&documents, id, node_id, reply, can_gc)
             },
             DevtoolScriptControlMsg::GetComputedStyle(id, node_id, reply) => {
                 devtools::handle_get_computed_style(&documents, id, node_id, reply, can_gc)

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -91,8 +91,20 @@ DOMInterfaces = {
     'canGc': ['CssRules', 'DeleteRule', 'InsertRule'],
 },
 
+'CSSKeyframeRule': {
+    'canGc': ['Style'],
+},
+
 'CSSKeyframesRule': {
     'canGc': ['AppendRule', 'CssRules', 'DeleteRule', 'FindRule'],
+},
+
+'CSSMediaRule': {
+    'canGc': ['Media'],
+},
+
+'CSSRuleList': {
+    'canGc': ['Item', 'IndexedGetter'],
 },
 
 'Crypto': {


### PR DESCRIPTION
Add CanGc as argument to methods in `CSSKeyframeRule`, `CSSMediaRule`, `CSSRule`.

Addressed part of https://github.com/servo/servo/issues/34573.

---

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they are a refactor.
