### PR TITLE
ci: convert comments in PULL_REQUEST_TEMPLATE.md to normal text

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,16 +1,16 @@
-<!-- Please describe your changes on the following line: -->
+**REMOVE:** Thank you for contributing to Servo! This template text contains instructions for the pull request author that should not be part of the final pull request description.
+Please follow these instructions and ensure such lines marked with **REMOVE:** are deleted when creating the pull request.
+Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process.
+Please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.  
+**REMOVE:** **Please describe your changes beginning on the following line.**
 
 
 ---
-<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
+**REMOVE:** Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data.
 - [ ] `./mach build -d` does not report any errors
 - [ ] `./mach test-tidy` does not report any errors
 - [ ] These changes fix #___ (GitHub issue number if applicable)
 
-<!-- Either: -->
+**REMOVE:** Please choose one of the following.
 - [ ] There are tests for these changes OR
 - [ ] These changes do not require tests because ___
-
-<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->
-
-<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->


### PR DESCRIPTION
Per discussion in Zulip, this change removes the commented lines from the template. The expectation is that the pull request author is responsible for removing these comments, so that the pull request description can be directly used as the commit message by enabling that in Github settings.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they only update the github pull request template file.