### PR TITLE
layout: Handle scroll offset in `getClientRects()` queries

### DIFF
--- a/components/layout_2020/fragment_tree/containing_block.rs
+++ b/components/layout_2020/fragment_tree/containing_block.rs
@@ -2,11 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use app_units::Au;
 use style::computed_values::position::T as ComputedPosition;
 
 use crate::fragment_tree::Fragment;
-use crate::geom::{PhysicalRect, PhysicalVec};
 
 /// A data structure used to track the containing block when recursing
 /// through the Fragment tree. It tracks the three types of containing
@@ -98,39 +96,6 @@ impl<'a, T> ContainingBlockManager<'a, T> {
             for_non_absolute_descendants,
             for_absolute_descendants: None,
             for_absolute_and_fixed_descendants,
-        }
-    }
-}
-
-/// Containing block rect with additional information required for a query.
-pub(crate) struct ContainingBlockQueryInfo {
-    /// Containing block rect, that bounds the children.
-    pub(crate) rect: PhysicalRect<Au>,
-
-    /// The scroll offset of the containing block has.
-    pub(crate) scroll_offset: PhysicalVec<Au>,
-}
-
-impl ContainingBlockQueryInfo {
-    /// Transform child's rectangle according to this containing block transformation.
-    /// TODO: this is supposed to handle CSS transform but it is not happening.
-    pub(crate) fn transform_rect_relative_to_self(
-        &self,
-        rect: PhysicalRect<Au>,
-    ) -> PhysicalRect<Au> {
-        rect.translate(self.rect.origin.to_vector() + self.scroll_offset)
-    }
-
-    /// New containing block that is a child of this containing block with
-    /// ancestor's transformation applied.
-    pub(crate) fn new_relative_transformed_child(
-        &self,
-        rect: PhysicalRect<Au>,
-        scroll_offset: PhysicalVec<Au>,
-    ) -> ContainingBlockQueryInfo {
-        ContainingBlockQueryInfo {
-            rect: self.transform_rect_relative_to_self(rect),
-            scroll_offset,
         }
     }
 }

--- a/components/layout_2020/fragment_tree/fragment.rs
+++ b/components/layout_2020/fragment_tree/fragment.rs
@@ -2,24 +2,28 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::collections::HashMap;
+use std::hash::RandomState;
 use std::sync::Arc;
 
 use app_units::Au;
 use base::id::PipelineId;
 use base::print_tree::PrintTree;
+use euclid::Vector2D;
 use fonts::{FontMetrics, GlyphStore};
 use servo_arc::Arc as ServoArc;
 use style::Zero;
 use style::properties::ComputedValues;
 use style::values::specified::text::TextDecorationLine;
-use webrender_api::{FontInstanceKey, ImageKey};
+use webrender_api::units::LayoutPixel;
+use webrender_api::{ExternalScrollId, FontInstanceKey, ImageKey};
 
 use super::{
-    BaseFragment, BoxFragment, ContainingBlockManager, HoistedSharedFragment, PositioningFragment,
-    Tag,
+    BaseFragment, BoxFragment, ContainingBlockManager, ContainingBlockQueryInfo,
+    HoistedSharedFragment, PositioningFragment, Tag,
 };
 use crate::cell::ArcRefCell;
-use crate::geom::{LogicalSides, PhysicalRect};
+use crate::geom::{LogicalSides, PhysicalRect, PhysicalVec};
 use crate::style_ext::ComputedValuesExt;
 
 #[derive(Clone)]
@@ -203,6 +207,105 @@ impl Fragment {
                     .children
                     .iter()
                     .find_map(|child| child.find(&new_manager, level + 1, process_func))
+            },
+            _ => None,
+        }
+    }
+
+    // Child find but we are considering scrollOffset. This will be the first step of
+    // implementing a find element architecture that support mapping of coordinate space.
+    pub(crate) fn find_v2<T>(
+        &self,
+        pipeline_id: PipelineId,
+        scroll_offsets: &HashMap<ExternalScrollId, Vector2D<f32, LayoutPixel>, RandomState>,
+        manager: &ContainingBlockManager<ContainingBlockQueryInfo>,
+        level: usize,
+        process_func: &mut impl FnMut(&Fragment, usize, &ContainingBlockQueryInfo) -> Option<T>,
+    ) -> Option<T> {
+        let containing_block = manager.get_containing_block_for_fragment(self);
+        if let Some(result) = process_func(self, level, containing_block) {
+            return Some(result);
+        }
+
+        match self {
+            Fragment::Box(fragment) | Fragment::Float(fragment) => {
+                let fragment = fragment.borrow();
+
+                let scroll_id = fragment.base.tag.map(|tag| {
+                    ExternalScrollId(
+                        tag.to_display_list_fragment_id(),
+                        pipeline_id.into(),
+                    )
+                });
+                let scroll_offset = scroll_id
+                    .and_then(|id| scroll_offsets.get(&id))
+                    .map(|offset| {
+                        PhysicalVec::new(Au::from_f32_px(offset.x), Au::from_f32_px(offset.y))
+                    })
+                    .unwrap_or_default();
+
+                let content_rect_info = containing_block
+                    .new_relative_transformed_child(fragment.content_rect, scroll_offset);
+                let padding_rect_info = containing_block
+                    .new_relative_transformed_child(fragment.padding_rect(), scroll_offset);
+
+                let new_manager = if fragment
+                    .style
+                    .establishes_containing_block_for_all_descendants(fragment.base.flags)
+                {
+                    manager.new_for_absolute_and_fixed_descendants(
+                        &content_rect_info,
+                        &padding_rect_info,
+                    )
+                } else if fragment
+                    .style
+                    .establishes_containing_block_for_absolute_descendants(fragment.base.flags)
+                {
+                    manager.new_for_absolute_descendants(&content_rect_info, &padding_rect_info)
+                } else {
+                    manager.new_for_non_absolute_descendants(&content_rect_info)
+                };
+
+                fragment.children.iter().find_map(|child| {
+                    child.find_v2(
+                        pipeline_id,
+                        scroll_offsets,
+                        &new_manager,
+                        level + 1,
+                        process_func,
+                    )
+                })
+            },
+            Fragment::Positioning(fragment) => {
+                let fragment = fragment.borrow();
+
+                let scroll_id = fragment.base.tag.map(|tag| {
+                    ExternalScrollId(
+                        tag.to_display_list_fragment_id(),
+                        pipeline_id.into(),
+                    )
+                });
+                let scroll_offset = scroll_id
+                    .and_then(|id| scroll_offsets.get(&id))
+                    .map(|offset| {
+                        PhysicalVec::new(Au::from_f32_px(offset.x), Au::from_f32_px(offset.y))
+                    })
+                    .unwrap_or_default();
+
+                let content_rect_info =
+                    containing_block.new_relative_transformed_child(fragment.rect, scroll_offset);
+
+                let new_manager = manager.new_for_non_absolute_descendants(&content_rect_info);
+
+                fragment.children.iter().find_map(|child| {
+                    child.find_v2(
+                        pipeline_id,
+                        scroll_offsets,
+                        &new_manager,
+                        level + 1,
+                        process_func,
+                    )
+                })
             },
             _ => None,
         }

--- a/components/layout_2020/fragment_tree/fragment.rs
+++ b/components/layout_2020/fragment_tree/fragment.rs
@@ -232,10 +232,7 @@ impl Fragment {
                 let fragment = fragment.borrow();
 
                 let scroll_id = fragment.base.tag.map(|tag| {
-                    ExternalScrollId(
-                        tag.to_display_list_fragment_id(),
-                        pipeline_id.into(),
-                    )
+                    ExternalScrollId(tag.to_display_list_fragment_id(), pipeline_id.into())
                 });
                 let scroll_offset = scroll_id
                     .and_then(|id| scroll_offsets.get(&id))
@@ -280,10 +277,7 @@ impl Fragment {
                 let fragment = fragment.borrow();
 
                 let scroll_id = fragment.base.tag.map(|tag| {
-                    ExternalScrollId(
-                        tag.to_display_list_fragment_id(),
-                        pipeline_id.into(),
-                    )
+                    ExternalScrollId(tag.to_display_list_fragment_id(), pipeline_id.into())
                 });
                 let scroll_offset = scroll_id
                     .and_then(|id| scroll_offsets.get(&id))

--- a/components/layout_2020/fragment_tree/fragment_tree.rs
+++ b/components/layout_2020/fragment_tree/fragment_tree.rs
@@ -17,11 +17,13 @@ use webrender_api::units::LayoutPixel;
 use webrender_api::{ExternalScrollId, units};
 use webrender_traits::display_list::AxesScrollSensitivity;
 
-use super::{ContainingBlockManager, Fragment, Tag};
+use super::{
+    ContainingBlockInfoContext, ContainingBlockInfoData, ContainingBlockManager,
+    ContainingBlockQueryInfo, Fragment, FragmentTreeQueryContext, Tag,
+};
 use crate::display_list::StackingContext;
 use crate::flow::CanvasBackground;
-use crate::fragment_tree::ContainingBlockQueryInfo;
-use crate::geom::{PhysicalPoint, PhysicalRect, PhysicalVec};
+use crate::geom::{PhysicalPoint, PhysicalRect};
 
 pub struct FragmentTree {
     /// Fragments at the top-level of the tree.
@@ -99,42 +101,25 @@ impl FragmentTree {
         });
     }
 
-    pub(crate) fn find_v2<T>(
+    pub(crate) fn find_v2(
         &self,
-        pipeline_id: PipelineId,
-        scroll_offsets: &HashMap<ExternalScrollId, Vector2D<f32, LayoutPixel>, RandomState>,
-        mut process_func: impl FnMut(&Fragment, usize, &ContainingBlockQueryInfo) -> Option<T>,
-    ) -> Option<T> {
-        let scroll_offset = scroll_offsets
-            .get(&pipeline_id.root_scroll_id())
-            .map(|offset| PhysicalVec::new(Au::from_f32_px(offset.x), Au::from_f32_px(offset.y)))
-            .unwrap_or_default();
-
-        let initial_containing_block_info = ContainingBlockQueryInfo {
-            rect: self.initial_containing_block,
-            scroll_offset,
-        };
-        let fixed_initial_containing_block_info = ContainingBlockQueryInfo {
-            rect: self.initial_containing_block,
-            scroll_offset: Vector2D::zero(),
-        };
-
-        let info = ContainingBlockManager {
-            for_non_absolute_descendants: &initial_containing_block_info,
-            for_absolute_descendants: Some(&initial_containing_block_info),
-            for_absolute_and_fixed_descendants: &fixed_initial_containing_block_info,
-        };
-
-        self.root_fragments.iter().find_map(|child| {
-            child.find_v2(pipeline_id, scroll_offsets, &info, 0, &mut process_func)
-        })
+        find_context: &ContainingBlockInfoContext,
+        process_func: &mut impl FnMut(
+            &Fragment,
+            &ContainingBlockInfoContext,
+        ) -> Option<ContainingBlockQueryInfo>,
+    ) -> Option<ContainingBlockQueryInfo> {
+        self.root_fragments
+            .iter()
+            .find_map(|child| child.find_v2(find_context, process_func))
     }
 
     /// Get the vector of rectangles that surrounds the fragments of the node with the given address.
     /// This function answers the `getClientRects()` query and the union of the rectangles answers
     /// the `getBoundingClientRect()` query.
     ///
-    /// TODO: This function is supposed to handle CSS Transform, but that isn't happening at all.
+    /// TODO: The `getClientRects()` query is supposed to consider result from Webrender display list,
+    ///       but that isn't happening, except for scroll offset.
     pub fn get_content_boxes_for_node(
         &self,
         requested_node: OpaqueNode,
@@ -143,31 +128,43 @@ impl FragmentTree {
     ) -> Vec<Rect<Au>> {
         let mut content_boxes = Vec::new();
         let tag_to_find = Tag::new(requested_node);
-        self.find_v2(
-            pipeline_id,
+
+        let context_additional_data = ContainingBlockInfoData {
             scroll_offsets,
-            |fragment, _, containing_block| {
-                if fragment.tag() != Some(tag_to_find) {
-                    return None::<()>;
-                }
+            pipeline_id,
+        };
 
-                let fragment_relative_rect = match fragment {
-                    Fragment::Box(fragment) | Fragment::Float(fragment) => {
-                        fragment.borrow().border_rect()
-                    },
-                    Fragment::Positioning(fragment) => fragment.borrow().rect,
-                    Fragment::Text(fragment) => fragment.borrow().rect,
-                    Fragment::AbsoluteOrFixedPositioned(_) |
-                    Fragment::Image(_) |
-                    Fragment::IFrame(_) => return None,
-                };
+        FragmentTreeQueryContext::for_fragment_tree_and_then(
+            self,
+            context_additional_data,
+            |find_context| {
+                self.find_v2(find_context, &mut |fragment, find_context| {
+                    if fragment.tag() != Some(tag_to_find) {
+                        return None;
+                    }
+                    let containing_block = find_context.get_payload(fragment);
 
-                let rect = containing_block.transform_rect_relative_to_self(fragment_relative_rect);
+                    let fragment_relative_rect = match fragment {
+                        Fragment::Box(fragment) | Fragment::Float(fragment) => {
+                            fragment.borrow().border_rect()
+                        },
+                        Fragment::Positioning(fragment) => fragment.borrow().rect,
+                        Fragment::Text(fragment) => fragment.borrow().rect,
+                        Fragment::AbsoluteOrFixedPositioned(_) |
+                        Fragment::Image(_) |
+                        Fragment::IFrame(_) => return None,
+                    };
 
-                content_boxes.push(rect.to_untyped());
-                None::<()>
+                    let rect = fragment_relative_rect.translate(
+                        containing_block.rect.origin.to_vector() + containing_block.scroll_offset,
+                    );
+
+                    content_boxes.push(rect.to_untyped());
+                    None
+                })
             },
         );
+
         content_boxes
     }
 

--- a/components/layout_2020/fragment_tree/mod.rs
+++ b/components/layout_2020/fragment_tree/mod.rs
@@ -10,6 +10,7 @@ mod fragment;
 mod fragment_tree;
 mod hoisted_shared_fragment;
 mod positioning_fragment;
+mod query;
 
 pub(crate) use base_fragment::*;
 pub(crate) use box_fragment::*;
@@ -18,3 +19,4 @@ pub(crate) use fragment::*;
 pub use fragment_tree::*;
 pub(crate) use hoisted_shared_fragment::*;
 pub(crate) use positioning_fragment::*;
+pub(crate) use query::*;

--- a/components/layout_2020/fragment_tree/query.rs
+++ b/components/layout_2020/fragment_tree/query.rs
@@ -1,0 +1,217 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::collections::HashMap;
+use std::hash::RandomState;
+
+use app_units::Au;
+use base::id::PipelineId;
+use euclid::Vector2D;
+use webrender_api::ExternalScrollId;
+use webrender_api::units::LayoutPixel;
+
+use super::{ContainingBlockManager, Fragment, FragmentTree};
+use crate::geom::{PhysicalRect, PhysicalVec};
+use crate::style_ext::ComputedValuesExt;
+
+/// Informations that could be stored and mutated between iteration of [Fragment::find_v2]
+pub struct FragmentTreeQueryContext<'a, T, D: 'a + Clone> {
+    manager: ContainingBlockManager<'a, T>,
+    level: usize,
+    additional_data: D,
+}
+
+/// Additional information to compute containing block for `getClientRect()`. In this case,
+/// we would store scroll offsets from LayoutThread for computation as well.
+///
+/// FIXME: Ideally, we should consider the Webrender display list.
+pub struct ContainingBlockInfoData<'a> {
+    /// Reference to scroll offsets from LayoutThread
+    pub(crate) scroll_offsets:
+        &'a HashMap<ExternalScrollId, Vector2D<f32, LayoutPixel>, RandomState>,
+    /// Pipeline information from LayoutThread
+    pub(crate) pipeline_id: PipelineId,
+}
+
+impl Clone for ContainingBlockInfoData<'_> {
+    fn clone(&self) -> Self {
+        Self {
+            scroll_offsets: self.scroll_offsets,
+            pipeline_id: self.pipeline_id,
+        }
+    }
+}
+
+impl<'a, T, D: Clone> FragmentTreeQueryContext<'a, T, D> {
+    fn new_for_next_level(&self, manager: ContainingBlockManager<'a, T>) -> Self {
+        Self {
+            manager,
+            level: self.level + 1,
+            additional_data: self.additional_data.clone(),
+        }
+    }
+}
+
+pub type ContainingBlockInfoContext<'a> =
+    FragmentTreeQueryContext<'a, ContainingBlockQueryInfo, ContainingBlockInfoData<'a>>;
+
+impl ContainingBlockInfoContext<'_> {
+    /// Create an [FragmentTreeQueryContext] context and run the predicate with it as the argument.
+    /// We run it inside the predicate to maintain the [ContainingBlockManager]'s borrow structure.
+    pub(crate) fn for_fragment_tree_and_then<
+        P: FnMut(&ContainingBlockInfoContext<'_>) -> Option<ContainingBlockQueryInfo>,
+    >(
+        fragment_tree: &FragmentTree,
+        additional_data: ContainingBlockInfoData,
+        mut predicate: P,
+    ) -> Option<ContainingBlockQueryInfo> {
+        let scroll_offset = additional_data
+            .scroll_offsets
+            .get(&additional_data.pipeline_id.root_scroll_id())
+            .map(|offset| PhysicalVec::new(Au::from_f32_px(offset.x), Au::from_f32_px(offset.y)))
+            .unwrap_or_default();
+
+        let initial_containing_block_info = ContainingBlockQueryInfo {
+            rect: fragment_tree.initial_containing_block,
+            scroll_offset,
+        };
+        let fixed_containing_block_info = ContainingBlockQueryInfo {
+            rect: fragment_tree.initial_containing_block,
+            scroll_offset: Vector2D::zero(),
+        };
+
+        let info: ContainingBlockManager<'_, ContainingBlockQueryInfo> = ContainingBlockManager {
+            for_non_absolute_descendants: &initial_containing_block_info,
+            for_absolute_descendants: Some(&initial_containing_block_info),
+            for_absolute_and_fixed_descendants: &fixed_containing_block_info,
+        };
+
+        let initial_context = FragmentTreeQueryContext {
+            manager: info,
+            level: 0,
+            additional_data,
+        };
+
+        predicate(&initial_context)
+    }
+
+    /// Create/mutate [FragmentTreeQueryContext] context and run the predicate with it as the argument.
+    /// We run it inside the predicate to maintain the [ContainingBlockManager]'s borrow structure.
+    pub(crate) fn precompute_state_and_then<
+        P: FnMut(&ContainingBlockInfoContext<'_>) -> Option<ContainingBlockQueryInfo>,
+    >(
+        &self,
+        parent: &Fragment,
+        mut predicate: P,
+    ) -> Option<ContainingBlockQueryInfo> {
+        let containing_block = self.manager.get_containing_block_for_fragment(parent);
+        let additional_data = &self.additional_data;
+
+        match parent {
+            Fragment::Box(fragment) | Fragment::Float(fragment) => {
+                let fragment = fragment.borrow();
+                let scroll_id = fragment.base.tag.map(|tag| {
+                    ExternalScrollId(
+                        tag.to_display_list_fragment_id(),
+                        additional_data.pipeline_id.into(),
+                    )
+                });
+                let scroll_offset = scroll_id
+                    .and_then(|id| additional_data.scroll_offsets.get(&id))
+                    .map(|offset| {
+                        PhysicalVec::new(Au::from_f32_px(offset.x), Au::from_f32_px(offset.y))
+                    })
+                    .unwrap_or_default();
+
+                let content_rect_info = containing_block
+                    .new_relative_transformed_child(fragment.content_rect, scroll_offset);
+                let padding_rect_info = containing_block
+                    .new_relative_transformed_child(fragment.padding_rect(), scroll_offset);
+
+                let new_manager = if fragment
+                    .style
+                    .establishes_containing_block_for_all_descendants(fragment.base.flags)
+                {
+                    self.manager.new_for_absolute_and_fixed_descendants(
+                        &content_rect_info,
+                        &padding_rect_info,
+                    )
+                } else if fragment
+                    .style
+                    .establishes_containing_block_for_absolute_descendants(fragment.base.flags)
+                {
+                    self.manager
+                        .new_for_absolute_descendants(&content_rect_info, &padding_rect_info)
+                } else {
+                    self.manager
+                        .new_for_non_absolute_descendants(&content_rect_info)
+                };
+
+                predicate(&self.new_for_next_level(new_manager))
+            },
+            Fragment::Positioning(fragment) => {
+                let fragment = fragment.borrow();
+                let scroll_id = fragment.base.tag.map(|tag| {
+                    ExternalScrollId(
+                        tag.to_display_list_fragment_id(),
+                        additional_data.pipeline_id.into(),
+                    )
+                });
+                let scroll_offset = scroll_id
+                    .and_then(|id| additional_data.scroll_offsets.get(&id))
+                    .map(|offset| {
+                        PhysicalVec::new(Au::from_f32_px(offset.x), Au::from_f32_px(offset.y))
+                    })
+                    .unwrap_or_default();
+
+                let content_rect_info =
+                    containing_block.new_relative_transformed_child(fragment.rect, scroll_offset);
+
+                let new_manager = self
+                    .manager
+                    .new_for_non_absolute_descendants(&content_rect_info);
+
+                predicate(&self.new_for_next_level(new_manager))
+            },
+            _ => None,
+        }
+    }
+
+    pub(crate) fn get_payload(&self, fragment: &Fragment) -> &ContainingBlockQueryInfo {
+        self.manager.get_containing_block_for_fragment(fragment)
+    }
+}
+
+/// Containing block rect with additional information required for a query.
+pub(crate) struct ContainingBlockQueryInfo {
+    /// Containing block rect, that bounds the children.
+    pub(crate) rect: PhysicalRect<Au>,
+
+    /// The scroll offset of the containing block has.
+    pub(crate) scroll_offset: PhysicalVec<Au>,
+}
+
+impl ContainingBlockQueryInfo {
+    /// Transform child's rectangle according to this containing block transformation.
+    /// TODO: this is supposed to handle CSS transform but it is not happening.
+    pub(crate) fn transform_rect_relative_to_self(
+        &self,
+        rect: PhysicalRect<Au>,
+    ) -> PhysicalRect<Au> {
+        rect.translate(self.rect.origin.to_vector() + self.scroll_offset)
+    }
+
+    /// New containing block that is a child of this containing block with
+    /// ancestor's transformation applied.
+    pub(crate) fn new_relative_transformed_child(
+        &self,
+        rect: PhysicalRect<Au>,
+        scroll_offset: PhysicalVec<Au>,
+    ) -> ContainingBlockQueryInfo {
+        ContainingBlockQueryInfo {
+            rect: self.transform_rect_relative_to_self(rect),
+            scroll_offset,
+        }
+    }
+}

--- a/components/layout_thread_2020/lib.rs
+++ b/components/layout_thread_2020/lib.rs
@@ -247,7 +247,7 @@ impl Layout for LayoutThread {
             node,
             self.fragment_tree.borrow().clone(),
             self.id,
-            &*self.scroll_offsets.borrow(),
+            &self.scroll_offsets.borrow(),
         )
     }
 
@@ -260,7 +260,7 @@ impl Layout for LayoutThread {
             node,
             self.fragment_tree.borrow().clone(),
             self.id,
-            &*self.scroll_offsets.borrow(),
+            &self.scroll_offsets.borrow(),
         )
     }
 

--- a/components/layout_thread_2020/lib.rs
+++ b/components/layout_thread_2020/lib.rs
@@ -243,7 +243,12 @@ impl Layout for LayoutThread {
         tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn query_content_box(&self, node: OpaqueNode) -> Option<UntypedRect<Au>> {
-        process_content_box_request(node, self.fragment_tree.borrow().clone())
+        process_content_box_request(
+            node,
+            self.fragment_tree.borrow().clone(),
+            self.id,
+            &*self.scroll_offsets.borrow(),
+        )
     }
 
     #[cfg_attr(
@@ -251,7 +256,12 @@ impl Layout for LayoutThread {
         tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn query_content_boxes(&self, node: OpaqueNode) -> Vec<UntypedRect<Au>> {
-        process_content_boxes_request(node, self.fragment_tree.borrow().clone())
+        process_content_boxes_request(
+            node,
+            self.fragment_tree.borrow().clone(),
+            self.id,
+            &*self.scroll_offsets.borrow(),
+        )
     }
 
     #[cfg_attr(

--- a/tests/wpt/meta/css/css-position/sticky/position-sticky-transforms.html.ini
+++ b/tests/wpt/meta/css/css-position/sticky/position-sticky-transforms.html.ini
@@ -1,7 +1,4 @@
 [position-sticky-transforms.html]
-  [Scale transforms are carried out on the stuck element position]
-    expected: FAIL
-
   [Rotate transforms are carried out on the stuck element position]
     expected: FAIL
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Element's [getClientRects](https://drafts.csswg.org/cssom-view/#dom-element-getclientrects) are supposed to consider scroll offset of it's scrollable ancestors. This will allow more of JS API to work properly. For example, we would be able to better handle several common use case for IntersectionObserver.

cc: @xiaochengh

[Try](https://github.com/stevennovaryo/servo/actions/runs/13673798299)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #35768

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
