### PR TITLE
Keep a list of slot descendants on each shadow root

### DIFF
--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -1346,7 +1346,11 @@ impl Node {
         // NOTE: This method traverses all descendants of the node and is potentially very
         // expensive. If the node is not a shadow root then assigning slottables to it won't
         // have any effect, so we take a fast path out.
-        if !self.is::<ShadowRoot>() {
+        let Some(shadow_root) = self.downcast::<ShadowRoot>() else {
+            return;
+        };
+
+        if !shadow_root.has_slot_descendants() {
             return;
         }
 


### PR DESCRIPTION
This makes it much faster to look up the slot with a given name, which is a fairly costly part of "assign slottables to a tree".

As a result the time it takes for the results to load on wpt.fyi is reduced from
over 3 minutes to about 5 seconds.



---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes (covered by wpt)

