### PR TITLE
hos CI: fix checking success

### DIFF
--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -239,4 +239,4 @@ jobs:
           servo_pid=$(hdc shell pidof org.servo.servo)
           [[ $servo_pid =~ ^[0-9]+$ ]] || { echo "It looks like servo crashed!" ; exit 1; }
           # If the grep fails, then the trace output for the "page loaded" prompt is missing
-          grep 'servoshell.* tracing_mark_write.*PageLoadEndedPrompt' test_output/servo.ftrace
+          grep 'org\.servo\.servo-.* tracing_mark_write.*PageLoadEndedPrompt' test_output/servo.ftrace


### PR DESCRIPTION
In #35804 we fixed the bundlename, but I assumed the servoshell in the grep expression was referring to the libraryname. As it turns out the tracelines start with the bundlename, so we need to update this name too.
This is the last line in the hos CI, and the grep
expression works locally so this time CI should really be fixed. As already mentioned in the previous PR, we can't really test this well, since this job only runs on self-hosted runners, which check out the github action yaml version from the main branch.


---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix hos ci.