### PR TITLE
layout: Make `transform-style: preserve-3d` establish a containing block for all descendants

### DIFF
--- a/components/layout_2020/style_ext.rs
+++ b/components/layout_2020/style_ext.rs
@@ -283,6 +283,7 @@ pub(crate) trait ComputedValuesExt {
         &self,
         containing_block_writing_mode: WritingMode,
     ) -> LogicalSides<LengthPercentageOrAuto<'_>>;
+    fn is_transformable(&self, fragment_flags: FragmentFlags) -> bool;
     fn has_transform_or_perspective(&self, fragment_flags: FragmentFlags) -> bool;
     fn effective_z_index(&self, fragment_flags: FragmentFlags) -> i32;
     fn effective_overflow(&self, fragment_flags: FragmentFlags) -> AxesOverflow;
@@ -463,9 +464,8 @@ impl ComputedValuesExt for ComputedValues {
         LogicalSides::from_physical(&self.physical_margin(), containing_block_writing_mode)
     }
 
-    /// Returns true if this style has a transform, or perspective property set and
-    /// it applies to this element.
-    fn has_transform_or_perspective(&self, fragment_flags: FragmentFlags) -> bool {
+    /// Returns true if this is a transformable element.
+    fn is_transformable(&self, fragment_flags: FragmentFlags) -> bool {
         // "A transformable element is an element in one of these categories:
         //   * all elements whose layout is governed by the CSS box model except for
         //     non-replaced inline boxes, table-column boxes, and table-column-group
@@ -473,14 +473,18 @@ impl ComputedValuesExt for ComputedValues {
         //   * all SVG paint server elements, the clipPath element  and SVG renderable
         //     elements with the exception of any descendant element of text content
         //     elements."
-        // https://drafts.csswg.org/css-transforms/#transformable-element
-        if self.get_box().display.is_inline_flow() &&
-            !fragment_flags.contains(FragmentFlags::IS_REPLACED)
-        {
-            return false;
-        }
+        // <https://drafts.csswg.org/css-transforms/#transformable-element>
+        // TODO: check for all cases listed in the above spec.
+        !self.get_box().display.is_inline_flow() ||
+            fragment_flags.contains(FragmentFlags::IS_REPLACED)
+    }
 
-        !self.get_box().transform.0.is_empty() || self.get_box().perspective != Perspective::None
+    /// Returns true if this style has a transform, or perspective property set and
+    /// it applies to this element.
+    fn has_transform_or_perspective(&self, fragment_flags: FragmentFlags) -> bool {
+        self.is_transformable(fragment_flags) &&
+            (!self.get_box().transform.0.is_empty() ||
+                self.get_box().perspective != Perspective::None)
     }
 
     /// Get the effective z-index of this fragment. Z-indices only apply to positioned elements
@@ -614,8 +618,9 @@ impl ComputedValuesExt for ComputedValues {
             return true;
         }
 
-        if self.get_box().transform_style == ComputedTransformStyle::Preserve3d ||
-            self.overrides_transform_style()
+        if self.is_transformable(fragment_flags) &&
+            (self.get_box().transform_style == ComputedTransformStyle::Preserve3d ||
+                self.overrides_transform_style())
         {
             return true;
         }
@@ -689,8 +694,9 @@ impl ComputedValuesExt for ComputedValues {
         }
 
         // See <https://drafts.csswg.org/css-transforms-2/#transform-style-property>.
-        if self.get_box().transform_style == ComputedTransformStyle::Preserve3d ||
-            self.overrides_transform_style()
+        if self.is_transformable(fragment_flags) &&
+            (self.get_box().transform_style == ComputedTransformStyle::Preserve3d ||
+                self.overrides_transform_style())
         {
             return true;
         }

--- a/components/layout_2020/style_ext.rs
+++ b/components/layout_2020/style_ext.rs
@@ -618,9 +618,9 @@ impl ComputedValuesExt for ComputedValues {
             return true;
         }
 
+        // See <https://drafts.csswg.org/css-transforms-2/#transform-style-property>.
         if self.is_transformable(fragment_flags) &&
-            (self.get_box().transform_style == ComputedTransformStyle::Preserve3d ||
-                self.overrides_transform_style())
+            self.get_box().transform_style == ComputedTransformStyle::Preserve3d
         {
             return true;
         }
@@ -695,8 +695,7 @@ impl ComputedValuesExt for ComputedValues {
 
         // See <https://drafts.csswg.org/css-transforms-2/#transform-style-property>.
         if self.is_transformable(fragment_flags) &&
-            (self.get_box().transform_style == ComputedTransformStyle::Preserve3d ||
-                self.overrides_transform_style())
+            self.get_box().transform_style == ComputedTransformStyle::Preserve3d
         {
             return true;
         }

--- a/components/layout_2020/style_ext.rs
+++ b/components/layout_2020/style_ext.rs
@@ -688,6 +688,13 @@ impl ComputedValuesExt for ComputedValues {
             return true;
         }
 
+        // See <https://drafts.csswg.org/css-transforms-2/#transform-style-property>.
+        if self.get_box().transform_style == ComputedTransformStyle::Preserve3d ||
+            self.overrides_transform_style()
+        {
+            return true;
+        }
+
         // TODO: We need to handle CSS Contain here.
         false
     }

--- a/tests/wpt/meta/css/css-masking/clip/clip-no-stacking-context.html.ini
+++ b/tests/wpt/meta/css/css-masking/clip/clip-no-stacking-context.html.ini
@@ -1,2 +1,0 @@
-[clip-no-stacking-context.html]
-  expected: FAIL

--- a/tests/wpt/tests/css/css-transforms/preserve3d-containing-block-ref.html
+++ b/tests/wpt/tests/css/css-transforms/preserve3d-containing-block-ref.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS test reference: "transform-style: preserve-3d" should establish a containing block for all descendants</title>
+<link rel="help" href="https://drafts.csswg.org/css-transforms-2/#transform-style-property">
+<style>
+body { transform: scale(1); height: 0 }
+div { background: green; width: 100px; height: 100px; }
+</style>
+<div></div>

--- a/tests/wpt/tests/css/css-transforms/preserve3d-containing-block-ref.html
+++ b/tests/wpt/tests/css/css-transforms/preserve3d-containing-block-ref.html
@@ -1,9 +1,0 @@
-<!DOCTYPE html>
-<meta charset="utf-8">
-<title>CSS test reference: "transform-style: preserve-3d" should establish a containing block for all descendants</title>
-<link rel="help" href="https://drafts.csswg.org/css-transforms-2/#transform-style-property">
-<style>
-body { transform: scale(1); height: 0 }
-div { background: green; width: 100px; height: 100px; }
-</style>
-<div></div>

--- a/tests/wpt/tests/css/css-transforms/preserve3d-containing-block.html
+++ b/tests/wpt/tests/css/css-transforms/preserve3d-containing-block.html
@@ -2,11 +2,12 @@
 <meta charset="utf-8">
 <title>CSS test: "transform-style: preserve-3d" should establish a containing block for all descendants</title>
 <link rel="help" href="https://drafts.csswg.org/css-transforms-2/#transform-style-property">
-<link rel="match" href="preserve3d-containing-block-ref.html">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <meta name="assert" content="The box should be green (not red) because the div establishes a containing block for all descendants.">
 <style>
 body { transform: scale(1); height: 0 }
 div { background: red; width: 100px; height: 100px; }
 div::before { content: ""; position: fixed; width: 100%; height: 100%; background: green; }
 </style>
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
 <div style="transform-style: preserve-3d"></div>

--- a/tests/wpt/tests/css/css-transforms/preserve3d-containing-block.html
+++ b/tests/wpt/tests/css/css-transforms/preserve3d-containing-block.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS test: "transform-style: preserve-3d" should establish a containing block for all descendants</title>
+<link rel="help" href="https://drafts.csswg.org/css-transforms-2/#transform-style-property">
+<link rel="match" href="preserve3d-containing-block-ref.html">
+<meta name="assert" content="The box should be green (not red) because the div establishes a containing block for all descendants.">
+<style>
+body { transform: scale(1); height: 0 }
+div { background: red; width: 100px; height: 100px; }
+div::before { content: ""; position: fixed; width: 100%; height: 100%; background: green; }
+</style>
+<div style="transform-style: preserve-3d"></div>


### PR DESCRIPTION
This makes `transform-style: preserve-3d` establish a containing block for all descendants, as specified here:
<https://drafts.csswg.org/css-transforms-2/#transform-style-property>

(This is my first time contributing to Servo; I think I followed the instructions properly but let me know if there's anything I need to fix.)

-----

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #35801 and #35824
- [x] There are tests for these changes
