### PR TITLE
layout: Assert that `hypothetical_cross_size` is already correct

### DIFF
--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -2000,7 +2000,10 @@ impl FlexItem<'_> {
                             size,
                         )
                     {
-                        non_stretch_layout_result.hypothetical_cross_size = hypothetical_cross_size;
+                        assert_eq!(
+                            non_stretch_layout_result.hypothetical_cross_size,
+                            hypothetical_cross_size
+                        );
                         return None;
                     }
                 }
@@ -2055,10 +2058,12 @@ impl FlexItem<'_> {
                     if non_stretch_layout_result
                         .compatible_with_containing_block_size(&item_as_containing_block)
                     {
-                        non_stretch_layout_result.hypothetical_cross_size =
+                        assert_eq!(
+                            non_stretch_layout_result.hypothetical_cross_size,
                             calculate_hypothetical_cross_size(
                                 non_stretch_layout_result.content_size.inline,
-                            );
+                            )
+                        );
                         return None;
                     }
                 }


### PR DESCRIPTION
There doesn't seem to be a need to recompute it.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because there is no behavior change

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
