### PR TITLE
Refactor common boilerplate out of serialize/transfer implementations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1065,7 +1065,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4294,7 +4294,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6471,6 +6471,7 @@ dependencies = [
  "serde",
  "servo_malloc_size_of",
  "servo_url",
+ "strum",
  "strum_macros",
  "style_traits",
  "stylo_atoms",
@@ -8804,7 +8805,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/components/script/dom/bindings/serializable.rs
+++ b/components/script/dom/bindings/serializable.rs
@@ -23,7 +23,10 @@ pub(crate) struct StorageKey {
 
 /// Interface for serializable platform objects.
 /// <https://html.spec.whatwg.org/multipage/#serializable>
-pub(crate) trait Serializable: DomObject where Self: Sized {
+pub(crate) trait Serializable: DomObject
+where
+    Self: Sized,
+{
     /// <https://html.spec.whatwg.org/multipage/#serialization-steps>
     fn serialize(&self, sc_writer: &mut StructuredDataWriter) -> Result<StorageKey, ()>;
     /// <https://html.spec.whatwg.org/multipage/#deserialization-steps>
@@ -32,8 +35,12 @@ pub(crate) trait Serializable: DomObject where Self: Sized {
         sc_reader: &mut StructuredDataReader,
         extra_data: StorageKey,
         can_gc: CanGc,
-    ) -> Result<DomRoot<Self>, ()> where Self: Sized;
+    ) -> Result<DomRoot<Self>, ()>
+    where
+        Self: Sized;
     /// Returns the field of [StructuredDataReader] that should be used to store
     /// deserialized instances of this type.
-    fn destination(reader: &mut StructuredDataReader) -> &mut Option<HashMap<StorageKey, DomRoot<Self>>>;
+    fn destination(
+        reader: &mut StructuredDataReader,
+    ) -> &mut Option<HashMap<StorageKey, DomRoot<Self>>>;
 }

--- a/components/script/dom/bindings/serializable.rs
+++ b/components/script/dom/bindings/serializable.rs
@@ -64,9 +64,7 @@ where
 
     /// Returns the field of [StructuredDataReader]/[StructuredDataWriter] that
     /// should be used to read/store serialized instances of this type.
-    fn serialized_storage<'a>(
-        reader: StructuredData<'a>,
-    ) -> &'a mut Option<HashMap<Self::Id, Self::Data>>;
+    fn serialized_storage(data: StructuredData<'_>) -> &mut Option<HashMap<Self::Id, Self::Data>>;
 
     /// Returns the field of [StructuredDataReader] that should be used to store
     /// deserialized instances of this type.

--- a/components/script/dom/bindings/serializable.rs
+++ b/components/script/dom/bindings/serializable.rs
@@ -5,7 +5,10 @@
 //! Trait representing the concept of [serializable objects]
 //! (<https://html.spec.whatwg.org/multipage/#serializable-objects>).
 
+use std::collections::HashMap;
+
 use crate::dom::bindings::reflector::DomObject;
+use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::structuredclone::{StructuredDataReader, StructuredDataWriter};
 use crate::dom::globalscope::GlobalScope;
 use crate::script_runtime::CanGc;
@@ -20,7 +23,7 @@ pub(crate) struct StorageKey {
 
 /// Interface for serializable platform objects.
 /// <https://html.spec.whatwg.org/multipage/#serializable>
-pub(crate) trait Serializable: DomObject {
+pub(crate) trait Serializable: DomObject where Self: Sized {
     /// <https://html.spec.whatwg.org/multipage/#serialization-steps>
     fn serialize(&self, sc_writer: &mut StructuredDataWriter) -> Result<StorageKey, ()>;
     /// <https://html.spec.whatwg.org/multipage/#deserialization-steps>
@@ -29,5 +32,8 @@ pub(crate) trait Serializable: DomObject {
         sc_reader: &mut StructuredDataReader,
         extra_data: StorageKey,
         can_gc: CanGc,
-    ) -> Result<(), ()>;
+    ) -> Result<DomRoot<Self>, ()> where Self: Sized;
+    /// Returns the field of [StructuredDataReader] that should be used to store
+    /// deserialized instances of this type.
+    fn destination(reader: &mut StructuredDataReader) -> &mut Option<HashMap<StorageKey, DomRoot<Self>>>;
 }

--- a/components/script/dom/bindings/serializable.rs
+++ b/components/script/dom/bindings/serializable.rs
@@ -6,10 +6,13 @@
 //! (<https://html.spec.whatwg.org/multipage/#serializable-objects>).
 
 use std::collections::HashMap;
+use std::num::NonZeroU32;
+
+use base::id::PipelineNamespaceId;
 
 use crate::dom::bindings::reflector::DomObject;
 use crate::dom::bindings::root::DomRoot;
-use crate::dom::bindings::structuredclone::{StructuredDataReader, StructuredDataWriter};
+use crate::dom::bindings::structuredclone::{StructuredData, StructuredDataReader};
 use crate::dom::globalscope::GlobalScope;
 use crate::script_runtime::CanGc;
 
@@ -21,26 +24,53 @@ pub(crate) struct StorageKey {
     pub(crate) name_space: u32,
 }
 
+impl StorageKey {
+    pub(crate) fn new(name_space: PipelineNamespaceId, index: NonZeroU32) -> StorageKey {
+        let name_space = name_space.0.to_ne_bytes();
+        let index = index.get().to_ne_bytes();
+        StorageKey {
+            index: u32::from_ne_bytes(index),
+            name_space: u32::from_ne_bytes(name_space),
+        }
+    }
+}
+
+pub(crate) trait IntoStorageKey
+where
+    Self: Sized,
+{
+    fn into_storage_key(self) -> StorageKey;
+}
+
 /// Interface for serializable platform objects.
 /// <https://html.spec.whatwg.org/multipage/#serializable>
 pub(crate) trait Serializable: DomObject
 where
     Self: Sized,
 {
+    type Id: Copy + Eq + std::hash::Hash + IntoStorageKey + From<StorageKey>;
+    type Data;
+
     /// <https://html.spec.whatwg.org/multipage/#serialization-steps>
-    fn serialize(&self, sc_writer: &mut StructuredDataWriter) -> Result<StorageKey, ()>;
+    fn serialize(&self) -> Result<(Self::Id, Self::Data), ()>;
     /// <https://html.spec.whatwg.org/multipage/#deserialization-steps>
     fn deserialize(
         owner: &GlobalScope,
-        sc_reader: &mut StructuredDataReader,
-        extra_data: StorageKey,
+        serialized: Self::Data,
         can_gc: CanGc,
     ) -> Result<DomRoot<Self>, ()>
     where
         Self: Sized;
+
+    /// Returns the field of [StructuredDataReader]/[StructuredDataWriter] that
+    /// should be used to read/store serialized instances of this type.
+    fn serialized_storage<'a>(
+        reader: StructuredData<'a>,
+    ) -> &'a mut Option<HashMap<Self::Id, Self::Data>>;
+
     /// Returns the field of [StructuredDataReader] that should be used to store
     /// deserialized instances of this type.
-    fn destination(
+    fn deserialized_storage(
         reader: &mut StructuredDataReader,
     ) -> &mut Option<HashMap<StorageKey, DomRoot<Self>>>;
 }

--- a/components/script/dom/bindings/structuredclone.rs
+++ b/components/script/dom/bindings/structuredclone.rs
@@ -24,12 +24,12 @@ use js::jsval::UndefinedValue;
 use js::rust::wrappers::{JS_ReadStructuredClone, JS_WriteStructuredClone};
 use js::rust::{CustomAutoRooterGuard, HandleValue, MutableHandleValue};
 use script_bindings::conversions::IDLInterface;
+use script_traits::serializable::BlobImpl;
+use script_traits::transferable::MessagePortImpl;
 use script_traits::{
     Serializable as SerializableInterface, StructuredSerializedData,
     Transferrable as TransferrableInterface,
 };
-use script_traits::serializable::BlobImpl;
-use script_traits::transferable::MessagePortImpl;
 use strum::IntoEnumIterator;
 
 use crate::dom::bindings::conversions::{ToJSValConvertible, root_from_object};
@@ -277,7 +277,9 @@ fn receive_object<T: Transferable>(
         }
         object
     } else {
-        panic!("An interface was transfer-received, yet the SC holder does not have any serialized objects");
+        panic!(
+            "An interface was transfer-received, yet the SC holder does not have any serialized objects"
+        );
     };
 
     if let Ok(received) = T::transfer_receive(&owner, id, serialized) {

--- a/components/script/dom/bindings/transferable.rs
+++ b/components/script/dom/bindings/transferable.rs
@@ -44,8 +44,6 @@ where
         serialized: Self::Data,
     ) -> Result<DomRoot<Self>, ()>;
 
-    fn serialized_storage<'a>(
-        data: StructuredData<'a>,
-    ) -> &'a mut Option<HashMap<Self::Id, Self::Data>>;
+    fn serialized_storage(data: StructuredData<'_>) -> &mut Option<HashMap<Self::Id, Self::Data>>;
     fn deserialized_storage(reader: &mut StructuredDataReader) -> &mut Option<Vec<DomRoot<Self>>>;
 }

--- a/components/script/dom/bindings/transferable.rs
+++ b/components/script/dom/bindings/transferable.rs
@@ -33,6 +33,10 @@ where
     type Id: Eq + std::hash::Hash + Copy + IdFromComponents + ExtractComponents;
     type Data;
 
+    fn can_transfer(&self) -> bool {
+        true
+    }
+
     fn transfer(&self) -> Result<(Self::Id, Self::Data), ()>;
     fn transfer_receive(
         owner: &GlobalScope,

--- a/components/script/dom/bindings/transferable.rs
+++ b/components/script/dom/bindings/transferable.rs
@@ -5,18 +5,39 @@
 //! Trait representing the concept of [transferable objects]
 //! (<https://html.spec.whatwg.org/multipage/#transferable-objects>).
 
-use js::jsapi::MutableHandleObject;
+use std::collections::HashMap;
+use std::num::NonZeroU32;
+
+use base::id::PipelineNamespaceId;
 
 use crate::dom::bindings::reflector::DomObject;
+use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::structuredclone::{StructuredDataReader, StructuredDataWriter};
 use crate::dom::globalscope::GlobalScope;
 
-pub(crate) trait Transferable: DomObject {
+pub(crate) trait IdFromComponents
+where
+    Self: Sized,
+{
+    fn from(namespace_id: PipelineNamespaceId, index: NonZeroU32) -> Self;
+}
+
+pub(crate) trait Transferable: DomObject
+where
+    Self: Sized,
+{
+    type Id: Eq + std::hash::Hash + Copy + IdFromComponents;
+    type Data;
+
     fn transfer(&self, sc_writer: &mut StructuredDataWriter) -> Result<u64, ()>;
     fn transfer_receive(
         owner: &GlobalScope,
-        sc_reader: &mut StructuredDataReader,
-        extra_data: u64,
-        return_object: MutableHandleObject,
-    ) -> Result<(), ()>;
+        id: Self::Id,
+        serialized: Self::Data,
+    ) -> Result<DomRoot<Self>, ()>;
+
+    fn serialized_storage(
+        reader: &mut StructuredDataReader,
+    ) -> &mut Option<HashMap<Self::Id, Self::Data>>;
+    fn deserialized_storage(reader: &mut StructuredDataReader) -> &mut Option<Vec<DomRoot<Self>>>;
 }

--- a/components/script/dom/blob.rs
+++ b/components/script/dom/blob.rs
@@ -120,9 +120,9 @@ impl Serializable for Blob {
         Ok(deserialized_blob)
     }
 
-    fn serialized_storage<'a>(
-        reader: StructuredData<'a>,
-    ) -> &'a mut Option<HashMap<Self::Id, Self::Data>> {
+    fn serialized_storage(
+        reader: StructuredData<'_>,
+    ) -> &mut Option<HashMap<Self::Id, Self::Data>> {
         match reader {
             StructuredData::Reader(r) => &mut r.blob_impls,
             StructuredData::Writer(w) => &mut w.blobs,

--- a/components/script/dom/blob.rs
+++ b/components/script/dom/blob.rs
@@ -158,7 +158,9 @@ impl Serializable for Blob {
         Ok(deserialized_blob)
     }
 
-    fn destination(data: &mut StructuredDataReader) -> &mut Option<HashMap<StorageKey, DomRoot<Self>>> {
+    fn destination(
+        data: &mut StructuredDataReader,
+    ) -> &mut Option<HashMap<StorageKey, DomRoot<Self>>> {
         &mut data.blobs
     }
 }

--- a/components/script/dom/blob.rs
+++ b/components/script/dom/blob.rs
@@ -130,7 +130,7 @@ impl Serializable for Blob {
         sc_reader: &mut StructuredDataReader,
         storage_key: StorageKey,
         can_gc: CanGc,
-    ) -> Result<(), ()> {
+    ) -> Result<DomRoot<Self>, ()> {
         // 1. Re-build the key for the storage location
         // of the serialized object.
         let namespace_id = PipelineNamespaceId(storage_key.name_space);
@@ -155,11 +155,11 @@ impl Serializable for Blob {
         }
 
         let deserialized_blob = Blob::new(owner, blob_impl, can_gc);
+        Ok(deserialized_blob)
+    }
 
-        let blobs = sc_reader.blobs.get_or_insert_with(HashMap::new);
-        blobs.insert(storage_key, deserialized_blob);
-
-        Ok(())
+    fn destination(data: &mut StructuredDataReader) -> &mut Option<HashMap<StorageKey, DomRoot<Self>>> {
+        &mut data.blobs
     }
 }
 

--- a/components/script/dom/messageport.rs
+++ b/components/script/dom/messageport.rs
@@ -190,9 +190,7 @@ impl Transferable for MessagePort {
         Ok(transferred_port)
     }
 
-    fn serialized_storage<'a>(
-        data: StructuredData<'a>,
-    ) -> &'a mut Option<HashMap<Self::Id, Self::Data>> {
+    fn serialized_storage(data: StructuredData<'_>) -> &mut Option<HashMap<Self::Id, Self::Data>> {
         match data {
             StructuredData::Reader(r) => &mut r.port_impls,
             StructuredData::Writer(w) => &mut w.ports,

--- a/components/script/dom/messageport.rs
+++ b/components/script/dom/messageport.rs
@@ -11,8 +11,8 @@ use base::id::{MessagePortId, MessagePortIndex, PipelineNamespaceId};
 use dom_struct::dom_struct;
 use js::jsapi::{Heap, JSObject};
 use js::rust::{CustomAutoRooter, CustomAutoRooterGuard, HandleValue};
-use script_traits::transferable::MessagePortImpl;
 use script_traits::PortMessageTask;
+use script_traits::transferable::MessagePortImpl;
 
 use crate::dom::bindings::codegen::Bindings::EventHandlerBinding::EventHandlerNonNull;
 use crate::dom::bindings::codegen::Bindings::MessagePortBinding::{
@@ -21,11 +21,7 @@ use crate::dom::bindings::codegen::Bindings::MessagePortBinding::{
 use crate::dom::bindings::conversions::root_from_object;
 use crate::dom::bindings::error::{Error, ErrorResult};
 use crate::dom::bindings::inheritance::Castable;
-<<<<<<< HEAD
-use crate::dom::bindings::reflector::{DomGlobal, DomObject, reflect_dom_object};
-=======
-use crate::dom::bindings::reflector::{reflect_dom_object, DomGlobal};
->>>>>>> 3d96c220c9 (script: Extract boilerplate from transfer-receive.)
+use crate::dom::bindings::reflector::{DomGlobal, reflect_dom_object};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::structuredclone::{self, StructuredData, StructuredDataReader};
 use crate::dom::bindings::trace::RootedTraceableBox;

--- a/components/shared/script/Cargo.toml
+++ b/components/shared/script/Cargo.toml
@@ -42,6 +42,7 @@ serde = { workspace = true }
 strum_macros = { workspace = true }
 stylo_atoms = { workspace = true }
 servo_url = { path = "../../url" }
+strum = { workspace = true, features = ["derive"] }
 style_traits = { workspace = true }
 uuid = { workspace = true }
 webdriver = { workspace = true }

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -742,7 +742,10 @@ pub struct StructuredSerializedData {
     pub ports: Option<HashMap<MessagePortId, MessagePortImpl>>,
 }
 
-pub(crate) trait BroadcastClone where Self: Sized {
+pub(crate) trait BroadcastClone
+where
+    Self: Sized,
+{
     /// The ID type that uniquely identify each value.
     type Id: Eq + std::hash::Hash + Copy;
     /// Clone this value so that it can be reused with a broadcast channel.
@@ -764,7 +767,7 @@ pub enum Serializable {
 impl Serializable {
     fn clone_values(&self) -> fn(&StructuredSerializedData, &mut StructuredSerializedData) {
         match self {
-            Serializable::Blob => StructuredSerializedData::clone_all_of_type::<BlobImpl>
+            Serializable::Blob => StructuredSerializedData::clone_all_of_type::<BlobImpl>,
         }
     }
 }
@@ -782,7 +785,7 @@ impl StructuredSerializedData {
             field.as_ref().is_some_and(|h| h.is_empty())
         }
         match val {
-            Transferrable::MessagePort => is_field_empty(&self.ports)
+            Transferrable::MessagePort => is_field_empty(&self.ports),
         }
     }
 

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -758,7 +758,7 @@ where
 }
 
 /// All the DOM interfaces that can be serialized.
-#[derive(Copy, Clone, Debug, EnumIter)]
+#[derive(Clone, Copy, Debug, EnumIter)]
 pub enum Serializable {
     /// The `Blob` interface.
     Blob,
@@ -773,7 +773,7 @@ impl Serializable {
 }
 
 /// All the DOM interfaces that can be transferred.
-#[derive(Copy, Clone, Debug, EnumIter)]
+#[derive(Clone, Copy, Debug, EnumIter)]
 pub enum Transferrable {
     /// The `MessagePort` interface.
     MessagePort,
@@ -810,7 +810,10 @@ impl StructuredSerializedData {
         for transferrable in Transferrable::iter() {
             if !self.is_empty(transferrable) {
                 // Not panicking only because this is called from the constellation.
-                warn!("Attempt to broadcast structured serialized data including {:?} (should never happen).", transferrable);
+                warn!(
+                    "Attempt to broadcast structured serialized data including {:?} (should never happen).",
+                    transferrable,
+                );
             }
         }
 

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -828,7 +828,7 @@ impl StructuredSerializedData {
 
         for serializable in Serializable::iter() {
             let clone_impl = serializable.clone_values();
-            clone_impl(&self, &mut cloned);
+            clone_impl(self, &mut cloned);
         }
 
         cloned

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -50,8 +50,8 @@ use pixels::PixelFormat;
 use profile_traits::{mem, time as profile_time};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use servo_url::{ImmutableOrigin, ServoUrl};
-use strum_macros::IntoStaticStr;
 use strum::{EnumIter, IntoEnumIterator};
+use strum_macros::IntoStaticStr;
 use style_traits::{CSSPixel, SpeculativePainter};
 use stylo_atoms::Atom;
 #[cfg(feature = "webgpu")]

--- a/components/shared/script/serializable.rs
+++ b/components/shared/script/serializable.rs
@@ -63,11 +63,15 @@ impl FileBlob {
 impl crate::BroadcastClone for BlobImpl {
     type Id = BlobId;
 
-    fn source(data: &crate::StructuredSerializedData) -> &Option<std::collections::HashMap<Self::Id, Self>> {
+    fn source(
+        data: &crate::StructuredSerializedData,
+    ) -> &Option<std::collections::HashMap<Self::Id, Self>> {
         &data.blobs
     }
 
-    fn destination(data: &mut crate::StructuredSerializedData) -> &mut Option<std::collections::HashMap<Self::Id, Self>> {
+    fn destination(
+        data: &mut crate::StructuredSerializedData,
+    ) -> &mut Option<std::collections::HashMap<Self::Id, Self>> {
         &mut data.blobs
     }
 

--- a/components/shared/script/serializable.rs
+++ b/components/shared/script/serializable.rs
@@ -74,7 +74,7 @@ impl crate::BroadcastClone for BlobImpl {
     fn clone_for_broadcast(&self) -> Option<Self> {
         let type_string = self.type_string();
 
-        if let BlobData::Memory(ref bytes) = self.blob_data() {
+        if let BlobData::Memory(bytes) = self.blob_data() {
             let blob_clone = BlobImpl::new_from_bytes(bytes.clone(), type_string);
 
             // Note: we insert the blob at the original id,

--- a/components/shared/script/serializable.rs
+++ b/components/shared/script/serializable.rs
@@ -60,6 +60,35 @@ impl FileBlob {
     }
 }
 
+impl crate::BroadcastClone for BlobImpl {
+    type Id = BlobId;
+
+    fn source(data: &crate::StructuredSerializedData) -> &Option<std::collections::HashMap<Self::Id, Self>> {
+        &data.blobs
+    }
+
+    fn destination(data: &mut crate::StructuredSerializedData) -> &mut Option<std::collections::HashMap<Self::Id, Self>> {
+        &mut data.blobs
+    }
+
+    fn clone_for_broadcast(&self) -> Option<Self> {
+        let type_string = self.type_string();
+
+        if let BlobData::Memory(ref bytes) = self.blob_data() {
+            let blob_clone = BlobImpl::new_from_bytes(bytes.clone(), type_string);
+
+            // Note: we insert the blob at the original id,
+            // otherwise this will not match the storage key as serialized by SM in `serialized`.
+            // The clone has it's own new Id however.
+            return Some(blob_clone);
+        } else {
+            // Not panicking only because this is called from the constellation.
+            log::warn!("Serialized blob not in memory format(should never happen).");
+        }
+        return None;
+    }
+}
+
 /// The data backing a DOM Blob.
 #[derive(Debug, Deserialize, MallocSizeOf, Serialize)]
 pub struct BlobImpl {

--- a/components/shared/script/serializable.rs
+++ b/components/shared/script/serializable.rs
@@ -89,7 +89,7 @@ impl crate::BroadcastClone for BlobImpl {
             // Not panicking only because this is called from the constellation.
             log::warn!("Serialized blob not in memory format(should never happen).");
         }
-        return None;
+        None
     }
 }
 

--- a/deny.toml
+++ b/deny.toml
@@ -159,10 +159,6 @@ skip = [
     # duplicated by font-kit
     "redox_users",
     "dirs-sys",
-
-    # duplicated by wgpu
-    "strum",
-    "strum_macros",
 ]
 
 # github.com organizations to allow git sources for

--- a/deny.toml
+++ b/deny.toml
@@ -159,6 +159,10 @@ skip = [
     # duplicated by font-kit
     "redox_users",
     "dirs-sys",
+
+    # duplicated by wgpu
+    "strum",
+    "strum_macros",
 ]
 
 # github.com organizations to allow git sources for


### PR DESCRIPTION
Following up on my original work from #33811, I've got a new set of changes that should make future Serializable/Transferable implementations much easier to write. Unlike #33811, I have not changed anything about how the structured clone implementation is designed—these changes only lift common boilerplate out of the interface-specific logic, and use static types to ensure all known interfaces are handled the same way.

There are two main issues with the current implementation of structured cloning:
* there are many places that need to be updated when adding a new serializable/transferable interface, and the compiler cannot verify that they are all updated
* the interface-specific logic is mixed in with logic that is identical across all interfaces

These changes start by introducing two enums in components/shared/script: Serializable and Transferable. These enums drive all of the logic for cloning/serializing/transfering, ensuring that the compiler will complain if any code requiring interface-specific logic has been missed.

The next important piece of these changes is making the Serializable and Transferable _traits_ from components/script identify which field of StructuredDataReader/Writer should be used for a given type. This ensures that the compiler will complain if those fields are not added when necessary, and allows hoisting the logic for storing/reading serialized/deserialized values out of the interface-specific logic.

The final important piece of these changes is in the trait interfaces for Serializable/Transferable. Now that the common logic is extracted into the common structured cloning implementation, users of these traits only need to write their implementations in terms of their serialized and deserialized types, leading to much simpler code.

[Try run](https://github.com/servo/servo/actions/runs/13714043021/job/38355664511)

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes