### PR TITLE
Fixes #35825 Reuse effects var in establishes_stacking_context

### DIFF
--- a/components/layout_2020/style_ext.rs
+++ b/components/layout_2020/style_ext.rs
@@ -606,11 +606,11 @@ impl ComputedValuesExt for ComputedValues {
             return true;
         }
 
-        if self.has_transform_or_perspective(fragment_flags) {
+        if !effects.filter.0.is_empty() {
             return true;
         }
 
-        if !self.get_effects().filter.0.is_empty() {
+        if self.has_transform_or_perspective(fragment_flags) {
             return true;
         }
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Minor change to reuse effects variable in establishes_stacking_context() and to keep effects related conditional checks together for readability.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #35825
- [X] These changes do not require tests because there is no behavior change