### PR TITLE
Don't run scripts in documents that don't have a browsing context

### DIFF
--- a/components/script/dom/servoparser/async_html.rs
+++ b/components/script/dom/servoparser/async_html.rs
@@ -267,6 +267,7 @@ impl Tokenizer {
         // Create new thread for HtmlTokenizer. This is where parser actions
         // will be generated from the input provided. These parser actions are then passed
         // onto the main thread to be executed.
+        let scripting_enabled = document.has_browsing_context();
         thread::Builder::new()
             .name(format!("Parse:{}", tokenizer.url.debug_compact()))
             .spawn(move || {
@@ -277,6 +278,7 @@ impl Tokenizer {
                     form_parse_node,
                     to_tokenizer_sender,
                     html_tokenizer_receiver,
+                    scripting_enabled,
                 );
             })
             .expect("HTML Parser thread spawning failed");
@@ -573,9 +575,11 @@ fn run(
     form_parse_node: Option<ParseNode>,
     sender: Sender<ToTokenizerMsg>,
     receiver: Receiver<ToHtmlTokenizerMsg>,
+    scripting_enabled: bool,
 ) {
     let options = TreeBuilderOpts {
         ignore_missing_rules: true,
+        scripting_enabled,
         ..Default::default()
     };
 

--- a/components/script/dom/servoparser/html.rs
+++ b/components/script/dom/servoparser/html.rs
@@ -56,6 +56,7 @@ impl Tokenizer {
 
         let options = TreeBuilderOpts {
             ignore_missing_rules: true,
+            scripting_enabled: document.has_browsing_context(),
             ..Default::default()
         };
 


### PR DESCRIPTION
For confirmation that this is correct, refer to the note under Step 3 of https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-domparser-parsefromstring.


---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes (covered by wpt)

