### PR TITLE
Fix animation frame callback cancellation

### DIFF
--- a/tests/wpt/meta/html/webappapis/animation-frames/cancel-pending.html.ini
+++ b/tests/wpt/meta/html/webappapis/animation-frames/cancel-pending.html.ini
@@ -1,3 +1,0 @@
-[cancel-pending.html]
-  [cancelAnimationFrame cancels a pending animation frame callback]
-    expected: FAIL


### PR DESCRIPTION
When two animation frame callbacks are fired in the same frame, the first one can cancel the second one.

This PR implements the logic properly by keeping all callbacks in the same deque.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
