### PR TITLE
Ignore RUSTSEC-2024-0436 (crate `paste` is unmaintained)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -15,6 +15,9 @@ ignore = [
     # This has been yanked, but upgrading to the next version breaks some WPT tests.
     # It needs investigation.
     "url@2.5.3",
+
+    # The crate `paste` is no longer maintained.
+    "RUSTSEC-2024-0436",
 ]
 
 # This section is considered when running `cargo deny check licenses`


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Unblock CI for now, filed #35856 to take care of the actual problem.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #35850
- [X] These changes do not require tests because there is no behavior change

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
