### PR TITLE
webgpu: leverage routed_promise in calls returning promises

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -157,7 +157,7 @@ use style_traits::CSSPixel;
 #[cfg(feature = "webgpu")]
 use webgpu::swapchain::WGPUImageMap;
 #[cfg(feature = "webgpu")]
-use webgpu::{self, WebGPU, WebGPURequest, WebGPUResponse};
+use webgpu::{self, WebGPU, WebGPURequest};
 #[cfg(feature = "webgpu")]
 use webrender::RenderApi;
 use webrender::RenderApiSender;
@@ -1936,7 +1936,7 @@ where
             FromScriptMsg::RequestAdapter(response_sender, options, adapter_id) => {
                 match webgpu_chan {
                     None => {
-                        if let Err(e) = response_sender.send(WebGPUResponse::None) {
+                        if let Err(e) = response_sender.send(None) {
                             warn!("Failed to send request adapter message: {}", e)
                         }
                     },

--- a/components/script/dom/servointernals.rs
+++ b/components/script/dom/servointernals.rs
@@ -52,11 +52,8 @@ impl ServoInternalsMethods<crate::DomTypeHolder> for ServoInternals {
     }
 }
 
-impl RoutedPromiseListener for ServoInternals {
-    type Response = MemoryReportResult;
-
-    #[cfg_attr(crown, allow(crown::unrooted_must_root))]
-    fn handle_response(&self, response: Self::Response, promise: &Rc<Promise>, can_gc: CanGc) {
+impl RoutedPromiseListener<MemoryReportResult> for ServoInternals {
+    fn handle_response(&self, response: MemoryReportResult, promise: &Rc<Promise>, can_gc: CanGc) {
         promise.resolve_native(&response.content, can_gc);
     }
 }

--- a/components/script/dom/webgpu/gpucomputepipeline.rs
+++ b/components/script/dom/webgpu/gpucomputepipeline.rs
@@ -5,7 +5,10 @@
 use dom_struct::dom_struct;
 use ipc_channel::ipc::IpcSender;
 use webgpu::wgc::pipeline::ComputePipelineDescriptor;
-use webgpu::{WebGPU, WebGPUBindGroupLayout, WebGPUComputePipeline, WebGPURequest, WebGPUResponse};
+use webgpu::{
+    WebGPU, WebGPUBindGroupLayout, WebGPUComputePipeline, WebGPUComputePipelineResponse,
+    WebGPURequest,
+};
 
 use crate::conversions::Convert;
 use crate::dom::bindings::cell::DomRefCell;
@@ -76,7 +79,7 @@ impl GPUComputePipeline {
     pub(crate) fn create(
         device: &GPUDevice,
         descriptor: &GPUComputePipelineDescriptor,
-        async_sender: Option<IpcSender<WebGPUResponse>>,
+        async_sender: Option<IpcSender<WebGPUComputePipelineResponse>>,
     ) -> WebGPUComputePipeline {
         let compute_pipeline_id = device.global().wgpu_id_hub().create_compute_pipeline_id();
 

--- a/components/script/dom/webgpu/gpurenderpipeline.rs
+++ b/components/script/dom/webgpu/gpurenderpipeline.rs
@@ -5,7 +5,10 @@
 use dom_struct::dom_struct;
 use ipc_channel::ipc::IpcSender;
 use webgpu::wgc::pipeline::RenderPipelineDescriptor;
-use webgpu::{WebGPU, WebGPUBindGroupLayout, WebGPURenderPipeline, WebGPURequest, WebGPUResponse};
+use webgpu::{
+    WebGPU, WebGPUBindGroupLayout, WebGPURenderPipeline, WebGPURenderPipelineResponse,
+    WebGPURequest,
+};
 
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::GPURenderPipelineMethods;
@@ -74,7 +77,7 @@ impl GPURenderPipeline {
         device: &GPUDevice,
         pipeline_layout: PipelineLayout,
         descriptor: RenderPipelineDescriptor<'static>,
-        async_sender: Option<IpcSender<WebGPUResponse>>,
+        async_sender: Option<IpcSender<WebGPURenderPipelineResponse>>,
     ) -> Fallible<WebGPURenderPipeline> {
         let render_pipeline_id = device.global().wgpu_id_hub().create_render_pipeline_id();
 

--- a/components/shared/script/script_msg.rs
+++ b/components/shared/script/script_msg.rs
@@ -24,7 +24,7 @@ use servo_url::{ImmutableOrigin, ServoUrl};
 use strum_macros::IntoStaticStr;
 use style_traits::CSSPixel;
 #[cfg(feature = "webgpu")]
-use webgpu::{WebGPU, WebGPUResponse, wgc};
+use webgpu::{WebGPU, WebGPUAdapterResponse, wgc};
 use webrender_api::ImageKey;
 
 use crate::mem::MemoryReportResult;
@@ -204,7 +204,7 @@ pub enum ScriptMsg {
     #[cfg(feature = "webgpu")]
     /// Create a WebGPU Adapter instance
     RequestAdapter(
-        IpcSender<WebGPUResponse>,
+        IpcSender<WebGPUAdapterResponse>,
         wgc::instance::RequestAdapterOptions,
         wgc::id::AdapterId,
     ),

--- a/components/webgpu/ipc_messages/to_dom.rs
+++ b/components/webgpu/ipc_messages/to_dom.rs
@@ -12,7 +12,6 @@ use wgc::id;
 use wgc::pipeline::CreateShaderModuleError;
 use wgpu_core::device::HostMap;
 use wgpu_core::instance::{RequestAdapterError, RequestDeviceError};
-use wgpu_core::resource::BufferAccessError;
 pub use {wgpu_core as wgc, wgpu_types as wgt};
 
 use crate::identity::*;
@@ -82,23 +81,14 @@ pub struct Mapping {
     pub range: Range<u64>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
-#[allow(clippy::large_enum_variant)]
-pub enum WebGPUResponse {
-    /// WebGPU is disabled
-    None,
-    Adapter(Result<Adapter, RequestAdapterError>),
-    Device(
-        (
-            WebGPUDevice,
-            WebGPUQueue,
-            Result<wgt::DeviceDescriptor<Option<String>>, RequestDeviceError>,
-        ),
-    ),
-    BufferMapAsync(Result<Mapping, BufferAccessError>),
-    SubmittedWorkDone,
-    PoppedErrorScope(Result<Option<Error>, PopError>),
-    CompilationInfo(Option<ShaderCompilationInfo>),
-    RenderPipeline(Result<Pipeline<id::RenderPipelineId>, Error>),
-    ComputePipeline(Result<Pipeline<id::ComputePipelineId>, Error>),
-}
+pub type WebGPUDeviceResponse = (
+    WebGPUDevice,
+    WebGPUQueue,
+    Result<wgt::DeviceDescriptor<Option<String>>, RequestDeviceError>,
+);
+
+pub type WebGPUAdapterResponse = Option<Result<Adapter, RequestAdapterError>>;
+
+pub type WebGPUPoppedErrorScopeResponse = Result<Option<Error>, PopError>;
+pub type WebGPURenderPipelineResponse = Result<Pipeline<id::RenderPipelineId>, Error>;
+pub type WebGPUComputePipelineResponse = Result<Pipeline<id::ComputePipelineId>, Error>;


### PR DESCRIPTION
Using the RoutedPromiseListener let us define a different response types for each promise. This removes unreachable branches that used to exist when they all shared the same WebGPUResponse.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

