### PR TITLE
Fix the parsing error of PrefValue::Array

### DIFF
--- a/components/config/pref_util.rs
+++ b/components/config/pref_util.rs
@@ -43,8 +43,8 @@ impl TryFrom<&Value> for PrefValue {
                 .unwrap_or(Err("Could not parse number from JSON".into())),
             Value::String(value) => Ok(value.clone().into()),
             Value::Array(array) => {
-                let mut array = array.iter().map(TryInto::try_into);
-                if !array.all(|v| v.is_ok()) {
+                let array = array.iter().map(TryInto::try_into);
+                if !array.clone().all(|v| v.is_ok()) {
                     return Err(format!(
                         "Cannot turn all array avlues into preference: {array:?}"
                     ));


### PR DESCRIPTION
Fix the parsing error of PrefValue::Array, which is used for the parsing of Preferences shell_background_color_rgba field.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
