### PR TITLE
Implement FinalizationRegistry cleanup callbacks

### DIFF
--- a/components/script/dom/bindings/refcounted.rs
+++ b/components/script/dom/bindings/refcounted.rs
@@ -296,19 +296,18 @@ impl LiveDOMReferences {
         LIVE_REFERENCES.with(|r| {
             let r = r.borrow();
             let live_refs = r.as_ref().unwrap();
-            live_refs
-                .finalization_callback_table
-                .borrow_mut()
-                .push(callback);
+            let mut callback_table = live_refs.finalization_callback_table.borrow_mut();
+            callback_table.push(callback);
         })
     }
 
-    pub(crate) fn get_finalization_callback() -> Option<Box<Heap<*mut JSFunction>>> {
+    // We Box the values because the values cannot be moved around under the GC
+    #[allow(clippy::vec_box)]
+    pub(crate) fn get_finalization_callbacks() -> Vec<Box<Heap<*mut JSFunction>>> {
         LIVE_REFERENCES.with(|r| {
             let r = r.borrow();
             let live_refs = r.as_ref().unwrap();
-            let cb = live_refs.finalization_callback_table.borrow_mut().pop();
-            cb
+            live_refs.finalization_callback_table.replace(Vec::new())
         })
     }
 }

--- a/components/script/dom/bindings/refcounted.rs
+++ b/components/script/dom/bindings/refcounted.rs
@@ -30,7 +30,8 @@ use std::marker::PhantomData;
 use std::rc::Rc;
 use std::sync::{Arc, Weak};
 
-use js::jsapi::JSTracer;
+use js::jsapi::{Heap, JSFunction, JSTracer};
+use js::rust::Trace;
 use script_bindings::script_runtime::CanGc;
 
 use crate::dom::bindings::conversions::ToJSValConvertible;
@@ -232,6 +233,9 @@ pub(crate) struct LiveDOMReferences {
     // keyed on pointer to Rust DOM object
     reflectable_table: RefCell<HashMap<*const libc::c_void, Weak<TrustedReference>>>,
     promise_table: RefCell<HashMap<*const Promise, Vec<Rc<Promise>>>>,
+    // We need to Box the values to prevent them from being moved
+    #[allow(clippy::vec_box)]
+    finalization_callback_table: RefCell<Vec<Box<Heap<*mut JSFunction>>>>,
 }
 
 impl LiveDOMReferences {
@@ -241,6 +245,7 @@ impl LiveDOMReferences {
             *r.borrow_mut() = Some(LiveDOMReferences {
                 reflectable_table: RefCell::new(HashMap::new()),
                 promise_table: RefCell::new(HashMap::new()),
+                finalization_callback_table: RefCell::new(Vec::new()),
             })
         });
     }
@@ -286,6 +291,26 @@ impl LiveDOMReferences {
             },
         }
     }
+
+    pub(crate) fn enqueue_finalization_callback(callback: Box<Heap<*mut JSFunction>>) {
+        LIVE_REFERENCES.with(|r| {
+            let r = r.borrow();
+            let live_refs = r.as_ref().unwrap();
+            live_refs
+                .finalization_callback_table
+                .borrow_mut()
+                .push(callback);
+        })
+    }
+
+    pub(crate) fn get_finalization_callback() -> Option<Box<Heap<*mut JSFunction>>> {
+        LIVE_REFERENCES.with(|r| {
+            let r = r.borrow();
+            let live_refs = r.as_ref().unwrap();
+            let cb = live_refs.finalization_callback_table.borrow_mut().pop();
+            cb
+        })
+    }
 }
 
 /// Remove null entries from the live references table
@@ -321,6 +346,13 @@ pub(crate) unsafe fn trace_refcounted_objects(tracer: *mut JSTracer) {
             let table = live_references.promise_table.borrow_mut();
             for promise in table.keys() {
                 trace_reflector(tracer, "refcounted", (**promise).reflector());
+            }
+        }
+
+        {
+            let callbacks = live_references.finalization_callback_table.borrow_mut();
+            for callback in callbacks.iter() {
+                callback.trace(tracer);
             }
         }
     });

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -374,6 +374,9 @@ pub(crate) struct GlobalScope {
     #[ignore_malloc_size_of = "Rc<T> is hard"]
     notification_permission_request_callback_map:
         DomRefCell<HashMap<String, Rc<NotificationPermissionCallback>>>,
+
+    /// Tracks whether there is a FinalizationRegistry cleanup callback task queued
+    has_finalization_task_queued: Cell<bool>,
 }
 
 /// A wrapper for glue-code between the ipc router and the event-loop.
@@ -766,6 +769,7 @@ impl GlobalScope {
             byte_length_queuing_strategy_size_function: OnceCell::new(),
             count_queuing_strategy_size_function: OnceCell::new(),
             notification_permission_request_callback_map: Default::default(),
+            has_finalization_task_queued: Default::default(),
         }
     }
 
@@ -3310,6 +3314,14 @@ impl GlobalScope {
             return worker.TrustedTypes(can_gc);
         }
         unreachable!();
+    }
+
+    pub(crate) fn set_has_finalization_callback_queued(&self, is_queued: bool) {
+        self.has_finalization_task_queued.set(is_queued);
+    }
+
+    pub(crate) fn get_has_finalization_callback_queued(&self) -> bool {
+        self.has_finalization_task_queued.get()
     }
 }
 

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -30,20 +30,21 @@ use js::glue::{
 use js::jsapi::{
     AsmJSOption, BuildIdCharVector, ContextOptionsRef, DisableIncrementalGC,
     Dispatchable as JSRunnable, Dispatchable_MaybeShuttingDown, GCDescription, GCOptions,
-    GCProgress, GCReason, GetPromiseUserInputEventHandlingState, HandleObject, HandleString, Heap,
-    InitConsumeStreamCallback, InitDispatchToEventLoop, JS_AddExtraGCRootsTracer,
-    JS_InitDestroyPrincipalsCallback, JS_InitReadPrincipalsCallback, JS_SetGCCallback,
-    JS_SetGCParameter, JS_SetGlobalJitCompilerOption, JS_SetOffthreadIonCompilationEnabled,
-    JS_SetParallelParsingEnabled, JS_SetSecurityCallbacks, JSContext as RawJSContext, JSGCParamKey,
-    JSGCStatus, JSJitCompilerOption, JSObject, JSSecurityCallbacks, JSTracer, JobQueue, MimeType,
-    PromiseRejectionHandlingState, PromiseUserInputEventHandlingState, RuntimeCode,
-    SetDOMCallbacks, SetGCSliceCallback, SetJobQueue, SetPreserveWrapperCallbacks,
+    GCProgress, GCReason, GetPromiseUserInputEventHandlingState, HandleObject, HandleString,
+    HandleValueArray, Heap, InitConsumeStreamCallback, InitDispatchToEventLoop,
+    JS_AddExtraGCRootsTracer, JS_InitDestroyPrincipalsCallback, JS_InitReadPrincipalsCallback,
+    JS_SetGCCallback, JS_SetGCParameter, JS_SetGlobalJitCompilerOption,
+    JS_SetOffthreadIonCompilationEnabled, JS_SetParallelParsingEnabled, JS_SetSecurityCallbacks,
+    JSContext as RawJSContext, JSFunction, JSGCParamKey, JSGCStatus, JSJitCompilerOption, JSObject,
+    JSSecurityCallbacks, JSTracer, JobQueue, MimeType, PromiseRejectionHandlingState,
+    PromiseUserInputEventHandlingState, RuntimeCode, SetDOMCallbacks, SetGCSliceCallback,
+    SetHostCleanupFinalizationRegistryCallback, SetJobQueue, SetPreserveWrapperCallbacks,
     SetProcessBuildIdOp, SetPromiseRejectionTrackerCallback, StreamConsumer as JSStreamConsumer,
 };
 use js::jsval::UndefinedValue;
 use js::panic::wrap_panic;
 pub(crate) use js::rust::ThreadSafeJSContext;
-use js::rust::wrappers::{GetPromiseIsHandled, JS_GetPromiseResult};
+use js::rust::wrappers::{GetPromiseIsHandled, JS_CallFunction, JS_GetPromiseResult};
 use js::rust::{
     Handle, HandleObject as RustHandleObject, IntoHandle, JSEngine, JSEngineHandle, ParentRuntime,
     Runtime as RustRuntime, describe_scripted_caller,
@@ -365,6 +366,37 @@ unsafe extern "C" fn promise_rejection_tracker(
 }
 
 #[allow(unsafe_code)]
+#[cfg_attr(crown, allow(crown::unrooted_must_root))]
+/// <https://tc39.es/proposal-weakrefs/#sec-host-cleanup-finalization-registry>
+unsafe extern "C" fn cleanup_finalization_registry(
+    do_cleanup: *mut JSFunction,
+    incumbent_global: *mut JSObject,
+    data: *mut c_void,
+) {
+    log::debug!("Finalization Registry Callback being queued");
+    LiveDOMReferences::enqueue_finalization_callback(Heap::boxed(do_cleanup));
+    let global = GlobalScope::from_object(incumbent_global);
+    // TODO: For perf reasons I believe we should actually only queue a task if this is the first
+    // callback we added for this global and then call all the callbacks queued for it at once.
+    global.task_manager()
+        .finalization_task_source()
+        .queue(task!(run_cleanup_callbacks: move || {
+            let cx = GlobalScope::get_cx();
+            rooted!(in(*cx) let mut undef = UndefinedValue());
+            let callback = LiveDOMReferences::get_finalization_callback();
+            match callback {
+                None => (),
+                Some(cb) => {
+                    rooted!(in(*cx) let mut rcb = cb.get());
+                    let ok = JS_CallFunction(*cx, RustHandleObject::null(), rcb.handle(), &HandleValueArray::empty(), undef.handle_mut());
+                    log::debug!("Finalization Registry Cleanup called");
+                    // TODO: we are supposed to raise an error event if we get an abrupt completion
+                }
+            }
+        }));
+}
+
+#[allow(unsafe_code)]
 unsafe extern "C" fn content_security_policy_allows(
     cx: *mut RawJSContext,
     runtime_code: RuntimeCode,
@@ -609,6 +641,13 @@ impl Runtime {
         );
         SetJobQueue(cx, job_queue);
         SetPromiseRejectionTrackerCallback(cx, Some(promise_rejection_tracker), ptr::null_mut());
+
+        log::debug!("Setting up finalization registry cleanup callback handler");
+        SetHostCleanupFinalizationRegistryCallback(
+            cx,
+            Some(cleanup_finalization_registry),
+            cx as *const _ as *mut c_void,
+        );
 
         EnsureModuleHooksInitialized(runtime.rt());
 

--- a/components/script/task_manager.rs
+++ b/components/script/task_manager.rs
@@ -135,7 +135,7 @@ impl TaskManager {
     task_source_functions!(self, canvas_blob_task_source, Canvas);
     task_source_functions!(self, dom_manipulation_task_source, DOMManipulation);
     task_source_functions!(self, file_reading_task_source, FileReading);
-    task_source_functions!(self, finalization_task_source, FinalizationRegistry);
+    task_source_functions!(self, javascript_engine_task_source, JavaScriptEngine);
     task_source_functions!(self, font_loading_task_source, FontLoading);
     task_source_functions!(self, gamepad_task_source, Gamepad);
     task_source_functions!(self, media_element_task_source, MediaElement);

--- a/components/script/task_manager.rs
+++ b/components/script/task_manager.rs
@@ -135,6 +135,7 @@ impl TaskManager {
     task_source_functions!(self, canvas_blob_task_source, Canvas);
     task_source_functions!(self, dom_manipulation_task_source, DOMManipulation);
     task_source_functions!(self, file_reading_task_source, FileReading);
+    task_source_functions!(self, finalization_task_source, FinalizationRegistry);
     task_source_functions!(self, font_loading_task_source, FontLoading);
     task_source_functions!(self, gamepad_task_source, Gamepad);
     task_source_functions!(self, media_element_task_source, MediaElement);

--- a/components/script/task_source.rs
+++ b/components/script/task_source.rs
@@ -42,7 +42,7 @@ pub(crate) enum TaskSourceName {
     Gamepad,
     /// <https://w3c.github.io/IntersectionObserver/#intersectionobserver-task-source>
     IntersectionObserver,
-    FinalizationRegistry,
+    JavaScriptEngine,
 }
 
 impl From<TaskSourceName> for ScriptThreadEventCategory {
@@ -66,7 +66,7 @@ impl From<TaskSourceName> for ScriptThreadEventCategory {
             TaskSourceName::Timer => ScriptThreadEventCategory::TimerEvent,
             TaskSourceName::Gamepad => ScriptThreadEventCategory::InputEvent,
             TaskSourceName::IntersectionObserver => ScriptThreadEventCategory::ScriptEvent,
-            TaskSourceName::FinalizationRegistry => ScriptThreadEventCategory::ScriptEvent,
+            TaskSourceName::JavaScriptEngine => ScriptThreadEventCategory::ScriptEvent,
         }
     }
 }

--- a/components/script/task_source.rs
+++ b/components/script/task_source.rs
@@ -42,6 +42,7 @@ pub(crate) enum TaskSourceName {
     Gamepad,
     /// <https://w3c.github.io/IntersectionObserver/#intersectionobserver-task-source>
     IntersectionObserver,
+    FinalizationRegistry,
 }
 
 impl From<TaskSourceName> for ScriptThreadEventCategory {
@@ -65,6 +66,7 @@ impl From<TaskSourceName> for ScriptThreadEventCategory {
             TaskSourceName::Timer => ScriptThreadEventCategory::TimerEvent,
             TaskSourceName::Gamepad => ScriptThreadEventCategory::InputEvent,
             TaskSourceName::IntersectionObserver => ScriptThreadEventCategory::ScriptEvent,
+            TaskSourceName::FinalizationRegistry => ScriptThreadEventCategory::ScriptEvent,
         }
     }
 }

--- a/tests/wpt/meta/js/builtins/weakrefs/finalizationregistry-cleanupCallback-gets-a-microtask.optional.any.js.ini
+++ b/tests/wpt/meta/js/builtins/weakrefs/finalizationregistry-cleanupCallback-gets-a-microtask.optional.any.js.ini
@@ -1,8 +1,0 @@
-[finalizationregistry-cleanupCallback-gets-a-microtask.optional.any.worker.html]
-  [HostCleanupFinalizationRegistry is an implementation-defined abstract operation that is expected to call CleanupFinalizationRegistry(finalizationRegistry) at some point in the future, if possible.]
-    expected: FAIL
-
-
-[finalizationregistry-cleanupCallback-gets-a-microtask.optional.any.html]
-  [HostCleanupFinalizationRegistry is an implementation-defined abstract operation that is expected to call CleanupFinalizationRegistry(finalizationRegistry) at some point in the future, if possible.]
-    expected: FAIL


### PR DESCRIPTION
FinalizationRegistry is exposed by default in SpiderMonkey now that Servo is using ESR 128 but Servo still needs to register to receive and queue FinalizationRegistry cleanup callbacks.

SpiderMonkey does not support `FinalizationRegistry.cleanupSome` so most of the `js/builtins/weakrefs` WPT tests will continue to fail.

I'm not 100% sure that I am using `LiveDOMReferences` correctly for this use but it was what @jdm suggested on Zulip. 
I am not sure if:
1) I will need to key the callbacks on the global scope
2) that I am tracing the values correctly
3) if I am going to need to filter out callbacks when a global scope is killed (if thats even possible without LiveDOMReferences getting cleaned up).

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #31072 
- [X] There are tests for these changes
