### PR TITLE
Show correctly computed element display type in devtools

### DIFF
--- a/components/devtools/actors/inspector/node.rs
+++ b/components/devtools/actors/inspector/node.rs
@@ -244,7 +244,7 @@ impl NodeInfoToProtocol for NodeInfo {
             causes_overflow: false,
             container_type: None,
             display_name: self.node_name.clone().to_lowercase(),
-            display_type: Some("block".into()),
+            display_type: self.display,
             inline_text_child,
             is_after_pseudo_element: false,
             is_anonymous: false,

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -52,6 +52,7 @@ use crate::document_loader::DocumentLoader;
 use crate::dom::attr::Attr;
 use crate::dom::bindings::cell::{DomRefCell, Ref, RefMut};
 use crate::dom::bindings::codegen::Bindings::AttrBinding::AttrMethods;
+use crate::dom::bindings::codegen::Bindings::CSSStyleDeclarationBinding::CSSStyleDeclarationMethods;
 use crate::dom::bindings::codegen::Bindings::CharacterDataBinding::CharacterDataMethods;
 use crate::dom::bindings::codegen::Bindings::DocumentBinding::DocumentMethods;
 use crate::dom::bindings::codegen::Bindings::ElementBinding::ElementMethods;
@@ -1207,6 +1208,12 @@ impl Node {
             self.ChildNodes().Length() as usize
         };
 
+        let window = self.owner_window();
+        let display = self
+            .downcast::<Element>()
+            .map(|elem| window.GetComputedStyle(elem, None))
+            .map(|style| style.Display().into());
+
         NodeInfo {
             unique_id: self.unique_id(),
             host,
@@ -1222,6 +1229,7 @@ impl Node {
             attrs: self.downcast().map(Element::summarize).unwrap_or(vec![]),
             is_shadow_host,
             shadow_root_mode,
+            display,
         }
     }
 

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -139,6 +139,7 @@ pub struct NodeInfo {
     pub is_top_level_document: bool,
     pub shadow_root_mode: Option<ShadowRootMode>,
     pub is_shadow_host: bool,
+    pub display: Option<String>,
 }
 
 pub struct StartedTimelineMarker {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Fixes an issue where devtools report all elements have block display. Implementation follows suggestions in #35296. Happy to take feedback on any improvements.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #35296 
- [ ] These changes do not require tests because ___

Unsure if tests are required for this one. Please point me in the right direction if I need to add something.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

Example with display badges

<img width="1982" alt="Screenshot 2025-03-09 at 7 24 20 PM" src="https://github.com/user-attachments/assets/71a03cf4-e325-47c6-8c6e-89d4f2d84d32" />
