### PR TITLE
Don't run scripts in documents that don't have a browsing context

### DIFF
--- a/components/script/dom/servoparser/async_html.rs
+++ b/components/script/dom/servoparser/async_html.rs
@@ -267,6 +267,7 @@ impl Tokenizer {
         // Create new thread for HtmlTokenizer. This is where parser actions
         // will be generated from the input provided. These parser actions are then passed
         // onto the main thread to be executed.
+        let scripting_enabled = document.has_browsing_context();
         thread::Builder::new()
             .name(format!("Parse:{}", tokenizer.url.debug_compact()))
             .spawn(move || {
@@ -277,6 +278,7 @@ impl Tokenizer {
                     form_parse_node,
                     to_tokenizer_sender,
                     html_tokenizer_receiver,
+                    scripting_enabled,
                 );
             })
             .expect("HTML Parser thread spawning failed");
@@ -573,9 +575,11 @@ fn run(
     form_parse_node: Option<ParseNode>,
     sender: Sender<ToTokenizerMsg>,
     receiver: Receiver<ToHtmlTokenizerMsg>,
+    scripting_enabled: bool,
 ) {
     let options = TreeBuilderOpts {
         ignore_missing_rules: true,
+        scripting_enabled,
         ..Default::default()
     };
 

--- a/components/script/dom/servoparser/html.rs
+++ b/components/script/dom/servoparser/html.rs
@@ -56,6 +56,7 @@ impl Tokenizer {
 
         let options = TreeBuilderOpts {
             ignore_missing_rules: true,
+            scripting_enabled: document.has_browsing_context(),
             ..Default::default()
         };
 

--- a/tests/wpt/meta/domparsing/DOMParser-parseFromString-html.html.ini
+++ b/tests/wpt/meta/domparsing/DOMParser-parseFromString-html.html.ini
@@ -1,3 +1,0 @@
-[DOMParser-parseFromString-html.html]
-  [must be parsed with scripting disabled, so noscript works]
-    expected: FAIL

--- a/tests/wpt/meta/html/syntax/parsing-html-fragments/tokenizer-modes-001.html.ini
+++ b/tests/wpt/meta/html/syntax/parsing-html-fragments/tokenizer-modes-001.html.ini
@@ -1,0 +1,3 @@
+[tokenizer-modes-001.html]
+  [</noscript> should not break out of noscript.]
+    expected: FAIL


### PR DESCRIPTION
This is the same as #35848 because GitHub apparently won't let me re-open a pull request after I've force pushed the branch (Apologies for the noise :/ ).

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes (covered by wpt)

