### PR TITLE
Register iframes with the devtools

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -4025,6 +4025,7 @@ where
                 let page_info = DevtoolsPageInfo {
                     title: new_pipeline.title.clone(),
                     url: new_pipeline.url.clone(),
+                    is_top_level_global: top_level_id == browsing_context_id,
                 };
                 let state = NavigationState::Stop(new_pipeline.id, page_info);
                 let _ = chan.send(DevtoolsControlMsg::FromScript(

--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -180,7 +180,11 @@ impl BrowsingContextActor {
         actors: &mut ActorRegistry,
     ) -> BrowsingContextActor {
         let name = actors.new_name("target");
-        let DevtoolsPageInfo { title, url } = page_info;
+        let DevtoolsPageInfo {
+            title,
+            url,
+            is_top_level_global,
+        } = page_info;
 
         let accessibility = AccessibilityActor::new(actors.new_name("accessibility"));
 
@@ -205,7 +209,7 @@ impl BrowsingContextActor {
 
         let style_sheets = StyleSheetsActor::new(actors.new_name("stylesheets"));
 
-        let tabdesc = TabDescriptorActor::new(actors, name.clone());
+        let tabdesc = TabDescriptorActor::new(actors, name.clone(), is_top_level_global);
 
         let thread = ThreadActor::new(actors.new_name("thread"));
 

--- a/components/devtools/actors/root.rs
+++ b/components/devtools/actors/root.rs
@@ -200,10 +200,14 @@ impl Actor for RootActor {
                     tabs: self
                         .tabs
                         .iter()
-                        .map(|target| {
-                            registry
-                                .find::<TabDescriptorActor>(target)
-                                .encodable(registry, false)
+                        .filter_map(|target| {
+                            let tab_actor = registry.find::<TabDescriptorActor>(target);
+                            // Filter out iframes and workers
+                            if tab_actor.is_top_level_global() {
+                                Some(tab_actor.encodable(registry, false))
+                            } else {
+                                None
+                            }
                         })
                         .collect(),
                 };

--- a/components/devtools/actors/tab.rs
+++ b/components/devtools/actors/tab.rs
@@ -65,6 +65,7 @@ struct GetWatcherReply {
 pub struct TabDescriptorActor {
     name: String,
     browsing_context_actor: String,
+    is_top_level_global: bool,
 }
 
 impl Actor for TabDescriptorActor {
@@ -125,6 +126,7 @@ impl TabDescriptorActor {
     pub(crate) fn new(
         actors: &mut ActorRegistry,
         browsing_context_actor: String,
+        is_top_level_global: bool,
     ) -> TabDescriptorActor {
         let name = actors.new_name("tab-description");
         let root = actors.find_mut::<RootActor>("root");
@@ -132,6 +134,7 @@ impl TabDescriptorActor {
         TabDescriptorActor {
             name,
             browsing_context_actor,
+            is_top_level_global,
         }
     }
 
@@ -156,5 +159,9 @@ impl TabDescriptorActor {
             },
             url,
         }
+    }
+
+    pub(crate) fn is_top_level_global(&self) -> bool {
+        self.is_top_level_global
     }
 }

--- a/components/script/dom/worker.rs
+++ b/components/script/dom/worker.rs
@@ -204,6 +204,7 @@ impl WorkerMethods<crate::DomTypeHolder> for Worker {
                 let page_info = DevtoolsPageInfo {
                     title,
                     url: worker_url.clone(),
+                    is_top_level_global: false,
                 };
                 let _ = chan.send(ScriptToDevtoolsControlMsg::NewGlobal(
                     (browsing_context, pipeline_id, Some(worker_id)),

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3238,13 +3238,14 @@ impl ScriptThread {
             .unwrap();
 
         // Notify devtools that a new script global exists.
-        if incomplete.top_level_browsing_context_id.0 == incomplete.browsing_context_id {
-            self.notify_devtools(
-                document.Title(),
-                final_url.clone(),
-                (incomplete.browsing_context_id, incomplete.pipeline_id, None),
-            );
-        }
+        let is_top_level_global =
+            incomplete.top_level_browsing_context_id.0 == incomplete.browsing_context_id;
+        self.notify_devtools(
+            document.Title(),
+            final_url.clone(),
+            is_top_level_global,
+            (incomplete.browsing_context_id, incomplete.pipeline_id, None),
+        );
 
         document.set_https_state(metadata.https_state);
         document.set_navigation_start(incomplete.navigation_start);
@@ -3272,12 +3273,14 @@ impl ScriptThread {
         &self,
         title: DOMString,
         url: ServoUrl,
+        is_top_level_global: bool,
         (bc, p, w): (BrowsingContextId, PipelineId, Option<WorkerId>),
     ) {
         if let Some(ref chan) = self.senders.devtools_server_sender {
             let page_info = DevtoolsPageInfo {
                 title: String::from(title),
                 url,
+                is_top_level_global,
             };
             chan.send(ScriptToDevtoolsControlMsg::NewGlobal(
                 (bc, p, w),

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -32,6 +32,7 @@ use uuid::Uuid;
 pub struct DevtoolsPageInfo {
     pub title: String,
     pub url: ServoUrl,
+    pub is_top_level_global: bool,
 }
 
 #[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]


### PR DESCRIPTION
Previously, the devtools didn't know about<iframe>s. 
They either ignored messages coming from iframes or crashed.

This reverts https://github.com/servo/servo/pull/34032 and then filters out non-tab globals in the "listTabs" message to the root actor to ensure that iframes and workers don't show up in the devtools tab list.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #34816
- [X] These changes do not require tests because we don't have devtools tests