### PR TITLE
layout: Only prevent fixed table layout when `inline-size` is `auto`

### DIFF
--- a/components/layout_2020/table/layout.rs
+++ b/components/layout_2020/table/layout.rs
@@ -240,15 +240,11 @@ impl Zero for CellOrTrackMeasure {
 
 impl<'a> TableLayout<'a> {
     fn new(table: &'a Table) -> TableLayout<'a> {
-        // It's not clear whether `inline-size: stretch` allows fixed table mode or not,
-        // we align with Gecko and Blink.
-        // <https://github.com/w3c/csswg-drafts/issues/10937>.
-        let is_in_fixed_mode = table.style.get_table().clone_table_layout() ==
-            TableLayoutMode::Fixed &&
-            !matches!(
-                table.style.box_size(table.style.writing_mode).inline,
-                Size::Initial | Size::MaxContent
-            );
+        // The CSSWG resolved that only `inline-size: auto` can prevent fixed table mode.
+        // <https://github.com/w3c/csswg-drafts/issues/10937#issuecomment-2669150397>
+        let style = &table.style;
+        let is_in_fixed_mode = style.get_table().table_layout == TableLayoutMode::Fixed &&
+            !style.box_size(style.writing_mode).inline.is_initial();
         Self {
             table,
             pbm: PaddingBorderMargin::zero(),

--- a/tests/wpt/meta/css/css-tables/fixed-layout-2.html.ini
+++ b/tests/wpt/meta/css/css-tables/fixed-layout-2.html.ini
@@ -1,3 +1,0 @@
-[fixed-layout-2.html]
-  [max-content]
-    expected: FAIL

--- a/tests/wpt/tests/css/css-tables/fixed-layout-2.html
+++ b/tests/wpt/tests/css/css-tables/fixed-layout-2.html
@@ -3,6 +3,7 @@
 <link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-tables-3/#in-fixed-mode">
 <link rel="help" href="https://github.com/w3c/csswg-drafts/issues/10937">
+<meta name="assert" content="Fixed table layout is triggered except when inline-size is auto.">
 <link rel="stylesheet" href="./support/base.css">
 
 <style>
@@ -52,26 +53,25 @@ x-td > div {
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
-let sizeData = {
-  "10px": true,
-  "100%": true,
-  "calc(10px + 100%)": true,
-  "auto": false,
-  "min-content": true,
-  "max-content": true,
-  "fit-content": true,
-  "calc-size(any, 10px + 100%)": true,
+let sizes = [
+  "10px",
+  "100%",
+  "calc(10px + 100%)",
+  "auto",
+  "min-content",
+  "max-content",
+  "fit-content",
+  "calc-size(any, 10px + 100%)",
+  "fit-content(0)",
+  "stretch",
+  "contain",
 
-  // These expectations are tentative, see https://github.com/w3c/csswg-drafts/issues/10937
-  "fit-content(0)": true,
-  "stretch": true,
-
-  // These are non-standard, expect the most popular behavior among the supporting implementations.
-  "-moz-available": true,
-  "-webkit-fill-available": true,
-  "intrinsic": true,
-  "min-intrinsic": true,
-};
+  // These are non-standard sizes.
+  "-moz-available",
+  "-webkit-fill-available",
+  "intrinsic",
+  "min-intrinsic",
+];
 
 function checkSize(size, allowsFixed) {
   let fragment = template.content.cloneNode(true);
@@ -101,8 +101,9 @@ function checkSize(size, allowsFixed) {
   }, size);
 }
 
-for (let [size, allowsFixed] of Object.entries(sizeData)) {
+for (let size of sizes) {
   if (CSS.supports("width", size)) {
+    let allowsFixed = size !== "auto";
     checkSize(size, allowsFixed);
 
     // calc-size() should trigger fixed table layout.


### PR DESCRIPTION
We were ignoring `table-layout: fixed` both for `inline-size: auto` and `inline-size: max-content`. However, the CSSWG resolved that fixed table layout should be triggered except when `inline-size` is `auto`. https://github.com/w3c/csswg-drafts/issues/10937#issuecomment-2669150397

Blink has already adopted this change, and they modified the WPT `/css/css-tables/fixed-layout-2.html` accordingly. Here I'm doing some further cosmetic cleanups to the test.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
