### PR TITLE
devtools: Fix DevTools failing to respond when inspecting multiple tabs

### DIFF
--- a/components/devtools/actors/tab.rs
+++ b/components/devtools/actors/tab.rs
@@ -140,7 +140,8 @@ impl TabDescriptorActor {
 
     pub fn encodable(&self, registry: &ActorRegistry, selected: bool) -> TabDescriptorActorMsg {
         let ctx_actor = registry.find::<BrowsingContextActor>(&self.browsing_context_actor);
-        let browser_id = ctx_actor.active_pipeline.get().index.0.get();
+        let browser_id = ctx_actor.browsing_context_id.index.0.get();
+        let outer_window_id = ctx_actor.active_pipeline.get().index.0.get();
         let browsing_context_id = ctx_actor.browsing_context_id.index.0.get();
         let title = ctx_actor.title.borrow().clone();
         let url = ctx_actor.url.borrow().clone();
@@ -150,7 +151,7 @@ impl TabDescriptorActor {
             browsing_context_id,
             browser_id,
             is_zombie_tab: false,
-            outer_window_id: browser_id,
+            outer_window_id,
             selected,
             title,
             traits: DescriptorTraits {


### PR DESCRIPTION
Currently, DevTools fails to respond when multiple tabs are open. This can also happen if you have a single tab open but then open a different one in the same tab. This issue occurs because we are using `active_pipeline` as the `browser_id`.

Every time we navigate, `active_pipeline` (also known as `pipeline_id` in some parts of the codebase) gets updated, while `browser_id` remains the same for a tab. This PR uses `browser_context_id` for `browser_id`, which aligns with what servo sends to the client. `outer_window_id` is `active_pipeline`, which is correct. Initially, we were using `active_pipeline` for `browser_id`,  which caused the bug.


Signed-off-by: atbrakhi <atbrakhi@igalia.com>

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #35879 
