### PR TITLE
Use explicit reborrows with mozjs::MutableHandle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -520,7 +520,7 @@ dependencies = [
  "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "regex",
@@ -1065,7 +1065,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2013,7 +2013,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2539,7 +2539,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3999,7 +3999,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi 0.5.0",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4682,11 +4682,10 @@ dependencies = [
 [[package]]
 name = "mozjs"
 version = "0.14.1"
-source = "git+https://github.com/servo/mozjs#87cabf4e9ddf9fafe19713a3d6bc8c5e6105544c"
+source = "git+https://github.com/servo/mozjs#26c35182c1b2b7fb2fbfa93b82669533d92c3a60"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
- "lazy_static",
  "libc",
  "log",
  "mozjs_sys",
@@ -4694,8 +4693,8 @@ dependencies = [
 
 [[package]]
 name = "mozjs_sys"
-version = "0.128.6-1"
-source = "git+https://github.com/servo/mozjs#87cabf4e9ddf9fafe19713a3d6bc8c5e6105544c"
+version = "0.128.9-0"
+source = "git+https://github.com/servo/mozjs#26c35182c1b2b7fb2fbfa93b82669533d92c3a60"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -6170,7 +6169,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7505,7 +7504,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8813,7 +8812,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/components/script/dom/bindings/buffer_source.rs
+++ b/components/script/dom/bindings/buffer_source.rs
@@ -626,7 +626,9 @@ pub(crate) fn create_buffer_source<T>(
 where
     T: TypedArrayElement + TypedArrayElementCreator,
 {
-    let res = unsafe { TypedArray::<T, *mut JSObject>::create(*cx, CreateWith::Slice(data), dest.reborrow()) };
+    let res = unsafe {
+        TypedArray::<T, *mut JSObject>::create(*cx, CreateWith::Slice(data), dest.reborrow())
+    };
 
     if res.is_err() {
         Err(())
@@ -644,7 +646,9 @@ fn create_buffer_source_with_length<T>(
 where
     T: TypedArrayElement + TypedArrayElementCreator,
 {
-    let res = unsafe { TypedArray::<T, *mut JSObject>::create(*cx, CreateWith::Length(len), dest.reborrow()) };
+    let res = unsafe {
+        TypedArray::<T, *mut JSObject>::create(*cx, CreateWith::Length(len), dest.reborrow())
+    };
 
     if res.is_err() {
         Err(())

--- a/components/script/dom/bindings/buffer_source.rs
+++ b/components/script/dom/bindings/buffer_source.rs
@@ -620,13 +620,13 @@ unsafe impl<T> crate::dom::bindings::trace::JSTraceable for HeapBufferSource<T> 
 pub(crate) fn create_buffer_source<T>(
     cx: JSContext,
     data: &[T::Element],
-    dest: MutableHandleObject,
+    mut dest: MutableHandleObject,
     _can_gc: CanGc,
 ) -> Result<TypedArray<T, *mut JSObject>, ()>
 where
     T: TypedArrayElement + TypedArrayElementCreator,
 {
-    let res = unsafe { TypedArray::<T, *mut JSObject>::create(*cx, CreateWith::Slice(data), dest) };
+    let res = unsafe { TypedArray::<T, *mut JSObject>::create(*cx, CreateWith::Slice(data), dest.reborrow()) };
 
     if res.is_err() {
         Err(())
@@ -638,13 +638,13 @@ where
 fn create_buffer_source_with_length<T>(
     cx: JSContext,
     len: usize,
-    dest: MutableHandleObject,
+    mut dest: MutableHandleObject,
     _can_gc: CanGc,
 ) -> Result<TypedArray<T, *mut JSObject>, ()>
 where
     T: TypedArrayElement + TypedArrayElementCreator,
 {
-    let res = unsafe { TypedArray::<T, *mut JSObject>::create(*cx, CreateWith::Length(len), dest) };
+    let res = unsafe { TypedArray::<T, *mut JSObject>::create(*cx, CreateWith::Length(len), dest.reborrow()) };
 
     if res.is_err() {
         Err(())

--- a/components/script/dom/bindings/frozenarray.rs
+++ b/components/script/dom/bindings/frozenarray.rs
@@ -36,7 +36,7 @@ impl CachedFrozenArray {
         }
 
         let array = f();
-        to_frozen_array(array.as_slice(), cx, retval, can_gc);
+        to_frozen_array(array.as_slice(), cx, retval.reborrow(), can_gc);
 
         // Safety: need to create the Heap value in its final memory location before setting it.
         *self.frozen_value.borrow_mut() = Some(Heap::default());

--- a/components/script/dom/bindings/interface.rs
+++ b/components/script/dom/bindings/interface.rs
@@ -241,7 +241,7 @@ pub(crate) fn create_interface_prototype_object(
     regular_properties: &[Guard<&'static [JSPropertySpec]>],
     constants: &[Guard<&[ConstantSpec]>],
     unscopable_names: &[&CStr],
-    rval: MutableHandleObject,
+    mut rval: MutableHandleObject,
 ) {
     create_object(
         cx,
@@ -251,7 +251,7 @@ pub(crate) fn create_interface_prototype_object(
         regular_methods,
         regular_properties,
         constants,
-        rval,
+        rval.reborrow(),
     );
 
     if !unscopable_names.is_empty() {
@@ -289,7 +289,7 @@ pub(crate) fn create_noncallback_interface_object(
     name: &CStr,
     length: u32,
     legacy_window_alias_names: &[&CStr],
-    rval: MutableHandleObject,
+    mut rval: MutableHandleObject,
 ) {
     create_object(
         cx,
@@ -299,7 +299,7 @@ pub(crate) fn create_noncallback_interface_object(
         static_methods,
         static_properties,
         constants,
-        rval,
+        rval.reborrow(),
     );
     unsafe {
         assert!(JS_LinkConstructorAndPrototype(
@@ -694,7 +694,7 @@ pub(crate) fn get_desired_proto(
                 global.handle(),
                 ProtoOrIfaceIndex::ID(proto_id),
                 creator,
-                desired_proto,
+                desired_proto.reborrow(),
             );
             if desired_proto.is_null() {
                 return Err(());

--- a/components/script/dom/bindings/namespace.rs
+++ b/components/script/dom/bindings/namespace.rs
@@ -47,6 +47,15 @@ pub(crate) fn create_namespace_object(
     name: &CStr,
     mut rval: MutableHandleObject,
 ) {
-    create_object(cx, global, proto, &class.0, methods, &[], constants, rval.reborrow());
+    create_object(
+        cx,
+        global,
+        proto,
+        &class.0,
+        methods,
+        &[],
+        constants,
+        rval.reborrow(),
+    );
     define_on_global_object(cx, global, name, rval.handle());
 }

--- a/components/script/dom/bindings/namespace.rs
+++ b/components/script/dom/bindings/namespace.rs
@@ -45,8 +45,8 @@ pub(crate) fn create_namespace_object(
     methods: &[Guard<&'static [JSFunctionSpec]>],
     constants: &[Guard<&'static [ConstantSpec]>],
     name: &CStr,
-    rval: MutableHandleObject,
+    mut rval: MutableHandleObject,
 ) {
-    create_object(cx, global, proto, &class.0, methods, &[], constants, rval);
+    create_object(cx, global, proto, &class.0, methods, &[], constants, rval.reborrow());
     define_on_global_object(cx, global, name, rval.handle());
 }

--- a/components/script/dom/bindings/proxyhandler.rs
+++ b/components/script/dom/bindings/proxyhandler.rs
@@ -172,7 +172,7 @@ pub(crate) unsafe fn ensure_expando_object(
     mut expando: MutableHandleObject,
 ) {
     assert!(is_dom_proxy(obj.get()));
-    get_expando_object(obj, expando);
+    get_expando_object(obj, expando.reborrow());
     if expando.is_null() {
         expando.set(JS_NewObjectWithGivenProto(
             cx,

--- a/components/script/dom/bindings/utils.rs
+++ b/components/script/dom/bindings/utils.rs
@@ -122,10 +122,10 @@ pub(crate) use script_bindings::utils::{DOMClass, DOMJSClass};
 pub(crate) fn to_frozen_array<T: ToJSValConvertible>(
     convertibles: &[T],
     cx: SafeJSContext,
-    rval: MutableHandleValue,
-    _can_gc: CanGc,
+     mut rval: MutableHandleValue,
+     _can_gc: CanGc,
 ) {
-    unsafe { convertibles.to_jsval(*cx, rval) };
+    unsafe { convertibles.to_jsval(*cx, rval.reborrow()) };
 
     rooted!(in(*cx) let obj = rval.to_object());
     unsafe { JS_FreezeObject(*cx, RawHandleObject::from(obj.handle())) };

--- a/components/script/dom/bindings/utils.rs
+++ b/components/script/dom/bindings/utils.rs
@@ -122,8 +122,8 @@ pub(crate) use script_bindings::utils::{DOMClass, DOMJSClass};
 pub(crate) fn to_frozen_array<T: ToJSValConvertible>(
     convertibles: &[T],
     cx: SafeJSContext,
-     mut rval: MutableHandleValue,
-     _can_gc: CanGc,
+    mut rval: MutableHandleValue,
+    _can_gc: CanGc,
 ) {
     unsafe { convertibles.to_jsval(*cx, rval.reborrow()) };
 

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -139,7 +139,7 @@ impl CustomElementRegistry {
     fn check_prototype(
         &self,
         constructor: HandleObject,
-        prototype: MutableHandleValue,
+        mut prototype: MutableHandleValue,
     ) -> ErrorResult {
         unsafe {
             // Step 10.1
@@ -147,7 +147,7 @@ impl CustomElementRegistry {
                 *GlobalScope::get_cx(),
                 constructor,
                 c"prototype".as_ptr(),
-                prototype,
+                prototype.reborrow(),
             ) {
                 return Err(Error::JSFailed);
             }

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -20,7 +20,7 @@ use js::jsapi::{
     NewUCRegExpObject, ObjectIsDate, RegExpFlag_Unicode, RegExpFlags,
 };
 use js::jsval::UndefinedValue;
-use js::rust::jsapi_wrapped::{CheckRegExpSyntax, ExecuteRegExpNoStatics, ObjectIsRegExp};
+use js::rust::wrappers::{CheckRegExpSyntax, ExecuteRegExpNoStatics, ObjectIsRegExp};
 use js::rust::{HandleObject, MutableHandleObject};
 use net_traits::blob_url_store::get_blob_origin;
 use net_traits::filemanager_thread::FileManagerThreadMsg;

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -3028,7 +3028,7 @@ fn check_js_regex_syntax(cx: SafeJSContext, pattern: &str) -> bool {
             RegExpFlags {
                 flags_: RegExpFlag_Unicode,
             },
-            &mut exception.handle_mut(),
+            exception.handle_mut(),
         );
 
         if !valid {
@@ -3081,7 +3081,7 @@ fn matches_js_regex(cx: SafeJSContext, regex_obj: HandleObject, value: &str) -> 
             value.len(),
             &mut index,
             true,
-            &mut rval.handle_mut(),
+            rval.handle_mut(),
         );
 
         if ok {

--- a/components/script/dom/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl2renderingcontext.rs
@@ -1217,14 +1217,14 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
             );
             handle_potential_webgl_error!(
                 self.base,
-                self.get_specific_fb_attachment_param(cx, &fb, target, attachment, pname, rval),
+                self.get_specific_fb_attachment_param(cx, &fb, target, attachment, pname, rval.reborrow()),
                 rval.set(NullValue())
             )
         } else {
             // The default framebuffer is bound to the target
             handle_potential_webgl_error!(
                 self.base,
-                self.get_default_fb_attachment_param(attachment, pname, rval),
+                self.get_default_fb_attachment_param(attachment, pname, rval.reborrow()),
                 rval.set(NullValue())
             )
         }

--- a/components/script/dom/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl2renderingcontext.rs
@@ -1217,7 +1217,14 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
             );
             handle_potential_webgl_error!(
                 self.base,
-                self.get_specific_fb_attachment_param(cx, &fb, target, attachment, pname, rval.reborrow()),
+                self.get_specific_fb_attachment_param(
+                    cx,
+                    &fb,
+                    target,
+                    attachment,
+                    pname,
+                    rval.reborrow()
+                ),
                 rval.set(NullValue())
             )
         } else {

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -3553,7 +3553,7 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
                 constants::VERTEX_ATTRIB_ARRAY_STRIDE => retval.set(Int32Value(data.stride as i32)),
                 constants::VERTEX_ATTRIB_ARRAY_BUFFER_BINDING => unsafe {
                     if let Some(buffer) = data.buffer() {
-                        buffer.to_jsval(*cx, retval);
+                        buffer.to_jsval(*cx, retval.reborrow());
                     } else {
                         retval.set(NullValue());
                     }

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -1441,7 +1441,12 @@ impl XMLHttpRequest {
         let json_text = decode_to_utf16_with_bom_removal(&bytes, UTF_8);
         // Step 5
         unsafe {
-            if !JS_ParseJSON(*cx, json_text.as_ptr(), json_text.len() as u32, rval.reborrow()) {
+            if !JS_ParseJSON(
+                *cx,
+                json_text.as_ptr(),
+                json_text.len() as u32,
+                rval.reborrow(),
+            ) {
                 JS_ClearPendingException(*cx);
                 return rval.set(NullValue());
             }

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -1441,7 +1441,7 @@ impl XMLHttpRequest {
         let json_text = decode_to_utf16_with_bom_removal(&bytes, UTF_8);
         // Step 5
         unsafe {
-            if !JS_ParseJSON(*cx, json_text.as_ptr(), json_text.len() as u32, rval) {
+            if !JS_ParseJSON(*cx, json_text.as_ptr(), json_text.len() as u32, rval.reborrow()) {
                 JS_ClearPendingException(*cx);
                 return rval.set(NullValue());
             }

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -488,7 +488,7 @@ impl ModuleTree {
                 warn!("fail to compile module script of {}", url);
 
                 rooted!(in(*cx) let mut exception = UndefinedValue());
-                assert!(JS_GetPendingException(*cx, &mut exception.handle_mut()));
+                assert!(JS_GetPendingException(*cx, exception.handle_mut()));
                 JS_ClearPendingException(*cx);
 
                 return Err(RethrowError(RootedTraceableBox::from_box(Heap::boxed(
@@ -531,7 +531,7 @@ impl ModuleTree {
                 warn!("fail to link & instantiate module");
 
                 rooted!(in(*cx) let mut exception = UndefinedValue());
-                assert!(JS_GetPendingException(*cx, &mut exception.handle_mut()));
+                assert!(JS_GetPendingException(*cx, exception.handle_mut()));
                 JS_ClearPendingException(*cx);
 
                 Err(RethrowError(RootedTraceableBox::from_box(Heap::boxed(
@@ -577,7 +577,7 @@ impl ModuleTree {
                 warn!("fail to evaluate module");
 
                 rooted!(in(*cx) let mut exception = UndefinedValue());
-                assert!(JS_GetPendingException(*cx, &mut exception.handle_mut()));
+                assert!(JS_GetPendingException(*cx, exception.handle_mut()));
                 JS_ClearPendingException(*cx);
 
                 Err(RethrowError(RootedTraceableBox::from_box(Heap::boxed(

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -27,8 +27,7 @@ use js::jsapi::{
     ThrowOnModuleEvaluationFailure, Value,
 };
 use js::jsval::{JSVal, PrivateValue, UndefinedValue};
-use js::rust::jsapi_wrapped::JS_GetPendingException;
-use js::rust::wrappers::JS_SetPendingException;
+use js::rust::wrappers::{JS_GetPendingException, JS_SetPendingException};
 use js::rust::{
     CompileOptionsWrapper, Handle, HandleObject as RustHandleObject, HandleValue, IntoHandle,
     MutableHandleObject as RustMutableHandleObject, transform_str_to_source_text,

--- a/components/script_bindings/codegen/CodegenRust.py
+++ b/components/script_bindings/codegen/CodegenRust.py
@@ -6394,13 +6394,13 @@ let cx = SafeJSContext::from_ptr(cx);
 {maybeCrossOriginGet}
 
 let proxy_lt = Handle::from_raw(proxy);
-let vp_lt = MutableHandle::from_raw(vp);
+let mut vp_lt = MutableHandle::from_raw(vp);
 let id_lt = Handle::from_raw(id);
 let receiver_lt = Handle::from_raw(receiver);
 
 {getIndexedOrExpando}
 let mut found = false;
-if !get_property_on_prototype(*cx, proxy_lt, receiver_lt, id_lt, &mut found, vp_lt) {{
+if !get_property_on_prototype(*cx, proxy_lt, receiver_lt, id_lt, &mut found, vp_lt.reborrow()) {{
     return false;
 }}
 
@@ -7285,7 +7285,7 @@ impl{self.generic} Clone for {self.makeClassName(self.dictionary)}{self.genericS
         memberInserts = [memberInsert(m) for m in self.memberInfo]
 
         if d.parent:
-            memberInserts = [CGGeneric("self.parent.to_jsobject(cx, obj);\n")] + memberInserts
+            memberInserts = [CGGeneric("self.parent.to_jsobject(cx, obj.reborrow());\n")] + memberInserts
 
         selfName = self.makeClassName(d)
         if self.membersNeedTracing():


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
`mozjs` allowed copying `MutableHandle`. `MutableHandle` currently implements `DerefMut`, allowing trivial undefined behavior (copy a Mutable handle, deref_mut both the original and the new one, and you have an aliasing violation). The `DerefMut` implementation itself needs to go eventually, but the principle of a unique-writer is probably going to stay.



---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors[^1]
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are the servo half of servo/mozjs#559 which fixes servo/mozjs#520 (though not all the aliasing issues discussed in it). 

<!-- Either: -->
- [x] These changes do not require tests because we are just better describing to the borrow checker and compiler what is happening

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

[^1]: When pointing `servo` at my local `mozjs` fork. This is my first time trying to make a change to mozjs/servo together (and my first change to servo in >9 years)... I'm guessing the procedure is merge the mozjs change, update the servo Cargo.lock, merge the servo change? Marking this PR as a draft since it won't build until the mozjs change is merged.
