### PR TITLE
Add a preference to stub out unimplemented DOM features

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -99,6 +99,15 @@ pub struct Preferences {
     pub dom_serviceworker_timeout_seconds: i64,
     pub dom_servo_helpers_enabled: bool,
     pub dom_servoparser_async_html_tokenizer_enabled: bool,
+    /// When enabled, Servo will create stub implementations for all DOM methods and attributes
+    /// that are known but not implemented. When a page tries to use one of these then a warning
+    /// with the method name will be logged and some appropriate default behaviour will be chosen:
+    /// * Getting the value of a stub attribute will return `undefined`
+    /// * Setting the value of a stub attribute will do nothing
+    /// * Calling a stub method will return `undefined`
+    ///
+    /// The warning is dispatched with target `dom-stubs`. Set `RUST_LOG=error,dom-stubs=warn` to see it.
+    pub dom_stub_unimplemented_features: bool,
     pub dom_svg_enabled: bool,
     pub dom_testable_crash_enabled: bool,
     pub dom_testbinding_enabled: bool,
@@ -272,6 +281,7 @@ impl Preferences {
             dom_serviceworker_timeout_seconds: 60,
             dom_servo_helpers_enabled: false,
             dom_servoparser_async_html_tokenizer_enabled: false,
+            dom_stub_unimplemented_features: false,
             dom_svg_enabled: false,
             dom_testable_crash_enabled: false,
             dom_testbinding_enabled: false,

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -25,6 +25,7 @@ js_backtrace = []
 refcell_backtrace = ["accountable-refcell"]
 webxr = ["webxr-api", "script_bindings/webxr"]
 webgpu = ["script_bindings/webgpu", "script_traits/webgpu"]
+stub-unimplemented-dom-interfaces = ["script_bindings/stub-unimplemented-dom-interfaces"]
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(crown)'] }

--- a/components/script/build.rs
+++ b/components/script/build.rs
@@ -19,6 +19,7 @@ fn main() {
         "ConcreteInheritTypes.rs",
         "UnionTypes.rs",
         "InterfaceObjectMapPhf.rs",
+        "StubbedInterfaces.rs",
     ]
     .iter()
     .map(Path::new)

--- a/components/script/dom/bindings/mod.rs
+++ b/components/script/dom/bindings/mod.rs
@@ -179,6 +179,9 @@ pub(crate) mod codegen {
     pub(crate) mod ConcreteInheritTypes {
         include!(concat!(env!("OUT_DIR"), "/ConcreteInheritTypes.rs"));
     }
+    pub(crate) mod StubbedInterfaces {
+        include!(concat!(env!("OUT_DIR"), "/StubbedInterfaces.rs"));
+    }
     pub(crate) use script_bindings::codegen::{PrototypeList, RegisterBindings};
     #[allow(dead_code)]
     pub(crate) mod UnionTypes {

--- a/components/script_bindings/Cargo.toml
+++ b/components/script_bindings/Cargo.toml
@@ -56,6 +56,7 @@ testbinding = []
 tracing = ["dep:tracing"]
 webgpu = []
 webxr = ["webxr-api"]
+stub-unimplemented-dom-interfaces = []
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(crown)'] }

--- a/components/script_bindings/codegen/Configuration.py
+++ b/components/script_bindings/codegen/Configuration.py
@@ -22,6 +22,8 @@ class Configuration:
         self.dictConfig = glbl['Dictionaries']
         self.unionConfig = glbl['Unions']
 
+        self.stubUnimplementedDomInterfaces = "CARGO_FEATURE_STUB_UNIMPLEMENTED_DOM_INTERFACES" in os.environ
+
         # Build descriptors for all the interfaces we have in the parse data.
         # This allows callers to specify a subset of interfaces by filtering
         # |parseData|.
@@ -37,6 +39,9 @@ class Configuration:
             assert not thing.isType()
 
             if not thing.isInterface() and not thing.isNamespace():
+                continue
+
+            if thing.getExtendedAttribute("Unimplemented") is not None and not self.stubUnimplementedDomInterfaces:
                 continue
 
             iface = thing
@@ -477,6 +482,9 @@ class Descriptor(DescriptorProvider):
         """
         return bool(self.interface.getExtendedAttribute("Global")
                     or self.interface.getExtendedAttribute("PrimaryGlobal"))
+
+    def isUnimplemented(self) -> bool:
+        return self.interface.getExtendedAttribute("Unimplemented") is not None
 
 
 # Some utility methods

--- a/components/script_bindings/codegen/run.py
+++ b/components/script_bindings/codegen/run.py
@@ -65,6 +65,7 @@ def main():
         ("ConcreteUnionTypes", "UnionTypes.rs"),
         ("DomTypes", "DomTypes.rs"),
         ("DomTypeHolder", "DomTypeHolder.rs"),
+        ("StubbedInterfaces", "StubbedInterfaces.rs")
     ]:
         generate(config, name, os.path.join(out_dir, filename))
     make_dir(doc_servo)

--- a/components/script_bindings/webidls/Accelerometer.webidl
+++ b/components/script_bindings/webidls/Accelerometer.webidl
@@ -5,10 +5,10 @@
 // https://w3c.github.io/accelerometer/#accelerometer-interface
 [Unimplemented, SecureContext, Exposed=Window]
 interface Accelerometer : Sensor {
-  constructor(optional AccelerometerSensorOptions options = {});
-  readonly attribute double? x;
-  readonly attribute double? y;
-  readonly attribute double? z;
+  [Unimplemented] constructor(optional AccelerometerSensorOptions options = {});
+  [Unimplemented] readonly attribute double? x;
+  [Unimplemented] readonly attribute double? y;
+  [Unimplemented] readonly attribute double? z;
 };
 
 enum AccelerometerLocalCoordinateSystem { "device", "screen" };

--- a/components/script_bindings/webidls/Accelerometer.webidl
+++ b/components/script_bindings/webidls/Accelerometer.webidl
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// https://w3c.github.io/accelerometer/#accelerometer-interface
+[Unimplemented, SecureContext, Exposed=Window]
+interface Accelerometer : Sensor {
+  constructor(optional AccelerometerSensorOptions options = {});
+  readonly attribute double? x;
+  readonly attribute double? y;
+  readonly attribute double? z;
+};
+
+enum AccelerometerLocalCoordinateSystem { "device", "screen" };
+
+dictionary AccelerometerSensorOptions : SensorOptions {
+  AccelerometerLocalCoordinateSystem referenceFrame = "device";
+};

--- a/components/script_bindings/webidls/CSSImportRule.webidl
+++ b/components/script_bindings/webidls/CSSImportRule.webidl
@@ -5,8 +5,8 @@
 // https://drafts.csswg.org/cssom/#cssimportrule
 [Exposed=Window]
 interface CSSImportRule : CSSRule {
-  // readonly attribute DOMString href;
-  // [SameObject, PutForwards=mediaText] readonly attribute MediaList media;
-  // [SameObject] readonly attribute CSSStyleSheet styleSheet;
+  [Unimplemented] readonly attribute DOMString href;
+  [Unimplemented, SameObject, PutForwards=mediaText] readonly attribute MediaList media;
+  [Unimplemented, SameObject] readonly attribute CSSStyleSheet styleSheet;
   readonly attribute DOMString? layerName;
 };

--- a/components/script_bindings/webidls/CSSRule.webidl
+++ b/components/script_bindings/webidls/CSSRule.webidl
@@ -16,7 +16,7 @@ interface CSSRule {
 
   readonly attribute unsigned short type;
   attribute DOMString cssText;
-  // readonly attribute CSSRule? parentRule;
+  [Unimplemented] readonly attribute CSSRule? parentRule;
   readonly attribute CSSStyleSheet? parentStyleSheet;
 };
 

--- a/components/script_bindings/webidls/CSSStyleSheet.webidl
+++ b/components/script_bindings/webidls/CSSStyleSheet.webidl
@@ -7,10 +7,12 @@
 interface CSSStyleSheet : StyleSheet {
   constructor(optional CSSStyleSheetInit options = {});
 
-  // readonly attribute CSSRule? ownerRule;
+  [Unimplemented] readonly attribute CSSRule? ownerRule;
   [Throws, SameObject] readonly attribute CSSRuleList cssRules;
   [Throws] unsigned long insertRule(DOMString rule, optional unsigned long index = 0);
   [Throws] undefined deleteRule(unsigned long index);
+
+  [Unimplemented] Promise<CSSStyleSheet> replace(USVString text);
   [Throws] undefined replaceSync(USVString text);
 };
 

--- a/components/script_bindings/webidls/GravitySensor.webidl
+++ b/components/script_bindings/webidls/GravitySensor.webidl
@@ -1,0 +1,9 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// https://w3c.github.io/accelerometer/#gravitysensor-interface
+[Unimplemented, SecureContext, Exposed=Window]
+interface GravitySensor : Accelerometer {
+  constructor(optional AccelerometerSensorOptions options = {});
+};

--- a/components/script_bindings/webidls/HTMLElement.webidl
+++ b/components/script_bindings/webidls/HTMLElement.webidl
@@ -44,9 +44,8 @@ interface HTMLElement : Element {
   //         attribute boolean draggable;
   // [SameObject, PutForwards=value] readonly attribute DOMTokenList dropzone;
   //         attribute HTMLMenuElement? contextMenu;
-  // [CEReactions]
-  //         attribute boolean spellcheck;
-  // void forceSpellCheck();
+  [Unimplemented, CEReactions] attribute boolean spellcheck;
+  [Unimplemented] undefined forceSpellCheck();
 
   [CEReactions] attribute [LegacyNullToEmptyString] DOMString innerText;
   [CEReactions, Throws] attribute [LegacyNullToEmptyString] DOMString outerText;

--- a/components/script_bindings/webidls/LinearAccelerationSensor.webidl
+++ b/components/script_bindings/webidls/LinearAccelerationSensor.webidl
@@ -5,5 +5,5 @@
 // https://w3c.github.io/accelerometer/#linearaccelerationsensor-interface
 [Unimplemented, SecureContext, Exposed=Window]
 interface LinearAccelerationSensor : Accelerometer {
-  constructor(optional AccelerometerSensorOptions options = {});
+  [Unimplemented] constructor(optional AccelerometerSensorOptions options = {});
 };

--- a/components/script_bindings/webidls/LinearAccelerationSensor.webidl
+++ b/components/script_bindings/webidls/LinearAccelerationSensor.webidl
@@ -1,0 +1,9 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// https://w3c.github.io/accelerometer/#linearaccelerationsensor-interface
+[Unimplemented, SecureContext, Exposed=Window]
+interface LinearAccelerationSensor : Accelerometer {
+  constructor(optional AccelerometerSensorOptions options = {});
+};

--- a/components/script_bindings/webidls/Sensor.webidl
+++ b/components/script_bindings/webidls/Sensor.webidl
@@ -5,14 +5,14 @@
 // https://w3c.github.io/sensors/#the-sensor-interface
 [Unimplemented, SecureContext, Exposed=(DedicatedWorker, Window)]
 interface Sensor : EventTarget {
-  readonly attribute boolean activated;
-  readonly attribute boolean hasReading;
-  readonly attribute DOMHighResTimeStamp? timestamp;
-  undefined start();
-  undefined stop();
-  attribute EventHandler onreading;
-  attribute EventHandler onactivate;
-  attribute EventHandler onerror;
+  [Unimplemented] readonly attribute boolean activated;
+  [Unimplemented] readonly attribute boolean hasReading;
+  [Unimplemented] readonly attribute DOMHighResTimeStamp? timestamp;
+  [Unimplemented] undefined start();
+  [Unimplemented] undefined stop();
+  [Unimplemented] attribute EventHandler onreading;
+  [Unimplemented] attribute EventHandler onactivate;
+  [Unimplemented] attribute EventHandler onerror;
 };
 
 dictionary SensorOptions {

--- a/components/script_bindings/webidls/Sensor.webidl
+++ b/components/script_bindings/webidls/Sensor.webidl
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// https://w3c.github.io/sensors/#the-sensor-interface
+[Unimplemented, SecureContext, Exposed=(DedicatedWorker, Window)]
+interface Sensor : EventTarget {
+  readonly attribute boolean activated;
+  readonly attribute boolean hasReading;
+  readonly attribute DOMHighResTimeStamp? timestamp;
+  undefined start();
+  undefined stop();
+  attribute EventHandler onreading;
+  attribute EventHandler onactivate;
+  attribute EventHandler onerror;
+};
+
+dictionary SensorOptions {
+  double frequency;
+};

--- a/components/script_bindings/webidls/StyleSheet.webidl
+++ b/components/script_bindings/webidls/StyleSheet.webidl
@@ -9,7 +9,7 @@ interface StyleSheet {
   readonly attribute DOMString? href;
 
   readonly attribute Element? ownerNode;
-  // readonly attribute StyleSheet? parentStyleSheet;
+  [Unimplemented] readonly attribute StyleSheet? parentStyleSheet;
   readonly attribute DOMString? title;
 
   [SameObject, PutForwards=mediaText] readonly attribute MediaList media;

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -62,6 +62,7 @@ webgpu = [
     "constellation/webgpu",
     "constellation_traits/webgpu",
 ]
+stub-unimplemented-dom-interfaces = ["script/stub-unimplemented-dom-interfaces"]
 
 [dependencies]
 background_hang_monitor = { path = "../background_hang_monitor" }

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -52,6 +52,7 @@ webdriver = ["libservo/webdriver"]
 webgl_backtrace = ["libservo/webgl_backtrace"]
 webgpu = ["libservo/webgpu"]
 webxr = ["libservo/webxr"]
+stub-unimplemented-dom-interfaces = ["libservo/stub-unimplemented-dom-interfaces"]
 
 [dependencies]
 cfg-if = { workspace = true }

--- a/third_party/WebIDL/WebIDL.py
+++ b/third_party/WebIDL/WebIDL.py
@@ -2107,6 +2107,7 @@ class IDLInterface(IDLInterfaceOrNamespace):
                 or identifier == "Abstract"
                 or identifier == "Inline"
                 or identifier == "Transferable"
+                or identifier == "Unimplemented"
             ):
                 # Known extended attributes that do not take values
                 if not attr.noArguments():
@@ -5939,6 +5940,7 @@ class IDLAttribute(IDLInterfaceMember):
             or identifier == "BinaryName"
             or identifier == "NonEnumerable"
             or identifier == "BindingTemplate"
+            or identifier == "Unimplemented"
         ):
             # Known attributes that we don't need to do anything with here
             pass
@@ -7018,6 +7020,7 @@ class IDLMethod(IDLInterfaceMember, IDLScope):
             or identifier == "NonEnumerable"
             or identifier == "Unexposed"
             or identifier == "WebExtensionStub"
+            or identifier == "Unimplemented"
         ):
             # Known attributes that we don't need to do anything with here
             pass
@@ -7076,6 +7079,7 @@ class IDLConstructor(IDLMethod):
             or identifier == "Trial"
             or identifier == "Pref"
             or identifier == "UseCounter"
+            or identifier == "Unimplemented"
         ):
             IDLMethod.handleExtendedAttribute(self, attr)
         elif identifier == "HTMLConstructor":

--- a/third_party/WebIDL/dom-stubs.patch
+++ b/third_party/WebIDL/dom-stubs.patch
@@ -1,0 +1,20 @@
+diff --git a/third_party/WebIDL/WebIDL.py b/third_party/WebIDL/WebIDL.py
+index 40e118e378..437e3640a6 100644
+--- a/third_party/WebIDL/WebIDL.py
++++ b/third_party/WebIDL/WebIDL.py
+@@ -5938,6 +5938,7 @@ class IDLAttribute(IDLInterfaceMember):
+             or identifier == "BinaryName"
+             or identifier == "NonEnumerable"
+             or identifier == "BindingTemplate"
++            or identifier == "Unimplemented"
+         ):
+             # Known attributes that we don't need to do anything with here
+             pass
+@@ -7017,6 +7018,7 @@ class IDLMethod(IDLInterfaceMember, IDLScope):
+             or identifier == "NonEnumerable"
+             or identifier == "Unexposed"
+             or identifier == "WebExtensionStub"
++            or identifier == "Unimplemented"
+         ):
+             # Known attributes that we don't need to do anything with here
+             pass

--- a/third_party/WebIDL/update.sh
+++ b/third_party/WebIDL/update.sh
@@ -8,6 +8,7 @@ patch < like-as-iterable.patch
 patch < builtin-array.patch
 patch < array-type.patch
 patch < transferable.patch
+patch < dom-stubs.patch
 
 wget https://hg.mozilla.org/mozilla-central/archive/tip.zip/dom/bindings/parser/tests/ -O tests.zip
 rm -r tests


### PR DESCRIPTION
This change adds a new preference, `dom_stub_unimplemented_features`. When enabled, it will generate stub implementations for methods and attributes in idl files that have the `Unimplemented` attribute. When the preference is disabled (which it is by default) then `Unimplemented` features will be treated as if they didn't exist.

The stub implementations do the absolute minimum about of work:
* Getting the value of a stub attribute will return `undefined`
* Setting the value of a stub attribute does nothing
* Calling a stub method will return `undefined`

More importantly, using them will log a warning message in the console. The intention is to enable this preference when debugging a website, to give you an idea of what changes are required to progress.

For demonstration purposes I have added the `Unimplemented` attribute to `HTMLElement::spellcheck` and `HTMLElement::forceSpellCheck`. If this is accepted I will add the attribute everywhere else in a followup change. 

When executing 
```js
let map = document.createElement("map");
map.forceSpellCheck();
map.spellcheck = true;
```
with `dom_stub_unimplemented_features` the following warnings will be logged:
```
[2025-03-10T21:24:20Z WARN  dom-stubs] Attempt to use unimplemented method or attribute HTMLElement::ForceSpellCheck
[2025-03-10T21:24:20Z WARN  dom-stubs] Attempt to use unimplemented method or attribute HTMLElement::SetSpellcheck
```

I have considered using a cargo feature instead of a preference, since generating all these stub methods might increase compile time. We could also be smarter and share their implementations, since they all do basically the same thing. For now I opted to use a preference since `CodegenRust.py` already supports those, but I can use a feature if requested.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes (the fact that this PR does not modify functionality when the preference is disabled is verified by WPT)

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
