### PR TITLE
base: Finish rename of `TopLevelBrowsingContextId` to `WebViewId`

### DIFF
--- a/components/compositing/webview.rs
+++ b/components/compositing/webview.rs
@@ -943,14 +943,13 @@ mod test {
     use std::num::NonZeroU32;
 
     use base::id::{
-        BrowsingContextId, BrowsingContextIndex, PipelineNamespace, PipelineNamespaceId,
-        TopLevelBrowsingContextId,
+        BrowsingContextId, BrowsingContextIndex, PipelineNamespace, PipelineNamespaceId, WebViewId,
     };
 
     use crate::webview::{UnknownWebView, WebViewAlreadyExists, WebViewManager};
 
-    fn top_level_id(namespace_id: u32, index: u32) -> TopLevelBrowsingContextId {
-        TopLevelBrowsingContextId(BrowsingContextId {
+    fn top_level_id(namespace_id: u32, index: u32) -> WebViewId {
+        WebViewId(BrowsingContextId {
             namespace_id: PipelineNamespaceId(namespace_id),
             index: BrowsingContextIndex(NonZeroU32::new(index).unwrap()),
         })
@@ -958,7 +957,7 @@ mod test {
 
     fn webviews_sorted<WebView: Clone>(
         webviews: &WebViewManager<WebView>,
-    ) -> Vec<(TopLevelBrowsingContextId, WebView)> {
+    ) -> Vec<(WebViewId, WebView)> {
         let mut keys = webviews.webviews.keys().collect::<Vec<_>>();
         keys.sort();
         keys.iter()
@@ -972,9 +971,9 @@ mod test {
         let mut webviews = WebViewManager::default();
 
         // add() adds the webview to the map, but not the painting order.
-        assert!(webviews.add(TopLevelBrowsingContextId::new(), 'a').is_ok());
-        assert!(webviews.add(TopLevelBrowsingContextId::new(), 'b').is_ok());
-        assert!(webviews.add(TopLevelBrowsingContextId::new(), 'c').is_ok());
+        assert!(webviews.add(WebViewId::new(), 'a').is_ok());
+        assert!(webviews.add(WebViewId::new(), 'b').is_ok());
+        assert!(webviews.add(WebViewId::new(), 'c').is_ok());
         assert_eq!(
             webviews_sorted(&webviews),
             vec![

--- a/components/constellation/browsingcontext.rs
+++ b/components/constellation/browsingcontext.rs
@@ -4,7 +4,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use base::id::{BrowsingContextGroupId, BrowsingContextId, PipelineId, TopLevelBrowsingContextId};
+use base::id::{BrowsingContextGroupId, BrowsingContextId, PipelineId, WebViewId};
 use euclid::Size2D;
 use log::warn;
 use style_traits::CSSPixel;
@@ -48,7 +48,7 @@ pub struct BrowsingContext {
     pub id: BrowsingContextId,
 
     /// The top-level browsing context ancestor
-    pub top_level_id: TopLevelBrowsingContextId,
+    pub top_level_id: WebViewId,
 
     /// The size of the frame.
     pub size: Size2D<f32, CSSPixel>,
@@ -82,7 +82,7 @@ impl BrowsingContext {
     pub fn new(
         bc_group_id: BrowsingContextGroupId,
         id: BrowsingContextId,
-        top_level_id: TopLevelBrowsingContextId,
+        top_level_id: WebViewId,
         pipeline_id: PipelineId,
         parent_pipeline_id: Option<PipelineId>,
         size: Size2D<f32, CSSPixel>,

--- a/components/constellation/logging.rs
+++ b/components/constellation/logging.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use std::thread;
 
 use backtrace::Backtrace;
-use base::id::TopLevelBrowsingContextId;
+use base::id::WebViewId;
 use compositing_traits::ConstellationMsg as FromCompositorMsg;
 use crossbeam_channel::Sender;
 use log::{Level, LevelFilter, Log, Metadata, Record};
@@ -87,7 +87,7 @@ impl Log for FromCompositorLogger {
 
     fn log(&self, record: &Record) {
         if let Some(entry) = log_entry(record) {
-            let top_level_id = TopLevelBrowsingContextId::installed();
+            let top_level_id = WebViewId::installed();
             let thread_name = thread::current().name().map(ToOwned::to_owned);
             let msg = FromCompositorMsg::LogEntry(top_level_id, thread_name, entry);
             let chan = self.constellation_chan.lock();

--- a/components/constellation/session_history.rs
+++ b/components/constellation/session_history.rs
@@ -5,7 +5,7 @@
 use std::cmp::PartialEq;
 use std::fmt;
 
-use base::id::{BrowsingContextId, HistoryStateId, PipelineId, TopLevelBrowsingContextId};
+use base::id::{BrowsingContextId, HistoryStateId, PipelineId, WebViewId};
 use euclid::Size2D;
 use log::debug;
 use script_traits::LoadData;
@@ -115,7 +115,7 @@ pub struct SessionHistoryChange {
     pub browsing_context_id: BrowsingContextId,
 
     /// The top-level browsing context ancestor.
-    pub top_level_browsing_context_id: TopLevelBrowsingContextId,
+    pub webview_id: WebViewId,
 
     /// The pipeline for the document being loaded.
     pub new_pipeline_id: PipelineId,

--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -5,7 +5,7 @@
 use std::cell::Cell;
 use std::ptr;
 
-use base::id::{BrowsingContextId, PipelineId, TopLevelBrowsingContextId};
+use base::id::{BrowsingContextId, PipelineId, WebViewId};
 use dom_struct::dom_struct;
 use html5ever::local_name;
 use indexmap::map::IndexMap;
@@ -81,7 +81,7 @@ pub(crate) struct WindowProxy {
     /// The frame id of the top-level ancestor browsing context.
     /// In the case that this is a top-level window, this is our id.
     #[no_trace]
-    top_level_browsing_context_id: TopLevelBrowsingContextId,
+    webview_id: WebViewId,
 
     /// The name of the browsing context (sometimes, but not always,
     /// equal to the name of a container element)
@@ -128,7 +128,7 @@ pub(crate) struct WindowProxy {
 impl WindowProxy {
     fn new_inherited(
         browsing_context_id: BrowsingContextId,
-        top_level_browsing_context_id: TopLevelBrowsingContextId,
+        webview_id: WebViewId,
         currently_active: Option<PipelineId>,
         frame_element: Option<&Element>,
         parent: Option<&WindowProxy>,
@@ -141,7 +141,7 @@ impl WindowProxy {
         WindowProxy {
             reflector: Reflector::new(),
             browsing_context_id,
-            top_level_browsing_context_id,
+            webview_id,
             name: DomRefCell::new(name),
             currently_active: Cell::new(currently_active),
             discarded: Cell::new(false),
@@ -161,7 +161,7 @@ impl WindowProxy {
     pub(crate) fn new(
         window: &Window,
         browsing_context_id: BrowsingContextId,
-        top_level_browsing_context_id: TopLevelBrowsingContextId,
+        webview_id: WebViewId,
         frame_element: Option<&Element>,
         parent: Option<&WindowProxy>,
         opener: Option<BrowsingContextId>,
@@ -187,7 +187,7 @@ impl WindowProxy {
             let current = Some(window.global().pipeline_id());
             let window_proxy = Box::new(WindowProxy::new_inherited(
                 browsing_context_id,
-                top_level_browsing_context_id,
+                webview_id,
                 current,
                 frame_element,
                 parent,
@@ -221,7 +221,7 @@ impl WindowProxy {
     pub(crate) fn new_dissimilar_origin(
         global_to_clone_from: &GlobalScope,
         browsing_context_id: BrowsingContextId,
-        top_level_browsing_context_id: TopLevelBrowsingContextId,
+        webview_id: WebViewId,
         parent: Option<&WindowProxy>,
         opener: Option<BrowsingContextId>,
         creator: CreatorBrowsingContextInfo,
@@ -234,7 +234,7 @@ impl WindowProxy {
             // Create a new browsing context.
             let window_proxy = Box::new(WindowProxy::new_inherited(
                 browsing_context_id,
-                top_level_browsing_context_id,
+                webview_id,
                 None,
                 None,
                 parent,
@@ -322,7 +322,7 @@ impl WindowProxy {
             parent_info: None,
             new_pipeline_id: response.new_pipeline_id,
             browsing_context_id: new_browsing_context_id,
-            top_level_browsing_context_id: response.new_webview_id,
+            webview_id: response.new_webview_id,
             opener: Some(self.browsing_context_id),
             load_data,
             window_size: window.window_size(),
@@ -585,8 +585,8 @@ impl WindowProxy {
         self.browsing_context_id
     }
 
-    pub(crate) fn top_level_browsing_context_id(&self) -> TopLevelBrowsingContextId {
-        self.top_level_browsing_context_id
+    pub(crate) fn webview_id(&self) -> WebViewId {
+        self.webview_id
     }
 
     pub(crate) fn frame_element(&self) -> Option<&Element> {

--- a/components/script/navigation.rs
+++ b/components/script/navigation.rs
@@ -9,7 +9,7 @@
 use std::cell::Cell;
 
 use base::cross_process_instant::CrossProcessInstant;
-use base::id::{BrowsingContextId, PipelineId, TopLevelBrowsingContextId};
+use base::id::{BrowsingContextId, PipelineId, WebViewId};
 use content_security_policy::Destination;
 use crossbeam_channel::Sender;
 use http::header;
@@ -128,7 +128,7 @@ pub(crate) struct InProgressLoad {
     pub(crate) browsing_context_id: BrowsingContextId,
     /// The top level ancestor browsing context.
     #[no_trace]
-    pub(crate) top_level_browsing_context_id: TopLevelBrowsingContextId,
+    pub(crate) webview_id: WebViewId,
     /// The parent pipeline and frame type associated with this load, if any.
     #[no_trace]
     pub(crate) parent_info: Option<PipelineId>,
@@ -166,7 +166,7 @@ impl InProgressLoad {
     pub(crate) fn new(
         id: PipelineId,
         browsing_context_id: BrowsingContextId,
-        top_level_browsing_context_id: TopLevelBrowsingContextId,
+        webview_id: WebViewId,
         parent_info: Option<PipelineId>,
         opener: Option<BrowsingContextId>,
         window_size: WindowSizeData,
@@ -177,7 +177,7 @@ impl InProgressLoad {
         InProgressLoad {
             pipeline_id: id,
             browsing_context_id,
-            top_level_browsing_context_id,
+            webview_id,
             parent_info,
             opener,
             window_size,
@@ -193,9 +193,9 @@ impl InProgressLoad {
 
     pub(crate) fn request_builder(&mut self) -> RequestBuilder {
         let id = self.pipeline_id;
-        let top_level_browsing_context_id = self.top_level_browsing_context_id;
+        let webview_id = self.webview_id;
         let mut request_builder = RequestBuilder::new(
-            Some(top_level_browsing_context_id),
+            Some(webview_id),
             self.load_data.url.clone(),
             self.load_data.referrer.clone(),
         )

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -264,9 +264,7 @@ pub(crate) unsafe fn jsval_to_webdriver(
             let window_proxy = window.window_proxy();
             if window_proxy.is_browsing_context_discarded() {
                 Err(WebDriverJSError::StaleElementReference)
-            } else if window_proxy.browsing_context_id() ==
-                window_proxy.top_level_browsing_context_id()
-            {
+            } else if window_proxy.browsing_context_id() == window_proxy.webview_id() {
                 Ok(WebDriverJSValue::Window(WebWindow(
                     window.Document().upcast::<Node>().unique_id(),
                 )))

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -32,8 +32,8 @@ use std::rc::{Rc, Weak};
 use std::sync::{Arc, Mutex};
 use std::thread;
 
-pub use base::id::TopLevelBrowsingContextId;
-use base::id::{PipelineNamespace, PipelineNamespaceId, WebViewId};
+pub use base::id::WebViewId;
+use base::id::{PipelineNamespace, PipelineNamespaceId};
 #[cfg(feature = "bluetooth")]
 use bluetooth::BluetoothThreadFactory;
 #[cfg(feature = "bluetooth")]
@@ -312,7 +312,7 @@ impl Servo {
         }
         debug_assert_eq!(webrender_gl.get_error(), gleam::gl::NO_ERROR,);
 
-        // Reserving a namespace to create TopLevelBrowsingContextId.
+        // Reserving a namespace to create WebViewId.
         PipelineNamespace::install(PipelineNamespaceId(0));
 
         // Get both endpoints of a special channel for communication between

--- a/components/shared/base/id.rs
+++ b/components/shared/base/id.rs
@@ -275,61 +275,58 @@ impl fmt::Display for BrowsingContextGroupId {
     }
 }
 
-thread_local!(pub static TOP_LEVEL_BROWSING_CONTEXT_ID: Cell<Option<TopLevelBrowsingContextId>> =
+thread_local!(pub static WEBVIEW_ID: Cell<Option<WebViewId>> =
     const { Cell::new(None) });
 
 #[derive(
     Clone, Copy, Deserialize, Eq, Hash, MallocSizeOf, Ord, PartialEq, PartialOrd, Serialize,
 )]
-pub struct TopLevelBrowsingContextId(pub BrowsingContextId);
-/// An alias to ID of top level browsing context. A web view is usually what people would treat as
-/// a normal web page.
-pub type WebViewId = TopLevelBrowsingContextId;
+pub struct WebViewId(pub BrowsingContextId);
 
-size_of_test!(TopLevelBrowsingContextId, 8);
-size_of_test!(Option<TopLevelBrowsingContextId>, 8);
+size_of_test!(WebViewId, 8);
+size_of_test!(Option<WebViewId>, 8);
 
-impl fmt::Debug for TopLevelBrowsingContextId {
+impl fmt::Debug for WebViewId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "TopLevel{:?}", self.0)
     }
 }
 
-impl fmt::Display for TopLevelBrowsingContextId {
+impl fmt::Display for WebViewId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "TopLevel{}", self.0)
     }
 }
 
-impl TopLevelBrowsingContextId {
-    pub fn new() -> TopLevelBrowsingContextId {
-        TopLevelBrowsingContextId(BrowsingContextId::new())
+impl WebViewId {
+    pub fn new() -> WebViewId {
+        WebViewId(BrowsingContextId::new())
     }
 
     /// Each script and layout thread should have the top-level browsing context id installed,
     /// since it is used by crash reporting.
-    pub fn install(id: TopLevelBrowsingContextId) {
-        TOP_LEVEL_BROWSING_CONTEXT_ID.with(|tls| tls.set(Some(id)))
+    pub fn install(id: WebViewId) {
+        WEBVIEW_ID.with(|tls| tls.set(Some(id)))
     }
 
-    pub fn installed() -> Option<TopLevelBrowsingContextId> {
-        TOP_LEVEL_BROWSING_CONTEXT_ID.with(|tls| tls.get())
+    pub fn installed() -> Option<WebViewId> {
+        WEBVIEW_ID.with(|tls| tls.get())
     }
 }
 
-impl From<TopLevelBrowsingContextId> for BrowsingContextId {
-    fn from(id: TopLevelBrowsingContextId) -> BrowsingContextId {
+impl From<WebViewId> for BrowsingContextId {
+    fn from(id: WebViewId) -> BrowsingContextId {
         id.0
     }
 }
 
-impl PartialEq<TopLevelBrowsingContextId> for BrowsingContextId {
-    fn eq(&self, rhs: &TopLevelBrowsingContextId) -> bool {
+impl PartialEq<WebViewId> for BrowsingContextId {
+    fn eq(&self, rhs: &WebViewId) -> bool {
         self.eq(&rhs.0)
     }
 }
 
-impl PartialEq<BrowsingContextId> for TopLevelBrowsingContextId {
+impl PartialEq<BrowsingContextId> for WebViewId {
     fn eq(&self, rhs: &BrowsingContextId) -> bool {
         self.0.eq(rhs)
     }
@@ -444,4 +441,4 @@ pub const TEST_BROWSING_CONTEXT_ID: BrowsingContextId = BrowsingContextId {
     index: TEST_BROWSING_CONTEXT_INDEX,
 };
 
-pub const TEST_WEBVIEW_ID: WebViewId = TopLevelBrowsingContextId(TEST_BROWSING_CONTEXT_ID);
+pub const TEST_WEBVIEW_ID: WebViewId = WebViewId(TEST_BROWSING_CONTEXT_ID);

--- a/components/shared/compositing/constellation_msg.rs
+++ b/components/shared/compositing/constellation_msg.rs
@@ -7,7 +7,7 @@ use std::fmt;
 use std::time::Duration;
 
 use base::Epoch;
-use base::id::{BrowsingContextId, PipelineId, TopLevelBrowsingContextId, WebViewId};
+use base::id::{BrowsingContextId, PipelineId, WebViewId};
 use embedder_traits::{
     Cursor, InputEvent, MediaSessionActionType, Theme, TraversalDirection, WebDriverCommandMsg,
 };
@@ -28,19 +28,19 @@ pub enum ConstellationMsg {
     GetPipeline(BrowsingContextId, IpcSender<Option<PipelineId>>),
     /// Request that the constellation send the current focused top-level browsing context id,
     /// over a provided channel.
-    GetFocusTopLevelBrowsingContext(IpcSender<Option<TopLevelBrowsingContextId>>),
+    GetFocusTopLevelBrowsingContext(IpcSender<Option<WebViewId>>),
     /// Query the constellation to see if the current compositor output is stable
     IsReadyToSaveImage(HashMap<PipelineId, Epoch>),
     /// Whether to allow script to navigate.
     AllowNavigationResponse(PipelineId, bool),
     /// Request to load a page.
-    LoadUrl(TopLevelBrowsingContextId, ServoUrl),
+    LoadUrl(WebViewId, ServoUrl),
     /// Clear the network cache.
     ClearCache,
     /// Request to traverse the joint session history of the provided browsing context.
-    TraverseHistory(TopLevelBrowsingContextId, TraversalDirection),
+    TraverseHistory(WebViewId, TraversalDirection),
     /// Inform the constellation of a window being resized.
-    WindowSize(TopLevelBrowsingContextId, WindowSizeData, WindowSizeType),
+    WindowSize(WebViewId, WindowSizeData, WindowSizeType),
     /// Inform the constellation of a theme change.
     ThemeChange(Theme),
     /// Requests that the constellation instruct layout to begin a new tick of the animation.
@@ -48,17 +48,17 @@ pub enum ConstellationMsg {
     /// Dispatch a webdriver command
     WebDriverCommand(WebDriverCommandMsg),
     /// Reload a top-level browsing context.
-    Reload(TopLevelBrowsingContextId),
+    Reload(WebViewId),
     /// A log entry, with the top-level browsing context id and thread name
-    LogEntry(Option<TopLevelBrowsingContextId>, Option<String>, LogEntry),
+    LogEntry(Option<WebViewId>, Option<String>, LogEntry),
     /// Create a new top level browsing context.
-    NewWebView(ServoUrl, TopLevelBrowsingContextId),
+    NewWebView(ServoUrl, WebViewId),
     /// Close a top level browsing context.
-    CloseWebView(TopLevelBrowsingContextId),
+    CloseWebView(WebViewId),
     /// Panic a top level browsing context.
-    SendError(Option<TopLevelBrowsingContextId>, String),
+    SendError(Option<WebViewId>, String),
     /// Make a webview focused.
-    FocusWebView(TopLevelBrowsingContextId),
+    FocusWebView(WebViewId),
     /// Make none of the webviews focused.
     BlurWebView,
     /// Forward an input event to an appropriate ScriptTask.
@@ -68,11 +68,11 @@ pub enum ConstellationMsg {
     /// Enable the sampling profiler, with a given sampling rate and max total sampling duration.
     ToggleProfiler(Duration, Duration),
     /// Request to exit from fullscreen mode
-    ExitFullScreen(TopLevelBrowsingContextId),
+    ExitFullScreen(WebViewId),
     /// Media session action.
     MediaSessionAction(MediaSessionActionType),
     /// Set whether to use less resources, by stopping animations and running timers at a heavily limited rate.
-    SetWebViewThrottled(TopLevelBrowsingContextId, bool),
+    SetWebViewThrottled(WebViewId, bool),
 }
 
 impl fmt::Debug for ConstellationMsg {

--- a/components/shared/compositing/lib.rs
+++ b/components/shared/compositing/lib.rs
@@ -9,7 +9,7 @@ mod constellation_msg;
 use std::fmt::{Debug, Error, Formatter};
 
 use base::Epoch;
-use base::id::{PipelineId, TopLevelBrowsingContextId, WebViewId};
+use base::id::{PipelineId, WebViewId};
 pub use constellation_msg::ConstellationMsg;
 use crossbeam_channel::{Receiver, Sender};
 use embedder_traits::{EventLoopWaker, MouseButton, MouseButtonAction};
@@ -63,7 +63,7 @@ pub enum CompositorMsg {
     /// Create or update a webview, given its frame tree.
     CreateOrUpdateWebView(SendableFrameTree),
     /// Remove a webview.
-    RemoveWebView(TopLevelBrowsingContextId),
+    RemoveWebView(WebViewId),
     /// Script has handled a touch event, and either prevented or allowed default actions.
     TouchEventProcessed(WebViewId, TouchEventResult),
     /// Composite to a PNG file and return the Image over a passed channel.
@@ -87,7 +87,7 @@ pub enum CompositorMsg {
     /// WebViewId and PipelienId.
     PendingPaintMetric(WebViewId, PipelineId, Epoch),
     /// The load of a page has completed
-    LoadComplete(TopLevelBrowsingContextId),
+    LoadComplete(WebViewId),
     /// WebDriver mouse button event
     WebDriverMouseButtonEvent(WebViewId, MouseButtonAction, MouseButton, f32, f32),
     /// WebDriver mouse move event
@@ -107,7 +107,7 @@ pub struct SendableFrameTree {
 #[derive(Clone)]
 pub struct CompositionPipeline {
     pub id: PipelineId,
-    pub top_level_browsing_context_id: TopLevelBrowsingContextId,
+    pub webview_id: WebViewId,
     pub script_chan: IpcSender<ScriptThreadMessage>,
 }
 

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -23,7 +23,7 @@ use base::Epoch;
 use base::cross_process_instant::CrossProcessInstant;
 use base::id::{
     BlobId, BrowsingContextId, HistoryStateId, MessagePortId, PipelineId, PipelineNamespaceId,
-    TopLevelBrowsingContextId, WebViewId,
+    WebViewId,
 };
 use bitflags::bitflags;
 #[cfg(feature = "bluetooth")]
@@ -216,7 +216,7 @@ pub struct NewLayoutInfo {
     /// Id of the browsing context associated with this pipeline.
     pub browsing_context_id: BrowsingContextId,
     /// Id of the top-level browsing context associated with this pipeline.
-    pub top_level_browsing_context_id: TopLevelBrowsingContextId,
+    pub webview_id: WebViewId,
     /// Id of the opener, if any
     pub opener: Option<BrowsingContextId>,
     /// Network request data which will be initiated by the script thread.
@@ -337,7 +337,7 @@ pub enum ScriptThreadMessage {
         /// The source of the message.
         source: PipelineId,
         /// The top level browsing context associated with the source pipeline.
-        source_browsing_context: TopLevelBrowsingContextId,
+        source_browsing_context: WebViewId,
         /// The expected origin of the target.
         target_origin: Option<ImmutableOrigin>,
         /// The source origin of the message.
@@ -351,7 +351,7 @@ pub enum ScriptThreadMessage {
     UpdatePipelineId(
         PipelineId,
         BrowsingContextId,
-        TopLevelBrowsingContextId,
+        WebViewId,
         PipelineId,
         UpdatePipelineIdReason,
     ),
@@ -497,7 +497,7 @@ pub struct InitialScriptState {
     /// The ID of the browsing context this script is part of.
     pub browsing_context_id: BrowsingContextId,
     /// The ID of the top-level browsing context this script is part of.
-    pub top_level_browsing_context_id: TopLevelBrowsingContextId,
+    pub webview_id: WebViewId,
     /// The ID of the opener, if any.
     pub opener: Option<BrowsingContextId>,
     /// Loading into a Secure Context
@@ -589,7 +589,7 @@ pub struct IFrameLoadInfo {
     /// The ID for this iframe's nested browsing context.
     pub browsing_context_id: BrowsingContextId,
     /// The ID for the top-level ancestor browsing context of this iframe's nested browsing context.
-    pub top_level_browsing_context_id: TopLevelBrowsingContextId,
+    pub webview_id: WebViewId,
     /// The new pipeline ID that the iframe has generated.
     pub new_pipeline_id: PipelineId,
     ///  Whether this iframe should be considered private

--- a/components/shared/script/script_msg.rs
+++ b/components/shared/script/script_msg.rs
@@ -8,8 +8,7 @@ use std::fmt;
 use base::Epoch;
 use base::id::{
     BroadcastChannelRouterId, BrowsingContextId, HistoryStateId, MessagePortId,
-    MessagePortRouterId, PipelineId, ServiceWorkerId, ServiceWorkerRegistrationId,
-    TopLevelBrowsingContextId, WebViewId,
+    MessagePortRouterId, PipelineId, ServiceWorkerId, ServiceWorkerRegistrationId, WebViewId,
 };
 use canvas_traits::canvas::{CanvasId, CanvasMsg};
 use devtools_traits::{ScriptToDevtoolsControlMsg, WorkerId};
@@ -150,10 +149,7 @@ pub enum ScriptMsg {
     /// Notifies the constellation that this frame has received focus.
     Focus,
     /// Get the top-level browsing context info for a given browsing context.
-    GetTopForBrowsingContext(
-        BrowsingContextId,
-        IpcSender<Option<TopLevelBrowsingContextId>>,
-    ),
+    GetTopForBrowsingContext(BrowsingContextId, IpcSender<Option<WebViewId>>),
     /// Get the browsing context id of the browsing context in which pipeline is
     /// embedded and the parent pipeline id of that browsing context.
     GetBrowsingContextInfo(

--- a/components/webdriver_server/actions.rs
+++ b/components/webdriver_server/actions.rs
@@ -279,7 +279,7 @@ impl Handler {
 
         let button = (action.button as u16).into();
         let cmd_msg = WebDriverCommandMsg::MouseButtonAction(
-            session.top_level_browsing_context_id,
+            session.webview_id,
             MouseButtonAction::Down,
             button,
             pointer_input_state.x as f32,
@@ -326,7 +326,7 @@ impl Handler {
 
         let button = (action.button as u16).into();
         let cmd_msg = WebDriverCommandMsg::MouseButtonAction(
-            session.top_level_browsing_context_id,
+            session.webview_id,
             MouseButtonAction::Up,
             button,
             pointer_input_state.x as f32,
@@ -389,10 +389,8 @@ impl Handler {
         };
 
         let (sender, receiver) = ipc::channel().unwrap();
-        let cmd_msg = WebDriverCommandMsg::GetWindowSize(
-            self.session.as_ref().unwrap().top_level_browsing_context_id,
-            sender,
-        );
+        let cmd_msg =
+            WebDriverCommandMsg::GetWindowSize(self.session.as_ref().unwrap().webview_id, sender);
         self.constellation_chan
             .send(ConstellationMsg::WebDriverCommand(cmd_msg))
             .unwrap();
@@ -471,11 +469,8 @@ impl Handler {
             // Step 7
             if x != current_x || y != current_y {
                 // Step 7.2
-                let cmd_msg = WebDriverCommandMsg::MouseMoveAction(
-                    session.top_level_browsing_context_id,
-                    x as f32,
-                    y as f32,
-                );
+                let cmd_msg =
+                    WebDriverCommandMsg::MouseMoveAction(session.webview_id, x as f32, y as f32);
                 self.constellation_chan
                     .send(ConstellationMsg::WebDriverCommand(cmd_msg))
                     .unwrap();


### PR DESCRIPTION
The `WebViewId` name is a lot more descriptive these days to the casual
reader, so I think we can go ahead and finish the rename.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they just rename a struct.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
