### PR TITLE
Eliminate to_shmem dependency from servo_url

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6880,7 +6880,6 @@ dependencies = [
  "servo_arc",
  "servo_malloc_size_of",
  "servo_rand",
- "to_shmem",
  "url",
  "uuid",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,7 +144,6 @@ thin-vec = "0.2.13"
 tikv-jemalloc-sys = "0.6.0"
 tikv-jemallocator = "0.6.0"
 time = { package = "time", version = "0.3", features = ["large-dates", "local-offset", "serde"] }
-to_shmem = { git = "https://github.com/servo/stylo", branch = "2025-03-01" }
 tokio = "1"
 tokio-rustls = { version = "0.26", default-features = false, features = ["logging"] }
 tower-service = "0.3"

--- a/components/url/Cargo.toml
+++ b/components/url/Cargo.toml
@@ -17,6 +17,5 @@ malloc_size_of_derive = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 servo_arc = { workspace = true }
 servo_rand = { path = "../rand" }
-to_shmem = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 uuid = { workspace = true, features = ["serde"] }

--- a/components/url/lib.rs
+++ b/components/url/lib.rs
@@ -18,7 +18,6 @@ use std::path::Path;
 use malloc_size_of_derive::MallocSizeOf;
 use serde::{Deserialize, Serialize};
 use servo_arc::Arc;
-use to_shmem::{SharedMemoryBuilder, ToShmem};
 pub use url::Host;
 use url::{Position, Url};
 
@@ -37,14 +36,6 @@ pub enum UrlError {
 
 #[derive(Clone, Deserialize, Eq, Hash, MallocSizeOf, Ord, PartialEq, PartialOrd, Serialize)]
 pub struct ServoUrl(#[ignore_malloc_size_of = "Arc"] Arc<Url>);
-
-impl ToShmem for ServoUrl {
-    fn to_shmem(&self, _builder: &mut SharedMemoryBuilder) -> to_shmem::Result<Self> {
-        unimplemented!(
-            "If servo wants to share stylesheets across processes, ToShmem for Url must be implemented"
-        )
-    }
-}
 
 impl ServoUrl {
     pub fn from_url(url: Url) -> Self {


### PR DESCRIPTION
This removes the `ToShmem` trait impl for `servo_url::Url` and then removes the dependency from `Cargo.toml` (Servo still depends on this crate indirectly via Stylo but that becomes an implementation detail).

This implementation was previously required to support `servo_url::Url` being used in Stylo, but Stylo now uses `url::Url` directly (and doesn't depend on `servo_url`) so this is no longer necessary.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors