### PR TITLE
Add support for parsing and applying `viewport` `<meta>` 

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -973,7 +973,11 @@ impl IOCompositor {
                     warn!("Sending response to get screen size failed ({error:?}).");
                 }
             },
-            CompositorMsg::Viewport(_webview_id, _viewport_description) => {},
+            CompositorMsg::Viewport(webview_id, viewport_description) => {
+                if let Some(webview) = self.webview_renderers.get_mut(webview_id) {
+                    webview.set_viewport_description(viewport_description);
+                }
+            },
         }
     }
 

--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -973,6 +973,7 @@ impl IOCompositor {
                     warn!("Sending response to get screen size failed ({error:?}).");
                 }
             },
+            CompositorMsg::Viewport(_webview_id, _viewport_description) => {},
         }
     }
 

--- a/components/compositing/tracing.rs
+++ b/components/compositing/tracing.rs
@@ -59,6 +59,7 @@ mod from_constellation {
                 Self::GetScreenSize(..) => target!("GetScreenSize"),
                 Self::GetAvailableScreenSize(..) => target!("GetAvailableScreenSize"),
                 Self::CollectMemoryReport(..) => target!("CollectMemoryReport"),
+                Self::Viewport(..) => target!("Viewport"),
             }
         }
     }

--- a/components/compositing/webview_renderer.rs
+++ b/components/compositing/webview_renderer.rs
@@ -8,6 +8,7 @@ use std::collections::{HashMap, VecDeque};
 use std::rc::Rc;
 
 use base::id::{PipelineId, WebViewId};
+use compositing_traits::viewport_description::ViewportDescription;
 use compositing_traits::{SendableFrameTree, WebViewTrait};
 use constellation_traits::{EmbedderToConstellationMessage, ScrollState, WindowSizeType};
 use embedder_traits::{
@@ -58,7 +59,7 @@ pub(crate) struct ScrollResult {
     pub offset: LayoutVector2D,
 }
 
-#[derive(PartialEq)]
+#[derive(Debug, PartialEq)]
 pub(crate) enum PinchZoomResult {
     DidPinchZoom,
     DidNotPinchZoom,
@@ -102,6 +103,8 @@ pub(crate) struct WebViewRenderer {
     pending_point_input_events: RefCell<VecDeque<InputEvent>>,
     /// WebRender is not ready between `SendDisplayList` and `WebRenderFrameReady` messages.
     pub webrender_frame_ready: Cell<bool>,
+    /// Viewport Description
+    viewport_description: Option<ViewportDescription>,
 }
 
 impl Drop for WebViewRenderer {
@@ -138,6 +141,7 @@ impl WebViewRenderer {
             animating: false,
             pending_point_input_events: Default::default(),
             webrender_frame_ready: Cell::default(),
+            viewport_description: None,
         }
     }
 
@@ -1041,6 +1045,10 @@ impl WebViewRenderer {
     pub(crate) fn available_screen_size(&self) -> Size2D<i32, DeviceIndependentPixel> {
         let screen_geometry = self.webview.screen_geometry().unwrap_or_default();
         (screen_geometry.available_size.to_f32() / self.hidpi_scale_factor).to_i32()
+    }
+
+    pub fn set_viewport_description(&mut self, viewport_description: ViewportDescription) {
+        self.viewport_description = Some(viewport_description);
     }
 }
 

--- a/components/script/dom/htmlmetaelement.rs
+++ b/components/script/dom/htmlmetaelement.rs
@@ -61,6 +61,9 @@ impl HTMLMetaElement {
             if name == "referrer" {
                 self.apply_referrer();
             }
+            if name == "viewport" {
+                self.parse_viewport();
+            }
         // https://html.spec.whatwg.org/multipage/#attr-meta-http-equiv
         } else if !self.HttpEquiv().is_empty() {
             // TODO: Implement additional http-equiv candidates
@@ -113,6 +116,11 @@ impl HTMLMetaElement {
                 doc.set_referrer_policy(determine_policy_for_token(attr_val));
             }
         }
+    }
+
+    /// <https://drafts.csswg.org/css-viewport/#parsing-algorithm>
+    fn parse_viewport(&self) {
+        let _element = self.upcast::<Element>();
     }
 
     /// <https://html.spec.whatwg.org/multipage/#attr-meta-http-equiv-content-security-policy>

--- a/components/shared/compositing/lib.rs
+++ b/components/shared/compositing/lib.rs
@@ -23,6 +23,7 @@ use webrender_api::DocumentId;
 
 pub mod display_list;
 pub mod rendering_context;
+pub mod viewport_description;
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};

--- a/components/shared/compositing/lib.rs
+++ b/components/shared/compositing/lib.rs
@@ -43,6 +43,8 @@ use webrender_api::{
     ImageKey, NativeFontHandle, PipelineId as WebRenderPipelineId,
 };
 
+use crate::viewport_description::ViewportDescription;
+
 /// Sends messages to the compositor.
 #[derive(Clone)]
 pub struct CompositorProxy {
@@ -177,6 +179,8 @@ pub enum CompositorMsg {
     /// Measure the current memory usage associated with the compositor.
     /// The report must be sent on the provided channel once it's complete.
     CollectMemoryReport(ReportsChan),
+    /// A top-level frame has parsed a viewport metatag and is sending the new constraints.
+    Viewport(WebViewId, ViewportDescription),
 }
 
 impl Debug for CompositorMsg {

--- a/components/shared/compositing/viewport_description.rs
+++ b/components/shared/compositing/viewport_description.rs
@@ -1,0 +1,139 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+//! This module contains helpers for Viewport
+
+use std::collections::HashMap;
+
+use euclid::default::Scale;
+use serde::{Deserialize, Serialize};
+
+/// Default viewport constraints
+///
+/// <https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag#initial-scale>
+pub const MIN_ZOOM: f32 = 0.1;
+/// <https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag#initial-scale>
+pub const MAX_ZOOM: f32 = 10.0;
+/// <https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag#initial-scale>
+pub const DEFAULT_ZOOM: f32 = 1.0;
+
+/// A set of viewport descriptors:
+///
+/// <https://www.w3.org/TR/css-viewport-1/#viewport-meta>
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct ViewportDescription {
+    // https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag#width
+    // the (minimum width) size of the viewport
+    // TODO: width Needs to be implemented
+    // https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag#width
+    // the (minimum height) size of the viewport
+    // TODO: height Needs to be implemented
+    /// <https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag#initial-scale>
+    /// the zoom level when the page is first loaded
+    pub initial_scale: Scale<f32>,
+
+    /// <https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag#minimum_scale>
+    /// how much zoom out is allowed on the page.
+    pub minimum_scale: Scale<f32>,
+
+    /// <https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag#maximum_scale>
+    /// how much zoom in is allowed on the page
+    pub maximum_scale: Scale<f32>,
+
+    /// <https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag#user_scalable>
+    /// whether zoom in and zoom out actions are allowed on the page
+    pub user_scalable: UserScalable,
+}
+
+/// The errors that the viewport parsing can generate.
+#[derive(Debug)]
+pub enum ViewportDescriptionParseError {
+    /// When viewport attribute string is empty
+    Empty,
+}
+
+/// A set of User Zoom values:
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub enum UserScalable {
+    /// Zoom is not allowed
+    No = 0,
+    /// Zoom is allowed
+    Yes = 1,
+}
+
+/// Parses a viewport user scalable value.
+impl TryFrom<&str> for UserScalable {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value.to_lowercase().as_str() {
+            "yes" => Ok(UserScalable::Yes),
+            "no" => Ok(UserScalable::No),
+            _ => match value.parse::<f32>() {
+                Ok(1.0) => Ok(UserScalable::Yes),
+                Ok(0.0) => Ok(UserScalable::No),
+                _ => Err("can't convert character to UserScalable"),
+            },
+        }
+    }
+}
+
+impl Default for ViewportDescription {
+    fn default() -> Self {
+        ViewportDescription {
+            initial_scale: Scale::new(DEFAULT_ZOOM),
+            minimum_scale: Scale::new(MIN_ZOOM),
+            maximum_scale: Scale::new(MAX_ZOOM),
+            user_scalable: UserScalable::Yes,
+        }
+    }
+}
+
+impl ViewportDescription {
+    /// Iterates over the key-value pairs generated from meta tag and returns a ViewportDescription
+    fn process_viewport_key_value_pair(pairs: HashMap<String, String>) -> ViewportDescription {
+        let mut description = ViewportDescription::default();
+        for (key, value) in &pairs {
+            match key.as_str() {
+                "initial-scale" => {
+                    if let Some(zoom) = Self::parse_viewport_value_as_zoom(value) {
+                        description.initial_scale = zoom;
+                    }
+                },
+                "minimum-scale" => {
+                    if let Some(zoom) = Self::parse_viewport_value_as_zoom(value) {
+                        description.minimum_scale = zoom;
+                    }
+                },
+                "maximum-scale" => {
+                    if let Some(zoom) = Self::parse_viewport_value_as_zoom(value) {
+                        description.maximum_scale = zoom;
+                    }
+                },
+                "user-scalable" => {
+                    if let Ok(user_zoom_allowed) = value.as_str().try_into() {
+                        description.user_scalable = user_zoom_allowed;
+                    }
+                },
+                _ => (),
+            }
+        }
+        description
+    }
+
+    /// Parses a viewport zoom value.
+    fn parse_viewport_value_as_zoom(value: &str) -> Option<Scale<f32>> {
+        value
+            .to_lowercase()
+            .as_str()
+            .parse::<f32>()
+            .ok()
+            .filter(|&n| (0.0..=10.0).contains(&n))
+            .map(Scale::new)
+    }
+
+    /// Constrains a zoom value within the allowed scale range
+    pub fn clamp_zoom(&self, zoom: f32) -> f32 {
+        zoom.clamp(self.minimum_scale.get(), self.maximum_scale.get())
+    }
+}

--- a/components/shared/compositing/viewport_description.rs
+++ b/components/shared/compositing/viewport_description.rs
@@ -95,7 +95,7 @@ impl Default for ViewportDescription {
 
 impl ViewportDescription {
     /// Iterates over the key-value pairs generated from meta tag and returns a ViewportDescription
-    fn process_viewport_key_value_pair(pairs: HashMap<String, String>) -> ViewportDescription {
+    fn process_viewport_key_value_pairs(pairs: HashMap<String, String>) -> ViewportDescription {
         let mut description = ViewportDescription::default();
         for (key, value) in &pairs {
             match key.as_str() {
@@ -170,6 +170,6 @@ impl FromStr for ViewportDescription {
             })
             .collect::<HashMap<String, String>>();
 
-        Ok(Self::process_viewport_key_value_pair(parsed_values))
+        Ok(Self::process_viewport_key_value_pairs(parsed_values))
     }
 }


### PR DESCRIPTION
This patch comprises following steps:
1. Parses the `viewport` Attribute from `<meta>`.
2. Creates a `ViewportDescription` struct.
3. Populate values into Viewport struct.
4. Pass & Stash Viewport Description to Webview.
5. Process parsed values of `viewport <meta>`

Testing: Tested locally.
Fixes: #36159 