### PR TITLE
compositor: Fix scroll offset checks for `CrossProcessCompositorMessage::SendScrollNode`

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -695,6 +695,8 @@ impl IOCompositor {
                         -offset,
                     )
                 {
+                    // TODO: We adjust the scroll offset here, but we are not syncing it with
+                    //       Window and LayoutThread scroll_offset "mirror".
                     let adjusted_scroll_offset = -offset;
                     let mut txn = Transaction::new();
                     txn.set_scroll_offsets(

--- a/tests/wpt/meta/css/css-position/sticky/position-sticky-left-003.html.ini
+++ b/tests/wpt/meta/css/css-position/sticky/position-sticky-left-003.html.ini
@@ -1,2 +1,0 @@
-[position-sticky-left-003.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-position/sticky/position-sticky-top-003.html.ini
+++ b/tests/wpt/meta/css/css-position/sticky/position-sticky-top-003.html.ini
@@ -1,2 +1,0 @@
-[position-sticky-top-003.html]
-  expected: FAIL


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Scroll offsets changes from `CrossProcessCompositorMessage::SendScrollNode` should consider the maximum scroll offsets of a Node. Since these checks happen several times, I believe it wouldn't hurt to introduce the utility functions as well.

[Try](https://github.com/stevennovaryo/servo/actions/runs/13779997408)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #35019 (GitHub issue number if applicable)

<!-- Either: -->
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
