### PR TITLE
Make input element display-inside always flow-root

### DIFF
--- a/components/layout_2020/fragment_tree/base_fragment.rs
+++ b/components/layout_2020/fragment_tree/base_fragment.rs
@@ -75,31 +75,33 @@ impl From<BaseFragmentInfo> for BaseFragment {
 bitflags! {
     /// Flags used to track various information about a DOM node during layout.
     #[derive(Clone, Copy, Debug)]
-    pub(crate) struct FragmentFlags: u8 {
+    pub(crate) struct FragmentFlags: u16 {
         /// Whether or not the node that created this fragment is a `<body>` element on an HTML document.
         const IS_BODY_ELEMENT_OF_HTML_ELEMENT_ROOT = 1 << 0;
         /// Whether or not the node that created this Fragment is a `<br>` element.
         const IS_BR_ELEMENT = 1 << 1;
+        /// Whether or not the node that created this Fragment is a `<input>` or `<textarea>` element.
+        const IS_TEXT_CONTROL = 1 << 2;
         /// Whether or not this Fragment is a flex item or a grid item.
-        const IS_FLEX_OR_GRID_ITEM = 1 << 2;
+        const IS_FLEX_OR_GRID_ITEM = 1 << 3;
         /// Whether or not this Fragment was created to contain a replaced element or is
         /// a replaced element.
-        const IS_REPLACED = 1 << 3;
+        const IS_REPLACED = 1 << 4;
         /// Whether or not the node that created was a `<table>`, `<th>` or
         /// `<td>` element. Note that this does *not* include elements with
         /// `display: table` or `display: table-cell`.
-        const IS_TABLE_TH_OR_TD_ELEMENT = 1 << 4;
+        const IS_TABLE_TH_OR_TD_ELEMENT = 1 << 5;
         /// Whether or not this Fragment was created to contain a list item marker
         /// with a used value of `list-style-position: outside`.
-        const IS_OUTSIDE_LIST_ITEM_MARKER = 1 << 5;
+        const IS_OUTSIDE_LIST_ITEM_MARKER = 1 << 6;
         /// Avoid painting the borders, backgrounds, and drop shadow for this fragment, this is used
         /// for empty table cells when 'empty-cells' is 'hide' and also table wrappers.  This flag
         /// doesn't avoid hit-testing nor does it prevent the painting outlines.
-        const DO_NOT_PAINT = 1 << 6;
+        const DO_NOT_PAINT = 1 << 7;
         /// Whether or not the size of this fragment depends on the block size of its container
         /// and the fragment can be a flex item. This flag is used to cache items during flex
         /// layout.
-        const SIZE_DEPENDS_ON_BLOCK_CONSTRAINTS_AND_CAN_BE_CHILD_OF_FLEX_ITEM = 1 << 7;
+        const SIZE_DEPENDS_ON_BLOCK_CONSTRAINTS_AND_CAN_BE_CHILD_OF_FLEX_ITEM = 1 << 8;
     }
 }
 

--- a/components/layout_2020/fragment_tree/box_fragment.rs
+++ b/components/layout_2020/fragment_tree/box_fragment.rs
@@ -15,7 +15,6 @@ use style::properties::ComputedValues;
 
 use super::{BaseFragment, BaseFragmentInfo, CollapsedBlockMargins, Fragment};
 use crate::formatting_contexts::Baselines;
-use crate::fragment_tree::FragmentFlags;
 use crate::geom::{
     AuOrAuto, LengthPercentageOrAuto, PhysicalPoint, PhysicalRect, PhysicalSides, ToLogical,
 };
@@ -346,8 +345,7 @@ impl BoxFragment {
     /// Whether this is a non-replaced inline-level box whose inner display type is `flow`.
     /// <https://drafts.csswg.org/css-display-3/#inline-box>
     pub(crate) fn is_inline_box(&self) -> bool {
-        self.style.get_box().display.is_inline_flow() &&
-            !self.base.flags.contains(FragmentFlags::IS_REPLACED)
+        self.style.is_inline_box(self.base.flags)
     }
 
     /// Whether this is a table wrapper box.

--- a/tests/wpt/tests/html/rendering/widgets/text-control-client-width.html
+++ b/tests/wpt/tests/html/rendering/widgets/text-control-client-width.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>text control with `display: inline` must not have 0 client width</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/rendering.html#form-controls">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<input id="input" style="display: inline;">
+<textarea id="textarea" style="display: inline;"></textarea>
+
+<script>
+test(() => {
+  assert_greater_than(document.querySelector("#input").clientWidth, 0);
+}, "Input with `display: inline` should have positive client width");
+
+test(() => {
+  assert_greater_than(document.querySelector("#textarea").clientWidth, 0);
+}, "Textarea with `display: inline` should have positive client width");
+</script>

--- a/tests/wpt/tests/html/rendering/widgets/text-control-flow-root-ref.html
+++ b/tests/wpt/tests/html/rendering/widgets/text-control-flow-root-ref.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+
+<input id="input1">
+<br>
+<input style="transform: scale(0.5);">
+<br>
+aaa<input>aaa
+<br>
+<textarea></textarea>
+<br>
+<textarea style="transform: scale(0.5);"></textarea>
+<br>
+aa<textarea style="transform: scale(0.5);">aa</textarea>aa

--- a/tests/wpt/tests/html/rendering/widgets/text-control-flow-root.html
+++ b/tests/wpt/tests/html/rendering/widgets/text-control-flow-root.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>display inside of text control should always be flow-root</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/rendering.html#form-controls">
+<link rel=match href="text-control-flow-root-ref.html">
+
+<input id="input1" style="display: inline;">
+<br>
+<input style="display: inline; transform: scale(0.5);">
+<br>
+aaa<input style="display: inline;">aaa
+<br>
+<textarea style="display: inline;"></textarea>
+<br>
+<textarea style="display: inline; transform: scale(0.5);"></textarea>
+<br>
+aa<textarea style="display: inline; transform: scale(0.5);">aa</textarea>aa


### PR DESCRIPTION
<https://html.spec.whatwg.org/multipage/rendering.html#form-controls>

Make so that inner display type of an input element always `flow-root`

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #33669
- [X] There are [tests](https://github.com/servo/servo/pull/35908/files#diff-a5c4b30fe962daa68bf1b6213a8bb864a545e49818202da0da29b62dbb7d3f49) for these changes OR 

Try: https://github.com/PotatoCP/servo/actions/runs/13891284110

cc @xiaochengh 

