### PR TITLE
ohos: Remove direct link to ace_napi.z

### DIFF
--- a/ports/servoshell/egl/ohos.rs
+++ b/ports/servoshell/egl/ohos.rs
@@ -41,10 +41,6 @@ use super::host_trait::HostTrait;
 mod resources;
 mod simpleservo;
 
-// Can be removed once <https://github.com/ohos-rs/ohos-rs/pull/105> is merged / released.
-#[link(name = "ace_napi.z")]
-extern "C" {}
-
 #[napi(object)]
 #[derive(Debug)]
 pub struct InitOpts {


### PR DESCRIPTION
The underlying issue was solved in napi-ohos 1.0.2, and we have already updated to 1.0.4


---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #35913
- [x] There are tests for these changes