### PR TITLE
Fix ./mach build --no-default-features

### DIFF
--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -42,7 +42,6 @@ use super::{headed_window, headless_window};
 use crate::desktop::app_state::RunningAppState;
 use crate::desktop::protocols;
 use crate::desktop::tracing::trace_winit_event;
-use crate::desktop::webxr::XrDiscoveryWebXrRegistry;
 use crate::desktop::window_trait::WindowPortsMethods;
 use crate::parser::{get_default_url, location_bar_input_to_url};
 use crate::prefs::ServoShellPreferences;
@@ -159,11 +158,12 @@ impl App {
             .event_loop_waker(self.waker.clone());
 
         #[cfg(feature = "webxr")]
-        let servo_builder = servo_builder.webxr_registry(XrDiscoveryWebXrRegistry::new_boxed(
-            window.clone(),
-            event_loop,
-            &self.preferences,
-        ));
+        let servo_builder =
+            servo_builder.webxr_registry(super::webxr::XrDiscoveryWebXrRegistry::new_boxed(
+                window.clone(),
+                event_loop,
+                &self.preferences,
+            ));
 
         let servo = servo_builder.build();
         servo.setup_logging();

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -17,7 +17,6 @@ use euclid::{Angle, Length, Point2D, Rotation3D, Scale, Size2D, UnknownUnit, Vec
 use keyboard_types::ShortcutMatcher;
 use log::{debug, info};
 use raw_window_handle::{HasDisplayHandle, HasWindowHandle, RawWindowHandle};
-use servo::servo_config::pref;
 use servo::servo_geometry::{
     DeviceIndependentIntRect, DeviceIndependentPixel, convert_rect_to_css_pixel,
 };
@@ -30,7 +29,6 @@ use servo::{
     TouchEvent, TouchEventType, TouchId, WebRenderDebugOption, WebView, WheelDelta, WheelEvent,
     WheelMode, WindowRenderingContext,
 };
-use surfman::{Context, Device};
 use url::Url;
 use winit::dpi::{LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize};
 use winit::event::{
@@ -746,6 +744,7 @@ impl WindowPortsMethods for Window {
         }
     }
 
+    #[cfg(feature = "webxr")]
     fn new_glwindow(
         &self,
         event_loop: &ActiveEventLoop,
@@ -854,6 +853,7 @@ fn load_icon(icon_bytes: &[u8]) -> Icon {
     Icon::from_rgba(icon_rgba, icon_width, icon_height).expect("Failed to load icon")
 }
 
+#[cfg(feature = "webxr")]
 struct XRWindow {
     winit_window: winit::window::Window,
     pose: Rc<XRWindowPose>,
@@ -864,11 +864,12 @@ struct XRWindowPose {
     xr_translation: Cell<Vector3D<f32, UnknownUnit>>,
 }
 
+#[cfg(feature = "webxr")]
 impl servo::webxr::glwindow::GlWindow for XRWindow {
     fn get_render_target(
         &self,
-        device: &mut Device,
-        _context: &mut Context,
+        device: &mut surfman::Device,
+        _context: &mut surfman::Context,
     ) -> servo::webxr::glwindow::GlWindowRenderTarget {
         self.winit_window.set_visible(true);
         let window_handle = self
@@ -893,6 +894,7 @@ impl servo::webxr::glwindow::GlWindow for XRWindow {
     }
 
     fn get_mode(&self) -> servo::webxr::glwindow::GlWindowMode {
+        use servo::servo_config::pref;
         if pref!(dom_webxr_glwindow_red_cyan) {
             servo::webxr::glwindow::GlWindowMode::StereoRedCyan
         } else if pref!(dom_webxr_glwindow_left_right) {

--- a/ports/servoshell/desktop/headless_window.rs
+++ b/ports/servoshell/desktop/headless_window.rs
@@ -141,6 +141,7 @@ impl WindowPortsMethods for Window {
         // Not expecting any winit events.
     }
 
+    #[cfg(feature = "webxr")]
     fn new_glwindow(
         &self,
         _events_loop: &winit::event_loop::ActiveEventLoop,

--- a/ports/servoshell/desktop/mod.rs
+++ b/ports/servoshell/desktop/mod.rs
@@ -19,5 +19,6 @@ mod keyutils;
 mod minibrowser;
 mod protocols;
 mod tracing;
+#[cfg(feature = "webxr")]
 mod webxr;
 mod window_trait;

--- a/ports/servoshell/desktop/webxr.rs
+++ b/ports/servoshell/desktop/webxr.rs
@@ -17,14 +17,12 @@ use winit::event_loop::ActiveEventLoop;
 
 use super::window_trait::WindowPortsMethods;
 
-#[cfg(feature = "webxr")]
 enum XrDiscovery {
     GlWindow(GlWindowDiscovery),
     #[cfg(target_os = "windows")]
     OpenXr(OpenXrDiscovery),
 }
 
-#[cfg(feature = "webxr")]
 pub(crate) struct XrDiscoveryWebXrRegistry {
     xr_discovery: RefCell<Option<XrDiscovery>>,
 }
@@ -75,7 +73,6 @@ impl prefs::Observer for XrPrefObserver {
     }
 }
 
-#[cfg(feature = "webxr")]
 impl WebXrRegistry for XrDiscoveryWebXrRegistry {
     fn register(&self, xr: &mut servo::webxr::MainThreadRegistry) {
         use servo::webxr::headless::HeadlessMockDiscovery;

--- a/ports/servoshell/desktop/window_trait.rs
+++ b/ports/servoshell/desktop/window_trait.rs
@@ -43,6 +43,7 @@ pub trait WindowPortsMethods {
     fn set_position(&self, _point: DeviceIntPoint) {}
     fn set_fullscreen(&self, _state: bool) {}
     fn set_cursor(&self, _cursor: Cursor) {}
+    #[cfg(feature = "webxr")]
     fn new_glwindow(
         &self,
         event_loop: &winit::event_loop::ActiveEventLoop,


### PR DESCRIPTION
Fix build failures when building without default features.

Testing: This was manually tested, but this PR does not add automated tests of `--no-default-features` to CI.