### PR TITLE
bhs: Remove direct link to `liblzma`

### DIFF
--- a/components/background_hang_monitor/sampler_linux.rs
+++ b/components/background_hang_monitor/sampler_linux.rs
@@ -15,11 +15,6 @@ use unwind_sys::{
 
 use crate::sampler::{NativeStack, Sampler};
 
-// Hack to workaround broken libunwind pkg-config contents for <1.1-3ubuntu.1.
-// https://bugs.launchpad.net/ubuntu/+source/libunwind/+bug/1336912
-#[link(name = "lzma")]
-extern "C" {}
-
 struct UncheckedSyncUnsafeCell<T>(std::cell::UnsafeCell<T>);
 
 /// Safety: dereferencing the pointer from `UnsafeCell::get` must involve external synchronization


### PR DESCRIPTION
This workaround doesn't seem to be necessary any longer.

Fixes #35914.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they just remove a manual dynamic link.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
