### PR TITLE
Boxes with `position: fixed` should not be a part of scrollable overflow of viewport

### DIFF
--- a/tests/wpt/meta/css/css-masking/clip-path/clip-path-fixed-scroll.html.ini
+++ b/tests/wpt/meta/css/css-masking/clip-path/clip-path-fixed-scroll.html.ini
@@ -1,2 +1,0 @@
-[clip-path-fixed-scroll.html]
-  expected: FAIL


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
When calculate `scrollable_overflow` rect for Fragment tree, should ignore child with `position: fixed`:
[Fixed boxes do not move when the document is scrolled](https://www.w3.org/TR/css-position-3/#fixed-position).

Test:
`tests/wpt/tests/css/css-masking/clip-path/clip-path-fixed-scroll.html`

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #35928 (GitHub issue number if applicable)

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
