### PR TITLE
deps: Correct stylo branch name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4557,7 +4557,7 @@ dependencies = [
 [[package]]
 name = "malloc_size_of"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-03-12#9f79a70177b83ead3b990d63de55fbd715cbf71a"
+source = "git+https://github.com/servo/stylo?branch=2025-03-11#4ff13d4fca78189988f1fa3d7351d10369e5c532"
 dependencies = [
  "app_units",
  "cssparser",
@@ -6577,7 +6577,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.26.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-12#9f79a70177b83ead3b990d63de55fbd715cbf71a"
+source = "git+https://github.com/servo/stylo?branch=2025-03-11#4ff13d4fca78189988f1fa3d7351d10369e5c532"
 dependencies = [
  "bitflags 2.9.0",
  "cssparser",
@@ -6862,7 +6862,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-12#9f79a70177b83ead3b990d63de55fbd715cbf71a"
+source = "git+https://github.com/servo/stylo?branch=2025-03-11#4ff13d4fca78189988f1fa3d7351d10369e5c532"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -7294,7 +7294,7 @@ dependencies = [
 [[package]]
 name = "style"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-03-12#9f79a70177b83ead3b990d63de55fbd715cbf71a"
+source = "git+https://github.com/servo/stylo?branch=2025-03-11#4ff13d4fca78189988f1fa3d7351d10369e5c532"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -7352,7 +7352,7 @@ dependencies = [
 [[package]]
 name = "style_derive"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-03-12#9f79a70177b83ead3b990d63de55fbd715cbf71a"
+source = "git+https://github.com/servo/stylo?branch=2025-03-11#4ff13d4fca78189988f1fa3d7351d10369e5c532"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -7382,7 +7382,7 @@ dependencies = [
 [[package]]
 name = "style_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-03-12#9f79a70177b83ead3b990d63de55fbd715cbf71a"
+source = "git+https://github.com/servo/stylo?branch=2025-03-11#4ff13d4fca78189988f1fa3d7351d10369e5c532"
 dependencies = [
  "app_units",
  "bitflags 2.9.0",
@@ -7404,7 +7404,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-12#9f79a70177b83ead3b990d63de55fbd715cbf71a"
+source = "git+https://github.com/servo/stylo?branch=2025-03-11#4ff13d4fca78189988f1fa3d7351d10369e5c532"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -7413,12 +7413,12 @@ dependencies = [
 [[package]]
 name = "stylo_config"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-12#9f79a70177b83ead3b990d63de55fbd715cbf71a"
+source = "git+https://github.com/servo/stylo?branch=2025-03-11#4ff13d4fca78189988f1fa3d7351d10369e5c532"
 
 [[package]]
 name = "stylo_dom"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-12#9f79a70177b83ead3b990d63de55fbd715cbf71a"
+source = "git+https://github.com/servo/stylo?branch=2025-03-11#4ff13d4fca78189988f1fa3d7351d10369e5c532"
 dependencies = [
  "bitflags 2.9.0",
  "malloc_size_of",
@@ -7427,7 +7427,7 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-12#9f79a70177b83ead3b990d63de55fbd715cbf71a"
+source = "git+https://github.com/servo/stylo?branch=2025-03-11#4ff13d4fca78189988f1fa3d7351d10369e5c532"
 
 [[package]]
 name = "subtle"
@@ -7794,7 +7794,7 @@ dependencies = [
 [[package]]
 name = "to_shmem"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-12#9f79a70177b83ead3b990d63de55fbd715cbf71a"
+source = "git+https://github.com/servo/stylo?branch=2025-03-11#4ff13d4fca78189988f1fa3d7351d10369e5c532"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -7807,7 +7807,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-12#9f79a70177b83ead3b990d63de55fbd715cbf71a"
+source = "git+https://github.com/servo/stylo?branch=2025-03-11#4ff13d4fca78189988f1fa3d7351d10369e5c532"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,25 +117,25 @@ rustls-pemfile = "2.0"
 rustls-pki-types = "1.11"
 script_layout_interface = { path = "components/shared/script_layout" }
 script_traits = { path = "components/shared/script" }
-selectors = { git = "https://github.com/servo/stylo", branch = "2025-03-12" }
+selectors = { git = "https://github.com/servo/stylo", branch = "2025-03-11" }
 serde = "1.0.219"
 serde_bytes = "0.11"
 serde_json = "1.0"
 servo-media = { git = "https://github.com/servo/media" }
 servo-media-dummy = { git = "https://github.com/servo/media" }
 servo-media-gstreamer = { git = "https://github.com/servo/media" }
-servo_arc = { git = "https://github.com/servo/stylo", branch = "2025-03-12", features = ["servo"] }
-stylo_atoms = { git = "https://github.com/servo/stylo", branch = "2025-03-12" }
+servo_arc = { git = "https://github.com/servo/stylo", branch = "2025-03-11", features = ["servo"] }
+stylo_atoms = { git = "https://github.com/servo/stylo", branch = "2025-03-11" }
 smallbitvec = "2.6.0"
 smallvec = "1.14"
 static_assertions = "1.1"
 string_cache = "0.8"
 string_cache_codegen = "0.5"
-style = { git = "https://github.com/servo/stylo", branch = "2025-03-12", features = ["servo"] }
-stylo_config = { git = "https://github.com/servo/stylo", branch = "2025-03-12" }
-stylo_dom = { git = "https://github.com/servo/stylo", branch = "2025-03-12" }
-style_malloc_size_of = { package = "malloc_size_of", git = "https://github.com/servo/stylo", branch = "2025-03-12", features = ["servo"] }
-style_traits = { git = "https://github.com/servo/stylo", branch = "2025-03-12", features = ["servo"] }
+style = { git = "https://github.com/servo/stylo", branch = "2025-03-11", features = ["servo"] }
+stylo_config = { git = "https://github.com/servo/stylo", branch = "2025-03-11" }
+stylo_dom = { git = "https://github.com/servo/stylo", branch = "2025-03-11" }
+style_malloc_size_of = { package = "malloc_size_of", git = "https://github.com/servo/stylo", branch = "2025-03-11", features = ["servo"] }
+style_traits = { git = "https://github.com/servo/stylo", branch = "2025-03-11", features = ["servo"] }
 surfman = { git = "https://github.com/servo/surfman", rev = "f7688b4585f9e0b5d4bf8ee8e4a91e82349610b1", features = ["chains"] }
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"


### PR DESCRIPTION
The `mirror` script in the stylo repository should determine the branch
name after an upgrade. By accident the wrong branch name was assigned
manually.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because this just modifies a branch name in deps.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
