### PR TITLE
Fix flickering cursor issue within the compositor

### DIFF
--- a/components/compositing/webview.rs
+++ b/components/compositing/webview.rs
@@ -285,7 +285,7 @@ impl WebView {
             return;
         };
 
-        self.global.borrow_mut().update_cursor(&result);
+        self.global.borrow_mut().update_cursor(point, &result);
 
         if let Err(error) =
             self.global


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Previously a member of IOCompositor, the `cursor_pos` DevicePoint did not reflect the true position of the cursor. This caused flickering on mouse hover, see [issue #35875.](https://github.com/servo/servo/issues/35875) The value of `cursor_pos` within IOCompositor was always (x=0, y=0) regardless of the true cursor position (it was never updated, must be a bug or an oversight?).

Moving `cursor_pos` to `ServoRenderer`, updating `cursor_pos` on `dispatch_input_event()`, and storing cursor position in `ServoRenderer` through method `update_cursor()` fixes the flickering previously observed.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #35875

<br>

- Tests not applicable on this issue.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
