### PR TITLE
devtools: improve `ID` naming for better readability and context

### DIFF
--- a/components/devtools/actor.rs
+++ b/components/devtools/actor.rs
@@ -32,7 +32,7 @@ pub(crate) trait Actor: Any + ActorAsAny {
         msg_type: &str,
         msg: &Map<String, Value>,
         stream: &mut TcpStream,
-        id: StreamId,
+        stream_id: StreamId,
     ) -> Result<ActorMessageStatus, ()>;
     fn name(&self) -> String;
     fn cleanup(&self, _id: StreamId) {}
@@ -77,9 +77,9 @@ impl ActorRegistry {
         }
     }
 
-    pub(crate) fn cleanup(&self, id: StreamId) {
+    pub(crate) fn cleanup(&self, stream_id: StreamId) {
         for actor in self.actors.values() {
-            actor.cleanup(id);
+            actor.cleanup(stream_id);
         }
     }
 
@@ -170,7 +170,7 @@ impl ActorRegistry {
         &mut self,
         msg: &Map<String, Value>,
         stream: &mut TcpStream,
-        id: StreamId,
+        stream_id: StreamId,
     ) -> Result<(), ()> {
         let to = match msg.get("to") {
             Some(to) => to.as_str().unwrap(),
@@ -184,7 +184,7 @@ impl ActorRegistry {
             None => log::warn!("message received for unknown actor \"{}\"", to),
             Some(actor) => {
                 let msg_type = msg.get("type").unwrap().as_str().unwrap();
-                if actor.handle_message(self, msg_type, msg, stream, id)? !=
+                if actor.handle_message(self, msg_type, msg, stream, stream_id)? !=
                     ActorMessageStatus::Processed
                 {
                     log::warn!(

--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -173,9 +173,9 @@ impl Actor for BrowsingContextActor {
 impl BrowsingContextActor {
     pub(crate) fn new(
         console: String,
-        id: BrowsingContextId,
+        browsing_context_id: BrowsingContextId,
         page_info: DevtoolsPageInfo,
-        pipeline: PipelineId,
+        pipeline_id: PipelineId,
         script_sender: IpcSender<DevtoolScriptControlMsg>,
         actors: &mut ActorRegistry,
     ) -> BrowsingContextActor {
@@ -224,8 +224,8 @@ impl BrowsingContextActor {
             script_chan: script_sender,
             title: RefCell::new(title),
             url: RefCell::new(url.into_string()),
-            active_pipeline: Cell::new(pipeline),
-            browsing_context_id: id,
+            active_pipeline: Cell::new(pipeline_id),
+            browsing_context_id,
             accessibility: accessibility.name(),
             console,
             css_properties: css_properties.name(),
@@ -308,8 +308,8 @@ impl BrowsingContextActor {
         }
     }
 
-    pub(crate) fn title_changed(&self, pipeline: PipelineId, title: String) {
-        if pipeline != self.active_pipeline.get() {
+    pub(crate) fn title_changed(&self, pipeline_id: PipelineId, title: String) {
+        if pipeline_id != self.active_pipeline.get() {
             return;
         }
         *self.title.borrow_mut() = title;

--- a/components/devtools/actors/console.rs
+++ b/components/devtools/actors/console.rs
@@ -155,7 +155,7 @@ impl ConsoleActor {
                     .active_pipeline
                     .get(),
             ),
-            Root::DedicatedWorker(w) => UniqueId::Worker(registry.find::<WorkerActor>(w).id),
+            Root::DedicatedWorker(w) => UniqueId::Worker(registry.find::<WorkerActor>(w).worker_id),
         }
     }
 

--- a/components/devtools/actors/framerate.rs
+++ b/components/devtools/actors/framerate.rs
@@ -16,7 +16,7 @@ use crate::actors::timeline::HighResolutionStamp;
 
 pub struct FramerateActor {
     name: String,
-    pipeline: PipelineId,
+    pipeline_id: PipelineId,
     script_sender: IpcSender<DevtoolScriptControlMsg>,
     is_recording: bool,
     ticks: Vec<HighResolutionStamp>,
@@ -49,7 +49,7 @@ impl FramerateActor {
         let actor_name = registry.new_name("framerate");
         let mut actor = FramerateActor {
             name: actor_name.clone(),
-            pipeline: pipeline_id,
+            pipeline_id,
             script_sender,
             is_recording: false,
             ticks: Vec::new(),
@@ -64,7 +64,7 @@ impl FramerateActor {
         self.ticks.push(HighResolutionStamp::wrap(tick));
 
         if self.is_recording {
-            let msg = DevtoolScriptControlMsg::RequestAnimationFrame(self.pipeline, self.name());
+            let msg = DevtoolScriptControlMsg::RequestAnimationFrame(self.pipeline_id, self.name());
             self.script_sender.send(msg).unwrap();
         }
     }
@@ -80,7 +80,7 @@ impl FramerateActor {
 
         self.is_recording = true;
 
-        let msg = DevtoolScriptControlMsg::RequestAnimationFrame(self.pipeline, self.name());
+        let msg = DevtoolScriptControlMsg::RequestAnimationFrame(self.pipeline_id, self.name());
         self.script_sender.send(msg).unwrap();
     }
 


### PR DESCRIPTION
Renamed various IDs  such as `stream_id`, `pipeline_id` `browsing_context_it` for better readability and context

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)
