### PR TITLE
Improve logic for establishing a stacking context

### DIFF
--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -257,7 +257,9 @@ impl FlexLineItem<'_> {
         }
 
         let mut fragment_info = self.item.box_.base_fragment_info();
-        fragment_info.flags.insert(FragmentFlags::IS_FLEX_ITEM);
+        fragment_info
+            .flags
+            .insert(FragmentFlags::IS_FLEX_OR_GRID_ITEM);
         if self.item.depends_on_block_constraints {
             fragment_info.flags.insert(
                 FragmentFlags::SIZE_DEPENDS_ON_BLOCK_CONSTRAINTS_AND_CAN_BE_CHILD_OF_FLEX_ITEM,

--- a/components/layout_2020/fragment_tree/base_fragment.rs
+++ b/components/layout_2020/fragment_tree/base_fragment.rs
@@ -80,8 +80,8 @@ bitflags! {
         const IS_BODY_ELEMENT_OF_HTML_ELEMENT_ROOT = 1 << 0;
         /// Whether or not the node that created this Fragment is a `<br>` element.
         const IS_BR_ELEMENT = 1 << 1;
-        /// Whether or not this Fragment is a flex item.
-        const IS_FLEX_ITEM = 1 << 2;
+        /// Whether or not this Fragment is a flex item or a grid item.
+        const IS_FLEX_OR_GRID_ITEM = 1 << 2;
         /// Whether or not this Fragment was created to contain a replaced element or is
         /// a replaced element.
         const IS_REPLACED = 1 << 3;

--- a/components/layout_2020/taffy/layout.rs
+++ b/components/layout_2020/taffy/layout.rs
@@ -20,7 +20,9 @@ use crate::formatting_contexts::{
     Baselines, IndependentFormattingContext, IndependentFormattingContextContents,
     IndependentLayout,
 };
-use crate::fragment_tree::{BoxFragment, CollapsedBlockMargins, Fragment, SpecificLayoutInfo};
+use crate::fragment_tree::{
+    BoxFragment, CollapsedBlockMargins, Fragment, FragmentFlags, SpecificLayoutInfo,
+};
 use crate::geom::{
     LogicalSides, LogicalVec2, PhysicalPoint, PhysicalRect, PhysicalSides, PhysicalSize, Size,
     SizeConstraint, Sizes,
@@ -560,8 +562,12 @@ impl TaffyContainer {
 
                 match &mut child.taffy_level_box {
                     TaffyItemBoxInner::InFlowBox(independent_box) => {
+                        let mut fragment_info = independent_box.base_fragment_info();
+                        fragment_info
+                            .flags
+                            .insert(FragmentFlags::IS_FLEX_OR_GRID_ITEM);
                         let mut box_fragment = BoxFragment::new(
-                            independent_box.base_fragment_info(),
+                            fragment_info,
                             independent_box.style().clone(),
                             std::mem::take(&mut child.child_fragments),
                             content_size,

--- a/tests/wpt/meta/css/css-grid/grid-items/grid-inline-z-axis-ordering-001.html.ini
+++ b/tests/wpt/meta/css/css-grid/grid-items/grid-inline-z-axis-ordering-001.html.ini
@@ -1,2 +1,0 @@
-[grid-inline-z-axis-ordering-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-grid/grid-items/grid-inline-z-axis-ordering-002.html.ini
+++ b/tests/wpt/meta/css/css-grid/grid-items/grid-inline-z-axis-ordering-002.html.ini
@@ -1,2 +1,0 @@
-[grid-inline-z-axis-ordering-002.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-grid/grid-items/grid-inline-z-axis-ordering-003.html.ini
+++ b/tests/wpt/meta/css/css-grid/grid-items/grid-inline-z-axis-ordering-003.html.ini
@@ -1,2 +1,0 @@
-[grid-inline-z-axis-ordering-003.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-grid/grid-items/grid-inline-z-axis-ordering-004.html.ini
+++ b/tests/wpt/meta/css/css-grid/grid-items/grid-inline-z-axis-ordering-004.html.ini
@@ -1,2 +1,0 @@
-[grid-inline-z-axis-ordering-004.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-grid/grid-items/grid-inline-z-axis-ordering-005.html.ini
+++ b/tests/wpt/meta/css/css-grid/grid-items/grid-inline-z-axis-ordering-005.html.ini
@@ -1,2 +1,0 @@
-[grid-inline-z-axis-ordering-005.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-grid/grid-items/grid-inline-z-axis-ordering-overlapped-items-001.html.ini
+++ b/tests/wpt/meta/css/css-grid/grid-items/grid-inline-z-axis-ordering-overlapped-items-001.html.ini
@@ -1,2 +1,0 @@
-[grid-inline-z-axis-ordering-overlapped-items-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-grid/grid-items/grid-inline-z-axis-ordering-overlapped-items-002.html.ini
+++ b/tests/wpt/meta/css/css-grid/grid-items/grid-inline-z-axis-ordering-overlapped-items-002.html.ini
@@ -1,2 +1,0 @@
-[grid-inline-z-axis-ordering-overlapped-items-002.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-grid/grid-items/grid-inline-z-axis-ordering-overlapped-items-003.html.ini
+++ b/tests/wpt/meta/css/css-grid/grid-items/grid-inline-z-axis-ordering-overlapped-items-003.html.ini
@@ -1,2 +1,0 @@
-[grid-inline-z-axis-ordering-overlapped-items-003.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-grid/grid-items/grid-inline-z-axis-ordering-overlapped-items-004.html.ini
+++ b/tests/wpt/meta/css/css-grid/grid-items/grid-inline-z-axis-ordering-overlapped-items-004.html.ini
@@ -1,2 +1,0 @@
-[grid-inline-z-axis-ordering-overlapped-items-004.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-grid/grid-items/grid-inline-z-axis-ordering-overlapped-items-005.html.ini
+++ b/tests/wpt/meta/css/css-grid/grid-items/grid-inline-z-axis-ordering-overlapped-items-005.html.ini
@@ -1,2 +1,0 @@
-[grid-inline-z-axis-ordering-overlapped-items-005.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-grid/grid-items/grid-inline-z-axis-ordering-overlapped-items-006.html.ini
+++ b/tests/wpt/meta/css/css-grid/grid-items/grid-inline-z-axis-ordering-overlapped-items-006.html.ini
@@ -1,2 +1,0 @@
-[grid-inline-z-axis-ordering-overlapped-items-006.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-grid/grid-items/grid-layout-z-order-a.html.ini
+++ b/tests/wpt/meta/css/css-grid/grid-items/grid-layout-z-order-a.html.ini
@@ -1,2 +1,0 @@
-[grid-layout-z-order-a.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-grid/grid-items/grid-layout-z-order-b.html.ini
+++ b/tests/wpt/meta/css/css-grid/grid-items/grid-layout-z-order-b.html.ini
@@ -1,2 +1,0 @@
-[grid-layout-z-order-b.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-grid/grid-items/grid-z-axis-ordering-001.html.ini
+++ b/tests/wpt/meta/css/css-grid/grid-items/grid-z-axis-ordering-001.html.ini
@@ -1,2 +1,0 @@
-[grid-z-axis-ordering-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-grid/grid-items/grid-z-axis-ordering-002.html.ini
+++ b/tests/wpt/meta/css/css-grid/grid-items/grid-z-axis-ordering-002.html.ini
@@ -1,2 +1,0 @@
-[grid-z-axis-ordering-002.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-grid/grid-items/grid-z-axis-ordering-003.html.ini
+++ b/tests/wpt/meta/css/css-grid/grid-items/grid-z-axis-ordering-003.html.ini
@@ -1,2 +1,0 @@
-[grid-z-axis-ordering-003.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-grid/grid-items/grid-z-axis-ordering-004.html.ini
+++ b/tests/wpt/meta/css/css-grid/grid-items/grid-z-axis-ordering-004.html.ini
@@ -1,2 +1,0 @@
-[grid-z-axis-ordering-004.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-grid/grid-items/grid-z-axis-ordering-005.html.ini
+++ b/tests/wpt/meta/css/css-grid/grid-items/grid-z-axis-ordering-005.html.ini
@@ -1,2 +1,0 @@
-[grid-z-axis-ordering-005.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-grid/grid-items/grid-z-axis-ordering-overlapped-items-001.html.ini
+++ b/tests/wpt/meta/css/css-grid/grid-items/grid-z-axis-ordering-overlapped-items-001.html.ini
@@ -1,2 +1,0 @@
-[grid-z-axis-ordering-overlapped-items-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-grid/grid-items/grid-z-axis-ordering-overlapped-items-002.html.ini
+++ b/tests/wpt/meta/css/css-grid/grid-items/grid-z-axis-ordering-overlapped-items-002.html.ini
@@ -1,2 +1,0 @@
-[grid-z-axis-ordering-overlapped-items-002.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-grid/grid-items/grid-z-axis-ordering-overlapped-items-003.html.ini
+++ b/tests/wpt/meta/css/css-grid/grid-items/grid-z-axis-ordering-overlapped-items-003.html.ini
@@ -1,2 +1,0 @@
-[grid-z-axis-ordering-overlapped-items-003.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-grid/grid-items/grid-z-axis-ordering-overlapped-items-004.html.ini
+++ b/tests/wpt/meta/css/css-grid/grid-items/grid-z-axis-ordering-overlapped-items-004.html.ini
@@ -1,2 +1,0 @@
-[grid-z-axis-ordering-overlapped-items-004.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-grid/grid-items/grid-z-axis-ordering-overlapped-items-005.html.ini
+++ b/tests/wpt/meta/css/css-grid/grid-items/grid-z-axis-ordering-overlapped-items-005.html.ini
@@ -1,2 +1,0 @@
-[grid-z-axis-ordering-overlapped-items-005.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-grid/grid-items/grid-z-axis-ordering-overlapped-items-006.html.ini
+++ b/tests/wpt/meta/css/css-grid/grid-items/grid-z-axis-ordering-overlapped-items-006.html.ini
@@ -1,2 +1,0 @@
-[grid-z-axis-ordering-overlapped-items-006.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-will-change/will-change-stacking-context-z-index-3.html.ini
+++ b/tests/wpt/meta/css/css-will-change/will-change-stacking-context-z-index-3.html.ini
@@ -1,0 +1,2 @@
+[will-change-stacking-context-z-index-3.html]
+  prefs: ["layout_grid_enabled:true"]

--- a/tests/wpt/tests/css/css-will-change/will-change-stacking-context-z-index-2.html
+++ b/tests/wpt/tests/css/css-will-change/will-change-stacking-context-z-index-2.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<title>CSS Test: `will-change: z-index`</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://www.w3.org/TR/css-will-change/#valdef-will-change-custom-ident">
+<link rel="help" href="https://www.w3.org/TR/css-flexbox-1/#painting">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/11827">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="
+  `will-change: z-index` establishes a stacking context on a flex item.
+">
+<style>
+.test {
+  will-change: z-index;
+  width: 100px;
+  background: red;
+}
+.test::before {
+  content: "";
+  display: block;
+  position: relative;
+  z-index: -1;
+  height: 100px;
+  background: green;
+}
+</style>
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div style="display: flex">
+  <div class="test"></div>
+</div>

--- a/tests/wpt/tests/css/css-will-change/will-change-stacking-context-z-index-3.html
+++ b/tests/wpt/tests/css/css-will-change/will-change-stacking-context-z-index-3.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<title>CSS Test: `will-change: z-index`</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://www.w3.org/TR/css-will-change/#valdef-will-change-custom-ident">
+<link rel="help" href="https://www.w3.org/TR/css-grid-2/#z-order">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/11827">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="
+  `will-change: z-index` establishes a stacking context on a grid item.
+">
+<style>
+.test {
+  will-change: z-index;
+  width: 100px;
+  background: red;
+}
+.test::before {
+  content: "";
+  display: block;
+  position: relative;
+  z-index: -1;
+  height: 100px;
+  background: green;
+}
+</style>
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div style="display: grid">
+  <div class="test"></div>
+</div>

--- a/tests/wpt/tests/css/css-will-change/will-change-stacking-context-z-index-4.html
+++ b/tests/wpt/tests/css/css-will-change/will-change-stacking-context-z-index-4.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<title>CSS Test: `will-change: z-index`</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://www.w3.org/TR/css-will-change/#valdef-will-change-custom-ident">
+<link rel="help" href="https://www.w3.org/TR/CSS2/visuren.html#z-index">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/11827">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="
+  `will-change: z-index` doesn't establish a stacking context on a non-positioned block box,
+   because `z-index` doesn't apply in that case.
+">
+<style>
+.test {
+  will-change: z-index;
+  width: 100px;
+  background: green;
+}
+.test::before {
+  content: "";
+  display: block;
+  position: relative;
+  z-index: -1;
+  height: 100px;
+  background: red;
+}
+</style>
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div class="test"></div>


### PR DESCRIPTION
In particular:
 - `z-index` will now work on unpositioned grid items.
 - `will-change: z-index` will only establish a stacking context if `z-index` applies, i.e. if the box is positioned or a flex/grid item.
 - The conditions in `establishes_stacking_context()` are reordered, so that the most likely ones are checked first.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
