### PR TITLE
Bring back DOM GC checkpoint to script_thread

### DIFF
--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1530,6 +1530,13 @@ impl ScriptThread {
             self.perform_a_microtask_checkpoint(can_gc);
         }
 
+        for (_, doc) in self.documents.borrow().iter() {
+            let window = doc.window();
+            window
+                .upcast::<GlobalScope>()
+                .perform_a_dom_garbage_collection_checkpoint();
+        }
+
         {
             // https://html.spec.whatwg.org/multipage/#the-end step 6
             let mut docs = self.docs_with_no_blocking_loads.borrow_mut();


### PR DESCRIPTION
This brings back the calls that were removed in a0743f60b36e

Not sure if we should be filtering the documents to just active documents.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #35927

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

I don't believe this affects any tests and don't know how we'd want to test them.