### PR TITLE
devtools: Use `webview_id` as `browser_id`

### DIFF
--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -84,8 +84,9 @@ pub struct BrowsingContextActorMsg {
     actor: String,
     title: String,
     url: String,
+    /// This correspond to webview_id
     #[serde(rename = "browserId")]
-    webview_id: u32,
+    browser_id: u32,
     #[serde(rename = "outerWindowID")]
     outer_window_id: u32,
     #[serde(rename = "browsingContextID")]
@@ -123,7 +124,8 @@ pub(crate) struct BrowsingContextActor {
     pub name: String,
     pub title: RefCell<String>,
     pub url: RefCell<String>,
-    pub webview_id: WebViewId,
+    /// This correspond to webview_id
+    pub browser_id: WebViewId,
     pub active_pipeline: Cell<PipelineId>,
     pub browsing_context_id: BrowsingContextId,
     pub accessibility: String,
@@ -176,7 +178,7 @@ impl Actor for BrowsingContextActor {
 impl BrowsingContextActor {
     pub(crate) fn new(
         console: String,
-        webview_id: WebViewId,
+        browser_id: WebViewId,
         browsing_context_id: BrowsingContextId,
         page_info: DevtoolsPageInfo,
         pipeline_id: PipelineId,
@@ -229,7 +231,7 @@ impl BrowsingContextActor {
             title: RefCell::new(title),
             url: RefCell::new(url.into_string()),
             active_pipeline: Cell::new(pipeline_id),
-            webview_id,
+            browser_id,
             browsing_context_id,
             accessibility: accessibility.name(),
             console,
@@ -268,7 +270,7 @@ impl BrowsingContextActor {
             },
             title: self.title.borrow().clone(),
             url: self.url.borrow().clone(),
-            webview_id: self.webview_id.0.index.0.get(),
+            browser_id: self.browser_id.0.index.0.get(),
             //FIXME: shouldn't ignore pipeline namespace field
             browsing_context_id: self.browsing_context_id.index.0.get(),
             //FIXME: shouldn't ignore pipeline namespace field

--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -10,7 +10,7 @@ use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::net::TcpStream;
 
-use base::id::{BrowsingContextId, PipelineId};
+use base::id::{BrowsingContextId, PipelineId, WebViewId};
 use devtools_traits::DevtoolScriptControlMsg::{self, GetCssDatabase, WantsLiveNotifications};
 use devtools_traits::{DevtoolsPageInfo, NavigationState};
 use ipc_channel::ipc::{self, IpcSender};
@@ -84,6 +84,8 @@ pub struct BrowsingContextActorMsg {
     actor: String,
     title: String,
     url: String,
+    #[serde(rename = "browserId")]
+    webview_id: u32,
     #[serde(rename = "outerWindowID")]
     outer_window_id: u32,
     #[serde(rename = "browsingContextID")]
@@ -121,6 +123,7 @@ pub(crate) struct BrowsingContextActor {
     pub name: String,
     pub title: RefCell<String>,
     pub url: RefCell<String>,
+    pub webview_id: WebViewId,
     pub active_pipeline: Cell<PipelineId>,
     pub browsing_context_id: BrowsingContextId,
     pub accessibility: String,
@@ -173,6 +176,7 @@ impl Actor for BrowsingContextActor {
 impl BrowsingContextActor {
     pub(crate) fn new(
         console: String,
+        webview_id: WebViewId,
         browsing_context_id: BrowsingContextId,
         page_info: DevtoolsPageInfo,
         pipeline_id: PipelineId,
@@ -225,6 +229,7 @@ impl BrowsingContextActor {
             title: RefCell::new(title),
             url: RefCell::new(url.into_string()),
             active_pipeline: Cell::new(pipeline_id),
+            webview_id,
             browsing_context_id,
             accessibility: accessibility.name(),
             console,
@@ -263,6 +268,7 @@ impl BrowsingContextActor {
             },
             title: self.title.borrow().clone(),
             url: self.url.borrow().clone(),
+            webview_id: self.webview_id.0.index.0.get(),
             //FIXME: shouldn't ignore pipeline namespace field
             browsing_context_id: self.browsing_context_id.index.0.get(),
             //FIXME: shouldn't ignore pipeline namespace field

--- a/components/devtools/actors/root.rs
+++ b/components/devtools/actors/root.rs
@@ -144,6 +144,7 @@ impl Actor for RootActor {
         stream: &mut TcpStream,
         _id: StreamId,
     ) -> Result<ActorMessageStatus, ()> {
+
         Ok(match msg_type {
             "connect" => {
                 let message = json!({
@@ -238,11 +239,11 @@ impl Actor for RootActor {
             },
 
             "getTab" => {
-                let Some(serde_json::Value::Number(browser_id)) = msg.get("browserId") else {
+                let Some(serde_json::Value::Number(webview_id)) = msg.get("browserId") else {
                     return Ok(ActorMessageStatus::Ignored);
                 };
 
-                let browser_id = browser_id.as_u64().unwrap();
+                let browser_id = webview_id.as_u64().unwrap();
                 let Some(tab) = self.get_tab_msg_by_browser_id(registry, browser_id as u32) else {
                     return Ok(ActorMessageStatus::Ignored);
                 };
@@ -310,6 +311,6 @@ impl RootActor {
                     .find::<TabDescriptorActor>(target)
                     .encodable(registry, true)
             })
-            .find(|tab| tab.id() == browser_id)
+            .find(|tab| tab.webview_id() == browser_id)
     }
 }

--- a/components/devtools/actors/root.rs
+++ b/components/devtools/actors/root.rs
@@ -238,11 +238,11 @@ impl Actor for RootActor {
             },
 
             "getTab" => {
-                let Some(serde_json::Value::Number(webview_id)) = msg.get("browserId") else {
+                let Some(serde_json::Value::Number(browser_id)) = msg.get("browserId") else {
                     return Ok(ActorMessageStatus::Ignored);
                 };
 
-                let browser_id = webview_id.as_u64().unwrap();
+                let browser_id = browser_id.as_u64().unwrap();
                 let Some(tab) = self.get_tab_msg_by_browser_id(registry, browser_id as u32) else {
                     return Ok(ActorMessageStatus::Ignored);
                 };
@@ -310,6 +310,6 @@ impl RootActor {
                     .find::<TabDescriptorActor>(target)
                     .encodable(registry, true)
             })
-            .find(|tab| tab.webview_id() == browser_id)
+            .find(|tab| tab.browser_id() == browser_id)
     }
 }

--- a/components/devtools/actors/root.rs
+++ b/components/devtools/actors/root.rs
@@ -144,7 +144,6 @@ impl Actor for RootActor {
         stream: &mut TcpStream,
         _id: StreamId,
     ) -> Result<ActorMessageStatus, ()> {
-
         Ok(match msg_type {
             "connect" => {
                 let message = json!({

--- a/components/devtools/actors/tab.rs
+++ b/components/devtools/actors/tab.rs
@@ -25,7 +25,8 @@ use crate::protocol::JsonPacketStream;
 #[serde(rename_all = "camelCase")]
 pub struct TabDescriptorActorMsg {
     actor: String,
-    browser_id: u32,
+    #[serde(rename = "browserId")]
+    webview_id: u32,
     #[serde(rename = "browsingContextID")]
     browsing_context_id: u32,
     is_zombie_tab: bool,
@@ -38,8 +39,8 @@ pub struct TabDescriptorActorMsg {
 }
 
 impl TabDescriptorActorMsg {
-    pub fn id(&self) -> u32 {
-        self.browser_id
+    pub fn webview_id(&self) -> u32 {
+        self.webview_id
     }
 }
 
@@ -140,16 +141,16 @@ impl TabDescriptorActor {
 
     pub fn encodable(&self, registry: &ActorRegistry, selected: bool) -> TabDescriptorActorMsg {
         let ctx_actor = registry.find::<BrowsingContextActor>(&self.browsing_context_actor);
-        let browser_id = ctx_actor.browsing_context_id.index.0.get();
-        let outer_window_id = ctx_actor.active_pipeline.get().index.0.get();
+        let webview_id = ctx_actor.webview_id.0.index.0.get();
         let browsing_context_id = ctx_actor.browsing_context_id.index.0.get();
+        let outer_window_id = ctx_actor.active_pipeline.get().index.0.get();
         let title = ctx_actor.title.borrow().clone();
         let url = ctx_actor.url.borrow().clone();
 
         TabDescriptorActorMsg {
             actor: self.name(),
+            webview_id,
             browsing_context_id,
-            browser_id,
             is_zombie_tab: false,
             outer_window_id,
             selected,

--- a/components/devtools/actors/tab.rs
+++ b/components/devtools/actors/tab.rs
@@ -25,8 +25,9 @@ use crate::protocol::JsonPacketStream;
 #[serde(rename_all = "camelCase")]
 pub struct TabDescriptorActorMsg {
     actor: String,
+    /// This correspond to webview_id
     #[serde(rename = "browserId")]
-    webview_id: u32,
+    browser_id: u32,
     #[serde(rename = "browsingContextID")]
     browsing_context_id: u32,
     is_zombie_tab: bool,
@@ -39,8 +40,8 @@ pub struct TabDescriptorActorMsg {
 }
 
 impl TabDescriptorActorMsg {
-    pub fn webview_id(&self) -> u32 {
-        self.webview_id
+    pub fn browser_id(&self) -> u32 {
+        self.browser_id
     }
 }
 
@@ -141,7 +142,7 @@ impl TabDescriptorActor {
 
     pub fn encodable(&self, registry: &ActorRegistry, selected: bool) -> TabDescriptorActorMsg {
         let ctx_actor = registry.find::<BrowsingContextActor>(&self.browsing_context_actor);
-        let webview_id = ctx_actor.webview_id.0.index.0.get();
+        let browser_id = ctx_actor.browser_id.0.index.0.get();
         let browsing_context_id = ctx_actor.browsing_context_id.index.0.get();
         let outer_window_id = ctx_actor.active_pipeline.get().index.0.get();
         let title = ctx_actor.title.borrow().clone();
@@ -149,7 +150,7 @@ impl TabDescriptorActor {
 
         TabDescriptorActorMsg {
             actor: self.name(),
-            webview_id,
+            browser_id,
             browsing_context_id,
             is_zombie_tab: false,
             outer_window_id,

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -19,7 +19,7 @@ use std::net::{Shutdown, TcpListener, TcpStream};
 use std::sync::{Arc, Mutex};
 use std::thread;
 
-use base::id::{BrowsingContextId, PipelineId};
+use base::id::{BrowsingContextId, PipelineId, WebViewId};
 use crossbeam_channel::{Receiver, Sender, unbounded};
 use devtools_traits::{
     ChromeToDevtoolsControlMsg, ConsoleMessage, ConsoleMessageBuilder, DevtoolScriptControlMsg,
@@ -343,13 +343,13 @@ impl DevtoolsInstance {
     // TODO: move this into the root or target modules?
     fn handle_new_global(
         &mut self,
-        ids: (BrowsingContextId, PipelineId, Option<WorkerId>),
+        ids: (BrowsingContextId, PipelineId, Option<WorkerId>, WebViewId),
         script_sender: IpcSender<DevtoolScriptControlMsg>,
         page_info: DevtoolsPageInfo,
     ) {
         let mut actors = self.actors.lock().unwrap();
 
-        let (browsing_context_id, pipeline_id, worker_id) = ids;
+        let (browsing_context_id, pipeline_id, worker_id, webview_id) = ids;
 
         let console_name = actors.new_name("console");
 
@@ -387,6 +387,7 @@ impl DevtoolsInstance {
                 .or_insert_with(|| {
                     let browsing_context_actor = BrowsingContextActor::new(
                         console_name.clone(),
+                        webview_id,
                         browsing_context_id,
                         page_info,
                         pipeline_id,

--- a/components/script/dom/worker.rs
+++ b/components/script/dom/worker.rs
@@ -6,7 +6,6 @@ use std::cell::Cell;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use base::id::WebViewId;
 use crossbeam_channel::{Sender, unbounded};
 use devtools_traits::{DevtoolsPageInfo, ScriptToDevtoolsControlMsg, WorkerId};
 use dom_struct::dom_struct;

--- a/components/script/dom/worker.rs
+++ b/components/script/dom/worker.rs
@@ -6,6 +6,7 @@ use std::cell::Cell;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
+use base::id::WebViewId;
 use crossbeam_channel::{Sender, unbounded};
 use devtools_traits::{DevtoolsPageInfo, ScriptToDevtoolsControlMsg, WorkerId};
 use dom_struct::dom_struct;
@@ -186,6 +187,11 @@ impl WorkerMethods<crate::DomTypeHolder> for Worker {
             pipeline_id: global.pipeline_id(),
         };
 
+        let webview_id = global
+            .downcast::<Window>()
+            .expect("Worker constructor should be called with a Window")
+            .webview_id();
+
         let browsing_context = global
             .downcast::<Window>()
             .map(|w| w.window_proxy().browsing_context_id())
@@ -207,7 +213,7 @@ impl WorkerMethods<crate::DomTypeHolder> for Worker {
                     is_top_level_global: false,
                 };
                 let _ = chan.send(ScriptToDevtoolsControlMsg::NewGlobal(
-                    (browsing_context, pipeline_id, Some(worker_id)),
+                    (browsing_context, pipeline_id, Some(worker_id), webview_id),
                     devtools_sender.clone(),
                     page_info,
                 ));

--- a/components/script/dom/worker.rs
+++ b/components/script/dom/worker.rs
@@ -187,10 +187,7 @@ impl WorkerMethods<crate::DomTypeHolder> for Worker {
             pipeline_id: global.pipeline_id(),
         };
 
-        let webview_id = global
-            .downcast::<Window>()
-            .expect("Worker constructor should be called with a Window")
-            .webview_id();
+        let webview_id = global.webview_id().expect("global must have a webview id");
 
         let browsing_context = global
             .downcast::<Window>()

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3248,7 +3248,12 @@ impl ScriptThread {
             document.Title(),
             final_url.clone(),
             is_top_level_global,
-            (incomplete.browsing_context_id, incomplete.pipeline_id, None, incomplete.webview_id),
+            (
+                incomplete.browsing_context_id,
+                incomplete.pipeline_id,
+                None,
+                incomplete.webview_id,
+            ),
         );
 
         document.set_https_state(metadata.https_state);
@@ -3278,7 +3283,12 @@ impl ScriptThread {
         title: DOMString,
         url: ServoUrl,
         is_top_level_global: bool,
-        (browsing_context_id, pipeline_id, worker_id, webview_id): (BrowsingContextId, PipelineId, Option<WorkerId>, WebViewId),
+        (browsing_context_id, pipeline_id, worker_id, webview_id): (
+            BrowsingContextId,
+            PipelineId,
+            Option<WorkerId>,
+            WebViewId,
+        ),
     ) {
         if let Some(ref chan) = self.senders.devtools_server_sender {
             let page_info = DevtoolsPageInfo {
@@ -3294,7 +3304,10 @@ impl ScriptThread {
             .unwrap();
 
             let state = NavigationState::Stop(pipeline_id, page_info);
-            let _ = chan.send(ScriptToDevtoolsControlMsg::Navigate(browsing_context_id, state));
+            let _ = chan.send(ScriptToDevtoolsControlMsg::Navigate(
+                browsing_context_id,
+                state,
+            ));
         }
     }
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3248,7 +3248,7 @@ impl ScriptThread {
             document.Title(),
             final_url.clone(),
             is_top_level_global,
-            (incomplete.browsing_context_id, incomplete.pipeline_id, None),
+            (incomplete.browsing_context_id, incomplete.pipeline_id, None, incomplete.webview_id),
         );
 
         document.set_https_state(metadata.https_state);
@@ -3278,7 +3278,7 @@ impl ScriptThread {
         title: DOMString,
         url: ServoUrl,
         is_top_level_global: bool,
-        (bc, p, w): (BrowsingContextId, PipelineId, Option<WorkerId>),
+        (browsing_context_id, pipeline_id, worker_id, webview_id): (BrowsingContextId, PipelineId, Option<WorkerId>, WebViewId),
     ) {
         if let Some(ref chan) = self.senders.devtools_server_sender {
             let page_info = DevtoolsPageInfo {
@@ -3287,14 +3287,14 @@ impl ScriptThread {
                 is_top_level_global,
             };
             chan.send(ScriptToDevtoolsControlMsg::NewGlobal(
-                (bc, p, w),
+                (browsing_context_id, pipeline_id, worker_id, webview_id),
                 self.senders.devtools_client_to_script_thread_sender.clone(),
                 page_info.clone(),
             ))
             .unwrap();
 
-            let state = NavigationState::Stop(p, page_info);
-            let _ = chan.send(ScriptToDevtoolsControlMsg::Navigate(bc, state));
+            let state = NavigationState::Stop(pipeline_id, page_info);
+            let _ = chan.send(ScriptToDevtoolsControlMsg::Navigate(browsing_context_id, state));
         }
     }
 

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -16,7 +16,7 @@ use std::net::TcpStream;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use base::cross_process_instant::CrossProcessInstant;
-use base::id::{BrowsingContextId, PipelineId};
+use base::id::{BrowsingContextId, PipelineId, WebViewId};
 use bitflags::bitflags;
 use http::{HeaderMap, Method};
 use ipc_channel::ipc::IpcSender;
@@ -82,7 +82,7 @@ pub enum ScriptToDevtoolsControlMsg {
     /// A new global object was created, associated with a particular pipeline.
     /// The means of communicating directly with it are provided.
     NewGlobal(
-        (BrowsingContextId, PipelineId, Option<WorkerId>),
+        (BrowsingContextId, PipelineId, Option<WorkerId>, WebViewId),
         IpcSender<DevtoolScriptControlMsg>,
         DevtoolsPageInfo,
     ),


### PR DESCRIPTION
This PR refactors DevTools to use `webview_id` as `browser_id`

These changes do not affect the current behavior of the DevTools in Servo.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #35953
