### PR TITLE
Hide servo-internal shadow roots from the inspector by default

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -146,6 +146,8 @@ pub struct Preferences {
     /// Whether or not subpixel antialiasing is enabled for text rendering.
     pub gfx_subpixel_text_antialiasing_enabled: bool,
     pub gfx_texture_swizzling_enabled: bool,
+    /// Whether or not the DOM inspector should show shadow roots of user-agent shadow trees
+    pub inspector_show_servo_internal_shadow_roots: bool,
     pub js_asmjs_enabled: bool,
     pub js_asyncstack: bool,
     pub js_baseline_interpreter_enabled: bool,
@@ -312,6 +314,7 @@ impl Preferences {
             gfx_text_antialiasing_enabled: true,
             gfx_subpixel_text_antialiasing_enabled: true,
             gfx_texture_swizzling_enabled: true,
+            inspector_show_servo_internal_shadow_roots: false,
             js_asmjs_enabled: true,
             js_asyncstack: false,
             js_baseline_interpreter_enabled: true,

--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -14,6 +14,7 @@ use devtools_traits::{
 use ipc_channel::ipc::IpcSender;
 use js::jsval::UndefinedValue;
 use js::rust::ToString;
+use servo_config::pref;
 use uuid::Uuid;
 
 use crate::document_collection::DocumentCollection;
@@ -162,7 +163,11 @@ pub(crate) fn handle_get_children(
 
             let mut children = vec![];
             if let Some(shadow_root) = parent.downcast::<Element>().and_then(Element::shadow_root) {
-                children.push(shadow_root.upcast::<Node>().summarize());
+                if !shadow_root.is_user_agent_widget() ||
+                    pref!(inspector_show_servo_internal_shadow_roots)
+                {
+                    children.push(shadow_root.upcast::<Node>().summarize());
+                }
             }
             let children_iter = parent.children().enumerate().filter_map(|(i, child)| {
                 // Filter whitespace only text nodes that are not inline level

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -542,6 +542,7 @@ impl Element {
             mode,
             slot_assignment_mode,
             clonable,
+            is_ua_widget,
             can_gc,
         );
 

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -77,6 +77,8 @@ pub(crate) struct ShadowRoot {
     available_to_element_internals: Cell<bool>,
 
     slots: DomRefCell<HashMap<DOMString, Vec<Dom<HTMLSlotElement>>>>,
+
+    is_user_agent_widget: bool,
 }
 
 impl ShadowRoot {
@@ -87,6 +89,7 @@ impl ShadowRoot {
         mode: ShadowRootMode,
         slot_assignment_mode: SlotAssignmentMode,
         clonable: bool,
+        is_user_agent_widget: IsUserAgentWidget,
     ) -> ShadowRoot {
         let document_fragment = DocumentFragment::new_inherited(document);
         let node = document_fragment.upcast::<Node>();
@@ -109,6 +112,7 @@ impl ShadowRoot {
             clonable,
             available_to_element_internals: Cell::new(false),
             slots: Default::default(),
+            is_user_agent_widget: is_user_agent_widget == IsUserAgentWidget::Yes,
         }
     }
 
@@ -118,6 +122,7 @@ impl ShadowRoot {
         mode: ShadowRootMode,
         slot_assignment_mode: SlotAssignmentMode,
         clonable: bool,
+        is_user_agent_widget: IsUserAgentWidget,
         can_gc: CanGc,
     ) -> DomRoot<ShadowRoot> {
         reflect_dom_object(
@@ -127,6 +132,7 @@ impl ShadowRoot {
                 mode,
                 slot_assignment_mode,
                 clonable,
+                is_user_agent_widget,
             )),
             document.window(),
             can_gc,
@@ -265,6 +271,10 @@ impl ShadowRoot {
     /// <https://dom.spec.whatwg.org/#shadowroot-available-to-element-internals>
     pub(crate) fn is_available_to_element_internals(&self) -> bool {
         self.available_to_element_internals.get()
+    }
+
+    pub(crate) fn is_user_agent_widget(&self) -> bool {
+        self.is_user_agent_widget
     }
 }
 


### PR DESCRIPTION
These shadow roots are used for things like the `details` element and are now hidden unless the `inspector_show_servo_internal_shadow_roots` preference is set.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because we don't currently test devtools changes

