### PR TITLE
script: Remove ThreadSafeLayoutNode::is_ignorable_whitespace

### DIFF
--- a/components/script/layout_dom/node.rs
+++ b/components/script/layout_dom/node.rs
@@ -23,21 +23,16 @@ use script_layout_interface::{
 use servo_arc::Arc;
 use servo_url::ServoUrl;
 use style;
-use style::computed_values::white_space_collapse::T as WhiteSpaceCollapse;
-use style::context::SharedStyleContext;
 use style::dom::{NodeInfo, TElement, TNode, TShadowRoot};
 use style::properties::ComputedValues;
-use style::str::is_whitespace;
 
 use super::{
     ServoLayoutDocument, ServoLayoutElement, ServoShadowRoot, ServoThreadSafeLayoutElement,
 };
 use crate::dom::bindings::inheritance::{CharacterDataTypeId, NodeTypeId, TextTypeId};
 use crate::dom::bindings::root::LayoutDom;
-use crate::dom::characterdata::LayoutCharacterDataHelpers;
 use crate::dom::element::{Element, LayoutElementHelpers};
 use crate::dom::node::{LayoutNodeHelpers, Node, NodeFlags, NodeTypeIdWrapper};
-use crate::dom::text::Text;
 
 /// A wrapper around a `LayoutDom<Node>` which provides a safe interface that
 /// can be used during layout. This implements the `LayoutNode` trait as well as
@@ -341,30 +336,6 @@ impl<'dom> ThreadSafeLayoutNode<'dom> for ServoThreadSafeLayoutNode<'dom> {
 
     fn layout_data(&self) -> Option<&'dom GenericLayoutData> {
         self.node.layout_data()
-    }
-
-    fn is_ignorable_whitespace(&self, context: &SharedStyleContext) -> bool {
-        unsafe {
-            let text: LayoutDom<Text> = match self.get_jsmanaged().downcast() {
-                Some(text) => text,
-                None => return false,
-            };
-
-            if !is_whitespace(text.upcast().data_for_layout()) {
-                return false;
-            }
-
-            // NB: See the rules for `white-space` here:
-            //
-            //    http://www.w3.org/TR/CSS21/text.html#propdef-white-space
-            //
-            // If you implement other values for this property, you will almost certainly
-            // want to update this check.
-            self.style(context)
-                .get_inherited_text()
-                .white_space_collapse ==
-                WhiteSpaceCollapse::Collapse
-        }
     }
 
     fn unsafe_get(self) -> Self::ConcreteNode {

--- a/components/shared/script_layout/wrapper_traits.rs
+++ b/components/shared/script_layout/wrapper_traits.rs
@@ -267,8 +267,6 @@ pub trait ThreadSafeLayoutNode<'dom>: Clone + Copy + Debug + NodeInfo + PartialE
         }
     }
 
-    fn is_ignorable_whitespace(&self, context: &SharedStyleContext) -> bool;
-
     /// Returns true if this node contributes content. This is used in the implementation of
     /// `empty_cells` per CSS 2.1 § 17.6.1.1.
     fn is_content(&self) -> bool {


### PR DESCRIPTION
This is now unused with the removal of legacy layout. I didn't see any
others methods in this trait that were unused.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they just remove dead code.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
