### PR TITLE
Check whether an element is custom in the spec-compliant way

### DIFF
--- a/components/script/dom/attr.rs
+++ b/components/script/dom/attr.rs
@@ -166,7 +166,7 @@ impl Attr {
 
         MutationObserver::queue_a_mutation_record(owner.upcast::<Node>(), mutation);
 
-        if owner.get_custom_element_definition().is_some() {
+        if owner.is_custom() {
             let reaction = CallbackReaction::AttributeChanged(
                 name,
                 Some(old_value),

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -421,7 +421,8 @@ impl Node {
 
     pub(crate) fn as_custom_element(&self) -> Option<DomRoot<Element>> {
         self.downcast::<Element>().and_then(|element| {
-            if element.get_custom_element_definition().is_some() {
+            if element.is_custom() {
+                assert!(element.get_custom_element_definition().is_some());
                 Some(DomRoot::from_ref(element))
             } else {
                 None
@@ -2330,7 +2331,7 @@ impl Node {
                 .filter_map(DomRoot::downcast::<Element>)
             {
                 // Step 7.7.2, whatwg/dom#833
-                if descendant.get_custom_element_definition().is_some() {
+                if descendant.is_custom() {
                     if descendant.is_connected() {
                         ScriptThread::enqueue_callback_reaction(
                             &descendant,

--- a/tests/wpt/meta/custom-elements/custom-element-reaction-queue.html.ini
+++ b/tests/wpt/meta/custom-elements/custom-element-reaction-queue.html.ini
@@ -1,4 +1,0 @@
-[custom-element-reaction-queue.html]
-  [Upgrading a custom element must not invoke attributeChangedCallback for the attribute that is changed during upgrading]
-    expected: FAIL
-

--- a/tests/wpt/tests/custom-elements/custom-element-reaction-queue.html
+++ b/tests/wpt/tests/custom-elements/custom-element-reaction-queue.html
@@ -85,6 +85,60 @@ test_with_window(function (contentWindow) {
 
 test_with_window(function (contentWindow) {
     const contentDocument = contentWindow.document;
+    contentDocument.write('<test-element>');
+
+    const element = contentDocument.querySelector('test-element');
+    assert_equals(Object.getPrototypeOf(element), contentWindow.HTMLElement.prototype);
+
+    let log = [];
+    class TestElement extends contentWindow.HTMLElement {
+        constructor() {
+            super();
+            this.remove();
+            log.push(create_constructor_log(this));
+        }
+        connectedCallback(...args) {
+            log.push(create_connected_callback_log(this, ...args));
+        }
+        disconnectedCallback(...args) {
+            log.push(create_disconnected_callback_log(this, ...args));
+        }
+    }
+    contentWindow.customElements.define('test-element', TestElement);
+    assert_equals(Object.getPrototypeOf(element), TestElement.prototype);
+
+    assert_equals(log.length, 2);
+    assert_constructor_log_entry(log[0], element);
+    assert_connected_log_entry(log[1], element);
+}, 'Upgrading a custom element must not invoke disconnectedCallback if the element is disconnected during upgrading');
+
+test_with_window(function (contentWindow) {
+    const contentDocument = contentWindow.document;
+    const element = contentDocument.createElement('test-element');
+    assert_equals(Object.getPrototypeOf(element), contentWindow.HTMLElement.prototype);
+
+    let log = [];
+    class TestElement extends contentWindow.HTMLElement {
+        constructor() {
+            super();
+            contentDocument.documentElement.appendChild(this);
+            log.push(create_constructor_log(this));
+        }
+        connectedCallback(...args) {
+            log.push(create_connected_callback_log(this, ...args));
+        }
+    }
+    contentWindow.customElements.define('test-element', TestElement);
+    contentWindow.customElements.upgrade(element);
+
+    assert_equals(Object.getPrototypeOf(element), TestElement.prototype);
+
+    assert_equals(log.length, 1);
+    assert_constructor_log_entry(log[0], element);
+}, 'Upgrading a disconnected custom element must not invoke connectedCallback if the element is connected during upgrading');
+
+test_with_window(function (contentWindow) {
+    const contentDocument = contentWindow.document;
     contentDocument.write('<test-element id="first-element">');
     contentDocument.write('<test-element id="second-element">');
 


### PR DESCRIPTION
Current code checks whether an element is custom by checking whether it has an associated custom element definition. This is different from the [spec](https://dom.spec.whatwg.org/#concept-element-custom), which says:

> An [element](https://dom.spec.whatwg.org/#concept-element) whose [custom element state](https://dom.spec.whatwg.org/#concept-element-custom-element-state) is "custom" is said to be custom.

The two definitions are identical in almost all cases, except during [custom element upgrade](https://html.spec.whatwg.org/multipage/custom-elements.html#upgrades), where the custom element state is set to `failed` until finished.

As a result, the current implementation may erroneously fire custom element callbacks for mutations during the upgrade.

This PR fixes it.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
