### PR TITLE
layout: Allow lazy resolution of automatic minimum sizes

### DIFF
--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -1715,7 +1715,7 @@ impl InitialFlexLineLayout<'_> {
                 item.item.content_cross_sizes.resolve(
                     axis,
                     Size::Stretch,
-                    Au::zero(),
+                    Au::zero,
                     Some(final_line_cross_size - item.item.pbm_auto_is_zero.cross),
                     || content_size.into(),
                     // Tables have a special sizing in the block axis in that handles collapsed rows,
@@ -1966,7 +1966,7 @@ impl FlexItem<'_> {
                 self.content_cross_sizes.resolve(
                     Direction::Inline,
                     automatic_size,
-                    Au::zero(),
+                    Au::zero,
                     Some(stretch_size),
                     get_content_size,
                     self.is_table(),
@@ -2117,7 +2117,7 @@ impl FlexItem<'_> {
                     self.content_cross_sizes.resolve(
                         Direction::Block,
                         Size::FitContent,
-                        Au::zero(),
+                        Au::zero,
                         stretch_size,
                         || content_block_size.into(),
                         self.is_table(),

--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -170,7 +170,7 @@ impl BlockLevelBox {
         let inline_size = content_box_sizes.inline.resolve(
             Direction::Inline,
             Size::Stretch,
-            Au::zero(),
+            Au::zero,
             Some(available_inline_size),
             get_inline_content_sizes,
             false, /* is_table */
@@ -1034,7 +1034,7 @@ fn layout_in_flow_non_replaced_block_level_same_formatting_context(
     let block_size = block_sizes.resolve(
         Direction::Block,
         Size::FitContent,
-        Au::zero(),
+        Au::zero,
         available_block_size,
         || content_block_size.into(),
         false, /* is_table */
@@ -1158,7 +1158,7 @@ impl IndependentNonReplacedContents {
         let block_size = block_sizes.resolve(
             Direction::Block,
             Size::FitContent,
-            Au::zero(),
+            Au::zero,
             available_block_size,
             || layout.content_block_size.into(),
             layout_style.is_table(),
@@ -1292,7 +1292,7 @@ impl IndependentNonReplacedContents {
             content_box_sizes.inline.resolve(
                 Direction::Inline,
                 automatic_inline_size,
-                Au::zero(),
+                Au::zero,
                 Some(stretch_size),
                 get_inline_content_sizes,
                 is_table,
@@ -1303,7 +1303,7 @@ impl IndependentNonReplacedContents {
             content_box_sizes.block.resolve(
                 Direction::Block,
                 Size::FitContent,
-                Au::zero(),
+                Au::zero,
                 available_block_size,
                 || layout.content_block_size.into(),
                 is_table,
@@ -1741,7 +1741,7 @@ fn solve_containing_block_padding_and_border_for_in_flow_box<'a>(
     let inline_size = content_box_sizes.inline.resolve(
         Direction::Inline,
         automatic_inline_size,
-        Au::zero(),
+        Au::zero,
         Some(available_inline_size),
         get_inline_content_sizes,
         is_table,
@@ -2252,7 +2252,7 @@ impl IndependentFormattingContext {
                 let inline_size = content_box_sizes_and_pbm.content_box_sizes.inline.resolve(
                     Direction::Inline,
                     Size::FitContent,
-                    Au::zero(),
+                    Au::zero,
                     Some(available_inline_size),
                     get_content_size,
                     is_table,
@@ -2283,7 +2283,7 @@ impl IndependentFormattingContext {
                 let block_size = content_box_sizes_and_pbm.content_box_sizes.block.resolve(
                     Direction::Block,
                     Size::FitContent,
-                    Au::zero(),
+                    Au::zero,
                     available_block_size,
                     || independent_layout.content_block_size.into(),
                     is_table,

--- a/components/layout_2020/geom.rs
+++ b/components/layout_2020/geom.rs
@@ -850,12 +850,12 @@ impl Size<Au> {
     #[inline]
     pub(crate) fn resolve_for_min<F: FnOnce() -> ContentSizes>(
         &self,
-        automatic_minimum_size: Au,
+        get_automatic_minimum_size: impl FnOnce() -> Au,
         stretch_size: Option<Au>,
         content_size: &LazyCell<ContentSizes, F>,
     ) -> Au {
         match self {
-            Self::Initial => automatic_minimum_size,
+            Self::Initial => get_automatic_minimum_size(),
             Self::MinContent => content_size.min_content,
             Self::MaxContent => content_size.max_content,
             Self::FitContent => content_size.shrink_to_fit(stretch_size.unwrap_or_default()),
@@ -974,7 +974,7 @@ impl Sizes {
         &self,
         axis: Direction,
         automatic_size: Size<Au>,
-        automatic_minimum_size: Au,
+        get_automatic_minimum_size: impl FnOnce() -> Au,
         stretch_size: Option<Au>,
         get_content_size: impl FnOnce() -> ContentSizes,
         is_table: bool,
@@ -994,9 +994,9 @@ impl Sizes {
         let preferred =
             self.preferred
                 .resolve_for_preferred(automatic_size, stretch_size, &content_size);
-        let mut min = self
-            .min
-            .resolve_for_min(automatic_minimum_size, stretch_size, &content_size);
+        let mut min =
+            self.min
+                .resolve_for_min(get_automatic_minimum_size, stretch_size, &content_size);
         if is_table {
             // In addition to the specified minimum, the inline size of a table is forced to be
             // at least as big as its min-content size.

--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -793,7 +793,7 @@ impl AbsoluteAxisSolver<'_> {
                 SizeConstraint::Definite(self.computed_sizes.resolve(
                     self.axis,
                     initial_behavior,
-                    Au::zero(),
+                    Au::zero,
                     Some(stretch_size),
                     get_content_size,
                     self.is_table,

--- a/components/layout_2020/replaced.rs
+++ b/components/layout_2020/replaced.rs
@@ -538,7 +538,7 @@ impl ReplacedContents {
         let inline_size = sizes.inline.resolve(
             Direction::Inline,
             automatic_size.inline,
-            Au::zero(),
+            Au::zero,
             Some(inline_stretch_size),
             get_inline_content_size,
             false, /* is_table */
@@ -558,7 +558,7 @@ impl ReplacedContents {
         let block_size = sizes.block.resolve(
             Direction::Block,
             automatic_size.block,
-            Au::zero(),
+            Au::zero,
             block_stretch_size,
             || *block_content_size,
             false, /* is_table */


### PR DESCRIPTION
`Size::resolve_for_min()` had an `Au` parameter, representing the value to be used for an automatic minimum size. However, this amount isn't trivial to compute in flexbox, so this patch changes the parameter to a function that can be called lazily.

Note flexbox isn't currently using `Size::resolve_for_min()`, but it will in #35961.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because there is no change in behavior

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
