### PR TITLE
script: Return text content from HTMLOptionElement::Label when label is empty

### DIFF
--- a/components/script/dom/htmloptionelement.rs
+++ b/components/script/dom/htmloptionelement.rs
@@ -258,13 +258,17 @@ impl HTMLOptionElementMethods<crate::DomTypeHolder> for HTMLOptionElement {
 
     // https://html.spec.whatwg.org/multipage/#attr-option-label
     fn Label(&self) -> DOMString {
-        let element = self.upcast::<Element>();
-        let attr = &local_name!("label");
-        if element.has_attribute(attr) {
-            element.get_string_attribute(attr)
-        } else {
-            self.Text()
+        // > The label of an option element is the value of the label content attribute, if there is one
+        // > and its value is not the empty string, or, otherwise, the value of the element's text IDL attribute.
+        let label = self
+            .upcast::<Element>()
+            .get_string_attribute(&local_name!("label"));
+
+        if label.is_empty() {
+            return self.Text();
         }
+
+        label
     }
 
     // https://html.spec.whatwg.org/multipage/#attr-option-label


### PR DESCRIPTION
Part of https://github.com/servo/servo/pull/35684

See https://html.spec.whatwg.org/multipage/#attr-option-label


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
