### PR TITLE
fix: inline-grid should be considered an atomic inline

### DIFF
--- a/components/layout_2020/display_list/stacking_context.rs
+++ b/components/layout_2020/display_list/stacking_context.rs
@@ -985,7 +985,7 @@ impl BoxFragment {
             return Some(StackingContextType::FloatStackingContainer);
         }
 
-        if box_style.display.is_atomic_inline_level() {
+        if self.is_atomic_inline_level() {
             return Some(StackingContextType::AtomicInlineStackingContainer);
         }
 

--- a/components/layout_2020/fragment_tree/box_fragment.rs
+++ b/components/layout_2020/fragment_tree/box_fragment.rs
@@ -359,6 +359,14 @@ impl BoxFragment {
         )
     }
 
+    /// Whether this is an atomic inline-level box.
+    /// <https://drafts.csswg.org/css-display-3/#atomic-inline>
+    pub(crate) fn is_atomic_inline_level(&self) -> bool {
+        let display = self.style.get_box().display;
+        display.outside() == DisplayOutside::Inline && !self.is_inline_box()
+            || matches!(display, Display::InlineGrid)
+    }
+
     pub(crate) fn has_collapsed_borders(&self) -> bool {
         match &self.specific_layout_info {
             Some(SpecificLayoutInfo::TableCellWithCollapsedBorders) => true,

--- a/components/layout_2020/fragment_tree/box_fragment.rs
+++ b/components/layout_2020/fragment_tree/box_fragment.rs
@@ -12,6 +12,7 @@ use style::computed_values::overflow_x::T as ComputedOverflow;
 use style::computed_values::position::T as ComputedPosition;
 use style::logical_geometry::WritingMode;
 use style::properties::ComputedValues;
+use style::values::specified::box_::DisplayOutside;
 
 use super::{BaseFragment, BaseFragmentInfo, CollapsedBlockMargins, Fragment};
 use crate::formatting_contexts::Baselines;

--- a/components/layout_2020/fragment_tree/box_fragment.rs
+++ b/components/layout_2020/fragment_tree/box_fragment.rs
@@ -350,6 +350,12 @@ impl BoxFragment {
             !self.base.flags.contains(FragmentFlags::IS_REPLACED)
     }
 
+    /// Whether this is an atomic inline-level box.
+    /// <https://drafts.csswg.org/css-display-3/#atomic-inline>
+    pub(crate) fn is_atomic_inline_level(&self) -> bool {
+        self.style.get_box().display.outside() == DisplayOutside::Inline && !self.is_inline_box()
+    }
+
     /// Whether this is a table wrapper box.
     /// <https://www.w3.org/TR/css-tables-3/#table-wrapper-box>
     pub(crate) fn is_table_wrapper(&self) -> bool {
@@ -357,14 +363,6 @@ impl BoxFragment {
             self.specific_layout_info,
             Some(SpecificLayoutInfo::TableWrapper)
         )
-    }
-
-    /// Whether this is an atomic inline-level box.
-    /// <https://drafts.csswg.org/css-display-3/#atomic-inline>
-    pub(crate) fn is_atomic_inline_level(&self) -> bool {
-        let display = self.style.get_box().display;
-        display.outside() == DisplayOutside::Inline && !self.is_inline_box()
-            || matches!(display, Display::InlineGrid)
     }
 
     pub(crate) fn has_collapsed_borders(&self) -> bool {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #35310  (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
