### PR TITLE
Move CustomTraceable to script_bindings.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6382,22 +6382,30 @@ name = "script_bindings"
 version = "0.0.1"
 dependencies = [
  "bitflags 2.9.0",
+ "crossbeam-channel",
  "cssparser",
  "html5ever",
+ "indexmap",
  "jstraceable_derive",
  "libc",
  "log",
  "malloc_size_of_derive",
  "mozjs",
  "num-traits",
+ "parking_lot",
  "phf_codegen",
  "phf_shared",
  "regex",
  "serde_json",
+ "servo_arc",
  "servo_config",
  "servo_malloc_size_of",
+ "smallvec",
  "style",
  "stylo_atoms",
+ "tendril",
+ "webxr-api",
+ "xml5ever",
 ]
 
 [[package]]

--- a/components/script/dom/bindings/conversions.rs
+++ b/components/script/dom/bindings/conversions.rs
@@ -42,7 +42,7 @@ use js::glue::GetProxyReservedSlot;
 use js::jsapi::{Heap, IsWindowProxy, JS_IsExceptionPending, JSContext, JSObject};
 use js::jsval::UndefinedValue;
 use js::rust::wrappers::{IsArrayObject, JS_GetProperty, JS_HasProperty};
-use js::rust::{HandleId, HandleObject, HandleValue, MutableHandleValue};
+use js::rust::{HandleObject, HandleValue, MutableHandleValue};
 use num_traits::Float;
 pub(crate) use script_bindings::conversions::*;
 
@@ -50,7 +50,6 @@ use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::num::Finite;
 use crate::dom::bindings::reflector::DomObject;
 use crate::dom::bindings::root::DomRoot;
-use crate::dom::bindings::str::DOMString;
 use crate::dom::bindings::trace::{JSTraceable, RootedTraceableBox};
 use crate::dom::bindings::utils::DOMClass;
 use crate::dom::filelist::FileList;
@@ -120,24 +119,6 @@ where
             ConversionResult::Failure(msg) => ConversionResult::Failure(msg),
         })
     }
-}
-
-/// Convert `id` to a `DOMString`. Returns `None` if `id` is not a string or
-/// integer.
-///
-/// Handling of invalid UTF-16 in strings depends on the relevant option.
-pub(crate) unsafe fn jsid_to_string(cx: *mut JSContext, id: HandleId) -> Option<DOMString> {
-    let id_raw = *id;
-    if id_raw.is_string() {
-        let jsstr = std::ptr::NonNull::new(id_raw.to_string()).unwrap();
-        return Some(jsstring_to_str(cx, jsstr));
-    }
-
-    if id_raw.is_int() {
-        return Some(id_raw.to_int().to_string().into());
-    }
-
-    None
 }
 
 pub(crate) use script_bindings::conversions::is_dom_proxy;

--- a/components/script/dom/bindings/import.rs
+++ b/components/script/dom/bindings/import.rs
@@ -99,6 +99,7 @@ pub(crate) mod module {
         JSCLASS_RESERVED_SLOTS_MASK, jsapi, typedarray,
     };
     pub(crate) use script_bindings::constant::{ConstantSpec, ConstantVal};
+    pub(crate) use script_bindings::record::Record;
     pub(crate) use servo_config::pref;
 
     pub(crate) use super::base::*;
@@ -144,7 +145,6 @@ pub(crate) mod module {
     pub(crate) use crate::dom::bindings::proxyhandler::{
         ensure_expando_object, get_expando_object, set_property_descriptor,
     };
-    pub(crate) use crate::dom::bindings::record::Record;
     pub(crate) use crate::dom::bindings::reflector::{
         DomObjectIteratorWrap, DomObjectWrap, Reflector,
     };

--- a/components/script/dom/bindings/mod.rs
+++ b/components/script/dom/bindings/mod.rs
@@ -154,7 +154,6 @@ pub(crate) mod namespace;
 pub(crate) mod num;
 pub(crate) mod principals;
 pub(crate) mod proxyhandler;
-pub(crate) mod record;
 pub(crate) mod refcounted;
 pub(crate) mod reflector;
 pub(crate) mod root;

--- a/components/script/dom/testbinding.rs
+++ b/components/script/dom/testbinding.rs
@@ -14,6 +14,7 @@ use js::jsapi::{Heap, JS_NewPlainObject, JSObject};
 use js::jsval::JSVal;
 use js::rust::{CustomAutoRooterGuard, HandleObject, HandleValue, MutableHandleValue};
 use js::typedarray::{self, Uint8ClampedArray};
+use script_bindings::record::Record;
 use script_traits::serializable::BlobImpl;
 use servo_config::prefs;
 
@@ -35,7 +36,6 @@ use crate::dom::bindings::codegen::UnionTypes::{
 };
 use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::num::Finite;
-use crate::dom::bindings::record::Record;
 use crate::dom::bindings::refcounted::TrustedPromise;
 use crate::dom::bindings::reflector::{DomGlobal, Reflector, reflect_dom_object_with_proto};
 use crate::dom::bindings::root::DomRoot;

--- a/components/script_bindings/Cargo.toml
+++ b/components/script_bindings/Cargo.toml
@@ -22,8 +22,10 @@ serde_json = { workspace = true }
 
 [dependencies]
 bitflags = { workspace = true }
+crossbeam-channel = { workspace = true }
 cssparser = { workspace = true }
 html5ever = { workspace = true }
+indexmap = { workspace = true }
 js = { workspace = true }
 jstraceable_derive = { path = "../jstraceable_derive" }
 libc = { workspace = true }
@@ -31,15 +33,21 @@ log = { workspace = true }
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
 num-traits = { workspace = true }
+parking_lot = { workspace = true }
 regex = { workspace = true }
+servo_arc = { workspace = true }
+smallvec = { workspace = true }
 stylo_atoms = { workspace = true }
 servo_config = { path = "../config" }
 style = { workspace = true }
+tendril = { version = "0.4.1", features = ["encoding_rs"] }
+webxr-api = { workspace = true, optional = true }
+xml5ever = { workspace = true }
 
 [features]
 bluetooth = []
 webgpu = []
-webxr = []
+webxr = ["webxr-api"]
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(crown)'] }

--- a/components/script_bindings/codegen/CodegenRust.py
+++ b/components/script_bindings/codegen/CodegenRust.py
@@ -2287,7 +2287,7 @@ class CGImports(CGWrapper):
                     extras += [descriptor.path, descriptor.bindingPath]
                     parentName = descriptor.getParentName()
             elif t.isType() and t.isRecord():
-                extras += ['crate::dom::bindings::record::Record']
+                extras += ['script_bindings::record::Record']
             elif isinstance(t, IDLPromiseType):
                 extras += ['crate::dom::promise::Promise']
             else:
@@ -2643,7 +2643,7 @@ def UnionTypes(descriptors, dictionaries, callbacks, typedefs, config):
         'crate::dom::bindings::import::base::*',
         'crate::dom::bindings::codegen::DomTypes::DomTypes',
         'crate::dom::bindings::conversions::windowproxy_from_handlevalue',
-        'crate::dom::bindings::record::Record',
+        'script_bindings::record::Record',
         'crate::dom::types::*',
         'crate::dom::windowproxy::WindowProxy',
         'js::typedarray',

--- a/components/script_bindings/conversions.rs
+++ b/components/script_bindings/conversions.rs
@@ -18,8 +18,8 @@ use js::jsapi::{
 };
 use js::jsval::{ObjectValue, StringValue, UndefinedValue};
 use js::rust::{
-    HandleValue, MutableHandleValue, ToString, get_object_class, is_dom_class, is_dom_object,
-    maybe_wrap_value,
+    HandleId, HandleValue, MutableHandleValue, ToString, get_object_class, is_dom_class,
+    is_dom_object, maybe_wrap_value,
 };
 
 use crate::inheritance::Castable;
@@ -386,4 +386,22 @@ where
         return Err(());
     }
     root_from_object(v.get().to_object(), cx)
+}
+
+/// Convert `id` to a `DOMString`. Returns `None` if `id` is not a string or
+/// integer.
+///
+/// Handling of invalid UTF-16 in strings depends on the relevant option.
+pub unsafe fn jsid_to_string(cx: *mut JSContext, id: HandleId) -> Option<DOMString> {
+    let id_raw = *id;
+    if id_raw.is_string() {
+        let jsstr = std::ptr::NonNull::new(id_raw.to_string()).unwrap();
+        return Some(jsstring_to_str(cx, jsstr));
+    }
+
+    if id_raw.is_int() {
+        return Some(id_raw.to_int().to_string().into());
+    }
+
+    None
 }

--- a/components/script_bindings/conversions.rs
+++ b/components/script_bindings/conversions.rs
@@ -392,6 +392,9 @@ where
 /// integer.
 ///
 /// Handling of invalid UTF-16 in strings depends on the relevant option.
+///
+/// # Safety
+/// - cx must point to a non-null, valid JSContext instance.
 pub unsafe fn jsid_to_string(cx: *mut JSContext, id: HandleId) -> Option<DOMString> {
     let id_raw = *id;
     if id_raw.is_string() {

--- a/components/script_bindings/lib.rs
+++ b/components/script_bindings/lib.rs
@@ -24,6 +24,7 @@ pub mod error;
 pub mod inheritance;
 pub mod iterable;
 pub mod like;
+pub mod record;
 pub mod reflector;
 pub mod root;
 pub mod script_runtime;
@@ -51,3 +52,5 @@ pub mod codegen {
 // Since they are used in derive macros,
 // it is useful that they are accessible at the root of the crate.
 pub(crate) use js::gc::Traceable as JSTraceable;
+
+pub(crate) use crate::trace::CustomTraceable;

--- a/components/script_bindings/record.rs
+++ b/components/script_bindings/record.rs
@@ -17,13 +17,14 @@ use js::jsapi::{
     JSITER_SYMBOLS, JSPROP_ENUMERATE, PropertyDescriptor,
 };
 use js::jsval::{ObjectValue, UndefinedValue};
+use js::rooted;
 use js::rust::wrappers::{GetPropertyKeys, JS_DefineUCProperty2, JS_GetPropertyById, JS_IdToValue};
 use js::rust::{HandleId, HandleValue, IdVector, MutableHandleValue};
 
-use crate::dom::bindings::conversions::jsid_to_string;
-use crate::dom::bindings::str::{ByteString, DOMString, USVString};
+use crate::conversions::jsid_to_string;
+use crate::str::{ByteString, DOMString, USVString};
 
-pub(crate) trait RecordKey: Eq + Hash + Sized {
+pub trait RecordKey: Eq + Hash + Sized {
     fn to_utf16_vec(&self) -> Vec<u16>;
     unsafe fn from_id(cx: *mut JSContext, id: HandleId) -> Result<ConversionResult<Self>, ()>;
 }
@@ -71,14 +72,14 @@ impl RecordKey for ByteString {
 
 /// The `Record` (open-ended dictionary) type.
 #[derive(Clone, JSTraceable)]
-pub(crate) struct Record<K: RecordKey, V> {
+pub struct Record<K: RecordKey, V> {
     #[custom_trace]
     map: IndexMap<K, V>,
 }
 
 impl<K: RecordKey, V> Record<K, V> {
     /// Create an empty `Record`.
-    pub(crate) fn new() -> Self {
+    pub fn new() -> Self {
         Record {
             map: IndexMap::new(),
         }

--- a/components/script_bindings/record.rs
+++ b/components/script_bindings/record.rs
@@ -26,6 +26,11 @@ use crate::str::{ByteString, DOMString, USVString};
 
 pub trait RecordKey: Eq + Hash + Sized {
     fn to_utf16_vec(&self) -> Vec<u16>;
+
+    /// Attempt to extract a key from a JS id.
+    /// # Safety
+    /// - cx must point to a non-null, valid JSContext.
+    #[allow(clippy::result_unit_err)]
     unsafe fn from_id(cx: *mut JSContext, id: HandleId) -> Result<ConversionResult<Self>, ()>;
 }
 

--- a/components/script_bindings/trace.rs
+++ b/components/script_bindings/trace.rs
@@ -8,7 +8,7 @@ use std::marker::PhantomData;
 
 use crossbeam_channel::Sender;
 use html5ever::interface::{Tracer as HtmlTracer, TreeSink};
-use html5ever::tokenizer::{Tokenizer, TokenSink};
+use html5ever::tokenizer::{TokenSink, Tokenizer};
 use html5ever::tree_builder::TreeBuilder;
 use indexmap::IndexMap;
 use js::glue::CallObjectTracer;
@@ -18,9 +18,9 @@ use servo_arc::Arc as ServoArc;
 use smallvec::SmallVec;
 use style::author_styles::AuthorStyles;
 use style::stylesheet_set::{AuthorStylesheetSet, DocumentStylesheetSet};
+use tendril::TendrilSink;
 use tendril::fmt::UTF8;
 use tendril::stream::LossyDecoder;
-use tendril::TendrilSink;
 #[cfg(feature = "webxr")]
 use webxr_api::{Finger, Hand};
 use xml5ever::interface::TreeSink as XmlTreeSink;

--- a/components/script_bindings/trace.rs
+++ b/components/script_bindings/trace.rs
@@ -2,9 +2,32 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::cell::OnceCell;
+use std::hash::{BuildHasher, Hash};
+use std::marker::PhantomData;
+
+use crossbeam_channel::Sender;
+use html5ever::interface::{Tracer as HtmlTracer, TreeSink};
+use html5ever::tokenizer::{Tokenizer, TokenSink};
+use html5ever::tree_builder::TreeBuilder;
+use indexmap::IndexMap;
 use js::glue::CallObjectTracer;
 use js::jsapi::{GCTraceKindToAscii, Heap, JSObject, JSTracer, TraceKind};
+use parking_lot::RwLock;
+use servo_arc::Arc as ServoArc;
+use smallvec::SmallVec;
+use style::author_styles::AuthorStyles;
+use style::stylesheet_set::{AuthorStylesheetSet, DocumentStylesheetSet};
+use tendril::fmt::UTF8;
+use tendril::stream::LossyDecoder;
+use tendril::TendrilSink;
+#[cfg(feature = "webxr")]
+use webxr_api::{Finger, Hand};
+use xml5ever::interface::TreeSink as XmlTreeSink;
+use xml5ever::tokenizer::XmlTokenizer;
+use xml5ever::tree_builder::{Tracer as XmlTracer, XmlTreeBuilder};
 
+use crate::JSTraceable;
 use crate::error::Error;
 use crate::reflector::Reflector;
 use crate::str::{DOMString, USVString};
@@ -53,3 +76,235 @@ macro_rules! unsafe_no_jsmanaged_fields(
 unsafe_no_jsmanaged_fields!(DOMString);
 unsafe_no_jsmanaged_fields!(USVString);
 unsafe_no_jsmanaged_fields!(Error);
+
+/// A trait to allow tracing only DOM sub-objects.
+///
+/// # Safety
+///
+/// This trait is unsafe; if it is implemented incorrectly, the GC may end up collecting objects
+/// that are still reachable.
+pub unsafe trait CustomTraceable {
+    /// Trace `self`.
+    ///
+    /// # Safety
+    ///
+    /// The `JSTracer` argument must point to a valid `JSTracer` in memory. In addition,
+    /// implementors of this method must ensure that all active objects are properly traced
+    /// or else the garbage collector may end up collecting objects that are still reachable.
+    unsafe fn trace(&self, trc: *mut JSTracer);
+}
+
+unsafe impl<T: CustomTraceable> CustomTraceable for Box<T> {
+    #[inline]
+    unsafe fn trace(&self, trc: *mut JSTracer) {
+        (**self).trace(trc);
+    }
+}
+
+unsafe impl<T: JSTraceable> CustomTraceable for OnceCell<T> {
+    unsafe fn trace(&self, tracer: *mut JSTracer) {
+        if let Some(value) = self.get() {
+            value.trace(tracer)
+        }
+    }
+}
+
+unsafe impl<T> CustomTraceable for Sender<T> {
+    unsafe fn trace(&self, _: *mut JSTracer) {}
+}
+
+unsafe impl<T: JSTraceable> CustomTraceable for ServoArc<T> {
+    unsafe fn trace(&self, trc: *mut JSTracer) {
+        (**self).trace(trc)
+    }
+}
+
+unsafe impl<T: JSTraceable> CustomTraceable for RwLock<T> {
+    unsafe fn trace(&self, trc: *mut JSTracer) {
+        self.read().trace(trc)
+    }
+}
+
+unsafe impl<T: JSTraceable + Eq + Hash> CustomTraceable for indexmap::IndexSet<T> {
+    #[inline]
+    unsafe fn trace(&self, trc: *mut JSTracer) {
+        for e in self.iter() {
+            e.trace(trc);
+        }
+    }
+}
+
+// XXXManishearth Check if the following three are optimized to no-ops
+// if e.trace() is a no-op (e.g it is an unsafe_no_jsmanaged_fields type)
+unsafe impl<T: JSTraceable + 'static> CustomTraceable for SmallVec<[T; 1]> {
+    #[inline]
+    unsafe fn trace(&self, trc: *mut JSTracer) {
+        for e in self.iter() {
+            e.trace(trc);
+        }
+    }
+}
+
+unsafe impl<K, V, S> CustomTraceable for IndexMap<K, V, S>
+where
+    K: Hash + Eq + JSTraceable,
+    V: JSTraceable,
+    S: BuildHasher,
+{
+    #[inline]
+    unsafe fn trace(&self, trc: *mut JSTracer) {
+        for (k, v) in self {
+            k.trace(trc);
+            v.trace(trc);
+        }
+    }
+}
+
+unsafe impl<S> CustomTraceable for DocumentStylesheetSet<S>
+where
+    S: JSTraceable + ::style::stylesheets::StylesheetInDocument + PartialEq + 'static,
+{
+    unsafe fn trace(&self, tracer: *mut JSTracer) {
+        for (s, _origin) in self.iter() {
+            s.trace(tracer)
+        }
+    }
+}
+
+unsafe impl<S> CustomTraceable for AuthorStylesheetSet<S>
+where
+    S: JSTraceable + ::style::stylesheets::StylesheetInDocument + PartialEq + 'static,
+{
+    unsafe fn trace(&self, tracer: *mut JSTracer) {
+        for s in self.iter() {
+            s.trace(tracer)
+        }
+    }
+}
+
+unsafe impl<S> CustomTraceable for AuthorStyles<S>
+where
+    S: JSTraceable + ::style::stylesheets::StylesheetInDocument + PartialEq + 'static,
+{
+    unsafe fn trace(&self, tracer: *mut JSTracer) {
+        self.stylesheets.trace(tracer)
+    }
+}
+
+unsafe impl<Sink> CustomTraceable for LossyDecoder<Sink>
+where
+    Sink: JSTraceable + TendrilSink<UTF8>,
+{
+    unsafe fn trace(&self, tracer: *mut JSTracer) {
+        self.inner_sink().trace(tracer);
+    }
+}
+
+#[cfg(feature = "webxr")]
+unsafe impl<J> CustomTraceable for Hand<J>
+where
+    J: JSTraceable,
+{
+    #[inline]
+    unsafe fn trace(&self, trc: *mut JSTracer) {
+        // exhaustive match so we don't miss new fields
+        let Hand {
+            ref wrist,
+            ref thumb_metacarpal,
+            ref thumb_phalanx_proximal,
+            ref thumb_phalanx_distal,
+            ref thumb_phalanx_tip,
+            ref index,
+            ref middle,
+            ref ring,
+            ref little,
+        } = *self;
+        wrist.trace(trc);
+        thumb_metacarpal.trace(trc);
+        thumb_phalanx_proximal.trace(trc);
+        thumb_phalanx_distal.trace(trc);
+        thumb_phalanx_tip.trace(trc);
+        index.trace(trc);
+        middle.trace(trc);
+        ring.trace(trc);
+        little.trace(trc);
+    }
+}
+
+#[cfg(feature = "webxr")]
+unsafe impl<J> CustomTraceable for Finger<J>
+where
+    J: JSTraceable,
+{
+    #[inline]
+    unsafe fn trace(&self, trc: *mut JSTracer) {
+        // exhaustive match so we don't miss new fields
+        let Finger {
+            ref metacarpal,
+            ref phalanx_proximal,
+            ref phalanx_intermediate,
+            ref phalanx_distal,
+            ref phalanx_tip,
+        } = *self;
+        metacarpal.trace(trc);
+        phalanx_proximal.trace(trc);
+        phalanx_intermediate.trace(trc);
+        phalanx_distal.trace(trc);
+        phalanx_tip.trace(trc);
+    }
+}
+
+unsafe impl<Handle: JSTraceable + Clone, Sink: TreeSink<Handle = Handle> + JSTraceable>
+    CustomTraceable for TreeBuilder<Handle, Sink>
+{
+    unsafe fn trace(&self, trc: *mut JSTracer) {
+        struct Tracer<Handle>(*mut JSTracer, PhantomData<Handle>);
+        let tracer = Tracer::<Handle>(trc, PhantomData);
+
+        impl<Handle: JSTraceable> HtmlTracer for Tracer<Handle> {
+            type Handle = Handle;
+            #[cfg_attr(crown, allow(crown::unrooted_must_root))]
+            fn trace_handle(&self, node: &Handle) {
+                unsafe {
+                    node.trace(self.0);
+                }
+            }
+        }
+
+        self.trace_handles(&tracer);
+        self.sink.trace(trc);
+    }
+}
+
+#[allow(unsafe_code)]
+unsafe impl<Handle: JSTraceable + Clone, Sink: TokenSink<Handle = Handle> + CustomTraceable>
+    CustomTraceable for Tokenizer<Sink>
+{
+    unsafe fn trace(&self, trc: *mut JSTracer) {
+        self.sink.trace(trc);
+    }
+}
+
+#[allow(unsafe_code)]
+unsafe impl<Handle: JSTraceable + Clone, Sink: JSTraceable + XmlTreeSink<Handle = Handle>>
+    CustomTraceable for XmlTokenizer<XmlTreeBuilder<Handle, Sink>>
+{
+    unsafe fn trace(&self, trc: *mut JSTracer) {
+        struct Tracer<Handle>(*mut JSTracer, PhantomData<Handle>);
+        let tracer = Tracer(trc, PhantomData);
+
+        impl<Handle: JSTraceable> XmlTracer for Tracer<Handle> {
+            type Handle = Handle;
+            #[cfg_attr(crown, allow(crown::unrooted_must_root))]
+            fn trace_handle(&self, node: &Handle) {
+                unsafe {
+                    node.trace(self.0);
+                }
+            }
+        }
+
+        let tree_builder = &self.sink;
+        tree_builder.trace_handles(&tracer);
+        tree_builder.sink.trace(trc);
+    }
+}


### PR DESCRIPTION
Since the record binding support relies on CustomTraceable, we need to move it to script_bindings. This requires some adjustment of the HTML parser code that relies on it, since we start running into the orphan rule since both the parser types and CustomTraceable are from different crates.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #1799
- [x] There are existing tests for these changes