### PR TITLE
Make DOMPoint and DOMPointReadOnly serializable

### DIFF
--- a/components/script/dom/abstractworker.rs
+++ b/components/script/dom/abstractworker.rs
@@ -16,7 +16,7 @@ pub(crate) enum WorkerScriptMsg {
     /// Message sent through Worker.postMessage
     DOMMessage {
         origin: ImmutableOrigin,
-        data: StructuredSerializedData,
+        data: Box<StructuredSerializedData>,
     },
 }
 

--- a/components/script/dom/bindings/structuredclone.rs
+++ b/components/script/dom/bindings/structuredclone.rs
@@ -9,7 +9,7 @@ use std::num::NonZeroU32;
 use std::os::raw;
 use std::ptr;
 
-use base::id::{BlobId, MessagePortId, PipelineNamespaceId};
+use base::id::{BlobId, DomPointId, MessagePortId, PipelineNamespaceId};
 use js::glue::{
     CopyJSStructuredCloneData, DeleteJSAutoStructuredCloneBuffer, GetLengthOfJSStructuredCloneData,
     NewJSAutoStructuredCloneBuffer, WriteBytesToJSStructuredCloneData,
@@ -24,7 +24,7 @@ use js::jsval::UndefinedValue;
 use js::rust::wrappers::{JS_ReadStructuredClone, JS_WriteStructuredClone};
 use js::rust::{CustomAutoRooterGuard, HandleValue, MutableHandleValue};
 use script_bindings::conversions::IDLInterface;
-use script_traits::serializable::BlobImpl;
+use script_traits::serializable::{BlobImpl, DomPoint};
 use script_traits::transferable::MessagePortImpl;
 use script_traits::{
     Serializable as SerializableInterface, StructuredSerializedData,
@@ -38,6 +38,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::serializable::{IntoStorageKey, Serializable, StorageKey};
 use crate::dom::bindings::transferable::{ExtractComponents, IdFromComponents, Transferable};
 use crate::dom::blob::Blob;
+use crate::dom::dompointreadonly::DOMPointReadOnly;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::messageport::MessagePort;
 use crate::realms::{AlreadyInRealm, InRealm, enter_realm};
@@ -54,6 +55,7 @@ pub(super) enum StructuredCloneTags {
     DomBlob = 0xFFFF8001,
     MessagePort = 0xFFFF8002,
     Principals = 0xFFFF8003,
+    DomPointReadOnly = 0xFFFF8004,
     Max = 0xFFFFFFFF,
 }
 
@@ -61,6 +63,7 @@ impl From<SerializableInterface> for StructuredCloneTags {
     fn from(v: SerializableInterface) -> Self {
         match v {
             SerializableInterface::Blob => StructuredCloneTags::DomBlob,
+            SerializableInterface::DomPointReadOnly => StructuredCloneTags::DomPointReadOnly,
         }
     }
 }
@@ -83,6 +86,7 @@ fn reader_for_type(
 ) -> *mut JSObject {
     match val {
         SerializableInterface::Blob => read_object::<Blob>,
+        SerializableInterface::DomPointReadOnly => read_object::<DOMPointReadOnly>,
     }
 }
 
@@ -214,6 +218,7 @@ type SerializeOperation = unsafe fn(
 fn serialize_for_type(val: SerializableInterface) -> SerializeOperation {
     match val {
         SerializableInterface::Blob => try_serialize::<Blob>,
+        SerializableInterface::DomPointReadOnly => try_serialize::<DOMPointReadOnly>,
     }
 }
 
@@ -465,6 +470,8 @@ pub(crate) enum StructuredData<'a> {
 pub(crate) struct StructuredDataReader {
     /// A map of deserialized blobs, stored temporarily here to keep them rooted.
     pub(crate) blobs: Option<HashMap<StorageKey, DomRoot<Blob>>>,
+    /// A map of deserialized points, stored temporarily here to keep them rooted.
+    pub(crate) points_read_only: Option<HashMap<StorageKey, DomRoot<DOMPointReadOnly>>>,
     /// A vec of transfer-received DOM ports,
     /// to be made available to script through a message event.
     pub(crate) message_ports: Option<Vec<DomRoot<MessagePort>>>,
@@ -476,12 +483,17 @@ pub(crate) struct StructuredDataReader {
     /// used as part of the "deserialize" steps of blobs,
     /// to produce the DOM blobs stored in `blobs` above.
     pub(crate) blob_impls: Option<HashMap<BlobId, BlobImpl>>,
+    /// A map of serialized points.
+    pub(crate) points: Option<HashMap<DomPointId, DomPoint>>,
 }
 
 /// A data holder for transferred and serialized objects.
+#[derive(Default)]
 pub(crate) struct StructuredDataWriter {
     /// Transferred ports.
     pub(crate) ports: Option<HashMap<MessagePortId, MessagePortImpl>>,
+    /// Serialized points.
+    pub(crate) points: Option<HashMap<DomPointId, DomPoint>>,
     /// Serialized blobs.
     pub(crate) blobs: Option<HashMap<BlobId, BlobImpl>>,
 }
@@ -497,10 +509,7 @@ pub(crate) fn write(
         if let Some(transfer) = transfer {
             transfer.to_jsval(*cx, val.handle_mut());
         }
-        let mut sc_writer = StructuredDataWriter {
-            ports: None,
-            blobs: None,
-        };
+        let mut sc_writer = StructuredDataWriter::default();
         let sc_writer_ptr = &mut sc_writer as *mut _;
 
         let scbuf = NewJSAutoStructuredCloneBuffer(
@@ -537,6 +546,7 @@ pub(crate) fn write(
         let data = StructuredSerializedData {
             serialized: data,
             ports: sc_writer.ports.take(),
+            points: sc_writer.points.take(),
             blobs: sc_writer.blobs.take(),
         };
 
@@ -556,8 +566,10 @@ pub(crate) fn read(
     let mut sc_reader = StructuredDataReader {
         blobs: None,
         message_ports: None,
+        points_read_only: None,
         port_impls: data.ports.take(),
         blob_impls: data.blobs.take(),
+        points: data.points.take(),
     };
     let sc_reader_ptr = &mut sc_reader as *mut _;
     unsafe {

--- a/components/script/dom/bindings/structuredclone.rs
+++ b/components/script/dom/bindings/structuredclone.rs
@@ -38,6 +38,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::serializable::{IntoStorageKey, Serializable, StorageKey};
 use crate::dom::bindings::transferable::{ExtractComponents, IdFromComponents, Transferable};
 use crate::dom::blob::Blob;
+use crate::dom::dompoint::DOMPoint;
 use crate::dom::dompointreadonly::DOMPointReadOnly;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::messageport::MessagePort;
@@ -56,6 +57,7 @@ pub(super) enum StructuredCloneTags {
     MessagePort = 0xFFFF8002,
     Principals = 0xFFFF8003,
     DomPointReadOnly = 0xFFFF8004,
+    DomPoint = 0xFFFF8005,
     Max = 0xFFFFFFFF,
 }
 
@@ -64,6 +66,7 @@ impl From<SerializableInterface> for StructuredCloneTags {
         match v {
             SerializableInterface::Blob => StructuredCloneTags::DomBlob,
             SerializableInterface::DomPointReadOnly => StructuredCloneTags::DomPointReadOnly,
+            SerializableInterface::DomPoint => StructuredCloneTags::DomPoint,
         }
     }
 }
@@ -87,6 +90,7 @@ fn reader_for_type(
     match val {
         SerializableInterface::Blob => read_object::<Blob>,
         SerializableInterface::DomPointReadOnly => read_object::<DOMPointReadOnly>,
+        SerializableInterface::DomPoint => read_object::<DOMPoint>,
     }
 }
 
@@ -219,6 +223,7 @@ fn serialize_for_type(val: SerializableInterface) -> SerializeOperation {
     match val {
         SerializableInterface::Blob => try_serialize::<Blob>,
         SerializableInterface::DomPointReadOnly => try_serialize::<DOMPointReadOnly>,
+        SerializableInterface::DomPoint => try_serialize::<DOMPoint>,
     }
 }
 
@@ -472,6 +477,7 @@ pub(crate) struct StructuredDataReader {
     pub(crate) blobs: Option<HashMap<StorageKey, DomRoot<Blob>>>,
     /// A map of deserialized points, stored temporarily here to keep them rooted.
     pub(crate) points_read_only: Option<HashMap<StorageKey, DomRoot<DOMPointReadOnly>>>,
+    pub(crate) dom_points: Option<HashMap<StorageKey, DomRoot<DOMPoint>>>,
     /// A vec of transfer-received DOM ports,
     /// to be made available to script through a message event.
     pub(crate) message_ports: Option<Vec<DomRoot<MessagePort>>>,
@@ -567,6 +573,7 @@ pub(crate) fn read(
         blobs: None,
         message_ports: None,
         points_read_only: None,
+        dom_points: None,
         port_impls: data.ports.take(),
         blob_impls: data.blobs.take(),
         points: data.points.take(),

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -564,7 +564,8 @@ impl DedicatedWorkerGlobalScope {
                 let target = self.upcast();
                 let _ac = enter_realm(self);
                 rooted!(in(*scope.get_cx()) let mut message = UndefinedValue());
-                if let Ok(ports) = structuredclone::read(scope.upcast(), data, message.handle_mut())
+                if let Ok(ports) =
+                    structuredclone::read(scope.upcast(), *data, message.handle_mut())
                 {
                     MessageEvent::dispatch_jsval(
                         target,

--- a/components/script/dom/dompoint.rs
+++ b/components/script/dom/dompoint.rs
@@ -2,14 +2,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::collections::HashMap;
+
+use base::id::DomPointId;
 use dom_struct::dom_struct;
 use js::rust::HandleObject;
+use script_traits::serializable::DomPoint;
 
 use crate::dom::bindings::codegen::Bindings::DOMPointBinding::{DOMPointInit, DOMPointMethods};
 use crate::dom::bindings::codegen::Bindings::DOMPointReadOnlyBinding::DOMPointReadOnlyMethods;
 use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::reflector::reflect_dom_object_with_proto;
 use crate::dom::bindings::root::DomRoot;
+use crate::dom::bindings::serializable::{Serializable, StorageKey};
+use crate::dom::bindings::structuredclone::{StructuredData, StructuredDataReader};
 use crate::dom::dompointreadonly::{DOMPointReadOnly, DOMPointWriteMethods};
 use crate::dom::globalscope::GlobalScope;
 use crate::script_runtime::CanGc;
@@ -122,5 +128,51 @@ impl DOMPointMethods<crate::DomTypeHolder> for DOMPoint {
     // https://dev.w3.org/fxtf/geometry/Overview.html#dom-dompointreadonly-w
     fn SetW(&self, value: f64) {
         self.point.SetW(value);
+    }
+}
+
+impl Serializable for DOMPoint {
+    type Id = DomPointId;
+    type Data = DomPoint;
+
+    fn serialize(&self) -> Result<(Self::Id, Self::Data), ()> {
+        let serialized = DomPoint {
+            x: self.X(),
+            y: self.Y(),
+            z: self.Z(),
+            w: self.W(),
+        };
+        Ok((DomPointId::new(), serialized))
+    }
+
+    fn deserialize(
+        owner: &GlobalScope,
+        serialized: Self::Data,
+        can_gc: CanGc,
+    ) -> Result<DomRoot<Self>, ()>
+    where
+        Self: Sized,
+    {
+        Ok(Self::new(
+            owner,
+            serialized.x,
+            serialized.y,
+            serialized.z,
+            serialized.w,
+            can_gc,
+        ))
+    }
+
+    fn serialized_storage(data: StructuredData<'_>) -> &mut Option<HashMap<Self::Id, Self::Data>> {
+        match data {
+            StructuredData::Reader(r) => &mut r.points,
+            StructuredData::Writer(w) => &mut w.points,
+        }
+    }
+
+    fn deserialized_storage(
+        reader: &mut StructuredDataReader,
+    ) -> &mut Option<HashMap<StorageKey, DomRoot<Self>>> {
+        &mut reader.dom_points
     }
 }

--- a/components/script/dom/dompoint.rs
+++ b/components/script/dom/dompoint.rs
@@ -165,8 +165,8 @@ impl Serializable for DOMPoint {
 
     fn serialized_storage(data: StructuredData<'_>) -> &mut Option<HashMap<Self::Id, Self::Data>> {
         match data {
-            StructuredData::Reader(r) => &mut r.points,
-            StructuredData::Writer(w) => &mut w.points,
+            StructuredData::Reader(reader) => &mut reader.points,
+            StructuredData::Writer(writer) => &mut writer.points,
         }
     }
 

--- a/components/script/dom/dompointreadonly.rs
+++ b/components/script/dom/dompointreadonly.rs
@@ -3,15 +3,21 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::cell::Cell;
+use std::collections::HashMap;
+use std::num::NonZeroU32;
 
+use base::id::{DomPointId, DomPointIndex, PipelineNamespaceId};
 use dom_struct::dom_struct;
 use js::rust::HandleObject;
+use script_traits::serializable::DomPoint;
 
 use crate::dom::bindings::codegen::Bindings::DOMPointBinding::DOMPointInit;
 use crate::dom::bindings::codegen::Bindings::DOMPointReadOnlyBinding::DOMPointReadOnlyMethods;
 use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 use crate::dom::bindings::root::DomRoot;
+use crate::dom::bindings::serializable::{IntoStorageKey, Serializable, StorageKey};
+use crate::dom::bindings::structuredclone::{StructuredData, StructuredDataReader};
 use crate::dom::globalscope::GlobalScope;
 use crate::script_runtime::CanGc;
 
@@ -132,5 +138,72 @@ impl DOMPointWriteMethods for DOMPointReadOnly {
 
     fn SetW(&self, value: f64) {
         self.w.set(value);
+    }
+}
+
+impl Serializable for DOMPointReadOnly {
+    type Id = DomPointId;
+    type Data = DomPoint;
+
+    fn serialize(&self) -> Result<(Self::Id, Self::Data), ()> {
+        let serialized = DomPoint {
+            x: self.x.get(),
+            y: self.y.get(),
+            z: self.z.get(),
+            w: self.w.get(),
+        };
+        Ok((DomPointId::new(), serialized))
+    }
+
+    fn deserialize(
+        owner: &GlobalScope,
+        serialized: Self::Data,
+        can_gc: CanGc,
+    ) -> Result<DomRoot<Self>, ()>
+    where
+        Self: Sized,
+    {
+        Ok(Self::new(
+            owner,
+            serialized.x,
+            serialized.y,
+            serialized.z,
+            serialized.w,
+            can_gc,
+        ))
+    }
+
+    fn serialized_storage(data: StructuredData<'_>) -> &mut Option<HashMap<Self::Id, Self::Data>> {
+        match data {
+            StructuredData::Reader(r) => &mut r.points,
+            StructuredData::Writer(w) => &mut w.points,
+        }
+    }
+
+    fn deserialized_storage(
+        reader: &mut StructuredDataReader,
+    ) -> &mut Option<HashMap<StorageKey, DomRoot<Self>>> {
+        &mut reader.points_read_only
+    }
+}
+
+impl From<StorageKey> for DomPointId {
+    fn from(storage_key: StorageKey) -> DomPointId {
+        let namespace_id = PipelineNamespaceId(storage_key.name_space);
+        let index = DomPointIndex(
+            NonZeroU32::new(storage_key.index).expect("Deserialized point index is zero"),
+        );
+
+        DomPointId {
+            namespace_id,
+            index,
+        }
+    }
+}
+
+impl IntoStorageKey for DomPointId {
+    fn into_storage_key(self) -> StorageKey {
+        let DomPointIndex(index) = self.index;
+        StorageKey::new(self.namespace_id, index)
     }
 }

--- a/components/script/dom/history.rs
+++ b/components/script/dom/history.rs
@@ -123,8 +123,7 @@ impl History {
             Some(data) => {
                 let data = StructuredSerializedData {
                     serialized: data,
-                    ports: None,
-                    blobs: None,
+                    ..Default::default()
                 };
                 rooted!(in(*GlobalScope::get_cx()) let mut state = UndefinedValue());
                 if structuredclone::read(self.window.as_global_scope(), data, state.handle_mut())

--- a/components/script/dom/serviceworkerglobalscope.rs
+++ b/components/script/dom/serviceworkerglobalscope.rs
@@ -443,7 +443,8 @@ impl ServiceWorkerGlobalScope {
                 let target = self.upcast();
                 let _ac = enter_realm(scope);
                 rooted!(in(*scope.get_cx()) let mut message = UndefinedValue());
-                if let Ok(ports) = structuredclone::read(scope.upcast(), data, message.handle_mut())
+                if let Ok(ports) =
+                    structuredclone::read(scope.upcast(), *data, message.handle_mut())
                 {
                     ExtendableMessageEvent::dispatch_jsval(
                         target,

--- a/components/script/dom/worker.rs
+++ b/components/script/dom/worker.rs
@@ -148,7 +148,7 @@ impl Worker {
             address,
             WorkerScriptMsg::DOMMessage {
                 origin: self.global().origin().immutable().clone(),
-                data,
+                data: Box::new(data),
             },
         ));
         Ok(())

--- a/components/script/serviceworker_manager.rs
+++ b/components/script/serviceworker_manager.rs
@@ -64,7 +64,10 @@ impl ServiceWorker {
     fn forward_dom_message(&self, msg: DOMMessage) {
         let DOMMessage { origin, data } = msg;
         let _ = self.sender.send(ServiceWorkerScriptMsg::CommonWorker(
-            WorkerScriptMsg::DOMMessage { origin, data },
+            WorkerScriptMsg::DOMMessage {
+                origin,
+                data: Box::new(data),
+            },
         ));
     }
 

--- a/components/shared/base/id.rs
+++ b/components/shared/base/id.rs
@@ -195,6 +195,7 @@ impl PipelineNamespace {
     namespace_id_method! {next_service_worker_registration_id, ServiceWorkerRegistrationId,
     self, ServiceWorkerRegistrationIndex}
     namespace_id_method! {next_blob_id, BlobId, self, BlobIndex}
+    namespace_id_method! {next_dom_point_id, DomPointId, self, DomPointIndex}
 }
 
 thread_local!(pub static PIPELINE_NAMESPACE: Cell<Option<PipelineNamespace>> = const { Cell::new(None) });
@@ -407,6 +408,19 @@ impl BlobId {
             let next_blob_id = namespace.next_blob_id();
             tls.set(Some(namespace));
             next_blob_id
+        })
+    }
+}
+
+namespace_id! {DomPointId, DomPointIndex, "DomPoint"}
+
+impl DomPointId {
+    pub fn new() -> DomPointId {
+        PIPELINE_NAMESPACE.with(|tls| {
+            let mut namespace = tls.get().expect("No namespace set for this thread!");
+            let next_point_id = namespace.next_dom_point_id();
+            tls.set(Some(namespace));
+            next_point_id
         })
     }
 }

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -680,6 +680,8 @@ where
 pub enum Serializable {
     /// The `Blob` interface.
     Blob,
+    /// The `DOMPoint` interface.
+    DomPoint,
     /// The `DOMPointReadOnly` interface.
     DomPointReadOnly,
 }
@@ -691,6 +693,7 @@ impl Serializable {
             Serializable::DomPointReadOnly => {
                 StructuredSerializedData::clone_all_of_type::<DomPoint>
             },
+            Serializable::DomPoint => StructuredSerializedData::clone_all_of_type::<DomPoint>,
         }
     }
 }

--- a/components/shared/script/serializable.rs
+++ b/components/shared/script/serializable.rs
@@ -11,7 +11,7 @@
 use std::cell::RefCell;
 use std::path::PathBuf;
 
-use base::id::BlobId;
+use base::id::{BlobId, DomPointId};
 use malloc_size_of_derive::MallocSizeOf;
 use net_traits::filemanager_thread::RelativePos;
 use serde::{Deserialize, Serialize};
@@ -180,5 +180,38 @@ impl BlobImpl {
     /// Get a mutable ref to the data
     pub fn blob_data_mut(&mut self) -> &mut BlobData {
         &mut self.blob_data
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
+/// A serializable version of the DOMPoint/DOMPointReadOnly interface.
+pub struct DomPoint {
+    /// The x coordinate.
+    pub x: f64,
+    /// The y coordinate.
+    pub y: f64,
+    /// The z coordinate.
+    pub z: f64,
+    /// The w coordinate.
+    pub w: f64,
+}
+
+impl crate::BroadcastClone for DomPoint {
+    type Id = DomPointId;
+
+    fn source(
+        data: &crate::StructuredSerializedData,
+    ) -> &Option<std::collections::HashMap<Self::Id, Self>> {
+        &data.points
+    }
+
+    fn destination(
+        data: &mut crate::StructuredSerializedData,
+    ) -> &mut Option<std::collections::HashMap<Self::Id, Self>> {
+        &mut data.points
+    }
+
+    fn clone_for_broadcast(&self) -> Option<Self> {
+        Some(self.clone())
     }
 }

--- a/tests/wpt/meta/css/geometry/structured-serialization.html.ini
+++ b/tests/wpt/meta/css/geometry/structured-serialization.html.ini
@@ -1,7 +1,4 @@
 [structured-serialization.html]
-  [DOMPoint clone: basic]
-    expected: FAIL
-
   [DOMRectReadOnly clone: basic]
     expected: FAIL
 

--- a/tests/wpt/meta/css/geometry/structured-serialization.html.ini
+++ b/tests/wpt/meta/css/geometry/structured-serialization.html.ini
@@ -1,26 +1,5 @@
 [structured-serialization.html]
-  [DOMPointReadOnly clone: basic]
-    expected: FAIL
-
-  [DOMPointReadOnly clone: custom property]
-    expected: FAIL
-
-  [DOMPointReadOnly clone: throwing getters]
-    expected: FAIL
-
-  [DOMPointReadOnly clone: non-initial values]
-    expected: FAIL
-
   [DOMPoint clone: basic]
-    expected: FAIL
-
-  [DOMPoint clone: custom property]
-    expected: FAIL
-
-  [DOMPoint clone: throwing getters]
-    expected: FAIL
-
-  [DOMPoint clone: non-initial values]
     expected: FAIL
 
   [DOMRectReadOnly clone: basic]


### PR DESCRIPTION
Building on the work from #35831, these changes make two new DOM interfaces serializable via postMessage. It still involves more copying and pasting than I would prefer, but I let the compiler errors guide me the entire way and I felt much more confident about the end result.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes