### PR TITLE
Upgrade Stylo to 2025-03-15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1401,9 +1401,8 @@ dependencies = [
 
 [[package]]
 name = "cssparser"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c66d1cd8ed61bf80b38432613a7a2f09401ab8d0501110655f8b341484a3e3"
+version = "0.34.1"
+source = "git+https://github.com/servo/rust-cssparser?rev=958a3f098acb92ddacdce18a7ef2c4a87ac3326f#958a3f098acb92ddacdce18a7ef2c4a87ac3326f"
 dependencies = [
  "cssparser-macros",
  "dtoa-short",
@@ -1416,8 +1415,7 @@ dependencies = [
 [[package]]
 name = "cssparser-macros"
 version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
+source = "git+https://github.com/servo/rust-cssparser?rev=958a3f098acb92ddacdce18a7ef2c4a87ac3326f#958a3f098acb92ddacdce18a7ef2c4a87ac3326f"
 dependencies = [
  "quote",
  "syn",
@@ -4472,7 +4470,7 @@ dependencies = [
 [[package]]
 name = "malloc_size_of"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-03-11#ae81d0a72e28eb9b4a39f13cc86d3af1389057a0"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#6aa5733a36de47b6f22879ee664266a1d59877d4"
 dependencies = [
  "app_units",
  "cssparser",
@@ -6516,7 +6514,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.26.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-11#ae81d0a72e28eb9b4a39f13cc86d3af1389057a0"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#6aa5733a36de47b6f22879ee664266a1d59877d4"
 dependencies = [
  "bitflags 2.9.0",
  "cssparser",
@@ -6801,7 +6799,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-11#ae81d0a72e28eb9b4a39f13cc86d3af1389057a0"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#6aa5733a36de47b6f22879ee664266a1d59877d4"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -7233,7 +7231,7 @@ dependencies = [
 [[package]]
 name = "style"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-03-11#ae81d0a72e28eb9b4a39f13cc86d3af1389057a0"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#6aa5733a36de47b6f22879ee664266a1d59877d4"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -7291,7 +7289,7 @@ dependencies = [
 [[package]]
 name = "style_derive"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-03-11#ae81d0a72e28eb9b4a39f13cc86d3af1389057a0"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#6aa5733a36de47b6f22879ee664266a1d59877d4"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -7321,13 +7319,12 @@ dependencies = [
 [[package]]
 name = "style_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-03-11#ae81d0a72e28eb9b4a39f13cc86d3af1389057a0"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#6aa5733a36de47b6f22879ee664266a1d59877d4"
 dependencies = [
  "app_units",
  "bitflags 2.9.0",
  "cssparser",
  "euclid",
- "lazy_static",
  "malloc_size_of",
  "malloc_size_of_derive",
  "selectors",
@@ -7343,7 +7340,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-11#ae81d0a72e28eb9b4a39f13cc86d3af1389057a0"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#6aa5733a36de47b6f22879ee664266a1d59877d4"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -7352,12 +7349,12 @@ dependencies = [
 [[package]]
 name = "stylo_config"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-11#ae81d0a72e28eb9b4a39f13cc86d3af1389057a0"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#6aa5733a36de47b6f22879ee664266a1d59877d4"
 
 [[package]]
 name = "stylo_dom"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-11#ae81d0a72e28eb9b4a39f13cc86d3af1389057a0"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#6aa5733a36de47b6f22879ee664266a1d59877d4"
 dependencies = [
  "bitflags 2.9.0",
  "malloc_size_of",
@@ -7366,7 +7363,7 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-11#ae81d0a72e28eb9b4a39f13cc86d3af1389057a0"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#6aa5733a36de47b6f22879ee664266a1d59877d4"
 
 [[package]]
 name = "subtle"
@@ -7733,7 +7730,7 @@ dependencies = [
 [[package]]
 name = "to_shmem"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-11#ae81d0a72e28eb9b4a39f13cc86d3af1389057a0"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#6aa5733a36de47b6f22879ee664266a1d59877d4"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -7746,7 +7743,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-11#ae81d0a72e28eb9b4a39f13cc86d3af1389057a0"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#6aa5733a36de47b6f22879ee664266a1d59877d4"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ compositing_traits = { path = "components/shared/compositing" }
 content-security-policy = { version = "0.5", features = ["serde"] }
 cookie = { package = "cookie", version = "0.18" }
 crossbeam-channel = "0.5"
-cssparser = { version = "0.34", features = ["serde"] }
+cssparser = { git = "https://github.com/servo/rust-cssparser", rev = "958a3f098acb92ddacdce18a7ef2c4a87ac3326f", features = ["serde"] }
 ctr = "0.9.2"
 darling = { version = "0.20", default-features = false }
 data-url = "0.3"
@@ -117,15 +117,15 @@ rustls-pemfile = "2.0"
 rustls-pki-types = "1.11"
 script_layout_interface = { path = "components/shared/script_layout" }
 script_traits = { path = "components/shared/script" }
-selectors = { git = "https://github.com/servo/stylo", branch = "2025-03-11" }
+selectors = { git = "https://github.com/servo/stylo", branch = "2025-03-15" }
 serde = "1.0.219"
 serde_bytes = "0.11"
 serde_json = "1.0"
 servo-media = { git = "https://github.com/servo/media" }
 servo-media-dummy = { git = "https://github.com/servo/media" }
 servo-media-gstreamer = { git = "https://github.com/servo/media" }
-servo_arc = { git = "https://github.com/servo/stylo", branch = "2025-03-11", features = ["servo"] }
-stylo_atoms = { git = "https://github.com/servo/stylo", branch = "2025-03-11" }
+servo_arc = { git = "https://github.com/servo/stylo", branch = "2025-03-15", features = ["servo"] }
+stylo_atoms = { git = "https://github.com/servo/stylo", branch = "2025-03-15" }
 smallbitvec = "2.6.0"
 smallvec = "1.14"
 static_assertions = "1.1"
@@ -133,11 +133,11 @@ string_cache = "0.8"
 string_cache_codegen = "0.5"
 strum = "0.26"
 strum_macros = "0.26"
-style = { git = "https://github.com/servo/stylo", branch = "2025-03-11", features = ["servo"] }
-stylo_config = { git = "https://github.com/servo/stylo", branch = "2025-03-11" }
-stylo_dom = { git = "https://github.com/servo/stylo", branch = "2025-03-11" }
-style_malloc_size_of = { package = "malloc_size_of", git = "https://github.com/servo/stylo", branch = "2025-03-11", features = ["servo"] }
-style_traits = { git = "https://github.com/servo/stylo", branch = "2025-03-11", features = ["servo"] }
+style = { git = "https://github.com/servo/stylo", branch = "2025-03-15", features = ["servo"] }
+stylo_config = { git = "https://github.com/servo/stylo", branch = "2025-03-15" }
+stylo_dom = { git = "https://github.com/servo/stylo", branch = "2025-03-15" }
+style_malloc_size_of = { package = "malloc_size_of", git = "https://github.com/servo/stylo", branch = "2025-03-15", features = ["servo"] }
+style_traits = { git = "https://github.com/servo/stylo", branch = "2025-03-15", features = ["servo"] }
 surfman = { git = "https://github.com/servo/surfman", rev = "f7688b4585f9e0b5d4bf8ee8e4a91e82349610b1", features = ["chains"] }
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"


### PR DESCRIPTION
Upgrade Stylo to version 2025-03-15.
Currently uses a git version of `cssparser` as the new version of Stylo requires unreleased cssparser changes.

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
