### PR TITLE
script: Implement `Range::getClientRects` and `Range::getBoundingClientRect`

### DIFF
--- a/components/layout_2020/fragment_tree/fragment_tree.rs
+++ b/components/layout_2020/fragment_tree/fragment_tree.rs
@@ -155,6 +155,7 @@ impl FragmentTree {
                     }
                 },
                 Fragment::Positioning(fragment) => fragment.borrow().rect.cast_unit(),
+                Fragment::Text(text_fragment) => text_fragment.borrow().rect,
                 _ => return None,
             };
 

--- a/components/script/dom/abstractrange.rs
+++ b/components/script/dom/abstractrange.rs
@@ -94,10 +94,13 @@ impl AbstractRangeMethods<crate::DomTypeHolder> for AbstractRange {
     }
 }
 
+/// <https://dom.spec.whatwg.org/#concept-range-bp>
 #[derive(DenyPublicFields, JSTraceable, MallocSizeOf)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 pub(crate) struct BoundaryPoint {
+    /// <https://dom.spec.whatwg.org/#boundary-point-node>
     node: MutDom<Node>,
+    /// <https://dom.spec.whatwg.org/#concept-range-bp-offset>
     offset: Cell<u32>,
 }
 

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -469,7 +469,7 @@ DOMInterfaces = {
 },
 
 'Range': {
-    'canGc': ['CloneContents', 'CloneRange', 'CreateContextualFragment', 'ExtractContents', 'SurroundContents', 'InsertNode'],
+    'canGc': ['CloneContents', 'CloneRange', 'CreateContextualFragment', 'ExtractContents', 'SurroundContents', 'InsertNode', 'GetClientRects', 'GetBoundingClientRect'],
     'weakReferenceable': True,
 },
 

--- a/components/script_bindings/webidls/Range.webidl
+++ b/components/script_bindings/webidls/Range.webidl
@@ -73,7 +73,6 @@ partial interface Range {
 
 // http://dev.w3.org/csswg/cssom-view/#extensions-to-the-range-interface
 partial interface Range {
-  // sequence<DOMRect> getClientRects();
-  // [NewObject]
-  // DOMRect getBoundingClientRect();
+  DOMRectList getClientRects();
+  [NewObject] DOMRect getBoundingClientRect();
 };

--- a/tests/wpt/meta/css/cssom-view/DOMRectList.html.ini
+++ b/tests/wpt/meta/css/cssom-view/DOMRectList.html.ini
@@ -1,3 +1,0 @@
-[DOMRectList.html]
-  [Range getClientRects()]
-    expected: FAIL

--- a/tests/wpt/meta/css/cssom-view/getBoundingClientRect-svg.html.ini
+++ b/tests/wpt/meta/css/cssom-view/getBoundingClientRect-svg.html.ini
@@ -1,9 +1,0 @@
-[getBoundingClientRect-svg.html]
-  [Element.getBoundingClientRect() and Range.getBoudingClientRect() should match for an SVG <text>]
-    expected: FAIL
-
-  [Element.getBoundingClientRect() and Range.getBoudingClientRect() should match for an SVG <text> with a transform]
-    expected: FAIL
-
-  [Element.getBoundingClientRect() and Range.getBoudingClientRect() should match for an SVG <text> with a rotate]
-    expected: FAIL

--- a/tests/wpt/meta/css/cssom-view/idlharness.html.ini
+++ b/tests/wpt/meta/css/cssom-view/idlharness.html.ini
@@ -26,9 +26,6 @@
   [Element interface: document.createElement("div") must inherit property "getBoxQuads(BoxQuadOptions)" with the proper type]
     expected: FAIL
 
-  [Range interface: new Range() must inherit property "getBoundingClientRect()" with the proper type]
-    expected: FAIL
-
   [Element interface: calling convertRectFromNode(DOMRectReadOnly, GeometryNode, ConvertCoordinateOptions) on document.createElementNS("x", "y") with too few arguments must throw TypeError]
     expected: FAIL
 
@@ -62,9 +59,6 @@
   [CaretPosition interface: attribute offset]
     expected: FAIL
 
-  [Range interface: operation getBoundingClientRect()]
-    expected: FAIL
-
   [Partial dictionary MouseEventInit: member names are unique]
     expected: FAIL
 
@@ -96,9 +90,6 @@
     expected: FAIL
 
   [CaretPosition interface: existence and properties of interface prototype object]
-    expected: FAIL
-
-  [Range interface: operation getClientRects()]
     expected: FAIL
 
   [Element interface: document.createElementNS("x", "y") must inherit property "convertRectFromNode(DOMRectReadOnly, GeometryNode, ConvertCoordinateOptions)" with the proper type]
@@ -270,9 +261,6 @@
     expected: FAIL
 
   [Element interface: document.createElement("img") must inherit property "convertPointFromNode(DOMPointInit, GeometryNode, ConvertCoordinateOptions)" with the proper type]
-    expected: FAIL
-
-  [Range interface: new Range() must inherit property "getClientRects()" with the proper type]
     expected: FAIL
 
   [Window interface: window must inherit property "screenLeft" with the proper type]


### PR DESCRIPTION
This allows the scripts on https://www.shadertoy.com/view/MdyGRW to run long enough for the shader to load and run.

The implementation is not complete, as we can't query the client rects of ranges within a text node yet, but it's a start.

---

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes 

