### PR TITLE
canvas: Update the image as part of update the rendering

### DIFF
--- a/components/canvas/canvas_paint_thread.rs
+++ b/components/canvas/canvas_paint_thread.rs
@@ -79,12 +79,6 @@ impl<'a> CanvasPaintThread<'a> {
                                         canvas_paint_thread.canvas(canvas_id).send_pixels(chan);
                                     },
                                 },
-                                Ok(CanvasMsg::FromLayout(message, canvas_id)) => match message {
-                                    FromLayoutMsg::UpdateImage(sender) => {
-                                        canvas_paint_thread.canvas(canvas_id).update_image_rendering();
-                                        sender.send(()).unwrap();
-                                    },
-                                },
                                 Err(e) => {
                                     warn!("Error on CanvasPaintThread receive ({})", e);
                                 },
@@ -255,6 +249,10 @@ impl<'a> CanvasPaintThread<'a> {
             },
             Canvas2dMsg::SetTextBaseline(text_baseline) => {
                 self.canvas(canvas_id).set_text_baseline(text_baseline)
+            },
+            Canvas2dMsg::UpdateImage(sender) => {
+                self.canvas(canvas_id).update_image_rendering();
+                sender.send(()).unwrap();
             },
         }
     }

--- a/components/layout_2020/dom.rs
+++ b/components/layout_2020/dom.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::marker::PhantomData;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use atomic_refcell::{AtomicRef, AtomicRefCell, AtomicRefMut};
 use base::id::{BrowsingContextId, PipelineId};
@@ -155,9 +155,7 @@ where
         let canvas_data = node.canvas_data()?;
         let source = match canvas_data.source {
             HTMLCanvasDataSource::WebGL(texture_id) => CanvasSource::WebGL(texture_id),
-            HTMLCanvasDataSource::Image((image_key, canvas_id, ipc_sender)) => {
-                CanvasSource::Image((image_key, canvas_id, Arc::new(Mutex::new(ipc_sender))))
-            },
+            HTMLCanvasDataSource::Image(image_key) => CanvasSource::Image(image_key),
             HTMLCanvasDataSource::WebGPU(image_key) => CanvasSource::WebGPU(image_key),
             HTMLCanvasDataSource::Empty => CanvasSource::Empty,
         };

--- a/components/script/canvas_state.rs
+++ b/components/script/canvas_state.rs
@@ -221,6 +221,18 @@ impl CanvasState {
             .unwrap()
     }
 
+    /// Updates WR image and blocks on completion
+    pub(crate) fn update_rendering(&self) {
+        let (sender, receiver) = ipc::channel().unwrap();
+        self.ipc_renderer
+            .send(CanvasMsg::Canvas2d(
+                Canvas2dMsg::UpdateImage(sender),
+                self.canvas_id,
+            ))
+            .unwrap();
+        receiver.recv().unwrap();
+    }
+
     // https://html.spec.whatwg.org/multipage/#concept-canvas-set-bitmap-dimensions
     pub(crate) fn set_bitmap_dimensions(&self, size: Size2D<u64>) {
         self.reset_to_initial_state();

--- a/components/script/canvas_state.rs
+++ b/components/script/canvas_state.rs
@@ -54,7 +54,7 @@ use crate::dom::element::{Element, cors_setting_for_element};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::htmlcanvaselement::{CanvasContext, HTMLCanvasElement};
 use crate::dom::imagedata::ImageData;
-use crate::dom::node::{Node, NodeDamage, NodeTraits};
+use crate::dom::node::{Node, NodeTraits};
 use crate::dom::offscreencanvas::{OffscreenCanvas, OffscreenCanvasContext};
 use crate::dom::paintworkletglobalscope::PaintWorkletGlobalScope;
 use crate::dom::textmetrics::TextMetrics;
@@ -620,7 +620,7 @@ impl CanvasState {
 
     pub(crate) fn mark_as_dirty(&self, canvas: Option<&HTMLCanvasElement>) {
         if let Some(canvas) = canvas {
-            canvas.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
+            canvas.mark_as_dirty();
         }
     }
 

--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -7,6 +7,7 @@ use dom_struct::dom_struct;
 use euclid::default::{Point2D, Rect, Size2D};
 use ipc_channel::ipc::IpcSharedMemory;
 use profile_traits::ipc;
+use script_bindings::inheritance::Castable;
 use script_layout_interface::HTMLCanvasDataSource;
 use servo_url::ServoUrl;
 
@@ -30,6 +31,7 @@ use crate::dom::dommatrix::DOMMatrix;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::htmlcanvaselement::HTMLCanvasElement;
 use crate::dom::imagedata::ImageData;
+use crate::dom::node::{Node, NodeDamage, NodeTraits};
 use crate::dom::textmetrics::TextMetrics;
 use crate::script_runtime::CanGc;
 
@@ -156,7 +158,10 @@ impl CanvasContext for CanvasRenderingContext2D {
     }
 
     fn mark_as_dirty(&self) {
-        self.canvas_state.mark_as_dirty(self.canvas.canvas())
+        if let Some(canvas) = self.canvas.canvas() {
+            canvas.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
+            canvas.owner_document().add_dirty_2d_canvas(self);
+        }
     }
 }
 

--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -116,11 +116,7 @@ impl CanvasRenderingContext2D {
 impl LayoutCanvasRenderingContextHelpers for LayoutDom<'_, CanvasRenderingContext2D> {
     fn canvas_data_source(self) -> HTMLCanvasDataSource {
         let canvas_state = &self.unsafe_get().canvas_state;
-        HTMLCanvasDataSource::Image((
-            canvas_state.image_key(),
-            canvas_state.get_canvas_id(),
-            canvas_state.get_ipc_renderer().clone(),
-        ))
+        HTMLCanvasDataSource::Image(canvas_state.image_key())
     }
 }
 
@@ -133,6 +129,10 @@ impl CanvasContext for CanvasRenderingContext2D {
 
     fn canvas(&self) -> HTMLCanvasElementOrOffscreenCanvas {
         self.canvas.clone()
+    }
+
+    fn update_rendering(&self) {
+        self.canvas_state.update_rendering();
     }
 
     fn resize(&self) {

--- a/components/script/dom/htmlcanvaselement.rs
+++ b/components/script/dom/htmlcanvaselement.rs
@@ -189,7 +189,7 @@ impl HTMLCanvasElement {
                 #[cfg(feature = "webgpu")]
                 CanvasContext::WebGPU(ref context) => context.mark_as_dirty(),
                 CanvasContext::Placeholder(ref _context) => {
-                    // TODO: should this be marked as dirty
+                    // TODO: Should this be marked as dirty?
                 },
             }
         }

--- a/components/script/dom/htmlcanvaselement.rs
+++ b/components/script/dom/htmlcanvaselement.rs
@@ -180,6 +180,21 @@ impl HTMLCanvasElement {
         }
     }
 
+    pub(crate) fn mark_as_dirty(&self) {
+        if let Some(ref context) = *self.context.borrow() {
+            match *context {
+                CanvasContext::Context2d(ref context) => context.mark_as_dirty(),
+                CanvasContext::WebGL(ref context) => context.mark_as_dirty(),
+                CanvasContext::WebGL2(ref context) => context.mark_as_dirty(),
+                #[cfg(feature = "webgpu")]
+                CanvasContext::WebGPU(ref context) => context.mark_as_dirty(),
+                CanvasContext::Placeholder(ref _context) => {
+                    // TODO: should this be marked as dirty
+                },
+            }
+        }
+    }
+
     pub(crate) fn set_natural_width(&self, value: u32, can_gc: CanGc) {
         let value = if value > UNSIGNED_LONG_MAX {
             DEFAULT_WIDTH

--- a/components/script/dom/paintrenderingcontext2d.rs
+++ b/components/script/dom/paintrenderingcontext2d.rs
@@ -4,10 +4,8 @@
 
 use std::cell::Cell;
 
-use canvas_traits::canvas::{CanvasId, CanvasMsg, FromLayoutMsg};
 use dom_struct::dom_struct;
 use euclid::{Scale, Size2D};
-use ipc_channel::ipc;
 use script_bindings::reflector::Reflector;
 use servo_url::ServoUrl;
 use style_traits::CSSPixel;
@@ -61,16 +59,9 @@ impl PaintRenderingContext2D {
         )
     }
 
-    pub(crate) fn get_canvas_id(&self) -> CanvasId {
-        self.canvas_state.get_canvas_id()
-    }
-
     /// Send update to canvas paint thread and returns [`ImageKey`]
     pub(crate) fn image_key(&self) -> ImageKey {
-        let (sender, receiver) = ipc::channel().unwrap();
-        let msg = CanvasMsg::FromLayout(FromLayoutMsg::UpdateImage(sender), self.get_canvas_id());
-        let _ = self.canvas_state.get_ipc_renderer().send(msg);
-        receiver.recv().unwrap();
+        self.canvas_state.update_rendering();
         self.canvas_state.image_key()
     }
 

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1941,6 +1941,7 @@ impl Window {
         let for_display = reflow_goal.needs_display();
         if for_display {
             document.flush_dirty_webgl_canvases();
+            document.flush_dirty_2d_canvases();
         }
 
         let pending_restyles = document.drain_pending_restyles();

--- a/components/shared/canvas/canvas.rs
+++ b/components/shared/canvas/canvas.rs
@@ -25,7 +25,6 @@ pub struct CanvasId(pub u64);
 #[derive(Debug, Deserialize, Serialize)]
 pub enum CanvasMsg {
     Canvas2d(Canvas2dMsg, CanvasId),
-    FromLayout(FromLayoutMsg, CanvasId),
     FromScript(FromScriptMsg, CanvasId),
     Recreate(Option<Size2D<u64>>, CanvasId),
     Close(CanvasId),
@@ -74,10 +73,6 @@ pub enum Canvas2dMsg {
     SetFont(FontStyleStruct),
     SetTextAlign(TextAlign),
     SetTextBaseline(TextBaseline),
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub enum FromLayoutMsg {
     UpdateImage(IpcSender<()>),
 }
 

--- a/components/shared/script_layout/lib.rs
+++ b/components/shared/script_layout/lib.rs
@@ -20,7 +20,6 @@ use atomic_refcell::AtomicRefCell;
 use base::Epoch;
 use base::id::{BrowsingContextId, PipelineId, WebViewId};
 use canvas_traits::canvas::{CanvasId, CanvasMsg};
-use constellation_traits::{ScrollState, UntrustedNodeAddress, WindowSizeData};
 use euclid::Size2D;
 use euclid::default::{Point2D, Rect};
 use fnv::FnvHashMap;
@@ -116,7 +115,7 @@ pub enum LayoutElementType {
 
 pub enum HTMLCanvasDataSource {
     WebGL(ImageKey),
-    Image((ImageKey, CanvasId, IpcSender<CanvasMsg>)),
+    Image(ImageKey),
     WebGPU(ImageKey),
     /// transparent black
     Empty,

--- a/components/shared/script_layout/lib.rs
+++ b/components/shared/script_layout/lib.rs
@@ -19,7 +19,7 @@ use app_units::Au;
 use atomic_refcell::AtomicRefCell;
 use base::Epoch;
 use base::id::{BrowsingContextId, PipelineId, WebViewId};
-use canvas_traits::canvas::{CanvasId, CanvasMsg};
+use constellation_traits::{ScrollState, UntrustedNodeAddress, WindowSizeData};
 use euclid::Size2D;
 use euclid::default::{Point2D, Rect};
 use fnv::FnvHashMap;


### PR DESCRIPTION
This moves update the image from layout to update the rendering which is more conceptually correct. Partial fix of https://github.com/servo/servo/issues/35733. Simplifies layouting of 2d canvas. 


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes in WPT

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
