### PR TITLE
layout: Obey sizing keywords in `layout_for_block_content_size()`

### DIFF
--- a/tests/wpt/tests/css/css-flexbox/flex-item-max-width-min-content-002.html
+++ b/tests/wpt/tests/css/css-flexbox/flex-item-max-width-min-content-002.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<title>CSS Test: flex item with `max-width: min-content`</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#flex-base-size">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-3/#min-content">
+
+<link rel="match" href="../reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="`max-width: min-content` limits the flex item to 100px wide,
+  so the floats need to stack vertically and thus the flex base size is 100px.">
+
+<p>Test passes if there is a filled green square.</p>
+<div style="display: flex; flex-direction: column; width: 200px; height: 100px">
+  <div style="max-width: min-content; background: green">
+    <div style="float: left; width: 100px; height: 50px"></div>
+    <div style="float: left; width: 100px; height: 50px"></div>
+  </div>
+</div>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
We were ignoring sizing keywords on the min and max sizing properties.
With this, flexbox layout has full support for sizing keywords.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -r` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #32853
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
