### PR TITLE
chore: Move unsafe operations in unsafe functions to unsafe blocks

### DIFF
--- a/components/allocator/Cargo.toml
+++ b/components/allocator/Cargo.toml
@@ -23,6 +23,3 @@ windows-sys = { workspace = true, features = ["Win32_System_Memory"] }
 
 [target.'cfg(target_env = "ohos")'.dependencies]
 libc = { workspace = true }
-
-[lints.rust]
-unsafe_op_in_unsafe_fn = { level = "allow" }

--- a/components/background_hang_monitor/Cargo.toml
+++ b/components/background_hang_monitor/Cargo.toml
@@ -32,6 +32,3 @@ mach2 = { version = "0.4", optional = true }
 [target.'cfg(all(target_os = "linux", not(any(target_arch = "arm", target_arch = "aarch64", target_env = "ohos", target_env = "musl"))))'.dependencies]
 nix = { workspace = true, features = ["signal"], optional = true }
 unwind-sys = { version = "0.1.4", optional = true }
-
-[lints.rust]
-unsafe_op_in_unsafe_fn = { level = "allow" }

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -131,6 +131,3 @@ sig = "1.0"
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { workspace = true, features = ["Win32_Graphics_Gdi"] }
 libservo = { path = "../../components/servo", features = ["no-wgl"] }
-
-[lints.rust]
-unsafe_op_in_unsafe_fn = { level = "allow" }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This PR addresses parts of low-hanging tasks of #35955 by removing `unsafe_op_in_unsafe_fn = { level = "allow" }` lint and cleaning up the unsafe codes in the following three crates:

- `allocator`
- `background_hang_monitor`
- `servoshell`

I have checked all platform builds and confirmed that there is no unsafe operation warning:

https://github.com/dklassic/servo/actions/runs/13908206395

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fixes part of #35955 (GitHub issue number if applicable)

<!-- Either: -->
- [x] These changes do not require tests because the is just a code cleanup

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
