### PR TITLE
Add --enable-experimental-web-platform-features command line

### DIFF
--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -347,6 +347,11 @@ pub(crate) fn parse_command_line_arguments(args: Vec<String>) -> ArgumentParsing
         "FILTER",
     );
 
+    opts.optflag(
+        "",
+        "enable-experimental-web-platform-features",
+        "Whether or not to enable experimental web platform features.",
+    );
     opts.optmulti(
         "",
         "pref",
@@ -539,6 +544,30 @@ pub(crate) fn parse_command_line_arguments(args: Vec<String>) -> ArgumentParsing
             (contents, url)
         })
         .collect();
+
+    if opt_match.opt_present("enable-experimental-web-platform-features") {
+        vec![
+            "dom_fontface_enabled",
+            "dom_imagebitmap_enabled",
+            "dom_intersection_observer_enabled",
+            "dom_mouse_event_which_enabled",
+            "dom_notification_enabled",
+            "dom_offscreen_canvas_enabled",
+            "dom_permissions_enabled",
+            "dom_resize_observer_enabled",
+            "dom_serviceworker_enabled",
+            "dom_svg_enabled",
+            "dom_webgl2_enabled",
+            "dom_webgpu_enabled",
+            "dom_xpath_enabled",
+            "layout_columns_enabled",
+            "layout_container_queries_enabled",
+            "layout_grid_enabled",
+            "layout_writing_mode_enabled",
+        ]
+        .iter()
+        .for_each(|pref| preferences.set_value(pref, PrefValue::Bool(true)));
+    }
 
     // Handle all command-line preferences overrides.
     for pref in opt_match.opt_strs("pref") {


### PR DESCRIPTION

<!-- Please describe your changes on the following line: -->

This command line argument will enable a set of web platform features that are under development but not ready to be enabled by default.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #35576 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because I'm not aware of tests for runtime features, but let me know if there are any and I'd look into adding one for this.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
