### PR TITLE
Devtools parser: normalise actor names to allow for diffing

### DIFF
--- a/components/devtools/actor.rs
+++ b/components/devtools/actor.rs
@@ -139,7 +139,7 @@ impl ActorRegistry {
     pub fn new_name(&self, prefix: &str) -> String {
         let suffix = self.next.get();
         self.next.set(suffix + 1);
-        format!("{}{}", prefix, suffix)
+        format!("server1.conn0.{}{}", prefix, suffix)
     }
 
     /// Add an actor to the registry of known actors that can receive messages.

--- a/etc/devtools_parser.py
+++ b/etc/devtools_parser.py
@@ -176,6 +176,10 @@ def process_data(input, port):
     # `["Mar 18, 2025 21:09:51.879661797 AWST", "Servo", 0, "{...}"]`
     return result
 
+paths = []
+actor_request_type_queues = {}
+actor_name_map = {}
+new_actor_name_counts = {}
 
 # Pretty prints the json message
 def parse_message(msg, *, json_output=False):
@@ -189,11 +193,32 @@ def parse_message(msg, *, json_output=False):
     try:
         content = json.loads(data)
         if json_output:
+            # print(content, file=sys.stderr)
             if "to" in content:
                 # This is a request
+                content["to"] = actor_name_map[content["to"]]
                 print(json.dumps({"_to": content["to"], "message": content}, sort_keys=True))
+                actor_request_type_queues.setdefault(content["to"], []).append(content["type"])
             elif "from" in content:
                 # This is a response
+                is_first_message = (i == 0)
+                if is_first_message:
+                    # This is the first message, the initial message from the root actor
+                    assert actor_request_type_queues == {}
+                    actor_name_map[content["from"]] = "root"
+                    content["from"] = actor_name_map[content["from"]]
+                    request_type = None
+                elif "type" in content:
+                    # This is a spontaneous message from the server
+                    content["from"] = actor_name_map[content["from"]]
+                    request_type = content["type"]
+                else:
+                    # This is a response from the server
+                    content["from"] = actor_name_map[content["from"]]
+                    request_type = actor_request_type_queues[content["from"]].pop(0)
+                actor_names = find_actor_names(content, actor=content["from"], request_type=request_type)
+                for actor, request_type, path in actor_names:
+                    new_actor_name = f"{actor}:{request_type}:{path}"
                 print(json.dumps({"_from": content["from"], "message": content}, sort_keys=True))
             else:
                 assert False, "Message is neither a request nor a response"
@@ -206,6 +231,33 @@ def parse_message(msg, *, json_output=False):
 
     if not json_output:
         print()
+
+
+def find_actor_names(value, *, actor, request_type, path=None):
+    result = []
+    if isinstance(value, dict):
+        items = value.items()
+    elif isinstance(value, list):
+        items = enumerate(value)
+    else:
+        assert False
+    for item_key, item_value in items:
+        if isinstance(item_key, int):
+            current_path=(path or []) + ["[]"]
+        else:
+            assert isinstance(item_key, str)
+            current_path=(path or []) + [item_key]
+        if isinstance(item_value, str) and item_value.startswith("server1.conn"):
+            if item_value not in actor_name_map:
+                result.append((actor, request_type, ".".join(current_path)))
+                new_actor_name_prefix = f"{actor}:{request_type}:{".".join(current_path)}"
+                actor_name_map[item_value] = f"{new_actor_name_prefix}#{new_actor_name_counts.setdefault(new_actor_name_prefix, 0)}"
+                print(f"{item_value} -> {actor_name_map[item_value]}", file=sys.stderr)
+                new_actor_name_counts[new_actor_name_prefix] += 1
+            value[item_key] = actor_name_map[item_value]
+        elif isinstance(item_value, (dict, list)):
+            result += find_actor_names(item_value, actor=actor, request_type=request_type, path=current_path)
+    return result
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
```diff
--- firefox.json	2025-03-18 22:26:23.540864829 +0800
+++ servo.json	2025-03-18 22:38:32.755526958 +0800
@@ -1,119 +1,57 @@
-{"_from": "root", "message": {"applicationType": "browser", "from": "root", "testConnectionPrefix": "root:None:testConnectionPrefix#0", "traits": {"networkMonitor": true, "resources": {"extensions-backgroundscript-status": true}, "workerConsoleApiMessagesDispatchedToMainThread": true}}}
+{"_from": "root", "message": {"applicationType": "browser", "from": "root", "traits": {"customHighlighters": true, "highlightable": true, "networkMonitor": false, "sources": false}}}
 {"_to": "root", "message": {"frontendVersion": "135.0.1", "to": "root", "type": "connect"}}
 {"_from": "root", "message": {"from": "root"}}
 {"_to": "root", "message": {"to": "root", "type": "getRoot"}}
-{"_from": "root", "message": {"addonsActor": "root:getRoot:addonsActor#0", "deviceActor": "root:getRoot:deviceActor#0", "from": "root", "heapSnapshotFileActor": "root:getRoot:heapSnapshotFileActor#0", "parentAccessibilityActor": "root:getRoot:parentAccessibilityActor#0", "perfActor": "root:getRoot:perfActor#0", "preferenceActor": "root:getRoot:preferenceActor#0", "screenshotActor": "root:getRoot:screenshotActor#0"}}
+{"_from": "root", "message": {"deviceActor": "root:getRoot:deviceActor#0", "from": "root", "performanceActor": "root:getRoot:performanceActor#0", "preferenceActor": "root:getRoot:preferenceActor#0", "selected": 0}}
 {"_to": "root:getRoot:deviceActor#0", "message": {"to": "root:getRoot:deviceActor#0", "type": "getDescription"}}
-{"_from": "root:getRoot:deviceActor#0", "message": {"from": "root:getRoot:deviceActor#0", "value": {"appbuildid": "20250216192613", "appid": "{ec8030f7-c20a-464f-9b0e-13a3a9e97384}", "apptype": "firefox", "arch": "x86_64", "brandName": "Mozilla Firefox", "canDebugServiceWorkers": true, "channel": "default", "compiler": "gcc3", "deviceName": null, "dpi": 108.85713958740234, "endianness": "LE", "geckobuildid": "20250216192613", "geckoversion": "135.0.1", "hardware": "unknown", "height": 1440, "hostname": "jupiter", "locale": "en-US", "name": "Firefox", "os": "Linux", "physicalHeight": 1440, "physicalWidth": 2560, "platform": "Linux", "platformbuildid": "20250216192613", "platformversion": "135.0.1", "processor": "x86_64", "profile": "tmp.cG2QziEmCF", "useragent": "Mozilla/5.0 (X11; Linux x86_64; rv:135.0) Gecko/20100101 Firefox/135.0", "vendor": "Mozilla", "version": "135.0.1", "width": 2560}}}
+{"_from": "root:getRoot:deviceActor#0", "message": {"from": "root:getRoot:deviceActor#0", "value": {"appbuildid": "20250318223533", "apptype": "servo", "brandName": "Servo", "platformversion": "133.0", "version": "0.0.1"}}}
 {"_to": "root:getRoot:deviceActor#0", "message": {"to": "root:getRoot:deviceActor#0", "type": "getDescription"}}
-{"_from": "root:getRoot:deviceActor#0", "message": {"from": "root:getRoot:deviceActor#0", "value": {"appbuildid": "20250216192613", "appid": "{ec8030f7-c20a-464f-9b0e-13a3a9e97384}", "apptype": "firefox", "arch": "x86_64", "brandName": "Mozilla Firefox", "canDebugServiceWorkers": true, "channel": "default", "compiler": "gcc3", "deviceName": null, "dpi": 108.85713958740234, "endianness": "LE", "geckobuildid": "20250216192613", "geckoversion": "135.0.1", "hardware": "unknown", "height": 1440, "hostname": "jupiter", "locale": "en-US", "name": "Firefox", "os": "Linux", "physicalHeight": 1440, "physicalWidth": 2560, "platform": "Linux", "platformbuildid": "20250216192613", "platformversion": "135.0.1", "processor": "x86_64", "profile": "tmp.cG2QziEmCF", "useragent": "Mozilla/5.0 (X11; Linux x86_64; rv:135.0) Gecko/20100101 Firefox/135.0", "vendor": "Mozilla", "version": "135.0.1", "width": 2560}}}
+{"_from": "root:getRoot:deviceActor#0", "message": {"from": "root:getRoot:deviceActor#0", "value": {"appbuildid": "20250318223533", "apptype": "servo", "brandName": "Servo", "platformversion": "133.0", "version": "0.0.1"}}}
 {"_to": "root:getRoot:preferenceActor#0", "message": {"to": "root:getRoot:preferenceActor#0", "type": "getBoolPref", "value": "devtools.debugger.prompt-connection"}}
 {"_from": "root:getRoot:preferenceActor#0", "message": {"from": "root:getRoot:preferenceActor#0", "value": false}}
 {"_to": "root:getRoot:preferenceActor#0", "message": {"to": "root:getRoot:preferenceActor#0", "type": "getBoolPref", "value": "browser.privatebrowsing.autostart"}}
 {"_from": "root:getRoot:preferenceActor#0", "message": {"from": "root:getRoot:preferenceActor#0", "value": false}}
 {"_to": "root:getRoot:preferenceActor#0", "message": {"to": "root:getRoot:preferenceActor#0", "type": "getBoolPref", "value": "dom.serviceWorkers.enabled"}}
-{"_from": "root:getRoot:preferenceActor#0", "message": {"from": "root:getRoot:preferenceActor#0", "value": true}}
-{"_to": "root", "message": {"resourceTypes": ["extensions-backgroundscript-status"], "to": "root", "type": "watchResources"}}
-{"_from": "root", "message": {"from": "root"}}
+{"_from": "root:getRoot:preferenceActor#0", "message": {"from": "root:getRoot:preferenceActor#0", "value": false}}
 {"_to": "root", "message": {"iconDataURL": true, "to": "root", "type": "listAddons"}}
 {"_to": "root", "message": {"to": "root", "type": "listTabs"}}
```


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
