### PR TITLE
resources: Remove baked in resources

### DIFF
--- a/components/shared/embedder/Cargo.toml
+++ b/components/shared/embedder/Cargo.toml
@@ -11,6 +11,11 @@ rust-version.workspace = true
 name = "embedder_traits"
 path = "lib.rs"
 
+[features]
+# bakes default resources into the library.
+# This feature is mainly intended for testing purposes.
+baked-default-resources = []
+
 [dependencies]
 base = { workspace = true }
 cfg-if = { workspace = true }

--- a/components/shared/embedder/resources.rs
+++ b/components/shared/embedder/resources.rs
@@ -3,30 +3,42 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::path::PathBuf;
-use std::sync::{LazyLock, RwLock};
+use std::sync::RwLock;
 
-use cfg_if::cfg_if;
+static RES: RwLock<Option<Box<dyn ResourceReaderMethods + Sync + Send>>> = RwLock::new(None);
 
-static RES: LazyLock<RwLock<Option<Box<dyn ResourceReaderMethods + Sync + Send>>>> =
-    LazyLock::new(|| {
-        cfg_if! {
-            if #[cfg(any(servo_production, target_env = "ohos"))] {
-                RwLock::new(None)
-            } else {
-                // Static assert that this is really a non-production build, rather
-                // than a failure of the build script’s production check.
-                const _: () = assert!(cfg!(servo_do_not_use_in_production));
+#[cfg(feature = "baked-default-resources")]
+static INIT_TEST_RESOURCES: std::sync::Once = std::sync::Once::new();
 
-                RwLock::new(Some(resources_for_tests()))
-            }
-        }
-    });
+#[cfg(all(feature = "baked-default-resources", servo_production))]
+const _: () = assert!(
+    false,
+    "baked-default-resources should not be used in production"
+);
 
+/// The Embedder should initialize the ResourceReader early.
 pub fn set(reader: Box<dyn ResourceReaderMethods + Sync + Send>) {
     *RES.write().unwrap() = Some(reader);
 }
 
+#[cfg(not(feature = "baked-default-resources"))]
 pub fn read_bytes(res: Resource) -> Vec<u8> {
+    if let Some(reader) = RES.read().unwrap().as_ref() {
+        reader.read(res)
+    } else {
+        log::error!("Resource reader not set.");
+        vec![]
+    }
+}
+
+#[cfg(feature = "baked-default-resources")]
+pub fn read_bytes(res: Resource) -> Vec<u8> {
+    INIT_TEST_RESOURCES.call_once(|| {
+        let mut reader = RES.write().unwrap();
+        if reader.is_none() {
+            *reader = Some(resources_for_tests())
+        }
+    });
     RES.read()
         .unwrap()
         .as_ref()
@@ -42,16 +54,16 @@ pub fn sandbox_access_files() -> Vec<PathBuf> {
     RES.read()
         .unwrap()
         .as_ref()
-        .expect("Resource reader not set.")
-        .sandbox_access_files()
+        .map(|reader| reader.sandbox_access_files())
+        .unwrap_or_default()
 }
 
 pub fn sandbox_access_files_dirs() -> Vec<PathBuf> {
     RES.read()
         .unwrap()
         .as_ref()
-        .expect("Resource reader not set.")
-        .sandbox_access_files_dirs()
+        .map(|reader| reader.sandbox_access_files_dirs())
+        .unwrap_or_default()
 }
 
 pub enum Resource {
@@ -93,10 +105,10 @@ pub enum Resource {
     QuirksModeCSS,
     /// A placeholder image to display if we couldn't get the requested image.
     ///
-    /// ## Safety
+    /// ## Panic
     ///
-    /// Servo will crash if this is an invalid image. Check `resources/rippy.png` in Servo codebase to see what
-    /// a default rippy png should look like.
+    /// If the resource is not provided, servo will fallback to a baked in default (See resources/rippy.png).
+    /// However, if the image is provided but invalid, Servo will crash.
     RippyPNG,
     /// A CSS file to style the media controls.
     /// It can be empty but then media controls will not be styled.
@@ -145,12 +157,10 @@ pub trait ResourceReaderMethods {
     fn sandbox_access_files_dirs(&self) -> Vec<PathBuf>;
 }
 
-/// Bake all of our resources into this crate for tests, unless we are `cfg!(servo_production)`.
+/// Provides baked in resources for tests.
 ///
-/// Local non-production embedder builds (e.g. servoshell) can still override these with [`set`].
-/// On OpenHarmony we never want to include files, since we ship all the files in the application
-/// bundle anyway.
-#[cfg(not(any(servo_production, target_env = "ohos")))]
+/// Embedder builds (e.g. servoshell) should use [`set`] and ship the resources themselves.
+#[cfg(feature = "baked-default-resources")]
 fn resources_for_tests() -> Box<dyn ResourceReaderMethods + Sync + Send> {
     struct ResourceReader;
     impl ResourceReaderMethods for ResourceReader {

--- a/components/shared/net/Cargo.toml
+++ b/components/shared/net/Cargo.toml
@@ -39,3 +39,6 @@ servo_rand = { path = "../../rand" }
 servo_url = { path = "../../url" }
 url = { workspace = true }
 uuid = { workspace = true }
+
+[dev-dependencies]
+embedder_traits = { workspace = true, features = ["baked-default-resources"] }


### PR DESCRIPTION
This allows removing a LazyLock around the resources.
We override the baked in resources unconditionally in servoshell
upon initialization anyway ([desktop](https://github.com/servo/servo/blob/9f93ccd9427265f39f1a2de38389fec0e80f7bea/ports/servoshell/desktop/cli.rs#L15), [android](https://github.com/servo/servo/blob/9f93ccd9427265f39f1a2de38389fec0e80f7bea/ports/servoshell/egl/android/simpleservo.rs#L49), [ohos](https://github.com/servo/servo/blob/9f93ccd9427265f39f1a2de38389fec0e80f7bea/ports/servoshell/egl/ohos/simpleservo.rs#L43) ), meaning that the baked in resources
are unused in servoshell.

For 3rd-party embedders, we probably also want to the let them know
early that they should initialize the resources, instead of
restricting the panics to production mode.

Rippy is the only resource which was required. Since it is only
253 bytes large, we just bake that resource in as a fallback.

We do want to make using the resources easy from tests, so we add
some logic to keep the baked in resources for tests only and initialize
the resource reader on first access.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

