### PR TITLE
layout: Don't consider a definite `stretch` size as intrinsic

### DIFF
--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -2144,11 +2144,13 @@ impl<'container> PlacementState<'container> {
 
 fn block_size_is_zero_or_intrinsic(size: &StyleSize, containing_block: &ContainingBlock) -> bool {
     match size {
-        StyleSize::Auto |
-        StyleSize::MinContent |
-        StyleSize::MaxContent |
-        StyleSize::FitContent |
-        StyleSize::Stretch => true,
+        StyleSize::Auto | StyleSize::MinContent | StyleSize::MaxContent | StyleSize::FitContent => {
+            true
+        },
+        StyleSize::Stretch => {
+            // TODO: Should this return true when the containing block has a definite size of 0px?
+            !containing_block.size.block.is_definite()
+        },
         StyleSize::LengthPercentage(lp) => {
             // TODO: Should this resolve definite percentages? Blink does it, Gecko and WebKit don't.
             lp.is_definitely_zero() ||

--- a/tests/wpt/meta/css/css-sizing/stretch/block-height-009.html.ini
+++ b/tests/wpt/meta/css/css-sizing/stretch/block-height-009.html.ini
@@ -1,2 +1,0 @@
-[block-height-009.html]
-  expected: FAIL


### PR DESCRIPTION
`block_size_is_zero_or_intrinsic()` was always returning true for `stretch`. This function is used for the margin collapse heuristics in block layout, so we were considering that an empty element with `height: stretch` would self-collapse.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -e` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #32853
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
