### PR TITLE
Cleanup Stylo dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,7 @@ serde_json = "1.0"
 servo-media = { git = "https://github.com/servo/media" }
 servo-media-dummy = { git = "https://github.com/servo/media" }
 servo-media-gstreamer = { git = "https://github.com/servo/media" }
-servo_arc = { git = "https://github.com/servo/stylo", branch = "2025-03-15", features = ["servo"] }
+servo_arc = { git = "https://github.com/servo/stylo", branch = "2025-03-15" }
 stylo_atoms = { git = "https://github.com/servo/stylo", branch = "2025-03-15" }
 smallbitvec = "2.6.0"
 smallvec = "1.14"
@@ -133,11 +133,11 @@ string_cache = "0.8"
 string_cache_codegen = "0.5"
 strum = "0.26"
 strum_macros = "0.26"
-style = { git = "https://github.com/servo/stylo", branch = "2025-03-15", features = ["servo"], package = "stylo" }
+stylo = { git = "https://github.com/servo/stylo", branch = "2025-03-15" }
 stylo_config = { git = "https://github.com/servo/stylo", branch = "2025-03-15" }
 stylo_dom = { git = "https://github.com/servo/stylo", branch = "2025-03-15" }
-style_malloc_size_of = { package = "stylo_malloc_size_of", git = "https://github.com/servo/stylo", branch = "2025-03-15", features = ["servo"] }
-style_traits = { git = "https://github.com/servo/stylo", branch = "2025-03-15", features = ["servo"], package = "stylo_traits" }
+stylo_malloc_size_of = { git = "https://github.com/servo/stylo", branch = "2025-03-15" }
+stylo_traits = { git = "https://github.com/servo/stylo", branch = "2025-03-15" }
 surfman = { git = "https://github.com/servo/surfman", rev = "f7688b4585f9e0b5d4bf8ee8e4a91e82349610b1", features = ["chains"] }
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"
@@ -217,11 +217,11 @@ codegen-units = 1
 # selectors = { path = "../stylo/selectors" }
 # servo_arc = { path = "../stylo/servo_arc" }
 # stylo_atoms = { path = "../stylo/stylo_atoms" }
-# style = { path = "../stylo/style", package = "stylo" }
+# stylo = { path = "../stylo/style" }
 # stylo_config = { path = "../stylo/stylo_config" }
 # stylo_dom = { path = "../stylo/stylo_dom" }
-# style_malloc_size_of = { path = "../stylo/malloc_size_of", package = "stylo_malloc_size_of" }
-# style_traits = { path = "../stylo/style_traits", package = "stylo_traits" }
+# stylo_malloc_size_of = { path = "../stylo/malloc_size_of" }
+# stylo_traits = { path = "../stylo/style_traits" }
 #
 # Or for WebRender:
 #

--- a/components/canvas/Cargo.toml
+++ b/components/canvas/Cargo.toml
@@ -37,7 +37,7 @@ pixels = { path = "../pixels" }
 range = { path = "../range" }
 raqote = "0.8.5"
 servo_arc = { workspace = true }
-style = { workspace = true }
+stylo = { workspace = true }
 surfman = { workspace = true }
 unicode-script = { workspace = true }
 webrender = { workspace = true }

--- a/components/compositing/Cargo.toml
+++ b/components/compositing/Cargo.toml
@@ -36,7 +36,7 @@ profile_traits = { workspace = true }
 script_traits = { workspace = true }
 servo_config = { path = "../config" }
 servo_geometry = { path = "../geometry" }
-style_traits = { workspace = true }
+stylo_traits = { workspace = true }
 tracing = { workspace = true, optional = true }
 webrender = { workspace = true }
 webrender_api = { workspace = true }

--- a/components/constellation/Cargo.toml
+++ b/components/constellation/Cargo.toml
@@ -45,7 +45,7 @@ serde = { workspace = true }
 servo_config = { path = "../config" }
 servo_rand = { path = "../rand" }
 servo_url = { path = "../url" }
-style_traits = { workspace = true }
+stylo_traits = { workspace = true }
 tracing = { workspace = true, optional = true }
 webgpu = { path = "../webgpu" }
 webrender = { workspace = true }

--- a/components/fonts/Cargo.toml
+++ b/components/fonts/Cargo.toml
@@ -44,7 +44,7 @@ stylo_atoms = { workspace = true }
 servo_config = { path = "../config" }
 servo_url = { path = "../url" }
 smallvec = { workspace = true, features = ["union"] }
-style = { workspace = true }
+stylo = { workspace = true }
 tracing = { workspace = true, optional = true }
 unicode-properties = { workspace = true }
 unicode-script = { workspace = true }

--- a/components/layout_2020/Cargo.toml
+++ b/components/layout_2020/Cargo.toml
@@ -46,8 +46,8 @@ servo_arc = { workspace = true }
 servo_config = { path = "../config" }
 servo_geometry = { path = "../geometry" }
 servo_url = { path = "../url" }
-style = { workspace = true }
-style_traits = { workspace = true }
+stylo = { workspace = true }
+stylo_traits = { workspace = true }
 taffy = { workspace = true }
 tracing = { workspace = true, optional = true }
 unicode-bidi = { workspace = true }

--- a/components/layout_thread_2020/Cargo.toml
+++ b/components/layout_thread_2020/Cargo.toml
@@ -39,8 +39,8 @@ servo_arc = { workspace = true }
 stylo_atoms = { workspace = true }
 servo_config = { path = "../config" }
 servo_url = { path = "../url" }
-style = { workspace = true }
-style_traits = { workspace = true }
+stylo = { workspace = true }
+stylo_traits = { workspace = true }
 tracing = { workspace = true, optional = true }
 url = { workspace = true }
 webrender_api = { workspace = true }

--- a/components/malloc_size_of/Cargo.toml
+++ b/components/malloc_size_of/Cargo.toml
@@ -25,9 +25,9 @@ servo_allocator = { path = "../allocator" }
 servo_arc = { workspace = true }
 smallvec = { workspace = true }
 string_cache = { workspace = true }
-style = { workspace = true }
+stylo = { workspace = true }
 stylo_dom = { workspace = true }
-style_malloc_size_of = { workspace = true }
+stylo_malloc_size_of = { workspace = true }
 thin-vec = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
 url = { workspace = true }

--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -52,7 +52,7 @@ use std::hash::{BuildHasher, Hash};
 use std::ops::Range;
 use std::sync::Arc;
 
-pub use style_malloc_size_of::MallocSizeOfOps;
+pub use stylo_malloc_size_of::MallocSizeOfOps;
 use uuid::Uuid;
 
 /// Trait for measuring the "deep" heap usage of a data structure. This is the
@@ -750,12 +750,12 @@ malloc_size_of_is_webrender_malloc_size_of!(webrender_api::MixBlendMode);
 malloc_size_of_is_webrender_malloc_size_of!(webrender_api::NormalBorder);
 malloc_size_of_is_webrender_malloc_size_of!(webrender_api::RepeatMode);
 
-macro_rules! malloc_size_of_is_style_malloc_size_of(
+macro_rules! malloc_size_of_is_stylo_malloc_size_of(
     ($($ty:ty),+) => (
         $(
             impl MallocSizeOf for $ty {
                 fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
-                    <$ty as style_malloc_size_of::MallocSizeOf>::size_of(self, ops)
+                    <$ty as stylo_malloc_size_of::MallocSizeOf>::size_of(self, ops)
                 }
             }
         )+
@@ -766,10 +766,10 @@ impl<S> MallocSizeOf for style::author_styles::GenericAuthorStyles<S>
 where
     S: style::stylesheets::StylesheetInDocument
         + std::cmp::PartialEq
-        + style_malloc_size_of::MallocSizeOf,
+        + stylo_malloc_size_of::MallocSizeOf,
 {
     fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
-        <style::author_styles::GenericAuthorStyles<S> as style_malloc_size_of::MallocSizeOf>::size_of(self, ops)
+        <style::author_styles::GenericAuthorStyles<S> as stylo_malloc_size_of::MallocSizeOf>::size_of(self, ops)
     }
 }
 
@@ -777,30 +777,30 @@ impl<S> MallocSizeOf for style::stylesheet_set::DocumentStylesheetSet<S>
 where
     S: style::stylesheets::StylesheetInDocument
         + std::cmp::PartialEq
-        + style_malloc_size_of::MallocSizeOf,
+        + stylo_malloc_size_of::MallocSizeOf,
 {
     fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
-        <style::stylesheet_set::DocumentStylesheetSet<S> as style_malloc_size_of::MallocSizeOf>::size_of(self, ops)
+        <style::stylesheet_set::DocumentStylesheetSet<S> as stylo_malloc_size_of::MallocSizeOf>::size_of(self, ops)
     }
 }
 
-malloc_size_of_is_style_malloc_size_of!(style::animation::DocumentAnimationSet);
-malloc_size_of_is_style_malloc_size_of!(style::attr::AttrIdentifier);
-malloc_size_of_is_style_malloc_size_of!(style::attr::AttrValue);
-malloc_size_of_is_style_malloc_size_of!(style::color::AbsoluteColor);
-malloc_size_of_is_style_malloc_size_of!(style::computed_values::font_variant_caps::T);
-malloc_size_of_is_style_malloc_size_of!(style::dom::OpaqueNode);
-malloc_size_of_is_style_malloc_size_of!(style::invalidation::element::restyle_hints::RestyleHint);
-malloc_size_of_is_style_malloc_size_of!(style::media_queries::MediaList);
-malloc_size_of_is_style_malloc_size_of!(style::properties::style_structs::Font);
-malloc_size_of_is_style_malloc_size_of!(style::selector_parser::PseudoElement);
-malloc_size_of_is_style_malloc_size_of!(style::selector_parser::RestyleDamage);
-malloc_size_of_is_style_malloc_size_of!(style::selector_parser::Snapshot);
-malloc_size_of_is_style_malloc_size_of!(style::shared_lock::SharedRwLock);
-malloc_size_of_is_style_malloc_size_of!(style::stylesheets::DocumentStyleSheet);
-malloc_size_of_is_style_malloc_size_of!(style::stylist::Stylist);
-malloc_size_of_is_style_malloc_size_of!(style::values::computed::FontStretch);
-malloc_size_of_is_style_malloc_size_of!(style::values::computed::FontStyle);
-malloc_size_of_is_style_malloc_size_of!(style::values::computed::FontWeight);
-malloc_size_of_is_style_malloc_size_of!(style::values::computed::font::SingleFontFamily);
-malloc_size_of_is_style_malloc_size_of!(stylo_dom::ElementState);
+malloc_size_of_is_stylo_malloc_size_of!(style::animation::DocumentAnimationSet);
+malloc_size_of_is_stylo_malloc_size_of!(style::attr::AttrIdentifier);
+malloc_size_of_is_stylo_malloc_size_of!(style::attr::AttrValue);
+malloc_size_of_is_stylo_malloc_size_of!(style::color::AbsoluteColor);
+malloc_size_of_is_stylo_malloc_size_of!(style::computed_values::font_variant_caps::T);
+malloc_size_of_is_stylo_malloc_size_of!(style::dom::OpaqueNode);
+malloc_size_of_is_stylo_malloc_size_of!(style::invalidation::element::restyle_hints::RestyleHint);
+malloc_size_of_is_stylo_malloc_size_of!(style::media_queries::MediaList);
+malloc_size_of_is_stylo_malloc_size_of!(style::properties::style_structs::Font);
+malloc_size_of_is_stylo_malloc_size_of!(style::selector_parser::PseudoElement);
+malloc_size_of_is_stylo_malloc_size_of!(style::selector_parser::RestyleDamage);
+malloc_size_of_is_stylo_malloc_size_of!(style::selector_parser::Snapshot);
+malloc_size_of_is_stylo_malloc_size_of!(style::shared_lock::SharedRwLock);
+malloc_size_of_is_stylo_malloc_size_of!(style::stylesheets::DocumentStyleSheet);
+malloc_size_of_is_stylo_malloc_size_of!(style::stylist::Stylist);
+malloc_size_of_is_stylo_malloc_size_of!(style::values::computed::FontStretch);
+malloc_size_of_is_stylo_malloc_size_of!(style::values::computed::FontStyle);
+malloc_size_of_is_stylo_malloc_size_of!(style::values::computed::FontWeight);
+malloc_size_of_is_stylo_malloc_size_of!(style::values::computed::font::SingleFontFamily);
+malloc_size_of_is_stylo_malloc_size_of!(stylo_dom::ElementState);

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -111,13 +111,13 @@ servo_geometry = { path = "../geometry" }
 servo_rand = { path = "../rand" }
 servo_url = { path = "../url" }
 smallvec = { workspace = true, features = ["union"] }
-style_malloc_size_of = { workspace = true }
+stylo_malloc_size_of = { workspace = true }
 glow = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
-style = { workspace = true }
+stylo = { workspace = true }
 stylo_dom = { workspace = true }
-style_traits = { workspace = true }
+stylo_traits = { workspace = true }
 swapper = "0.1"
 tempfile = "3"
 tendril = { version = "0.4.1", features = ["encoding_rs"] }

--- a/components/script/dom/documentorshadowroot.rs
+++ b/components/script/dom/documentorshadowroot.rs
@@ -41,8 +41,8 @@ pub(crate) struct StyleSheetInDocument {
 
 // This is necessary because this type is contained within a Stylo type which needs
 // Stylo's version of MallocSizeOf.
-impl style_malloc_size_of::MallocSizeOf for StyleSheetInDocument {
-    fn size_of(&self, ops: &mut style_malloc_size_of::MallocSizeOfOps) -> usize {
+impl stylo_malloc_size_of::MallocSizeOf for StyleSheetInDocument {
+    fn size_of(&self, ops: &mut stylo_malloc_size_of::MallocSizeOfOps) -> usize {
         <StyleSheetInDocument as malloc_size_of::MallocSizeOf>::size_of(self, ops)
     }
 }

--- a/components/script_bindings/Cargo.toml
+++ b/components/script_bindings/Cargo.toml
@@ -39,7 +39,7 @@ servo_arc = { workspace = true }
 smallvec = { workspace = true }
 stylo_atoms = { workspace = true }
 servo_config = { path = "../config" }
-style = { workspace = true }
+stylo = { workspace = true }
 tendril = { version = "0.4.1", features = ["encoding_rs"] }
 webxr-api = { workspace = true, optional = true }
 xml5ever = { workspace = true }

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -98,8 +98,8 @@ servo-media-gstreamer = { workspace = true, optional = true }
 servo_config = { path = "../config" }
 servo_geometry = { path = "../geometry" }
 servo_url = { path = "../url" }
-style = { workspace = true }
-style_traits = { workspace = true }
+stylo = { workspace = true }
+stylo_traits = { workspace = true }
 surfman = { workspace = true }
 tracing = { workspace = true, optional = true }
 url = { workspace = true }

--- a/components/shared/canvas/Cargo.toml
+++ b/components/shared/canvas/Cargo.toml
@@ -18,6 +18,7 @@ webgl_backtrace = []
 base = { workspace = true }
 crossbeam-channel = { workspace = true }
 euclid = { workspace = true }
+glow = { workspace = true }
 ipc-channel = { workspace = true }
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
@@ -25,7 +26,6 @@ pixels = { path = "../../pixels" }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
 servo_config = { path = "../../config" }
-glow = { workspace = true }
-style = { workspace = true }
+stylo = { workspace = true }
 webrender_api = { workspace = true }
 webxr-api = { workspace = true, features = ["ipc"] }

--- a/components/shared/compositing/Cargo.toml
+++ b/components/shared/compositing/Cargo.toml
@@ -23,6 +23,6 @@ pixels = { path = '../../pixels' }
 script_traits = { workspace = true }
 servo_url = { path = "../../url" }
 strum_macros = { workspace = true }
-style_traits = { workspace = true }
+stylo_traits = { workspace = true }
 webrender_api = { workspace = true }
 webrender_traits = { workspace = true }

--- a/components/shared/embedder/Cargo.toml
+++ b/components/shared/embedder/Cargo.toml
@@ -33,7 +33,7 @@ pixels = { path = "../../pixels" }
 serde = { workspace = true }
 servo_url = { path = "../../url" }
 strum_macros = { workspace = true }
-style_traits = { workspace = true }
+stylo_traits = { workspace = true }
 url = { workspace = true }
 webdriver = { workspace = true }
 webrender_api = { workspace = true }

--- a/components/shared/script/Cargo.toml
+++ b/components/shared/script/Cargo.toml
@@ -43,7 +43,7 @@ strum_macros = { workspace = true }
 stylo_atoms = { workspace = true }
 servo_url = { path = "../../url" }
 strum = { workspace = true, features = ["derive"] }
-style_traits = { workspace = true }
+stylo_traits = { workspace = true }
 uuid = { workspace = true }
 webdriver = { workspace = true }
 webgpu = { path = "../../webgpu" }

--- a/components/shared/script_layout/Cargo.toml
+++ b/components/shared/script_layout/Cargo.toml
@@ -35,7 +35,7 @@ selectors = { workspace = true }
 serde = { workspace = true }
 servo_arc = { workspace = true }
 servo_url = { path = "../../url" }
-style = { workspace = true }
-style_traits = { workspace = true }
+stylo = { workspace = true }
+stylo_traits = { workspace = true }
 webrender_api = { workspace = true }
 webrender_traits = { workspace = true }

--- a/components/shared/webrender/Cargo.toml
+++ b/components/shared/webrender/Cargo.toml
@@ -29,7 +29,7 @@ webrender_api = { workspace = true }
 serde = { workspace = true }
 servo_geometry = { path = "../../geometry" }
 servo-media = { workspace = true }
-style = { workspace = true }
+stylo = { workspace = true }
 surfman = { workspace = true, features = ["sm-x11"] }
 raw-window-handle = { version = "0.6" }
 dpi = { version = "0.1" }

--- a/components/webdriver_server/Cargo.toml
+++ b/components/webdriver_server/Cargo.toml
@@ -31,6 +31,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 servo_config = { path = "../config" }
 servo_url = { path = "../url" }
-style_traits = { workspace = true }
+stylo_traits = { workspace = true }
 uuid = { workspace = true }
 webdriver = { workspace = true }

--- a/tests/unit/style/Cargo.toml
+++ b/tests/unit/style/Cargo.toml
@@ -22,6 +22,6 @@ serde_json = { workspace = true }
 selectors = { workspace = true }
 servo_arc = { workspace = true }
 stylo_atoms = { workspace = true }
-style = { workspace = true }
-style_traits = { workspace = true }
+stylo = { workspace = true }
+stylo_traits = { workspace = true }
 url = { workspace = true }


### PR DESCRIPTION
Now that Stylo considers `servo` as the default feature, Servo doesn't need to specify `features = ["servo"]`.

Also use the same crate names as Stylo, rather than renaming them with `package`.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -e` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because there is no behavior change

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
