### PR TITLE
Propagate CanGc arguments through HTMLCollection constructors

### DIFF
--- a/components/script/dom/htmlcollection.rs
+++ b/components/script/dom/htmlcollection.rs
@@ -319,6 +319,7 @@ impl HTMLCollection {
         after: &'a Node,
     ) -> impl Iterator<Item = DomRoot<Element>> + 'a {
         // Iterate forwards from a node.
+        // Iterate forward from a node
         after
             .following_nodes(&self.root)
             .filter_map(DomRoot::downcast)

--- a/components/script/dom/htmlcollection.rs
+++ b/components/script/dom/htmlcollection.rs
@@ -319,7 +319,6 @@ impl HTMLCollection {
         after: &'a Node,
     ) -> impl Iterator<Item = DomRoot<Element>> + 'a {
         // Iterate forwards from a node.
-        // Iterate forward from a node
         after
             .following_nodes(&self.root)
             .filter_map(DomRoot::downcast)


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
fix #36002 Propagate CanGc arguments through HTMLCollection constructors

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ x] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ x] These changes fix #36002  (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
