### PR TITLE
pixels: Extend `Image` to allow for  multiple frames

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -30,7 +30,7 @@ use fnv::FnvHashMap;
 use ipc_channel::ipc::{self, IpcSharedMemory};
 use libc::c_void;
 use log::{debug, info, trace, warn};
-use pixels::{CorsStatus, Image, PixelFormat};
+use pixels::{CorsStatus, Image, ImageFrame, PixelFormat};
 use profile_traits::time::{self as profile_time, ProfilerCategory};
 use profile_traits::time_profile;
 use script_traits::{
@@ -1454,7 +1454,12 @@ impl IOCompositor {
                 width: image.width(),
                 height: image.height(),
                 format: PixelFormat::RGBA8,
-                bytes: ipc::IpcSharedMemory::from_bytes(&image),
+                frames: vec![ImageFrame {
+                    delay: None,
+                    bytes: ipc::IpcSharedMemory::from_bytes(&image),
+                    width: image.width(),
+                    height: image.height(),
+                }],
                 id: None,
                 cors_status: CorsStatus::Safe,
             }))

--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -55,14 +55,15 @@ fn set_webrender_image_key(compositor_api: &CrossProcessCompositorApi, image: &m
         return;
     }
     let mut bytes = Vec::new();
+    let frame_bytes = image.bytes();
     let is_opaque = match image.format {
         PixelFormat::BGRA8 => {
-            bytes.extend_from_slice(&image.bytes);
+            bytes.extend_from_slice(&frame_bytes);
             pixels::rgba8_premultiply_inplace(bytes.as_mut_slice())
         },
         PixelFormat::RGB8 => {
-            bytes.reserve(image.bytes.len() / 3 * 4);
-            for bgr in image.bytes.chunks(3) {
+            bytes.reserve(frame_bytes.len() / 3 * 4);
+            for bgr in frame_bytes.chunks(3) {
                 bytes.extend_from_slice(&[bgr[2], bgr[1], bgr[0], 0xff]);
             }
 

--- a/components/script/canvas_state.rs
+++ b/components/script/canvas_state.rs
@@ -292,7 +292,7 @@ impl CanvasState {
 
         let image_size = Size2D::new(img.width, img.height);
         let image_data = match img.format {
-            PixelFormat::BGRA8 => img.bytes.clone(),
+            PixelFormat::BGRA8 => img.bytes(),
             pixel_format => unimplemented!("unsupported pixel format ({:?})", pixel_format),
         };
 

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -619,7 +619,7 @@ impl WebGLRenderingContext {
 
                 let size = Size2D::new(img.width, img.height);
 
-                TexPixels::new(img.bytes.clone(), size, img.format, false)
+                TexPixels::new(img.bytes(), size, img.format, false)
             },
             // TODO(emilio): Getting canvas data is implemented in CanvasRenderingContext2D,
             // but we need to refactor it moving it to `HTMLCanvasElement` and support

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -1677,7 +1677,7 @@ impl Handler {
             "Unexpected screenshot pixel format"
         );
 
-        let rgb = RgbaImage::from_raw(img.width, img.height, img.bytes.to_vec()).unwrap();
+        let rgb = RgbaImage::from_raw(img.width, img.height, img.bytes().to_vec()).unwrap();
         let mut png_data = Cursor::new(Vec::new());
         DynamicImage::ImageRgba8(rgb)
             .write_to(&mut png_data, ImageFormat::Png)


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Partial of https://github.com/servo/servo/issues/36057

Add the ability to parse `Gif` animated image into multiple `ImageFrame`.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they should not affect any WPT tests.
