### PR TITLE
layout: Max assign outer block size to cell measures

### DIFF
--- a/components/layout_2020/table/layout.rs
+++ b/components/layout_2020/table/layout.rs
@@ -1161,7 +1161,7 @@ impl<'a> TableLayout<'a> {
                 self.cell_measures[row_index][column_index]
                     .block
                     .content_sizes
-                    .max_assign(layout.layout.content_block_size.into());
+                    .max_assign(layout.outer_block_size().into());
             }
         }
     }

--- a/tests/wpt/meta/css/css-tables/tentative/rowspan-height-redistribution.html.ini
+++ b/tests/wpt/meta/css/css-tables/tentative/rowspan-height-redistribution.html.ini
@@ -1,9 +1,3 @@
 [rowspan-height-redistribution.html]
   [table 17]
     expected: FAIL
-
-  [table 22]
-    expected: FAIL
-
-  [table 23]
-    expected: FAIL


### PR DESCRIPTION
Previously, we have a bug for height of a row that span > 1.

```
<table style="border-collapse: separate">
  <tr>
    <td rowspan="2" style="border: 30px solid;">
      lorem ipsum
    </td>
  </tr>
  <tr></tr>
</table>
```

![image](https://github.com/user-attachments/assets/1aba50e0-5339-43d3-8651-fbd27b9ffdf3)

After the change, it looks much better
![image](https://github.com/user-attachments/assets/29b00c9a-85b2-4003-9cd9-06a6cfd0d5cf)

However we still have some issue with property `border-collapse: collapse`
![image](https://github.com/user-attachments/assets/612e4d1b-5ff0-42c2-847b-b5e8b9627ffa)

This change also pass the previously failed subtest of `rowspan-height-redistribution.html` (test 22 and 23)

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] This is discussed here [comment](https://github.com/servo/servo/issues/35113)

- [X] There are [tests](https://github.com/servo/servo/pull/36064/files#diff-ffa437be03e46134f3688076223d9e5eecb1af3f03ccb9d10ed2962332ba6fe7) for these changes

Try: https://github.com/PotatoCP/servo/actions/runs/13962809558

@Loirooriol 
cc: @xiaochengh @d-desiatkin 