### PR TITLE
mach: Fix cross-compiling from windows to non windows

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -512,6 +512,19 @@ class CommandBase(object):
 
         self.target.configure_build_environment(env, self.config, self.context.topdir)
 
+        if sys.platform == 'win32' and 'windows' not in self.target.triple():
+            # aws-lc-rs only supports the Ninja Generator when cross-compiling on windows hosts to non-windows.
+            env['TARGET_CMAKE_GENERATOR'] = "Ninja"
+            if shutil.which('ninja') is None:
+                print("Error: Cross-compiling servo on windows requires the Ninja tool to be installed and in PATH.")
+                print("Hint: Ninja-build is available on github at: https://github.com/ninja-build/ninja/releases")
+                exit(1)
+            # `tr` is also required by the CMake build rules of `aws-lc-rs`
+            if shutil.which('tr') is None:
+                print("Error: Cross-compiling servo on windows requires the `tr` tool, which was not found.")
+                print("Hint: Try running ./mach from `git bash` instead of powershell.")
+                exit(1)
+
         return env
 
     @staticmethod


### PR DESCRIPTION
Since we switched to using `aws-lc-rs` instead of `ring`, cross-compiling on windows (to non-windows) had been broken. Using the default MSVC Generator results in CMake erroneously being configured for the host platform, with failing compiler checks. Switching to Ninja fixes that issue.

The CMake build rules of aws-lc-rs also make use of `tr` and assume it is installed, hence we provide a helpful error message suggesting to try using mach from `git bash` which does provide the `tr` command.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix  cross-compiling servo on windows hosts to non-windows targets
- [x] These changes do not require tests because: We don't test cross-compiling from windows hosts in CI. These changes were manually tested by compiling for OpenHarmony on windows.

