### PR TITLE
Upgrade cssparser to 0.35

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1401,8 +1401,9 @@ dependencies = [
 
 [[package]]
 name = "cssparser"
-version = "0.34.1"
-source = "git+https://github.com/servo/rust-cssparser?rev=958a3f098acb92ddacdce18a7ef2c4a87ac3326f#958a3f098acb92ddacdce18a7ef2c4a87ac3326f"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e901edd733a1472f944a45116df3f846f54d37e67e68640ac8bb69689aca2aa"
 dependencies = [
  "cssparser-macros",
  "dtoa-short",
@@ -1415,7 +1416,8 @@ dependencies = [
 [[package]]
 name = "cssparser-macros"
 version = "0.6.1"
-source = "git+https://github.com/servo/rust-cssparser?rev=958a3f098acb92ddacdce18a7ef2c4a87ac3326f#958a3f098acb92ddacdce18a7ef2c4a87ac3326f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
  "syn",
@@ -6498,7 +6500,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.26.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-15#df459eca2e8e71b5e85c7c20a64208f3410184e0"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#4b44fbdb7f93c3f57eb99ad5f14cda5e82af4467"
 dependencies = [
  "bitflags 2.9.0",
  "cssparser",
@@ -6783,7 +6785,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-15#df459eca2e8e71b5e85c7c20a64208f3410184e0"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#4b44fbdb7f93c3f57eb99ad5f14cda5e82af4467"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -7233,7 +7235,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-03-15#df459eca2e8e71b5e85c7c20a64208f3410184e0"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#4b44fbdb7f93c3f57eb99ad5f14cda5e82af4467"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -7291,7 +7293,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-15#df459eca2e8e71b5e85c7c20a64208f3410184e0"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#4b44fbdb7f93c3f57eb99ad5f14cda5e82af4467"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -7300,12 +7302,12 @@ dependencies = [
 [[package]]
 name = "stylo_config"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-15#df459eca2e8e71b5e85c7c20a64208f3410184e0"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#4b44fbdb7f93c3f57eb99ad5f14cda5e82af4467"
 
 [[package]]
 name = "stylo_derive"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-03-15#df459eca2e8e71b5e85c7c20a64208f3410184e0"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#4b44fbdb7f93c3f57eb99ad5f14cda5e82af4467"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -7317,7 +7319,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-15#df459eca2e8e71b5e85c7c20a64208f3410184e0"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#4b44fbdb7f93c3f57eb99ad5f14cda5e82af4467"
 dependencies = [
  "bitflags 2.9.0",
  "stylo_malloc_size_of",
@@ -7326,7 +7328,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-03-15#df459eca2e8e71b5e85c7c20a64208f3410184e0"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#4b44fbdb7f93c3f57eb99ad5f14cda5e82af4467"
 dependencies = [
  "app_units",
  "cssparser",
@@ -7343,12 +7345,12 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-15#df459eca2e8e71b5e85c7c20a64208f3410184e0"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#4b44fbdb7f93c3f57eb99ad5f14cda5e82af4467"
 
 [[package]]
 name = "stylo_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-03-15#df459eca2e8e71b5e85c7c20a64208f3410184e0"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#4b44fbdb7f93c3f57eb99ad5f14cda5e82af4467"
 dependencies = [
  "app_units",
  "bitflags 2.9.0",
@@ -7731,7 +7733,7 @@ dependencies = [
 [[package]]
 name = "to_shmem"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-15#df459eca2e8e71b5e85c7c20a64208f3410184e0"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#4b44fbdb7f93c3f57eb99ad5f14cda5e82af4467"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -7744,7 +7746,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-15#df459eca2e8e71b5e85c7c20a64208f3410184e0"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#4b44fbdb7f93c3f57eb99ad5f14cda5e82af4467"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ compositing_traits = { path = "components/shared/compositing" }
 content-security-policy = { version = "0.5", features = ["serde"] }
 cookie = { package = "cookie", version = "0.18" }
 crossbeam-channel = "0.5"
-cssparser = { git = "https://github.com/servo/rust-cssparser", rev = "958a3f098acb92ddacdce18a7ef2c4a87ac3326f", features = ["serde"] }
+cssparser = { version = "0.35", features = ["serde"] }
 ctr = "0.9.2"
 darling = { version = "0.20", default-features = false }
 data-url = "0.3"


### PR DESCRIPTION
Upgrades:
- cssparser to 0.35
- stylo to a version that uses cssparser 0.35

Both Servo and Stylo were already using the same version of cssparser (just as a git dependency). This updates them to pull it in as a crates.io dependency now that it has been published.

Stylo PR (to be merged first):
- [x] https://github.com/servo/stylo/pull/155

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors