### PR TITLE
layout: Cache `IndependentNonReplacedContents::layout()`

### DIFF
--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -25,16 +25,13 @@ use style::values::generics::length::LengthPercentageOrNormal;
 use style::values::specified::align::AlignFlags;
 
 use super::geom::{FlexAxis, FlexRelativeRect, FlexRelativeSides, FlexRelativeVec2};
-use super::{
-    CachedBlockSizeContribution, FlexContainer, FlexContainerConfig, FlexItemBox, FlexLevelBox,
-};
+use super::{FlexContainer, FlexContainerConfig, FlexItemBox, FlexLevelBox};
 use crate::cell::ArcRefCell;
 use crate::context::LayoutContext;
-use crate::formatting_contexts::{
-    Baselines, IndependentFormattingContextContents, IndependentLayout,
-};
+use crate::formatting_contexts::{Baselines, IndependentFormattingContextContents};
 use crate::fragment_tree::{BoxFragment, CollapsedBlockMargins, Fragment, FragmentFlags};
 use crate::geom::{AuOrAuto, LogicalRect, LogicalSides, LogicalVec2, Size, Sizes};
+use crate::layout_box_base::CacheableLayoutResult;
 use crate::positioned::{
     AbsolutelyPositionedBox, PositioningContext, PositioningContextLength, relative_adjustement,
 };
@@ -650,8 +647,10 @@ impl FlexContainer {
         layout_context: &LayoutContext,
         positioning_context: &mut PositioningContext,
         containing_block: &ContainingBlock,
-    ) -> IndependentLayout {
-        let depends_on_block_constraints = self.config.flex_direction == FlexDirection::Column;
+        depends_on_block_constraints: bool,
+    ) -> CacheableLayoutResult {
+        let depends_on_block_constraints =
+            depends_on_block_constraints || self.config.flex_direction == FlexDirection::Column;
 
         let mut flex_context = FlexContext {
             config: self.config.clone(),
@@ -985,13 +984,14 @@ impl FlexContainer {
                 .or(all_baselines.last),
         };
 
-        IndependentLayout {
+        CacheableLayoutResult {
             fragments,
             content_block_size,
             content_inline_size_for_table: None,
             baselines,
             depends_on_block_constraints,
             specific_layout_info: None,
+            collapsible_margins_in_children: CollapsedBlockMargins::zero(),
         }
     }
 
@@ -1950,29 +1950,23 @@ impl FlexItem<'_> {
                     }
                 }
 
-                let cache = self.box_.block_content_size_cache.borrow_mut().take();
-                let layout = if let Some(cache) = cache.filter(|cache| {
-                    cache.compatible_with_item_as_containing_block(&item_as_containing_block)
-                }) {
-                    positioning_context = cache.positioning_context;
-                    cache.layout
-                } else {
-                    non_replaced.layout(
-                        flex_context.layout_context,
-                        &mut positioning_context,
-                        &item_as_containing_block,
-                        containing_block,
-                    )
-                };
-                let IndependentLayout {
+                let layout = non_replaced.layout_with_caching(
+                    flex_context.layout_context,
+                    &mut positioning_context,
+                    &item_as_containing_block,
+                    containing_block,
+                    &independent_formatting_context.base,
+                    flex_axis == FlexAxis::Column ||
+                        self.stretches_to_line() ||
+                        self.depends_on_block_constraints,
+                );
+                let CacheableLayoutResult {
                     fragments,
                     content_block_size,
                     baselines: content_box_baselines,
                     depends_on_block_constraints,
                     ..
                 } = layout;
-                let depends_on_block_constraints = depends_on_block_constraints ||
-                    (flex_axis == FlexAxis::Row && self.stretches_to_line());
 
                 let has_child_which_depends_on_block_constraints = fragments.iter().any(|fragment| {
                         fragment.base().is_some_and(|base|
@@ -2696,37 +2690,17 @@ impl FlexItemBox {
                     },
                     style,
                 };
-                let content_block_size = || {
-                    if let Some(cache) = &*self.block_content_size_cache.borrow() {
-                        if inline_size == cache.containing_block_inline_size {
-                            return cache.layout.content_block_size;
-                        } else {
-                            #[cfg(feature = "tracing")]
-                            tracing::warn!(
-                                name: "NonReplaced cache miss",
-                                cached = ?cache.containing_block_inline_size,
-                                required = ?inline_size,
-                            );
-                        }
-                    } else {
-                        #[cfg(feature = "tracing")]
-                        tracing::warn!(name: "NonReplaced no cache", required = ?inline_size);
-                    }
-
-                    let layout = non_replaced.layout(
-                        flex_context.layout_context,
-                        &mut positioning_context,
-                        &item_as_containing_block,
-                        flex_context.containing_block,
-                    );
-                    let content_block_size = layout.content_block_size;
-                    *self.block_content_size_cache.borrow_mut() =
-                        Some(CachedBlockSizeContribution {
-                            containing_block_inline_size: item_as_containing_block.size.inline,
-                            layout,
-                            positioning_context,
-                        });
-                    content_block_size
+                let mut content_block_size = || {
+                    non_replaced
+                        .layout_with_caching(
+                            flex_context.layout_context,
+                            &mut positioning_context,
+                            &item_as_containing_block,
+                            flex_context.containing_block,
+                            &self.independent_formatting_context.base,
+                            false, /* depends_on_block_constraints */
+                        )
+                        .content_block_size
                 };
                 match intrinsic_sizing_mode {
                     IntrinsicSizingMode::Contribution => {

--- a/components/layout_2020/flexbox/mod.rs
+++ b/components/layout_2020/flexbox/mod.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use app_units::Au;
 use geom::{FlexAxis, MainStartCrossStart};
 use servo_arc::Arc as ServoArc;
 use style::logical_geometry::WritingMode;
@@ -13,15 +12,15 @@ use style::properties::longhands::flex_wrap::computed_value::T as FlexWrap;
 use style::values::computed::{AlignContent, JustifyContent};
 use style::values::specified::align::AlignFlags;
 
+use crate::PropagatedBoxTreeData;
 use crate::cell::ArcRefCell;
 use crate::construct_modern::{ModernContainerBuilder, ModernItemKind};
 use crate::context::LayoutContext;
 use crate::dom::{LayoutBox, NodeExt};
 use crate::dom_traversal::{NodeAndStyleInfo, NonReplacedContents};
-use crate::formatting_contexts::{IndependentFormattingContext, IndependentLayout};
+use crate::formatting_contexts::IndependentFormattingContext;
 use crate::fragment_tree::BaseFragmentInfo;
-use crate::positioned::{AbsolutelyPositionedBox, PositioningContext};
-use crate::{ContainingBlock, PropagatedBoxTreeData};
+use crate::positioned::AbsolutelyPositionedBox;
 
 mod geom;
 mod layout;
@@ -146,7 +145,6 @@ pub(crate) enum FlexLevelBox {
 
 pub(crate) struct FlexItemBox {
     independent_formatting_context: IndependentFormattingContext,
-    block_content_size_cache: ArcRefCell<Option<CachedBlockSizeContribution>>,
 }
 
 impl std::fmt::Debug for FlexItemBox {
@@ -159,7 +157,6 @@ impl FlexItemBox {
     fn new(independent_formatting_context: IndependentFormattingContext) -> Self {
         Self {
             independent_formatting_context,
-            block_content_size_cache: Default::default(),
         }
     }
 
@@ -169,21 +166,5 @@ impl FlexItemBox {
 
     fn base_fragment_info(&self) -> BaseFragmentInfo {
         self.independent_formatting_context.base_fragment_info()
-    }
-}
-
-struct CachedBlockSizeContribution {
-    containing_block_inline_size: Au,
-    layout: IndependentLayout,
-    positioning_context: PositioningContext,
-}
-
-impl CachedBlockSizeContribution {
-    fn compatible_with_item_as_containing_block(
-        &self,
-        item_as_containing_block: &ContainingBlock,
-    ) -> bool {
-        item_as_containing_block.size.inline == self.containing_block_inline_size &&
-            !item_as_containing_block.size.block.is_definite()
     }
 }

--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -26,7 +26,7 @@ use crate::flow::float::{
 };
 use crate::formatting_contexts::{
     Baselines, IndependentFormattingContext, IndependentFormattingContextContents,
-    IndependentLayout, IndependentLayoutResult, IndependentNonReplacedContents,
+    IndependentNonReplacedContents,
 };
 use crate::fragment_tree::{
     BaseFragmentInfo, BoxFragment, CollapsedBlockMargins, CollapsedMargin, Fragment, FragmentFlags,
@@ -35,7 +35,7 @@ use crate::geom::{
     AuOrAuto, LogicalRect, LogicalSides, LogicalSides1D, LogicalVec2, PhysicalPoint, PhysicalRect,
     PhysicalSides, Size, Sizes, ToLogical, ToLogicalWithContainingBlock,
 };
-use crate::layout_box_base::LayoutBoxBase;
+use crate::layout_box_base::{CacheableLayoutResult, LayoutBoxBase};
 use crate::positioned::{AbsolutelyPositionedBox, PositioningContext, PositioningContextLength};
 use crate::replaced::ReplacedContents;
 use crate::sizing::{self, ComputeInlineContentSizes, ContentSizes, InlineContentSizesResult};
@@ -219,18 +219,6 @@ impl BlockLevelBox {
     }
 }
 
-pub(crate) struct FlowLayout {
-    pub fragments: Vec<Fragment>,
-    pub content_block_size: Au,
-    pub collapsible_margins_in_children: CollapsedBlockMargins,
-    /// The offset of the baselines in this layout in the content area, if there were some. This is
-    /// used to propagate inflow baselines to the ancestors of `display: inline-block` elements
-    /// and table content.
-    pub baselines: Baselines,
-    /// Whether or not this layout depends on the block size of its containing block.
-    pub depends_on_block_constraints: bool,
-}
-
 #[derive(Clone, Copy)]
 pub(crate) struct CollapsibleWithParentStartMargin(bool);
 
@@ -362,7 +350,8 @@ impl BlockFormattingContext {
         layout_context: &LayoutContext,
         positioning_context: &mut PositioningContext,
         containing_block: &ContainingBlock,
-    ) -> IndependentLayout {
+        depends_on_block_constraints: bool,
+    ) -> CacheableLayoutResult {
         let mut sequential_layout_state = if self.contains_floats || !layout_context.use_rayon {
             Some(SequentialLayoutState::new(containing_block.size.inline))
         } else {
@@ -395,15 +384,17 @@ impl BlockFormattingContext {
             sequential_layout_state.calculate_clearance(Clear::Both, &CollapsedMargin::zero())
         });
 
-        IndependentLayout {
+        CacheableLayoutResult {
             fragments: flow_layout.fragments,
             content_block_size: flow_layout.content_block_size +
                 flow_layout.collapsible_margins_in_children.end.solve() +
                 clearance.unwrap_or_default(),
             content_inline_size_for_table: None,
             baselines: flow_layout.baselines,
-            depends_on_block_constraints: flow_layout.depends_on_block_constraints,
+            depends_on_block_constraints: depends_on_block_constraints ||
+                flow_layout.depends_on_block_constraints,
             specific_layout_info: None,
+            collapsible_margins_in_children: CollapsedBlockMargins::zero(),
         }
     }
 
@@ -573,7 +564,7 @@ impl BlockContainer {
         sequential_layout_state: Option<&mut SequentialLayoutState>,
         collapsible_with_parent_start_margin: CollapsibleWithParentStartMargin,
         ignore_block_margins_for_stretch: LogicalSides1D<bool>,
-    ) -> FlowLayout {
+    ) -> CacheableLayoutResult {
         match self {
             BlockContainer::BlockLevelBoxes(child_boxes) => layout_block_level_children(
                 layout_context,
@@ -627,7 +618,7 @@ fn layout_block_level_children(
     mut sequential_layout_state: Option<&mut SequentialLayoutState>,
     collapsible_with_parent_start_margin: CollapsibleWithParentStartMargin,
     ignore_block_margins_for_stretch: LogicalSides1D<bool>,
-) -> FlowLayout {
+) -> CacheableLayoutResult {
     let mut placement_state =
         PlacementState::new(collapsible_with_parent_start_margin, containing_block);
 
@@ -660,12 +651,14 @@ fn layout_block_level_children(
     });
 
     let (content_block_size, collapsible_margins_in_children, baselines) = placement_state.finish();
-    FlowLayout {
+    CacheableLayoutResult {
         fragments,
         content_block_size,
         collapsible_margins_in_children,
         baselines,
         depends_on_block_constraints,
+        content_inline_size_for_table: None,
+        specific_layout_info: None,
     }
 }
 
@@ -1150,6 +1143,7 @@ impl IndependentNonReplacedContents {
             positioning_context,
             &containing_block_for_children,
             containing_block,
+            false, /* depends_on_block_constraints */
         );
 
         let inline_size = layout
@@ -1299,7 +1293,7 @@ impl IndependentNonReplacedContents {
             )
         };
 
-        let compute_block_size = |layout: &IndependentLayout| {
+        let compute_block_size = |layout: &CacheableLayoutResult| {
             content_box_sizes.block.resolve(
                 Direction::Block,
                 Size::FitContent,
@@ -1335,6 +1329,7 @@ impl IndependentNonReplacedContents {
                     style,
                 },
                 containing_block,
+                false, /* depends_on_block_constraints */
             );
 
             content_size = LogicalVec2 {
@@ -1398,6 +1393,7 @@ impl IndependentNonReplacedContents {
                         style,
                     },
                     containing_block,
+                    false, /* depends_on_block_constraints */
                 );
 
                 let inline_size = if let Some(inline_size) = layout.content_inline_size_for_table {
@@ -2160,6 +2156,12 @@ fn block_size_is_zero_or_intrinsic(size: &StyleSize, containing_block: &Containi
     }
 }
 
+pub(crate) struct IndependentFloatOrAtomicLayoutResult {
+    pub fragment: BoxFragment,
+    pub baselines: Option<Baselines>,
+    pub pbm_sums: LogicalSides<Au>,
+}
+
 impl IndependentFormattingContext {
     pub(crate) fn layout_in_flow_block_level(
         &self,
@@ -2194,7 +2196,7 @@ impl IndependentFormattingContext {
         layout_context: &LayoutContext,
         child_positioning_context: &mut PositioningContext,
         containing_block: &ContainingBlock,
-    ) -> IndependentLayoutResult {
+    ) -> IndependentFloatOrAtomicLayoutResult {
         let style = self.style();
         let container_writing_mode = containing_block.style.writing_mode;
         let layout_style = self.layout_style();
@@ -2278,6 +2280,7 @@ impl IndependentFormattingContext {
                     child_positioning_context,
                     &containing_block_for_children,
                     containing_block,
+                    false, /* depends_on_block_constraints */
                 );
                 let inline_size = independent_layout
                     .content_inline_size_for_table
@@ -2328,7 +2331,7 @@ impl IndependentFormattingContext {
             CollapsedBlockMargins::zero(),
         );
 
-        IndependentLayoutResult {
+        IndependentFloatOrAtomicLayoutResult {
             fragment,
             baselines,
             pbm_sums,

--- a/components/layout_2020/flow/root.rs
+++ b/components/layout_2020/flow/root.rs
@@ -365,6 +365,7 @@ impl BoxTree {
             layout_context,
             &mut positioning_context,
             &(&initial_containing_block).into(),
+            false, /* depends_on_block_constraints */
         );
 
         let mut root_fragments = independent_layout.fragments.into_iter().collect::<Vec<_>>();

--- a/components/layout_2020/fragment_tree/fragment.rs
+++ b/components/layout_2020/fragment_tree/fragment.rs
@@ -45,6 +45,7 @@ pub(crate) enum Fragment {
     IFrame(ArcRefCell<IFrameFragment>),
 }
 
+#[derive(Clone)]
 pub(crate) struct CollapsedBlockMargins {
     pub collapsed_through: bool,
     pub start: CollapsedMargin,

--- a/components/layout_2020/layout_box_base.rs
+++ b/components/layout_2020/layout_box_base.rs
@@ -2,15 +2,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::fmt::{Debug, Formatter};
+
+use app_units::Au;
 use atomic_refcell::AtomicRefCell;
 use servo_arc::Arc;
 use style::properties::ComputedValues;
 
-use crate::ConstraintSpace;
 use crate::context::LayoutContext;
-use crate::fragment_tree::BaseFragmentInfo;
+use crate::formatting_contexts::Baselines;
+use crate::fragment_tree::{BaseFragmentInfo, CollapsedBlockMargins, Fragment, SpecificLayoutInfo};
 use crate::geom::SizeConstraint;
+use crate::positioned::PositioningContext;
 use crate::sizing::{ComputeInlineContentSizes, InlineContentSizesResult};
+use crate::{ConstraintSpace, ContainingBlockSize};
 
 /// A box tree node that handles containing information about style and the original DOM
 /// node or pseudo-element that it is based on. This also handles caching of layout values
@@ -18,12 +23,12 @@ use crate::sizing::{ComputeInlineContentSizes, InlineContentSizesResult};
 /// passes.
 ///
 /// In the future, this will hold layout results to support incremental layout.
-#[derive(Debug)]
 pub(crate) struct LayoutBoxBase {
     pub base_fragment_info: BaseFragmentInfo,
     pub style: Arc<ComputedValues>,
     pub cached_inline_content_size:
         AtomicRefCell<Option<(SizeConstraint, InlineContentSizesResult)>>,
+    pub cached_layout_result: AtomicRefCell<Option<CacheableLayoutResultAndInputs>>,
 }
 
 impl LayoutBoxBase {
@@ -32,6 +37,7 @@ impl LayoutBoxBase {
             base_fragment_info,
             style,
             cached_inline_content_size: AtomicRefCell::default(),
+            cached_layout_result: AtomicRefCell::default(),
         }
     }
 
@@ -57,4 +63,46 @@ impl LayoutBoxBase {
         *cache = Some((constraint_space.block_size, result));
         result
     }
+}
+
+impl Debug for LayoutBoxBase {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        f.debug_struct("LayoutBoxBase").finish()
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct CacheableLayoutResult {
+    pub fragments: Vec<Fragment>,
+
+    /// <https://drafts.csswg.org/css2/visudet.html#root-height>
+    pub content_block_size: Au,
+
+    /// If this layout is for a block container, this tracks the collapsable size
+    /// of start and end margins and whether or not the block container collapsed through.
+    pub collapsible_margins_in_children: CollapsedBlockMargins,
+
+    /// The contents of a table may force it to become wider than what we would expect
+    /// from 'width' and 'min-width'. This is the resulting inline content size,
+    /// or None for non-table layouts.
+    pub content_inline_size_for_table: Option<Au>,
+
+    /// The offset of the last inflow baseline of this layout in the content area, if
+    /// there was one. This is used to propagate baselines to the ancestors of `display:
+    /// inline-block`.
+    pub baselines: Baselines,
+
+    /// Whether or not this layout depends on the containing block size.
+    pub depends_on_block_constraints: bool,
+
+    /// Additional information of this layout that could be used by Javascripts and devtools.
+    pub specific_layout_info: Option<SpecificLayoutInfo>,
+}
+
+pub(crate) struct CacheableLayoutResultAndInputs {
+    pub result: CacheableLayoutResult,
+
+    pub containing_block_for_children_size: ContainingBlockSize,
+
+    pub positioning_context: PositioningContext,
 }

--- a/components/layout_2020/lib.rs
+++ b/components/layout_2020/lib.rs
@@ -112,7 +112,7 @@ impl<'a> From<&'_ DefiniteContainingBlock<'a>> for IndefiniteContainingBlock {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub(crate) struct ContainingBlockSize {
     inline: Au,
     block: SizeConstraint,

--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -41,6 +41,7 @@ pub(crate) struct AbsolutelyPositionedBox {
     pub context: IndependentFormattingContext,
 }
 
+#[derive(Clone)]
 pub(crate) struct PositioningContext {
     for_nearest_positioned_ancestor: Option<Vec<HoistedAbsolutelyPositionedBox>>,
 
@@ -50,6 +51,7 @@ pub(crate) struct PositioningContext {
     for_nearest_containing_block_for_all_descendants: Vec<HoistedAbsolutelyPositionedBox>,
 }
 
+#[derive(Clone)]
 pub(crate) struct HoistedAbsolutelyPositionedBox {
     absolutely_positioned_box: ArcRefCell<AbsolutelyPositionedBox>,
 
@@ -299,7 +301,7 @@ impl PositioningContext {
             .push(box_)
     }
 
-    fn is_empty(&self) -> bool {
+    pub(crate) fn is_empty(&self) -> bool {
         self.for_nearest_containing_block_for_all_descendants
             .is_empty() &&
             self.for_nearest_positioned_ancestor
@@ -627,6 +629,7 @@ impl HoistedAbsolutelyPositionedBox {
                         &mut positioning_context,
                         &containing_block_for_children,
                         containing_block,
+                        false, /* depends_on_block_constraints */
                     );
 
                     let inline_size = if let Some(inline_size) =


### PR DESCRIPTION
This replaces `IndependentLayout` with `CacheableLayoutResult` and stores it in `LayoutBoxBase` so it can be reused when we need to lay out a box multiple times.

This is a generalization of the caching that we had for flexbox, which is now removed in favor of the new one.

With this, the number of runs per second in the Chromium perf test `flexbox-deeply-nested-column-flow.html` are multiplied by 3.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -r` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because there should be no behavior change

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
