### PR TITLE
Create a `constellation_traits` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1085,6 +1085,7 @@ dependencies = [
  "base",
  "bitflags 2.9.0",
  "compositing_traits",
+ "constellation_traits",
  "crossbeam-channel",
  "dpi",
  "embedder_traits",
@@ -1118,11 +1119,9 @@ dependencies = [
  "embedder_traits",
  "euclid",
  "ipc-channel",
- "keyboard-types",
  "log",
  "pixels",
  "script_traits",
- "servo_url",
  "strum_macros",
  "stylo_traits",
  "webrender_api",
@@ -1149,6 +1148,7 @@ dependencies = [
  "bluetooth_traits",
  "canvas_traits",
  "compositing_traits",
+ "constellation_traits",
  "crossbeam-channel",
  "devtools_traits",
  "embedder_traits",
@@ -1176,6 +1176,24 @@ dependencies = [
  "webrender_api",
  "webrender_traits",
  "webxr-api",
+]
+
+[[package]]
+name = "constellation_traits"
+version = "0.0.1"
+dependencies = [
+ "base",
+ "bitflags 2.9.0",
+ "embedder_traits",
+ "euclid",
+ "ipc-channel",
+ "malloc_size_of_derive",
+ "serde",
+ "servo_malloc_size_of",
+ "servo_url",
+ "strum_macros",
+ "stylo_traits",
+ "webrender_api",
 ]
 
 [[package]]
@@ -4195,6 +4213,7 @@ version = "0.0.1"
 dependencies = [
  "app_units",
  "base",
+ "constellation_traits",
  "embedder_traits",
  "euclid",
  "fnv",
@@ -4328,6 +4347,7 @@ dependencies = [
  "compositing",
  "compositing_traits",
  "constellation",
+ "constellation_traits",
  "crossbeam-channel",
  "devtools",
  "devtools_traits",
@@ -6271,6 +6291,7 @@ dependencies = [
  "cbc",
  "chrono",
  "cipher",
+ "constellation_traits",
  "content-security-policy",
  "cookie 0.18.1",
  "crossbeam-channel",
@@ -6400,6 +6421,7 @@ dependencies = [
  "atomic_refcell",
  "base",
  "canvas_traits",
+ "constellation_traits",
  "euclid",
  "fnv",
  "fonts",
@@ -6444,6 +6466,7 @@ dependencies = [
  "bitflags 2.9.0",
  "bluetooth_traits",
  "canvas_traits",
+ "constellation_traits",
  "cookie 0.18.1",
  "crossbeam-channel",
  "devtools_traits",
@@ -8499,7 +8522,7 @@ version = "0.0.1"
 dependencies = [
  "base",
  "base64 0.22.1",
- "compositing_traits",
+ "constellation_traits",
  "cookie 0.18.1",
  "crossbeam-channel",
  "embedder_traits",
@@ -8619,6 +8642,7 @@ name = "webrender_traits"
 version = "0.0.1"
 dependencies = [
  "base",
+ "constellation_traits",
  "dpi",
  "embedder_traits",
  "euclid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ cfg-if = "1.0.0"
 chrono = { version = "0.4", features = ["serde"] }
 cipher = { version = "0.4.4", features = ["alloc"] }
 compositing_traits = { path = "components/shared/compositing" }
+constellation_traits = { path = "components/shared/constellation" }
 content-security-policy = { version = "0.5", features = ["serde"] }
 cookie = { package = "cookie", version = "0.18" }
 crossbeam-channel = "0.5"

--- a/components/compositing/Cargo.toml
+++ b/components/compositing/Cargo.toml
@@ -21,6 +21,7 @@ webxr = ["dep:webxr"]
 base = { workspace = true }
 bitflags = { workspace = true }
 compositing_traits = { workspace = true }
+constellation_traits = { workspace = true }
 crossbeam-channel = { workspace = true }
 dpi = { workspace = true }
 embedder_traits = { workspace = true }

--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -18,8 +18,11 @@ use base::id::{PipelineId, WebViewId};
 use base::{Epoch, WebRenderEpochToU16};
 use bitflags::bitflags;
 use compositing_traits::{
-    CompositionPipeline, CompositorMsg, CompositorReceiver, ConstellationMsg, PaintMetricEvent,
-    SendableFrameTree,
+    CompositionPipeline, CompositorMsg, CompositorReceiver, SendableFrameTree,
+};
+use constellation_traits::{
+    AnimationTickType, CompositorHitTestResult, ConstellationMsg, PaintMetricEvent,
+    UntrustedNodeAddress, WindowSizeData, WindowSizeType,
 };
 use crossbeam_channel::Sender;
 use dpi::PhysicalSize;
@@ -34,7 +37,7 @@ use log::{debug, info, trace, warn};
 use pixels::{CorsStatus, Image, ImageFrame, PixelFormat};
 use profile_traits::time::{self as profile_time, ProfilerCategory};
 use profile_traits::time_profile;
-use script_traits::{AnimationState, AnimationTickType, WindowSizeData, WindowSizeType};
+use script_traits::AnimationState;
 use servo_config::opts;
 use servo_geometry::DeviceIndependentPixel;
 use style_traits::{CSSPixel, PinchZoomFactor};
@@ -52,9 +55,7 @@ use webrender_api::{
 };
 use webrender_traits::display_list::{HitTestInfo, ScrollTree};
 use webrender_traits::rendering_context::RenderingContext;
-use webrender_traits::{
-    CompositorHitTestResult, CrossProcessCompositorMessage, ImageUpdate, UntrustedNodeAddress,
-};
+use webrender_traits::{CrossProcessCompositorMessage, ImageUpdate};
 
 use crate::InitialCompositorState;
 use crate::webview::{UnknownWebView, WebView, WebViewManager};

--- a/components/compositing/lib.rs
+++ b/components/compositing/lib.rs
@@ -7,7 +7,8 @@
 use std::cell::Cell;
 use std::rc::Rc;
 
-use compositing_traits::{CompositorProxy, CompositorReceiver, ConstellationMsg};
+use compositing_traits::{CompositorProxy, CompositorReceiver};
+use constellation_traits::ConstellationMsg;
 use crossbeam_channel::Sender;
 use embedder_traits::ShutdownState;
 use profile_traits::{mem, time};

--- a/components/compositing/webview.rs
+++ b/components/compositing/webview.rs
@@ -8,7 +8,8 @@ use std::collections::hash_map::{Entry, Keys, Values, ValuesMut};
 use std::rc::Rc;
 
 use base::id::{PipelineId, WebViewId};
-use compositing_traits::{ConstellationMsg, SendableFrameTree};
+use compositing_traits::SendableFrameTree;
+use constellation_traits::{CompositorHitTestResult, ConstellationMsg, ScrollState};
 use embedder_traits::{
     InputEvent, MouseButton, MouseButtonAction, MouseButtonEvent, MouseMoveEvent, ShutdownState,
     TouchEvent, TouchEventType, TouchId,
@@ -22,7 +23,6 @@ use webrender_api::units::{DeviceIntPoint, DevicePoint, DeviceRect, LayoutVector
 use webrender_api::{
     ExternalScrollId, HitTestFlags, RenderReasons, SampledScrollOffset, ScrollLocation,
 };
-use webrender_traits::{CompositorHitTestResult, ScrollState};
 
 use crate::IOCompositor;
 use crate::compositor::{PipelineDetails, ServoRenderer};

--- a/components/constellation/Cargo.toml
+++ b/components/constellation/Cargo.toml
@@ -26,6 +26,7 @@ base = { workspace = true }
 bluetooth_traits = { workspace = true, optional = true }
 canvas_traits = { workspace = true }
 compositing_traits = { workspace = true }
+constellation_traits = { workspace = true }
 crossbeam-channel = { workspace = true }
 devtools_traits = { workspace = true }
 embedder_traits = { workspace = true }

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -108,9 +108,10 @@ use bluetooth_traits::BluetoothRequest;
 use canvas_traits::ConstellationCanvasMsg;
 use canvas_traits::canvas::{CanvasId, CanvasMsg};
 use canvas_traits::webgl::WebGLThreads;
-use compositing_traits::{
-    CompositorMsg, CompositorProxy, ConstellationMsg as FromCompositorMsg, PaintMetricEvent,
-    SendableFrameTree,
+use compositing_traits::{CompositorMsg, CompositorProxy, SendableFrameTree};
+use constellation_traits::{
+    AnimationTickType, CompositorHitTestResult, ConstellationMsg as FromCompositorMsg, LogEntry,
+    PaintMetricEvent, ScrollState, TraversalDirection, WindowSizeData, WindowSizeType,
 };
 use crossbeam_channel::{Receiver, Sender, select, unbounded};
 use devtools_traits::{
@@ -121,7 +122,7 @@ use embedder_traits::resources::{self, Resource};
 use embedder_traits::{
     Cursor, EmbedderMsg, EmbedderProxy, ImeEvent, InputEvent, MediaSessionActionType,
     MediaSessionEvent, MediaSessionPlaybackState, MouseButton, MouseButtonAction, MouseButtonEvent,
-    Theme, TraversalDirection, WebDriverCommandMsg, WebDriverLoadStatus,
+    Theme, WebDriverCommandMsg, WebDriverLoadStatus,
 };
 use euclid::Size2D;
 use euclid::default::Size2D as UntypedSize2D;
@@ -139,14 +140,13 @@ use net_traits::{self, IpcSend, ReferrerPolicy, ResourceThreads};
 use profile_traits::{mem, time};
 use script_layout_interface::{LayoutFactory, ScriptThreadFactory};
 use script_traits::{
-    AnimationState, AnimationTickType, AuxiliaryWebViewCreationRequest,
-    AuxiliaryWebViewCreationResponse, BroadcastMsg, ConstellationInputEvent,
-    DiscardBrowsingContext, DocumentActivity, DocumentState, IFrameLoadInfo,
-    IFrameLoadInfoWithData, IFrameSandboxState, IFrameSizeMsg, Job, LoadData, LoadOrigin, LogEntry,
-    MessagePortMsg, NavigationHistoryBehavior, PortMessageTask, ProgressiveWebMetricType,
-    SWManagerMsg, SWManagerSenders, ScriptMsg as FromScriptMsg, ScriptThreadMessage,
-    ScriptToConstellationChan, ServiceWorkerManagerFactory, ServiceWorkerMsg,
-    StructuredSerializedData, UpdatePipelineIdReason, WindowSizeData, WindowSizeType,
+    AnimationState, AuxiliaryWebViewCreationRequest, AuxiliaryWebViewCreationResponse,
+    BroadcastMsg, ConstellationInputEvent, DiscardBrowsingContext, DocumentActivity, DocumentState,
+    IFrameLoadInfo, IFrameLoadInfoWithData, IFrameSandboxState, IFrameSizeMsg, Job, LoadData,
+    LoadOrigin, MessagePortMsg, NavigationHistoryBehavior, PortMessageTask,
+    ProgressiveWebMetricType, SWManagerMsg, SWManagerSenders, ScriptMsg as FromScriptMsg,
+    ScriptThreadMessage, ScriptToConstellationChan, ServiceWorkerManagerFactory, ServiceWorkerMsg,
+    StructuredSerializedData, UpdatePipelineIdReason,
 };
 use serde::{Deserialize, Serialize};
 use servo_config::{opts, pref};
@@ -161,7 +161,7 @@ use webgpu::{self, WebGPU, WebGPURequest, WebGPUResponse};
 use webrender::RenderApi;
 use webrender::RenderApiSender;
 use webrender_api::{DocumentId, ImageKey};
-use webrender_traits::{CompositorHitTestResult, ScrollState, WebrenderExternalImageRegistry};
+use webrender_traits::WebrenderExternalImageRegistry;
 
 use crate::browsingcontext::{
     AllBrowsingContextsIterator, BrowsingContext, FullyActiveBrowsingContextsIterator,

--- a/components/constellation/logging.rs
+++ b/components/constellation/logging.rs
@@ -12,11 +12,11 @@ use std::thread;
 
 use backtrace::Backtrace;
 use base::id::WebViewId;
-use compositing_traits::ConstellationMsg as FromCompositorMsg;
+use constellation_traits::{ConstellationMsg as FromCompositorMsg, LogEntry};
 use crossbeam_channel::Sender;
 use log::{Level, LevelFilter, Log, Metadata, Record};
 use parking_lot::ReentrantMutex;
-use script_traits::{LogEntry, ScriptMsg as FromScriptMsg, ScriptToConstellationChan};
+use script_traits::{ScriptMsg as FromScriptMsg, ScriptToConstellationChan};
 
 /// A logger directed at the constellation from content processes
 /// #[derive(Clone)]

--- a/components/constellation/pipeline.rs
+++ b/components/constellation/pipeline.rs
@@ -20,6 +20,7 @@ use base::id::{
 use bluetooth_traits::BluetoothRequest;
 use canvas_traits::webgl::WebGLPipeline;
 use compositing_traits::{CompositionPipeline, CompositorMsg, CompositorProxy};
+use constellation_traits::WindowSizeData;
 use crossbeam_channel::{Sender, unbounded};
 use devtools_traits::{DevtoolsControlMsg, ScriptToDevtoolsControlMsg};
 use fonts::{SystemFontServiceProxy, SystemFontServiceProxySender};
@@ -35,7 +36,7 @@ use profile_traits::{mem as profile_mem, time};
 use script_layout_interface::{LayoutFactory, ScriptThreadFactory};
 use script_traits::{
     AnimationState, DiscardBrowsingContext, DocumentActivity, InitialScriptState, LoadData,
-    NewLayoutInfo, SWManagerMsg, ScriptThreadMessage, ScriptToConstellationChan, WindowSizeData,
+    NewLayoutInfo, SWManagerMsg, ScriptThreadMessage, ScriptToConstellationChan,
 };
 use serde::{Deserialize, Serialize};
 use servo_config::opts::{self, Opts};

--- a/components/constellation/tracing.rs
+++ b/components/constellation/tracing.rs
@@ -46,7 +46,7 @@ mod from_compositor {
         };
     }
 
-    impl LogTarget for compositing_traits::ConstellationMsg {
+    impl LogTarget for constellation_traits::ConstellationMsg {
         fn log_target(&self) -> &'static str {
             match self {
                 Self::Exit => target!("Exit"),

--- a/components/layout_2020/display_list/clip_path.rs
+++ b/components/layout_2020/display_list/clip_path.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use app_units::Au;
+use base::id::ScrollTreeNodeId;
 use style::values::computed::basic_shape::{BasicShape, ClipPath};
 use style::values::computed::length_percentage::NonNegativeLengthPercentage;
 use style::values::computed::position::Position;
@@ -10,7 +11,6 @@ use style::values::generics::basic_shape::{GenericShapeRadius, ShapeBox, ShapeGe
 use style::values::generics::position::GenericPositionOrAuto;
 use webrender_api::ClipChainId;
 use webrender_api::units::{LayoutRect, LayoutSideOffsets, LayoutSize};
-use webrender_traits::display_list::ScrollTreeNodeId;
 
 use super::{BuilderForBoxFragment, DisplayList, compute_margin_box_radius, normalize_radii};
 

--- a/components/layout_2020/display_list/mod.rs
+++ b/components/layout_2020/display_list/mod.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 
 use app_units::Au;
 use base::WebRenderEpochToU16;
+use base::id::ScrollTreeNodeId;
 use embedder_traits::Cursor;
 use euclid::{Point2D, SideOffsets2D, Size2D, UnknownUnit};
 use fonts::GlyphStore;
@@ -35,9 +36,7 @@ use webrender_api::{
     self as wr, BorderDetails, BoxShadowClipMode, ClipChainId, CommonItemProperties,
     ImageRendering, NinePatchBorder, NinePatchBorderSource, units,
 };
-use webrender_traits::display_list::{
-    AxesScrollSensitivity, CompositorDisplayListInfo, ScrollTreeNodeId,
-};
+use webrender_traits::display_list::{AxesScrollSensitivity, CompositorDisplayListInfo};
 use wr::units::LayoutVector2D;
 
 use crate::context::LayoutContext;

--- a/components/layout_2020/display_list/stacking_context.rs
+++ b/components/layout_2020/display_list/stacking_context.rs
@@ -7,6 +7,7 @@ use std::cell::RefCell;
 use std::mem;
 
 use app_units::Au;
+use base::id::ScrollTreeNodeId;
 use base::print_tree::PrintTree;
 use euclid::SideOffsets2D;
 use euclid::default::{Point2D, Rect, Size2D};
@@ -27,7 +28,7 @@ use style::values::generics::transform::{self, GenericRotate, GenericScale, Gene
 use style::values::specified::box_::DisplayOutside;
 use webrender_api::units::{LayoutPoint, LayoutRect, LayoutTransform, LayoutVector2D};
 use webrender_api::{self as wr, BorderRadius};
-use webrender_traits::display_list::{AxesScrollSensitivity, ScrollTreeNodeId, ScrollableNodeInfo};
+use webrender_traits::display_list::{AxesScrollSensitivity, ScrollableNodeInfo};
 use wr::units::{LayoutPixel, LayoutSize};
 use wr::{ClipChainId, SpatialTreeItemKey, StickyOffsetBounds};
 

--- a/components/layout_thread_2020/Cargo.toml
+++ b/components/layout_thread_2020/Cargo.toml
@@ -17,6 +17,7 @@ tracing = ["dep:tracing", "layout/tracing"]
 [dependencies]
 app_units = { workspace = true }
 base = { workspace = true }
+constellation_traits = { workspace = true }
 embedder_traits = { workspace = true }
 euclid = { workspace = true }
 fnv = { workspace = true }

--- a/components/layout_thread_2020/lib.rs
+++ b/components/layout_thread_2020/lib.rs
@@ -17,6 +17,7 @@ use std::sync::{Arc, LazyLock};
 use app_units::Au;
 use base::Epoch;
 use base::id::{PipelineId, WebViewId};
+use constellation_traits::{ScrollState, UntrustedNodeAddress, WindowSizeData};
 use embedder_traits::resources::{self, Resource};
 use euclid::default::{Point2D as UntypedPoint2D, Rect as UntypedRect, Size2D as UntypedSize2D};
 use euclid::{Point2D, Scale, Size2D, Vector2D};
@@ -48,10 +49,7 @@ use script_layout_interface::{
     Layout, LayoutConfig, LayoutFactory, NodesFromPointQueryType, OffsetParentResponse, ReflowGoal,
     ReflowRequest, ReflowResult, TrustedNodeAddress,
 };
-use script_traits::{
-    DrawAPaintImageResult, PaintWorkletError, Painter, ScriptThreadMessage, UntrustedNodeAddress,
-    WindowSizeData,
-};
+use script_traits::{DrawAPaintImageResult, PaintWorkletError, Painter, ScriptThreadMessage};
 use servo_arc::Arc as ServoArc;
 use servo_config::opts::{self, DebugOptions};
 use servo_config::pref;
@@ -88,7 +86,7 @@ use stylo_atoms::Atom;
 use url::Url;
 use webrender_api::units::{DevicePixel, LayoutPixel};
 use webrender_api::{ExternalScrollId, HitTestFlags, units};
-use webrender_traits::{CrossProcessCompositorApi, ScrollState};
+use webrender_traits::CrossProcessCompositorApi;
 
 // This mutex is necessary due to syncronisation issues between two different types of thread-local storage
 // which manifest themselves when the layout thread tries to layout iframes in parallel with the main page
@@ -292,7 +290,7 @@ impl Layout for LayoutThread {
             .compositor_api
             .hit_test(Some(self.id.into()), client_point, flags);
 
-        results.iter().map(|result| result.node.into()).collect()
+        results.iter().map(|result| result.node).collect()
     }
 
     #[cfg_attr(

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -45,6 +45,7 @@ bincode = { workspace = true }
 bitflags = { workspace = true }
 bluetooth_traits = { workspace = true, optional = true }
 canvas_traits = { workspace = true }
+constellation_traits = { workspace = true }
 cbc = { workspace = true }
 cipher = { workspace = true }
 chrono = { workspace = true }

--- a/components/script/animations.rs
+++ b/components/script/animations.rs
@@ -7,10 +7,11 @@
 use std::cell::Cell;
 
 use base::id::PipelineId;
+use constellation_traits::UntrustedNodeAddress;
 use cssparser::ToCss;
 use fxhash::{FxHashMap, FxHashSet};
 use libc::c_void;
-use script_traits::{AnimationState as AnimationsPresentState, ScriptMsg, UntrustedNodeAddress};
+use script_traits::{AnimationState as AnimationsPresentState, ScriptMsg};
 use serde::{Deserialize, Serialize};
 use style::animation::{
     Animation, AnimationSetKey, AnimationState, DocumentAnimationSet, ElementAnimationSet,

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -19,6 +19,7 @@ use base::cross_process_instant::CrossProcessInstant;
 use base::id::WebViewId;
 use canvas_traits::webgl::{self, WebGLContextId, WebGLMsg};
 use chrono::Local;
+use constellation_traits::{AnimationTickType, CompositorHitTestResult};
 use content_security_policy::{self as csp, CspList, PolicyDisposition};
 use cookie::Cookie;
 use cssparser::match_ignore_ascii_case;
@@ -51,8 +52,7 @@ use profile_traits::ipc as profile_ipc;
 use profile_traits::time::TimerMetadataFrameType;
 use script_layout_interface::{PendingRestyle, TrustedNodeAddress};
 use script_traits::{
-    AnimationState, AnimationTickType, ConstellationInputEvent, DocumentActivity,
-    ProgressiveWebMetricType, ScriptMsg,
+    AnimationState, ConstellationInputEvent, DocumentActivity, ProgressiveWebMetricType, ScriptMsg,
 };
 use servo_arc::Arc;
 use servo_config::pref;
@@ -72,7 +72,6 @@ use uuid::Uuid;
 #[cfg(feature = "webgpu")]
 use webgpu::swapchain::WebGPUContextId;
 use webrender_api::units::DeviceIntRect;
-use webrender_traits::CompositorHitTestResult;
 
 use super::bindings::codegen::Bindings::XPathEvaluatorBinding::XPathEvaluatorMethods;
 use super::clipboardevent::ClipboardEventType;

--- a/components/script/dom/documentorshadowroot.rs
+++ b/components/script/dom/documentorshadowroot.rs
@@ -4,9 +4,9 @@
 
 use std::fmt;
 
+use constellation_traits::UntrustedNodeAddress;
 use euclid::default::Point2D;
 use script_layout_interface::{NodesFromPointQueryType, QueryMsg};
-use script_traits::UntrustedNodeAddress;
 use servo_arc::Arc;
 use style::invalidation::media_queries::{MediaListKey, ToMediaListKey};
 use style::media_queries::MediaList;

--- a/components/script/dom/history.rs
+++ b/components/script/dom/history.rs
@@ -6,8 +6,8 @@ use std::cell::Cell;
 use std::cmp::Ordering;
 
 use base::id::HistoryStateId;
+use constellation_traits::TraversalDirection;
 use dom_struct::dom_struct;
-use embedder_traits::TraversalDirection;
 use js::jsapi::Heap;
 use js::jsval::{JSVal, NullValue, UndefinedValue};
 use js::rust::{HandleValue, MutableHandleValue};

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -6,6 +6,7 @@ use std::cell::Cell;
 
 use base::id::{BrowsingContextId, PipelineId, WebViewId};
 use bitflags::bitflags;
+use constellation_traits::WindowSizeData;
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Prefix, local_name, namespace_url, ns};
 use js::rust::HandleObject;
@@ -14,7 +15,7 @@ use profile_traits::ipc as ProfiledIpc;
 use script_traits::IFrameSandboxState::{IFrameSandboxed, IFrameUnsandboxed};
 use script_traits::{
     IFrameLoadInfo, IFrameLoadInfoWithData, JsEvalResult, LoadData, LoadOrigin,
-    NavigationHistoryBehavior, NewLayoutInfo, ScriptMsg, UpdatePipelineIdReason, WindowSizeData,
+    NavigationHistoryBehavior, NewLayoutInfo, ScriptMsg, UpdatePipelineIdReason,
 };
 use servo_url::ServoUrl;
 use style::attr::{AttrValue, LengthOrPercentageOrAuto};

--- a/components/script/dom/mouseevent.rs
+++ b/components/script/dom/mouseevent.rs
@@ -5,11 +5,11 @@
 use std::cell::Cell;
 use std::default::Default;
 
+use constellation_traits::CompositorHitTestResult;
 use dom_struct::dom_struct;
 use euclid::default::Point2D;
 use js::rust::HandleObject;
 use servo_config::pref;
-use webrender_traits::CompositorHitTestResult;
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::Event_Binding::EventMethods;
 use crate::dom::bindings::codegen::Bindings::MouseEventBinding;

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -15,6 +15,9 @@ use std::{cmp, fmt, iter};
 use app_units::Au;
 use base::id::{BrowsingContextId, PipelineId};
 use bitflags::bitflags;
+use constellation_traits::{
+    UntrustedNodeAddress, UntrustedNodeAddress as CompositorUntrustedNodeAddress,
+};
 use devtools_traits::NodeInfo;
 use dom_struct::dom_struct;
 use euclid::default::{Rect, Size2D, Vector2D};
@@ -28,7 +31,7 @@ use script_layout_interface::{
     GenericLayoutData, HTMLCanvasData, HTMLMediaData, LayoutElementType, LayoutNodeType, QueryMsg,
     SVGSVGData, StyleData, TrustedNodeAddress,
 };
-use script_traits::{DocumentActivity, UntrustedNodeAddress};
+use script_traits::DocumentActivity;
 use selectors::matching::{
     MatchingContext, MatchingForInvalidation, MatchingMode, NeedsSelectorFlags,
     matches_selector_list,
@@ -44,7 +47,6 @@ use style::properties::ComputedValues;
 use style::selector_parser::{SelectorImpl, SelectorParser};
 use style::stylesheets::{Stylesheet, UrlExtraData};
 use uuid::Uuid;
-use webrender_traits::UntrustedNodeAddress as CompositorUntrustedNodeAddress;
 use xml5ever::serialize as xml_serialize;
 
 use super::globalscope::GlobalScope;

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -21,6 +21,7 @@ use base64::Engine;
 #[cfg(feature = "bluetooth")]
 use bluetooth_traits::BluetoothRequest;
 use canvas_traits::webgl::WebGLChan;
+use constellation_traits::{ScrollState, WindowSizeData, WindowSizeType};
 use crossbeam_channel::{Sender, unbounded};
 use cssparser::{Parser, ParserInput, SourceLocation};
 use devtools_traits::{ScriptToDevtoolsControlMsg, TimelineMarker, TimelineMarkerType};
@@ -61,7 +62,7 @@ use script_layout_interface::{
 };
 use script_traits::{
     DocumentState, LoadData, LoadOrigin, NavigationHistoryBehavior, ScriptMsg, ScriptThreadMessage,
-    ScriptToConstellationChan, StructuredSerializedData, WindowSizeData, WindowSizeType,
+    ScriptToConstellationChan, StructuredSerializedData,
 };
 use selectors::attr::CaseSensitivity;
 use servo_arc::Arc as ServoArc;
@@ -83,7 +84,7 @@ use stylo_atoms::Atom;
 use url::Position;
 use webrender_api::units::{DevicePixel, LayoutPixel};
 use webrender_api::{DocumentId, ExternalScrollId};
-use webrender_traits::{CrossProcessCompositorApi, ScrollState};
+use webrender_traits::CrossProcessCompositorApi;
 
 use super::bindings::codegen::Bindings::MessagePortBinding::StructuredSerializeOptions;
 use super::bindings::trace::HashMapTracedValues;

--- a/components/script/iframe_collection.rs
+++ b/components/script/iframe_collection.rs
@@ -6,10 +6,11 @@ use std::cell::Cell;
 use std::default::Default;
 
 use base::id::BrowsingContextId;
+use constellation_traits::{WindowSizeData, WindowSizeType};
 use euclid::{Scale, Size2D};
 use fnv::FnvHashMap;
 use script_layout_interface::IFrameSizes;
-use script_traits::{IFrameSizeMsg, WindowSizeData, WindowSizeType};
+use script_traits::IFrameSizeMsg;
 use style_traits::CSSPixel;
 use webrender_api::units::DevicePixel;
 

--- a/components/script/layout_dom/element.rs
+++ b/components/script/layout_dom/element.rs
@@ -7,13 +7,13 @@ use std::sync::atomic::Ordering;
 use std::{fmt, slice};
 
 use atomic_refcell::{AtomicRef, AtomicRefMut};
+use constellation_traits::UntrustedNodeAddress;
 use html5ever::{LocalName, Namespace, local_name, namespace_url, ns};
 use js::jsapi::JSObject;
 use script_layout_interface::wrapper_traits::{
     LayoutNode, PseudoElementType, ThreadSafeLayoutElement, ThreadSafeLayoutNode,
 };
 use script_layout_interface::{LayoutNodeType, StyleData};
-use script_traits::UntrustedNodeAddress;
 use selectors::attr::{AttrSelectorOperation, CaseSensitivity, NamespaceConstraint};
 use selectors::bloom::{BLOOM_HASH_MASK, BloomFilter};
 use selectors::matching::{ElementSelectorFlags, MatchingContext, VisitedHandlingMode};

--- a/components/script/navigation.rs
+++ b/components/script/navigation.rs
@@ -10,6 +10,7 @@ use std::cell::Cell;
 
 use base::cross_process_instant::CrossProcessInstant;
 use base::id::{BrowsingContextId, PipelineId, WebViewId};
+use constellation_traits::WindowSizeData;
 use content_security_policy::Destination;
 use crossbeam_channel::Sender;
 use http::header;
@@ -21,7 +22,7 @@ use net_traits::{
     BoxedFetchCallback, CoreResourceThread, DOCUMENT_ACCEPT_HEADER_VALUE, FetchResponseMsg,
     Metadata, fetch_async, set_default_accept_language,
 };
-use script_traits::{DocumentActivity, LoadData, WindowSizeData};
+use script_traits::{DocumentActivity, LoadData};
 use servo_url::{MutableOrigin, ServoUrl};
 
 use crate::fetch::FetchCanceller;

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -37,6 +37,7 @@ use base::cross_process_instant::CrossProcessInstant;
 use base::id::{BrowsingContextId, HistoryStateId, PipelineId, PipelineNamespace, WebViewId};
 use canvas_traits::webgl::WebGLPipeline;
 use chrono::{DateTime, Local};
+use constellation_traits::{CompositorHitTestResult, ScrollState, WindowSizeData, WindowSizeType};
 use crossbeam_channel::unbounded;
 use devtools_traits::{
     CSSError, DevtoolScriptControlMsg, DevtoolsPageInfo, NavigationState,
@@ -80,7 +81,7 @@ use script_traits::{
     ConstellationInputEvent, DiscardBrowsingContext, DocumentActivity, InitialScriptState,
     JsEvalResult, LoadData, LoadOrigin, NavigationHistoryBehavior, NewLayoutInfo, Painter,
     ProgressiveWebMetricType, ScriptMsg, ScriptThreadMessage, ScriptToConstellationChan,
-    StructuredSerializedData, UpdatePipelineIdReason, WindowSizeData, WindowSizeType,
+    StructuredSerializedData, UpdatePipelineIdReason,
 };
 use servo_config::opts;
 use servo_url::{ImmutableOrigin, MutableOrigin, ServoUrl};
@@ -92,7 +93,7 @@ use url::Position;
 #[cfg(feature = "webgpu")]
 use webgpu::{WebGPUDevice, WebGPUMsg};
 use webrender_api::DocumentId;
-use webrender_traits::{CompositorHitTestResult, CrossProcessCompositorApi, ScrollState};
+use webrender_traits::CrossProcessCompositorApi;
 
 use crate::document_collection::DocumentCollection;
 use crate::document_loader::DocumentLoader;

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -66,6 +66,7 @@ cfg-if = { workspace = true }
 compositing = { path = "../compositing" }
 compositing_traits = { workspace = true }
 constellation = { path = "../constellation" }
+constellation_traits = { workspace = true }
 crossbeam-channel = { workspace = true }
 devtools = { path = "../devtools" }
 devtools_traits = { workspace = true }

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -45,7 +45,7 @@ use canvas_traits::webgl::{GlType, WebGLThreads};
 use clipboard_delegate::StringRequest;
 use compositing::windowing::{EmbedderMethods, WindowMethods};
 use compositing::{IOCompositor, InitialCompositorState};
-use compositing_traits::{CompositorMsg, CompositorProxy, CompositorReceiver, ConstellationMsg};
+use compositing_traits::{CompositorMsg, CompositorProxy, CompositorReceiver};
 #[cfg(all(
     not(target_os = "windows"),
     not(target_os = "ios"),
@@ -59,6 +59,7 @@ use constellation::{
     Constellation, FromCompositorLogger, FromScriptLogger, InitialConstellationState,
     UnprivilegedContent,
 };
+use constellation_traits::{ConstellationMsg, WindowSizeData};
 use crossbeam_channel::{Receiver, Sender, unbounded};
 pub use embedder_traits::*;
 use env_logger::Builder as EnvLoggerBuilder;
@@ -85,7 +86,7 @@ use net::resource_thread::new_resource_threads;
 use profile::{mem as profile_mem, time as profile_time};
 use profile_traits::{mem, time};
 use script::{JSEngineSetup, ServiceWorkerManager};
-use script_traits::{ScriptToConstellationChan, WindowSizeData};
+use script_traits::ScriptToConstellationChan;
 use servo_config::opts::Opts;
 use servo_config::prefs::Preferences;
 use servo_config::{opts, pref, prefs};

--- a/components/servo/proxies.rs
+++ b/components/servo/proxies.rs
@@ -5,7 +5,7 @@
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use compositing_traits::ConstellationMsg;
+use constellation_traits::ConstellationMsg;
 use crossbeam_channel::{SendError, Sender};
 use log::warn;
 

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -10,11 +10,10 @@ use std::time::Duration;
 use base::id::WebViewId;
 use compositing::IOCompositor;
 use compositing::windowing::WebRenderDebugOption;
-use compositing_traits::ConstellationMsg;
+use constellation_traits::{ConstellationMsg, TraversalDirection};
 use dpi::PhysicalSize;
 use embedder_traits::{
     Cursor, InputEvent, LoadStatus, MediaSessionActionType, Theme, TouchEventType,
-    TraversalDirection,
 };
 use url::Url;
 use webrender_api::ScrollLocation;

--- a/components/servo/webview_delegate.rs
+++ b/components/servo/webview_delegate.rs
@@ -5,7 +5,7 @@
 use std::path::PathBuf;
 
 use base::id::PipelineId;
-use compositing_traits::ConstellationMsg;
+use constellation_traits::ConstellationMsg;
 use embedder_traits::{
     AllowOrDeny, AuthenticationResponse, ContextMenuResult, Cursor, FilterPattern,
     GamepadHapticEffectType, InputMethodType, LoadStatus, MediaSessionEvent, PermissionFeature,

--- a/components/shared/base/id.rs
+++ b/components/shared/base/id.rs
@@ -16,7 +16,7 @@ use malloc_size_of::malloc_size_of_is_0;
 use malloc_size_of_derive::MallocSizeOf;
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
-use webrender_api::{ExternalScrollId, PipelineId as WebRenderPipelineId};
+use webrender_api::{ExternalScrollId, PipelineId as WebRenderPipelineId, SpatialId};
 
 /// Asserts the size of a type at compile time.
 macro_rules! size_of_test {
@@ -442,3 +442,15 @@ pub const TEST_BROWSING_CONTEXT_ID: BrowsingContextId = BrowsingContextId {
 };
 
 pub const TEST_WEBVIEW_ID: WebViewId = WebViewId(TEST_BROWSING_CONTEXT_ID);
+
+/// An id for a ScrollTreeNode in the ScrollTree. This contains both the index
+/// to the node in the tree's array of nodes as well as the corresponding SpatialId
+/// for the SpatialNode in the WebRender display list.
+#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Serialize)]
+pub struct ScrollTreeNodeId {
+    /// The index of this scroll tree node in the tree's array of nodes.
+    pub index: usize,
+
+    /// The WebRender spatial id of this scroll tree node.
+    pub spatial_id: SpatialId,
+}

--- a/components/shared/compositing/lib.rs
+++ b/components/shared/compositing/lib.rs
@@ -2,14 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-//! Communication with the compositor thread.
-
-mod constellation_msg;
+//! The interface to the `compositing` crate.
 
 use std::fmt::{Debug, Error, Formatter};
 
 use base::id::{PipelineId, WebViewId};
-pub use constellation_msg::{ConstellationMsg, PaintMetricEvent};
 use crossbeam_channel::{Receiver, Sender};
 use embedder_traits::{EventLoopWaker, MouseButton, MouseButtonAction};
 use euclid::Rect;

--- a/components/shared/constellation/Cargo.toml
+++ b/components/shared/constellation/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "compositing_traits"
+name = "constellation_traits"
 version.workspace = true
 authors.workspace = true
 license.workspace = true
@@ -8,19 +8,19 @@ publish.workspace = true
 rust-version.workspace = true
 
 [lib]
-name = "compositing_traits"
+name = "constellation_traits"
 path = "lib.rs"
 
 [dependencies]
 base = { workspace = true }
-crossbeam-channel = { workspace = true }
+bitflags = { workspace = true }
 embedder_traits = { workspace = true }
 euclid = { workspace = true }
 ipc-channel = { workspace = true }
-log = { workspace = true }
-pixels = { path = '../../pixels' }
-script_traits = { workspace = true }
+malloc_size_of = { workspace = true }
+malloc_size_of_derive = { workspace = true }
+serde = { workspace = true }
+servo_url = { path = "../../url" }
 strum_macros = { workspace = true }
 stylo_traits = { workspace = true }
 webrender_api = { workspace = true }
-webrender_traits = { workspace = true }

--- a/components/shared/constellation/lib.rs
+++ b/components/shared/constellation/lib.rs
@@ -1,0 +1,224 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+//! The interface to the `Constellation`, which prevents other crates from depending directly on
+//! the `constellation` crate itself. In addition to all messages to the `Constellation`, this
+//! crate is responsible for defining types that cross the process boundary from the
+//! embedding/rendering layer all the way to script, thus it should have very minimal dependencies
+//! on other parts of Servo.
+
+use std::collections::HashMap;
+use std::ffi::c_void;
+use std::fmt;
+use std::time::Duration;
+
+use base::Epoch;
+use base::cross_process_instant::CrossProcessInstant;
+use base::id::{PipelineId, ScrollTreeNodeId, WebViewId};
+use bitflags::bitflags;
+use embedder_traits::{Cursor, InputEvent, MediaSessionActionType, Theme, WebDriverCommandMsg};
+use euclid::{Scale, Size2D, Vector2D};
+use ipc_channel::ipc::IpcSender;
+use malloc_size_of::malloc_size_of_is_0;
+use malloc_size_of_derive::MallocSizeOf;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use servo_url::ServoUrl;
+use strum_macros::IntoStaticStr;
+use style_traits::CSSPixel;
+use webrender_api::ExternalScrollId;
+use webrender_api::units::{DevicePixel, LayoutPixel};
+
+/// Messages to the constellation.
+#[derive(IntoStaticStr)]
+pub enum ConstellationMsg {
+    /// Exit the constellation.
+    Exit,
+    /// Request that the constellation send the current focused top-level browsing context id,
+    /// over a provided channel.
+    GetFocusTopLevelBrowsingContext(IpcSender<Option<WebViewId>>),
+    /// Query the constellation to see if the current compositor output is stable
+    IsReadyToSaveImage(HashMap<PipelineId, Epoch>),
+    /// Whether to allow script to navigate.
+    AllowNavigationResponse(PipelineId, bool),
+    /// Request to load a page.
+    LoadUrl(WebViewId, ServoUrl),
+    /// Clear the network cache.
+    ClearCache,
+    /// Request to traverse the joint session history of the provided browsing context.
+    TraverseHistory(WebViewId, TraversalDirection),
+    /// Inform the constellation of a window being resized.
+    WindowSize(WebViewId, WindowSizeData, WindowSizeType),
+    /// Inform the constellation of a theme change.
+    ThemeChange(Theme),
+    /// Requests that the constellation instruct layout to begin a new tick of the animation.
+    TickAnimation(PipelineId, AnimationTickType),
+    /// Dispatch a webdriver command
+    WebDriverCommand(WebDriverCommandMsg),
+    /// Reload a top-level browsing context.
+    Reload(WebViewId),
+    /// A log entry, with the top-level browsing context id and thread name
+    LogEntry(Option<WebViewId>, Option<String>, LogEntry),
+    /// Create a new top level browsing context.
+    NewWebView(ServoUrl, WebViewId),
+    /// Close a top level browsing context.
+    CloseWebView(WebViewId),
+    /// Panic a top level browsing context.
+    SendError(Option<WebViewId>, String),
+    /// Make a webview focused.
+    FocusWebView(WebViewId),
+    /// Make none of the webviews focused.
+    BlurWebView,
+    /// Forward an input event to an appropriate ScriptTask.
+    ForwardInputEvent(WebViewId, InputEvent, Option<CompositorHitTestResult>),
+    /// Requesting a change to the onscreen cursor.
+    SetCursor(WebViewId, Cursor),
+    /// Enable the sampling profiler, with a given sampling rate and max total sampling duration.
+    ToggleProfiler(Duration, Duration),
+    /// Request to exit from fullscreen mode
+    ExitFullScreen(WebViewId),
+    /// Media session action.
+    MediaSessionAction(MediaSessionActionType),
+    /// Set whether to use less resources, by stopping animations and running timers at a heavily limited rate.
+    SetWebViewThrottled(WebViewId, bool),
+    /// The Servo renderer scrolled and is updating the scroll states of the nodes in the
+    /// given pipeline via the constellation.
+    SetScrollStates(PipelineId, Vec<ScrollState>),
+    /// Notify the constellation that a particular paint metric event has happened for the given pipeline.
+    PaintMetric(PipelineId, PaintMetricEvent),
+}
+
+/// A description of a paint metric that is sent from the Servo renderer to the
+/// constellation.
+pub enum PaintMetricEvent {
+    FirstPaint(CrossProcessInstant, bool /* first_reflow */),
+    FirstContentfulPaint(CrossProcessInstant, bool /* first_reflow */),
+}
+
+impl fmt::Debug for ConstellationMsg {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let variant_string: &'static str = self.into();
+        write!(formatter, "ConstellationMsg::{variant_string}")
+    }
+}
+
+/// A log entry reported to the constellation
+/// We don't report all log entries, just serious ones.
+/// We need a separate type for this because `LogLevel` isn't serializable.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum LogEntry {
+    /// Panic, with a reason and backtrace
+    Panic(String, String),
+    /// Error, with a reason
+    Error(String),
+    /// warning, with a reason
+    Warn(String),
+}
+
+/// Data about the window size.
+#[derive(Clone, Copy, Debug, Deserialize, MallocSizeOf, PartialEq, Serialize)]
+pub struct WindowSizeData {
+    /// The size of the initial layout viewport, before parsing an
+    /// <http://www.w3.org/TR/css-device-adapt/#initial-viewport>
+    pub initial_viewport: Size2D<f32, CSSPixel>,
+
+    /// The resolution of the window in dppx, not including any "pinch zoom" factor.
+    pub device_pixel_ratio: Scale<f32, CSSPixel, DevicePixel>,
+}
+
+/// The type of window size change.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, MallocSizeOf, PartialEq, Serialize)]
+pub enum WindowSizeType {
+    /// Initial load.
+    Initial,
+    /// Window resize.
+    Resize,
+}
+
+bitflags! {
+    #[derive(Debug, Default, Deserialize, Serialize)]
+    /// Specifies if rAF should be triggered and/or CSS Animations and Transitions.
+    pub struct AnimationTickType: u8 {
+        /// Trigger a call to requestAnimationFrame.
+        const REQUEST_ANIMATION_FRAME = 0b001;
+        /// Trigger restyles for CSS Animations and Transitions.
+        const CSS_ANIMATIONS_AND_TRANSITIONS = 0b010;
+    }
+}
+
+/// The result of a hit test in the compositor.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct CompositorHitTestResult {
+    /// The pipeline id of the resulting item.
+    pub pipeline_id: PipelineId,
+
+    /// The hit test point in the item's viewport.
+    pub point_in_viewport: euclid::default::Point2D<f32>,
+
+    /// The hit test point relative to the item itself.
+    pub point_relative_to_item: euclid::default::Point2D<f32>,
+
+    /// The node address of the hit test result.
+    pub node: UntrustedNodeAddress,
+
+    /// The cursor that should be used when hovering the item hit by the hit test.
+    pub cursor: Option<Cursor>,
+
+    /// The scroll tree node associated with this hit test item.
+    pub scroll_tree_node: ScrollTreeNodeId,
+}
+
+/// The scroll state of a stacking context.
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
+pub struct ScrollState {
+    /// The ID of the scroll root.
+    pub scroll_id: ExternalScrollId,
+    /// The scrolling offset of this stacking context.
+    pub scroll_offset: Vector2D<f32, LayoutPixel>,
+}
+
+/// The address of a node. Layout sends these back. They must be validated via
+/// `from_untrusted_node_address` before they can be used, because we do not trust layout.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct UntrustedNodeAddress(pub *const c_void);
+
+malloc_size_of_is_0!(UntrustedNodeAddress);
+
+#[allow(unsafe_code)]
+unsafe impl Send for UntrustedNodeAddress {}
+
+impl From<style_traits::dom::OpaqueNode> for UntrustedNodeAddress {
+    fn from(o: style_traits::dom::OpaqueNode) -> Self {
+        UntrustedNodeAddress(o.0 as *const c_void)
+    }
+}
+
+impl Serialize for UntrustedNodeAddress {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        (self.0 as usize).serialize(s)
+    }
+}
+
+impl<'de> Deserialize<'de> for UntrustedNodeAddress {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<UntrustedNodeAddress, D::Error> {
+        let value: usize = Deserialize::deserialize(d)?;
+        Ok(UntrustedNodeAddress::from_id(value))
+    }
+}
+
+impl UntrustedNodeAddress {
+    /// Creates an `UntrustedNodeAddress` from the given pointer address value.
+    #[inline]
+    pub fn from_id(id: usize) -> UntrustedNodeAddress {
+        UntrustedNodeAddress(id as *const c_void)
+    }
+}
+
+/// The direction of a history traversal
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub enum TraversalDirection {
+    /// Travel forward the given number of documents.
+    Forward(usize),
+    /// Travel backward the given number of documents.
+    Back(usize),
+}

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -2,6 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+//! Types used by the embedding layer and/or exposed to the API. This crate is responsible for
+//! defining types that cross the process boundary from the embedding/rendering layer all the way
+//! to script, thus it should have very minimal dependencies on other parts of Servo. If a type
+//! is not exposed in the API or doesn't involve messages sent to the embedding/libservo layer, it
+//! is probably a better fit for the `constellation_traits` crate.
+
 pub mod input_events;
 pub mod resources;
 mod webdriver;
@@ -524,15 +530,6 @@ impl WebResourceResponse {
         self.status_message = status_message;
         self
     }
-}
-
-/// The direction of a history traversal
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
-pub enum TraversalDirection {
-    /// Travel forward the given number of documents.
-    Forward(usize),
-    /// Travel backward the given number of documents.
-    Back(usize),
 }
 
 /// The type of platform theme.

--- a/components/shared/script/Cargo.toml
+++ b/components/shared/script/Cargo.toml
@@ -21,6 +21,7 @@ base = { workspace = true }
 bitflags = { workspace = true }
 bluetooth_traits = { workspace = true, optional = true }
 canvas_traits = { workspace = true }
+constellation_traits = { workspace = true }
 cookie = { workspace = true }
 crossbeam-channel = { workspace = true }
 devtools_traits = { workspace = true }

--- a/components/shared/script/script_msg.rs
+++ b/components/shared/script/script_msg.rs
@@ -11,10 +11,9 @@ use base::id::{
     MessagePortRouterId, PipelineId, ServiceWorkerId, ServiceWorkerRegistrationId, WebViewId,
 };
 use canvas_traits::canvas::{CanvasId, CanvasMsg};
+use constellation_traits::{LogEntry, TraversalDirection};
 use devtools_traits::{ScriptToDevtoolsControlMsg, WorkerId};
-use embedder_traits::{
-    EmbedderMsg, MediaSessionEvent, TouchEventType, TouchSequenceId, TraversalDirection,
-};
+use embedder_traits::{EmbedderMsg, MediaSessionEvent, TouchEventType, TouchSequenceId};
 use euclid::Size2D;
 use euclid::default::Size2D as UntypedSize2D;
 use ipc_channel::ipc::{IpcReceiver, IpcSender};
@@ -53,19 +52,6 @@ pub enum TouchEventResult {
     DefaultAllowed(TouchSequenceId, TouchEventType),
     /// Prevented by web content
     DefaultPrevented(TouchSequenceId, TouchEventType),
-}
-
-/// A log entry reported to the constellation
-/// We don't report all log entries, just serious ones.
-/// We need a separate type for this because `LogLevel` isn't serializable.
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub enum LogEntry {
-    /// Panic, with a reason and backtrace
-    Panic(String, String),
-    /// Error, with a reason
-    Error(String),
-    /// warning, with a reason
-    Warn(String),
 }
 
 /// Messages from the script to the constellation.

--- a/components/shared/script/tests/compositor.rs
+++ b/components/shared/script/tests/compositor.rs
@@ -2,11 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use base::id::ScrollTreeNodeId;
 use euclid::Size2D;
 use webrender_api::units::LayoutVector2D;
 use webrender_api::{ExternalScrollId, PipelineId, ScrollLocation, SpatialId};
 use webrender_traits::display_list::{
-    AxesScrollSensitivity, ScrollSensitivity, ScrollTree, ScrollTreeNodeId, ScrollableNodeInfo,
+    AxesScrollSensitivity, ScrollSensitivity, ScrollTree, ScrollableNodeInfo,
 };
 
 fn add_mock_scroll_node(tree: &mut ScrollTree) -> ScrollTreeNodeId {

--- a/components/shared/script_layout/Cargo.toml
+++ b/components/shared/script_layout/Cargo.toml
@@ -16,6 +16,7 @@ base = { workspace = true }
 app_units = { workspace = true }
 atomic_refcell = { workspace = true }
 canvas_traits = { workspace = true }
+constellation_traits = { workspace = true }
 euclid = { workspace = true }
 fnv = { workspace = true }
 fonts = { path = "../../fonts" }

--- a/components/shared/script_layout/lib.rs
+++ b/components/shared/script_layout/lib.rs
@@ -20,6 +20,7 @@ use atomic_refcell::AtomicRefCell;
 use base::Epoch;
 use base::id::{BrowsingContextId, PipelineId, WebViewId};
 use canvas_traits::canvas::{CanvasId, CanvasMsg};
+use constellation_traits::{ScrollState, UntrustedNodeAddress, WindowSizeData};
 use euclid::Size2D;
 use euclid::default::{Point2D, Rect};
 use fnv::FnvHashMap;
@@ -30,10 +31,7 @@ use malloc_size_of_derive::MallocSizeOf;
 use net_traits::image_cache::{ImageCache, PendingImageId};
 use profile_traits::mem::Report;
 use profile_traits::time;
-use script_traits::{
-    InitialScriptState, LoadData, Painter, ScriptThreadMessage, UntrustedNodeAddress,
-    WindowSizeData,
-};
+use script_traits::{InitialScriptState, LoadData, Painter, ScriptThreadMessage};
 use serde::{Deserialize, Serialize};
 use servo_arc::Arc as ServoArc;
 use servo_url::{ImmutableOrigin, ServoUrl};
@@ -51,7 +49,7 @@ use style::selector_parser::{PseudoElement, RestyleDamage, Snapshot};
 use style::stylesheets::Stylesheet;
 use style_traits::CSSPixel;
 use webrender_api::ImageKey;
-use webrender_traits::{CrossProcessCompositorApi, ScrollState};
+use webrender_traits::CrossProcessCompositorApi;
 
 pub type GenericLayoutData = dyn Any + Send + Sync;
 

--- a/components/shared/webrender/Cargo.toml
+++ b/components/shared/webrender/Cargo.toml
@@ -17,6 +17,7 @@ no-wgl = ["surfman/sm-angle-default"]
 
 [dependencies]
 base = { workspace = true }
+constellation_traits = { workspace = true }
 embedder_traits = { workspace = true }
 euclid = { workspace = true }
 image = { workspace = true }

--- a/components/shared/webrender/display_list.rs
+++ b/components/shared/webrender/display_list.rs
@@ -4,6 +4,7 @@
 
 //! Defines data structures which are consumed by the Compositor.
 
+use base::id::ScrollTreeNodeId;
 use embedder_traits::Cursor;
 use serde::{Deserialize, Serialize};
 use style::values::specified::Overflow;
@@ -52,18 +53,6 @@ pub struct HitTestInfo {
 
     /// The id of the [ScrollTree] associated with this hit test item.
     pub scroll_tree_node: ScrollTreeNodeId,
-}
-
-/// An id for a ScrollTreeNode in the ScrollTree. This contains both the index
-/// to the node in the tree's array of nodes as well as the corresponding SpatialId
-/// for the SpatialNode in the WebRender display list.
-#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Serialize)]
-pub struct ScrollTreeNodeId {
-    /// The index of this scroll tree node in the tree's array of nodes.
-    pub index: usize,
-
-    /// The WebRender spatial id of this scroll tree node.
-    pub spatial_id: SpatialId,
 }
 
 /// Data stored for nodes in the [ScrollTree] that actually scroll,

--- a/components/shared/webrender/lib.rs
+++ b/components/shared/webrender/lib.rs
@@ -11,17 +11,15 @@ use core::fmt;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
-use base::id::{PipelineId, WebViewId};
-use display_list::{CompositorDisplayListInfo, ScrollTreeNodeId};
-use embedder_traits::Cursor;
-use euclid::Vector2D;
+use base::id::WebViewId;
+use constellation_traits::CompositorHitTestResult;
+use display_list::CompositorDisplayListInfo;
 use euclid::default::Size2D as UntypedSize2D;
 use ipc_channel::ipc::{self, IpcSender, IpcSharedMemory};
-use libc::c_void;
 use log::warn;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::{Deserialize, Serialize};
 use servo_geometry::{DeviceIndependentIntRect, DeviceIndependentIntSize};
-use webrender_api::units::{DevicePoint, LayoutPixel, LayoutPoint, TexelRect};
+use webrender_api::units::{DevicePoint, LayoutPoint, TexelRect};
 use webrender_api::{
     BuiltDisplayList, BuiltDisplayListDescriptor, ExternalImage, ExternalImageData,
     ExternalImageHandler, ExternalImageId, ExternalImageSource, ExternalScrollId,
@@ -479,64 +477,4 @@ impl From<SerializableImageData> for ImageData {
             SerializableImageData::External(image) => ImageData::External(image),
         }
     }
-}
-
-/// The address of a node. Layout sends these back. They must be validated via
-/// `from_untrusted_node_address` before they can be used, because we do not trust layout.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub struct UntrustedNodeAddress(pub *const c_void);
-
-#[allow(unsafe_code)]
-unsafe impl Send for UntrustedNodeAddress {}
-
-impl Serialize for UntrustedNodeAddress {
-    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
-        (self.0 as usize).serialize(s)
-    }
-}
-
-impl<'de> Deserialize<'de> for UntrustedNodeAddress {
-    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<UntrustedNodeAddress, D::Error> {
-        let value: usize = Deserialize::deserialize(d)?;
-        Ok(UntrustedNodeAddress::from_id(value))
-    }
-}
-
-impl UntrustedNodeAddress {
-    /// Creates an `UntrustedNodeAddress` from the given pointer address value.
-    #[inline]
-    pub fn from_id(id: usize) -> UntrustedNodeAddress {
-        UntrustedNodeAddress(id as *const c_void)
-    }
-}
-
-/// The result of a hit test in the compositor.
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct CompositorHitTestResult {
-    /// The pipeline id of the resulting item.
-    pub pipeline_id: PipelineId,
-
-    /// The hit test point in the item's viewport.
-    pub point_in_viewport: euclid::default::Point2D<f32>,
-
-    /// The hit test point relative to the item itself.
-    pub point_relative_to_item: euclid::default::Point2D<f32>,
-
-    /// The node address of the hit test result.
-    pub node: UntrustedNodeAddress,
-
-    /// The cursor that should be used when hovering the item hit by the hit test.
-    pub cursor: Option<Cursor>,
-
-    /// The scroll tree node associated with this hit test item.
-    pub scroll_tree_node: ScrollTreeNodeId,
-}
-
-/// The scroll state of a stacking context.
-#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
-pub struct ScrollState {
-    /// The ID of the scroll root.
-    pub scroll_id: ExternalScrollId,
-    /// The scrolling offset of this stacking context.
-    pub scroll_offset: Vector2D<f32, LayoutPixel>,
 }

--- a/components/webdriver_server/Cargo.toml
+++ b/components/webdriver_server/Cargo.toml
@@ -14,7 +14,7 @@ path = "lib.rs"
 [dependencies]
 base = { workspace = true }
 base64 = { workspace = true }
-compositing_traits = { workspace = true }
+constellation_traits = { workspace = true }
 cookie = { workspace = true }
 crossbeam-channel = { workspace = true }
 embedder_traits = { workspace = true }

--- a/components/webdriver_server/actions.rs
+++ b/components/webdriver_server/actions.rs
@@ -6,7 +6,7 @@ use std::collections::HashSet;
 use std::time::{Duration, Instant};
 use std::{cmp, thread};
 
-use compositing_traits::ConstellationMsg;
+use constellation_traits::ConstellationMsg;
 use embedder_traits::{MouseButtonAction, WebDriverCommandMsg, WebDriverScriptCommand};
 use ipc_channel::ipc;
 use keyboard_types::webdriver::KeyInputState;

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -19,13 +19,12 @@ use std::{env, fmt, mem, process, thread};
 use base::id::{BrowsingContextId, WebViewId};
 use base64::Engine;
 use capabilities::ServoCapabilities;
-use compositing_traits::ConstellationMsg;
+use constellation_traits::{ConstellationMsg, TraversalDirection};
 use cookie::{CookieBuilder, Expiration};
 use crossbeam_channel::{Receiver, Sender, after, select, unbounded};
 use embedder_traits::{
-    TraversalDirection, WebDriverCommandMsg, WebDriverCookieError, WebDriverFrameId,
-    WebDriverJSError, WebDriverJSResult, WebDriverJSValue, WebDriverLoadStatus,
-    WebDriverScriptCommand,
+    WebDriverCommandMsg, WebDriverCookieError, WebDriverFrameId, WebDriverJSError,
+    WebDriverJSResult, WebDriverJSValue, WebDriverLoadStatus, WebDriverScriptCommand,
 };
 use euclid::{Rect, Size2D};
 use http::method::Method;


### PR DESCRIPTION
This change creates a `constellation_traits` crate. Previously messages
to the `Constellation` were in the `compositing_traits` crate, which
came about organically. This change moves these to a new crate which
also contains data types that are used in both compositing/libservo and
script (ie types that cross the process boundary). The idea is similar
to `embedding_traits`, but this is meant for types *not* exposed to the
API.

This change allows deduplicating `UntrustedNodeAddress`, which
previously had two versions to avoid circular dependencies.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #35984.
- [x] These changes do not require tests because they just move data types to different crates.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
