### PR TITLE
compositor: Remove the script channel from the compositor

### DIFF
--- a/components/compositing/webview.rs
+++ b/components/compositing/webview.rs
@@ -17,7 +17,7 @@ use embedder_traits::{
 use euclid::{Point2D, Scale, Vector2D};
 use fnv::FnvHashSet;
 use log::{debug, warn};
-use script_traits::{AnimationState, ScriptThreadMessage, TouchEventResult};
+use script_traits::{AnimationState, TouchEventResult};
 use webrender::Transaction;
 use webrender_api::units::{DeviceIntPoint, DevicePoint, DeviceRect, LayoutVector2D};
 use webrender_api::{
@@ -158,10 +158,14 @@ impl WebView {
             }
         });
 
-        if let Some(pipeline) = details.pipeline.as_ref() {
-            let message = ScriptThreadMessage::SetScrollStates(pipeline_id, scroll_states);
-            let _ = pipeline.script_chan.send(message);
-        }
+        let _ = self
+            .global
+            .borrow()
+            .constellation_sender
+            .send(ConstellationMsg::SetScrollStates(
+                pipeline_id,
+                scroll_states,
+            ));
     }
 
     pub(crate) fn set_frame_tree_on_pipeline_details(

--- a/components/constellation/event_loop.rs
+++ b/components/constellation/event_loop.rs
@@ -38,9 +38,4 @@ impl EventLoop {
     pub fn send(&self, msg: ScriptThreadMessage) -> Result<(), Error> {
         self.script_chan.send(msg)
     }
-
-    /// The underlying channel to the script thread.
-    pub fn sender(&self) -> IpcSender<ScriptThreadMessage> {
-        self.script_chan.clone()
-    }
 }

--- a/components/constellation/pipeline.rs
+++ b/components/constellation/pipeline.rs
@@ -422,7 +422,6 @@ impl Pipeline {
         CompositionPipeline {
             id: self.id,
             webview_id: self.webview_id,
-            script_chan: self.event_loop.sender(),
         }
     }
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1876,16 +1876,12 @@ impl ScriptThread {
                 panic!("should have handled {:?} already", msg)
             },
             ScriptThreadMessage::SetScrollStates(pipeline_id, scroll_states) => {
-                self.handle_set_scroll_states_offsets(pipeline_id, scroll_states)
+                self.handle_set_scroll_states(pipeline_id, scroll_states)
             },
         }
     }
 
-    fn handle_set_scroll_states_offsets(
-        &self,
-        pipeline_id: PipelineId,
-        scroll_states: Vec<ScrollState>,
-    ) {
+    fn handle_set_scroll_states(&self, pipeline_id: PipelineId, scroll_states: Vec<ScrollState>) {
         let Some(window) = self.documents.borrow().find_window(pipeline_id) else {
             warn!("Received scroll states for closed pipeline {pipeline_id}");
             return;

--- a/components/shared/compositing/lib.rs
+++ b/components/shared/compositing/lib.rs
@@ -13,7 +13,7 @@ use euclid::Rect;
 use ipc_channel::ipc::IpcSender;
 use log::warn;
 use pixels::Image;
-use script_traits::{AnimationState, ScriptThreadMessage, TouchEventResult};
+use script_traits::{AnimationState, TouchEventResult};
 use strum_macros::IntoStaticStr;
 use style_traits::CSSPixel;
 use webrender_api::DocumentId;
@@ -102,7 +102,6 @@ pub struct SendableFrameTree {
 pub struct CompositionPipeline {
     pub id: PipelineId,
     pub webview_id: WebViewId,
-    pub script_chan: IpcSender<ScriptThreadMessage>,
 }
 
 impl Debug for CompositorMsg {


### PR DESCRIPTION
This is a clean up after #36062 and #35985. It removes the script
channel for each pipeline from the compositor. Now all messages are sent
via the `Constellation` first, which will allow breaking the dependency
on script in the compositor.

In addition, scroll states are actually sent via the `Constellation`,
which was an oversight from #36062. Finally, a typo in a method name is
fixed.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #35984.
- [x] These changes are covered by existing WPT tests and have no observable behavior effects.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
