### PR TITLE
Fix `willValidate` behavior for readonly inputs

### DIFF
--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -477,24 +477,6 @@ impl HTMLInputElement {
         textinput.set_content(value);
     }
 
-    fn does_readonly_apply(&self) -> bool {
-        matches!(
-            self.input_type(),
-            InputType::Text |
-                InputType::Search |
-                InputType::Url |
-                InputType::Tel |
-                InputType::Email |
-                InputType::Password |
-                InputType::Date |
-                InputType::Month |
-                InputType::Week |
-                InputType::Time |
-                InputType::DatetimeLocal |
-                InputType::Number
-        )
-    }
-
     fn does_minmaxlength_apply(&self) -> bool {
         matches!(
             self.input_type(),
@@ -2753,7 +2735,7 @@ impl Validatable for HTMLInputElement {
             InputType::Hidden | InputType::Button | InputType::Reset => false,
             _ => {
                 !(self.upcast::<Element>().disabled_state() ||
-                    (self.ReadOnly() && self.does_readonly_apply()) ||
+                    self.ReadOnly() ||
                     is_barred_by_datalist_ancestor(self.upcast()))
             },
         }

--- a/tests/wpt/meta/html/semantics/forms/constraints/form-validation-willValidate.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/constraints/form-validation-willValidate.html.ini
@@ -1,9 +1,0 @@
-[form-validation-willValidate.html]
-  [[INPUT in COLOR status\] Must be barred from the constraint validation if it is readonly]
-    expected: FAIL
-
-  [[INPUT in FILE status\] Must be barred from the constraint validation if it is readonly]
-    expected: FAIL
-
-  [[INPUT in SUBMIT status\] Must be barred from the constraint validation if it is readonly]
-    expected: FAIL


### PR DESCRIPTION
This PR fixes an issue where certain non-text form inputs failed the `willValidate` property test due to an unnecessary check in `is_instance_validatable`.  

### **What Changed?**  
- Removed the `does_readonly_apply()` check, as the HTML specification states that any input with the `readonly` attribute must be barred from constraint validation.  
- **Updated the expected test results** in the `.ini` file to match the correct behavior.  

### **Why?**  
- The HTML spec does not require checking if `readonly` applies to an input type for validation purposes.  
- The extra check (`does_readonly_apply()`) caused test failures in:  
  ```
  tests/wpt/meta/html/semantics/forms/constraints/form-validation-willValidate.html.ini
  ```
- Updating the test expectations ensures the tests reflect the correct behavior.  

### **How to Test?**  
Run the following command to verify the fix and updated expectations:  
```sh
./mach test-wpt tests/wpt/tests/html/semantics/forms/constraints/form-validation-willValidate.html
```
✅ Expected result: **All previously failing tests should now pass.**  

### **References**  
- [Servo Testing Guide - Updating WPT Expectations](https://book.servo.org/hacking/testing.html#updating-web-platform-test-expectations)
- [HTML Spec - Readonly and Constraint Validation](https://html.spec.whatwg.org/multipage/)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #36076

<!-- Either: -->
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
