### PR TITLE
crown: Do not check trait item projections.

### DIFF
--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -127,7 +127,6 @@ impl LayoutCanvasRenderingContextHelpers for LayoutDom<'_, CanvasRenderingContex
 impl CanvasContext for CanvasRenderingContext2D {
     type ID = CanvasId;
 
-    #[cfg_attr(crown, allow(crown::unrooted_must_root))] // Crown is wrong here #35570
     fn context_id(&self) -> Self::ID {
         self.canvas_state.get_canvas_id()
     }

--- a/components/script/dom/testbindingmaplikewithinterface.rs
+++ b/components/script/dom/testbindingmaplikewithinterface.rs
@@ -89,9 +89,6 @@ impl TestBindingMaplikeWithInterfaceMethods<crate::DomTypeHolder>
     }
 }
 
-// this error is wrong because if we inline Self::Key and Self::Value all errors are gone
-// TODO: FIX THIS
-#[cfg_attr(crown, allow(crown::unrooted_must_root))]
 impl Maplike for TestBindingMaplikeWithInterface {
     type Key = DOMString;
     type Value = DomRoot<TestBinding>;

--- a/components/script/dom/testbindingmaplikewithprimitive.rs
+++ b/components/script/dom/testbindingmaplikewithprimitive.rs
@@ -87,9 +87,6 @@ impl TestBindingMaplikeWithPrimitiveMethods<crate::DomTypeHolder>
     }
 }
 
-// this error is wrong because if we inline Self::Key and Self::Value all errors are gone
-// TODO: FIX THIS
-#[cfg_attr(crown, allow(crown::unrooted_must_root))]
 impl Maplike for TestBindingMaplikeWithPrimitive {
     type Key = DOMString;
     type Value = i32;

--- a/components/script/dom/testbindingsetlikewithinterface.rs
+++ b/components/script/dom/testbindingsetlikewithinterface.rs
@@ -61,9 +61,6 @@ impl TestBindingSetlikeWithInterfaceMethods<crate::DomTypeHolder>
     }
 }
 
-// this error is wrong because if we inline Self::Key and Self::Value all errors are gone
-// TODO: FIX THIS
-#[cfg_attr(crown, allow(crown::unrooted_must_root))]
 impl Setlike for TestBindingSetlikeWithInterface {
     type Key = DomRoot<TestBinding>;
 

--- a/components/script/dom/testbindingsetlikewithprimitive.rs
+++ b/components/script/dom/testbindingsetlikewithprimitive.rs
@@ -61,9 +61,6 @@ impl TestBindingSetlikeWithPrimitiveMethods<crate::DomTypeHolder>
     }
 }
 
-// this error is wrong because if we inline Self::Key and Self::Value all errors are gone
-// TODO: FIX THIS
-#[cfg_attr(crown, allow(crown::unrooted_must_root))]
 impl Setlike for TestBindingSetlikeWithPrimitive {
     type Key = DOMString;
 

--- a/components/script/dom/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl2renderingcontext.rs
@@ -903,7 +903,6 @@ impl WebGL2RenderingContext {
 impl CanvasContext for WebGL2RenderingContext {
     type ID = WebGLContextId;
 
-    #[cfg_attr(crown, allow(crown::unrooted_must_root))] // Crown is wrong here #35570
     fn context_id(&self) -> Self::ID {
         self.base.context_id()
     }

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -1864,7 +1864,6 @@ impl WebGLRenderingContext {
 impl CanvasContext for WebGLRenderingContext {
     type ID = WebGLContextId;
 
-    #[cfg_attr(crown, allow(crown::unrooted_must_root))] // Crown is wrong here #35570
     fn context_id(&self) -> Self::ID {
         self.webgl_sender.context_id()
     }

--- a/components/script/dom/webgpu/gpucanvascontext.rs
+++ b/components/script/dom/webgpu/gpucanvascontext.rs
@@ -253,7 +253,6 @@ impl GPUCanvasContext {
 impl CanvasContext for GPUCanvasContext {
     type ID = WebGPUContextId;
 
-    #[cfg_attr(crown, allow(crown::unrooted_must_root))] // Crown is wrong here #35570
     fn context_id(&self) -> WebGPUContextId {
         self.context_id
     }

--- a/components/script/dom/webgpu/gpusupportedfeatures.rs
+++ b/components/script/dom/webgpu/gpusupportedfeatures.rs
@@ -139,8 +139,6 @@ pub(crate) fn gpu_to_wgt_feature(feature: GPUFeatureName) -> Option<Features> {
     }
 }
 
-// this error is wrong because if we inline Self::Key and Self::Value all errors are gone
-#[cfg_attr(crown, allow(crown::unrooted_must_root))]
 impl Setlike for GPUSupportedFeatures {
     type Key = DOMString;
 

--- a/components/script/dom/webgpu/wgsllanguagefeatures.rs
+++ b/components/script/dom/webgpu/wgsllanguagefeatures.rs
@@ -54,8 +54,6 @@ impl WGSLLanguageFeaturesMethods<crate::DomTypeHolder> for WGSLLanguageFeatures 
     }
 }
 
-// this error is wrong because if we inline Self::Key and Self::Value all errors are gone
-#[cfg_attr(crown, allow(crown::unrooted_must_root))]
 impl Setlike for WGSLLanguageFeatures {
     type Key = DOMString;
 

--- a/support/crown/tests/run-pass/alias-projection-ignored.rs
+++ b/support/crown/tests/run-pass/alias-projection-ignored.rs
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+//@rustc-env:RUSTC_BOOTSTRAP=1
+
+#![allow(dead_code)]
+
+fn main() {}
+
+struct CanvasId(u64);
+
+trait CanvasContext {
+    type ID;
+
+    fn context_id(&self) -> Self::ID;
+}
+
+#[crown::unrooted_must_root_lint::must_root]
+struct Context;
+
+impl CanvasContext for Context {
+    type ID = CanvasId;
+
+    fn context_id(&self) -> Self::ID { CanvasId(0) }
+}


### PR DESCRIPTION
When crown recurses on a trait method like `fn id(&self) -> Self::ID`, the `Self::ID` is an alias type that is a projection. The type walker will first consider the alias, then recurse to the Self type. This is overly conservative, since it doesn't matter if the Self type must be rooted, since we're only referring to an associated item here.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #35570
- [x] There are tests for these changes