### PR TITLE
script: Support converting JS values to Rc<Promise> with FromJSValConvertible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4702,7 +4702,7 @@ dependencies = [
 [[package]]
 name = "mozjs"
 version = "0.14.1"
-source = "git+https://github.com/servo/mozjs#26c35182c1b2b7fb2fbfa93b82669533d92c3a60"
+source = "git+https://github.com/servo/mozjs#39db84352d79ffa3e4fe756c8034af9def788f22"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -4714,7 +4714,7 @@ dependencies = [
 [[package]]
 name = "mozjs_sys"
 version = "0.128.9-0"
-source = "git+https://github.com/servo/mozjs#26c35182c1b2b7fb2fbfa93b82669533d92c3a60"
+source = "git+https://github.com/servo/mozjs#39db84352d79ffa3e4fe756c8034af9def788f22"
 dependencies = [
  "bindgen 0.71.1",
  "cc",

--- a/components/script/dom/testbinding.rs
+++ b/components/script/dom/testbinding.rs
@@ -910,6 +910,7 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
     fn FuncControlledMethodDisabled(&self) {}
     fn FuncControlledMethodEnabled(&self) {}
 
+    fn PassRecordPromise(&self, _: Record<DOMString, Rc<Promise>>) {}
     fn PassRecord(&self, _: Record<DOMString, i32>) {}
     fn PassRecordWithUSVStringKey(&self, _: Record<USVString, i32>) {}
     fn PassRecordWithByteStringKey(&self, _: Record<ByteString, i32>) {}

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -490,7 +490,7 @@ DOMInterfaces = {
 
 'Promise': {
     'spiderMonkeyInterface': True,
-    'additionalTraits': ["crate::dom::promise::PromiseHelpers<Self>"]
+    'additionalTraits': ["crate::dom::promise::PromiseHelpers<Self>", "js::conversions::FromJSValConvertibleRc"]
 },
 
 'Range': {

--- a/components/script_bindings/webidls/TestBinding.webidl
+++ b/components/script_bindings/webidls/TestBinding.webidl
@@ -479,6 +479,7 @@ interface TestBinding {
   sequence<sequence<long>> returnSequenceSequence();
   undefined passUnionSequenceSequence((long or sequence<sequence<long>>) seq);
 
+  undefined passRecordPromise(record<DOMString, Promise<undefined>> arg);
   undefined passRecord(record<DOMString, long> arg);
   undefined passRecordWithUSVStringKey(record<USVString, long> arg);
   undefined passRecordWithByteStringKey(record<ByteString, long> arg);


### PR DESCRIPTION
Depends on https://github.com/servo/mozjs/pull/568.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #36086
- [x] There are tests for these changes