### PR TITLE
Add patch definition for html5ever crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -212,6 +212,12 @@ codegen-units = 1
 #
 #     <crate> = { path = "/path/to/local/checkout" }
 #
+# For html5ever:
+#
+# markup5ever = { path = "../html5ever/markup5ever" }
+# html5ever = { path = "../html5ever/html5ever" }
+# xml5ever = { path = "../html5ever/xml5ever" }
+#
 # Or for Stylo:
 #
 # [patch."https://github.com/servo/stylo"]


### PR DESCRIPTION
I find myself frequently needing to build with a local html5ever version. We have similar blocks for stylo and webrender, and I think it makes sense to have them for every group of dependencies that is owned by servo.

