### PR TITLE
script: Ensure promises are considered DOM interfaces when generating bindings.

### DIFF
--- a/components/script_bindings/codegen/CodegenRust.py
+++ b/components/script_bindings/codegen/CodegenRust.py
@@ -74,7 +74,7 @@ def isDomInterface(t, logging=False):
         t = t.inner
     if isinstance(t, IDLInterface):
         return True
-    if t.isCallback():
+    if t.isCallback() or t.isPromise():
         return True
     return t.isInterface() and (t.isGeckoInterface() or (t.isSpiderMonkeyInterface() and not t.isBufferSource()))
 
@@ -88,12 +88,12 @@ def containsDomInterface(t, logging=False):
         t = t.inner
     if t.isEnum():
         return False
-    if isDomInterface(t):
-        return True
     if t.isUnion():
         return any(map(lambda x: containsDomInterface(x), t.flatMemberTypes))
     if t.isDictionary():
         return any(map(lambda x: containsDomInterface(x), t.members)) or (t.parent and containsDomInterface(t.parent))
+    if isDomInterface(t):
+        return True
     if t.isSequence():
         return containsDomInterface(t.inner)
     return False

--- a/components/script_bindings/webidls/TestBinding.webidl
+++ b/components/script_bindings/webidls/TestBinding.webidl
@@ -616,3 +616,5 @@ namespace TestNS {
     const unsigned long ONE   = 1;
     const unsigned long TWO   = 0x2;
 };
+
+typedef Promise<undefined> PromiseUndefined;


### PR DESCRIPTION
Promises in the generated bindings rely on the `<D: DomTypes>` generics which is driven by the containsDomType function. In code that only considers the Promise type (such as a typedef), we were not adding the generics correctly because promises were not considered DOM types.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #36083
- [x] There are tests for these changes