### PR TITLE
Add CanGc to new_js_regex and matches_js_regex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,6 @@
 [workspace]
 resolver = "2"
-members = [
-    "ports/servoshell",
+members = ["ports/servoshell",
     "tests/unit/*",
 ]
 default-members = ["ports/servoshell"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
-members = ["ports/servoshell",
+members = [
+    "ports/servoshell",
     "tests/unit/*",
 ]
 default-members = ["ports/servoshell"]

--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -437,7 +437,7 @@ pub(crate) fn handle_modify_attribute(
                     can_gc,
                 );
             },
-            None => elem.RemoveAttribute(DOMString::from(modification.attribute_name), can_gc),
+            None => elem.RemoveAttribute(DOMString::from(modification.attribute_name)),
         }
     }
 }

--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -437,7 +437,7 @@ pub(crate) fn handle_modify_attribute(
                     can_gc,
                 );
             },
-            None => elem.RemoveAttribute(DOMString::from(modification.attribute_name)),
+            None => elem.RemoveAttribute(DOMString::from(modification.attribute_name), can_gc),
         }
     }
 }

--- a/components/script/dom/attr.rs
+++ b/components/script/dom/attr.rs
@@ -112,10 +112,10 @@ impl AttrMethods<crate::DomTypeHolder> for Attr {
     }
 
     // https://dom.spec.whatwg.org/#dom-attr-value
-    fn SetValue(&self, value: DOMString, can_gc: CanGc) {
+    fn SetValue(&self, value: DOMString) {
         if let Some(owner) = self.owner() {
             let value = owner.parse_attribute(self.namespace(), self.local_name(), value);
-            self.set_value(value, &owner, can_gc);
+            self.set_value(value, &owner, CanGc::note());
         } else {
             *self.value.borrow_mut() = AttrValue::String(value.into());
         }

--- a/components/script/dom/characterdata.rs
+++ b/components/script/dom/characterdata.rs
@@ -260,9 +260,9 @@ impl CharacterDataMethods<crate::DomTypeHolder> for CharacterData {
     }
 
     // https://dom.spec.whatwg.org/#dom-childnode-remove
-    fn Remove(&self) {
+    fn Remove(&self, can_gc: CanGc) {
         let node = self.upcast::<Node>();
-        node.remove_self();
+        node.remove_self(can_gc);
     }
 
     // https://dom.spec.whatwg.org/#dom-nondocumenttypechildnode-previouselementsibling

--- a/components/script/dom/characterdata.rs
+++ b/components/script/dom/characterdata.rs
@@ -260,9 +260,9 @@ impl CharacterDataMethods<crate::DomTypeHolder> for CharacterData {
     }
 
     // https://dom.spec.whatwg.org/#dom-childnode-remove
-    fn Remove(&self, can_gc: CanGc) {
+    fn Remove(&self) {
         let node = self.upcast::<Node>();
-        node.remove_self(can_gc);
+        node.remove_self(CanGc::note());
     }
 
     // https://dom.spec.whatwg.org/#dom-nondocumenttypechildnode-previouselementsibling

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -878,7 +878,7 @@ pub(crate) fn upgrade_element(
             // We know this element is is form-associated, so we can use the implementation of
             // `FormControl` for HTMLElement, which makes that assumption.
             // Step 9.1: Reset the form owner of element
-            html_element.reset_form_owner();
+            html_element.reset_form_owner(can_gc);
             if let Some(form) = html_element.form_owner() {
                 // Even though the tree hasn't structurally mutated,
                 // HTMLCollections need to be invalidated.

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -2248,13 +2248,13 @@ impl Document {
             for node in nodes {
                 match node {
                     NodeOrString::Node(node) => {
-                        fragment.AppendChild(&node, can_gc)?;
+                        fragment.AppendChild(&node)?;
                     },
                     NodeOrString::String(string) => {
                         let node = DomRoot::upcast::<Node>(self.CreateTextNode(string, can_gc));
                         // No try!() here because appending a text node
                         // should not fail.
-                        fragment.AppendChild(&node, can_gc).unwrap();
+                        fragment.AppendChild(&node).unwrap();
                     },
                 }
             }
@@ -5211,7 +5211,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
     }
 
     // https://dom.spec.whatwg.org/#dom-document-adoptnode
-    fn AdoptNode(&self, node: &Node, can_gc: CanGc) -> Fallible<DomRoot<Node>> {
+    fn AdoptNode(&self, node: &Node) -> Fallible<DomRoot<Node>> {
         // Step 1.
         if node.is::<Document>() {
             return Err(Error::NotSupported);
@@ -5223,7 +5223,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
         }
 
         // Step 3.
-        Node::adopt(node, self, can_gc);
+        Node::adopt(node, self, CanGc::note());
 
         // Step 4.
         Ok(DomRoot::from_ref(node))
@@ -5358,7 +5358,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
                     let parent = root.upcast::<Node>();
                     let child = elem.upcast::<Node>();
                     parent
-                        .InsertBefore(child, parent.GetFirstChild().as_deref(), can_gc)
+                        .InsertBefore(child, parent.GetFirstChild().as_deref())
                         .unwrap()
                 },
             }
@@ -5381,9 +5381,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
                             None,
                             can_gc,
                         );
-                        head.upcast::<Node>()
-                            .AppendChild(elem.upcast(), can_gc)
-                            .unwrap()
+                        head.upcast::<Node>().AppendChild(elem.upcast()).unwrap()
                     },
                     None => return,
                 },
@@ -5430,7 +5428,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-document-body
-    fn SetBody(&self, new_body: Option<&HTMLElement>, can_gc: CanGc) -> ErrorResult {
+    fn SetBody(&self, new_body: Option<&HTMLElement>) -> ErrorResult {
         // Step 1.
         let new_body = match new_body {
             Some(new_body) => new_body,
@@ -5456,7 +5454,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
             // Step 3.
             (Some(ref root), Some(child)) => {
                 let root = root.upcast::<Node>();
-                root.ReplaceChild(new_body.upcast(), child.upcast(), can_gc)
+                root.ReplaceChild(new_body.upcast(), child.upcast())
                     .unwrap();
             },
 
@@ -5466,7 +5464,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
             // Step 5.
             (Some(ref root), &None) => {
                 let root = root.upcast::<Node>();
-                root.AppendChild(new_body.upcast(), can_gc).unwrap();
+                root.AppendChild(new_body.upcast()).unwrap();
             },
         }
         Ok(())

--- a/components/script/dom/documenttype.rs
+++ b/components/script/dom/documenttype.rs
@@ -103,7 +103,7 @@ impl DocumentTypeMethods<crate::DomTypeHolder> for DocumentType {
     }
 
     // https://dom.spec.whatwg.org/#dom-childnode-remove
-    fn Remove(&self) {
-        self.upcast::<Node>().remove_self();
+    fn Remove(&self, can_gc: CanGc) {
+        self.upcast::<Node>().remove_self(can_gc);
     }
 }

--- a/components/script/dom/documenttype.rs
+++ b/components/script/dom/documenttype.rs
@@ -103,7 +103,7 @@ impl DocumentTypeMethods<crate::DomTypeHolder> for DocumentType {
     }
 
     // https://dom.spec.whatwg.org/#dom-childnode-remove
-    fn Remove(&self, can_gc: CanGc) {
-        self.upcast::<Node>().remove_self(can_gc);
+    fn Remove(&self) {
+        self.upcast::<Node>().remove_self(CanGc::note());
     }
 }

--- a/components/script/dom/domimplementation.rs
+++ b/components/script/dom/domimplementation.rs
@@ -137,12 +137,12 @@ impl DOMImplementationMethods<crate::DomTypeHolder> for DOMImplementation {
 
             // Step 4.
             if let Some(doc_type) = maybe_doctype {
-                doc_node.AppendChild(doc_type.upcast(), can_gc).unwrap();
+                doc_node.AppendChild(doc_type.upcast()).unwrap();
             }
 
             // Step 5.
             if let Some(ref elem) = maybe_elem {
-                doc_node.AppendChild(elem.upcast(), can_gc).unwrap();
+                doc_node.AppendChild(elem.upcast()).unwrap();
             }
         }
 
@@ -183,7 +183,7 @@ impl DOMImplementationMethods<crate::DomTypeHolder> for DOMImplementation {
             // Step 3.
             let doc_node = doc.upcast::<Node>();
             let doc_type = DocumentType::new(DOMString::from("html"), None, None, &doc, can_gc);
-            doc_node.AppendChild(doc_type.upcast(), can_gc).unwrap();
+            doc_node.AppendChild(doc_type.upcast()).unwrap();
         }
 
         {
@@ -196,9 +196,7 @@ impl DOMImplementationMethods<crate::DomTypeHolder> for DOMImplementation {
                 None,
                 can_gc,
             ));
-            doc_node
-                .AppendChild(&doc_html, can_gc)
-                .expect("Appending failed");
+            doc_node.AppendChild(&doc_html).expect("Appending failed");
 
             {
                 // Step 5.
@@ -209,7 +207,7 @@ impl DOMImplementationMethods<crate::DomTypeHolder> for DOMImplementation {
                     None,
                     can_gc,
                 ));
-                doc_html.AppendChild(&doc_head, can_gc).unwrap();
+                doc_html.AppendChild(&doc_head).unwrap();
 
                 // Step 6.
                 if let Some(title_str) = title {
@@ -221,17 +219,17 @@ impl DOMImplementationMethods<crate::DomTypeHolder> for DOMImplementation {
                         None,
                         can_gc,
                     ));
-                    doc_head.AppendChild(&doc_title, can_gc).unwrap();
+                    doc_head.AppendChild(&doc_title).unwrap();
 
                     // Step 6.2.
                     let title_text = Text::new(title_str, &doc, can_gc);
-                    doc_title.AppendChild(title_text.upcast(), can_gc).unwrap();
+                    doc_title.AppendChild(title_text.upcast()).unwrap();
                 }
             }
 
             // Step 7.
             let doc_body = HTMLBodyElement::new(local_name!("body"), None, &doc, None, can_gc);
-            doc_html.AppendChild(doc_body.upcast(), can_gc).unwrap();
+            doc_html.AppendChild(doc_body.upcast()).unwrap();
         }
 
         // Step 8.

--- a/components/script/dom/domimplementation.rs
+++ b/components/script/dom/domimplementation.rs
@@ -137,12 +137,12 @@ impl DOMImplementationMethods<crate::DomTypeHolder> for DOMImplementation {
 
             // Step 4.
             if let Some(doc_type) = maybe_doctype {
-                doc_node.AppendChild(doc_type.upcast()).unwrap();
+                doc_node.AppendChild(doc_type.upcast(), can_gc).unwrap();
             }
 
             // Step 5.
             if let Some(ref elem) = maybe_elem {
-                doc_node.AppendChild(elem.upcast()).unwrap();
+                doc_node.AppendChild(elem.upcast(), can_gc).unwrap();
             }
         }
 
@@ -183,7 +183,7 @@ impl DOMImplementationMethods<crate::DomTypeHolder> for DOMImplementation {
             // Step 3.
             let doc_node = doc.upcast::<Node>();
             let doc_type = DocumentType::new(DOMString::from("html"), None, None, &doc, can_gc);
-            doc_node.AppendChild(doc_type.upcast()).unwrap();
+            doc_node.AppendChild(doc_type.upcast(), can_gc).unwrap();
         }
 
         {
@@ -196,7 +196,9 @@ impl DOMImplementationMethods<crate::DomTypeHolder> for DOMImplementation {
                 None,
                 can_gc,
             ));
-            doc_node.AppendChild(&doc_html).expect("Appending failed");
+            doc_node
+                .AppendChild(&doc_html, can_gc)
+                .expect("Appending failed");
 
             {
                 // Step 5.
@@ -207,7 +209,7 @@ impl DOMImplementationMethods<crate::DomTypeHolder> for DOMImplementation {
                     None,
                     can_gc,
                 ));
-                doc_html.AppendChild(&doc_head).unwrap();
+                doc_html.AppendChild(&doc_head, can_gc).unwrap();
 
                 // Step 6.
                 if let Some(title_str) = title {
@@ -219,17 +221,17 @@ impl DOMImplementationMethods<crate::DomTypeHolder> for DOMImplementation {
                         None,
                         can_gc,
                     ));
-                    doc_head.AppendChild(&doc_title).unwrap();
+                    doc_head.AppendChild(&doc_title, can_gc).unwrap();
 
                     // Step 6.2.
                     let title_text = Text::new(title_str, &doc, can_gc);
-                    doc_title.AppendChild(title_text.upcast()).unwrap();
+                    doc_title.AppendChild(title_text.upcast(), can_gc).unwrap();
                 }
             }
 
             // Step 7.
             let doc_body = HTMLBodyElement::new(local_name!("body"), None, &doc, None, can_gc);
-            doc_html.AppendChild(doc_body.upcast()).unwrap();
+            doc_html.AppendChild(doc_body.upcast(), can_gc).unwrap();
         }
 
         // Step 8.

--- a/components/script/dom/domstringmap.rs
+++ b/components/script/dom/domstringmap.rs
@@ -39,8 +39,8 @@ impl DOMStringMap {
 // https://html.spec.whatwg.org/multipage/#domstringmap
 impl DOMStringMapMethods<crate::DomTypeHolder> for DOMStringMap {
     // https://html.spec.whatwg.org/multipage/#dom-domstringmap-removeitem
-    fn NamedDeleter(&self, name: DOMString) {
-        self.element.delete_custom_attr(name)
+    fn NamedDeleter(&self, name: DOMString, can_gc: CanGc) {
+        self.element.delete_custom_attr(name, can_gc)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-domstringmap-setitem

--- a/components/script/dom/domstringmap.rs
+++ b/components/script/dom/domstringmap.rs
@@ -39,8 +39,8 @@ impl DOMStringMap {
 // https://html.spec.whatwg.org/multipage/#domstringmap
 impl DOMStringMapMethods<crate::DomTypeHolder> for DOMStringMap {
     // https://html.spec.whatwg.org/multipage/#dom-domstringmap-removeitem
-    fn NamedDeleter(&self, name: DOMString, can_gc: CanGc) {
-        self.element.delete_custom_attr(name, can_gc)
+    fn NamedDeleter(&self, name: DOMString) {
+        self.element.delete_custom_attr(name, CanGc::note())
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-domstringmap-setitem

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -2171,10 +2171,7 @@ impl Element {
         let fragment = DocumentFragment::new(&context_document, can_gc);
         // Step 4.
         for child in new_children {
-            fragment
-                .upcast::<Node>()
-                .AppendChild(&child, can_gc)
-                .unwrap();
+            fragment.upcast::<Node>().AppendChild(&child).unwrap();
         }
         // Step 5.
         Ok(fragment)
@@ -2516,7 +2513,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
     }
 
     // https://dom.spec.whatwg.org/#dom-element-setattributenode
-    fn SetAttributeNode(&self, attr: &Attr, can_gc: CanGc) -> Fallible<Option<DomRoot<Attr>>> {
+    fn SetAttributeNode(&self, attr: &Attr) -> Fallible<Option<DomRoot<Attr>>> {
         // Step 1.
         if let Some(owner) = attr.GetOwnerElement() {
             if &*owner != self {
@@ -2566,7 +2563,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
                 vtable.attribute_mutated(
                     attr,
                     AttributeMutation::Set(Some(&old_attr.value())),
-                    can_gc,
+                    CanGc::note(),
                 );
             }
 
@@ -2575,7 +2572,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         } else {
             // Step 5.
             attr.set_owner(Some(self));
-            self.push_attribute(attr, can_gc);
+            self.push_attribute(attr, CanGc::note());
 
             // Step 6.
             Ok(None)
@@ -2583,31 +2580,26 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
     }
 
     // https://dom.spec.whatwg.org/#dom-element-setattributenodens
-    fn SetAttributeNodeNS(&self, attr: &Attr, can_gc: CanGc) -> Fallible<Option<DomRoot<Attr>>> {
-        self.SetAttributeNode(attr, can_gc)
+    fn SetAttributeNodeNS(&self, attr: &Attr) -> Fallible<Option<DomRoot<Attr>>> {
+        self.SetAttributeNode(attr)
     }
 
     // https://dom.spec.whatwg.org/#dom-element-removeattribute
-    fn RemoveAttribute(&self, name: DOMString, can_gc: CanGc) {
+    fn RemoveAttribute(&self, name: DOMString) {
         let name = self.parsed_name(name);
-        self.remove_attribute_by_name(&name, can_gc);
+        self.remove_attribute_by_name(&name, CanGc::note());
     }
 
     // https://dom.spec.whatwg.org/#dom-element-removeattributens
-    fn RemoveAttributeNS(
-        &self,
-        namespace: Option<DOMString>,
-        local_name: DOMString,
-        can_gc: CanGc,
-    ) {
+    fn RemoveAttributeNS(&self, namespace: Option<DOMString>, local_name: DOMString) {
         let namespace = namespace_from_domstring(namespace);
         let local_name = LocalName::from(local_name);
-        self.remove_attribute(&namespace, &local_name, can_gc);
+        self.remove_attribute(&namespace, &local_name, CanGc::note());
     }
 
     // https://dom.spec.whatwg.org/#dom-element-removeattributenode
-    fn RemoveAttributeNode(&self, attr: &Attr, can_gc: CanGc) -> Fallible<DomRoot<Attr>> {
-        self.remove_first_matching_attribute(|a| a == attr, can_gc)
+    fn RemoveAttributeNode(&self, attr: &Attr) -> Fallible<DomRoot<Attr>> {
+        self.remove_first_matching_attribute(|a| a == attr, CanGc::note())
             .ok_or(Error::NotFound)
     }
 
@@ -2977,7 +2969,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
 
         // For each node in newChildren, append node to fragment.
         for child in new_children {
-            frag.upcast::<Node>().AppendChild(&child, can_gc).unwrap();
+            frag.upcast::<Node>().AppendChild(&child).unwrap();
         }
 
         // Replace all with fragment within target.
@@ -3097,7 +3089,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         // Step 5.
         let frag = parent.parse_fragment(value, can_gc)?;
         // Step 6.
-        context_parent.ReplaceChild(frag.upcast(), context_node, can_gc)?;
+        context_parent.ReplaceChild(frag.upcast(), context_node)?;
         Ok(())
     }
 
@@ -3184,8 +3176,8 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
     }
 
     // https://dom.spec.whatwg.org/#dom-childnode-remove
-    fn Remove(&self, can_gc: CanGc) {
-        self.upcast::<Node>().remove_self(can_gc);
+    fn Remove(&self) {
+        self.upcast::<Node>().remove_self(CanGc::note());
     }
 
     // https://dom.spec.whatwg.org/#dom-element-matches
@@ -3241,10 +3233,9 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         &self,
         where_: DOMString,
         element: &Element,
-        can_gc: CanGc,
     ) -> Fallible<Option<DomRoot<Element>>> {
         let where_ = where_.parse::<AdjacentPosition>()?;
-        let inserted_node = self.insert_adjacent(where_, element.upcast(), can_gc)?;
+        let inserted_node = self.insert_adjacent(where_, element.upcast(), CanGc::note())?;
         Ok(inserted_node.map(|node| DomRoot::downcast(node).unwrap()))
     }
 

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -566,7 +566,7 @@ impl Element {
 
             // Step 4.3.1. Remove all of currentShadowRoot’s children, in tree order.
             for child in current_shadow_root.upcast::<Node>().children() {
-                child.remove_self();
+                child.remove_self(can_gc);
             }
 
             // Step 4.3.2. Set currentShadowRoot’s declarative to false.
@@ -621,7 +621,7 @@ impl Element {
             tree_is_in_a_document_tree: self.upcast::<Node>().is_in_a_document_tree(),
             tree_is_in_a_shadow_tree: true,
         };
-        shadow_root.bind_to_tree(&bind_context);
+        shadow_root.bind_to_tree(&bind_context, can_gc);
 
         let node = self.upcast::<Node>();
         node.dirty(NodeDamage::OtherNodeDamage);
@@ -630,7 +630,7 @@ impl Element {
         Ok(shadow_root)
     }
 
-    pub(crate) fn detach_shadow(&self) {
+    pub(crate) fn detach_shadow(&self, can_gc: CanGc) {
         let Some(ref shadow_root) = self.shadow_root() else {
             unreachable!("Trying to detach a non-attached shadow root");
         };
@@ -639,7 +639,7 @@ impl Element {
         node.note_dirty_descendants();
         node.rev_version();
 
-        shadow_root.detach();
+        shadow_root.detach(can_gc);
         self.ensure_rare_data().shadow_root = None;
     }
 
@@ -1635,10 +1635,10 @@ impl Element {
             Some(self),
             can_gc,
         );
-        self.push_attribute(&attr);
+        self.push_attribute(&attr, can_gc);
     }
 
-    pub(crate) fn push_attribute(&self, attr: &Attr) {
+    pub(crate) fn push_attribute(&self, attr: &Attr, can_gc: CanGc) {
         let name = attr.local_name().clone();
         let namespace = attr.namespace().clone();
         let mutation = LazyCell::new(|| Mutation::Attribute {
@@ -1659,7 +1659,7 @@ impl Element {
         self.will_mutate_attr(attr);
         self.attrs.borrow_mut().push(Dom::from_ref(attr));
         if attr.namespace() == &ns!() {
-            vtable_for(self.upcast()).attribute_mutated(attr, AttributeMutation::Set(None));
+            vtable_for(self.upcast()).attribute_mutated(attr, AttributeMutation::Set(None), can_gc);
         }
     }
 
@@ -1788,7 +1788,7 @@ impl Element {
             .find(|attr| find(attr))
             .map(|js| DomRoot::from_ref(&**js));
         if let Some(attr) = attr {
-            attr.set_value(value, self);
+            attr.set_value(value, self, can_gc);
         } else {
             self.push_new_attribute(local_name, value, name, namespace, prefix, can_gc);
         };
@@ -1811,17 +1811,23 @@ impl Element {
         &self,
         namespace: &Namespace,
         local_name: &LocalName,
+        can_gc: CanGc,
     ) -> Option<DomRoot<Attr>> {
-        self.remove_first_matching_attribute(|attr| {
-            attr.namespace() == namespace && attr.local_name() == local_name
-        })
+        self.remove_first_matching_attribute(
+            |attr| attr.namespace() == namespace && attr.local_name() == local_name,
+            can_gc,
+        )
     }
 
-    pub(crate) fn remove_attribute_by_name(&self, name: &LocalName) -> Option<DomRoot<Attr>> {
-        self.remove_first_matching_attribute(|attr| attr.name() == name)
+    pub(crate) fn remove_attribute_by_name(
+        &self,
+        name: &LocalName,
+        can_gc: CanGc,
+    ) -> Option<DomRoot<Attr>> {
+        self.remove_first_matching_attribute(|attr| attr.name() == name, can_gc)
     }
 
-    fn remove_first_matching_attribute<F>(&self, find: F) -> Option<DomRoot<Attr>>
+    fn remove_first_matching_attribute<F>(&self, find: F, can_gc: CanGc) -> Option<DomRoot<Attr>>
     where
         F: Fn(&Attr) -> bool,
     {
@@ -1850,7 +1856,11 @@ impl Element {
             self.attrs.borrow_mut().remove(idx);
             attr.set_owner(None);
             if attr.namespace() == &ns!() {
-                vtable_for(self.upcast()).attribute_mutated(&attr, AttributeMutation::Removed);
+                vtable_for(self.upcast()).attribute_mutated(
+                    &attr,
+                    AttributeMutation::Removed,
+                    can_gc,
+                );
             }
             attr
         })
@@ -1892,7 +1902,7 @@ impl Element {
         if value {
             self.set_string_attribute(local_name, DOMString::new(), can_gc);
         } else {
-            self.remove_attribute(&ns!(), local_name);
+            self.remove_attribute(&ns!(), local_name, can_gc);
         }
     }
 
@@ -1961,7 +1971,7 @@ impl Element {
                 self.set_string_attribute(local_name, val, can_gc);
             },
             None => {
-                self.remove_attribute(&ns!(), local_name);
+                self.remove_attribute(&ns!(), local_name, can_gc);
             },
         }
     }
@@ -2056,23 +2066,31 @@ impl Element {
         &self,
         where_: AdjacentPosition,
         node: &Node,
+        can_gc: CanGc,
     ) -> Fallible<Option<DomRoot<Node>>> {
         let self_node = self.upcast::<Node>();
         match where_ {
             AdjacentPosition::BeforeBegin => {
                 if let Some(parent) = self_node.GetParentNode() {
-                    Node::pre_insert(node, &parent, Some(self_node)).map(Some)
+                    Node::pre_insert(node, &parent, Some(self_node), can_gc).map(Some)
                 } else {
                     Ok(None)
                 }
             },
-            AdjacentPosition::AfterBegin => {
-                Node::pre_insert(node, self_node, self_node.GetFirstChild().as_deref()).map(Some)
+            AdjacentPosition::AfterBegin => Node::pre_insert(
+                node,
+                self_node,
+                self_node.GetFirstChild().as_deref(),
+                can_gc,
+            )
+            .map(Some),
+            AdjacentPosition::BeforeEnd => {
+                Node::pre_insert(node, self_node, None, can_gc).map(Some)
             },
-            AdjacentPosition::BeforeEnd => Node::pre_insert(node, self_node, None).map(Some),
             AdjacentPosition::AfterEnd => {
                 if let Some(parent) = self_node.GetParentNode() {
-                    Node::pre_insert(node, &parent, self_node.GetNextSibling().as_deref()).map(Some)
+                    Node::pre_insert(node, &parent, self_node.GetNextSibling().as_deref(), can_gc)
+                        .map(Some)
                 } else {
                     Ok(None)
                 }
@@ -2153,7 +2171,10 @@ impl Element {
         let fragment = DocumentFragment::new(&context_document, can_gc);
         // Step 4.
         for child in new_children {
-            fragment.upcast::<Node>().AppendChild(&child).unwrap();
+            fragment
+                .upcast::<Node>()
+                .AppendChild(&child, can_gc)
+                .unwrap();
         }
         // Step 5.
         Ok(fragment)
@@ -2437,7 +2458,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
             Some(_index) => match force {
                 // Step 5.
                 None | Some(false) => {
-                    self.remove_attribute_by_name(&name);
+                    self.remove_attribute_by_name(&name, can_gc);
                     Ok(false)
                 },
                 // Step 6.
@@ -2495,7 +2516,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
     }
 
     // https://dom.spec.whatwg.org/#dom-element-setattributenode
-    fn SetAttributeNode(&self, attr: &Attr) -> Fallible<Option<DomRoot<Attr>>> {
+    fn SetAttributeNode(&self, attr: &Attr, can_gc: CanGc) -> Fallible<Option<DomRoot<Attr>>> {
         // Step 1.
         if let Some(owner) = attr.GetOwnerElement() {
             if &*owner != self {
@@ -2542,7 +2563,11 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
             self.attrs.borrow_mut()[position] = Dom::from_ref(attr);
             old_attr.set_owner(None);
             if attr.namespace() == &ns!() {
-                vtable.attribute_mutated(attr, AttributeMutation::Set(Some(&old_attr.value())));
+                vtable.attribute_mutated(
+                    attr,
+                    AttributeMutation::Set(Some(&old_attr.value())),
+                    can_gc,
+                );
             }
 
             // Step 6.
@@ -2550,7 +2575,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         } else {
             // Step 5.
             attr.set_owner(Some(self));
-            self.push_attribute(attr);
+            self.push_attribute(attr, can_gc);
 
             // Step 6.
             Ok(None)
@@ -2558,26 +2583,31 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
     }
 
     // https://dom.spec.whatwg.org/#dom-element-setattributenodens
-    fn SetAttributeNodeNS(&self, attr: &Attr) -> Fallible<Option<DomRoot<Attr>>> {
-        self.SetAttributeNode(attr)
+    fn SetAttributeNodeNS(&self, attr: &Attr, can_gc: CanGc) -> Fallible<Option<DomRoot<Attr>>> {
+        self.SetAttributeNode(attr, can_gc)
     }
 
     // https://dom.spec.whatwg.org/#dom-element-removeattribute
-    fn RemoveAttribute(&self, name: DOMString) {
+    fn RemoveAttribute(&self, name: DOMString, can_gc: CanGc) {
         let name = self.parsed_name(name);
-        self.remove_attribute_by_name(&name);
+        self.remove_attribute_by_name(&name, can_gc);
     }
 
     // https://dom.spec.whatwg.org/#dom-element-removeattributens
-    fn RemoveAttributeNS(&self, namespace: Option<DOMString>, local_name: DOMString) {
+    fn RemoveAttributeNS(
+        &self,
+        namespace: Option<DOMString>,
+        local_name: DOMString,
+        can_gc: CanGc,
+    ) {
         let namespace = namespace_from_domstring(namespace);
         let local_name = LocalName::from(local_name);
-        self.remove_attribute(&namespace, &local_name);
+        self.remove_attribute(&namespace, &local_name, can_gc);
     }
 
     // https://dom.spec.whatwg.org/#dom-element-removeattributenode
-    fn RemoveAttributeNode(&self, attr: &Attr) -> Fallible<DomRoot<Attr>> {
-        self.remove_first_matching_attribute(|a| a == attr)
+    fn RemoveAttributeNode(&self, attr: &Attr, can_gc: CanGc) -> Fallible<DomRoot<Attr>> {
+        self.remove_first_matching_attribute(|a| a == attr, can_gc)
             .ok_or(Error::NotFound)
     }
 
@@ -2947,11 +2977,11 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
 
         // For each node in newChildren, append node to fragment.
         for child in new_children {
-            frag.upcast::<Node>().AppendChild(&child).unwrap();
+            frag.upcast::<Node>().AppendChild(&child, can_gc).unwrap();
         }
 
         // Replace all with fragment within target.
-        Node::replace_all(Some(frag.upcast()), &target);
+        Node::replace_all(Some(frag.upcast()), &target, can_gc);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-element-gethtml>
@@ -3013,7 +3043,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         // Step 1.
         let frag = self.parse_fragment(value, can_gc)?;
 
-        Node::replace_all(Some(frag.upcast()), &target);
+        Node::replace_all(Some(frag.upcast()), &target, can_gc);
         Ok(())
     }
 
@@ -3067,7 +3097,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         // Step 5.
         let frag = parent.parse_fragment(value, can_gc)?;
         // Step 6.
-        context_parent.ReplaceChild(frag.upcast(), context_node)?;
+        context_parent.ReplaceChild(frag.upcast(), context_node, can_gc)?;
         Ok(())
     }
 
@@ -3154,8 +3184,8 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
     }
 
     // https://dom.spec.whatwg.org/#dom-childnode-remove
-    fn Remove(&self) {
-        self.upcast::<Node>().remove_self();
+    fn Remove(&self, can_gc: CanGc) {
+        self.upcast::<Node>().remove_self(can_gc);
     }
 
     // https://dom.spec.whatwg.org/#dom-element-matches
@@ -3211,9 +3241,10 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         &self,
         where_: DOMString,
         element: &Element,
+        can_gc: CanGc,
     ) -> Fallible<Option<DomRoot<Element>>> {
         let where_ = where_.parse::<AdjacentPosition>()?;
-        let inserted_node = self.insert_adjacent(where_, element.upcast())?;
+        let inserted_node = self.insert_adjacent(where_, element.upcast(), can_gc)?;
         Ok(inserted_node.map(|node| DomRoot::downcast(node).unwrap()))
     }
 
@@ -3224,7 +3255,8 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
 
         // Step 2.
         let where_ = where_.parse::<AdjacentPosition>()?;
-        self.insert_adjacent(where_, text.upcast()).map(|_| ())
+        self.insert_adjacent(where_, text.upcast(), can_gc)
+            .map(|_| ())
     }
 
     // https://w3c.github.io/DOM-Parsing/#dom-element-insertadjacenthtml
@@ -3263,7 +3295,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         let fragment = context.parse_fragment(text, can_gc)?;
 
         // Step 4.
-        self.insert_adjacent(position, fragment.upcast())
+        self.insert_adjacent(position, fragment.upcast(), can_gc)
             .map(|_| ())
     }
 
@@ -3713,8 +3745,10 @@ impl VirtualMethods for Element {
             .attribute_affects_presentational_hints(attr)
     }
 
-    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation) {
-        self.super_type().unwrap().attribute_mutated(attr, mutation);
+    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation, can_gc: CanGc) {
+        self.super_type()
+            .unwrap()
+            .attribute_mutated(attr, mutation, can_gc);
         let node = self.upcast::<Node>();
         let doc = node.owner_doc();
         match attr.local_name() {
@@ -3776,25 +3810,25 @@ impl VirtualMethods for Element {
                             if let Some(old_value) = old_value {
                                 let old_value = old_value.as_atom().clone();
                                 if let Some(ref shadow_root) = containing_shadow_root {
-                                    shadow_root.unregister_element_id(self, old_value);
+                                    shadow_root.unregister_element_id(self, old_value, can_gc);
                                 } else {
-                                    doc.unregister_element_id(self, old_value);
+                                    doc.unregister_element_id(self, old_value, can_gc);
                                 }
                             }
                             if value != atom!("") {
                                 if let Some(ref shadow_root) = containing_shadow_root {
-                                    shadow_root.register_element_id(self, value);
+                                    shadow_root.register_element_id(self, value, can_gc);
                                 } else {
-                                    doc.register_element_id(self, value);
+                                    doc.register_element_id(self, value, can_gc);
                                 }
                             }
                         },
                         AttributeMutation::Removed => {
                             if value != atom!("") {
                                 if let Some(ref shadow_root) = containing_shadow_root {
-                                    shadow_root.unregister_element_id(self, value);
+                                    shadow_root.unregister_element_id(self, value, can_gc);
                                 } else {
-                                    doc.unregister_element_id(self, value);
+                                    doc.unregister_element_id(self, value, can_gc);
                                 }
                             }
                         },
@@ -3873,19 +3907,19 @@ impl VirtualMethods for Element {
         }
     }
 
-    fn bind_to_tree(&self, context: &BindContext) {
+    fn bind_to_tree(&self, context: &BindContext, can_gc: CanGc) {
         if let Some(s) = self.super_type() {
-            s.bind_to_tree(context);
+            s.bind_to_tree(context, can_gc);
         }
 
         if let Some(f) = self.as_maybe_form_control() {
-            f.bind_form_control_to_tree();
+            f.bind_form_control_to_tree(can_gc);
         }
 
         let doc = self.owner_document();
 
         if let Some(ref shadow_root) = self.shadow_root() {
-            shadow_root.bind_to_tree(context);
+            shadow_root.bind_to_tree(context, can_gc);
         }
 
         if !context.is_in_tree() {
@@ -3896,9 +3930,9 @@ impl VirtualMethods for Element {
 
         if let Some(ref id) = *self.id_attribute.borrow() {
             if let Some(shadow_root) = self.containing_shadow_root() {
-                shadow_root.register_element_id(self, id.clone());
+                shadow_root.register_element_id(self, id.clone(), can_gc);
             } else {
-                doc.register_element_id(self, id.clone());
+                doc.register_element_id(self, id.clone(), can_gc);
             }
         }
         if let Some(ref name) = self.name_attribute() {
@@ -3911,14 +3945,14 @@ impl VirtualMethods for Element {
         doc.increment_dom_count();
     }
 
-    fn unbind_from_tree(&self, context: &UnbindContext) {
-        self.super_type().unwrap().unbind_from_tree(context);
+    fn unbind_from_tree(&self, context: &UnbindContext, can_gc: CanGc) {
+        self.super_type().unwrap().unbind_from_tree(context, can_gc);
 
         if let Some(f) = self.as_maybe_form_control() {
             // TODO: The valid state of ancestors might be wrong if the form control element
             // has a fieldset ancestor, for instance: `<form><fieldset><input>`,
             // if `<input>` is unbound, `<form><fieldset>` should trigger a call to `update_validity()`.
-            f.unbind_form_control_from_tree();
+            f.unbind_form_control_from_tree(can_gc);
         }
 
         if !context.tree_is_in_a_document_tree && !context.tree_is_in_a_shadow_tree {
@@ -3938,10 +3972,10 @@ impl VirtualMethods for Element {
                 // Only unregister the element id if the node was disconnected from it's shadow root
                 // (as opposed to the whole shadow tree being disconnected as a whole)
                 if !self.upcast::<Node>().is_in_a_shadow_tree() {
-                    shadow_root.unregister_element_id(self, value.clone());
+                    shadow_root.unregister_element_id(self, value.clone(), can_gc);
                 }
             } else {
-                doc.unregister_element_id(self, value.clone());
+                doc.unregister_element_id(self, value.clone(), can_gc);
             }
         }
         if let Some(ref value) = self.name_attribute() {
@@ -3980,8 +4014,8 @@ impl VirtualMethods for Element {
         }
     }
 
-    fn adopting_steps(&self, old_doc: &Document) {
-        self.super_type().unwrap().adopting_steps(old_doc);
+    fn adopting_steps(&self, old_doc: &Document, can_gc: CanGc) {
+        self.super_type().unwrap().adopting_steps(old_doc, can_gc);
 
         if self.owner_document().is_html_document() != old_doc.is_html_document() {
             self.tag_name.clear();
@@ -4426,12 +4460,12 @@ impl Element {
         element
     }
 
-    pub(crate) fn is_invalid(&self, needs_update: bool) -> bool {
+    pub(crate) fn is_invalid(&self, needs_update: bool, can_gc: CanGc) -> bool {
         if let Some(validatable) = self.as_maybe_validatable() {
             if needs_update {
                 validatable
                     .validity_state()
-                    .perform_validation_and_update(ValidationFlags::all());
+                    .perform_validation_and_update(ValidationFlags::all(), can_gc);
             }
             return validatable.is_instance_validatable() && !validatable.satisfies_constraints();
         }
@@ -4844,7 +4878,7 @@ pub(crate) fn set_cross_origin_attribute(
     match value {
         Some(val) => element.set_string_attribute(&local_name!("crossorigin"), val, can_gc),
         None => {
-            element.remove_attribute(&ns!(), &local_name!("crossorigin"));
+            element.remove_attribute(&ns!(), &local_name!("crossorigin"), can_gc);
         },
     }
 }

--- a/components/script/dom/elementinternals.rs
+++ b/components/script/dom/elementinternals.rs
@@ -234,6 +234,7 @@ impl ElementInternalsMethods<crate::DomTypeHolder> for ElementInternals {
         flags: &ValidityStateFlags,
         message: Option<DOMString>,
         anchor: Option<&HTMLElement>,
+        can_gc: CanGc,
     ) -> ErrorResult {
         // Steps 1-2: Check form-associated custom element
         if !self.is_target_form_associated() {
@@ -253,7 +254,7 @@ impl ElementInternalsMethods<crate::DomTypeHolder> for ElementInternals {
         // Step 4: For each entry `flag` → `value` of `flags`, set element's validity flag with the name
         // `flag` to `value`.
         self.validity_state().update_invalid_flags(bits);
-        self.validity_state().update_pseudo_classes();
+        self.validity_state().update_pseudo_classes(can_gc);
 
         // Step 5: Set element's validation message to the empty string if message is not given
         // or all of element's validity flags are false, or to message otherwise.

--- a/components/script/dom/elementinternals.rs
+++ b/components/script/dom/elementinternals.rs
@@ -234,7 +234,6 @@ impl ElementInternalsMethods<crate::DomTypeHolder> for ElementInternals {
         flags: &ValidityStateFlags,
         message: Option<DOMString>,
         anchor: Option<&HTMLElement>,
-        can_gc: CanGc,
     ) -> ErrorResult {
         // Steps 1-2: Check form-associated custom element
         if !self.is_target_form_associated() {
@@ -254,7 +253,7 @@ impl ElementInternalsMethods<crate::DomTypeHolder> for ElementInternals {
         // Step 4: For each entry `flag` → `value` of `flags`, set element's validity flag with the name
         // `flag` to `value`.
         self.validity_state().update_invalid_flags(bits);
-        self.validity_state().update_pseudo_classes(can_gc);
+        self.validity_state().update_pseudo_classes(CanGc::note());
 
         // Step 5: Set element's validation message to the empty string if message is not given
         // or all of element's validity flags are false, or to message otherwise.

--- a/components/script/dom/event.rs
+++ b/components/script/dom/event.rs
@@ -584,7 +584,7 @@ impl Event {
             if let Some(target) = self.GetTarget() {
                 if let Some(node) = target.downcast::<Node>() {
                     let vtable = vtable_for(node);
-                    vtable.handle_event(self);
+                    vtable.handle_event(self, can_gc);
                 }
             }
         }

--- a/components/script/dom/htmlanchorelement.rs
+++ b/components/script/dom/htmlanchorelement.rs
@@ -100,8 +100,10 @@ impl VirtualMethods for HTMLAnchorElement {
         }
     }
 
-    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation) {
-        self.super_type().unwrap().attribute_mutated(attr, mutation);
+    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation, can_gc: CanGc) {
+        self.super_type()
+            .unwrap()
+            .attribute_mutated(attr, mutation, can_gc);
 
         match *attr.local_name() {
             local_name!("rel") | local_name!("rev") => {
@@ -112,9 +114,9 @@ impl VirtualMethods for HTMLAnchorElement {
         }
     }
 
-    fn bind_to_tree(&self, context: &BindContext) {
+    fn bind_to_tree(&self, context: &BindContext, can_gc: CanGc) {
         if let Some(s) = self.super_type() {
-            s.bind_to_tree(context);
+            s.bind_to_tree(context, can_gc);
         }
 
         self.relations

--- a/components/script/dom/htmlareaelement.rs
+++ b/components/script/dom/htmlareaelement.rs
@@ -321,8 +321,10 @@ impl VirtualMethods for HTMLAreaElement {
         }
     }
 
-    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation) {
-        self.super_type().unwrap().attribute_mutated(attr, mutation);
+    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation, can_gc: CanGc) {
+        self.super_type()
+            .unwrap()
+            .attribute_mutated(attr, mutation, can_gc);
 
         match *attr.local_name() {
             local_name!("rel") | local_name!("rev") => {
@@ -333,9 +335,9 @@ impl VirtualMethods for HTMLAreaElement {
         }
     }
 
-    fn bind_to_tree(&self, context: &BindContext) {
+    fn bind_to_tree(&self, context: &BindContext, can_gc: CanGc) {
         if let Some(s) = self.super_type() {
-            s.bind_to_tree(context);
+            s.bind_to_tree(context, can_gc);
         }
 
         self.relations

--- a/components/script/dom/htmlbaseelement.rs
+++ b/components/script/dom/htmlbaseelement.rs
@@ -117,20 +117,22 @@ impl VirtualMethods for HTMLBaseElement {
         Some(self.upcast::<HTMLElement>() as &dyn VirtualMethods)
     }
 
-    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation) {
-        self.super_type().unwrap().attribute_mutated(attr, mutation);
+    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation, can_gc: CanGc) {
+        self.super_type()
+            .unwrap()
+            .attribute_mutated(attr, mutation, can_gc);
         if *attr.local_name() == local_name!("href") {
             self.owner_document().refresh_base_element();
         }
     }
 
-    fn bind_to_tree(&self, context: &BindContext) {
-        self.super_type().unwrap().bind_to_tree(context);
+    fn bind_to_tree(&self, context: &BindContext, can_gc: CanGc) {
+        self.super_type().unwrap().bind_to_tree(context, can_gc);
         self.bind_unbind(context.tree_is_in_a_document_tree);
     }
 
-    fn unbind_from_tree(&self, context: &UnbindContext) {
-        self.super_type().unwrap().unbind_from_tree(context);
+    fn unbind_from_tree(&self, context: &UnbindContext, can_gc: CanGc) {
+        self.super_type().unwrap().unbind_from_tree(context, can_gc);
         self.bind_unbind(context.tree_is_in_a_document_tree);
     }
 }

--- a/components/script/dom/htmlbodyelement.rs
+++ b/components/script/dom/htmlbodyelement.rs
@@ -141,9 +141,9 @@ impl VirtualMethods for HTMLBodyElement {
             .attribute_affects_presentational_hints(attr)
     }
 
-    fn bind_to_tree(&self, context: &BindContext) {
+    fn bind_to_tree(&self, context: &BindContext, can_gc: CanGc) {
         if let Some(s) = self.super_type() {
-            s.bind_to_tree(context);
+            s.bind_to_tree(context, can_gc);
         }
 
         if !context.tree_is_in_a_document_tree {
@@ -176,7 +176,7 @@ impl VirtualMethods for HTMLBodyElement {
         }
     }
 
-    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation) {
+    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation, can_gc: CanGc) {
         let do_super_mutate = match (attr.local_name(), mutation) {
             (name, AttributeMutation::Set(_)) if name.starts_with("on") => {
                 let window = self.owner_window();
@@ -218,7 +218,9 @@ impl VirtualMethods for HTMLBodyElement {
         };
 
         if do_super_mutate {
-            self.super_type().unwrap().attribute_mutated(attr, mutation);
+            self.super_type()
+                .unwrap()
+                .attribute_mutated(attr, mutation, can_gc);
         }
     }
 }

--- a/components/script/dom/htmlbuttonelement.rs
+++ b/components/script/dom/htmlbuttonelement.rs
@@ -242,8 +242,10 @@ impl VirtualMethods for HTMLButtonElement {
         Some(self.upcast::<HTMLElement>() as &dyn VirtualMethods)
     }
 
-    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation) {
-        self.super_type().unwrap().attribute_mutated(attr, mutation);
+    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation, can_gc: CanGc) {
+        self.super_type()
+            .unwrap()
+            .attribute_mutated(attr, mutation, can_gc);
         match *attr.local_name() {
             local_name!("disabled") => {
                 let el = self.upcast::<Element>();
@@ -261,7 +263,7 @@ impl VirtualMethods for HTMLButtonElement {
                 }
                 el.update_sequentially_focusable_status(CanGc::note());
                 self.validity_state()
-                    .perform_validation_and_update(ValidationFlags::all());
+                    .perform_validation_and_update(ValidationFlags::all(), can_gc);
             },
             local_name!("type") => match mutation {
                 AttributeMutation::Set(_) => {
@@ -272,32 +274,32 @@ impl VirtualMethods for HTMLButtonElement {
                     };
                     self.button_type.set(value);
                     self.validity_state()
-                        .perform_validation_and_update(ValidationFlags::all());
+                        .perform_validation_and_update(ValidationFlags::all(), can_gc);
                 },
                 AttributeMutation::Removed => {
                     self.button_type.set(ButtonType::Submit);
                 },
             },
             local_name!("form") => {
-                self.form_attribute_mutated(mutation);
+                self.form_attribute_mutated(mutation, can_gc);
                 self.validity_state()
-                    .perform_validation_and_update(ValidationFlags::empty());
+                    .perform_validation_and_update(ValidationFlags::empty(), can_gc);
             },
             _ => {},
         }
     }
 
-    fn bind_to_tree(&self, context: &BindContext) {
+    fn bind_to_tree(&self, context: &BindContext, can_gc: CanGc) {
         if let Some(s) = self.super_type() {
-            s.bind_to_tree(context);
+            s.bind_to_tree(context, can_gc);
         }
 
         self.upcast::<Element>()
             .check_ancestors_disabled_state_for_form_control();
     }
 
-    fn unbind_from_tree(&self, context: &UnbindContext) {
-        self.super_type().unwrap().unbind_from_tree(context);
+    fn unbind_from_tree(&self, context: &UnbindContext, can_gc: CanGc) {
+        self.super_type().unwrap().unbind_from_tree(context, can_gc);
 
         let node = self.upcast::<Node>();
         let el = self.upcast::<Element>();

--- a/components/script/dom/htmlcanvaselement.rs
+++ b/components/script/dom/htmlcanvaselement.rs
@@ -698,8 +698,10 @@ impl VirtualMethods for HTMLCanvasElement {
         Some(self.upcast::<HTMLElement>() as &dyn VirtualMethods)
     }
 
-    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation) {
-        self.super_type().unwrap().attribute_mutated(attr, mutation);
+    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation, can_gc: CanGc) {
+        self.super_type()
+            .unwrap()
+            .attribute_mutated(attr, mutation, can_gc);
         match attr.local_name() {
             &local_name!("width") | &local_name!("height") => self.recreate_contexts_after_resize(),
             _ => (),

--- a/components/script/dom/htmldetailselement.rs
+++ b/components/script/dom/htmldetailselement.rs
@@ -118,22 +118,22 @@ impl HTMLDetailsElement {
 
         let summary = HTMLSlotElement::new(local_name!("slot"), None, &document, None, can_gc);
         root.upcast::<Node>()
-            .AppendChild(summary.upcast::<Node>(), can_gc)
+            .AppendChild(summary.upcast::<Node>())
             .unwrap();
 
         let fallback_summary =
-            HTMLElement::new(local_name!("summary"), None, &document, None, can_gc);
+            HTMLElement::new(local_name!("summary"), None, &document, None, CanGc::note());
         fallback_summary
             .upcast::<Node>()
             .SetTextContent(Some(DEFAULT_SUMMARY.into()), can_gc);
         summary
             .upcast::<Node>()
-            .AppendChild(fallback_summary.upcast::<Node>(), can_gc)
+            .AppendChild(fallback_summary.upcast::<Node>())
             .unwrap();
 
         let descendants = HTMLSlotElement::new(local_name!("slot"), None, &document, None, can_gc);
         root.upcast::<Node>()
-            .AppendChild(descendants.upcast::<Node>(), can_gc)
+            .AppendChild(descendants.upcast::<Node>())
             .unwrap();
 
         let _ = self.shadow_tree.borrow_mut().insert(ShadowTree {

--- a/components/script/dom/htmldetailselement.rs
+++ b/components/script/dom/htmldetailselement.rs
@@ -118,7 +118,7 @@ impl HTMLDetailsElement {
 
         let summary = HTMLSlotElement::new(local_name!("slot"), None, &document, None, can_gc);
         root.upcast::<Node>()
-            .AppendChild(summary.upcast::<Node>())
+            .AppendChild(summary.upcast::<Node>(), can_gc)
             .unwrap();
 
         let fallback_summary =
@@ -128,12 +128,12 @@ impl HTMLDetailsElement {
             .SetTextContent(Some(DEFAULT_SUMMARY.into()), can_gc);
         summary
             .upcast::<Node>()
-            .AppendChild(fallback_summary.upcast::<Node>())
+            .AppendChild(fallback_summary.upcast::<Node>(), can_gc)
             .unwrap();
 
         let descendants = HTMLSlotElement::new(local_name!("slot"), None, &document, None, can_gc);
         root.upcast::<Node>()
-            .AppendChild(descendants.upcast::<Node>())
+            .AppendChild(descendants.upcast::<Node>(), can_gc)
             .unwrap();
 
         let _ = self.shadow_tree.borrow_mut().insert(ShadowTree {
@@ -232,8 +232,10 @@ impl VirtualMethods for HTMLDetailsElement {
         Some(self.upcast::<HTMLElement>() as &dyn VirtualMethods)
     }
 
-    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation) {
-        self.super_type().unwrap().attribute_mutated(attr, mutation);
+    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation, can_gc: CanGc) {
+        self.super_type()
+            .unwrap()
+            .attribute_mutated(attr, mutation, can_gc);
 
         if attr.local_name() == &local_name!("open") {
             self.update_shadow_tree_styles(CanGc::note());
@@ -261,8 +263,8 @@ impl VirtualMethods for HTMLDetailsElement {
         self.update_shadow_tree_contents(CanGc::note());
     }
 
-    fn bind_to_tree(&self, context: &BindContext) {
-        self.super_type().unwrap().bind_to_tree(context);
+    fn bind_to_tree(&self, context: &BindContext, can_gc: CanGc) {
+        self.super_type().unwrap().bind_to_tree(context, can_gc);
 
         self.update_shadow_tree_contents(CanGc::note());
         self.update_shadow_tree_styles(CanGc::note());

--- a/components/script/dom/htmldialogelement.rs
+++ b/components/script/dom/htmldialogelement.rs
@@ -99,13 +99,13 @@ impl HTMLDialogElementMethods<crate::DomTypeHolder> for HTMLDialogElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-dialog-close
-    fn Close(&self, return_value: Option<DOMString>) {
+    fn Close(&self, return_value: Option<DOMString>, can_gc: CanGc) {
         let element = self.upcast::<Element>();
         let target = self.upcast::<EventTarget>();
 
         // Step 1 & 2
         if element
-            .remove_attribute(&ns!(), &local_name!("open"))
+            .remove_attribute(&ns!(), &local_name!("open"), can_gc)
             .is_none()
         {
             return;

--- a/components/script/dom/htmldialogelement.rs
+++ b/components/script/dom/htmldialogelement.rs
@@ -99,13 +99,13 @@ impl HTMLDialogElementMethods<crate::DomTypeHolder> for HTMLDialogElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-dialog-close
-    fn Close(&self, return_value: Option<DOMString>, can_gc: CanGc) {
+    fn Close(&self, return_value: Option<DOMString>) {
         let element = self.upcast::<Element>();
         let target = self.upcast::<EventTarget>();
 
         // Step 1 & 2
         if element
-            .remove_attribute(&ns!(), &local_name!("open"), can_gc)
+            .remove_attribute(&ns!(), &local_name!("open"), CanGc::note())
             .is_none()
         {
             return;

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -532,13 +532,11 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
         if fragment.upcast::<Node>().children_count() == 0 {
             let text_node = Text::new(DOMString::from("".to_owned()), &document, can_gc);
 
-            fragment
-                .upcast::<Node>()
-                .AppendChild(text_node.upcast(), can_gc)?;
+            fragment.upcast::<Node>().AppendChild(text_node.upcast())?;
         }
 
         // Step 6: Replace this with fragment within this's parent.
-        parent.ReplaceChild(fragment.upcast(), node, can_gc)?;
+        parent.ReplaceChild(fragment.upcast(), node)?;
 
         // Step 7: If next is non-null and next's previous sibling is a Text node, then merge with
         // the next text node given next's previous sibling.
@@ -672,7 +670,7 @@ fn append_text_node_to_fragment(
     let text = Text::new(DOMString::from(text), document, can_gc);
     fragment
         .upcast::<Node>()
-        .AppendChild(text.upcast(), can_gc)
+        .AppendChild(text.upcast())
         .unwrap();
 }
 
@@ -1018,10 +1016,7 @@ impl HTMLElement {
                     }
 
                     let br = HTMLBRElement::new(local_name!("br"), None, &document, None, can_gc);
-                    fragment
-                        .upcast::<Node>()
-                        .AppendChild(br.upcast(), can_gc)
-                        .unwrap();
+                    fragment.upcast::<Node>().AppendChild(br.upcast()).unwrap();
                 },
                 _ => {
                     // Collect a sequence of code points that are not U+000A LF or U+000D CR from

--- a/components/script/dom/htmlfieldsetelement.rs
+++ b/components/script/dom/htmlfieldsetelement.rs
@@ -71,12 +71,12 @@ impl HTMLFieldSetElement {
         )
     }
 
-    pub(crate) fn update_validity(&self) {
+    pub(crate) fn update_validity(&self, can_gc: CanGc) {
         let has_invalid_child = self
             .upcast::<Node>()
             .traverse_preorder(ShadowIncluding::No)
             .flat_map(DomRoot::downcast::<Element>)
-            .any(|element| element.is_invalid(false));
+            .any(|element| element.is_invalid(false, can_gc));
 
         self.upcast::<Element>()
             .set_state(ElementState::VALID, !has_invalid_child);
@@ -153,8 +153,10 @@ impl VirtualMethods for HTMLFieldSetElement {
         Some(self.upcast::<HTMLElement>() as &dyn VirtualMethods)
     }
 
-    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation) {
-        self.super_type().unwrap().attribute_mutated(attr, mutation);
+    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation, can_gc: CanGc) {
+        self.super_type()
+            .unwrap()
+            .attribute_mutated(attr, mutation, can_gc);
         match *attr.local_name() {
             local_name!("disabled") => {
                 let disabled_state = match mutation {
@@ -243,7 +245,7 @@ impl VirtualMethods for HTMLFieldSetElement {
                 element.update_sequentially_focusable_status(CanGc::note());
             },
             local_name!("form") => {
-                self.form_attribute_mutated(mutation);
+                self.form_attribute_mutated(mutation, can_gc);
             },
             _ => {},
         }

--- a/components/script/dom/htmlheadelement.rs
+++ b/components/script/dom/htmlheadelement.rs
@@ -132,9 +132,9 @@ impl VirtualMethods for HTMLHeadElement {
     fn super_type(&self) -> Option<&dyn VirtualMethods> {
         Some(self.upcast::<HTMLElement>() as &dyn VirtualMethods)
     }
-    fn bind_to_tree(&self, context: &BindContext) {
+    fn bind_to_tree(&self, context: &BindContext, can_gc: CanGc) {
         if let Some(s) = self.super_type() {
-            s.bind_to_tree(context);
+            s.bind_to_tree(context, can_gc);
         }
         load_script(self);
     }

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -343,7 +343,7 @@ impl HTMLIFrameElement {
                     return;
                 }
             }
-            ancestor = a.parent().map(DomRoot::from_ref);
+            ancestor = Some(a.parent().map(DomRoot::from_ref));
         }
 
         let creator_pipeline_id = if url.as_str() == "about:blank" {
@@ -374,7 +374,7 @@ impl HTMLIFrameElement {
             NavigationHistoryBehavior::Push
         };
 
-        self.navigate_or_reload_child_browsing_context(load_data, history_handling, can_gc);
+        self.navigate_or_reload_child_browsing_context(load_data, history_handling, CanGc::note);
     }
 
     fn create_nested_browsing_context(&self, can_gc: CanGc) {
@@ -676,8 +676,10 @@ impl VirtualMethods for HTMLIFrameElement {
         Some(self.upcast::<HTMLElement>() as &dyn VirtualMethods)
     }
 
-    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation) {
-        self.super_type().unwrap().attribute_mutated(attr, mutation);
+    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation, can_gc: CanGc) {
+        self.super_type()
+            .unwrap()
+            .attribute_mutated(attr, mutation, can_gc);
         match *attr.local_name() {
             local_name!("sandbox") => {
                 self.sandbox_allowance
@@ -761,8 +763,8 @@ impl VirtualMethods for HTMLIFrameElement {
         }
     }
 
-    fn unbind_from_tree(&self, context: &UnbindContext) {
-        self.super_type().unwrap().unbind_from_tree(context);
+    fn unbind_from_tree(&self, context: &UnbindContext, can_gc: CanGc) {
+        self.super_type().unwrap().unbind_from_tree(context, can_gc);
 
         let blocker = &self.load_blocker;
         LoadBlocker::terminate(blocker, CanGc::note());

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -343,7 +343,7 @@ impl HTMLIFrameElement {
                     return;
                 }
             }
-            ancestor = Some(a.parent().map(DomRoot::from_ref));
+            ancestor = a.parent().map(DomRoot::from_ref);
         }
 
         let creator_pipeline_id = if url.as_str() == "about:blank" {
@@ -374,7 +374,7 @@ impl HTMLIFrameElement {
             NavigationHistoryBehavior::Push
         };
 
-        self.navigate_or_reload_child_browsing_context(load_data, history_handling, CanGc::note);
+        self.navigate_or_reload_child_browsing_context(load_data, history_handling, can_gc);
     }
 
     fn create_nested_browsing_context(&self, can_gc: CanGc) {

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -1776,7 +1776,7 @@ impl VirtualMethods for HTMLImageElement {
         }
     }
 
-    fn handle_event(&self, event: &Event, can_gc: CanGc) {
+    fn handle_event(&self, event: &Event, _can_gc: CanGc) {
         if event.type_() != atom!("click") {
             return;
         }

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -1743,13 +1743,15 @@ impl VirtualMethods for HTMLImageElement {
         Some(self.upcast::<HTMLElement>() as &dyn VirtualMethods)
     }
 
-    fn adopting_steps(&self, old_doc: &Document) {
-        self.super_type().unwrap().adopting_steps(old_doc);
+    fn adopting_steps(&self, old_doc: &Document, can_gc: CanGc) {
+        self.super_type().unwrap().adopting_steps(old_doc, can_gc);
         self.update_the_image_data(CanGc::note());
     }
 
-    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation) {
-        self.super_type().unwrap().attribute_mutated(attr, mutation);
+    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation, can_gc: CanGc) {
+        self.super_type()
+            .unwrap()
+            .attribute_mutated(attr, mutation, can_gc);
         match attr.local_name() {
             &local_name!("src") |
             &local_name!("srcset") |
@@ -1774,7 +1776,7 @@ impl VirtualMethods for HTMLImageElement {
         }
     }
 
-    fn handle_event(&self, event: &Event) {
+    fn handle_event(&self, event: &Event, can_gc: CanGc) {
         if event.type_() != atom!("click") {
             return;
         }
@@ -1814,9 +1816,9 @@ impl VirtualMethods for HTMLImageElement {
         }
     }
 
-    fn bind_to_tree(&self, context: &BindContext) {
+    fn bind_to_tree(&self, context: &BindContext, can_gc: CanGc) {
         if let Some(s) = self.super_type() {
-            s.bind_to_tree(context);
+            s.bind_to_tree(context, can_gc);
         }
         let document = self.owner_document();
         if context.tree_connected {
@@ -1832,8 +1834,8 @@ impl VirtualMethods for HTMLImageElement {
         }
     }
 
-    fn unbind_from_tree(&self, context: &UnbindContext) {
-        self.super_type().unwrap().unbind_from_tree(context);
+    fn unbind_from_tree(&self, context: &UnbindContext, can_gc: CanGc) {
+        self.super_type().unwrap().unbind_from_tree(context, can_gc);
         let document = self.owner_document();
         document.unregister_responsive_image(self);
 

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -2774,7 +2774,7 @@ impl Validatable for HTMLInputElement {
     fn perform_validation(
         &self,
         validate_flags: ValidationFlags,
-        can_gc: CanGc,
+        _can_gc: CanGc,
     ) -> ValidationFlags {
         let mut failed_flags = ValidationFlags::empty();
         let value = self.Value();
@@ -3068,7 +3068,7 @@ fn new_js_regex(
     cx: SafeJSContext,
     pattern: &str,
     mut out_regex: MutableHandleObject,
-    can_gc: CanGc,
+    _can_gc: CanGc,
 ) -> bool {
     let pattern: Vec<u16> = pattern.encode_utf16().collect();
     unsafe {
@@ -3093,7 +3093,7 @@ fn matches_js_regex(
     cx: SafeJSContext,
     regex_obj: HandleObject,
     value: &str,
-    can_gc: CanGc,
+    _can_gc: CanGc,
 ) -> Result<bool, ()> {
     let mut value: Vec<u16> = value.encode_utf16().collect();
 

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -172,20 +172,20 @@ impl InputType {
     fn is_textual(&self) -> bool {
         matches!(
             *self,
-            InputType::Color |
-                InputType::Date |
-                InputType::DatetimeLocal |
-                InputType::Email |
-                InputType::Hidden |
-                InputType::Month |
-                InputType::Number |
-                InputType::Range |
-                InputType::Search |
-                InputType::Tel |
-                InputType::Text |
-                InputType::Time |
-                InputType::Url |
-                InputType::Week
+            InputType::Color
+                | InputType::Date
+                | InputType::DatetimeLocal
+                | InputType::Email
+                | InputType::Hidden
+                | InputType::Month
+                | InputType::Number
+                | InputType::Range
+                | InputType::Search
+                | InputType::Tel
+                | InputType::Text
+                | InputType::Time
+                | InputType::Url
+                | InputType::Week
         )
     }
 
@@ -427,28 +427,28 @@ impl HTMLInputElement {
     // https://html.spec.whatwg.org/multipage/#concept-input-apply
     fn value_mode(&self) -> ValueMode {
         match self.input_type() {
-            InputType::Submit |
-            InputType::Reset |
-            InputType::Button |
-            InputType::Image |
-            InputType::Hidden => ValueMode::Default,
+            InputType::Submit
+            | InputType::Reset
+            | InputType::Button
+            | InputType::Image
+            | InputType::Hidden => ValueMode::Default,
 
             InputType::Checkbox | InputType::Radio => ValueMode::DefaultOn,
 
-            InputType::Color |
-            InputType::Date |
-            InputType::DatetimeLocal |
-            InputType::Email |
-            InputType::Month |
-            InputType::Number |
-            InputType::Password |
-            InputType::Range |
-            InputType::Search |
-            InputType::Tel |
-            InputType::Text |
-            InputType::Time |
-            InputType::Url |
-            InputType::Week => ValueMode::Value,
+            InputType::Color
+            | InputType::Date
+            | InputType::DatetimeLocal
+            | InputType::Email
+            | InputType::Month
+            | InputType::Number
+            | InputType::Password
+            | InputType::Range
+            | InputType::Search
+            | InputType::Tel
+            | InputType::Text
+            | InputType::Time
+            | InputType::Url
+            | InputType::Week => ValueMode::Value,
 
             InputType::File => ValueMode::Filename,
         }
@@ -477,27 +477,45 @@ impl HTMLInputElement {
         textinput.set_content(value);
     }
 
+    fn does_readonly_apply(&self) -> bool {
+        matches!(
+            self.input_type(),
+            InputType::Text
+                | InputType::Search
+                | InputType::Url
+                | InputType::Tel
+                | InputType::Email
+                | InputType::Password
+                | InputType::Date
+                | InputType::Month
+                | InputType::Week
+                | InputType::Time
+                | InputType::DatetimeLocal
+                | InputType::Number
+        )
+    }
+
     fn does_minmaxlength_apply(&self) -> bool {
         matches!(
             self.input_type(),
-            InputType::Text |
-                InputType::Search |
-                InputType::Url |
-                InputType::Tel |
-                InputType::Email |
-                InputType::Password
+            InputType::Text
+                | InputType::Search
+                | InputType::Url
+                | InputType::Tel
+                | InputType::Email
+                | InputType::Password
         )
     }
 
     fn does_pattern_apply(&self) -> bool {
         matches!(
             self.input_type(),
-            InputType::Text |
-                InputType::Search |
-                InputType::Url |
-                InputType::Tel |
-                InputType::Email |
-                InputType::Password
+            InputType::Text
+                | InputType::Search
+                | InputType::Url
+                | InputType::Tel
+                | InputType::Email
+                | InputType::Password
         )
     }
 
@@ -510,13 +528,13 @@ impl HTMLInputElement {
     fn does_value_as_number_apply(&self) -> bool {
         matches!(
             self.input_type(),
-            InputType::Date |
-                InputType::Month |
-                InputType::Week |
-                InputType::Time |
-                InputType::DatetimeLocal |
-                InputType::Number |
-                InputType::Range
+            InputType::Date
+                | InputType::Month
+                | InputType::Week
+                | InputType::Time
+                | InputType::DatetimeLocal
+                | InputType::Number
+                | InputType::Range
         )
     }
 
@@ -824,10 +842,10 @@ impl HTMLInputElement {
             },
             // https://html.spec.whatwg.org/multipage/#the-required-attribute%3Asuffering-from-being-missing
             _ => {
-                self.Required() &&
-                    self.value_mode() == ValueMode::Value &&
-                    self.is_mutable() &&
-                    value.is_empty()
+                self.Required()
+                    && self.value_mode() == ValueMode::Value
+                    && self.is_mutable()
+                    && value.is_empty()
             },
         }
     }
@@ -871,10 +889,11 @@ impl HTMLInputElement {
 
         if compile_pattern(cx, &pattern_str, pattern.handle_mut()) {
             if self.Multiple() && self.does_multiple_apply() {
-                !split_commas(value)
-                    .all(|s| matches_js_regex(cx, pattern.handle(), s).unwrap_or(true))
+                !split_commas(value).all(|s| {
+                    matches_js_regex(cx, pattern.handle(), s, CanGc::note()).unwrap_or(true)
+                })
             } else {
-                !matches_js_regex(cx, pattern.handle(), value).unwrap_or(true)
+                !matches_js_regex(cx, pattern.handle(), value, CanGc::note()).unwrap_or(true)
             }
         } else {
             // Element doesn't suffer from pattern mismatch if pattern is invalid.
@@ -1138,11 +1157,11 @@ impl TextControlElement for HTMLInputElement {
     fn selection_api_applies(&self) -> bool {
         matches!(
             self.input_type(),
-            InputType::Text |
-                InputType::Search |
-                InputType::Url |
-                InputType::Tel |
-                InputType::Password
+            InputType::Text
+                | InputType::Search
+                | InputType::Url
+                | InputType::Tel
+                | InputType::Password
         )
     }
 
@@ -1155,29 +1174,29 @@ impl TextControlElement for HTMLInputElement {
     // rendered as a text control: file
     fn has_selectable_text(&self) -> bool {
         match self.input_type() {
-            InputType::Text |
-            InputType::Search |
-            InputType::Url |
-            InputType::Tel |
-            InputType::Password |
-            InputType::Email |
-            InputType::Date |
-            InputType::Month |
-            InputType::Week |
-            InputType::Time |
-            InputType::DatetimeLocal |
-            InputType::Number |
-            InputType::Color => true,
+            InputType::Text
+            | InputType::Search
+            | InputType::Url
+            | InputType::Tel
+            | InputType::Password
+            | InputType::Email
+            | InputType::Date
+            | InputType::Month
+            | InputType::Week
+            | InputType::Time
+            | InputType::DatetimeLocal
+            | InputType::Number
+            | InputType::Color => true,
 
-            InputType::Button |
-            InputType::Checkbox |
-            InputType::File |
-            InputType::Hidden |
-            InputType::Image |
-            InputType::Radio |
-            InputType::Range |
-            InputType::Reset |
-            InputType::Submit => false,
+            InputType::Button
+            | InputType::Checkbox
+            | InputType::File
+            | InputType::Hidden
+            | InputType::Image
+            | InputType::Radio
+            | InputType::Range
+            | InputType::Reset
+            | InputType::Submit => false,
         }
     }
 
@@ -1713,9 +1732,9 @@ fn in_same_group(
         return false;
     }
 
-    if other.input_type() != InputType::Radio ||
-        other.form_owner().as_deref() != owner ||
-        other.radio_group_name().as_ref() != group
+    if other.input_type() != InputType::Radio
+        || other.form_owner().as_deref() != owner
+        || other.radio_group_name().as_ref() != group
     {
         return false;
     }
@@ -2104,14 +2123,14 @@ impl HTMLInputElement {
             },
             // The following inputs don't have a value sanitization algorithm.
             // See https://html.spec.whatwg.org/multipage/#value-sanitization-algorithm
-            InputType::Button |
-            InputType::Checkbox |
-            InputType::File |
-            InputType::Hidden |
-            InputType::Image |
-            InputType::Radio |
-            InputType::Reset |
-            InputType::Submit => (),
+            InputType::Button
+            | InputType::Checkbox
+            | InputType::File
+            | InputType::Hidden
+            | InputType::Image
+            | InputType::Radio
+            | InputType::Reset
+            | InputType::Submit => (),
         }
     }
 
@@ -2155,21 +2174,21 @@ impl HTMLInputElement {
                     .unwrap()
                     .filter_map(DomRoot::downcast::<HTMLInputElement>)
                     .filter(|input| {
-                        input.form_owner() == owner &&
-                            matches!(
+                        input.form_owner() == owner
+                            && matches!(
                                 input.input_type(),
-                                InputType::Text |
-                                    InputType::Search |
-                                    InputType::Url |
-                                    InputType::Tel |
-                                    InputType::Email |
-                                    InputType::Password |
-                                    InputType::Date |
-                                    InputType::Month |
-                                    InputType::Week |
-                                    InputType::Time |
-                                    InputType::DatetimeLocal |
-                                    InputType::Number
+                                InputType::Text
+                                    | InputType::Search
+                                    | InputType::Url
+                                    | InputType::Tel
+                                    | InputType::Email
+                                    | InputType::Password
+                                    | InputType::Date
+                                    | InputType::Month
+                                    | InputType::Week
+                                    | InputType::Time
+                                    | InputType::DatetimeLocal
+                                    | InputType::Number
                             )
                     });
 
@@ -2386,8 +2405,8 @@ impl VirtualMethods for HTMLInputElement {
                         let new_value_mode = self.value_mode();
                         match (&old_value_mode, old_idl_value.is_empty(), new_value_mode) {
                             // Step 1
-                            (&ValueMode::Value, false, ValueMode::Default) |
-                            (&ValueMode::Value, false, ValueMode::DefaultOn) => {
+                            (&ValueMode::Value, false, ValueMode::Default)
+                            | (&ValueMode::Value, false, ValueMode::DefaultOn) => {
                                 self.SetValue(old_idl_value, CanGc::note())
                                     .expect("Failed to set input value on type change to a default ValueMode.");
                             },
@@ -2608,9 +2627,9 @@ impl VirtualMethods for HTMLInputElement {
                     }
                 }
             }
-        } else if event.type_() == atom!("keydown") &&
-            !event.DefaultPrevented() &&
-            self.input_type().is_textual_or_password()
+        } else if event.type_() == atom!("keydown")
+            && !event.DefaultPrevented()
+            && self.input_type().is_textual_or_password()
         {
             if let Some(keyevent) = event.downcast::<KeyboardEvent>() {
                 // This can't be inlined, as holding on to textinput.borrow_mut()
@@ -2633,9 +2652,9 @@ impl VirtualMethods for HTMLInputElement {
                     Nothing => (),
                 }
             }
-        } else if event.type_() == atom!("keypress") &&
-            !event.DefaultPrevented() &&
-            self.input_type().is_textual_or_password()
+        } else if event.type_() == atom!("keypress")
+            && !event.DefaultPrevented()
+            && self.input_type().is_textual_or_password()
         {
             if event.IsTrusted() {
                 self.owner_global()
@@ -2648,10 +2667,10 @@ impl VirtualMethods for HTMLInputElement {
                         EventCancelable::NotCancelable,
                     );
             }
-        } else if (event.type_() == atom!("compositionstart") ||
-            event.type_() == atom!("compositionupdate") ||
-            event.type_() == atom!("compositionend")) &&
-            self.input_type().is_textual_or_password()
+        } else if (event.type_() == atom!("compositionstart")
+            || event.type_() == atom!("compositionupdate")
+            || event.type_() == atom!("compositionend"))
+            && self.input_type().is_textual_or_password()
         {
             if let Some(compositionevent) = event.downcast::<CompositionEvent>() {
                 if event.type_() == atom!("compositionend") {
@@ -2736,9 +2755,15 @@ impl Validatable for HTMLInputElement {
         match self.input_type() {
             InputType::Hidden | InputType::Button | InputType::Reset => false,
             _ => {
+<<<<<<< HEAD
                 !(self.upcast::<Element>().disabled_state() ||
                     self.ReadOnly() ||
                     is_barred_by_datalist_ancestor(self.upcast()))
+=======
+                !(self.upcast::<Element>().disabled_state()
+                    || (self.ReadOnly() && self.does_readonly_apply())
+                    || is_barred_by_datalist_ancestor(self.upcast()))
+>>>>>>> a4a6c131b7 (new_js_regex and matches_js_regex need a CanGc argument)
             },
         }
     }
@@ -2747,26 +2772,26 @@ impl Validatable for HTMLInputElement {
         let mut failed_flags = ValidationFlags::empty();
         let value = self.Value();
 
-        if validate_flags.contains(ValidationFlags::VALUE_MISSING) &&
-            self.suffers_from_being_missing(&value)
+        if validate_flags.contains(ValidationFlags::VALUE_MISSING)
+            && self.suffers_from_being_missing(&value)
         {
             failed_flags.insert(ValidationFlags::VALUE_MISSING);
         }
 
-        if validate_flags.contains(ValidationFlags::TYPE_MISMATCH) &&
-            self.suffers_from_type_mismatch(&value)
+        if validate_flags.contains(ValidationFlags::TYPE_MISMATCH)
+            && self.suffers_from_type_mismatch(&value)
         {
             failed_flags.insert(ValidationFlags::TYPE_MISMATCH);
         }
 
-        if validate_flags.contains(ValidationFlags::PATTERN_MISMATCH) &&
-            self.suffers_from_pattern_mismatch(&value)
+        if validate_flags.contains(ValidationFlags::PATTERN_MISMATCH)
+            && self.suffers_from_pattern_mismatch(&value)
         {
             failed_flags.insert(ValidationFlags::PATTERN_MISMATCH);
         }
 
-        if validate_flags.contains(ValidationFlags::BAD_INPUT) &&
-            self.suffers_from_bad_input(&value)
+        if validate_flags.contains(ValidationFlags::BAD_INPUT)
+            && self.suffers_from_bad_input(&value)
         {
             failed_flags.insert(ValidationFlags::BAD_INPUT);
         }
@@ -2776,9 +2801,9 @@ impl Validatable for HTMLInputElement {
         }
 
         if validate_flags.intersects(
-            ValidationFlags::RANGE_UNDERFLOW |
-                ValidationFlags::RANGE_OVERFLOW |
-                ValidationFlags::STEP_MISMATCH,
+            ValidationFlags::RANGE_UNDERFLOW
+                | ValidationFlags::RANGE_OVERFLOW
+                | ValidationFlags::STEP_MISMATCH,
         ) {
             failed_flags |= self.suffers_from_range_issues(&value);
         }
@@ -2991,7 +3016,7 @@ fn compile_pattern(cx: SafeJSContext, pattern_str: &str, out_regex: MutableHandl
     if check_js_regex_syntax(cx, pattern_str) {
         // ...and if it does make pattern that matches only the entirety of string
         let pattern_str = format!("^(?:{})$", pattern_str);
-        new_js_regex(cx, &pattern_str, out_regex)
+        new_js_regex(cx, &pattern_str, out_regex, CanGc::note())
     } else {
         false
     }
@@ -3027,7 +3052,12 @@ fn check_js_regex_syntax(cx: SafeJSContext, pattern: &str) -> bool {
 }
 
 #[allow(unsafe_code)]
-fn new_js_regex(cx: SafeJSContext, pattern: &str, mut out_regex: MutableHandleObject) -> bool {
+fn new_js_regex(
+    cx: SafeJSContext,
+    pattern: &str,
+    mut out_regex: MutableHandleObject,
+    can_gc: CanGc,
+) -> bool {
     let pattern: Vec<u16> = pattern.encode_utf16().collect();
     unsafe {
         out_regex.set(NewUCRegExpObject(
@@ -3047,7 +3077,12 @@ fn new_js_regex(cx: SafeJSContext, pattern: &str, mut out_regex: MutableHandleOb
 }
 
 #[allow(unsafe_code)]
-fn matches_js_regex(cx: SafeJSContext, regex_obj: HandleObject, value: &str) -> Result<bool, ()> {
+fn matches_js_regex(
+    cx: SafeJSContext,
+    regex_obj: HandleObject,
+    value: &str,
+    can_gc: CanGc,
+) -> Result<bool, ()> {
     let mut value: Vec<u16> = value.encode_utf16().collect();
 
     unsafe {

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -2320,7 +2320,9 @@ impl VirtualMethods for HTMLInputElement {
     }
 
     fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation, can_gc: CanGc) {
-        self.super_type().unwrap().attribute_mutated(attr, mutation, can_gc);
+        self.super_type()
+            .unwrap()
+            .attribute_mutated(attr, mutation, can_gc);
         match *attr.local_name() {
             local_name!("disabled") => {
                 let disabled_state = match mutation {
@@ -2744,7 +2746,11 @@ impl Validatable for HTMLInputElement {
         }
     }
 
-    fn perform_validation(&self, validate_flags: ValidationFlags, _can_gc: CanGc) -> ValidationFlags {
+    fn perform_validation(
+        &self,
+        validate_flags: ValidationFlags,
+        _can_gc: CanGc,
+    ) -> ValidationFlags {
         let mut failed_flags = ValidationFlags::empty();
         let value = self.Value();
 

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -172,20 +172,20 @@ impl InputType {
     fn is_textual(&self) -> bool {
         matches!(
             *self,
-            InputType::Color
-                | InputType::Date
-                | InputType::DatetimeLocal
-                | InputType::Email
-                | InputType::Hidden
-                | InputType::Month
-                | InputType::Number
-                | InputType::Range
-                | InputType::Search
-                | InputType::Tel
-                | InputType::Text
-                | InputType::Time
-                | InputType::Url
-                | InputType::Week
+            InputType::Color |
+                InputType::Date |
+                InputType::DatetimeLocal |
+                InputType::Email |
+                InputType::Hidden |
+                InputType::Month |
+                InputType::Number |
+                InputType::Range |
+                InputType::Search |
+                InputType::Tel |
+                InputType::Text |
+                InputType::Time |
+                InputType::Url |
+                InputType::Week
         )
     }
 
@@ -427,28 +427,28 @@ impl HTMLInputElement {
     // https://html.spec.whatwg.org/multipage/#concept-input-apply
     fn value_mode(&self) -> ValueMode {
         match self.input_type() {
-            InputType::Submit
-            | InputType::Reset
-            | InputType::Button
-            | InputType::Image
-            | InputType::Hidden => ValueMode::Default,
+            InputType::Submit |
+            InputType::Reset |
+            InputType::Button |
+            InputType::Image |
+            InputType::Hidden => ValueMode::Default,
 
             InputType::Checkbox | InputType::Radio => ValueMode::DefaultOn,
 
-            InputType::Color
-            | InputType::Date
-            | InputType::DatetimeLocal
-            | InputType::Email
-            | InputType::Month
-            | InputType::Number
-            | InputType::Password
-            | InputType::Range
-            | InputType::Search
-            | InputType::Tel
-            | InputType::Text
-            | InputType::Time
-            | InputType::Url
-            | InputType::Week => ValueMode::Value,
+            InputType::Color |
+            InputType::Date |
+            InputType::DatetimeLocal |
+            InputType::Email |
+            InputType::Month |
+            InputType::Number |
+            InputType::Password |
+            InputType::Range |
+            InputType::Search |
+            InputType::Tel |
+            InputType::Text |
+            InputType::Time |
+            InputType::Url |
+            InputType::Week => ValueMode::Value,
 
             InputType::File => ValueMode::Filename,
         }
@@ -480,42 +480,42 @@ impl HTMLInputElement {
     fn does_readonly_apply(&self) -> bool {
         matches!(
             self.input_type(),
-            InputType::Text
-                | InputType::Search
-                | InputType::Url
-                | InputType::Tel
-                | InputType::Email
-                | InputType::Password
-                | InputType::Date
-                | InputType::Month
-                | InputType::Week
-                | InputType::Time
-                | InputType::DatetimeLocal
-                | InputType::Number
+            InputType::Text |
+                InputType::Search |
+                InputType::Url |
+                InputType::Tel |
+                InputType::Email |
+                InputType::Password |
+                InputType::Date |
+                InputType::Month |
+                InputType::Week |
+                InputType::Time |
+                InputType::DatetimeLocal |
+                InputType::Number
         )
     }
 
     fn does_minmaxlength_apply(&self) -> bool {
         matches!(
             self.input_type(),
-            InputType::Text
-                | InputType::Search
-                | InputType::Url
-                | InputType::Tel
-                | InputType::Email
-                | InputType::Password
+            InputType::Text |
+                InputType::Search |
+                InputType::Url |
+                InputType::Tel |
+                InputType::Email |
+                InputType::Password
         )
     }
 
     fn does_pattern_apply(&self) -> bool {
         matches!(
             self.input_type(),
-            InputType::Text
-                | InputType::Search
-                | InputType::Url
-                | InputType::Tel
-                | InputType::Email
-                | InputType::Password
+            InputType::Text |
+                InputType::Search |
+                InputType::Url |
+                InputType::Tel |
+                InputType::Email |
+                InputType::Password
         )
     }
 
@@ -528,13 +528,13 @@ impl HTMLInputElement {
     fn does_value_as_number_apply(&self) -> bool {
         matches!(
             self.input_type(),
-            InputType::Date
-                | InputType::Month
-                | InputType::Week
-                | InputType::Time
-                | InputType::DatetimeLocal
-                | InputType::Number
-                | InputType::Range
+            InputType::Date |
+                InputType::Month |
+                InputType::Week |
+                InputType::Time |
+                InputType::DatetimeLocal |
+                InputType::Number |
+                InputType::Range
         )
     }
 
@@ -842,10 +842,10 @@ impl HTMLInputElement {
             },
             // https://html.spec.whatwg.org/multipage/#the-required-attribute%3Asuffering-from-being-missing
             _ => {
-                self.Required()
-                    && self.value_mode() == ValueMode::Value
-                    && self.is_mutable()
-                    && value.is_empty()
+                self.Required() &&
+                    self.value_mode() == ValueMode::Value &&
+                    self.is_mutable() &&
+                    value.is_empty()
             },
         }
     }
@@ -1157,11 +1157,11 @@ impl TextControlElement for HTMLInputElement {
     fn selection_api_applies(&self) -> bool {
         matches!(
             self.input_type(),
-            InputType::Text
-                | InputType::Search
-                | InputType::Url
-                | InputType::Tel
-                | InputType::Password
+            InputType::Text |
+                InputType::Search |
+                InputType::Url |
+                InputType::Tel |
+                InputType::Password
         )
     }
 
@@ -1174,29 +1174,29 @@ impl TextControlElement for HTMLInputElement {
     // rendered as a text control: file
     fn has_selectable_text(&self) -> bool {
         match self.input_type() {
-            InputType::Text
-            | InputType::Search
-            | InputType::Url
-            | InputType::Tel
-            | InputType::Password
-            | InputType::Email
-            | InputType::Date
-            | InputType::Month
-            | InputType::Week
-            | InputType::Time
-            | InputType::DatetimeLocal
-            | InputType::Number
-            | InputType::Color => true,
+            InputType::Text |
+            InputType::Search |
+            InputType::Url |
+            InputType::Tel |
+            InputType::Password |
+            InputType::Email |
+            InputType::Date |
+            InputType::Month |
+            InputType::Week |
+            InputType::Time |
+            InputType::DatetimeLocal |
+            InputType::Number |
+            InputType::Color => true,
 
-            InputType::Button
-            | InputType::Checkbox
-            | InputType::File
-            | InputType::Hidden
-            | InputType::Image
-            | InputType::Radio
-            | InputType::Range
-            | InputType::Reset
-            | InputType::Submit => false,
+            InputType::Button |
+            InputType::Checkbox |
+            InputType::File |
+            InputType::Hidden |
+            InputType::Image |
+            InputType::Radio |
+            InputType::Range |
+            InputType::Reset |
+            InputType::Submit => false,
         }
     }
 
@@ -1732,9 +1732,9 @@ fn in_same_group(
         return false;
     }
 
-    if other.input_type() != InputType::Radio
-        || other.form_owner().as_deref() != owner
-        || other.radio_group_name().as_ref() != group
+    if other.input_type() != InputType::Radio ||
+        other.form_owner().as_deref() != owner ||
+        other.radio_group_name().as_ref() != group
     {
         return false;
     }
@@ -2123,14 +2123,14 @@ impl HTMLInputElement {
             },
             // The following inputs don't have a value sanitization algorithm.
             // See https://html.spec.whatwg.org/multipage/#value-sanitization-algorithm
-            InputType::Button
-            | InputType::Checkbox
-            | InputType::File
-            | InputType::Hidden
-            | InputType::Image
-            | InputType::Radio
-            | InputType::Reset
-            | InputType::Submit => (),
+            InputType::Button |
+            InputType::Checkbox |
+            InputType::File |
+            InputType::Hidden |
+            InputType::Image |
+            InputType::Radio |
+            InputType::Reset |
+            InputType::Submit => (),
         }
     }
 
@@ -2174,21 +2174,21 @@ impl HTMLInputElement {
                     .unwrap()
                     .filter_map(DomRoot::downcast::<HTMLInputElement>)
                     .filter(|input| {
-                        input.form_owner() == owner
-                            && matches!(
+                        input.form_owner() == owner &&
+                            matches!(
                                 input.input_type(),
-                                InputType::Text
-                                    | InputType::Search
-                                    | InputType::Url
-                                    | InputType::Tel
-                                    | InputType::Email
-                                    | InputType::Password
-                                    | InputType::Date
-                                    | InputType::Month
-                                    | InputType::Week
-                                    | InputType::Time
-                                    | InputType::DatetimeLocal
-                                    | InputType::Number
+                                InputType::Text |
+                                    InputType::Search |
+                                    InputType::Url |
+                                    InputType::Tel |
+                                    InputType::Email |
+                                    InputType::Password |
+                                    InputType::Date |
+                                    InputType::Month |
+                                    InputType::Week |
+                                    InputType::Time |
+                                    InputType::DatetimeLocal |
+                                    InputType::Number
                             )
                     });
 
@@ -2405,8 +2405,8 @@ impl VirtualMethods for HTMLInputElement {
                         let new_value_mode = self.value_mode();
                         match (&old_value_mode, old_idl_value.is_empty(), new_value_mode) {
                             // Step 1
-                            (&ValueMode::Value, false, ValueMode::Default)
-                            | (&ValueMode::Value, false, ValueMode::DefaultOn) => {
+                            (&ValueMode::Value, false, ValueMode::Default) |
+                            (&ValueMode::Value, false, ValueMode::DefaultOn) => {
                                 self.SetValue(old_idl_value, CanGc::note())
                                     .expect("Failed to set input value on type change to a default ValueMode.");
                             },
@@ -2627,9 +2627,9 @@ impl VirtualMethods for HTMLInputElement {
                     }
                 }
             }
-        } else if event.type_() == atom!("keydown")
-            && !event.DefaultPrevented()
-            && self.input_type().is_textual_or_password()
+        } else if event.type_() == atom!("keydown") &&
+            !event.DefaultPrevented() &&
+            self.input_type().is_textual_or_password()
         {
             if let Some(keyevent) = event.downcast::<KeyboardEvent>() {
                 // This can't be inlined, as holding on to textinput.borrow_mut()
@@ -2652,9 +2652,9 @@ impl VirtualMethods for HTMLInputElement {
                     Nothing => (),
                 }
             }
-        } else if event.type_() == atom!("keypress")
-            && !event.DefaultPrevented()
-            && self.input_type().is_textual_or_password()
+        } else if event.type_() == atom!("keypress") &&
+            !event.DefaultPrevented() &&
+            self.input_type().is_textual_or_password()
         {
             if event.IsTrusted() {
                 self.owner_global()
@@ -2667,10 +2667,10 @@ impl VirtualMethods for HTMLInputElement {
                         EventCancelable::NotCancelable,
                     );
             }
-        } else if (event.type_() == atom!("compositionstart")
-            || event.type_() == atom!("compositionupdate")
-            || event.type_() == atom!("compositionend"))
-            && self.input_type().is_textual_or_password()
+        } else if (event.type_() == atom!("compositionstart") ||
+            event.type_() == atom!("compositionupdate") ||
+            event.type_() == atom!("compositionend")) &&
+            self.input_type().is_textual_or_password()
         {
             if let Some(compositionevent) = event.downcast::<CompositionEvent>() {
                 if event.type_() == atom!("compositionend") {
@@ -2755,15 +2755,14 @@ impl Validatable for HTMLInputElement {
         match self.input_type() {
             InputType::Hidden | InputType::Button | InputType::Reset => false,
             _ => {
-<<<<<<< HEAD
-                !(self.upcast::<Element>().disabled_state() ||
-                    self.ReadOnly() ||
-                    is_barred_by_datalist_ancestor(self.upcast()))
-=======
+
+               
+
                 !(self.upcast::<Element>().disabled_state()
                     || (self.ReadOnly() && self.does_readonly_apply())
                     || is_barred_by_datalist_ancestor(self.upcast()))
->>>>>>> a4a6c131b7 (new_js_regex and matches_js_regex need a CanGc argument)
+
+
             },
         }
     }
@@ -2772,26 +2771,26 @@ impl Validatable for HTMLInputElement {
         let mut failed_flags = ValidationFlags::empty();
         let value = self.Value();
 
-        if validate_flags.contains(ValidationFlags::VALUE_MISSING)
-            && self.suffers_from_being_missing(&value)
+        if validate_flags.contains(ValidationFlags::VALUE_MISSING) &&
+            self.suffers_from_being_missing(&value)
         {
             failed_flags.insert(ValidationFlags::VALUE_MISSING);
         }
 
-        if validate_flags.contains(ValidationFlags::TYPE_MISMATCH)
-            && self.suffers_from_type_mismatch(&value)
+        if validate_flags.contains(ValidationFlags::TYPE_MISMATCH) &&
+            self.suffers_from_type_mismatch(&value)
         {
             failed_flags.insert(ValidationFlags::TYPE_MISMATCH);
         }
 
-        if validate_flags.contains(ValidationFlags::PATTERN_MISMATCH)
-            && self.suffers_from_pattern_mismatch(&value)
+        if validate_flags.contains(ValidationFlags::PATTERN_MISMATCH) &&
+            self.suffers_from_pattern_mismatch(&value)
         {
             failed_flags.insert(ValidationFlags::PATTERN_MISMATCH);
         }
 
-        if validate_flags.contains(ValidationFlags::BAD_INPUT)
-            && self.suffers_from_bad_input(&value)
+        if validate_flags.contains(ValidationFlags::BAD_INPUT) &&
+            self.suffers_from_bad_input(&value)
         {
             failed_flags.insert(ValidationFlags::BAD_INPUT);
         }
@@ -2801,9 +2800,9 @@ impl Validatable for HTMLInputElement {
         }
 
         if validate_flags.intersects(
-            ValidationFlags::RANGE_UNDERFLOW
-                | ValidationFlags::RANGE_OVERFLOW
-                | ValidationFlags::STEP_MISMATCH,
+            ValidationFlags::RANGE_UNDERFLOW |
+                ValidationFlags::RANGE_OVERFLOW |
+                ValidationFlags::STEP_MISMATCH,
         ) {
             failed_flags |= self.suffers_from_range_issues(&value);
         }

--- a/components/script/dom/htmllabelelement.rs
+++ b/components/script/dom/htmllabelelement.rs
@@ -157,10 +157,12 @@ impl VirtualMethods for HTMLLabelElement {
         }
     }
 
-    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation) {
-        self.super_type().unwrap().attribute_mutated(attr, mutation);
+    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation, can_gc: CanGc) {
+        self.super_type()
+            .unwrap()
+            .attribute_mutated(attr, mutation, can_gc);
         if *attr.local_name() == local_name!("form") {
-            self.form_attribute_mutated(mutation);
+            self.form_attribute_mutated(mutation, can_gc);
         }
     }
 }

--- a/components/script/dom/htmllegendelement.rs
+++ b/components/script/dom/htmllegendelement.rs
@@ -61,17 +61,17 @@ impl VirtualMethods for HTMLLegendElement {
         Some(self.upcast::<HTMLElement>() as &dyn VirtualMethods)
     }
 
-    fn bind_to_tree(&self, context: &BindContext) {
+    fn bind_to_tree(&self, context: &BindContext, can_gc: CanGc) {
         if let Some(s) = self.super_type() {
-            s.bind_to_tree(context);
+            s.bind_to_tree(context, can_gc);
         }
 
         self.upcast::<Element>()
             .check_ancestors_disabled_state_for_form_control();
     }
 
-    fn unbind_from_tree(&self, context: &UnbindContext) {
-        self.super_type().unwrap().unbind_from_tree(context);
+    fn unbind_from_tree(&self, context: &UnbindContext, can_gc: CanGc) {
+        self.super_type().unwrap().unbind_from_tree(context, can_gc);
 
         let node = self.upcast::<Node>();
         let el = self.upcast::<Element>();

--- a/components/script/dom/htmllinkelement.rs
+++ b/components/script/dom/htmllinkelement.rs
@@ -216,8 +216,10 @@ impl VirtualMethods for HTMLLinkElement {
         Some(self.upcast::<HTMLElement>() as &dyn VirtualMethods)
     }
 
-    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation) {
-        self.super_type().unwrap().attribute_mutated(attr, mutation);
+    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation, can_gc: CanGc) {
+        self.super_type()
+            .unwrap()
+            .attribute_mutated(attr, mutation, can_gc);
         if !self.upcast::<Node>().is_connected() || mutation.is_removal() {
             return;
         }
@@ -265,9 +267,9 @@ impl VirtualMethods for HTMLLinkElement {
         }
     }
 
-    fn bind_to_tree(&self, context: &BindContext) {
+    fn bind_to_tree(&self, context: &BindContext, can_gc: CanGc) {
         if let Some(s) = self.super_type() {
-            s.bind_to_tree(context);
+            s.bind_to_tree(context, can_gc);
         }
 
         self.relations
@@ -294,9 +296,9 @@ impl VirtualMethods for HTMLLinkElement {
         }
     }
 
-    fn unbind_from_tree(&self, context: &UnbindContext) {
+    fn unbind_from_tree(&self, context: &UnbindContext, can_gc: CanGc) {
         if let Some(s) = self.super_type() {
-            s.unbind_from_tree(context);
+            s.unbind_from_tree(context, can_gc);
         }
 
         if let Some(s) = self.stylesheet.borrow_mut().take() {

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -1927,7 +1927,7 @@ impl HTMLMediaElement {
             .SetTextContent(Some(DOMString::from(media_controls_script)), can_gc);
         if let Err(e) = shadow_root
             .upcast::<Node>()
-            .AppendChild(script.upcast::<Node>(), can_gc)
+            .AppendChild(script.upcast::<Node>())
         {
             warn!("Could not render media controls {:?}", e);
             return;
@@ -1948,7 +1948,7 @@ impl HTMLMediaElement {
 
         if let Err(e) = shadow_root
             .upcast::<Node>()
-            .AppendChild(style.upcast::<Node>(), can_gc)
+            .AppendChild(style.upcast::<Node>())
         {
             warn!("Could not render media controls {:?}", e);
         }

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -1927,7 +1927,7 @@ impl HTMLMediaElement {
             .SetTextContent(Some(DOMString::from(media_controls_script)), can_gc);
         if let Err(e) = shadow_root
             .upcast::<Node>()
-            .AppendChild(script.upcast::<Node>())
+            .AppendChild(script.upcast::<Node>(), can_gc)
         {
             warn!("Could not render media controls {:?}", e);
             return;
@@ -1948,7 +1948,7 @@ impl HTMLMediaElement {
 
         if let Err(e) = shadow_root
             .upcast::<Node>()
-            .AppendChild(style.upcast::<Node>())
+            .AppendChild(style.upcast::<Node>(), can_gc)
         {
             warn!("Could not render media controls {:?}", e);
         }
@@ -1956,9 +1956,9 @@ impl HTMLMediaElement {
         self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
     }
 
-    fn remove_controls(&self) {
+    fn remove_controls(&self, can_gc: CanGc) {
         if let Some(id) = self.media_controls_id.borrow_mut().take() {
-            self.owner_document().unregister_media_controls(&id);
+            self.owner_document().unregister_media_controls(&id, can_gc);
         }
     }
 
@@ -2486,8 +2486,10 @@ impl VirtualMethods for HTMLMediaElement {
         Some(self.upcast::<HTMLElement>() as &dyn VirtualMethods)
     }
 
-    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation) {
-        self.super_type().unwrap().attribute_mutated(attr, mutation);
+    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation, can_gc: CanGc) {
+        self.super_type()
+            .unwrap()
+            .attribute_mutated(attr, mutation, can_gc);
 
         match *attr.local_name() {
             local_name!("muted") => {
@@ -2502,9 +2504,9 @@ impl VirtualMethods for HTMLMediaElement {
             },
             local_name!("controls") => {
                 if mutation.new_value(attr).is_some() {
-                    self.render_controls(CanGc::note());
+                    self.render_controls(can_gc);
                 } else {
-                    self.remove_controls();
+                    self.remove_controls(can_gc);
                 }
             },
             _ => (),
@@ -2512,10 +2514,10 @@ impl VirtualMethods for HTMLMediaElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#playing-the-media-resource:remove-an-element-from-a-document
-    fn unbind_from_tree(&self, context: &UnbindContext) {
-        self.super_type().unwrap().unbind_from_tree(context);
+    fn unbind_from_tree(&self, context: &UnbindContext, can_gc: CanGc) {
+        self.super_type().unwrap().unbind_from_tree(context, can_gc);
 
-        self.remove_controls();
+        self.remove_controls(can_gc);
 
         if context.tree_connected {
             let task = MediaElementMicrotask::PauseIfNotInDocument {

--- a/components/script/dom/htmlmetaelement.rs
+++ b/components/script/dom/htmlmetaelement.rs
@@ -252,9 +252,9 @@ impl VirtualMethods for HTMLMetaElement {
         Some(self.upcast::<HTMLElement>() as &dyn VirtualMethods)
     }
 
-    fn bind_to_tree(&self, context: &BindContext) {
+    fn bind_to_tree(&self, context: &BindContext, can_gc: CanGc) {
         if let Some(s) = self.super_type() {
-            s.bind_to_tree(context);
+            s.bind_to_tree(context, can_gc);
         }
 
         if context.tree_connected {
@@ -262,17 +262,17 @@ impl VirtualMethods for HTMLMetaElement {
         }
     }
 
-    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation) {
+    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation, can_gc: CanGc) {
         if let Some(s) = self.super_type() {
-            s.attribute_mutated(attr, mutation);
+            s.attribute_mutated(attr, mutation, can_gc);
         }
 
         self.process_referrer_attribute();
     }
 
-    fn unbind_from_tree(&self, context: &UnbindContext) {
+    fn unbind_from_tree(&self, context: &UnbindContext, can_gc: CanGc) {
         if let Some(s) = self.super_type() {
-            s.unbind_from_tree(context);
+            s.unbind_from_tree(context, can_gc);
         }
 
         if context.tree_connected {

--- a/components/script/dom/htmlmeterelement.rs
+++ b/components/script/dom/htmlmeterelement.rs
@@ -94,7 +94,7 @@ impl HTMLMeterElement {
 
         let meter_value = HTMLDivElement::new(local_name!("div"), None, &document, None, can_gc);
         root.upcast::<Node>()
-            .AppendChild(meter_value.upcast::<Node>(), can_gc)
+            .AppendChild(meter_value.upcast::<Node>())
             .unwrap();
 
         let _ = self.shadow_tree.borrow_mut().insert(ShadowTree {

--- a/components/script/dom/htmlmeterelement.rs
+++ b/components/script/dom/htmlmeterelement.rs
@@ -94,7 +94,7 @@ impl HTMLMeterElement {
 
         let meter_value = HTMLDivElement::new(local_name!("div"), None, &document, None, can_gc);
         root.upcast::<Node>()
-            .AppendChild(meter_value.upcast::<Node>())
+            .AppendChild(meter_value.upcast::<Node>(), can_gc)
             .unwrap();
 
         let _ = self.shadow_tree.borrow_mut().insert(ShadowTree {
@@ -331,8 +331,10 @@ impl VirtualMethods for HTMLMeterElement {
         Some(self.upcast::<HTMLElement>() as &dyn VirtualMethods)
     }
 
-    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation) {
-        self.super_type().unwrap().attribute_mutated(attr, mutation);
+    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation, can_gc: CanGc) {
+        self.super_type()
+            .unwrap()
+            .attribute_mutated(attr, mutation, can_gc);
 
         let is_important_attribute = matches!(
             attr.local_name(),
@@ -354,8 +356,8 @@ impl VirtualMethods for HTMLMeterElement {
         self.update_state(CanGc::note());
     }
 
-    fn bind_to_tree(&self, context: &BindContext) {
-        self.super_type().unwrap().bind_to_tree(context);
+    fn bind_to_tree(&self, context: &BindContext, can_gc: CanGc) {
+        self.super_type().unwrap().bind_to_tree(context, can_gc);
 
         self.update_state(CanGc::note());
     }

--- a/components/script/dom/htmlobjectelement.rs
+++ b/components/script/dom/htmlobjectelement.rs
@@ -153,8 +153,10 @@ impl VirtualMethods for HTMLObjectElement {
         Some(self.upcast::<HTMLElement>() as &dyn VirtualMethods)
     }
 
-    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation) {
-        self.super_type().unwrap().attribute_mutated(attr, mutation);
+    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation, can_gc: CanGc) {
+        self.super_type()
+            .unwrap()
+            .attribute_mutated(attr, mutation, can_gc);
         match *attr.local_name() {
             local_name!("data") => {
                 if let AttributeMutation::Set(_) = mutation {
@@ -162,7 +164,7 @@ impl VirtualMethods for HTMLObjectElement {
                 }
             },
             local_name!("form") => {
-                self.form_attribute_mutated(mutation);
+                self.form_attribute_mutated(mutation, can_gc);
             },
             _ => {},
         }

--- a/components/script/dom/htmloptgroupelement.rs
+++ b/components/script/dom/htmloptgroupelement.rs
@@ -64,11 +64,11 @@ impl HTMLOptGroupElement {
         )
     }
 
-    fn update_select_validity(&self) {
+    fn update_select_validity(&self, can_gc: CanGc) {
         if let Some(select) = self.owner_select_element() {
             select
                 .validity_state()
-                .perform_validation_and_update(ValidationFlags::all());
+                .perform_validation_and_update(ValidationFlags::all(), can_gc);
         }
     }
 
@@ -98,8 +98,10 @@ impl VirtualMethods for HTMLOptGroupElement {
         Some(self.upcast::<HTMLElement>() as &dyn VirtualMethods)
     }
 
-    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation) {
-        self.super_type().unwrap().attribute_mutated(attr, mutation);
+    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation, can_gc: CanGc) {
+        self.super_type()
+            .unwrap()
+            .attribute_mutated(attr, mutation, can_gc);
         if attr.local_name() == &local_name!("disabled") {
             let disabled_state = match mutation {
                 AttributeMutation::Set(None) => true,
@@ -132,21 +134,21 @@ impl VirtualMethods for HTMLOptGroupElement {
         }
     }
 
-    fn bind_to_tree(&self, context: &BindContext) {
+    fn bind_to_tree(&self, context: &BindContext, can_gc: CanGc) {
         if let Some(s) = self.super_type() {
-            s.bind_to_tree(context);
+            s.bind_to_tree(context, can_gc);
         }
 
-        self.update_select_validity();
+        self.update_select_validity(can_gc);
     }
 
-    fn unbind_from_tree(&self, context: &UnbindContext) {
-        self.super_type().unwrap().unbind_from_tree(context);
+    fn unbind_from_tree(&self, context: &UnbindContext, can_gc: CanGc) {
+        self.super_type().unwrap().unbind_from_tree(context, can_gc);
 
         if let Some(select) = context.parent.downcast::<HTMLSelectElement>() {
             select
                 .validity_state()
-                .perform_validation_and_update(ValidationFlags::all());
+                .perform_validation_and_update(ValidationFlags::all(), can_gc);
         }
     }
 }

--- a/components/script/dom/htmloptionelement.rs
+++ b/components/script/dom/htmloptionelement.rs
@@ -282,11 +282,11 @@ impl HTMLOptionElementMethods<crate::DomTypeHolder> for HTMLOptionElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-option-selected
-    fn SetSelected(&self, selected: bool, can_gc: CanGc) {
+    fn SetSelected(&self, selected: bool) {
         self.dirtiness.set(true);
         self.selectedness.set(selected);
         self.pick_if_selected_and_reset();
-        self.update_select_validity(can_gc);
+        self.update_select_validity(CanGc::note());
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-option-index

--- a/components/script/dom/htmloptionscollection.rs
+++ b/components/script/dom/htmloptionscollection.rs
@@ -64,7 +64,7 @@ impl HTMLOptionsCollection {
             let element =
                 HTMLOptionElement::new(local_name!("option"), None, &document, None, can_gc);
             let node = element.upcast::<Node>();
-            root.AppendChild(node, can_gc)?;
+            root.AppendChild(node)?;
         }
         Ok(())
     }
@@ -122,11 +122,11 @@ impl HTMLOptionsCollectionMethods<crate::DomTypeHolder> for HTMLOptionsCollectio
                 let child = self.upcast().IndexedGetter(index).unwrap();
                 let child_node = child.upcast::<Node>();
 
-                root.ReplaceChild(node, child_node, can_gc).map(|_| ())
+                root.ReplaceChild(node, child_node).map(|_| ())
             }
         } else {
             // Step 1
-            self.Remove(index as i32, can_gc);
+            self.Remove(index as i32);
             Ok(())
         }
     }
@@ -161,7 +161,7 @@ impl HTMLOptionsCollectionMethods<crate::DomTypeHolder> for HTMLOptionsCollectio
                 // Step 3.1. Let n be current − value.
                 // Step 3.2 Remove the last n nodes in the collection from their parent nodes.
                 for index in (length..current).rev() {
-                    self.Remove(index as i32, can_gc)
+                    self.Remove(index as i32)
                 }
             },
             _ => {},
@@ -173,7 +173,6 @@ impl HTMLOptionsCollectionMethods<crate::DomTypeHolder> for HTMLOptionsCollectio
         &self,
         element: HTMLOptionElementOrHTMLOptGroupElement,
         before: Option<HTMLElementOrLong>,
-        can_gc: CanGc,
     ) -> ErrorResult {
         let root = self.upcast().root_node();
 
@@ -221,13 +220,13 @@ impl HTMLOptionsCollectionMethods<crate::DomTypeHolder> for HTMLOptionsCollectio
         };
 
         // Step 6
-        Node::pre_insert(node, &parent, reference_node.as_deref(), can_gc).map(|_| ())
+        Node::pre_insert(node, &parent, reference_node.as_deref(), CanGc::note()).map(|_| ())
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-htmloptionscollection-remove>
-    fn Remove(&self, index: i32, can_gc: CanGc) {
+    fn Remove(&self, index: i32) {
         if let Some(element) = self.upcast().IndexedGetter(index as u32) {
-            element.Remove(can_gc);
+            element.Remove();
         }
     }
 

--- a/components/script/dom/htmloptionscollection.rs
+++ b/components/script/dom/htmloptionscollection.rs
@@ -64,7 +64,7 @@ impl HTMLOptionsCollection {
             let element =
                 HTMLOptionElement::new(local_name!("option"), None, &document, None, can_gc);
             let node = element.upcast::<Node>();
-            root.AppendChild(node)?;
+            root.AppendChild(node, can_gc)?;
         }
         Ok(())
     }
@@ -117,16 +117,16 @@ impl HTMLOptionsCollectionMethods<crate::DomTypeHolder> for HTMLOptionsCollectio
             let node = value.upcast::<Node>();
             let root = self.upcast().root_node();
             if n >= 0 {
-                Node::pre_insert(node, &root, None).map(|_| ())
+                Node::pre_insert(node, &root, None, can_gc).map(|_| ())
             } else {
                 let child = self.upcast().IndexedGetter(index).unwrap();
                 let child_node = child.upcast::<Node>();
 
-                root.ReplaceChild(node, child_node).map(|_| ())
+                root.ReplaceChild(node, child_node, can_gc).map(|_| ())
             }
         } else {
             // Step 1
-            self.Remove(index as i32);
+            self.Remove(index as i32, can_gc);
             Ok(())
         }
     }
@@ -161,7 +161,7 @@ impl HTMLOptionsCollectionMethods<crate::DomTypeHolder> for HTMLOptionsCollectio
                 // Step 3.1. Let n be current − value.
                 // Step 3.2 Remove the last n nodes in the collection from their parent nodes.
                 for index in (length..current).rev() {
-                    self.Remove(index as i32)
+                    self.Remove(index as i32, can_gc)
                 }
             },
             _ => {},
@@ -173,6 +173,7 @@ impl HTMLOptionsCollectionMethods<crate::DomTypeHolder> for HTMLOptionsCollectio
         &self,
         element: HTMLOptionElementOrHTMLOptGroupElement,
         before: Option<HTMLElementOrLong>,
+        can_gc: CanGc,
     ) -> ErrorResult {
         let root = self.upcast().root_node();
 
@@ -220,13 +221,13 @@ impl HTMLOptionsCollectionMethods<crate::DomTypeHolder> for HTMLOptionsCollectio
         };
 
         // Step 6
-        Node::pre_insert(node, &parent, reference_node.as_deref()).map(|_| ())
+        Node::pre_insert(node, &parent, reference_node.as_deref(), can_gc).map(|_| ())
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-htmloptionscollection-remove>
-    fn Remove(&self, index: i32) {
+    fn Remove(&self, index: i32, can_gc: CanGc) {
         if let Some(element) = self.upcast().IndexedGetter(index as u32) {
-            element.Remove();
+            element.Remove(can_gc);
         }
     }
 

--- a/components/script/dom/htmloutputelement.rs
+++ b/components/script/dom/htmloutputelement.rs
@@ -159,10 +159,12 @@ impl VirtualMethods for HTMLOutputElement {
         Some(self.upcast::<HTMLElement>() as &dyn VirtualMethods)
     }
 
-    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation) {
-        self.super_type().unwrap().attribute_mutated(attr, mutation);
+    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation, can_gc: CanGc) {
+        self.super_type()
+            .unwrap()
+            .attribute_mutated(attr, mutation, can_gc);
         if attr.local_name() == &local_name!("form") {
-            self.form_attribute_mutated(mutation);
+            self.form_attribute_mutated(mutation, can_gc);
         }
     }
 }

--- a/components/script/dom/htmlprogresselement.rs
+++ b/components/script/dom/htmlprogresselement.rs
@@ -96,7 +96,7 @@ impl HTMLProgressElement {
             .upcast::<Element>()
             .SetId("-servo-progress-bar".into(), can_gc);
         root.upcast::<Node>()
-            .AppendChild(progress_bar.upcast::<Node>())
+            .AppendChild(progress_bar.upcast::<Node>(), can_gc)
             .unwrap();
 
         let _ = self.shadow_tree.borrow_mut().insert(ShadowTree {
@@ -227,8 +227,10 @@ impl VirtualMethods for HTMLProgressElement {
         Some(self.upcast::<HTMLElement>() as &dyn VirtualMethods)
     }
 
-    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation) {
-        self.super_type().unwrap().attribute_mutated(attr, mutation);
+    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation, can_gc: CanGc) {
+        self.super_type()
+            .unwrap()
+            .attribute_mutated(attr, mutation, can_gc);
 
         let is_important_attribute = matches!(
             attr.local_name(),
@@ -239,8 +241,8 @@ impl VirtualMethods for HTMLProgressElement {
         }
     }
 
-    fn bind_to_tree(&self, context: &BindContext) {
-        self.super_type().unwrap().bind_to_tree(context);
+    fn bind_to_tree(&self, context: &BindContext, can_gc: CanGc) {
+        self.super_type().unwrap().bind_to_tree(context, can_gc);
 
         self.update_state(CanGc::note());
     }

--- a/components/script/dom/htmlprogresselement.rs
+++ b/components/script/dom/htmlprogresselement.rs
@@ -96,7 +96,7 @@ impl HTMLProgressElement {
             .upcast::<Element>()
             .SetId("-servo-progress-bar".into(), can_gc);
         root.upcast::<Node>()
-            .AppendChild(progress_bar.upcast::<Node>(), can_gc)
+            .AppendChild(progress_bar.upcast::<Node>())
             .unwrap();
 
         let _ = self.shadow_tree.borrow_mut().insert(ShadowTree {

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -1242,8 +1242,10 @@ impl VirtualMethods for HTMLScriptElement {
         Some(self.upcast::<HTMLElement>() as &dyn VirtualMethods)
     }
 
-    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation) {
-        self.super_type().unwrap().attribute_mutated(attr, mutation);
+    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation, can_gc: CanGc) {
+        self.super_type()
+            .unwrap()
+            .attribute_mutated(attr, mutation, can_gc);
         if *attr.local_name() == local_name!("src") {
             if let AttributeMutation::Set(_) = mutation {
                 if !self.parser_inserted.get() && self.upcast::<Node>().is_connected() {
@@ -1288,9 +1290,10 @@ impl VirtualMethods for HTMLScriptElement {
         copy: &Node,
         maybe_doc: Option<&Document>,
         clone_children: CloneChildrenFlag,
+        can_gc: CanGc,
     ) {
         if let Some(s) = self.super_type() {
-            s.cloning_steps(copy, maybe_doc, clone_children);
+            s.cloning_steps(copy, maybe_doc, clone_children, can_gc);
         }
 
         // https://html.spec.whatwg.org/multipage/#already-started

--- a/components/script/dom/htmlselectelement.rs
+++ b/components/script/dom/htmlselectelement.rs
@@ -523,7 +523,7 @@ impl Validatable for HTMLSelectElement {
     fn perform_validation(
         &self,
         validate_flags: ValidationFlags,
-        can_gc: CanGc,
+        _can_gc: CanGc,
     ) -> ValidationFlags {
         let mut failed_flags = ValidationFlags::empty();
 

--- a/components/script/dom/htmlselectelement.rs
+++ b/components/script/dom/htmlselectelement.rs
@@ -223,8 +223,9 @@ impl HTMLSelectElementMethods<crate::DomTypeHolder> for HTMLSelectElement {
         &self,
         element: HTMLOptionElementOrHTMLOptGroupElement,
         before: Option<HTMLElementOrLong>,
+        can_gc: CanGc,
     ) -> ErrorResult {
-        self.Options().Add(element, before)
+        self.Options().Add(element, before, can_gc)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-fe-disabled
@@ -320,13 +321,13 @@ impl HTMLSelectElementMethods<crate::DomTypeHolder> for HTMLSelectElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-select-remove
-    fn Remove_(&self, index: i32) {
-        self.Options().Remove(index)
+    fn Remove_(&self, index: i32, can_gc: CanGc) {
+        self.Options().Remove(index, can_gc)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-select-remove
-    fn Remove(&self) {
-        self.upcast::<Element>().Remove()
+    fn Remove(&self, can_gc: CanGc) {
+        self.upcast::<Element>().Remove(can_gc)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-select-value
@@ -339,7 +340,7 @@ impl HTMLSelectElementMethods<crate::DomTypeHolder> for HTMLSelectElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-select-value
-    fn SetValue(&self, value: DOMString) {
+    fn SetValue(&self, value: DOMString, can_gc: CanGc) {
         let mut opt_iter = self.list_of_options();
         // Reset until we find an <option> with a matching value
         for opt in opt_iter.by_ref() {
@@ -356,7 +357,7 @@ impl HTMLSelectElementMethods<crate::DomTypeHolder> for HTMLSelectElement {
         }
 
         self.validity_state()
-            .perform_validation_and_update(ValidationFlags::VALUE_MISSING);
+            .perform_validation_and_update(ValidationFlags::VALUE_MISSING, can_gc);
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-select-selectedindex
@@ -421,12 +422,14 @@ impl VirtualMethods for HTMLSelectElement {
         Some(self.upcast::<HTMLElement>() as &dyn VirtualMethods)
     }
 
-    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation) {
-        self.super_type().unwrap().attribute_mutated(attr, mutation);
+    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation, can_gc: CanGc) {
+        self.super_type()
+            .unwrap()
+            .attribute_mutated(attr, mutation, can_gc);
         match *attr.local_name() {
             local_name!("required") => {
                 self.validity_state()
-                    .perform_validation_and_update(ValidationFlags::VALUE_MISSING);
+                    .perform_validation_and_update(ValidationFlags::VALUE_MISSING, can_gc);
             },
             local_name!("disabled") => {
                 let el = self.upcast::<Element>();
@@ -443,26 +446,26 @@ impl VirtualMethods for HTMLSelectElement {
                 }
 
                 self.validity_state()
-                    .perform_validation_and_update(ValidationFlags::VALUE_MISSING);
+                    .perform_validation_and_update(ValidationFlags::VALUE_MISSING, can_gc);
             },
             local_name!("form") => {
-                self.form_attribute_mutated(mutation);
+                self.form_attribute_mutated(mutation, can_gc);
             },
             _ => {},
         }
     }
 
-    fn bind_to_tree(&self, context: &BindContext) {
+    fn bind_to_tree(&self, context: &BindContext, can_gc: CanGc) {
         if let Some(s) = self.super_type() {
-            s.bind_to_tree(context);
+            s.bind_to_tree(context, can_gc);
         }
 
         self.upcast::<Element>()
             .check_ancestors_disabled_state_for_form_control();
     }
 
-    fn unbind_from_tree(&self, context: &UnbindContext) {
-        self.super_type().unwrap().unbind_from_tree(context);
+    fn unbind_from_tree(&self, context: &UnbindContext, can_gc: CanGc) {
+        self.super_type().unwrap().unbind_from_tree(context, can_gc);
 
         let node = self.upcast::<Node>();
         let el = self.upcast::<Element>();
@@ -517,7 +520,11 @@ impl Validatable for HTMLSelectElement {
         !self.upcast::<Element>().disabled_state() && !is_barred_by_datalist_ancestor(self.upcast())
     }
 
-    fn perform_validation(&self, validate_flags: ValidationFlags) -> ValidationFlags {
+    fn perform_validation(
+        &self,
+        validate_flags: ValidationFlags,
+        can_gc: CanGc,
+    ) -> ValidationFlags {
         let mut failed_flags = ValidationFlags::empty();
 
         // https://html.spec.whatwg.org/multipage/#suffering-from-being-missing

--- a/components/script/dom/htmlselectelement.rs
+++ b/components/script/dom/htmlselectelement.rs
@@ -223,9 +223,8 @@ impl HTMLSelectElementMethods<crate::DomTypeHolder> for HTMLSelectElement {
         &self,
         element: HTMLOptionElementOrHTMLOptGroupElement,
         before: Option<HTMLElementOrLong>,
-        can_gc: CanGc,
     ) -> ErrorResult {
-        self.Options().Add(element, before, can_gc)
+        self.Options().Add(element, before)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-fe-disabled
@@ -321,13 +320,13 @@ impl HTMLSelectElementMethods<crate::DomTypeHolder> for HTMLSelectElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-select-remove
-    fn Remove_(&self, index: i32, can_gc: CanGc) {
-        self.Options().Remove(index, can_gc)
+    fn Remove_(&self, index: i32) {
+        self.Options().Remove(index)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-select-remove
-    fn Remove(&self, can_gc: CanGc) {
-        self.upcast::<Element>().Remove(can_gc)
+    fn Remove(&self) {
+        self.upcast::<Element>().Remove()
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-select-value
@@ -340,7 +339,7 @@ impl HTMLSelectElementMethods<crate::DomTypeHolder> for HTMLSelectElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-select-value
-    fn SetValue(&self, value: DOMString, can_gc: CanGc) {
+    fn SetValue(&self, value: DOMString) {
         let mut opt_iter = self.list_of_options();
         // Reset until we find an <option> with a matching value
         for opt in opt_iter.by_ref() {
@@ -357,7 +356,7 @@ impl HTMLSelectElementMethods<crate::DomTypeHolder> for HTMLSelectElement {
         }
 
         self.validity_state()
-            .perform_validation_and_update(ValidationFlags::VALUE_MISSING, can_gc);
+            .perform_validation_and_update(ValidationFlags::VALUE_MISSING, CanGc::note());
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-select-selectedindex

--- a/components/script/dom/htmlslotelement.rs
+++ b/components/script/dom/htmlslotelement.rs
@@ -461,8 +461,10 @@ impl VirtualMethods for HTMLSlotElement {
     }
 
     /// <https://dom.spec.whatwg.org/#shadow-tree-slots>
-    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation) {
-        self.super_type().unwrap().attribute_mutated(attr, mutation);
+    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation, can_gc: CanGc) {
+        self.super_type()
+            .unwrap()
+            .attribute_mutated(attr, mutation, can_gc);
 
         if attr.local_name() == &local_name!("name") && attr.namespace() == &ns!() {
             if let Some(shadow_root) = self.containing_shadow_root() {
@@ -486,9 +488,9 @@ impl VirtualMethods for HTMLSlotElement {
         }
     }
 
-    fn bind_to_tree(&self, context: &super::node::BindContext) {
+    fn bind_to_tree(&self, context: &super::node::BindContext, can_gc: CanGc) {
         if let Some(s) = self.super_type() {
-            s.bind_to_tree(context);
+            s.bind_to_tree(context, can_gc);
         }
 
         if !context.tree_is_in_a_shadow_tree {
@@ -500,9 +502,9 @@ impl VirtualMethods for HTMLSlotElement {
             .register_slot(self);
     }
 
-    fn unbind_from_tree(&self, context: &super::node::UnbindContext) {
+    fn unbind_from_tree(&self, context: &super::node::UnbindContext, can_gc: CanGc) {
         if let Some(s) = self.super_type() {
-            s.unbind_from_tree(context);
+            s.unbind_from_tree(context, can_gc);
         }
 
         if let Some(shadow_root) = self.containing_shadow_root() {

--- a/components/script/dom/htmlsourceelement.rs
+++ b/components/script/dom/htmlsourceelement.rs
@@ -72,8 +72,10 @@ impl VirtualMethods for HTMLSourceElement {
         Some(self.upcast::<HTMLElement>() as &dyn VirtualMethods)
     }
 
-    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation) {
-        self.super_type().unwrap().attribute_mutated(attr, mutation);
+    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation, can_gc: CanGc) {
+        self.super_type()
+            .unwrap()
+            .attribute_mutated(attr, mutation, can_gc);
         match attr.local_name() {
             &local_name!("srcset") |
             &local_name!("sizes") |
@@ -90,8 +92,8 @@ impl VirtualMethods for HTMLSourceElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#the-source-element:nodes-are-inserted>
-    fn bind_to_tree(&self, context: &BindContext) {
-        self.super_type().unwrap().bind_to_tree(context);
+    fn bind_to_tree(&self, context: &BindContext, can_gc: CanGc) {
+        self.super_type().unwrap().bind_to_tree(context, can_gc);
         let parent = self.upcast::<Node>().GetParentNode().unwrap();
         if let Some(media) = parent.downcast::<HTMLMediaElement>() {
             media.handle_source_child_insertion(CanGc::note());
@@ -103,8 +105,8 @@ impl VirtualMethods for HTMLSourceElement {
         );
     }
 
-    fn unbind_from_tree(&self, context: &UnbindContext) {
-        self.super_type().unwrap().unbind_from_tree(context);
+    fn unbind_from_tree(&self, context: &UnbindContext, can_gc: CanGc) {
+        self.super_type().unwrap().unbind_from_tree(context, can_gc);
         if let Some(next_sibling) = context.next_sibling {
             let next_sibling_iterator = next_sibling.inclusively_following_siblings();
             HTMLSourceElement::iterate_next_html_image_element_siblings(

--- a/components/script/dom/htmlstyleelement.rs
+++ b/components/script/dom/htmlstyleelement.rs
@@ -220,8 +220,8 @@ impl VirtualMethods for HTMLStyleElement {
         }
     }
 
-    fn bind_to_tree(&self, context: &BindContext) {
-        self.super_type().unwrap().bind_to_tree(context);
+    fn bind_to_tree(&self, context: &BindContext, can_gc: CanGc) {
+        self.super_type().unwrap().bind_to_tree(context, can_gc);
 
         // https://html.spec.whatwg.org/multipage/#update-a-style-block
         // Handles the case when:
@@ -244,9 +244,9 @@ impl VirtualMethods for HTMLStyleElement {
         }
     }
 
-    fn unbind_from_tree(&self, context: &UnbindContext) {
+    fn unbind_from_tree(&self, context: &UnbindContext, can_gc: CanGc) {
         if let Some(s) = self.super_type() {
-            s.unbind_from_tree(context);
+            s.unbind_from_tree(context, can_gc);
         }
 
         if context.tree_connected {
@@ -254,9 +254,9 @@ impl VirtualMethods for HTMLStyleElement {
         }
     }
 
-    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation) {
+    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation, can_gc: CanGc) {
         if let Some(s) = self.super_type() {
-            s.attribute_mutated(attr, mutation);
+            s.attribute_mutated(attr, mutation, can_gc);
         }
 
         let node = self.upcast::<Node>();

--- a/components/script/dom/htmltableelement.rs
+++ b/components/script/dom/htmltableelement.rs
@@ -133,7 +133,7 @@ impl HTMLTableElement {
             let reference_element = node.child_elements().find(reference_predicate);
             let reference_node = reference_element.as_ref().map(|e| e.upcast());
 
-            node.InsertBefore(section.upcast(), reference_node, can_gc)?;
+            node.InsertBefore(section.upcast(), reference_node)?;
         }
 
         Ok(())
@@ -153,8 +153,8 @@ impl HTMLTableElement {
         let section =
             HTMLTableSectionElement::new(atom.clone(), None, &self.owner_document(), None, can_gc);
         match *atom {
-            local_name!("thead") => self.SetTHead(Some(&section), can_gc),
-            local_name!("tfoot") => self.SetTFoot(Some(&section), can_gc),
+            local_name!("thead") => self.SetTHead(Some(&section)),
+            local_name!("tfoot") => self.SetTFoot(Some(&section)),
             _ => unreachable!("unexpected section type"),
         }
         .expect("unexpected section type");
@@ -205,18 +205,14 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-table-caption
-    fn SetCaption(
-        &self,
-        new_caption: Option<&HTMLTableCaptionElement>,
-        can_gc: CanGc,
-    ) -> Fallible<()> {
+    fn SetCaption(&self, new_caption: Option<&HTMLTableCaptionElement>) -> Fallible<()> {
         if let Some(ref caption) = self.GetCaption() {
-            caption.upcast::<Node>().remove_self(can_gc);
+            caption.upcast::<Node>().remove_self(CanGc::note());
         }
 
         if let Some(caption) = new_caption {
             let node = self.upcast::<Node>();
-            node.InsertBefore(caption.upcast(), node.GetFirstChild().as_deref(), can_gc)?;
+            node.InsertBefore(caption.upcast(), node.GetFirstChild().as_deref())?;
         }
 
         Ok(())
@@ -234,7 +230,7 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
                     None,
                     can_gc,
                 );
-                self.SetCaption(Some(&caption), can_gc)
+                self.SetCaption(Some(&caption))
                     .expect("Generated caption is invalid");
                 caption
             },
@@ -242,9 +238,9 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-table-deletecaption
-    fn DeleteCaption(&self, can_gc: CanGc) {
+    fn DeleteCaption(&self) {
         if let Some(caption) = self.GetCaption() {
-            caption.upcast::<Node>().remove_self(can_gc);
+            caption.upcast::<Node>().remove_self(CanGc::note());
         }
     }
 
@@ -254,12 +250,12 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-table-thead
-    fn SetTHead(&self, thead: Option<&HTMLTableSectionElement>, can_gc: CanGc) -> ErrorResult {
+    fn SetTHead(&self, thead: Option<&HTMLTableSectionElement>) -> ErrorResult {
         self.set_first_section_of_type(
             &local_name!("thead"),
             thead,
             |n| !n.is::<HTMLTableCaptionElement>() && !n.is::<HTMLTableColElement>(),
-            can_gc,
+            CanGc::note(),
         )
     }
 
@@ -269,8 +265,8 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-table-deletethead
-    fn DeleteTHead(&self, can_gc: CanGc) {
-        self.delete_first_section_of_type(&local_name!("thead"), can_gc)
+    fn DeleteTHead(&self) {
+        self.delete_first_section_of_type(&local_name!("thead"), CanGc::note())
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-table-tfoot
@@ -279,7 +275,7 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-table-tfoot
-    fn SetTFoot(&self, tfoot: Option<&HTMLTableSectionElement>, can_gc: CanGc) -> ErrorResult {
+    fn SetTFoot(&self, tfoot: Option<&HTMLTableSectionElement>) -> ErrorResult {
         self.set_first_section_of_type(
             &local_name!("tfoot"),
             tfoot,
@@ -297,7 +293,7 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
 
                 true
             },
-            can_gc,
+            CanGc::note(),
         )
     }
 
@@ -307,8 +303,8 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-table-deletetfoot
-    fn DeleteTFoot(&self, can_gc: CanGc) {
-        self.delete_first_section_of_type(&local_name!("tfoot"), can_gc)
+    fn DeleteTFoot(&self) {
+        self.delete_first_section_of_type(&local_name!("tfoot"), CanGc::note())
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-table-tbodies
@@ -342,7 +338,7 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
             .find(|n| n.is::<HTMLTableSectionElement>() && n.local_name() == &local_name!("tbody"));
         let reference_element = last_tbody.and_then(|t| t.upcast::<Node>().GetNextSibling());
 
-        node.InsertBefore(tbody.upcast(), reference_element.as_deref(), can_gc)
+        node.InsertBefore(tbody.upcast(), reference_element.as_deref())
             .expect("Insertion failed");
         tbody
     }
@@ -376,16 +372,16 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
             {
                 last_tbody
                     .upcast::<Node>()
-                    .AppendChild(new_row.upcast::<Node>(), can_gc)
+                    .AppendChild(new_row.upcast::<Node>())
                     .expect("InsertRow failed to append first row.");
             } else {
                 let tbody = self.CreateTBody(can_gc);
-                node.AppendChild(tbody.upcast(), can_gc)
+                node.AppendChild(tbody.upcast())
                     .expect("InsertRow failed to append new tbody.");
 
                 tbody
                     .upcast::<Node>()
-                    .AppendChild(new_row.upcast::<Node>(), can_gc)
+                    .AppendChild(new_row.upcast::<Node>())
                     .expect("InsertRow failed to append first row.");
             }
         } else if index == number_of_row_elements as i32 || index == -1 {
@@ -401,7 +397,7 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
 
             last_row_parent
                 .upcast::<Node>()
-                .AppendChild(new_row.upcast::<Node>(), can_gc)
+                .AppendChild(new_row.upcast::<Node>())
                 .expect("InsertRow failed to append last row.");
         } else {
             // insert new row before the index-th row in rows using the same parent
@@ -416,11 +412,7 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
 
             ith_row_parent
                 .upcast::<Node>()
-                .InsertBefore(
-                    new_row.upcast::<Node>(),
-                    Some(ith_row.upcast::<Node>()),
-                    can_gc,
-                )
+                .InsertBefore(new_row.upcast::<Node>(), Some(ith_row.upcast::<Node>()))
                 .expect("InsertRow failed to append row");
         }
 
@@ -428,7 +420,7 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-table-deleterow>
-    fn DeleteRow(&self, mut index: i32, can_gc: CanGc) -> Fallible<()> {
+    fn DeleteRow(&self, mut index: i32) -> Fallible<()> {
         let rows = self.Rows();
         let num_rows = rows.Length() as i32;
 
@@ -451,7 +443,7 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
         }
 
         // Step 3: Otherwise, remove the indexth element in the rows collection from its parent.
-        DomRoot::upcast::<Node>(rows.Item(index as u32).unwrap()).remove_self(can_gc);
+        DomRoot::upcast::<Node>(rows.Item(index as u32).unwrap()).remove_self(CanGc::note());
 
         Ok(())
     }

--- a/components/script/dom/htmltablerowelement.rs
+++ b/components/script/dom/htmltablerowelement.rs
@@ -104,13 +104,19 @@ impl HTMLTableRowElementMethods<crate::DomTypeHolder> for HTMLTableRowElement {
             index,
             || self.Cells(),
             || HTMLTableCellElement::new(local_name!("td"), None, &node.owner_doc(), None, can_gc),
+            can_gc,
         )
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-tr-deletecell
-    fn DeleteCell(&self, index: i32) -> ErrorResult {
+    fn DeleteCell(&self, index: i32, can_gc: CanGc) -> ErrorResult {
         let node = self.upcast::<Node>();
-        node.delete_cell_or_row(index, || self.Cells(), |n| n.is::<HTMLTableCellElement>())
+        node.delete_cell_or_row(
+            index,
+            || self.Cells(),
+            |n| n.is::<HTMLTableCellElement>(),
+            can_gc,
+        )
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-tr-rowindex

--- a/components/script/dom/htmltablerowelement.rs
+++ b/components/script/dom/htmltablerowelement.rs
@@ -109,13 +109,13 @@ impl HTMLTableRowElementMethods<crate::DomTypeHolder> for HTMLTableRowElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-tr-deletecell
-    fn DeleteCell(&self, index: i32, can_gc: CanGc) -> ErrorResult {
+    fn DeleteCell(&self, index: i32) -> ErrorResult {
         let node = self.upcast::<Node>();
         node.delete_cell_or_row(
             index,
             || self.Cells(),
             |n| n.is::<HTMLTableCellElement>(),
-            can_gc,
+            CanGc::note(),
         )
     }
 

--- a/components/script/dom/htmltablesectionelement.rs
+++ b/components/script/dom/htmltablesectionelement.rs
@@ -77,13 +77,19 @@ impl HTMLTableSectionElementMethods<crate::DomTypeHolder> for HTMLTableSectionEl
             index,
             || self.Rows(),
             || HTMLTableRowElement::new(local_name!("tr"), None, &node.owner_doc(), None, can_gc),
+            can_gc,
         )
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-tbody-deleterow
-    fn DeleteRow(&self, index: i32) -> ErrorResult {
+    fn DeleteRow(&self, index: i32, can_gc: CanGc) -> ErrorResult {
         let node = self.upcast::<Node>();
-        node.delete_cell_or_row(index, || self.Rows(), |n| n.is::<HTMLTableRowElement>())
+        node.delete_cell_or_row(
+            index,
+            || self.Rows(),
+            |n| n.is::<HTMLTableRowElement>(),
+            can_gc,
+        )
     }
 }
 

--- a/components/script/dom/htmltablesectionelement.rs
+++ b/components/script/dom/htmltablesectionelement.rs
@@ -82,13 +82,13 @@ impl HTMLTableSectionElementMethods<crate::DomTypeHolder> for HTMLTableSectionEl
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-tbody-deleterow
-    fn DeleteRow(&self, index: i32, can_gc: CanGc) -> ErrorResult {
+    fn DeleteRow(&self, index: i32) -> ErrorResult {
         let node = self.upcast::<Node>();
         node.delete_cell_or_row(
             index,
             || self.Rows(),
             |n| n.is::<HTMLTableRowElement>(),
-            can_gc,
+            CanGc::note(),
         )
     }
 }

--- a/components/script/dom/htmltemplateelement.rs
+++ b/components/script/dom/htmltemplateelement.rs
@@ -149,7 +149,7 @@ impl VirtualMethods for HTMLTemplateElement {
                 CloneChildrenFlag::CloneChildren,
                 CanGc::note(),
             );
-            copy_contents.AppendChild(&copy_child, can_gc).unwrap();
+            copy_contents.AppendChild(&copy_child).unwrap();
         }
     }
 }

--- a/components/script/dom/htmltemplateelement.rs
+++ b/components/script/dom/htmltemplateelement.rs
@@ -113,14 +113,14 @@ impl VirtualMethods for HTMLTemplateElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#template-adopting-steps>
-    fn adopting_steps(&self, old_doc: &Document) {
-        self.super_type().unwrap().adopting_steps(old_doc);
+    fn adopting_steps(&self, old_doc: &Document, can_gc: CanGc) {
+        self.super_type().unwrap().adopting_steps(old_doc, can_gc);
         // Step 1.
         let doc = self
             .owner_document()
             .appropriate_template_contents_owner_document(CanGc::note());
         // Step 2.
-        Node::adopt(self.Content(CanGc::note()).upcast(), &doc);
+        Node::adopt(self.Content(CanGc::note()).upcast(), &doc, can_gc);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#the-template-element:concept-node-clone-ext>
@@ -129,10 +129,11 @@ impl VirtualMethods for HTMLTemplateElement {
         copy: &Node,
         maybe_doc: Option<&Document>,
         clone_children: CloneChildrenFlag,
+        can_gc: CanGc,
     ) {
         self.super_type()
             .unwrap()
-            .cloning_steps(copy, maybe_doc, clone_children);
+            .cloning_steps(copy, maybe_doc, clone_children, can_gc);
         if clone_children == CloneChildrenFlag::DoNotCloneChildren {
             // Step 1.
             return;
@@ -148,7 +149,7 @@ impl VirtualMethods for HTMLTemplateElement {
                 CloneChildrenFlag::CloneChildren,
                 CanGc::note(),
             );
-            copy_contents.AppendChild(&copy_child).unwrap();
+            copy_contents.AppendChild(&copy_child, can_gc).unwrap();
         }
     }
 }

--- a/components/script/dom/htmltextareaelement.rs
+++ b/components/script/dom/htmltextareaelement.rs
@@ -327,7 +327,7 @@ impl HTMLTextAreaElementMethods<crate::DomTypeHolder> for HTMLTextAreaElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-textarea-value
-    fn SetValue(&self, value: DOMString, can_gc: CanGc) {
+    fn SetValue(&self, value: DOMString) {
         {
             let mut textinput = self.textinput.borrow_mut();
 
@@ -347,7 +347,7 @@ impl HTMLTextAreaElementMethods<crate::DomTypeHolder> for HTMLTextAreaElement {
         }
 
         self.validity_state()
-            .perform_validation_and_update(ValidationFlags::all(), can_gc);
+            .perform_validation_and_update(ValidationFlags::all(), CanGc::note());
         self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
     }
 

--- a/components/script/dom/htmltextareaelement.rs
+++ b/components/script/dom/htmltextareaelement.rs
@@ -327,7 +327,7 @@ impl HTMLTextAreaElementMethods<crate::DomTypeHolder> for HTMLTextAreaElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-textarea-value
-    fn SetValue(&self, value: DOMString) {
+    fn SetValue(&self, value: DOMString, can_gc: CanGc) {
         {
             let mut textinput = self.textinput.borrow_mut();
 
@@ -347,7 +347,7 @@ impl HTMLTextAreaElementMethods<crate::DomTypeHolder> for HTMLTextAreaElement {
         }
 
         self.validity_state()
-            .perform_validation_and_update(ValidationFlags::all());
+            .perform_validation_and_update(ValidationFlags::all(), can_gc);
         self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
     }
 
@@ -468,8 +468,10 @@ impl VirtualMethods for HTMLTextAreaElement {
         Some(self.upcast::<HTMLElement>() as &dyn VirtualMethods)
     }
 
-    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation) {
-        self.super_type().unwrap().attribute_mutated(attr, mutation);
+    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation, can_gc: CanGc) {
+        self.super_type()
+            .unwrap()
+            .attribute_mutated(attr, mutation, can_gc);
         match *attr.local_name() {
             local_name!("disabled") => {
                 let el = self.upcast::<Element>();
@@ -538,25 +540,25 @@ impl VirtualMethods for HTMLTextAreaElement {
                 }
             },
             local_name!("form") => {
-                self.form_attribute_mutated(mutation);
+                self.form_attribute_mutated(mutation, can_gc);
             },
             _ => {},
         }
 
         self.validity_state()
-            .perform_validation_and_update(ValidationFlags::all());
+            .perform_validation_and_update(ValidationFlags::all(), can_gc);
     }
 
-    fn bind_to_tree(&self, context: &BindContext) {
+    fn bind_to_tree(&self, context: &BindContext, can_gc: CanGc) {
         if let Some(s) = self.super_type() {
-            s.bind_to_tree(context);
+            s.bind_to_tree(context, can_gc);
         }
 
         self.upcast::<Element>()
             .check_ancestors_disabled_state_for_form_control();
 
         self.validity_state()
-            .perform_validation_and_update(ValidationFlags::all());
+            .perform_validation_and_update(ValidationFlags::all(), can_gc);
     }
 
     fn parse_plain_attribute(&self, name: &LocalName, value: DOMString) -> AttrValue {
@@ -576,8 +578,8 @@ impl VirtualMethods for HTMLTextAreaElement {
         }
     }
 
-    fn unbind_from_tree(&self, context: &UnbindContext) {
-        self.super_type().unwrap().unbind_from_tree(context);
+    fn unbind_from_tree(&self, context: &UnbindContext, can_gc: CanGc) {
+        self.super_type().unwrap().unbind_from_tree(context, can_gc);
 
         let node = self.upcast::<Node>();
         let el = self.upcast::<Element>();
@@ -591,7 +593,7 @@ impl VirtualMethods for HTMLTextAreaElement {
         }
 
         self.validity_state()
-            .perform_validation_and_update(ValidationFlags::all());
+            .perform_validation_and_update(ValidationFlags::all(), can_gc);
     }
 
     // The cloning steps for textarea elements must propagate the raw value
@@ -601,9 +603,10 @@ impl VirtualMethods for HTMLTextAreaElement {
         copy: &Node,
         maybe_doc: Option<&Document>,
         clone_children: CloneChildrenFlag,
+        can_gc: CanGc,
     ) {
         if let Some(s) = self.super_type() {
-            s.cloning_steps(copy, maybe_doc, clone_children);
+            s.cloning_steps(copy, maybe_doc, clone_children, can_gc);
         }
         let el = copy.downcast::<HTMLTextAreaElement>().unwrap();
         el.value_dirty.set(self.value_dirty.get());
@@ -612,7 +615,7 @@ impl VirtualMethods for HTMLTextAreaElement {
             textinput.set_content(self.textinput.borrow().get_content());
         }
         el.validity_state()
-            .perform_validation_and_update(ValidationFlags::all());
+            .perform_validation_and_update(ValidationFlags::all(), can_gc);
     }
 
     fn children_changed(&self, mutation: &ChildrenMutation) {
@@ -625,9 +628,9 @@ impl VirtualMethods for HTMLTextAreaElement {
     }
 
     // copied and modified from htmlinputelement.rs
-    fn handle_event(&self, event: &Event) {
+    fn handle_event(&self, event: &Event, can_gc: CanGc) {
         if let Some(s) = self.super_type() {
-            s.handle_event(event);
+            s.handle_event(event, can_gc);
         }
 
         if event.type_() == atom!("click") && !event.DefaultPrevented() {
@@ -691,7 +694,7 @@ impl VirtualMethods for HTMLTextAreaElement {
         }
 
         self.validity_state()
-            .perform_validation_and_update(ValidationFlags::all());
+            .perform_validation_and_update(ValidationFlags::all(), can_gc);
     }
 
     fn pop(&self) {
@@ -735,7 +738,11 @@ impl Validatable for HTMLTextAreaElement {
             !is_barred_by_datalist_ancestor(self.upcast())
     }
 
-    fn perform_validation(&self, validate_flags: ValidationFlags) -> ValidationFlags {
+    fn perform_validation(
+        &self,
+        validate_flags: ValidationFlags,
+        can_gc: CanGc,
+    ) -> ValidationFlags {
         let mut failed_flags = ValidationFlags::empty();
 
         let textinput = self.textinput.borrow();

--- a/components/script/dom/htmltextareaelement.rs
+++ b/components/script/dom/htmltextareaelement.rs
@@ -741,7 +741,7 @@ impl Validatable for HTMLTextAreaElement {
     fn perform_validation(
         &self,
         validate_flags: ValidationFlags,
-        can_gc: CanGc,
+        _can_gc: CanGc,
     ) -> ValidationFlags {
         let mut failed_flags = ValidationFlags::empty();
 

--- a/components/script/dom/htmltitleelement.rs
+++ b/components/script/dom/htmltitleelement.rs
@@ -92,9 +92,9 @@ impl VirtualMethods for HTMLTitleElement {
         }
     }
 
-    fn bind_to_tree(&self, context: &BindContext) {
+    fn bind_to_tree(&self, context: &BindContext, can_gc: CanGc) {
         if let Some(s) = self.super_type() {
-            s.bind_to_tree(context);
+            s.bind_to_tree(context, can_gc);
         }
         let node = self.upcast::<Node>();
         if context.tree_is_in_a_document_tree {

--- a/components/script/dom/htmlvideoelement.rs
+++ b/components/script/dom/htmlvideoelement.rs
@@ -305,8 +305,10 @@ impl VirtualMethods for HTMLVideoElement {
         Some(self.upcast::<HTMLMediaElement>() as &dyn VirtualMethods)
     }
 
-    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation) {
-        self.super_type().unwrap().attribute_mutated(attr, mutation);
+    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation, can_gc: CanGc) {
+        self.super_type()
+            .unwrap()
+            .attribute_mutated(attr, mutation, can_gc);
 
         if attr.local_name() == &local_name!("poster") {
             if let Some(new_value) = mutation.new_value(attr) {

--- a/components/script/dom/namednodemap.rs
+++ b/components/script/dom/namednodemap.rs
@@ -66,20 +66,20 @@ impl NamedNodeMapMethods<crate::DomTypeHolder> for NamedNodeMap {
     }
 
     // https://dom.spec.whatwg.org/#dom-namednodemap-setnameditem
-    fn SetNamedItem(&self, attr: &Attr, can_gc: CanGc) -> Fallible<Option<DomRoot<Attr>>> {
-        self.owner.SetAttributeNode(attr, can_gc)
+    fn SetNamedItem(&self, attr: &Attr) -> Fallible<Option<DomRoot<Attr>>> {
+        self.owner.SetAttributeNode(attr)
     }
 
     // https://dom.spec.whatwg.org/#dom-namednodemap-setnameditemns
-    fn SetNamedItemNS(&self, attr: &Attr, can_gc: CanGc) -> Fallible<Option<DomRoot<Attr>>> {
-        self.SetNamedItem(attr, can_gc)
+    fn SetNamedItemNS(&self, attr: &Attr) -> Fallible<Option<DomRoot<Attr>>> {
+        self.SetNamedItem(attr)
     }
 
     // https://dom.spec.whatwg.org/#dom-namednodemap-removenameditem
-    fn RemoveNamedItem(&self, name: DOMString, can_gc: CanGc) -> Fallible<DomRoot<Attr>> {
+    fn RemoveNamedItem(&self, name: DOMString) -> Fallible<DomRoot<Attr>> {
         let name = self.owner.parsed_name(name);
         self.owner
-            .remove_attribute_by_name(&name, can_gc)
+            .remove_attribute_by_name(&name, CanGc::note())
             .ok_or(Error::NotFound)
     }
 
@@ -88,11 +88,10 @@ impl NamedNodeMapMethods<crate::DomTypeHolder> for NamedNodeMap {
         &self,
         namespace: Option<DOMString>,
         local_name: DOMString,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<Attr>> {
         let ns = namespace_from_domstring(namespace);
         self.owner
-            .remove_attribute(&ns, &LocalName::from(local_name), can_gc)
+            .remove_attribute(&ns, &LocalName::from(local_name), CanGc::note())
             .ok_or(Error::NotFound)
     }
 

--- a/components/script/dom/namednodemap.rs
+++ b/components/script/dom/namednodemap.rs
@@ -66,20 +66,20 @@ impl NamedNodeMapMethods<crate::DomTypeHolder> for NamedNodeMap {
     }
 
     // https://dom.spec.whatwg.org/#dom-namednodemap-setnameditem
-    fn SetNamedItem(&self, attr: &Attr) -> Fallible<Option<DomRoot<Attr>>> {
-        self.owner.SetAttributeNode(attr)
+    fn SetNamedItem(&self, attr: &Attr, can_gc: CanGc) -> Fallible<Option<DomRoot<Attr>>> {
+        self.owner.SetAttributeNode(attr, can_gc)
     }
 
     // https://dom.spec.whatwg.org/#dom-namednodemap-setnameditemns
-    fn SetNamedItemNS(&self, attr: &Attr) -> Fallible<Option<DomRoot<Attr>>> {
-        self.SetNamedItem(attr)
+    fn SetNamedItemNS(&self, attr: &Attr, can_gc: CanGc) -> Fallible<Option<DomRoot<Attr>>> {
+        self.SetNamedItem(attr, can_gc)
     }
 
     // https://dom.spec.whatwg.org/#dom-namednodemap-removenameditem
-    fn RemoveNamedItem(&self, name: DOMString) -> Fallible<DomRoot<Attr>> {
+    fn RemoveNamedItem(&self, name: DOMString, can_gc: CanGc) -> Fallible<DomRoot<Attr>> {
         let name = self.owner.parsed_name(name);
         self.owner
-            .remove_attribute_by_name(&name)
+            .remove_attribute_by_name(&name, can_gc)
             .ok_or(Error::NotFound)
     }
 
@@ -88,10 +88,11 @@ impl NamedNodeMapMethods<crate::DomTypeHolder> for NamedNodeMap {
         &self,
         namespace: Option<DOMString>,
         local_name: DOMString,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<Attr>> {
         let ns = namespace_from_domstring(namespace);
         self.owner
-            .remove_attribute(&ns, &LocalName::from(local_name))
+            .remove_attribute(&ns, &LocalName::from(local_name), can_gc)
             .ok_or(Error::NotFound)
     }
 

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -248,7 +248,7 @@ impl Node {
     /// Adds a new child to the end of this node's list of children.
     ///
     /// Fails unless `new_child` is disconnected from the tree.
-    fn add_child(&self, new_child: &Node, before: Option<&Node>) {
+    fn add_child(&self, new_child: &Node, before: Option<&Node>, can_gc: CanGc) {
         assert!(new_child.parent_node.get().is_none());
         assert!(new_child.prev_sibling.get().is_none());
         assert!(new_child.next_sibling.get().is_none());
@@ -307,11 +307,14 @@ impl Node {
 
             // Out-of-document elements never have the descendants flag set.
             debug_assert!(!node.get_flag(NodeFlags::HAS_DIRTY_DESCENDANTS));
-            vtable_for(&node).bind_to_tree(&BindContext {
-                tree_connected: parent_is_connected,
-                tree_is_in_a_document_tree: parent_is_in_a_document_tree,
-                tree_is_in_a_shadow_tree: parent_in_shadow_tree,
-            });
+            vtable_for(&node).bind_to_tree(
+                &BindContext {
+                    tree_connected: parent_is_connected,
+                    tree_is_in_a_document_tree: parent_is_in_a_document_tree,
+                    tree_is_in_a_shadow_tree: parent_in_shadow_tree,
+                },
+                can_gc,
+            );
         }
     }
 
@@ -323,7 +326,7 @@ impl Node {
 
     /// Clean up flags and runs steps 11-14 of remove a node.
     /// <https://dom.spec.whatwg.org/#concept-node-remove>
-    pub(crate) fn complete_remove_subtree(root: &Node, context: &UnbindContext) {
+    pub(crate) fn complete_remove_subtree(root: &Node, context: &UnbindContext, can_gc: CanGc) {
         // Flags that reset when a node is disconnected
         const RESET_FLAGS: NodeFlags = NodeFlags::IS_IN_A_DOCUMENT_TREE
             .union(NodeFlags::IS_CONNECTED)
@@ -356,7 +359,7 @@ impl Node {
             // This needs to be in its own loop, because unbind_from_tree may
             // rely on the state of IS_IN_DOC of the context node's descendants,
             // e.g. when removing a <form>.
-            vtable_for(&node).unbind_from_tree(context);
+            vtable_for(&node).unbind_from_tree(context, can_gc);
 
             // Step 12 & 14.2. Enqueue disconnected custom element reactions.
             if is_parent_connected {
@@ -374,7 +377,7 @@ impl Node {
     /// Removes the given child from this node's list of children.
     ///
     /// Fails unless `child` is a child of this node.
-    fn remove_child(&self, child: &Node, cached_index: Option<u32>) {
+    fn remove_child(&self, child: &Node, cached_index: Option<u32>, can_gc: CanGc) {
         assert!(child.parent_node.get().as_deref() == Some(self));
         self.note_dirty_descendants();
 
@@ -413,7 +416,7 @@ impl Node {
         child.parent_node.set(None);
         self.children_count.set(self.children_count.get() - 1);
 
-        Self::complete_remove_subtree(child, &context);
+        Self::complete_remove_subtree(child, &context, can_gc);
     }
 
     pub(crate) fn to_untrusted_node_address(&self) -> UntrustedNodeAddress {
@@ -958,7 +961,7 @@ impl Node {
         };
 
         // Step 6.
-        Node::pre_insert(&node, &parent, viable_previous_sibling.as_deref())?;
+        Node::pre_insert(&node, &parent, viable_previous_sibling.as_deref(), can_gc)?;
 
         Ok(())
     }
@@ -983,7 +986,7 @@ impl Node {
             .node_from_nodes_and_strings(nodes, can_gc)?;
 
         // Step 5.
-        Node::pre_insert(&node, &parent, viable_next_sibling.as_deref())?;
+        Node::pre_insert(&node, &parent, viable_next_sibling.as_deref(), can_gc)?;
 
         Ok(())
     }
@@ -1008,7 +1011,7 @@ impl Node {
             parent.ReplaceChild(&node, self)?;
         } else {
             // Step 6.
-            Node::pre_insert(&node, &parent, viable_next_sibling.as_deref())?;
+            Node::pre_insert(&node, &parent, viable_next_sibling.as_deref(), can_gc)?;
         }
         Ok(())
     }
@@ -1020,7 +1023,7 @@ impl Node {
         let node = doc.node_from_nodes_and_strings(nodes, can_gc)?;
         // Step 2.
         let first_child = self.first_child.get();
-        Node::pre_insert(&node, self, first_child.as_deref()).map(|_| ())
+        Node::pre_insert(&node, self, first_child.as_deref(), can_gc).map(|_| ())
     }
 
     /// <https://dom.spec.whatwg.org/#dom-parentnode-append>
@@ -1029,7 +1032,7 @@ impl Node {
         let doc = self.owner_doc();
         let node = doc.node_from_nodes_and_strings(nodes, can_gc)?;
         // Step 2.
-        self.AppendChild(&node).map(|_| ())
+        self.AppendChild(&node, can_gc).map(|_| ())
     }
 
     /// <https://dom.spec.whatwg.org/#dom-parentnode-replacechildren>
@@ -1040,7 +1043,7 @@ impl Node {
         // Step 2.
         Node::ensure_pre_insertion_validity(&node, self, None)?;
         // Step 3.
-        Node::replace_all(Some(&node), self);
+        Node::replace_all(Some(&node), self, can_gc);
         Ok(())
     }
 
@@ -1185,9 +1188,9 @@ impl Node {
             .peekable()
     }
 
-    pub(crate) fn remove_self(&self) {
+    pub(crate) fn remove_self(&self, can_gc: CanGc) {
         if let Some(ref parent) = self.GetParentNode() {
-            Node::remove(self, parent, SuppressObserver::Unsuppressed);
+            Node::remove(self, parent, SuppressObserver::Unsuppressed, can_gc);
         }
     }
 
@@ -1264,6 +1267,7 @@ impl Node {
         index: i32,
         get_items: F,
         new_child: G,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<HTMLElement>>
     where
         F: Fn() -> DomRoot<HTMLCollection>,
@@ -1279,7 +1283,7 @@ impl Node {
         {
             let tr_node = tr.upcast::<Node>();
             if index == -1 {
-                self.InsertBefore(tr_node, None)?;
+                self.InsertBefore(tr_node, None, can_gc)?;
             } else {
                 let items = get_items();
                 let node = match items
@@ -1292,7 +1296,7 @@ impl Node {
                     None => return Err(Error::IndexSize),
                     Some(node) => node,
                 };
-                self.InsertBefore(tr_node, node.as_deref())?;
+                self.InsertBefore(tr_node, node.as_deref(), can_gc)?;
             }
         }
 
@@ -1305,6 +1309,7 @@ impl Node {
         index: i32,
         get_items: F,
         is_delete_type: G,
+        can_gc: CanGc,
     ) -> ErrorResult
     where
         F: Fn() -> DomRoot<HTMLCollection>,
@@ -1329,7 +1334,7 @@ impl Node {
             },
         };
 
-        element.upcast::<Node>().remove_self();
+        element.upcast::<Node>().remove_self(can_gc);
         Ok(())
     }
 
@@ -2046,7 +2051,7 @@ impl Node {
     }
 
     /// <https://dom.spec.whatwg.org/#concept-node-adopt>
-    pub(crate) fn adopt(node: &Node, document: &Document) {
+    pub(crate) fn adopt(node: &Node, document: &Document, can_gc: CanGc) {
         document.add_script_and_layout_blocker();
 
         // Step 1. Let oldDocument be node’s node document.
@@ -2054,7 +2059,7 @@ impl Node {
         old_doc.add_script_and_layout_blocker();
 
         // Step 2. If node’s parent is non-null, then remove node.
-        node.remove_self();
+        node.remove_self(can_gc);
 
         // Step 3. If document is not oldDocument:
         if &*old_doc != document {
@@ -2089,7 +2094,7 @@ impl Node {
             // Step 3.3 For each inclusiveDescendant in node’s shadow-including inclusive descendants,
             // in shadow-including tree order, run the adopting steps with inclusiveDescendant and oldDocument.
             for descendant in node.traverse_preorder(ShadowIncluding::Yes) {
-                vtable_for(&descendant).adopting_steps(&old_doc);
+                vtable_for(&descendant).adopting_steps(&old_doc, can_gc);
             }
         }
 
@@ -2220,6 +2225,7 @@ impl Node {
         node: &Node,
         parent: &Node,
         child: Option<&Node>,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<Node>> {
         // Step 1.
         Node::ensure_pre_insertion_validity(node, parent, child)?;
@@ -2235,7 +2241,7 @@ impl Node {
         };
 
         // Step 4.
-        Node::adopt(node, &parent.owner_document());
+        Node::adopt(node, &parent.owner_document(), can_gc);
 
         // Step 5.
         Node::insert(
@@ -2243,6 +2249,7 @@ impl Node {
             parent,
             reference_child,
             SuppressObserver::Unsuppressed,
+            CanGc::note(),
         );
 
         // Step 6.
@@ -2255,6 +2262,7 @@ impl Node {
         parent: &Node,
         child: Option<&Node>,
         suppress_observers: SuppressObserver,
+        can_gc: CanGc,
     ) {
         node.owner_doc().add_script_and_layout_blocker();
         debug_assert!(*node.owner_doc() == *parent.owner_doc());
@@ -2280,7 +2288,7 @@ impl Node {
             new_nodes.extend(node.children().map(|kid| Dom::from_ref(&*kid)));
             // Step 4.
             for kid in &*new_nodes {
-                Node::remove(kid, node, SuppressObserver::Suppressed);
+                Node::remove(kid, node, SuppressObserver::Suppressed, can_gc);
             }
             // Step 5.
             vtable_for(node).children_changed(&ChildrenMutation::replace_all(new_nodes.r(), &[]));
@@ -2309,7 +2317,7 @@ impl Node {
         // Step 7.
         for kid in new_nodes {
             // Step 7.1.
-            parent.add_child(kid, child);
+            parent.add_child(kid, child, can_gc);
 
             // Step 7.4 If parent is a shadow host whose shadow root’s slot assignment is "named"
             // and node is a slottable, then assign a slot for node.
@@ -2407,11 +2415,11 @@ impl Node {
     }
 
     /// <https://dom.spec.whatwg.org/#concept-node-replace-all>
-    pub(crate) fn replace_all(node: Option<&Node>, parent: &Node) {
+    pub(crate) fn replace_all(node: Option<&Node>, parent: &Node, can_gc: CanGc) {
         parent.owner_doc().add_script_and_layout_blocker();
         // Step 1.
         if let Some(node) = node {
-            Node::adopt(node, &parent.owner_doc());
+            Node::adopt(node, &parent.owner_doc(), can_gc);
         }
         // Step 2.
         rooted_vec!(let removed_nodes <- parent.children().map(|c| DomRoot::as_traced(&c)));
@@ -2429,11 +2437,11 @@ impl Node {
         };
         // Step 4.
         for child in &*removed_nodes {
-            Node::remove(child, parent, SuppressObserver::Suppressed);
+            Node::remove(child, parent, SuppressObserver::Suppressed, can_gc);
         }
         // Step 5.
         if let Some(node) = node {
-            Node::insert(node, parent, None, SuppressObserver::Suppressed);
+            Node::insert(node, parent, None, SuppressObserver::Suppressed, can_gc);
         }
         // Step 6.
         vtable_for(parent).children_changed(&ChildrenMutation::replace_all(
@@ -2456,15 +2464,15 @@ impl Node {
     /// <https://dom.spec.whatwg.org/multipage/#string-replace-all>
     pub(crate) fn string_replace_all(string: DOMString, parent: &Node, can_gc: CanGc) {
         if string.len() == 0 {
-            Node::replace_all(None, parent);
+            Node::replace_all(None, parent, can_gc);
         } else {
             let text = Text::new(string, &parent.owner_document(), can_gc);
-            Node::replace_all(Some(text.upcast::<Node>()), parent);
+            Node::replace_all(Some(text.upcast::<Node>()), parent, can_gc);
         };
     }
 
     /// <https://dom.spec.whatwg.org/#concept-node-pre-remove>
-    fn pre_remove(child: &Node, parent: &Node) -> Fallible<DomRoot<Node>> {
+    fn pre_remove(child: &Node, parent: &Node, can_gc: CanGc) -> Fallible<DomRoot<Node>> {
         // Step 1.
         match child.GetParentNode() {
             Some(ref node) if &**node != parent => return Err(Error::NotFound),
@@ -2473,14 +2481,14 @@ impl Node {
         }
 
         // Step 2.
-        Node::remove(child, parent, SuppressObserver::Unsuppressed);
+        Node::remove(child, parent, SuppressObserver::Unsuppressed, can_gc);
 
         // Step 3.
         Ok(DomRoot::from_ref(child))
     }
 
     /// <https://dom.spec.whatwg.org/#concept-node-remove>
-    fn remove(node: &Node, parent: &Node, suppress_observers: SuppressObserver) {
+    fn remove(node: &Node, parent: &Node, suppress_observers: SuppressObserver, can_gc: CanGc) {
         parent.owner_doc().add_script_and_layout_blocker();
 
         // Step 2.
@@ -2517,7 +2525,7 @@ impl Node {
 
         // Step 7. Remove node from its parent's children.
         // Step 11-14. Run removing steps and enqueue disconnected custom element reactions for the subtree.
-        parent.remove_child(node, cached_index);
+        parent.remove_child(node, cached_index, can_gc);
 
         // Step 8. If node is assigned, then run assign slottables for node’s assigned slot.
         if let Some(slot) = node.assigned_slot() {
@@ -2707,14 +2715,14 @@ impl Node {
 
         // Step 5: Run any cloning steps defined for node in other applicable specifications and pass copy,
         // node, document, and the clone children flag if set, as parameters.
-        vtable_for(node).cloning_steps(&copy, maybe_doc, clone_children);
+        vtable_for(node).cloning_steps(&copy, maybe_doc, clone_children, can_gc);
 
         // Step 6. If the clone children flag is set, then for each child child of node, in tree order: append the
         // result of cloning child with document and the clone children flag set, to copy.
         if clone_children == CloneChildrenFlag::CloneChildren {
             for child in node.children() {
                 let child_copy = Node::clone(&child, Some(&document), clone_children, can_gc);
-                let _inserted_node = Node::pre_insert(&child_copy, &copy, None);
+                let _inserted_node = Node::pre_insert(&child_copy, &copy, None, can_gc);
             }
         }
 
@@ -2757,8 +2765,12 @@ impl Node {
                     );
 
                     // TODO: Should we handle the error case here and in step 6?
-                    let _inserted_node =
-                        Node::pre_insert(&child_copy, copy_shadow_root.upcast::<Node>(), None);
+                    let _inserted_node = Node::pre_insert(
+                        &child_copy,
+                        copy_shadow_root.upcast::<Node>(),
+                        None,
+                        can_gc,
+                    );
                 }
             }
         }
@@ -3069,11 +3081,11 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-node-nodevalue>
-    fn SetNodeValue(&self, val: Option<DOMString>) {
+    fn SetNodeValue(&self, val: Option<DOMString>, can_gc: CanGc) {
         match self.type_id() {
             NodeTypeId::Attr => {
                 let attr = self.downcast::<Attr>().unwrap();
-                attr.SetValue(val.unwrap_or_default());
+                attr.SetValue(val.unwrap_or_default(), can_gc);
             },
             NodeTypeId::CharacterData(_) => {
                 let character_data = self.downcast::<CharacterData>().unwrap();
@@ -3115,11 +3127,11 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
                 };
 
                 // Step 3.
-                Node::replace_all(node.as_deref(), self);
+                Node::replace_all(node.as_deref(), self, can_gc);
             },
             NodeTypeId::Attr => {
                 let attr = self.downcast::<Attr>().unwrap();
-                attr.SetValue(value);
+                attr.SetValue(value, can_gc);
             },
             NodeTypeId::CharacterData(..) => {
                 let characterdata = self.downcast::<CharacterData>().unwrap();
@@ -3130,17 +3142,22 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-node-insertbefore>
-    fn InsertBefore(&self, node: &Node, child: Option<&Node>) -> Fallible<DomRoot<Node>> {
-        Node::pre_insert(node, self, child)
+    fn InsertBefore(
+        &self,
+        node: &Node,
+        child: Option<&Node>,
+        can_gc: CanGc,
+    ) -> Fallible<DomRoot<Node>> {
+        Node::pre_insert(node, self, child, can_gc)
     }
 
     /// <https://dom.spec.whatwg.org/#dom-node-appendchild>
-    fn AppendChild(&self, node: &Node) -> Fallible<DomRoot<Node>> {
-        Node::pre_insert(node, self, None)
+    fn AppendChild(&self, node: &Node, can_gc: CanGc) -> Fallible<DomRoot<Node>> {
+        Node::pre_insert(node, self, None, can_gc)
     }
 
     /// <https://dom.spec.whatwg.org/#concept-node-replace>
-    fn ReplaceChild(&self, node: &Node, child: &Node) -> Fallible<DomRoot<Node>> {
+    fn ReplaceChild(&self, node: &Node, child: &Node, can_gc: CanGc) -> Fallible<DomRoot<Node>> {
         // Step 1.
         match self.type_id() {
             NodeTypeId::Document(_) | NodeTypeId::DocumentFragment(_) | NodeTypeId::Element(..) => {
@@ -3238,11 +3255,11 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
 
         // Step 10.
         let document = self.owner_document();
-        Node::adopt(node, &document);
+        Node::adopt(node, &document, can_gc);
 
         let removed_child = if node != child {
             // Step 11.
-            Node::remove(child, self, SuppressObserver::Suppressed);
+            Node::remove(child, self, SuppressObserver::Suppressed, can_gc);
             Some(child)
         } else {
             None
@@ -3261,7 +3278,13 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
         };
 
         // Step 13.
-        Node::insert(node, self, reference_child, SuppressObserver::Suppressed);
+        Node::insert(
+            node,
+            self,
+            reference_child,
+            SuppressObserver::Suppressed,
+            can_gc,
+        );
 
         // Step 14.
         vtable_for(self).children_changed(&ChildrenMutation::replace(
@@ -3285,19 +3308,19 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-node-removechild>
-    fn RemoveChild(&self, node: &Node) -> Fallible<DomRoot<Node>> {
-        Node::pre_remove(node, self)
+    fn RemoveChild(&self, node: &Node, can_gc: CanGc) -> Fallible<DomRoot<Node>> {
+        Node::pre_remove(node, self, can_gc)
     }
 
     /// <https://dom.spec.whatwg.org/#dom-node-normalize>
-    fn Normalize(&self) {
+    fn Normalize(&self, can_gc: CanGc) {
         let mut children = self.children().enumerate().peekable();
         while let Some((_, node)) = children.next() {
             if let Some(text) = node.downcast::<Text>() {
                 let cdata = text.upcast::<CharacterData>();
                 let mut length = cdata.Length();
                 if length == 0 {
-                    Node::remove(&node, self, SuppressObserver::Unsuppressed);
+                    Node::remove(&node, self, SuppressObserver::Unsuppressed, can_gc);
                     continue;
                 }
                 while children
@@ -3313,10 +3336,10 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
                     let sibling_cdata = sibling.downcast::<CharacterData>().unwrap();
                     length += sibling_cdata.Length();
                     cdata.append_data(&sibling_cdata.data());
-                    Node::remove(&sibling, self, SuppressObserver::Unsuppressed);
+                    Node::remove(&sibling, self, SuppressObserver::Unsuppressed, can_gc);
                 }
             } else {
-                node.Normalize();
+                node.Normalize(can_gc);
             }
         }
     }
@@ -3726,8 +3749,8 @@ impl VirtualMethods for Node {
 
     // This handles the ranges mentioned in steps 2-3 when removing a node.
     /// <https://dom.spec.whatwg.org/#concept-node-remove>
-    fn unbind_from_tree(&self, context: &UnbindContext) {
-        self.super_type().unwrap().unbind_from_tree(context);
+    fn unbind_from_tree(&self, context: &UnbindContext, can_gc: CanGc) {
+        self.super_type().unwrap().unbind_from_tree(context, can_gc);
         if !self.ranges_is_empty() {
             self.ranges().drain_to_parent(context, self);
         }

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -1008,7 +1008,7 @@ impl Node {
             .node_from_nodes_and_strings(nodes, can_gc)?;
         if self.parent_node == Some(&*parent) {
             // Step 5.
-            parent.ReplaceChild(&node, self)?;
+            parent.ReplaceChild(&node, self, can_gc)?;
         } else {
             // Step 6.
             Node::pre_insert(&node, &parent, viable_next_sibling.as_deref(), can_gc)?;

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -596,7 +596,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
                     .unwrap();
                 let clone = cdata.clone_with_data(data, &start_node.owner_doc(), can_gc);
                 // Step 4.3.
-                fragment.upcast::<Node>().AppendChild(&clone, can_gc)?;
+                fragment.upcast::<Node>().AppendChild(&clone)?;
                 // Step 4.4
                 return Ok(fragment);
             }
@@ -619,12 +619,12 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
                     .unwrap();
                 let clone = cdata.clone_with_data(data, &start_node.owner_doc(), can_gc);
                 // Step 13.3.
-                fragment.upcast::<Node>().AppendChild(&clone, can_gc)?;
+                fragment.upcast::<Node>().AppendChild(&clone)?;
             } else {
                 // Step 14.1.
                 let clone = child.CloneNode(/* deep */ false, can_gc)?;
                 // Step 14.2.
-                fragment.upcast::<Node>().AppendChild(&clone, can_gc)?;
+                fragment.upcast::<Node>().AppendChild(&clone)?;
                 // Step 14.3.
                 let subrange = Range::new(
                     &clone.owner_doc(),
@@ -637,7 +637,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
                 // Step 14.4.
                 let subfragment = subrange.CloneContents(can_gc)?;
                 // Step 14.5.
-                clone.AppendChild(subfragment.upcast(), can_gc)?;
+                clone.AppendChild(subfragment.upcast())?;
             }
         }
 
@@ -646,7 +646,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
             // Step 15.1.
             let clone = child.CloneNode(/* deep */ true, can_gc)?;
             // Step 15.2.
-            fragment.upcast::<Node>().AppendChild(&clone, can_gc)?;
+            fragment.upcast::<Node>().AppendChild(&clone)?;
         }
 
         if let Some(child) = last_partially_contained_child {
@@ -657,19 +657,19 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
                 let data = cdata.SubstringData(0, end_offset).unwrap();
                 let clone = cdata.clone_with_data(data, &start_node.owner_doc(), can_gc);
                 // Step 16.3.
-                fragment.upcast::<Node>().AppendChild(&clone, can_gc)?;
+                fragment.upcast::<Node>().AppendChild(&clone)?;
             } else {
                 // Step 17.1.
                 let clone = child.CloneNode(/* deep */ false, can_gc)?;
                 // Step 17.2.
-                fragment.upcast::<Node>().AppendChild(&clone, can_gc)?;
+                fragment.upcast::<Node>().AppendChild(&clone)?;
                 // Step 17.3.
                 let subrange =
                     Range::new(&clone.owner_doc(), &child, 0, &end_node, end_offset, can_gc);
                 // Step 17.4.
                 let subfragment = subrange.CloneContents(can_gc)?;
                 // Step 17.5.
-                clone.AppendChild(subfragment.upcast(), can_gc)?;
+                clone.AppendChild(subfragment.upcast())?;
             }
         }
 
@@ -705,7 +705,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
                     .unwrap()
                     .SetData(text.unwrap());
                 // Step 4.3.
-                fragment.upcast::<Node>().AppendChild(&clone, can_gc)?;
+                fragment.upcast::<Node>().AppendChild(&clone)?;
                 // Step 4.4.
                 end_data.ReplaceData(start_offset, end_offset - start_offset, DOMString::new())?;
                 // Step 4.5.
@@ -749,7 +749,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
                     .unwrap()
                     .SetData(text.unwrap());
                 // Step 15.3.
-                fragment.upcast::<Node>().AppendChild(&clone, can_gc)?;
+                fragment.upcast::<Node>().AppendChild(&clone)?;
                 // Step 15.4.
                 start_data.ReplaceData(
                     start_offset,
@@ -760,7 +760,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
                 // Step 16.1.
                 let clone = child.CloneNode(/* deep */ false, can_gc)?;
                 // Step 16.2.
-                fragment.upcast::<Node>().AppendChild(&clone, can_gc)?;
+                fragment.upcast::<Node>().AppendChild(&clone)?;
                 // Step 16.3.
                 let subrange = Range::new(
                     &clone.owner_doc(),
@@ -773,13 +773,13 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
                 // Step 16.4.
                 let subfragment = subrange.ExtractContents(can_gc)?;
                 // Step 16.5.
-                clone.AppendChild(subfragment.upcast(), can_gc)?;
+                clone.AppendChild(subfragment.upcast())?;
             }
         }
 
         // Step 17.
         for child in contained_children {
-            fragment.upcast::<Node>().AppendChild(&child, can_gc)?;
+            fragment.upcast::<Node>().AppendChild(&child)?;
         }
 
         if let Some(child) = last_partially_contained_child {
@@ -794,21 +794,21 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
                     .unwrap()
                     .SetData(text.unwrap());
                 // Step 18.3.
-                fragment.upcast::<Node>().AppendChild(&clone, can_gc)?;
+                fragment.upcast::<Node>().AppendChild(&clone)?;
                 // Step 18.4.
                 end_data.ReplaceData(0, end_offset, DOMString::new())?;
             } else {
                 // Step 19.1.
                 let clone = child.CloneNode(/* deep */ false, can_gc)?;
                 // Step 19.2.
-                fragment.upcast::<Node>().AppendChild(&clone, can_gc)?;
+                fragment.upcast::<Node>().AppendChild(&clone)?;
                 // Step 19.3.
                 let subrange =
                     Range::new(&clone.owner_doc(), &child, 0, &end_node, end_offset, can_gc);
                 // Step 19.4.
                 let subfragment = subrange.ExtractContents(can_gc)?;
                 // Step 19.5.
-                clone.AppendChild(subfragment.upcast(), can_gc)?;
+                clone.AppendChild(subfragment.upcast())?;
             }
         }
 
@@ -911,7 +911,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-range-deletecontents>
-    fn DeleteContents(&self, can_gc: CanGc) -> ErrorResult {
+    fn DeleteContents(&self) -> ErrorResult {
         // Step 1.
         if self.collapsed() {
             return Ok(());
@@ -980,7 +980,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
 
         // Step 8.
         for child in &*contained_children {
-            child.remove_self(can_gc);
+            child.remove_self(CanGc::note());
         }
 
         // Step 9.
@@ -1029,7 +1029,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
         self.InsertNode(new_parent, can_gc)?;
 
         // Step 6.
-        new_parent.AppendChild(fragment.upcast(), can_gc)?;
+        new_parent.AppendChild(fragment.upcast())?;
 
         // Step 7.
         self.SelectNode(new_parent)

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -596,7 +596,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
                     .unwrap();
                 let clone = cdata.clone_with_data(data, &start_node.owner_doc(), can_gc);
                 // Step 4.3.
-                fragment.upcast::<Node>().AppendChild(&clone)?;
+                fragment.upcast::<Node>().AppendChild(&clone, can_gc)?;
                 // Step 4.4
                 return Ok(fragment);
             }
@@ -619,12 +619,12 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
                     .unwrap();
                 let clone = cdata.clone_with_data(data, &start_node.owner_doc(), can_gc);
                 // Step 13.3.
-                fragment.upcast::<Node>().AppendChild(&clone)?;
+                fragment.upcast::<Node>().AppendChild(&clone, can_gc)?;
             } else {
                 // Step 14.1.
                 let clone = child.CloneNode(/* deep */ false, can_gc)?;
                 // Step 14.2.
-                fragment.upcast::<Node>().AppendChild(&clone)?;
+                fragment.upcast::<Node>().AppendChild(&clone, can_gc)?;
                 // Step 14.3.
                 let subrange = Range::new(
                     &clone.owner_doc(),
@@ -637,7 +637,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
                 // Step 14.4.
                 let subfragment = subrange.CloneContents(can_gc)?;
                 // Step 14.5.
-                clone.AppendChild(subfragment.upcast())?;
+                clone.AppendChild(subfragment.upcast(), can_gc)?;
             }
         }
 
@@ -646,7 +646,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
             // Step 15.1.
             let clone = child.CloneNode(/* deep */ true, can_gc)?;
             // Step 15.2.
-            fragment.upcast::<Node>().AppendChild(&clone)?;
+            fragment.upcast::<Node>().AppendChild(&clone, can_gc)?;
         }
 
         if let Some(child) = last_partially_contained_child {
@@ -657,19 +657,19 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
                 let data = cdata.SubstringData(0, end_offset).unwrap();
                 let clone = cdata.clone_with_data(data, &start_node.owner_doc(), can_gc);
                 // Step 16.3.
-                fragment.upcast::<Node>().AppendChild(&clone)?;
+                fragment.upcast::<Node>().AppendChild(&clone, can_gc)?;
             } else {
                 // Step 17.1.
                 let clone = child.CloneNode(/* deep */ false, can_gc)?;
                 // Step 17.2.
-                fragment.upcast::<Node>().AppendChild(&clone)?;
+                fragment.upcast::<Node>().AppendChild(&clone, can_gc)?;
                 // Step 17.3.
                 let subrange =
                     Range::new(&clone.owner_doc(), &child, 0, &end_node, end_offset, can_gc);
                 // Step 17.4.
                 let subfragment = subrange.CloneContents(can_gc)?;
                 // Step 17.5.
-                clone.AppendChild(subfragment.upcast())?;
+                clone.AppendChild(subfragment.upcast(), can_gc)?;
             }
         }
 
@@ -705,7 +705,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
                     .unwrap()
                     .SetData(text.unwrap());
                 // Step 4.3.
-                fragment.upcast::<Node>().AppendChild(&clone)?;
+                fragment.upcast::<Node>().AppendChild(&clone, can_gc)?;
                 // Step 4.4.
                 end_data.ReplaceData(start_offset, end_offset - start_offset, DOMString::new())?;
                 // Step 4.5.
@@ -749,7 +749,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
                     .unwrap()
                     .SetData(text.unwrap());
                 // Step 15.3.
-                fragment.upcast::<Node>().AppendChild(&clone)?;
+                fragment.upcast::<Node>().AppendChild(&clone, can_gc)?;
                 // Step 15.4.
                 start_data.ReplaceData(
                     start_offset,
@@ -760,7 +760,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
                 // Step 16.1.
                 let clone = child.CloneNode(/* deep */ false, can_gc)?;
                 // Step 16.2.
-                fragment.upcast::<Node>().AppendChild(&clone)?;
+                fragment.upcast::<Node>().AppendChild(&clone, can_gc)?;
                 // Step 16.3.
                 let subrange = Range::new(
                     &clone.owner_doc(),
@@ -773,13 +773,13 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
                 // Step 16.4.
                 let subfragment = subrange.ExtractContents(can_gc)?;
                 // Step 16.5.
-                clone.AppendChild(subfragment.upcast())?;
+                clone.AppendChild(subfragment.upcast(), can_gc)?;
             }
         }
 
         // Step 17.
         for child in contained_children {
-            fragment.upcast::<Node>().AppendChild(&child)?;
+            fragment.upcast::<Node>().AppendChild(&child, can_gc)?;
         }
 
         if let Some(child) = last_partially_contained_child {
@@ -794,21 +794,21 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
                     .unwrap()
                     .SetData(text.unwrap());
                 // Step 18.3.
-                fragment.upcast::<Node>().AppendChild(&clone)?;
+                fragment.upcast::<Node>().AppendChild(&clone, can_gc)?;
                 // Step 18.4.
                 end_data.ReplaceData(0, end_offset, DOMString::new())?;
             } else {
                 // Step 19.1.
                 let clone = child.CloneNode(/* deep */ false, can_gc)?;
                 // Step 19.2.
-                fragment.upcast::<Node>().AppendChild(&clone)?;
+                fragment.upcast::<Node>().AppendChild(&clone, can_gc)?;
                 // Step 19.3.
                 let subrange =
                     Range::new(&clone.owner_doc(), &child, 0, &end_node, end_offset, can_gc);
                 // Step 19.4.
                 let subfragment = subrange.ExtractContents(can_gc)?;
                 // Step 19.5.
-                clone.AppendChild(subfragment.upcast())?;
+                clone.AppendChild(subfragment.upcast(), can_gc)?;
             }
         }
 
@@ -884,7 +884,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
         };
 
         // Step 9.
-        node.remove_self();
+        node.remove_self(can_gc);
 
         // Step 10.
         let new_offset = reference_node
@@ -900,7 +900,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
             };
 
         // Step 12.
-        Node::pre_insert(node, &parent, reference_node.as_deref())?;
+        Node::pre_insert(node, &parent, reference_node.as_deref(), can_gc)?;
 
         // Step 13.
         if self.collapsed() {
@@ -911,7 +911,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-range-deletecontents>
-    fn DeleteContents(&self) -> ErrorResult {
+    fn DeleteContents(&self, can_gc: CanGc) -> ErrorResult {
         // Step 1.
         if self.collapsed() {
             return Ok(());
@@ -980,7 +980,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
 
         // Step 8.
         for child in &*contained_children {
-            child.remove_self();
+            child.remove_self(can_gc);
         }
 
         // Step 9.
@@ -1023,13 +1023,13 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
         let fragment = self.ExtractContents(can_gc)?;
 
         // Step 4.
-        Node::replace_all(None, new_parent);
+        Node::replace_all(None, new_parent, can_gc);
 
         // Step 5.
         self.InsertNode(new_parent, can_gc)?;
 
         // Step 6.
-        new_parent.AppendChild(fragment.upcast())?;
+        new_parent.AppendChild(fragment.upcast(), can_gc)?;
 
         // Step 7.
         self.SelectNode(new_parent)

--- a/components/script/dom/selection.rs
+++ b/components/script/dom/selection.rs
@@ -453,11 +453,11 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
     }
 
     // https://w3c.github.io/selection-api/#dom-selection-deletecontents
-    fn DeleteFromDocument(&self) -> ErrorResult {
+    fn DeleteFromDocument(&self, can_gc: CanGc) -> ErrorResult {
         if let Some(range) = self.range.get() {
             // Since the range is changing, it should trigger a
             // selectionchange event as it would if if mutated any other way
-            return range.DeleteContents();
+            return range.DeleteContents(can_gc);
         }
         Ok(())
     }

--- a/components/script/dom/selection.rs
+++ b/components/script/dom/selection.rs
@@ -453,11 +453,11 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
     }
 
     // https://w3c.github.io/selection-api/#dom-selection-deletecontents
-    fn DeleteFromDocument(&self, can_gc: CanGc) -> ErrorResult {
+    fn DeleteFromDocument(&self) -> ErrorResult {
         if let Some(range) = self.range.get() {
             // Since the range is changing, it should trigger a
             // selectionchange event as it would if if mutated any other way
-            return range.DeleteContents(can_gc);
+            return range.DeleteContents();
         }
         Ok(())
     }

--- a/components/script/dom/servoparser/async_html.rs
+++ b/components/script/dom/servoparser/async_html.rs
@@ -484,7 +484,7 @@ impl Tokenizer {
 
                 document
                     .upcast::<Node>()
-                    .AppendChild(doctype.upcast())
+                    .AppendChild(doctype.upcast(), can_gc)
                     .expect("Appending failed");
             },
             ParseOperation::AddAttrsIfMissing { target, attrs } => {
@@ -503,7 +503,7 @@ impl Tokenizer {
             },
             ParseOperation::RemoveFromParent { target } => {
                 if let Some(ref parent) = self.get_node(&target).GetParentNode() {
-                    parent.RemoveChild(&self.get_node(&target)).unwrap();
+                    parent.RemoveChild(&self.get_node(&target), can_gc).unwrap();
                 }
             },
             ParseOperation::MarkScriptAlreadyStarted { node } => {
@@ -517,7 +517,7 @@ impl Tokenizer {
                 let parent = self.get_node(&parent);
                 let new_parent = self.get_node(&new_parent);
                 while let Some(child) = parent.GetFirstChild() {
-                    new_parent.AppendChild(&child).unwrap();
+                    new_parent.AppendChild(&child, can_gc).unwrap();
                 }
             },
             ParseOperation::AssociateWithForm {
@@ -546,7 +546,7 @@ impl Tokenizer {
                 let control = elem.and_then(|e| e.as_maybe_form_control());
 
                 if let Some(control) = control {
-                    control.set_form_owner_from_parser(&form);
+                    control.set_form_owner_from_parser(&form, can_gc);
                 }
             },
             ParseOperation::Pop { node } => {

--- a/components/script/dom/servoparser/async_html.rs
+++ b/components/script/dom/servoparser/async_html.rs
@@ -484,7 +484,7 @@ impl Tokenizer {
 
                 document
                     .upcast::<Node>()
-                    .AppendChild(doctype.upcast(), can_gc)
+                    .AppendChild(doctype.upcast())
                     .expect("Appending failed");
             },
             ParseOperation::AddAttrsIfMissing { target, attrs } => {
@@ -503,7 +503,7 @@ impl Tokenizer {
             },
             ParseOperation::RemoveFromParent { target } => {
                 if let Some(ref parent) = self.get_node(&target).GetParentNode() {
-                    parent.RemoveChild(&self.get_node(&target), can_gc).unwrap();
+                    parent.RemoveChild(&self.get_node(&target)).unwrap();
                 }
             },
             ParseOperation::MarkScriptAlreadyStarted { node } => {
@@ -517,7 +517,7 @@ impl Tokenizer {
                 let parent = self.get_node(&parent);
                 let new_parent = self.get_node(&new_parent);
                 while let Some(child) = parent.GetFirstChild() {
-                    new_parent.AppendChild(&child, can_gc).unwrap();
+                    new_parent.AppendChild(&child).unwrap();
                 }
             },
             ParseOperation::AssociateWithForm {

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -713,7 +713,7 @@ where
 
     fn next(&mut self) -> Option<DomRoot<Node>> {
         let next = self.inner.next()?;
-        next.remove_self();
+        next.remove_self(CanGc::note());
         Some(next)
     }
 
@@ -920,7 +920,7 @@ impl FetchResponseListener for ParserContext {
                 let img = HTMLImageElement::new(local_name!("img"), None, doc, None, CanGc::note());
                 img.SetSrc(USVString(self.url.to_string()));
                 doc_body
-                    .AppendChild(&DomRoot::upcast::<Node>(img))
+                    .AppendChild(&DomRoot::upcast::<Node>(img), CanGc::note())
                     .expect("Appending failed");
             },
             (mime::TEXT, mime::PLAIN, _) => {
@@ -1102,7 +1102,7 @@ fn insert(
             if element_in_non_fragment {
                 ScriptThread::push_new_element_queue();
             }
-            parent.InsertBefore(&n, reference_child).unwrap();
+            parent.InsertBefore(&n, reference_child, can_gc).unwrap();
             if element_in_non_fragment {
                 ScriptThread::pop_current_element_queue(can_gc);
             }
@@ -1118,7 +1118,9 @@ fn insert(
                 text.upcast::<CharacterData>().append_data(&t);
             } else {
                 let text = Text::new(String::from(t).into(), &parent.owner_doc(), can_gc);
-                parent.InsertBefore(text.upcast(), reference_child).unwrap();
+                parent
+                    .InsertBefore(text.upcast(), reference_child, can_gc)
+                    .unwrap();
             }
         },
     }
@@ -1264,7 +1266,7 @@ impl TreeSink for Sink {
         let control = elem.and_then(|e| e.as_maybe_form_control());
 
         if let Some(control) = control {
-            control.set_form_owner_from_parser(&form);
+            control.set_form_owner_from_parser(&form, CanGc::note());
         }
     }
 
@@ -1330,7 +1332,7 @@ impl TreeSink for Sink {
             CanGc::note(),
         );
         doc.upcast::<Node>()
-            .AppendChild(doctype.upcast())
+            .AppendChild(doctype.upcast(), CanGc::note())
             .expect("Appending failed");
     }
 
@@ -1350,7 +1352,7 @@ impl TreeSink for Sink {
 
     fn remove_from_parent(&self, target: &Dom<Node>) {
         if let Some(ref parent) = target.GetParentNode() {
-            parent.RemoveChild(target).unwrap();
+            parent.RemoveChild(target, CanGc::note()).unwrap();
         }
     }
 
@@ -1372,7 +1374,7 @@ impl TreeSink for Sink {
 
     fn reparent_children(&self, node: &Dom<Node>, new_parent: &Dom<Node>) {
         while let Some(ref child) = node.GetFirstChild() {
-            new_parent.AppendChild(child).unwrap();
+            new_parent.AppendChild(child, CanGc::note()).unwrap();
         }
     }
 

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -920,7 +920,7 @@ impl FetchResponseListener for ParserContext {
                 let img = HTMLImageElement::new(local_name!("img"), None, doc, None, CanGc::note());
                 img.SetSrc(USVString(self.url.to_string()));
                 doc_body
-                    .AppendChild(&DomRoot::upcast::<Node>(img), CanGc::note())
+                    .AppendChild(&DomRoot::upcast::<Node>(img))
                     .expect("Appending failed");
             },
             (mime::TEXT, mime::PLAIN, _) => {
@@ -1102,7 +1102,7 @@ fn insert(
             if element_in_non_fragment {
                 ScriptThread::push_new_element_queue();
             }
-            parent.InsertBefore(&n, reference_child, can_gc).unwrap();
+            parent.InsertBefore(&n, reference_child).unwrap();
             if element_in_non_fragment {
                 ScriptThread::pop_current_element_queue(can_gc);
             }
@@ -1118,9 +1118,7 @@ fn insert(
                 text.upcast::<CharacterData>().append_data(&t);
             } else {
                 let text = Text::new(String::from(t).into(), &parent.owner_doc(), can_gc);
-                parent
-                    .InsertBefore(text.upcast(), reference_child, can_gc)
-                    .unwrap();
+                parent.InsertBefore(text.upcast(), reference_child).unwrap();
             }
         },
     }
@@ -1332,7 +1330,7 @@ impl TreeSink for Sink {
             CanGc::note(),
         );
         doc.upcast::<Node>()
-            .AppendChild(doctype.upcast(), CanGc::note())
+            .AppendChild(doctype.upcast())
             .expect("Appending failed");
     }
 
@@ -1352,7 +1350,7 @@ impl TreeSink for Sink {
 
     fn remove_from_parent(&self, target: &Dom<Node>) {
         if let Some(ref parent) = target.GetParentNode() {
-            parent.RemoveChild(target, CanGc::note()).unwrap();
+            parent.RemoveChild(target).unwrap();
         }
     }
 
@@ -1374,7 +1372,7 @@ impl TreeSink for Sink {
 
     fn reparent_children(&self, node: &Dom<Node>, new_parent: &Dom<Node>) {
         while let Some(ref child) = node.GetFirstChild() {
-            new_parent.AppendChild(child, CanGc::note()).unwrap();
+            new_parent.AppendChild(child).unwrap();
         }
     }
 

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -221,7 +221,7 @@ impl ShadowRoot {
 
     /// Remove any existing association between the provided id and any elements
     /// in this shadow tree.
-    pub(crate) fn unregister_element_id(&self, to_unregister: &Element, id: Atom, can_gc: CanGc) {
+    pub(crate) fn unregister_element_id(&self, to_unregister: &Element, id: Atom, _can_gc: CanGc) {
         self.document_or_shadow_root.unregister_named_element(
             self.document_fragment.id_map(),
             to_unregister,
@@ -230,7 +230,7 @@ impl ShadowRoot {
     }
 
     /// Associate an element present in this shadow tree with the provided id.
-    pub(crate) fn register_element_id(&self, element: &Element, id: Atom, can_gc: CanGc) {
+    pub(crate) fn register_element_id(&self, element: &Element, id: Atom, _can_gc: CanGc) {
         let root = self
             .upcast::<Node>()
             .inclusive_ancestors(ShadowIncluding::No)

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -153,11 +153,11 @@ impl ShadowRoot {
         )
     }
 
-    pub(crate) fn detach(&self) {
+    pub(crate) fn detach(&self, can_gc: CanGc) {
         self.document.unregister_shadow_root(self);
         let node = self.upcast::<Node>();
         node.set_containing_shadow_root(None);
-        Node::complete_remove_subtree(node, &UnbindContext::new(node, None, None, None));
+        Node::complete_remove_subtree(node, &UnbindContext::new(node, None, None, None), can_gc);
         self.host.set(None);
     }
 
@@ -221,7 +221,7 @@ impl ShadowRoot {
 
     /// Remove any existing association between the provided id and any elements
     /// in this shadow tree.
-    pub(crate) fn unregister_element_id(&self, to_unregister: &Element, id: Atom) {
+    pub(crate) fn unregister_element_id(&self, to_unregister: &Element, id: Atom, can_gc: CanGc) {
         self.document_or_shadow_root.unregister_named_element(
             self.document_fragment.id_map(),
             to_unregister,
@@ -230,7 +230,7 @@ impl ShadowRoot {
     }
 
     /// Associate an element present in this shadow tree with the provided id.
-    pub(crate) fn register_element_id(&self, element: &Element, id: Atom) {
+    pub(crate) fn register_element_id(&self, element: &Element, id: Atom, can_gc: CanGc) {
         let root = self
             .upcast::<Node>()
             .inclusive_ancestors(ShadowIncluding::No)
@@ -445,7 +445,7 @@ impl ShadowRootMethods<crate::DomTypeHolder> for ShadowRoot {
         };
 
         // Step 4. Replace all with fragment within this.
-        Node::replace_all(Some(frag.upcast()), self.upcast());
+        Node::replace_all(Some(frag.upcast()), self.upcast(), can_gc);
     }
 
     /// <https://dom.spec.whatwg.org/#dom-shadowroot-slotassignment>
@@ -462,9 +462,9 @@ impl VirtualMethods for ShadowRoot {
         Some(self.upcast::<DocumentFragment>() as &dyn VirtualMethods)
     }
 
-    fn bind_to_tree(&self, context: &BindContext) {
+    fn bind_to_tree(&self, context: &BindContext, can_gc: CanGc) {
         if let Some(s) = self.super_type() {
-            s.bind_to_tree(context);
+            s.bind_to_tree(context, can_gc);
         }
 
         if context.tree_connected {
@@ -482,17 +482,20 @@ impl VirtualMethods for ShadowRoot {
 
             // Out-of-document elements never have the descendants flag set
             debug_assert!(!node.get_flag(NodeFlags::HAS_DIRTY_DESCENDANTS));
-            vtable_for(&node).bind_to_tree(&BindContext {
-                tree_connected: context.tree_connected,
-                tree_is_in_a_document_tree: false,
-                tree_is_in_a_shadow_tree: true,
-            });
+            vtable_for(&node).bind_to_tree(
+                &BindContext {
+                    tree_connected: context.tree_connected,
+                    tree_is_in_a_document_tree: false,
+                    tree_is_in_a_shadow_tree: true,
+                },
+                can_gc,
+            );
         }
     }
 
-    fn unbind_from_tree(&self, context: &UnbindContext) {
+    fn unbind_from_tree(&self, context: &UnbindContext, can_gc: CanGc) {
         if let Some(s) = self.super_type() {
-            s.unbind_from_tree(context);
+            s.unbind_from_tree(context, can_gc);
         }
 
         if context.tree_connected {

--- a/components/script/dom/svgsvgelement.rs
+++ b/components/script/dom/svgsvgelement.rs
@@ -79,8 +79,10 @@ impl VirtualMethods for SVGSVGElement {
         Some(self.upcast::<SVGGraphicsElement>() as &dyn VirtualMethods)
     }
 
-    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation) {
-        self.super_type().unwrap().attribute_mutated(attr, mutation);
+    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation, can_gc: CanGc) {
+        self.super_type()
+            .unwrap()
+            .attribute_mutated(attr, mutation, can_gc);
     }
 
     fn parse_plain_attribute(&self, name: &LocalName, value: DOMString) -> AttrValue {

--- a/components/script/dom/text.rs
+++ b/components/script/dom/text.rs
@@ -89,7 +89,7 @@ impl TextMethods<crate::DomTypeHolder> for Text {
         if let Some(ref parent) = parent {
             // Step 7.1.
             parent
-                .InsertBefore(new_node.upcast(), node.GetNextSibling().as_deref())
+                .InsertBefore(new_node.upcast(), node.GetNextSibling().as_deref(), can_gc)
                 .unwrap();
             // Steps 7.2-3.
             node.ranges()

--- a/components/script/dom/text.rs
+++ b/components/script/dom/text.rs
@@ -89,7 +89,7 @@ impl TextMethods<crate::DomTypeHolder> for Text {
         if let Some(ref parent) = parent {
             // Step 7.1.
             parent
-                .InsertBefore(new_node.upcast(), node.GetNextSibling().as_deref(), can_gc)
+                .InsertBefore(new_node.upcast(), node.GetNextSibling().as_deref())
                 .unwrap();
             // Steps 7.2-3.
             node.ranges()

--- a/components/script/dom/validation.rs
+++ b/components/script/dom/validation.rs
@@ -28,7 +28,7 @@ pub(crate) trait Validatable {
     fn perform_validation(
         &self,
         _validate_flags: ValidationFlags,
-        can_gc: CanGc,
+        _can_gc: CanGc,
     ) -> ValidationFlags {
         ValidationFlags::empty()
     }

--- a/components/script/dom/validation.rs
+++ b/components/script/dom/validation.rs
@@ -25,7 +25,11 @@ pub(crate) trait Validatable {
     fn is_instance_validatable(&self) -> bool;
 
     // Check if element satisfies its constraints, excluding custom errors
-    fn perform_validation(&self, _validate_flags: ValidationFlags) -> ValidationFlags {
+    fn perform_validation(
+        &self,
+        _validate_flags: ValidationFlags,
+        can_gc: CanGc,
+    ) -> ValidationFlags {
         ValidationFlags::empty()
     }
 

--- a/components/script/dom/validitystate.rs
+++ b/components/script/dom/validitystate.rs
@@ -107,7 +107,7 @@ impl ValidityState {
     // https://html.spec.whatwg.org/multipage/#custom-validity-error-message
     pub(crate) fn set_custom_error_message(&self, error: DOMString) {
         *self.custom_error_message.borrow_mut() = error;
-        self.perform_validation_and_update(ValidationFlags::CUSTOM_ERROR);
+        self.perform_validation_and_update(ValidationFlags::CUSTOM_ERROR, CanGc::note());
     }
 
     /// Given a set of [ValidationFlags], recalculate their value by performing
@@ -115,12 +115,16 @@ impl ValidityState {
     /// if [ValidationFlags::CUSTOM_ERROR] is in `update_flags` and a custom
     /// error has been set on this [ValidityState], the state will be updated
     /// to reflect the existance of a custom error.
-    pub(crate) fn perform_validation_and_update(&self, update_flags: ValidationFlags) {
+    pub(crate) fn perform_validation_and_update(
+        &self,
+        update_flags: ValidationFlags,
+        can_gc: CanGc,
+    ) {
         let mut invalid_flags = self.invalid_flags.get();
         invalid_flags.remove(update_flags);
 
         if let Some(validatable) = self.element.as_maybe_validatable() {
-            let new_flags = validatable.perform_validation(update_flags);
+            let new_flags = validatable.perform_validation(update_flags, can_gc);
             invalid_flags.insert(new_flags);
         }
 
@@ -132,7 +136,7 @@ impl ValidityState {
         }
 
         self.invalid_flags.set(invalid_flags);
-        self.update_pseudo_classes();
+        self.update_pseudo_classes(can_gc);
     }
 
     pub(crate) fn update_invalid_flags(&self, update_flags: ValidationFlags) {
@@ -143,7 +147,7 @@ impl ValidityState {
         self.invalid_flags.get()
     }
 
-    pub(crate) fn update_pseudo_classes(&self) {
+    pub(crate) fn update_pseudo_classes(&self, can_gc: CanGc) {
         if self.element.is_instance_validatable() {
             let is_valid = self.invalid_flags.get().is_empty();
             self.element.set_state(ElementState::VALID, is_valid);
@@ -155,7 +159,7 @@ impl ValidityState {
 
         if let Some(form_control) = self.element.as_maybe_form_control() {
             if let Some(form_owner) = form_control.form_owner() {
-                form_owner.update_validity();
+                form_owner.update_validity(can_gc);
             }
         }
 
@@ -166,7 +170,7 @@ impl ValidityState {
             .filter_map(DomRoot::downcast::<HTMLFieldSetElement>)
             .next()
         {
-            fieldset.update_validity();
+            fieldset.update_validity(can_gc);
         }
     }
 }

--- a/components/script/dom/virtualmethods.rs
+++ b/components/script/dom/virtualmethods.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use html5ever::LocalName;
+use script_bindings::script_runtime::CanGc;
 use style::attr::AttrValue;
 
 use crate::dom::attr::Attr;
@@ -72,9 +73,9 @@ pub(crate) trait VirtualMethods {
     /// Called when attributes of a node are mutated.
     /// <https://dom.spec.whatwg.org/#attribute-is-set>
     /// <https://dom.spec.whatwg.org/#attribute-is-removed>
-    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation) {
+    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation, can_gc: CanGc) {
         if let Some(s) = self.super_type() {
-            s.attribute_mutated(attr, mutation);
+            s.attribute_mutated(attr, mutation, can_gc);
         }
     }
 
@@ -107,9 +108,9 @@ pub(crate) trait VirtualMethods {
 
     /// Called when a Node is appended to a tree, where 'tree_connected' indicates
     /// whether the tree is part of a Document.
-    fn bind_to_tree(&self, context: &BindContext) {
+    fn bind_to_tree(&self, context: &BindContext, can_gc: CanGc) {
         if let Some(s) = self.super_type() {
-            s.bind_to_tree(context);
+            s.bind_to_tree(context, can_gc);
         }
     }
 
@@ -117,9 +118,9 @@ pub(crate) trait VirtualMethods {
     /// indicates whether the tree is part of a Document.
     /// Implements removing steps:
     /// <https://dom.spec.whatwg.org/#concept-node-remove-ext>
-    fn unbind_from_tree(&self, context: &UnbindContext) {
+    fn unbind_from_tree(&self, context: &UnbindContext, can_gc: CanGc) {
         if let Some(s) = self.super_type() {
-            s.unbind_from_tree(context);
+            s.unbind_from_tree(context, can_gc);
         }
     }
 
@@ -131,16 +132,16 @@ pub(crate) trait VirtualMethods {
     }
 
     /// Called during event dispatch after the bubbling phase completes.
-    fn handle_event(&self, event: &Event) {
+    fn handle_event(&self, event: &Event, can_gc: CanGc) {
         if let Some(s) = self.super_type() {
-            s.handle_event(event);
+            s.handle_event(event, can_gc);
         }
     }
 
     /// <https://dom.spec.whatwg.org/#concept-node-adopt-ext>
-    fn adopting_steps(&self, old_doc: &Document) {
+    fn adopting_steps(&self, old_doc: &Document, can_gc: CanGc) {
         if let Some(s) = self.super_type() {
-            s.adopting_steps(old_doc);
+            s.adopting_steps(old_doc, can_gc);
         }
     }
 
@@ -150,9 +151,10 @@ pub(crate) trait VirtualMethods {
         copy: &Node,
         maybe_doc: Option<&Document>,
         clone_children: CloneChildrenFlag,
+        can_gc: CanGc,
     ) {
         if let Some(s) = self.super_type() {
-            s.cloning_steps(copy, maybe_doc, clone_children);
+            s.cloning_steps(copy, maybe_doc, clone_children, can_gc);
         }
     }
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2311,7 +2311,7 @@ impl ScriptThread {
                 )
             },
             WebDriverScriptCommand::GetUrl(reply) => {
-                webdriver_handlers::handle_get_url(&documents, pipeline_id, reply)
+                webdriver_handlers::handle_get_url(&documents, pipeline_id, reply, can_gc)
             },
             WebDriverScriptCommand::IsEnabled(element_id, reply) => {
                 webdriver_handlers::handle_is_enabled(&documents, pipeline_id, element_id, reply)

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -1148,6 +1148,7 @@ pub(crate) fn handle_get_url(
     documents: &DocumentCollection,
     pipeline: PipelineId,
     reply: IpcSender<ServoUrl>,
+    _can_gc: CanGc,
 ) {
     reply
         .send(
@@ -1233,10 +1234,11 @@ pub(crate) fn handle_element_click(
                             match parent_node.downcast::<HTMLSelectElement>() {
                                 Some(select_element) => {
                                     if select_element.Multiple() {
-                                        option_element.SetSelected(!option_element.Selected());
+                                        option_element
+                                            .SetSelected(!option_element.Selected(), can_gc);
                                     }
                                 },
-                                None => option_element.SetSelected(true),
+                                None => option_element.SetSelected(true, can_gc),
                             }
 
                             // Step 8.6.4

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -1234,11 +1234,10 @@ pub(crate) fn handle_element_click(
                             match parent_node.downcast::<HTMLSelectElement>() {
                                 Some(select_element) => {
                                     if select_element.Multiple() {
-                                        option_element
-                                            .SetSelected(!option_element.Selected(), can_gc);
+                                        option_element.SetSelected(!option_element.Selected());
                                     }
                                 },
-                                None => option_element.SetSelected(true, can_gc),
+                                None => option_element.SetSelected(true),
                             }
 
                             // Step 8.6.4


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

resolve issue https://github.com/servo/servo/issues/36074 new_js_regex and matches_js_regex need a CanGc argument

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ x] `./mach build -d` does not report any errors
- [x ] `./mach test-tidy` does not report any errors
- [x] These changes fix #36074  (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
