### PR TITLE
Fix Backspace deleting entire previous line in `<textarea>`

### DIFF
--- a/components/script/textinput.rs
+++ b/components/script/textinput.rs
@@ -671,8 +671,14 @@ impl<T: ClipboardProvider> TextInput<T> {
             Direction::Backward => {
                 let remaining = self.edit_point.index;
                 if adjust > remaining && self.edit_point.line > 0 {
+                    // Preserve the current selection origin because `adjust_vertical`
+                    // modifies `selection_origin`. Since we are moving backward instead of
+                    // highlighting vertically, we need to restore it after adjusting the line.
+                    let selection_origin_temp = self.selection_origin;
                     self.adjust_vertical(-1, select);
                     self.edit_point.index = self.current_line_length();
+                    // Restore the original selection origin to maintain expected behavior.
+                    self.selection_origin = selection_origin_temp;
                     // one shift is consumed by the change of line, hence the -1
                     self.adjust_horizontal(
                         adjust.saturating_sub(remaining + UTF8Bytes::one()),

--- a/tests/unit/script/textinput.rs
+++ b/tests/unit/script/textinput.rs
@@ -856,3 +856,11 @@ fn test_select_all() {
         textinput.selection_end()
     );
 }
+
+#[test]
+fn test_backspace_in_textarea_at_beginning_of_line() {
+    let mut textinput = text_input(Lines::Multiple, "first line\n");
+    textinput.handle_keydown_aux(Key::ArrowDown, Modifiers::empty(), false);
+    textinput.handle_keydown_aux(Key::Backspace, Modifiers::empty(), false);
+    assert_eq!(textinput.get_content(), DOMString::from("first line"));
+}


### PR DESCRIPTION
This PR addresses issue **#27523**, where pressing backspace at the beginning of a line in a `<textarea>` incorrectly deletes the entire contents of the previous line instead of just merging the lines.  

---

### **Current Behavior**  
- When the cursor is at the start of the second line and backspace is pressed, the first line **disappears entirely** instead of merging with the second line.  

### **Expected Behavior (Per Standard)**  
- Pressing backspace at the start of a line should **move the cursor to the previous line**, deleting the newline character but **preserving the previous line's text**.  

---

### **Root Cause**  
- The function `adjust_vertical(-1, select)` modifies `selection_origin` and `edit_point`.  
- After the vertical adjustment, `self.edit_point.index = self.current_line_length();` was set without restoring `selection_origin`.  
- This led to an incorrect selection range, causing `replace_operation` to erase the entire previous line instead of just removing the newline.  

---

### **Fix**  
- Temporarily store `selection_origin` before adjusting vertical position.  
- Restore `selection_origin` after setting `edit_point.index`.  
- Ensure proper cursor movement and selection behavior.  
- Modify how backspace handles newline characters in multi-line text input to ensure only the **newline character** is removed when backspace is pressed at the start of a line while **preserving the previous line’s text**.  

---

### **Tasks**  
- [x] Reproduce the issue with tests 
- [x] Modify text deletion logic for backspace at line start  
- [x] Update test expectations  

---

### **Tests**  
- Added `test_backspace_in_textarea_at_beginning_of_line` to reproduce the issue and verify the fix.  

#### **How to Test?**  
Run:  
```sh
./mach test-unit -p script
```  
**Expected Outcome:** Backspace should merge lines without deleting text incorrectly.  

---

### **References**  
- Issue: #27523  
- [HTML Spec - Textarea Behavior](https://html.spec.whatwg.org/multipage/forms.html#the-textarea-element)

---

### **Checklist**  
- [x] `./mach build -d` does not report any errors  
- [x] `./mach test-tidy` does not report any errors  
- [x] These changes fix #27523  
- [x] There are tests for these changes  
