### PR TITLE
localStorage single write and non blocking receive loop

### DIFF
--- a/tests/wpt/meta/webstorage/storage_local_setitem_quotaexceedederr.window.js.ini
+++ b/tests/wpt/meta/webstorage/storage_local_setitem_quotaexceedederr.window.js.ini
@@ -1,2 +1,0 @@
-[storage_local_setitem_quotaexceedederr.window.html]
-    expected: TIMEOUT


### PR DESCRIPTION
Implementing https://github.com/servo/servo/issues/36034#issuecomment-2737625579

For `localStorage`, we only write the data to JSON file when exiting, instead of eagerly doing it every time we set, remove, or clear the data. We also add a non-blocking receive to catch a batch of ingoing data. 

This is done to prevent make the storage performance faster, and prevent timeout on test.

Note that mention [here](https://github.com/servo/servo/issues/36034#issuecomment-2735318618) and [here](https://github.com/servo/servo/issues/36034#issuecomment-2737625579), we allow the program to lose data when it crashes.

Try: https://github.com/PotatoCP/servo/actions/runs/13989613781

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #36034 
- [X] There are tests for these changes OR
