### PR TITLE
script: Expose new methods for obtaining a global that require a realm.

### DIFF
--- a/components/script/dom/bindings/import.rs
+++ b/components/script/dom/bindings/import.rs
@@ -44,6 +44,7 @@ pub(crate) mod base {
     };
     pub(crate) use crate::dom::globalscope::{GlobalScope, GlobalScopeHelpers};
     pub(crate) use crate::dom::promise::PromiseHelpers;
+    pub(crate) use crate::realms::{AlreadyInRealm, InRealm};
     pub(crate) use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
 }
 

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -2021,10 +2021,7 @@ impl GlobalScope {
     /// Returns the global scope of the realm that the given DOM object's reflector
     /// was created in.
     #[allow(unsafe_code)]
-    pub(crate) fn from_reflector<T: DomObject>(
-        reflector: &T,
-        _realm: &AlreadyInRealm,
-    ) -> DomRoot<Self> {
+    pub(crate) fn from_reflector<T: DomObject>(reflector: &T, _realm: InRealm) -> DomRoot<Self> {
         unsafe { GlobalScope::from_object(*reflector.reflector().get_jsobject()) }
     }
 
@@ -3337,10 +3334,7 @@ pub(crate) trait GlobalScopeHelpers<D: crate::DomTypes> {
     unsafe fn from_context(cx: *mut JSContext, realm: InRealm) -> DomRoot<D::GlobalScope>;
     fn get_cx() -> SafeJSContext;
     unsafe fn from_object(obj: *mut JSObject) -> DomRoot<D::GlobalScope>;
-    fn from_reflector(
-        reflector: &impl DomObject,
-        realm: &AlreadyInRealm,
-    ) -> DomRoot<D::GlobalScope>;
+    fn from_reflector(reflector: &impl DomObject, realm: InRealm) -> DomRoot<D::GlobalScope>;
 
     unsafe fn from_object_maybe_wrapped(
         obj: *mut JSObject,
@@ -3370,7 +3364,7 @@ impl GlobalScopeHelpers<crate::DomTypeHolder> for GlobalScope {
         GlobalScope::from_object(obj)
     }
 
-    fn from_reflector(reflector: &impl DomObject, realm: &AlreadyInRealm) -> DomRoot<Self> {
+    fn from_reflector(reflector: &impl DomObject, realm: InRealm) -> DomRoot<Self> {
         GlobalScope::from_reflector(reflector, realm)
     }
 

--- a/components/script/dom/promise.rs
+++ b/components/script/dom/promise.rs
@@ -270,10 +270,10 @@ impl Promise {
     pub(crate) fn append_native_handler(
         &self,
         handler: &PromiseNativeHandler,
-        _comp: InRealm,
+        realm: InRealm,
         can_gc: CanGc,
     ) {
-        let _ais = AutoEntryScript::new(&handler.global());
+        let _ais = AutoEntryScript::new(&handler.global_(realm));
         let cx = GlobalScope::get_cx();
         rooted!(in(*cx) let resolve_func =
                 create_native_handler_function(*cx,

--- a/components/script/realms.rs
+++ b/components/script/realms.rs
@@ -33,6 +33,18 @@ pub(crate) enum InRealm<'a> {
     Entered(&'a JSAutoRealm),
 }
 
+impl<'a> From<&'a AlreadyInRealm> for InRealm<'a> {
+    fn from(token: &'a AlreadyInRealm) -> InRealm<'a> {
+        InRealm::already(token)
+    }
+}
+
+impl<'a> From<&'a JSAutoRealm> for InRealm<'a> {
+    fn from(token: &'a JSAutoRealm) -> InRealm<'a> {
+        InRealm::entered(token)
+    }
+}
+
 impl InRealm<'_> {
     pub(crate) fn already(token: &AlreadyInRealm) -> InRealm {
         InRealm::Already(token)

--- a/components/script_bindings/codegen/CodegenRust.py
+++ b/components/script_bindings/codegen/CodegenRust.py
@@ -3960,7 +3960,7 @@ class CGCallGenerator(CGThing):
             if static:
                 glob = "global.upcast::<D::GlobalScope>()"
             else:
-                glob = "&this.global()"
+                glob = "&this.global_(InRealm::already(&AlreadyInRealm::assert_for_cx(cx)))"
 
             self.cgRoot.append(CGGeneric(
                 "let result = match result {\n"
@@ -8453,7 +8453,8 @@ class CGIterableMethodGenerator(CGGeneric):
             return
         CGGeneric.__init__(self, fill(
             """
-            let result = ${iterClass}::new(this, IteratorType::${itrMethod});
+            let realm = AlreadyInRealm::assert_for_cx(cx);
+            let result = ${iterClass}::new(this, IteratorType::${itrMethod}, InRealm::already(&realm));
             """,
             iterClass=iteratorNativeType(descriptor, True),
             ifaceName=descriptor.interface.identifier.name,


### PR DESCRIPTION
Similarly to the ongoing campaign to propagate CanGc arguments, we need to start being more diligent about InRealm arguments. The realm required for calling `global()` is one of the widest impact, so this PR makes it possible to migrate callsites incrementally.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #27037
- [x] These changes do not require tests because they do not affect runtime behaviour