### PR TITLE
Upgrade to Stylo e941241

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6513,7 +6513,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.26.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-15#bd0a7031b68ed87f9dbba0714e735fa5cf9df676"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#e9412412ed5daca6bbbdda5227858b514c1ff488"
 dependencies = [
  "bitflags 2.9.0",
  "cssparser",
@@ -6798,7 +6798,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-15#bd0a7031b68ed87f9dbba0714e735fa5cf9df676"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#e9412412ed5daca6bbbdda5227858b514c1ff488"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -7248,7 +7248,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-03-15#bd0a7031b68ed87f9dbba0714e735fa5cf9df676"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#e9412412ed5daca6bbbdda5227858b514c1ff488"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -7306,7 +7306,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-15#bd0a7031b68ed87f9dbba0714e735fa5cf9df676"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#e9412412ed5daca6bbbdda5227858b514c1ff488"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -7315,12 +7315,12 @@ dependencies = [
 [[package]]
 name = "stylo_config"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-15#bd0a7031b68ed87f9dbba0714e735fa5cf9df676"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#e9412412ed5daca6bbbdda5227858b514c1ff488"
 
 [[package]]
 name = "stylo_derive"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-03-15#bd0a7031b68ed87f9dbba0714e735fa5cf9df676"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#e9412412ed5daca6bbbdda5227858b514c1ff488"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -7332,7 +7332,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-15#bd0a7031b68ed87f9dbba0714e735fa5cf9df676"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#e9412412ed5daca6bbbdda5227858b514c1ff488"
 dependencies = [
  "bitflags 2.9.0",
  "stylo_malloc_size_of",
@@ -7341,7 +7341,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-03-15#bd0a7031b68ed87f9dbba0714e735fa5cf9df676"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#e9412412ed5daca6bbbdda5227858b514c1ff488"
 dependencies = [
  "app_units",
  "cssparser",
@@ -7358,12 +7358,12 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-15#bd0a7031b68ed87f9dbba0714e735fa5cf9df676"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#e9412412ed5daca6bbbdda5227858b514c1ff488"
 
 [[package]]
 name = "stylo_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-03-15#bd0a7031b68ed87f9dbba0714e735fa5cf9df676"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#e9412412ed5daca6bbbdda5227858b514c1ff488"
 dependencies = [
  "app_units",
  "bitflags 2.9.0",
@@ -7746,7 +7746,7 @@ dependencies = [
 [[package]]
 name = "to_shmem"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-15#bd0a7031b68ed87f9dbba0714e735fa5cf9df676"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#e9412412ed5daca6bbbdda5227858b514c1ff488"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -7759,7 +7759,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-15#bd0a7031b68ed87f9dbba0714e735fa5cf9df676"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#e9412412ed5daca6bbbdda5227858b514c1ff488"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/components/fonts/tests/font_context.rs
+++ b/components/fonts/tests/font_context.rs
@@ -29,11 +29,9 @@ mod font_context {
     use style::properties::longhands::font_variant_caps::computed_value::T as FontVariantCaps;
     use style::properties::style_structs::Font as FontStyleStruct;
     use style::values::computed::font::{
-        FamilyName, FontFamily, FontFamilyList, FontFamilyNameSyntax, FontSize, FontStretch,
-        FontStyle, FontWeight, SingleFontFamily,
+        FamilyName, FontFamily, FontFamilyList, FontFamilyNameSyntax, FontStretch, FontStyle,
+        FontWeight, SingleFontFamily,
     };
-    use style::values::computed::{FontLanguageOverride, XLang};
-    use style::values::generics::font::LineHeight;
     use stylo_atoms::Atom;
     use webrender_api::{FontInstanceKey, FontKey, IdNamespace};
     use webrender_traits::CrossProcessCompositorApi;
@@ -194,18 +192,7 @@ mod font_context {
     }
 
     fn style() -> FontStyleStruct {
-        let mut style = FontStyleStruct {
-            font_family: FontFamily::serif(),
-            font_style: FontStyle::NORMAL,
-            font_variant_caps: FontVariantCaps::Normal,
-            font_weight: FontWeight::normal(),
-            font_size: FontSize::medium(),
-            font_stretch: FontStretch::hundred(),
-            hash: 0,
-            font_language_override: FontLanguageOverride::normal(),
-            line_height: LineHeight::Normal,
-            _x_lang: XLang::get_initial_value(),
-        };
+        let mut style = FontStyleStruct::initial_values();
         style.compute_font_hash();
         style
     }


### PR DESCRIPTION
Ensure that Servo is using the latest Stylo `main`


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors