### PR TITLE
layout: Ensure compatible positioning context during flexbox block content sizing calculation

### DIFF
--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -2619,11 +2619,14 @@ impl FlexItemBox {
         auto_cross_size_stretches_to_container_size: bool,
         intrinsic_sizing_mode: IntrinsicSizingMode,
     ) -> Au {
-        let mut positioning_context = PositioningContext::new_for_subtree(
-            flex_context
-                .positioning_context
-                .collects_for_nearest_positioned_ancestor(),
-        );
+        let mut positioning_context = PositioningContext::new_for_style(self.style())
+            .unwrap_or_else(|| {
+                PositioningContext::new_for_subtree(
+                    flex_context
+                        .positioning_context
+                        .collects_for_nearest_positioned_ancestor(),
+                )
+            });
 
         let style = self.independent_formatting_context.style();
         match &self.independent_formatting_context.contents {

--- a/tests/wpt/tests/css/css-flexbox/mixed-containing-blocks-crash.html
+++ b/tests/wpt/tests/css/css-flexbox/mixed-containing-blocks-crash.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<title>CSS Flexbox: Mixed containing blocks</title>
+
+<link rel="help" href="https://drafts.csswg.org/css-flexbox">
+<link rel="help" href="https://github.com/servo/servo/issues/36121">
+<meta name="assert" content="This test ensures that flex boxes that establish a containing block for fixed position descendants do not cause a crash when combined with flex items that establish a containing block for absolutely positioned descendants.">
+
+<html>
+    <div class="box" style="display: flex; flex-direction: column; transform: translateX(1px)">
+      <div style="position: relative;"><div>Three</div><div style="position: absolute">fixed</div></div>
+    </div>
+</div>
+


### PR DESCRIPTION
Sometimes column Flexbox needs to do an early layout pass to determine
the preferred block content size of flex items. Previously the
absolutely positioned children created during this pass were discarded,
but now they are cached to be possibly used during the final layout
phase of the flex item. Since they are not thrown away, it is necessary
that the `PositioningContext` used to collect them is compatible with
their final `PositioningContext`.

Fixes #36121.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
