### PR TITLE
Changed `MAX_TASK_NS` from `u64` to `u128`; removed a then superfluous `into()`

### DIFF
--- a/components/metrics/lib.rs
+++ b/components/metrics/lib.rs
@@ -18,7 +18,7 @@ use servo_url::ServoUrl;
 
 /// TODO make this configurable
 /// maximum task time is 50ms (in ns)
-pub const MAX_TASK_NS: u64 = 50000000;
+pub const MAX_TASK_NS: u128 = 50000000;
 /// 10 second window
 const INTERACTIVE_WINDOW_SECONDS: Duration = Duration::from_secs(10);
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1726,7 +1726,7 @@ impl ScriptThread {
         let task_duration = start.elapsed();
         for (doc_id, doc) in self.documents.borrow().iter() {
             if let Some(pipeline_id) = pipeline_id {
-                if pipeline_id == doc_id && task_duration.as_nanos() > MAX_TASK_NS.into() {
+                if pipeline_id == doc_id && task_duration.as_nanos() > MAX_TASK_NS {
                     if self.print_pwm {
                         println!(
                             "Task took longer than max allowed ({:?}) {:?}",


### PR DESCRIPTION
Both were required to fix #36122 with `1.87.0-nightly (307cbfda3 2025-03-20)`.

`MAX_TASK_NS` was changed from `u64` to `u128` in `components/metrics/lib.rs`.

A superfluous `into()` was removed from `MAX_TASK_NS.into()` in `components/script/script_thread.rs`.

Even if both sides of the `>` were `u128` the latest `rustc` would still barf about the `into()`.

I.e. both changes were required to make this build with `nightly`.
 
---
- [x] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
```
➤  Checking config file (./servo-tidy.toml)...
 ➤  Checking directories for correct file extensions...
 ➤  Checking files for tidiness...
 ➤  Checking WPT manifests for cleanliness...
 ➤  Linting WPT suite (tests)...
 ➤  Linting WPT suite (mozilla/tests)...
 ➤  Running `cargo-deny` checks...
  | /home/ritz/code/crates/servo/deny.toml:42: unknown term: Ubuntu-font-1.0
 ➤  Checking formatting of Rust files...
 ➤  Checking formatting of toml files...

 ❌ test-tidy reported errors.
```
- [x] These changes fix #36122 

- [x] These changes do not require tests because *this change is trivial*.
