### PR TITLE
Fix check in get_array_index_from_id to return early on ASCII char

### DIFF
--- a/components/script/dom/bindings/utils.rs
+++ b/components/script/dom/bindings/utils.rs
@@ -196,7 +196,7 @@ pub(crate) unsafe fn get_array_index_from_id(_cx: *mut JSContext, id: HandleId) 
     let first_char = char::decode_utf16(chars.iter().cloned())
         .next()
         .map_or('\0', |r| r.unwrap_or('\0'));
-    if !first_char.is_ascii_lowercase() {
+    if first_char.is_ascii_lowercase() {
         return None;
     }
 

--- a/tests/wpt/meta/dom/collections/HTMLCollection-supported-property-indices.html.ini
+++ b/tests/wpt/meta/dom/collections/HTMLCollection-supported-property-indices.html.ini
@@ -1,10 +1,4 @@
 [HTMLCollection-supported-property-indices.html]
-  [Handling of property names that look like integers around 2^31]
-    expected: FAIL
-
-  [Handling of property names that look like integers around 2^32]
-    expected: FAIL
-
   [Trying to set an expando that would shadow an already-existing indexed property]
     expected: FAIL
 

--- a/tests/wpt/meta/html/browsers/the-window-object/window-indexed-properties-strict.html.ini
+++ b/tests/wpt/meta/html/browsers/the-window-object/window-indexed-properties-strict.html.ini
@@ -1,6 +1,3 @@
 [window-indexed-properties-strict.html]
   [Indexed properties of the window object (strict mode) 1]
     expected: FAIL
-
-  [Borderline numeric key: 2 ** 32 - 2 is an index (strict mode)]
-    expected: FAIL

--- a/tests/wpt/meta/html/browsers/the-window-object/window-indexed-properties.html.ini
+++ b/tests/wpt/meta/html/browsers/the-window-object/window-indexed-properties.html.ini
@@ -1,6 +1,3 @@
 [window-indexed-properties.html]
   [Indexed properties of the window object (non-strict mode) 1]
     expected: FAIL
-
-  [Borderline numeric key: 2 ** 32 - 2 is an index]
-    expected: FAIL


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #35529

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

I've dug into this for a while, and I'm reasonably sure that this is just a typo that's survived for four years. The [corresponding block in Firefox](https://searchfox.org/mozilla-central/source/dom/bindings/ProxyHandlerUtils.h#49) returns early if the first character is an ASCII lowercase character:

```
  char16_t firstChar = JS::GetLinearStringCharAt(str, 0);
  if (MOZ_LIKELY(IsAsciiLowercaseAlpha(firstChar))) {
    return UINT32_MAX;
  }
```

The old behavior also seems weird: if the id begins with a non-numeric value, then it shouldn't be an array index. From what I believe is [the relevant spec](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-canonicalnumericindexstring):

> If argument is either "-0" or exactly matches [ToString](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-tostring)(n) for some Number value n, it returns the respective Number value.

As I understand it, nothing that starts with an alpha character would match `ToString(n)` (since that, when called on a number, comes back in base 10). Of course, I'm skeptical that this has gone unnoticed for so long, so if I'm misinterpreting this, please let me know 🙂

I haven't added any tests related to #35529 because I'm not sure where or how those would work. I'm happy to add those with a point in the right direction.