### PR TITLE
Update names of stylo crates in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,16 +33,17 @@ updates:
         - "servo-media*"
   ignore:
   # Ignore all stylo crates as their upgrades are coordinated via companion PRs.
-  - dependency-name: servo_atoms
+  - dependency-name: stylo_atoms
   - dependency-name: derive_common
   - dependency-name: malloc_size_of
   - dependency-name: selectors
   - dependency-name: servo_arc
   - dependency-name: size_of_test
-  - dependency-name: style
-  - dependency-name: style_config
-  - dependency-name: style_derive
-  - dependency-name: style_static_prefs
-  - dependency-name: style_traits
+  - dependency-name: stylo
+  - dependency-name: stylo_config
+  - dependency-name: stylo_derive
+  - dependency-name: stylo_dom
+  - dependency-name: stylo_static_prefs
+  - dependency-name: stylo_traits
   - dependency-name: to_shmem
   - dependency-name: to_shmem_derive


### PR DESCRIPTION
This is response to https://github.com/servo/servo/pull/36128 that is caused by renames that happened in upstream https://github.com/servo/stylo/pull/150.

I want over all PRs that dependabot opened and fix names of those crates.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they are for dependabot

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
