### PR TITLE
build: bump nixpkgs to nixos-unstable

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -5,7 +5,7 @@
   buildAndroid ? false
 }:
 with import (builtins.fetchTarball {
-  url = "https://github.com/NixOS/nixpkgs/archive/5d67ea6b4b63378b9c13be21e2ec9d1afc921713.tar.gz";
+  url = "https://github.com/NixOS/nixpkgs/archive/1e5b653dff12029333a6546c11e108ede13052eb.tar.gz";
 }) {
   overlays = [
     (import (builtins.fetchTarball {


### PR DESCRIPTION
This fixes an issue with cargo-deny 0.16.3 that causes all crates to be reported as "yanked" even though they are not. This patch upgrades cargo-deny to 0.18.2 which works correctly.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they only modify nixos build setup. I've tested that we are able to build and run servo with the bumped `nixpkgs` version.