### PR TITLE
Animation: Aggregate Animated Image Info to Document

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6426,6 +6426,7 @@ dependencies = [
  "fnv",
  "fonts",
  "fonts_traits",
+ "fxhash",
  "html5ever",
  "ipc-channel",
  "libc",

--- a/components/layout_2020/replaced.rs
+++ b/components/layout_2020/replaced.rs
@@ -182,6 +182,10 @@ impl ReplacedContents {
             }
         };
 
+        if let ReplacedContentKind::Image(Some(ref image)) = kind {
+            context.handle_animated_image(element.opaque(), image.clone());
+        }
+
         let natural_size = if let Some(naturalc_size_in_dots) = natural_size_in_dots {
             // FIXME: should 'image-resolution' (when implemented) be used *instead* of
             // `script::dom::htmlimageelement::ImageRequest::current_pixel_density`?

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -199,6 +199,7 @@ use crate::dom::xpathevaluator::XPathEvaluator;
 use crate::drag_data_store::{DragDataStore, Kind, Mode};
 use crate::fetch::FetchCanceller;
 use crate::iframe_collection::IFrameCollection;
+use crate::image_animation::ImageAnimationManager;
 use crate::messaging::{CommonScriptMsg, MainThreadScriptMsg};
 use crate::network_listener::{NetworkListener, PreInvoke};
 use crate::realms::{AlreadyInRealm, InRealm, enter_realm};
@@ -484,6 +485,8 @@ pub(crate) struct Document {
     animation_timeline: DomRefCell<AnimationTimeline>,
     /// Animations for this Document
     animations: DomRefCell<Animations>,
+    /// Image Animation Manager for this Document
+    image_animation_manager: DomRefCell<ImageAnimationManager>,
     /// The nearest inclusive ancestors to all the nodes that require a restyle.
     dirty_root: MutNullableDom<Element>,
     /// <https://html.spec.whatwg.org/multipage/#will-declaratively-refresh>
@@ -3877,6 +3880,7 @@ impl Document {
                 DomRefCell::new(AnimationTimeline::new())
             },
             animations: DomRefCell::new(Animations::new()),
+            image_animation_manager: DomRefCell::new(ImageAnimationManager::new()),
             dirty_root: Default::default(),
             declarative_refresh: Default::default(),
             pending_animation_ticks: Default::default(),
@@ -4713,6 +4717,13 @@ impl Document {
         // Steps 4 through 7 occur inside `send_pending_events().`
         let _realm = enter_realm(self);
         self.animations().send_pending_events(self.window(), can_gc);
+    }
+
+    pub(crate) fn image_animation_manager(&self) -> Ref<ImageAnimationManager> {
+        self.image_animation_manager.borrow()
+    }
+    pub(crate) fn image_animation_manager_mut(&self) -> RefMut<ImageAnimationManager> {
+        self.image_animation_manager.borrow_mut()
     }
 
     pub(crate) fn will_declaratively_refresh(&self) -> bool {

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1967,6 +1967,9 @@ impl Window {
             pending_restyles,
             animation_timeline_value: document.current_animation_timeline_value(),
             animations: document.animations().sets.clone(),
+            node_to_image_animation_map: document
+                .image_animation_manager_mut()
+                .take_image_animate_set(),
             theme: self.theme.get(),
         };
 
@@ -2017,7 +2020,9 @@ impl Window {
         if !size_messages.is_empty() {
             self.send_to_constellation(ScriptMsg::IFrameSizes(size_messages));
         }
-
+        document
+            .image_animation_manager_mut()
+            .restore_image_animate_set(results.node_to_image_animation_map);
         document.update_animations_post_reflow();
         self.update_constellation_epoch();
 

--- a/components/script/image_animation.rs
+++ b/components/script/image_animation.rs
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use fxhash::FxHashMap;
+use script_layout_interface::ImageAnimationState;
+use style::dom::OpaqueNode;
+
+#[derive(Clone, Debug, Default, JSTraceable, MallocSizeOf)]
+pub struct ImageAnimationManager {
+    #[no_trace]
+    pub node_to_image_map: FxHashMap<OpaqueNode, ImageAnimationState>,
+}
+
+impl ImageAnimationManager {
+    pub fn new() -> Self {
+        ImageAnimationManager {
+            node_to_image_map: Default::default(),
+        }
+    }
+
+    pub fn take_image_animate_set(&mut self) -> FxHashMap<OpaqueNode, ImageAnimationState> {
+        std::mem::take(&mut self.node_to_image_map)
+    }
+
+    pub fn restore_image_animate_set(&mut self, map: FxHashMap<OpaqueNode, ImageAnimationState>) {
+        let _ = std::mem::replace(&mut self.node_to_image_map, map);
+    }
+}

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -43,6 +43,7 @@ mod layout_image;
 
 pub(crate) mod document_collection;
 pub(crate) mod iframe_collection;
+pub(crate) mod image_animation;
 pub mod layout_dom;
 mod mem;
 #[allow(unsafe_code)]

--- a/components/shared/script_layout/Cargo.toml
+++ b/components/shared/script_layout/Cargo.toml
@@ -21,6 +21,7 @@ euclid = { workspace = true }
 fnv = { workspace = true }
 fonts = { path = "../../fonts" }
 fonts_traits = { workspace = true }
+fxhash = { workspace = true }
 html5ever = { workspace = true }
 ipc-channel = { workspace = true }
 libc = { workspace = true }

--- a/components/shared/script_layout/lib.rs
+++ b/components/shared/script_layout/lib.rs
@@ -24,10 +24,12 @@ use euclid::Size2D;
 use euclid::default::{Point2D, Rect};
 use fnv::FnvHashMap;
 use fonts::{FontContext, SystemFontServiceProxy};
+use fxhash::FxHashMap;
 use ipc_channel::ipc::IpcSender;
 use libc::c_void;
 use malloc_size_of_derive::MallocSizeOf;
 use net_traits::image_cache::{ImageCache, PendingImageId};
+use pixels::Image;
 use profile_traits::mem::Report;
 use profile_traits::time;
 use script_traits::{InitialScriptState, LoadData, Painter, ScriptThreadMessage};
@@ -400,6 +402,8 @@ pub struct ReflowResult {
     /// to communicate them with the Constellation and also the `Window`
     /// element of their content pages.
     pub iframe_sizes: IFrameSizes,
+    /// The mapping of node to animated image, need to be returned to ImageAnimationManager
+    pub node_to_image_animation_map: FxHashMap<OpaqueNode, ImageAnimationState>,
 }
 
 /// Information needed for a script-initiated reflow.
@@ -427,6 +431,8 @@ pub struct ReflowRequest {
     pub animation_timeline_value: f64,
     /// The set of animations for this document.
     pub animations: DocumentAnimationSet,
+    /// The set of image animations.
+    pub node_to_image_animation_map: FxHashMap<OpaqueNode, ImageAnimationState>,
     /// The theme for the window
     pub theme: PrefersColorScheme,
 }
@@ -500,4 +506,26 @@ pub fn node_id_from_scroll_id(id: usize) -> Option<usize> {
         return Some(id & !3);
     }
     None
+}
+
+#[derive(Clone, Debug, MallocSizeOf)]
+pub struct ImageAnimationState {
+    #[ignore_malloc_size_of = "Arc is hard"]
+    image: Arc<Image>,
+    active_frame: usize,
+    last_update_time: f64,
+}
+
+impl ImageAnimationState {
+    pub fn new(image: Arc<Image>) -> Self {
+        Self {
+            image,
+            active_frame: 0,
+            last_update_time: 0.,
+        }
+    }
+
+    pub fn image_key(&self) -> Option<ImageKey> {
+        self.image.id
+    }
 }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Part of https://github.com/servo/servo/issues/36057

This PR tries to aggregate the Animated Image information that servo need to track, and store it in Document.
- The animated Image is identify and queue into a `pending_image_animation_actions` during layout, and will be handled after reflow. 
- Stop tracking animated image in node that is no longer in fragment tree.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because it should not affect any wpt test.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
[Try](https://github.com/rayguo17/servo/actions/runs/14104046576)