### PR TITLE
script: Eliminate `PseudoElementType`

### DIFF
--- a/components/layout_2020/dom_traversal.rs
+++ b/components/layout_2020/dom_traversal.rs
@@ -407,8 +407,8 @@ where
     Node: NodeExt<'dom>,
 {
     match which {
-        WhichPseudoElement::Before => element.to_threadsafe().get_before_pseudo(),
-        WhichPseudoElement::After => element.to_threadsafe().get_after_pseudo(),
+        WhichPseudoElement::After => element.to_threadsafe().get_pseudo(PseudoElement::After),
+        WhichPseudoElement::Before => element.to_threadsafe().get_pseudo(PseudoElement::Before),
     }
     .and_then(|pseudo_element| {
         let style = pseudo_element.style(context.shared_context());

--- a/components/layout_2020/fragment_tree/base_fragment.rs
+++ b/components/layout_2020/fragment_tree/base_fragment.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use bitflags::bitflags;
-use script_layout_interface::{FragmentType, combine_id_with_fragment_type};
+use script_layout_interface::combine_id_with_fragment_type;
 use style::dom::OpaqueNode;
 use style::selector_parser::PseudoElement;
 
@@ -132,11 +132,6 @@ impl Tag {
     }
 
     pub(crate) fn to_display_list_fragment_id(self) -> u64 {
-        let fragment_type = match self.pseudo {
-            Some(PseudoElement::Before) => FragmentType::BeforePseudoContent,
-            Some(PseudoElement::After) => FragmentType::AfterPseudoContent,
-            _ => FragmentType::FragmentBody,
-        };
-        combine_id_with_fragment_type(self.node.id(), fragment_type)
+        combine_id_with_fragment_type(self.node.id(), self.pseudo.into())
     }
 }

--- a/components/layout_2020/query.rs
+++ b/components/layout_2020/query.rs
@@ -9,7 +9,6 @@ use app_units::Au;
 use euclid::default::{Point2D, Rect};
 use euclid::{SideOffsets2D, Size2D, Vector2D};
 use itertools::Itertools;
-use log::warn;
 use script_layout_interface::wrapper_traits::{
     LayoutNode, ThreadSafeLayoutElement, ThreadSafeLayoutNode,
 };
@@ -117,15 +116,10 @@ pub fn process_resolved_style_request<'dom>(
     // We call process_resolved_style_request after performing a whole-document
     // traversal, so in the common case, the element is styled.
     let layout_element = node.to_threadsafe().as_element().unwrap();
-    let layout_element = match *pseudo {
-        None => Some(layout_element),
-        Some(PseudoElement::Before) => layout_element.get_before_pseudo(),
-        Some(PseudoElement::After) => layout_element.get_after_pseudo(),
-        Some(_) => {
-            warn!("Got unexpected pseudo element type!");
-            None
-        },
-    };
+    let layout_element = pseudo.map_or_else(
+        || Some(layout_element),
+        |pseudo_element| layout_element.get_pseudo(pseudo_element),
+    );
 
     let layout_element = match layout_element {
         None => {

--- a/components/script/layout_dom/element.rs
+++ b/components/script/layout_dom/element.rs
@@ -11,7 +11,7 @@ use constellation_traits::UntrustedNodeAddress;
 use html5ever::{LocalName, Namespace, local_name, namespace_url, ns};
 use js::jsapi::JSObject;
 use script_layout_interface::wrapper_traits::{
-    LayoutNode, PseudoElementType, ThreadSafeLayoutElement, ThreadSafeLayoutNode,
+    LayoutNode, ThreadSafeLayoutElement, ThreadSafeLayoutNode,
 };
 use script_layout_interface::{LayoutNodeType, StyleData};
 use selectors::attr::{AttrSelectorOperation, CaseSensitivity, NamespaceConstraint};
@@ -785,9 +785,9 @@ impl<'dom> ::selectors::Element for ServoLayoutElement<'dom> {
 pub struct ServoThreadSafeLayoutElement<'dom> {
     pub(super) element: ServoLayoutElement<'dom>,
 
-    /// The pseudo-element type, with (optionally)
-    /// a specified display value to override the stylesheet.
-    pub(super) pseudo: PseudoElementType,
+    /// The pseudo-element type for this element, or `None` if it is the non-pseudo
+    /// version of the element.
+    pub(super) pseudo: Option<PseudoElement>,
 }
 
 impl<'dom> ThreadSafeLayoutElement<'dom> for ServoThreadSafeLayoutElement<'dom> {
@@ -801,14 +801,14 @@ impl<'dom> ThreadSafeLayoutElement<'dom> for ServoThreadSafeLayoutElement<'dom> 
         }
     }
 
-    fn get_pseudo_element_type(&self) -> PseudoElementType {
+    fn pseudo_element(&self) -> Option<PseudoElement> {
         self.pseudo
     }
 
-    fn with_pseudo(&self, pseudo: PseudoElementType) -> Self {
+    fn with_pseudo(&self, pseudo: PseudoElement) -> Self {
         ServoThreadSafeLayoutElement {
             element: self.element,
-            pseudo,
+            pseudo: Some(pseudo),
         }
     }
 

--- a/components/shared/script_layout/lib.rs
+++ b/components/shared/script_layout/lib.rs
@@ -460,6 +460,16 @@ pub enum FragmentType {
     AfterPseudoContent,
 }
 
+impl From<Option<PseudoElement>> for FragmentType {
+    fn from(value: Option<PseudoElement>) -> Self {
+        match value {
+            Some(PseudoElement::After) => FragmentType::AfterPseudoContent,
+            Some(PseudoElement::Before) => FragmentType::BeforePseudoContent,
+            _ => FragmentType::FragmentBody,
+        }
+    }
+}
+
 /// The next ID that will be used for a special scroll root id.
 ///
 /// A special scroll root is a scroll root that is created for generated content.


### PR DESCRIPTION
Servo has a `PseudoElementType` which more or less duplicate's Stylo's
`PseudoElement` with the addition of a non-pseudo element variant. This
type needs to be converted into `PseudoElement` anyway when asking for
the style of an element from Stylo, so eliminate Servo's version and
simply use `Option<PseudoElement>` with the `None` variant meaning the
non-pseudo.

This is preparation for adding support for the `::marker` pseudo
element.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they just remove an intermediate data type.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
