### PR TITLE
Stop using `RootedGuard's` DerefMut impl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -520,7 +520,7 @@ dependencies = [
  "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "regex",
@@ -1065,7 +1065,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2031,7 +2031,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2557,7 +2557,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4018,7 +4018,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi 0.5.0",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4312,7 +4312,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4703,7 +4703,7 @@ dependencies = [
 [[package]]
 name = "mozjs"
 version = "0.14.1"
-source = "git+https://github.com/servo/mozjs#39db84352d79ffa3e4fe756c8034af9def788f22"
+source = "git+https://github.com/servo/mozjs#e4d4f9ac06162fe2647078dc4be8c270b7219807"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -4715,7 +4715,7 @@ dependencies = [
 [[package]]
 name = "mozjs_sys"
 version = "0.128.9-0"
-source = "git+https://github.com/servo/mozjs#39db84352d79ffa3e4fe756c8034af9def788f22"
+source = "git+https://github.com/servo/mozjs#e4d4f9ac06162fe2647078dc4be8c270b7219807"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -6190,7 +6190,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7530,7 +7530,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8839,7 +8839,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/components/script/dom/bindings/interface.rs
+++ b/components/script/dom/bindings/interface.rs
@@ -641,7 +641,7 @@ pub(crate) fn get_desired_proto(
             // We might still have a cross-compartment wrapper for a known DOM
             // constructor.  CheckedUnwrapStatic is fine here, because we're looking for
             // DOM constructors and those can't be cross-origin objects.
-            *new_target = CheckedUnwrapStatic(*new_target);
+            new_target.set(CheckedUnwrapStatic(*new_target));
             if !new_target.is_null() && *new_target != *original_new_target {
                 get_proto_id_for_new_target(new_target.handle())
             } else {

--- a/components/script/dom/readablestreamdefaultreader.rs
+++ b/components/script/dom/readablestreamdefaultreader.rs
@@ -98,8 +98,7 @@ impl Callback for ReadLoopFulFillmentHandler {
             };
 
             // Append the bytes represented by chunk to bytes.
-            let mut bytes = self.bytes.borrow_mut();
-            bytes.extend_from_slice(&chunk);
+            self.bytes.borrow_mut().extend_from_slice(&chunk);
 
             // Read-loop given reader, bytes, successSteps, and failureSteps.
             rooted!(in(*cx) let mut this = Some(self.clone()));

--- a/components/script/dom/readablestreamdefaultreader.rs
+++ b/components/script/dom/readablestreamdefaultreader.rs
@@ -8,6 +8,7 @@ use std::mem;
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
+use js::gc::MutableHandle;
 use js::jsapi::Heap;
 use js::jsval::{JSVal, UndefinedValue};
 use js::rust::{HandleObject as SafeHandleObject, HandleValue as SafeHandleValue};
@@ -101,9 +102,10 @@ impl Callback for ReadLoopFulFillmentHandler {
             bytes.extend_from_slice(&chunk);
 
             // Read-loop given reader, bytes, successSteps, and failureSteps.
+            rooted!(in(*cx) let mut this = Some(self.clone()));
             read_loop(
                 &global,
-                &mut Some(self.clone()),
+                this.handle_mut(),
                 Box::new(ReadLoopRejectionHandler {
                     failure_steps: self.failure_steps.clone(),
                 }),
@@ -133,7 +135,7 @@ impl Callback for ReadLoopRejectionHandler {
 /// <https://streams.spec.whatwg.org/#read-loop>
 fn read_loop(
     global: &GlobalScope,
-    fulfillment_handler: &mut Option<ReadLoopFulFillmentHandler>,
+    mut fulfillment_handler: MutableHandle<Option<ReadLoopFulFillmentHandler>>,
     rejection_handler: Box<ReadLoopRejectionHandler>,
     realm: InRealm,
     can_gc: CanGc,
@@ -500,7 +502,7 @@ impl ReadableStreamDefaultReader {
         let rejection_handler = Box::new(ReadLoopRejectionHandler { failure_steps });
         read_loop(
             global,
-            &mut fulfillment_handler,
+            fulfillment_handler.handle_mut(),
             rejection_handler,
             realm,
             can_gc,

--- a/components/script_bindings/codegen/CodegenRust.py
+++ b/components/script_bindings/codegen/CodegenRust.py
@@ -3107,12 +3107,12 @@ SetProxyReservedSlot(
             create = """
 rooted!(in(*cx) let mut proto = ptr::null_mut::<JSObject>());
 if let Some(given) = given_proto {
-    *proto = *given;
+    proto.set(*given);
     if get_context_realm(*cx) != get_object_realm(*given) {
         assert!(JS_WrapObject(*cx, proto.handle_mut()));
     }
 } else {
-    *proto = *canonical_proto;
+    proto.set(*canonical_proto);
 }
 rooted!(in(*cx) let obj = JS_NewObjectWithGivenProto(
     *cx,


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Stop using the `RootedGuard::deref_mut` impl entirely, so it can be removed. Notably including making `read_loop` not hold an `&mut` reference to a rooted object while calling functions which use the garbage collector, almost certainly resulting in undefined behavior.

This accompanies servo/mozjs#572, and prevents it from breaking servo. It also needs it for crown to understand that `MutableHandle` may point at a unrooted type without itself being rooted, and should not be merged until the `use accompying mozjs pr` commit is updated to point at a merged version of the PR.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [x] These changes do not require tests because no behavior is changed, only the kind of reference used and the method of de-referencing it

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
