### PR TITLE
Stop using MutableHandle's DerefMut impl

### DIFF
--- a/components/script/dom/bindings/proxyhandler.rs
+++ b/components/script/dom/bindings/proxyhandler.rs
@@ -687,7 +687,7 @@ unsafe fn is_cross_origin_allowlisted_prop(cx: SafeJSContext, id: RawHandleId) -
 
     rooted!(in(*cx) let mut allowed_id: jsid);
     ALLOWLISTED_SYMBOL_CODES.iter().any(|&allowed_code| {
-        *allowed_id.handle_mut() = SymbolId(GetWellKnownSymbol(*cx, allowed_code));
+        allowed_id.set(SymbolId(GetWellKnownSymbol(*cx, allowed_code)));
         // `jsid`s containing `JS::Symbol *` can be compared by
         // referential equality
         allowed_id.get().asBits_ == id.asBits_
@@ -710,7 +710,7 @@ unsafe fn append_cross_origin_allowlisted_prop_keys(
     AppendToIdVector(props, id.handle());
 
     for &allowed_code in ALLOWLISTED_SYMBOL_CODES.iter() {
-        *id.handle_mut() = SymbolId(GetWellKnownSymbol(*cx, allowed_code));
+        id.set(SymbolId(GetWellKnownSymbol(*cx, allowed_code)));
         AppendToIdVector(props, id.handle());
     }
 }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

`MutableHandle`'s `DerefMut` impl cannot be safe, because it allows holding a `&mut` pointer to the pointee over a GC pause, violating aliasing guarantees. This PR clears the way for servo/mozjs#573 which removes the impl, similar to #36158 which does the same for `RootedGuard`.

We actually stop using mutable handle all together in the two cases where the `DerefMut` impl is used, since we can just use the `RootedGuard` we created the mutable handle from directly. This is merely a coincidence, e.g. we could do `allowed_id.handle_mut().set(...)` instead of `allowed_id.set(...)`, the latter is just cleaner so while we're making the change we might as well remove the unnecessary `handle_mut()` calls.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [x] These changes do not require tests because they just change how a pointer-type is dereferenced

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
