### PR TITLE
Stop using JS::MutableHandle's DerefMut impl

### DIFF
--- a/components/script/dom/promise.rs
+++ b/components/script/dom/promise.rs
@@ -317,7 +317,7 @@ unsafe extern "C" fn do_nothing_promise_executor(
     vp: *mut JSVal,
 ) -> bool {
     let args = CallArgs::from_vp(vp, argc);
-    *args.rval() = UndefinedValue();
+    args.rval().set(UndefinedValue());
     true
 }
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
`JS::MutableHandle`'s `DerefMut` impl cannot be safe, because it allows holding a `&mut` pointer to the pointee over a GC pause, violating aliasing guarantees. Furthermore `JS::MutableHandle` doesn't track lifetimes, so it allows outright use after frees. This PR clears the way for https://github.com/servo/mozjs/pull/574 which removes the impl, similar to https://github.com/servo/servo/pull/36160 which does the same for `MutableHandle` and https://github.com/servo/servo/pull/36158 which does the same for `RootedGuard.`

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [x] This changes does not require tests because it merely changes how a pointer is de-referenced

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
