### PR TITLE
Devtools: initial Debugger > Sources panel

### DIFF
--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -102,6 +102,9 @@ pub enum ScriptToDevtoolsControlMsg {
 
     /// Report a page title change
     TitleChanged(PipelineId, String),
+
+    /// Get source information from script
+    ScriptSourceLoaded(PipelineId, SourceInfo),
 }
 
 /// Serialized JS return values
@@ -539,4 +542,10 @@ impl fmt::Display for ShadowRootMode {
             Self::Closed => write!(f, "close"),
         }
     }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct SourceInfo {
+    pub url: ServoUrl,
+    pub external: bool,
 }


### PR DESCRIPTION
This patch adds support for listing scripts in the Sources panel. Classic scripts, both external and inline, are implemented, but worker scripts and imported module scripts are not yet implemented.

For example:

```html
<!-- sources.html -->
<!doctype html><meta charset=utf-8>
<script src="classic.js"></script>
<script>
    console.log("inline classic");
    new Worker("worker.js");
</script>
<script type="module">
    import module from "./module.js";
    console.log("inline module");
</script>
<script src="https://servo.org/js/load-table.js"></script>
```

```js
// classic.js
console.log("external classic");
```

```js
// worker.js
console.log("external classic worker");
```

```js
// module.js
export default 1;
console.log("external module");
```

![image](https://github.com/user-attachments/assets/2f1d8d7c-501f-4fe5-bd07-085c95e504f2)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes partially implement #36027

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes require tests, but they are blocked on #36325