### PR TITLE
fix(parser): Set shadow’s available to element internals in attach_declarative_shadow

### DIFF
--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -1477,6 +1477,9 @@ impl TreeSink for Sink {
                 let shadow = shadow_root.upcast::<DocumentFragment>();
                 template_element.set_contents(Some(shadow));
 
+                // Step 8.5. Set shadow’s available to element internals to true.
+                shadow_root.set_available_to_element_internals(true);
+
                 Ok(())
             },
             Err(_) => Err(String::from("Attaching shadow fails")),

--- a/tests/wpt/meta/shadow-dom/declarative/declarative-shadow-dom-available-to-element-internals.html.ini
+++ b/tests/wpt/meta/shadow-dom/declarative/declarative-shadow-dom-available-to-element-internals.html.ini
@@ -1,3 +1,0 @@
-[declarative-shadow-dom-available-to-element-internals.html]
-  [Declarative Shadow DOM: shadow root should be available to element internals]
-    expected: FAIL


### PR DESCRIPTION
This PR ensures that the Servo parser correctly follows step 8.5 of the HTML spec when handling `<template>` elements by setting `shadow_root.set_available_to_element_internals(true)` in `attach_declarative_shadow`.  

#### **Changes**
- **Fix:** Added `shadow_root.set_available_to_element_internals(true);` after setting the template's contents property.
- **Cleanup:** Removed `tests/wpt/meta/shadow-dom/declarative/declarative-shadow-dom-available-to-element-internals.html.ini` as the test now passes.

#### **Spec Reference**
[HTML Spec - Parsing a `<template>` in the InHead state](https://html.spec.whatwg.org/multipage/#parsing-main-inhead) (Step 8.5)  

#### **Testing**
- Confirmed WPT tests pass with the updated behavior.  
- Verified that `shadow-dom/declarative/declarative-shadow-dom-available-to-element-internals.html` now behaves as expected.  

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #36167

<!-- Either: -->
- [X] There are tests for these changes 