### PR TITLE
fix: root element not establishing stacking context (#35390)

### DIFF
--- a/components/layout_2020/dom_traversal.rs
+++ b/components/layout_2020/dom_traversal.rs
@@ -125,11 +125,10 @@ where
                 ))
             ) {
                 flags.insert(FragmentFlags::IS_TEXT_CONTROL);
-            } else if matches!(
-                element.type_id(),
-                Some(LayoutNodeType::Element(LayoutElementType::HTMLHtmlElement))
-            ) {
-                flags.insert(FragmentFlags::IS_ROOT_HTML_ELEMENT);
+            }
+
+            if ThreadSafeLayoutElement::is_root(&element) {
+                flags.insert(FragmentFlags::IS_ROOT_ELEMENT);
             }
         };
 

--- a/components/layout_2020/dom_traversal.rs
+++ b/components/layout_2020/dom_traversal.rs
@@ -107,6 +107,7 @@ where
             if element.is_body_element_of_html_element_root() {
                 flags.insert(FragmentFlags::IS_BODY_ELEMENT_OF_HTML_ELEMENT_ROOT);
             }
+
             match element.get_local_name() {
                 &local_name!("br") => {
                     flags.insert(FragmentFlags::IS_BR_ELEMENT);
@@ -124,6 +125,11 @@ where
                 ))
             ) {
                 flags.insert(FragmentFlags::IS_TEXT_CONTROL);
+            } else if matches!(
+                element.type_id(),
+                Some(LayoutNodeType::Element(LayoutElementType::HTMLHtmlElement))
+            ) {
+                flags.insert(FragmentFlags::IS_ROOT_HTML_ELEMENT);
             }
         };
 

--- a/components/layout_2020/fragment_tree/base_fragment.rs
+++ b/components/layout_2020/fragment_tree/base_fragment.rs
@@ -102,6 +102,8 @@ bitflags! {
         /// and the fragment can be a flex item. This flag is used to cache items during flex
         /// layout.
         const SIZE_DEPENDS_ON_BLOCK_CONSTRAINTS_AND_CAN_BE_CHILD_OF_FLEX_ITEM = 1 << 8;
+        /// Whether or not the node that created this fragment is an `<html>` element on an HTML document.
+        const IS_ROOT_HTML_ELEMENT = 1 << 9;
     }
 }
 

--- a/components/layout_2020/fragment_tree/base_fragment.rs
+++ b/components/layout_2020/fragment_tree/base_fragment.rs
@@ -102,7 +102,7 @@ bitflags! {
         /// and the fragment can be a flex item. This flag is used to cache items during flex
         /// layout.
         const SIZE_DEPENDS_ON_BLOCK_CONSTRAINTS_AND_CAN_BE_CHILD_OF_FLEX_ITEM = 1 << 8;
-        /// Whether or not the node that created this fragment is the root element on an HTML document.
+        /// Whether or not the node that created this fragment is the root element.
         const IS_ROOT_ELEMENT = 1 << 9;
     }
 }

--- a/components/layout_2020/fragment_tree/base_fragment.rs
+++ b/components/layout_2020/fragment_tree/base_fragment.rs
@@ -102,8 +102,8 @@ bitflags! {
         /// and the fragment can be a flex item. This flag is used to cache items during flex
         /// layout.
         const SIZE_DEPENDS_ON_BLOCK_CONSTRAINTS_AND_CAN_BE_CHILD_OF_FLEX_ITEM = 1 << 8;
-        /// Whether or not the node that created this fragment is an `<html>` element on an HTML document.
-        const IS_ROOT_HTML_ELEMENT = 1 << 9;
+        /// Whether or not the node that created this fragment is the root element on an HTML document.
+        const IS_ROOT_ELEMENT = 1 << 9;
     }
 }
 

--- a/components/layout_2020/style_ext.rs
+++ b/components/layout_2020/style_ext.rs
@@ -746,6 +746,12 @@ impl ComputedValuesExt for ComputedValues {
             return true;
         }
 
+        // From https://www.w3.org/TR/CSS22/visuren.html#z-index:
+        // > The root element forms the root stacking context.
+        if fragment_flags.intersects(FragmentFlags::IS_ROOT_HTML_ELEMENT) {
+            return true;
+        }
+
         // TODO: We need to handle CSS Contain here.
         false
     }

--- a/components/layout_2020/style_ext.rs
+++ b/components/layout_2020/style_ext.rs
@@ -748,7 +748,7 @@ impl ComputedValuesExt for ComputedValues {
 
         // From https://www.w3.org/TR/CSS22/visuren.html#z-index:
         // > The root element forms the root stacking context.
-        if fragment_flags.intersects(FragmentFlags::IS_ROOT_HTML_ELEMENT) {
+        if fragment_flags.contains(FragmentFlags::IS_ROOT_ELEMENT) {
             return true;
         }
 

--- a/components/script/layout_dom/element.rs
+++ b/components/script/layout_dom/element.rs
@@ -843,6 +843,10 @@ impl<'dom> ThreadSafeLayoutElement<'dom> for ServoThreadSafeLayoutElement<'dom> 
     fn is_body_element_of_html_element_root(&self) -> bool {
         self.element.is_html_document_body_element()
     }
+
+    fn is_root(&self) -> bool {
+        self.element.is_root()
+    }
 }
 
 /// This implementation of `::selectors::Element` is used for implementing lazy

--- a/components/shared/script_layout/wrapper_traits.rs
+++ b/components/shared/script_layout/wrapper_traits.rs
@@ -429,4 +429,10 @@ pub trait ThreadSafeLayoutElement<'dom>:
     /// of the parent data is fine, since the bottom-up traversal will not process
     /// the parent until all the children have been processed.
     fn is_body_element_of_html_element_root(&self) -> bool;
+
+    /// Returns whether this node is the root element in an HTML document element.
+    ///
+    /// Note that, like `is_body_element_of_html_element_root`, this accesses the parent.
+    /// As in that case, since this is an immutable borrow, we do not violate thread safety.
+    fn is_root(&self) -> bool;
 }

--- a/components/shared/script_layout/wrapper_traits.rs
+++ b/components/shared/script_layout/wrapper_traits.rs
@@ -432,7 +432,7 @@ pub trait ThreadSafeLayoutElement<'dom>:
 
     /// Returns whether this node is the root element in an HTML document element.
     ///
-    /// Note that, like `is_body_element_of_html_element_root`, this accesses the parent.
+    /// Note that, like `Self::is_body_element_of_html_element_root`, this accesses the parent.
     /// As in that case, since this is an immutable borrow, we do not violate thread safety.
     fn is_root(&self) -> bool;
 }

--- a/tests/wpt/tests/css/CSS2/stacking-context/root-element-creates-stacking-context-ref.html
+++ b/tests/wpt/tests/css/CSS2/stacking-context/root-element-creates-stacking-context-ref.html
@@ -1,3 +1,4 @@
 <!DOCTYPE html>
-<html style="width: 0; height: 0; border: 50px solid">
-  <body style="border: 50px solid green; margin: -50px; position: relative">
+<body style="width: 100px; margin: 0">
+  <div style="height: 100px; background: green"></div>
+</body>

--- a/tests/wpt/tests/css/CSS2/stacking-context/root-element-creates-stacking-context-ref.html
+++ b/tests/wpt/tests/css/CSS2/stacking-context/root-element-creates-stacking-context-ref.html
@@ -1,2 +1,3 @@
+<!DOCTYPE html>
 <html style="width: 0; height: 0; border: 50px solid">
-  <body style="border: 50px solid green; margin: 0; position: relative; inset: -50px">
+  <body style="border: 50px solid green; margin: -50px; position: relative">

--- a/tests/wpt/tests/css/CSS2/stacking-context/root-element-creates-stacking-context-ref.html
+++ b/tests/wpt/tests/css/CSS2/stacking-context/root-element-creates-stacking-context-ref.html
@@ -1,0 +1,2 @@
+<html style="width: 0; height: 0; border: 50px solid">
+  <body style="border: 50px solid green; margin: 0; position: relative; inset: -50px">

--- a/tests/wpt/tests/css/CSS2/stacking-context/root-element-creates-stacking-context.html
+++ b/tests/wpt/tests/css/CSS2/stacking-context/root-element-creates-stacking-context.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html style="width: 0; height: 0; border: 50px solid red">
+  <link rel="help" href="https://drafts.csswg.org/css2/#stacking-context">
+  <link rel="match" href="root-element-creates-stacking-context-ref.html">
+  <link rel="author" title="Michael Rees" href="mailto:mrees@noeontheend.com">
+  <meta name="" content="root element forms the root stacking context">
+  <body style="border: 50px solid green; margin: 0; position: relative; inset: -50px; z-index: -1">
+  </body>
+</html>

--- a/tests/wpt/tests/css/CSS2/stacking-context/root-element-creates-stacking-context.html
+++ b/tests/wpt/tests/css/CSS2/stacking-context/root-element-creates-stacking-context.html
@@ -3,7 +3,7 @@
   <link rel="help" href="https://drafts.csswg.org/css2/#stacking-context">
   <link rel="match" href="root-element-creates-stacking-context-ref.html">
   <link rel="author" title="Michael Rees" href="mailto:mrees@noeontheend.com">
-  <meta name="" content="root element forms the root stacking context">
-  <body style="border: 50px solid green; margin: 0; position: relative; inset: -50px; z-index: -1">
+  <meta name="assert" content="root element forms the root stacking context">
+  <body style="border: 50px solid green; margin: -50px; position: relative; z-index: -1">
   </body>
 </html>


### PR DESCRIPTION
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #35390 
- [X] There are tests for these changes

[Successful WPT run](https://github.com/reesmichael1/servo/actions/runs/14097679625) (which includes the new test files)

(I didn't make the formatting changes intentionally--those came from `mach format` following `mach test-tidy`.)