### PR TITLE
Replace some uses of window.global() with upcast.

### DIFF
--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -184,7 +184,7 @@ impl WindowProxy {
             assert!(!js_proxy.is_null());
 
             // Create a new browsing context.
-            let current = Some(window.global().pipeline_id());
+            let current = Some(window.upcast::<GlobalScope>().pipeline_id());
             let window_proxy = Box::new(WindowProxy::new_inherited(
                 browsing_context_id,
                 webview_id,

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2530,7 +2530,7 @@ impl ScriptThread {
                 // FIXME: synchronously talks to constellation.
                 // send the required info as part of postmessage instead.
                 let source = match self.remote_window_proxy(
-                    &window.global(),
+                    window.upcast::<GlobalScope>(),
                     source_browsing_context,
                     source_pipeline_id,
                     None,


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
All Window objects are also GlobalScope objects, made changes in `servo/components/script/script_thread.rs` and `servo/components/script/dom/windowproxy.rs` to obtain the global scope with `window.upcast::<GlobalScope>()`.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #36117
- [X] These changes do not require tests because the changes compile.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
