### PR TITLE
Propagate CanGc arguments through HTMLCollection constructors

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -4968,8 +4968,12 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
         if let Some(entry) = self.tag_map.borrow_mut().get(&qualified_name) {
             return DomRoot::from_ref(entry);
         }
-        let result =
-            HTMLCollection::by_qualified_name(&self.window, self.upcast(), qualified_name.clone());
+        let result = HTMLCollection::by_qualified_name(
+            &self.window,
+            self.upcast(),
+            qualified_name.clone(),
+            CanGc::note(),
+        );
         self.tag_map
             .borrow_mut()
             .insert(qualified_name, Dom::from_ref(&*result));
@@ -4988,7 +4992,12 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
         if let Some(collection) = self.tagns_map.borrow().get(&qname) {
             return DomRoot::from_ref(collection);
         }
-        let result = HTMLCollection::by_qual_tag_name(&self.window, self.upcast(), qname.clone());
+        let result = HTMLCollection::by_qual_tag_name(
+            &self.window,
+            self.upcast(),
+            qname.clone(),
+            CanGc::note(),
+        );
         self.tagns_map
             .borrow_mut()
             .insert(qname, Dom::from_ref(&*result));
@@ -5001,8 +5010,12 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
         if let Some(collection) = self.classes_map.borrow().get(&class_atoms) {
             return DomRoot::from_ref(collection);
         }
-        let result =
-            HTMLCollection::by_atomic_class_name(&self.window, self.upcast(), class_atoms.clone());
+        let result = HTMLCollection::by_atomic_class_name(
+            &self.window,
+            self.upcast(),
+            class_atoms.clone(),
+            CanGc::note(),
+        );
         self.classes_map
             .borrow_mut()
             .insert(class_atoms, Dom::from_ref(&*result));
@@ -5478,18 +5491,24 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
     // https://html.spec.whatwg.org/multipage/#dom-document-images
     fn Images(&self) -> DomRoot<HTMLCollection> {
         self.images.or_init(|| {
-            HTMLCollection::new_with_filter_fn(&self.window, self.upcast(), |element, _| {
-                element.is::<HTMLImageElement>()
-            })
+            HTMLCollection::new_with_filter_fn(
+                &self.window,
+                self.upcast(),
+                |element, _| element.is::<HTMLImageElement>(),
+                CanGc::note(),
+            )
         })
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-document-embeds
     fn Embeds(&self) -> DomRoot<HTMLCollection> {
         self.embeds.or_init(|| {
-            HTMLCollection::new_with_filter_fn(&self.window, self.upcast(), |element, _| {
-                element.is::<HTMLEmbedElement>()
-            })
+            HTMLCollection::new_with_filter_fn(
+                &self.window,
+                self.upcast(),
+                |element, _| element.is::<HTMLEmbedElement>(),
+                CanGc::note(),
+            )
         })
     }
 
@@ -5501,44 +5520,60 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
     // https://html.spec.whatwg.org/multipage/#dom-document-links
     fn Links(&self) -> DomRoot<HTMLCollection> {
         self.links.or_init(|| {
-            HTMLCollection::new_with_filter_fn(&self.window, self.upcast(), |element, _| {
-                (element.is::<HTMLAnchorElement>() || element.is::<HTMLAreaElement>()) &&
-                    element.has_attribute(&local_name!("href"))
-            })
+            HTMLCollection::new_with_filter_fn(
+                &self.window,
+                self.upcast(),
+                |element, _| {
+                    (element.is::<HTMLAnchorElement>() || element.is::<HTMLAreaElement>()) &&
+                        element.has_attribute(&local_name!("href"))
+                },
+                CanGc::note(),
+            )
         })
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-document-forms
     fn Forms(&self) -> DomRoot<HTMLCollection> {
         self.forms.or_init(|| {
-            HTMLCollection::new_with_filter_fn(&self.window, self.upcast(), |element, _| {
-                element.is::<HTMLFormElement>()
-            })
+            HTMLCollection::new_with_filter_fn(
+                &self.window,
+                self.upcast(),
+                |element, _| element.is::<HTMLFormElement>(),
+                CanGc::note(),
+            )
         })
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-document-scripts
     fn Scripts(&self) -> DomRoot<HTMLCollection> {
         self.scripts.or_init(|| {
-            HTMLCollection::new_with_filter_fn(&self.window, self.upcast(), |element, _| {
-                element.is::<HTMLScriptElement>()
-            })
+            HTMLCollection::new_with_filter_fn(
+                &self.window,
+                self.upcast(),
+                |element, _| element.is::<HTMLScriptElement>(),
+                CanGc::note(),
+            )
         })
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-document-anchors
     fn Anchors(&self) -> DomRoot<HTMLCollection> {
         self.anchors.or_init(|| {
-            HTMLCollection::new_with_filter_fn(&self.window, self.upcast(), |element, _| {
-                element.is::<HTMLAnchorElement>() && element.has_attribute(&local_name!("href"))
-            })
+            HTMLCollection::new_with_filter_fn(
+                &self.window,
+                self.upcast(),
+                |element, _| {
+                    element.is::<HTMLAnchorElement>() && element.has_attribute(&local_name!("href"))
+                },
+                CanGc::note(),
+            )
         })
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-document-applets
     fn Applets(&self) -> DomRoot<HTMLCollection> {
         self.applets
-            .or_init(|| HTMLCollection::always_empty(&self.window, self.upcast()))
+            .or_init(|| HTMLCollection::always_empty(&self.window, self.upcast(), CanGc::note()))
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-document-location
@@ -5552,7 +5587,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
 
     // https://dom.spec.whatwg.org/#dom-parentnode-children
     fn Children(&self) -> DomRoot<HTMLCollection> {
-        HTMLCollection::children(&self.window, self.upcast())
+        HTMLCollection::children(&self.window, self.upcast(), CanGc::note())
     }
 
     // https://dom.spec.whatwg.org/#dom-parentnode-firstelementchild

--- a/components/script/dom/documentfragment.rs
+++ b/components/script/dom/documentfragment.rs
@@ -78,7 +78,7 @@ impl DocumentFragmentMethods<crate::DomTypeHolder> for DocumentFragment {
     // https://dom.spec.whatwg.org/#dom-parentnode-children
     fn Children(&self) -> DomRoot<HTMLCollection> {
         let window = self.owner_window();
-        HTMLCollection::children(&window, self.upcast())
+        HTMLCollection::children(&window, self.upcast(), CanGc::note())
     }
 
     // https://dom.spec.whatwg.org/#dom-nonelementparentnode-getelementbyid

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -2594,7 +2594,12 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
     // https://dom.spec.whatwg.org/#dom-element-getelementsbytagname
     fn GetElementsByTagName(&self, localname: DOMString) -> DomRoot<HTMLCollection> {
         let window = self.owner_window();
-        HTMLCollection::by_qualified_name(&window, self.upcast(), LocalName::from(&*localname))
+        HTMLCollection::by_qualified_name(
+            &window,
+            self.upcast(),
+            LocalName::from(&*localname),
+            CanGc::note(),
+        )
     }
 
     // https://dom.spec.whatwg.org/#dom-element-getelementsbytagnamens
@@ -2604,13 +2609,13 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         localname: DOMString,
     ) -> DomRoot<HTMLCollection> {
         let window = self.owner_window();
-        HTMLCollection::by_tag_name_ns(&window, self.upcast(), localname, maybe_ns)
+        HTMLCollection::by_tag_name_ns(&window, self.upcast(), localname, maybe_ns, CanGc::note())
     }
 
     // https://dom.spec.whatwg.org/#dom-element-getelementsbyclassname
     fn GetElementsByClassName(&self, classes: DOMString) -> DomRoot<HTMLCollection> {
         let window = self.owner_window();
-        HTMLCollection::by_class_name(&window, self.upcast(), classes)
+        HTMLCollection::by_class_name(&window, self.upcast(), classes, CanGc::note())
     }
 
     // https://drafts.csswg.org/cssom-view/#dom-element-getclientrects
@@ -3090,7 +3095,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
     // https://dom.spec.whatwg.org/#dom-parentnode-children
     fn Children(&self) -> DomRoot<HTMLCollection> {
         let window = self.owner_window();
-        HTMLCollection::children(&window, self.upcast())
+        HTMLCollection::children(&window, self.upcast(), CanGc::note())
     }
 
     // https://dom.spec.whatwg.org/#dom-parentnode-firstelementchild

--- a/components/script/dom/htmldatalistelement.rs
+++ b/components/script/dom/htmldatalistelement.rs
@@ -54,8 +54,11 @@ impl HTMLDataListElement {
 impl HTMLDataListElementMethods<crate::DomTypeHolder> for HTMLDataListElement {
     // https://html.spec.whatwg.org/multipage/#dom-datalist-options
     fn Options(&self) -> DomRoot<HTMLCollection> {
-        HTMLCollection::new_with_filter_fn(&self.owner_window(), self.upcast(), |element, _| {
-            element.is::<HTMLOptionElement>()
-        })
+        HTMLCollection::new_with_filter_fn(
+            &self.owner_window(),
+            self.upcast(),
+            |element, _| element.is::<HTMLOptionElement>(),
+            CanGc::note(),
+        )
     }
 }

--- a/components/script/dom/htmlfieldsetelement.rs
+++ b/components/script/dom/htmlfieldsetelement.rs
@@ -88,11 +88,16 @@ impl HTMLFieldSetElement {
 impl HTMLFieldSetElementMethods<crate::DomTypeHolder> for HTMLFieldSetElement {
     // https://html.spec.whatwg.org/multipage/#dom-fieldset-elements
     fn Elements(&self) -> DomRoot<HTMLCollection> {
-        HTMLCollection::new_with_filter_fn(&self.owner_window(), self.upcast(), |element, _| {
-            element
-                .downcast::<HTMLElement>()
-                .is_some_and(HTMLElement::is_listed_element)
-        })
+        HTMLCollection::new_with_filter_fn(
+            &self.owner_window(),
+            self.upcast(),
+            |element, _| {
+                element
+                    .downcast::<HTMLElement>()
+                    .is_some_and(HTMLElement::is_listed_element)
+            },
+            CanGc::note(),
+        )
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-fieldset-disabled

--- a/components/script/dom/htmltableelement.rs
+++ b/components/script/dom/htmltableelement.rs
@@ -309,6 +309,7 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
                         element.local_name() == &local_name!("tbody") &&
                         element.upcast::<Node>().GetParentNode().as_deref() == Some(root)
                 },
+                CanGc::note(),
             )
         })
     }

--- a/components/script/dom/htmltablerowelement.rs
+++ b/components/script/dom/htmltablerowelement.rs
@@ -93,6 +93,7 @@ impl HTMLTableRowElementMethods<crate::DomTypeHolder> for HTMLTableRowElement {
                     (element.is::<HTMLTableCellElement>()) &&
                         element.upcast::<Node>().GetParentNode().as_deref() == Some(root)
                 },
+                CanGc::note(),
             )
         })
     }

--- a/components/script/dom/htmltablesectionelement.rs
+++ b/components/script/dom/htmltablesectionelement.rs
@@ -64,10 +64,15 @@ impl HTMLTableSectionElement {
 impl HTMLTableSectionElementMethods<crate::DomTypeHolder> for HTMLTableSectionElement {
     // https://html.spec.whatwg.org/multipage/#dom-tbody-rows
     fn Rows(&self) -> DomRoot<HTMLCollection> {
-        HTMLCollection::new_with_filter_fn(&self.owner_window(), self.upcast(), |element, root| {
-            element.is::<HTMLTableRowElement>() &&
-                element.upcast::<Node>().GetParentNode().as_deref() == Some(root)
-        })
+        HTMLCollection::new_with_filter_fn(
+            &self.owner_window(),
+            self.upcast(),
+            |element, root| {
+                element.is::<HTMLTableRowElement>() &&
+                    element.upcast::<Node>().GetParentNode().as_deref() == Some(root)
+            },
+            CanGc::note(),
+        )
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-tbody-insertrow

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2128,6 +2128,7 @@ impl ScriptThread {
                     pipeline_id,
                     selector,
                     reply,
+                    can_gc,
                 )
             },
             WebDriverScriptCommand::FindElementsCSS(selector, reply) => {
@@ -2153,6 +2154,7 @@ impl ScriptThread {
                     pipeline_id,
                     selector,
                     reply,
+                    can_gc,
                 )
             },
             WebDriverScriptCommand::FindElementElementCSS(selector, element_id, reply) => {
@@ -2184,6 +2186,7 @@ impl ScriptThread {
                     element_id,
                     selector,
                     reply,
+                    can_gc,
                 )
             },
             WebDriverScriptCommand::FindElementElementsCSS(selector, element_id, reply) => {
@@ -2215,6 +2218,7 @@ impl ScriptThread {
                     element_id,
                     selector,
                     reply,
+                    can_gc,
                 )
             },
             WebDriverScriptCommand::FocusElement(element_id, reply) => {

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -551,6 +551,7 @@ pub(crate) fn handle_find_element_tag_name(
     pipeline: PipelineId,
     selector: String,
     reply: IpcSender<Result<Option<String>, ErrorStatus>>,
+    _can_gc: CanGc,
 ) {
     reply
         .send(
@@ -618,6 +619,7 @@ pub(crate) fn handle_find_elements_tag_name(
     pipeline: PipelineId,
     selector: String,
     reply: IpcSender<Result<Vec<String>, ErrorStatus>>,
+    _can_gc: CanGc,
 ) {
     reply
         .send(
@@ -675,6 +677,7 @@ pub(crate) fn handle_find_element_element_tag_name(
     element_id: String,
     selector: String,
     reply: IpcSender<Result<Option<String>, ErrorStatus>>,
+    _can_gc: CanGc,
 ) {
     reply
         .send(
@@ -737,6 +740,7 @@ pub(crate) fn handle_find_element_elements_tag_name(
     element_id: String,
     selector: String,
     reply: IpcSender<Result<Vec<String>, ErrorStatus>>,
+    _can_gc: CanGc,
 ) {
     reply
         .send(


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Propagate CanGc arguments through HTMLCollection constructors

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #36002

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
