### PR TITLE
net: Add missing feature required for unit tests.

### DIFF
--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -78,7 +78,7 @@ flate2 = "1"
 futures = { version = "0.3", features = ["compat"] }
 hyper = { workspace = true, features = ["full"] }
 hyper-util = { workspace = true, features = ["server-graceful"] }
-rustls = { workspace = true }
+rustls = { workspace = true, features = ["aws-lc-rs"] }
 
 [[test]]
 name = "main"


### PR DESCRIPTION
Running `./mach test-unit -p net` fails to build because the unit tests rely on the aws-lc-rs feature of rustls being enabled, but the net package does not actually enable it.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because we do not verify that individual packages can run their unit tests in isolation.