### PR TITLE
Fix content-type when creating a `Request` with `FormData` body

### DIFF
--- a/components/script/body.rs
+++ b/components/script/body.rs
@@ -539,7 +539,7 @@ impl Extractable for FormData {
         let bytes = encode_multipart_form_data(&mut self.datums(), boundary.clone(), UTF_8);
         let total_bytes = bytes.len();
         let content_type = Some(DOMString::from(format!(
-            "multipart/form-data;boundary={}",
+            "multipart/form-data; boundary={}",
             boundary
         )));
         let stream = ReadableStream::new_from_bytes(global, bytes, can_gc)?;

--- a/tests/wpt/meta/fetch/api/basic/request-headers.any.js.ini
+++ b/tests/wpt/meta/fetch/api/basic/request-headers.any.js.ini
@@ -5,16 +5,10 @@
   expected: ERROR
 
 [request-headers.any.html]
-  [Fetch with POST with FormData body]
-    expected: FAIL
-
   [Fetch with POST with Float16Array body]
     expected: FAIL
 
 
 [request-headers.any.worker.html]
-  [Fetch with POST with FormData body]
-    expected: FAIL
-
   [Fetch with POST with Float16Array body]
     expected: FAIL

--- a/tests/wpt/meta/fetch/api/request/request-init-contenttype.any.js.ini
+++ b/tests/wpt/meta/fetch/api/request/request-init-contenttype.any.js.ini
@@ -1,8 +1,0 @@
-[request-init-contenttype.any.worker.html]
-  [Default Content-Type for Request with FormData body]
-    expected: FAIL
-
-
-[request-init-contenttype.any.html]
-  [Default Content-Type for Request with FormData body]
-    expected: FAIL

--- a/tests/wpt/meta/fetch/api/response/response-consume.html.ini
+++ b/tests/wpt/meta/fetch/api/response/response-consume.html.ini
@@ -16,3 +16,6 @@
 
   [Consume response's body: from multipart form data blob to formData]
     expected: FAIL
+
+  [Consume response's body: from FormData to blob]
+    expected: FAIL

--- a/tests/wpt/meta/fetch/api/response/response-init-contenttype.any.js.ini
+++ b/tests/wpt/meta/fetch/api/response/response-init-contenttype.any.js.ini
@@ -1,8 +1,0 @@
-[response-init-contenttype.any.worker.html]
-  [Default Content-Type for Response with FormData body]
-    expected: FAIL
-
-
-[response-init-contenttype.any.html]
-  [Default Content-Type for Response with FormData body]
-    expected: FAIL

--- a/tests/wpt/meta/fetch/content-length/api-and-duplicate-headers.any.js.ini
+++ b/tests/wpt/meta/fetch/content-length/api-and-duplicate-headers.any.js.ini
@@ -6,3 +6,6 @@
 [api-and-duplicate-headers.any.worker.html]
   [XMLHttpRequest and duplicate Content-Length/Content-Type headers]
     expected: FAIL
+
+  [fetch() and duplicate Content-Length/Content-Type headers]
+    expected: FAIL

--- a/tests/wpt/meta/xhr/setrequestheader-content-type.htm.ini
+++ b/tests/wpt/meta/xhr/setrequestheader-content-type.htm.ini
@@ -8,8 +8,5 @@
   [HTML Document request keeps setRequestHeader() Content-Type, with charset adjusted to UTF-8]
     expected: FAIL
 
-  [FormData request has correct default Content-Type of "multipart/form-data; boundary=_"]
-    expected: FAIL
-
   [URLSearchParams request keeps setRequestHeader() Content-Type, with charset adjusted to UTF-8]
     expected: FAIL


### PR DESCRIPTION
When you create a `Request` object with a `FormData` body, the spec
says that the `Content-Type` header should start with
`multipart/form-data; boundary=`. However, in Servo's implementation
it started with `multipart/form-data;boundary=`, without the space.

While all reasonable servers should be able to that headers whether
the space is present or not, this brings Servo closer to the spec, and
also makes some WPT tests pass.

Note that submitting a form with `enctype="multipart/form-data"` does
produce a `Content-Type` header with the space (see
`HTMLFormElement::submit_entity_body`).

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
