### PR TITLE
Fix: prevent missing value error for radio button inputs without a name 

### DIFF
--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -810,6 +810,9 @@ impl HTMLInputElement {
             InputType::Checkbox => self.Required() && !self.Checked(),
             // https://html.spec.whatwg.org/multipage/#radio-button-state-(type%3Dradio)%3Asuffering-from-being-missing
             InputType::Radio => {
+                if self.radio_group_name().is_none() {
+                    return false;
+                }
                 let mut is_required = self.Required();
                 let mut is_checked = self.Checked();
                 for other in radio_group_iter(self, self.radio_group_name().as_ref()) {

--- a/tests/wpt/meta/html/semantics/forms/constraints/form-validation-validity-valueMissing.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/constraints/form-validation-validity-valueMissing.html.ini
@@ -1,5 +1,0 @@
-[form-validation-validity-valueMissing.html]
-  type: testharness
-  [[INPUT in RADIO status\] The checked attribute is false and the name attribute is empty]
-    expected: FAIL
-


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This fix explicitly checks if `self.radio_group_name()` is `None` and returns `false` from the constraint validation implementation, ensuring we pass the relevant WPT test.   

This fix removes references to the `tests/wpt/tests/html/semantics/forms/constraints/form-validation-validity-valueMissing.htmltest` test, as its expectation is now PASS, and deletes the .ini file since it no longer contains any expectations.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [X] These changes fix #36077
- [X] This change passed this test `./mach test-wpt tests/wpt/tests/html/semantics/forms/constraints/form-validation-validity-valueMissing.html`


<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
