### PR TITLE
compositor: Make viewport metrics per-WebView

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -4588,9 +4588,12 @@ where
                 self.compositor_proxy
                     .send(CompositorMsg::WebDriverMouseMoveEvent(webview_id, x, y));
             },
-            WebDriverCommandMsg::TakeScreenshot(_, rect, response_sender) => {
-                self.compositor_proxy
-                    .send(CompositorMsg::CreatePng(rect, response_sender));
+            WebDriverCommandMsg::TakeScreenshot(webview_id, rect, response_sender) => {
+                self.compositor_proxy.send(CompositorMsg::CreatePng(
+                    webview_id,
+                    rect,
+                    response_sender,
+                ));
             },
         }
     }

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -596,10 +596,6 @@ impl Servo {
             .retain(|_webview_id, webview| webview.strong_count() > 0);
     }
 
-    pub fn pinch_zoom_level(&self) -> f32 {
-        self.compositor.borrow_mut().pinch_zoom_level().get()
-    }
-
     pub fn setup_logging(&self) {
         let constellation_chan = self.constellation_proxy.sender();
         let env = env_logger::Env::default();

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -391,21 +391,21 @@ impl WebView {
         self.inner()
             .compositor
             .borrow_mut()
-            .resize_rendering_context(new_size);
+            .resize_rendering_context(self.id(), new_size);
     }
 
     pub fn set_zoom(&self, new_zoom: f32) {
         self.inner()
             .compositor
             .borrow_mut()
-            .on_zoom_window_event(new_zoom);
+            .on_zoom_window_event(self.id(), new_zoom);
     }
 
     pub fn reset_zoom(&self) {
         self.inner()
             .compositor
             .borrow_mut()
-            .on_zoom_reset_window_event();
+            .on_zoom_reset_window_event(self.id());
     }
 
     pub fn set_pinch_zoom(&self, new_pinch_zoom: f32) {

--- a/components/shared/compositing/lib.rs
+++ b/components/shared/compositing/lib.rs
@@ -86,7 +86,11 @@ pub enum CompositorMsg {
     /// Script has handled a touch event, and either prevented or allowed default actions.
     TouchEventProcessed(WebViewId, TouchEventResult),
     /// Composite to a PNG file and return the Image over a passed channel.
-    CreatePng(Option<Rect<f32, CSSPixel>>, IpcSender<Option<Image>>),
+    CreatePng(
+        WebViewId,
+        Option<Rect<f32, CSSPixel>>,
+        IpcSender<Option<Image>>,
+    ),
     /// A reply to the compositor asking if the output image is stable.
     IsReadyToSaveImageReply(bool),
     /// Set whether to use less resources by stopping animations.


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
In this patch, moving the viewport attributes to webview.

Keeping it separate for better understanding and visibility.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
