### PR TITLE
Fixed the problem that touchmove cannot be disabled when preventDefault is invoked on touchstart.

### DIFF
--- a/components/compositing/webview.rs
+++ b/components/compositing/webview.rs
@@ -574,11 +574,13 @@ impl WebView {
                         self.touch_handler
                             .set_handling_touch_move(self.touch_handler.current_sequence_id, false);
                         if let Some(info) = self.touch_handler.get_touch_sequence_mut(sequence_id) {
-                            info.prevent_move = TouchMoveAllowed::Allowed;
-                            if let TouchSequenceState::PendingFling { velocity, cursor } =
-                                info.state
-                            {
-                                info.state = TouchSequenceState::Flinging { velocity, cursor }
+                            if info.prevent_move == TouchMoveAllowed::Pending {
+                                info.prevent_move = TouchMoveAllowed::Allowed;
+                                if let TouchSequenceState::PendingFling { velocity, cursor } =
+                                    info.state
+                                {
+                                    info.state = TouchSequenceState::Flinging { velocity, cursor }
+                                }
                             }
                         }
                     },


### PR DESCRIPTION
Fixed the problem that touchmove cannot be disabled when preventDefault is invoked on touchstart.

<!-- Please describe your changes on the following line: -->

If preventDefault is set to Prevented when touchstart is performed, TouchMoveAllowed is set to Prevented. However, when touchmove is called back, TouchMoveAllowed is directly set to Allowed if it is allowed. The situation that TouchMoveAllowed has been prevented is not considered.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
