### PR TITLE
Install tshark for automated tests in #36033

### DIFF
--- a/python/servo/platform/linux.py
+++ b/python/servo/platform/linux.py
@@ -15,15 +15,15 @@ from typing import Optional, Tuple
 from .base import Base
 from .build_target import BuildTarget
 
-# Please keep these in sync with the packages on the wiki, using the instructions below
-# https://github.com/servo/servo/wiki/Building
+# Please keep these in sync with the packages in the book, using the instructions below
+# https://book.servo.org/hacking/setting-up-your-environment.html
 
 # https://packages.debian.org
 # https://packages.ubuntu.com
 # 1. open devtools
 # 2. paste in the whole APT_PKGS = [...]
 # 3. copy(`sudo apt install ${APT_PKGS.join(" ")}`)
-# 4. paste into https://github.com/servo/servo/wiki/Building#debian-based-distributions
+# 4. paste into https://github.com/servo/book/edit/main/src/hacking/setting-up-your-environment.md
 APT_PKGS = [
     'build-essential', 'ccache', 'clang', 'cmake', 'curl', 'g++', 'git',
     'gperf', 'libdbus-1-dev', 'libfreetype6-dev', 'libgl1-mesa-dri',
@@ -39,14 +39,15 @@ APT_PKGS = [
     'libharfbuzz-dev', 'liblzma-dev', 'libudev-dev', 'libunwind-dev',
     'libvulkan1', 'libx11-dev', 'libxcb-render0-dev', 'libxcb-shape0-dev',
     'libxcb-xfixes0-dev', 'libxmu-dev', 'libxmu6', 'libegl1-mesa-dev',
-    'llvm-dev', 'm4', 'xorg-dev', 'libxkbcommon0', "libxkbcommon-x11-0"
+    'llvm-dev', 'm4', 'xorg-dev', 'libxkbcommon0', "libxkbcommon-x11-0",
+    'tshark',
 ]
 
 # https://packages.fedoraproject.org
 # 1. open devtools
 # 2. paste in the whole DNF_PKGS = [...]
 # 3. copy(`sudo dnf install ${DNF_PKGS.join(" ")}`)
-# 4. paste into https://github.com/servo/servo/wiki/Building#fedora
+# 4. paste into https://github.com/servo/book/edit/main/src/hacking/setting-up-your-environment.md
 DNF_PKGS = ['libtool', 'gcc-c++', 'libXi-devel', 'freetype-devel',
             'libunwind-devel', 'mesa-libGL-devel', 'mesa-libEGL-devel',
             'glib2-devel', 'libX11-devel', 'libXrandr-devel', 'gperf',
@@ -58,13 +59,13 @@ DNF_PKGS = ['libtool', 'gcc-c++', 'libXi-devel', 'freetype-devel',
             'gstreamer1-plugins-good', 'gstreamer1-plugins-bad-free-devel',
             'gstreamer1-plugins-ugly-free', 'libjpeg-turbo-devel',
             'zlib-ng', 'libjpeg-turbo', 'vulkan-loader', 'libxkbcommon',
-            'libxkbcommon-x11']
+            'libxkbcommon-x11', 'wireshark-cli']
 
 # https://voidlinux.org/packages/
 # 1. open devtools
 # 2. paste in the whole XBPS_PKGS = [...]
 # 3. copy(`sudo xbps-install ${XBPS_PKGS.join(" ")}`)
-# 4. paste into https://github.com/servo/servo/wiki/Building#void-linux
+# 4. paste into https://github.com/servo/book/edit/main/src/hacking/setting-up-your-environment.md
 XBPS_PKGS = ['libtool', 'gcc', 'libXi-devel', 'freetype-devel',
              'libunwind-devel', 'MesaLib-devel', 'glib-devel', 'pkg-config',
              'libX11-devel', 'libXrandr-devel', 'gperf', 'bzip2-devel',

--- a/shell.nix
+++ b/shell.nix
@@ -81,6 +81,7 @@ stdenv.mkDerivation (androidEnvironment // {
     llvmPackages.bintools # provides lld
 
     udev # Needed by libudev-sys for GamePad API.
+    wireshark-cli  # for `tshark` in etc/devtools_parser.py
 
     # Build utilities
     cmake dbus gcc git pkg-config which llvm perl yasm m4


### PR DESCRIPTION
This patch adds tshark(1) to the list of programs installed by mach bootstrap, for new automated tests in #36033. See also servo/book#63, which does the same in [_Setting up your environment_](https://book.servo.org/hacking/setting-up-your-environment.html).

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes unblock #36033

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they solely enable automated testing in #36033