### PR TITLE
Use a simpler GitHub pull request template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,16 +1,4 @@
-<!-- Please describe your changes on the following line: -->
+*Describe the changes that this pull request makes here. This will be the commit message.*
 
-
----
-<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
-- [ ] `./mach build -d` does not report any errors
-- [ ] `./mach test-tidy` does not report any errors
-- [ ] These changes fix #___ (GitHub issue number if applicable)
-
-<!-- Either: -->
-- [ ] There are tests for these changes OR
-- [ ] These changes do not require tests because ___
-
-<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->
-
-<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
+Testing: *Describe how this pull request is tested or why it doesn't require tests*
+Fixes: *Link to an issue this pull requests fixes or remove this line if there is no issue*


### PR DESCRIPTION
The idea here is that we can use the pull request description as the
commit message, so that the git history is cleaner. This requires:

1. Removing comments from the message, as GitHub doesn't remove them
   from the pull request descriptions when committing.
2. Remove the checklist, which is now verified by the CI instead, so
   is less important.
3. Ask the contributor to remove the lines expicitly.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they just update the PR template

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
