### PR TITLE
layout: Implement support for `image-set()` notation

### DIFF
--- a/tests/wpt/meta/css/css-images/image-set/image-set-calc-x-rendering-2.html.ini
+++ b/tests/wpt/meta/css/css-images/image-set/image-set-calc-x-rendering-2.html.ini
@@ -1,2 +1,0 @@
-[image-set-calc-x-rendering-2.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-images/image-set/image-set-calc-x-rendering.html.ini
+++ b/tests/wpt/meta/css/css-images/image-set/image-set-calc-x-rendering.html.ini
@@ -1,2 +1,0 @@
-[image-set-calc-x-rendering.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-images/image-set/image-set-conic-gradient-rendering.html.ini
+++ b/tests/wpt/meta/css/css-images/image-set/image-set-conic-gradient-rendering.html.ini
@@ -1,2 +1,0 @@
-[image-set-conic-gradient-rendering.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-images/image-set/image-set-dpcm-rendering.html.ini
+++ b/tests/wpt/meta/css/css-images/image-set/image-set-dpcm-rendering.html.ini
@@ -1,2 +1,0 @@
-[image-set-dpcm-rendering.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-images/image-set/image-set-dpi-rendering-2.html.ini
+++ b/tests/wpt/meta/css/css-images/image-set/image-set-dpi-rendering-2.html.ini
@@ -1,2 +1,0 @@
-[image-set-dpi-rendering-2.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-images/image-set/image-set-dpi-rendering.html.ini
+++ b/tests/wpt/meta/css/css-images/image-set/image-set-dpi-rendering.html.ini
@@ -1,2 +1,0 @@
-[image-set-dpi-rendering.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-images/image-set/image-set-dppx-rendering.html.ini
+++ b/tests/wpt/meta/css/css-images/image-set/image-set-dppx-rendering.html.ini
@@ -1,2 +1,0 @@
-[image-set-dppx-rendering.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-images/image-set/image-set-empty-url-rendering.html.ini
+++ b/tests/wpt/meta/css/css-images/image-set/image-set-empty-url-rendering.html.ini
@@ -1,2 +1,0 @@
-[image-set-empty-url-rendering.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-images/image-set/image-set-first-match-rendering.html.ini
+++ b/tests/wpt/meta/css/css-images/image-set/image-set-first-match-rendering.html.ini
@@ -1,2 +1,0 @@
-[image-set-first-match-rendering.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-images/image-set/image-set-linear-gradient-rendering.html.ini
+++ b/tests/wpt/meta/css/css-images/image-set/image-set-linear-gradient-rendering.html.ini
@@ -1,2 +1,0 @@
-[image-set-linear-gradient-rendering.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-images/image-set/image-set-no-res-rendering-2.html.ini
+++ b/tests/wpt/meta/css/css-images/image-set/image-set-no-res-rendering-2.html.ini
@@ -1,2 +1,0 @@
-[image-set-no-res-rendering-2.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-images/image-set/image-set-no-res-rendering.html.ini
+++ b/tests/wpt/meta/css/css-images/image-set/image-set-no-res-rendering.html.ini
@@ -1,2 +1,0 @@
-[image-set-no-res-rendering.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-images/image-set/image-set-no-url-rendering.html.ini
+++ b/tests/wpt/meta/css/css-images/image-set/image-set-no-url-rendering.html.ini
@@ -1,2 +1,0 @@
-[image-set-no-url-rendering.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-images/image-set/image-set-radial-gradient-rendering.html.ini
+++ b/tests/wpt/meta/css/css-images/image-set/image-set-radial-gradient-rendering.html.ini
@@ -1,2 +1,0 @@
-[image-set-radial-gradient-rendering.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-images/image-set/image-set-rendering-2.html.ini
+++ b/tests/wpt/meta/css/css-images/image-set/image-set-rendering-2.html.ini
@@ -1,2 +1,0 @@
-[image-set-rendering-2.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-images/image-set/image-set-rendering.html.ini
+++ b/tests/wpt/meta/css/css-images/image-set/image-set-rendering.html.ini
@@ -1,2 +1,0 @@
-[image-set-rendering.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-images/image-set/image-set-repeating-conic-gradient-rendering.html.ini
+++ b/tests/wpt/meta/css/css-images/image-set/image-set-repeating-conic-gradient-rendering.html.ini
@@ -1,2 +1,0 @@
-[image-set-repeating-conic-gradient-rendering.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-images/image-set/image-set-repeating-linear-gradient-rendering.html.ini
+++ b/tests/wpt/meta/css/css-images/image-set/image-set-repeating-linear-gradient-rendering.html.ini
@@ -1,2 +1,0 @@
-[image-set-repeating-linear-gradient-rendering.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-images/image-set/image-set-repeating-radial-gradient-rendering.html.ini
+++ b/tests/wpt/meta/css/css-images/image-set/image-set-repeating-radial-gradient-rendering.html.ini
@@ -1,2 +1,0 @@
-[image-set-repeating-radial-gradient-rendering.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-images/image-set/image-set-type-first-match-rendering.html.ini
+++ b/tests/wpt/meta/css/css-images/image-set/image-set-type-first-match-rendering.html.ini
@@ -1,2 +1,0 @@
-[image-set-type-first-match-rendering.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-images/image-set/image-set-type-rendering-2.html.ini
+++ b/tests/wpt/meta/css/css-images/image-set/image-set-type-rendering-2.html.ini
@@ -1,2 +1,0 @@
-[image-set-type-rendering-2.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-images/image-set/image-set-type-rendering-3.html.ini
+++ b/tests/wpt/meta/css/css-images/image-set/image-set-type-rendering-3.html.ini
@@ -1,2 +1,0 @@
-[image-set-type-rendering-3.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-images/image-set/image-set-type-rendering.html.ini
+++ b/tests/wpt/meta/css/css-images/image-set/image-set-type-rendering.html.ini
@@ -1,2 +1,0 @@
-[image-set-type-rendering.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-images/image-set/image-set-type-skip-unsupported-rendering.html.ini
+++ b/tests/wpt/meta/css/css-images/image-set/image-set-type-skip-unsupported-rendering.html.ini
@@ -1,2 +1,0 @@
-[image-set-type-skip-unsupported-rendering.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-images/image-set/image-set-unordered-res-rendering.html.ini
+++ b/tests/wpt/meta/css/css-images/image-set/image-set-unordered-res-rendering.html.ini
@@ -1,2 +1,0 @@
-[image-set-unordered-res-rendering.html]
-  expected: FAIL


### PR DESCRIPTION
This PR adds support for `image-set()` notation described in https://drafts.csswg.org/css-images-4/#image-set-notation.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
