### PR TITLE
Remove redundant `rooted_vec` macro

### DIFF
--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -38,7 +38,6 @@ use std::ops::{Deref, DerefMut};
 
 /// A trait to allow tracing (only) DOM objects.
 pub(crate) use js::gc::Traceable as JSTraceable;
-pub(crate) use js::gc::{RootableVec, RootedVec};
 use js::glue::{CallScriptTracer, CallStringTracer, CallValueTracer};
 use js::jsapi::{GCTraceKindToAscii, Heap, JSScript, JSString, JSTracer, TraceKind};
 use js::jsval::JSVal;

--- a/components/script/dom/macros.rs
+++ b/components/script/dom/macros.rs
@@ -637,22 +637,6 @@ macro_rules! document_and_element_event_handlers(
     )
 );
 
-#[macro_export]
-macro_rules! rooted_vec {
-    (let mut $name:ident) => {
-        let mut root = $crate::dom::bindings::trace::RootableVec::new_unrooted();
-        let mut $name = $crate::dom::bindings::trace::RootedVec::new(&mut root);
-    };
-    (let $name:ident <- $iter:expr) => {
-        let mut root = $crate::dom::bindings::trace::RootableVec::new_unrooted();
-        let $name = $crate::dom::bindings::trace::RootedVec::from_iter(&mut root, $iter);
-    };
-    (let mut $name:ident <- $iter:expr) => {
-        let mut root = $crate::dom::bindings::trace::RootableVec::new_unrooted();
-        let mut $name = $crate::dom::bindings::trace::RootedVec::from_iter(&mut root, $iter);
-    };
-}
-
 /// DOM struct implementation for simple interfaces inheriting from PerformanceEntry.
 macro_rules! impl_performance_entry_struct(
     ($binding:ident, $struct:ident, $type:expr) => (


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This macro was copied into mozjs in 2023, in servo/mozjs#352

The two versions are identical, and rooting infrastructure generally lives in mozjs. Let's not keep this redundant copy around.

The mozjs version is already imported evyerwhere via `#[macro_use]`.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they don't change any behavior

[Link to mozjs version](https://github.com/servo/mozjs/blob/f5ed6f95f58e4ba683afcbbba46fd309c3ca8839/mozjs/src/gc/macros.rs#L24)

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
