### PR TITLE
Miscellaneous script splitting preparation changes

### DIFF
--- a/components/script/dom/bindings/callback.rs
+++ b/components/script/dom/bindings/callback.rs
@@ -15,6 +15,7 @@ use js::jsapi::{
 use js::jsval::{JSVal, ObjectValue, UndefinedValue};
 use js::rust::wrappers::{JS_GetProperty, JS_WrapObject};
 use js::rust::{MutableHandleValue, Runtime};
+use script_bindings::interfaces::DocumentHelpers;
 
 use crate::DomTypes;
 use crate::dom::bindings::codegen::Bindings::WindowBinding::Window_Binding::WindowMethods;
@@ -23,7 +24,6 @@ use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::settings_stack::{GenericAutoEntryScript, GenericAutoIncumbentScript};
 use crate::dom::bindings::utils::AsCCharPtrPtr;
-use crate::dom::document::DocumentHelpers;
 use crate::dom::globalscope::GlobalScopeHelpers;
 use crate::realms::{InRealm, enter_realm};
 use crate::script_runtime::{CanGc, JSContext};

--- a/components/script/dom/bindings/conversions.rs
+++ b/components/script/dom/bindings/conversions.rs
@@ -90,7 +90,7 @@ pub(crate) fn root_from_object_static<T>(obj: *mut JSObject) -> Result<DomRoot<T
 where
     T: DomObject + IDLInterface,
 {
-    native_from_object_static(obj).map(|ptr| unsafe { DomRoot::from_ref(&*ptr) })
+    unsafe { native_from_object_static(obj).map(|ptr| DomRoot::from_ref(&*ptr)) }
 }
 
 /// Get a `DomRoot<T>` for a DOM object accessible from a `HandleObject`.

--- a/components/script/dom/bindings/conversions.rs
+++ b/components/script/dom/bindings/conversions.rs
@@ -107,7 +107,10 @@ where
 /// Returns whether `value` is an array-like object (Array, FileList,
 /// HTMLCollection, HTMLFormControlsCollection, HTMLOptionsCollection,
 /// NodeList).
-pub(crate) unsafe fn is_array_like<D: crate::DomTypes>(cx: *mut JSContext, value: HandleValue) -> bool {
+pub(crate) unsafe fn is_array_like<D: crate::DomTypes>(
+    cx: *mut JSContext,
+    value: HandleValue,
+) -> bool {
     let mut is_array = false;
     assert!(IsArrayObject(cx, value, &mut is_array));
     if is_array {

--- a/components/script/dom/bindings/conversions.rs
+++ b/components/script/dom/bindings/conversions.rs
@@ -48,11 +48,6 @@ use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::reflector::DomObject;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::trace::{JSTraceable, RootedTraceableBox};
-use crate::dom::filelist::FileList;
-use crate::dom::htmlcollection::HTMLCollection;
-use crate::dom::htmlformcontrolscollection::HTMLFormControlsCollection;
-use crate::dom::htmloptionscollection::HTMLOptionsCollection;
-use crate::dom::nodelist::NodeList;
 
 impl<T: ToJSValConvertible + JSTraceable> ToJSValConvertible for RootedTraceableBox<T> {
     #[inline]
@@ -112,7 +107,7 @@ where
 /// Returns whether `value` is an array-like object (Array, FileList,
 /// HTMLCollection, HTMLFormControlsCollection, HTMLOptionsCollection,
 /// NodeList).
-pub(crate) unsafe fn is_array_like(cx: *mut JSContext, value: HandleValue) -> bool {
+pub(crate) unsafe fn is_array_like<D: crate::DomTypes>(cx: *mut JSContext, value: HandleValue) -> bool {
     let mut is_array = false;
     assert!(IsArrayObject(cx, value, &mut is_array));
     if is_array {
@@ -124,19 +119,19 @@ pub(crate) unsafe fn is_array_like(cx: *mut JSContext, value: HandleValue) -> bo
         _ => return false,
     };
 
-    if root_from_object::<FileList>(object, cx).is_ok() {
+    if root_from_object::<D::FileList>(object, cx).is_ok() {
         return true;
     }
-    if root_from_object::<HTMLCollection>(object, cx).is_ok() {
+    if root_from_object::<D::HTMLCollection>(object, cx).is_ok() {
         return true;
     }
-    if root_from_object::<HTMLFormControlsCollection>(object, cx).is_ok() {
+    if root_from_object::<D::HTMLFormControlsCollection>(object, cx).is_ok() {
         return true;
     }
-    if root_from_object::<HTMLOptionsCollection>(object, cx).is_ok() {
+    if root_from_object::<D::HTMLOptionsCollection>(object, cx).is_ok() {
         return true;
     }
-    if root_from_object::<NodeList>(object, cx).is_ok() {
+    if root_from_object::<D::NodeList>(object, cx).is_ok() {
         return true;
     }
 

--- a/components/script/dom/bindings/conversions.rs
+++ b/components/script/dom/bindings/conversions.rs
@@ -48,7 +48,6 @@ use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::reflector::DomObject;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::trace::{JSTraceable, RootedTraceableBox};
-use crate::dom::bindings::utils::DOMClass;
 use crate::dom::filelist::FileList;
 use crate::dom::htmlcollection::HTMLCollection;
 use crate::dom::htmlformcontrolscollection::HTMLFormControlsCollection;
@@ -86,35 +85,6 @@ where
 
 pub(crate) use script_bindings::conversions::is_dom_proxy;
 
-/// Get a `*const libc::c_void` for the given DOM object, unless it is a DOM
-/// wrapper, and checking if the object is of the correct type.
-///
-/// Returns Err(()) if `obj` is a wrapper or if the object is not an object
-/// for a DOM object of the given type (as defined by the proto_id and proto_depth).
-#[inline]
-unsafe fn private_from_proto_check_static(
-    obj: *mut JSObject,
-    proto_check: fn(&'static DOMClass) -> bool,
-) -> Result<*const libc::c_void, ()> {
-    let dom_class = get_dom_class(obj).map_err(|_| ())?;
-    if proto_check(dom_class) {
-        trace!("good prototype");
-        Ok(private_from_object(obj))
-    } else {
-        trace!("bad prototype");
-        Err(())
-    }
-}
-
-/// Get a `*const T` for a DOM object accessible from a `JSObject`, where the DOM object
-/// is guaranteed not to be a wrapper.
-pub(crate) fn native_from_object_static<T>(obj: *mut JSObject) -> Result<*const T, ()>
-where
-    T: DomObject + IDLInterface,
-{
-    unsafe { private_from_proto_check_static(obj, T::derives).map(|ptr| ptr as *const T) }
-}
-
 /// Get a `DomRoot<T>` for the given DOM object, unwrapping any wrapper
 /// around it first, and checking if the object is of the correct type.
 ///
@@ -126,18 +96,6 @@ where
     T: DomObject + IDLInterface,
 {
     native_from_object_static(obj).map(|ptr| unsafe { DomRoot::from_ref(&*ptr) })
-}
-
-/// Get a `*const T` for a DOM object accessible from a `HandleValue`.
-/// Caller is responsible for throwing a JS exception if needed in case of error.
-pub(crate) fn native_from_handlevalue<T>(v: HandleValue, cx: *mut JSContext) -> Result<*const T, ()>
-where
-    T: DomObject + IDLInterface,
-{
-    if !v.get().is_object() {
-        return Err(());
-    }
-    unsafe { native_from_object(v.get().to_object(), cx) }
 }
 
 /// Get a `DomRoot<T>` for a DOM object accessible from a `HandleObject`.

--- a/components/script/dom/bindings/error.rs
+++ b/components/script/dom/bindings/error.rs
@@ -20,7 +20,6 @@ pub(crate) use script_bindings::error::*;
 
 #[cfg(feature = "js_backtrace")]
 use crate::dom::bindings::cell::DomRefCell;
-use crate::dom::bindings::codegen::PrototypeList::proto_id_to_name;
 use crate::dom::bindings::conversions::{
     ConversionResult, FromJSValConvertible, ToJSValConvertible, root_from_object,
 };
@@ -255,23 +254,6 @@ pub(crate) fn report_pending_exception(
             can_gc,
         );
     }
-}
-
-/// Throw an exception to signal that a `JSObject` can not be converted to a
-/// given DOM type.
-pub(crate) fn throw_invalid_this(cx: SafeJSContext, proto_id: u16) {
-    debug_assert!(unsafe { !JS_IsExceptionPending(*cx) });
-    let error = format!(
-        "\"this\" object does not implement interface {}.",
-        proto_id_to_name(proto_id)
-    );
-    unsafe { throw_type_error(*cx, &error) };
-}
-
-pub(crate) fn throw_constructor_without_new(cx: SafeJSContext, name: &str) {
-    debug_assert!(unsafe { !JS_IsExceptionPending(*cx) });
-    let error = format!("{} constructor: 'new' is required", name);
-    unsafe { throw_type_error(*cx, &error) };
 }
 
 pub(crate) trait ErrorToJsval {

--- a/components/script/dom/bindings/import.rs
+++ b/components/script/dom/bindings/import.rs
@@ -125,7 +125,7 @@ pub(crate) mod module {
     pub(crate) use crate::dom::bindings::error::{
         Error, ErrorResult, throw_constructor_without_new,
     };
-    pub(crate) use crate::dom::bindings::finalize::{
+    pub(crate) use script_bindings::finalize::{
         finalize_common, finalize_global, finalize_weak_referenceable,
     };
     pub(crate) use crate::dom::bindings::guard::{Condition, Guard};

--- a/components/script/dom/bindings/import.rs
+++ b/components/script/dom/bindings/import.rs
@@ -16,6 +16,7 @@ pub(crate) mod base {
     pub(crate) use js::panic::maybe_resume_unwind;
     pub(crate) use js::rust::wrappers::{Call, JS_WrapValue};
     pub(crate) use js::rust::{HandleObject, HandleValue, MutableHandleObject, MutableHandleValue};
+    pub(crate) use script_bindings::lock::ThreadUnsafeOnceLock;
 
     pub(crate) use crate::dom::bindings::callback::{
         CallSetup, CallbackContainer, CallbackFunction, CallbackInterface, CallbackObject,
@@ -39,7 +40,6 @@ pub(crate) mod base {
     pub(crate) use crate::dom::bindings::root::DomRoot;
     pub(crate) use crate::dom::bindings::str::{ByteString, DOMString, USVString};
     pub(crate) use crate::dom::bindings::trace::RootedTraceableBox;
-    pub(crate) use script_bindings::lock::ThreadUnsafeOnceLock;
     pub(crate) use crate::dom::bindings::utils::{
         DomHelpers, get_dictionary_property, set_dictionary_property,
     };
@@ -100,7 +100,12 @@ pub(crate) mod module {
         JS_CALLEE, JSCLASS_GLOBAL_SLOT_COUNT, JSCLASS_IS_DOMJSCLASS, JSCLASS_IS_GLOBAL,
         JSCLASS_RESERVED_SLOTS_MASK, jsapi, typedarray,
     };
+    pub(crate) use script_bindings::codegen::Globals::Globals;
     pub(crate) use script_bindings::constant::{ConstantSpec, ConstantVal};
+    pub(crate) use script_bindings::finalize::{
+        finalize_common, finalize_global, finalize_weak_referenceable,
+    };
+    pub(crate) use script_bindings::interfaces::*;
     pub(crate) use script_bindings::record::Record;
     pub(crate) use servo_config::pref;
 
@@ -111,8 +116,6 @@ pub(crate) mod module {
         ChannelInterpretationValues,
     };
     pub(crate) use crate::dom::bindings::codegen::Bindings::EventTargetBinding::EventTarget_Binding;
-    pub(crate) use script_bindings::codegen::Globals::Globals;
-    pub(crate) use script_bindings::interfaces::*;
     pub(crate) use crate::dom::bindings::codegen::{
         InterfaceObjectMap, PrototypeList, RegisterBindings,
     };
@@ -126,9 +129,6 @@ pub(crate) mod module {
     };
     pub(crate) use crate::dom::bindings::error::{
         Error, ErrorResult, throw_constructor_without_new,
-    };
-    pub(crate) use script_bindings::finalize::{
-        finalize_common, finalize_global, finalize_weak_referenceable,
     };
     pub(crate) use crate::dom::bindings::guard::{Condition, Guard};
     pub(crate) use crate::dom::bindings::inheritance::Castable;

--- a/components/script/dom/bindings/import.rs
+++ b/components/script/dom/bindings/import.rs
@@ -39,8 +39,9 @@ pub(crate) mod base {
     pub(crate) use crate::dom::bindings::root::DomRoot;
     pub(crate) use crate::dom::bindings::str::{ByteString, DOMString, USVString};
     pub(crate) use crate::dom::bindings::trace::RootedTraceableBox;
+    pub(crate) use script_bindings::lock::ThreadUnsafeOnceLock;
     pub(crate) use crate::dom::bindings::utils::{
-        DomHelpers, ThreadUnsafeOnceLock, get_dictionary_property, set_dictionary_property,
+        DomHelpers, get_dictionary_property, set_dictionary_property,
     };
     pub(crate) use crate::dom::globalscope::{GlobalScope, GlobalScopeHelpers};
     pub(crate) use crate::dom::promise::PromiseHelpers;

--- a/components/script/dom/bindings/import.rs
+++ b/components/script/dom/bindings/import.rs
@@ -111,6 +111,8 @@ pub(crate) mod module {
         ChannelInterpretationValues,
     };
     pub(crate) use crate::dom::bindings::codegen::Bindings::EventTargetBinding::EventTarget_Binding;
+    pub(crate) use script_bindings::codegen::Globals::Globals;
+    pub(crate) use script_bindings::interfaces::*;
     pub(crate) use crate::dom::bindings::codegen::{
         InterfaceObjectMap, PrototypeList, RegisterBindings,
     };

--- a/components/script/dom/bindings/interface.rs
+++ b/components/script/dom/bindings/interface.rs
@@ -44,8 +44,6 @@ use crate::dom::bindings::principals::ServoJSPrincipals;
 use crate::dom::bindings::utils::{
     DOM_PROTOTYPE_SLOT, DOMJSClass, JSCLASS_DOM_GLOBAL, ProtoOrIfaceArray, get_proto_or_iface_array,
 };
-use crate::dom::globalscope::GlobalScope;
-use crate::realms::{AlreadyInRealm, InRealm};
 use crate::script_runtime::JSContext as SafeJSContext;
 
 /// The class of a non-callback interface object.
@@ -423,16 +421,6 @@ pub(crate) fn is_exposed_in(object: HandleObject, globals: Globals) -> bool {
         let unwrapped = UncheckedUnwrapObject(object.get(), /* stopAtWindowProxy = */ false);
         let dom_class = get_dom_class(unwrapped).unwrap();
         globals.contains(dom_class.global)
-    }
-}
-
-/// The navigator.servo api is only exposed to about: pages except about:blank
-pub(crate) fn is_servo_internal(cx: SafeJSContext, _object: HandleObject) -> bool {
-    unsafe {
-        let in_realm_proof = AlreadyInRealm::assert_for_cx(cx);
-        let global_scope = GlobalScope::from_context(*cx, InRealm::Already(&in_realm_proof));
-        let url = global_scope.get_url();
-        url.scheme() == "about" && url.as_str() != "about:blank"
     }
 }
 

--- a/components/script/dom/bindings/interface.rs
+++ b/components/script/dom/bindings/interface.rs
@@ -35,6 +35,7 @@ use js::rust::{
 use script_bindings::constant::{ConstantSpec, define_constants};
 use servo_url::MutableOrigin;
 
+use crate::DomTypes;
 use crate::dom::bindings::codegen::InterfaceObjectMap::Globals;
 use crate::dom::bindings::codegen::PrototypeList;
 use crate::dom::bindings::conversions::{DOM_OBJECT_SLOT, get_dom_class};
@@ -213,7 +214,7 @@ fn select_compartment(cx: SafeJSContext, options: &mut RealmOptions) {
 }
 
 /// Create and define the interface object of a callback interface.
-pub(crate) fn create_callback_interface_object(
+pub(crate) fn create_callback_interface_object<D: DomTypes>(
     cx: SafeJSContext,
     global: HandleObject,
     constants: &[Guard<&[ConstantSpec]>],
@@ -225,14 +226,14 @@ pub(crate) fn create_callback_interface_object(
         rval.set(JS_NewObject(*cx, ptr::null()));
     }
     assert!(!rval.is_null());
-    define_guarded_constants(cx, rval.handle(), constants, global);
+    define_guarded_constants::<D>(cx, rval.handle(), constants, global);
     define_name(cx, rval.handle(), name);
     define_on_global_object(cx, global, name, rval.handle());
 }
 
 /// Create the interface prototype object of a non-callback interface.
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn create_interface_prototype_object(
+pub(crate) fn create_interface_prototype_object<D: DomTypes>(
     cx: SafeJSContext,
     global: HandleObject,
     proto: HandleObject,
@@ -243,7 +244,7 @@ pub(crate) fn create_interface_prototype_object(
     unscopable_names: &[&CStr],
     mut rval: MutableHandleObject,
 ) {
-    create_object(
+    create_object::<D>(
         cx,
         global,
         proto,
@@ -277,7 +278,7 @@ pub(crate) fn create_interface_prototype_object(
 
 /// Create and define the interface object of a non-callback interface.
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn create_noncallback_interface_object(
+pub(crate) fn create_noncallback_interface_object<D: DomTypes>(
     cx: SafeJSContext,
     global: HandleObject,
     proto: HandleObject,
@@ -291,7 +292,7 @@ pub(crate) fn create_noncallback_interface_object(
     legacy_window_alias_names: &[&CStr],
     mut rval: MutableHandleObject,
 ) {
-    create_object(
+    create_object::<D>(
         cx,
         global,
         proto,
@@ -350,7 +351,7 @@ pub(crate) fn create_named_constructors(
 
 /// Create a new object with a unique type.
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn create_object(
+pub(crate) fn create_object<D: DomTypes>(
     cx: SafeJSContext,
     global: HandleObject,
     proto: HandleObject,
@@ -364,34 +365,34 @@ pub(crate) fn create_object(
         rval.set(JS_NewObjectWithGivenProto(*cx, class, proto));
     }
     assert!(!rval.is_null());
-    define_guarded_methods(cx, rval.handle(), methods, global);
-    define_guarded_properties(cx, rval.handle(), properties, global);
-    define_guarded_constants(cx, rval.handle(), constants, global);
+    define_guarded_methods::<D>(cx, rval.handle(), methods, global);
+    define_guarded_properties::<D>(cx, rval.handle(), properties, global);
+    define_guarded_constants::<D>(cx, rval.handle(), constants, global);
 }
 
 /// Conditionally define constants on an object.
-pub(crate) fn define_guarded_constants(
+pub(crate) fn define_guarded_constants<D: DomTypes>(
     cx: SafeJSContext,
     obj: HandleObject,
     constants: &[Guard<&[ConstantSpec]>],
     global: HandleObject,
 ) {
     for guard in constants {
-        if let Some(specs) = guard.expose(cx, obj, global) {
+        if let Some(specs) = guard.expose::<D>(cx, obj, global) {
             define_constants(cx, obj, specs);
         }
     }
 }
 
 /// Conditionally define methods on an object.
-pub(crate) fn define_guarded_methods(
+pub(crate) fn define_guarded_methods<D: DomTypes>(
     cx: SafeJSContext,
     obj: HandleObject,
     methods: &[Guard<&'static [JSFunctionSpec]>],
     global: HandleObject,
 ) {
     for guard in methods {
-        if let Some(specs) = guard.expose(cx, obj, global) {
+        if let Some(specs) = guard.expose::<D>(cx, obj, global) {
             unsafe {
                 define_methods(*cx, obj, specs).unwrap();
             }
@@ -400,14 +401,14 @@ pub(crate) fn define_guarded_methods(
 }
 
 /// Conditionally define properties on an object.
-pub(crate) fn define_guarded_properties(
+pub(crate) fn define_guarded_properties<D: DomTypes>(
     cx: SafeJSContext,
     obj: HandleObject,
     properties: &[Guard<&'static [JSPropertySpec]>],
     global: HandleObject,
 ) {
     for guard in properties {
-        if let Some(specs) = guard.expose(cx, obj, global) {
+        if let Some(specs) = guard.expose::<D>(cx, obj, global) {
             unsafe {
                 define_properties(*cx, obj, specs).unwrap();
             }

--- a/components/script/dom/bindings/mod.rs
+++ b/components/script/dom/bindings/mod.rs
@@ -141,7 +141,6 @@ pub(crate) mod cell;
 pub(crate) mod constructor;
 pub(crate) mod conversions;
 pub(crate) mod error;
-pub(crate) mod finalize;
 pub(crate) mod frozenarray;
 pub(crate) mod function;
 pub(crate) mod guard;

--- a/components/script/dom/bindings/mod.rs
+++ b/components/script/dom/bindings/mod.rs
@@ -151,7 +151,6 @@ pub(crate) mod interface;
 pub(crate) mod iterable;
 pub(crate) mod like;
 pub(crate) mod namespace;
-pub(crate) mod num;
 pub(crate) mod principals;
 pub(crate) mod proxyhandler;
 pub(crate) mod refcounted;
@@ -166,6 +165,8 @@ pub(crate) mod transferable;
 pub(crate) mod utils;
 pub(crate) mod weakref;
 pub(crate) mod xmlname;
+
+pub(crate) use script_bindings::num;
 
 /// Generated JS-Rust bindings.
 #[allow(missing_docs, non_snake_case)]

--- a/components/script/dom/bindings/namespace.rs
+++ b/components/script/dom/bindings/namespace.rs
@@ -11,6 +11,7 @@ use js::jsapi::{JSClass, JSFunctionSpec};
 use js::rust::{HandleObject, MutableHandleObject};
 use script_bindings::constant::ConstantSpec;
 
+use crate::DomTypes;
 use crate::dom::bindings::guard::Guard;
 use crate::dom::bindings::interface::{create_object, define_on_global_object};
 use crate::script_runtime::JSContext;
@@ -37,7 +38,7 @@ impl NamespaceObjectClass {
 
 /// Create a new namespace object.
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn create_namespace_object(
+pub(crate) fn create_namespace_object<D: DomTypes>(
     cx: JSContext,
     global: HandleObject,
     proto: HandleObject,
@@ -47,7 +48,7 @@ pub(crate) fn create_namespace_object(
     name: &CStr,
     mut rval: MutableHandleObject,
 ) {
-    create_object(
+    create_object::<D>(
         cx,
         global,
         proto,

--- a/components/script/dom/bindings/utils.rs
+++ b/components/script/dom/bindings/utils.rs
@@ -34,13 +34,13 @@ use js::rust::wrappers::{
     JS_SetPendingException, JS_SetProperty,
 };
 use js::rust::{
-    GCMethods, Handle, HandleId, HandleObject, HandleValue, MutableHandleValue, ToString,
+    Handle, HandleId, HandleObject, HandleValue, MutableHandleValue, ToString,
     get_object_class, is_dom_class,
 };
 
 use crate::DomTypes;
 use crate::dom::bindings::codegen::InterfaceObjectMap;
-use crate::dom::bindings::codegen::PrototypeList::{self, PROTO_OR_IFACE_LENGTH};
+use crate::dom::bindings::codegen::PrototypeList;
 use crate::dom::bindings::constructor::call_html_constructor;
 use crate::dom::bindings::conversions::{
     DerivedFrom, PrototypeCheck, jsstring_to_str, private_from_proto_check,
@@ -319,18 +319,6 @@ pub(crate) unsafe fn has_property_on_prototype(
     }
     assert!(!proto.is_null());
     JS_HasPropertyById(cx, proto.handle(), id, found)
-}
-
-/// Drop the resources held by reserved slots of a global object
-pub(crate) unsafe fn finalize_global(obj: *mut JSObject) {
-    let protolist = get_proto_or_iface_array(obj);
-    let list = (*protolist).as_mut_ptr();
-    for idx in 0..PROTO_OR_IFACE_LENGTH as isize {
-        let entry = list.offset(idx);
-        let value = *entry;
-        <*mut JSObject>::post_barrier(entry, value, ptr::null_mut());
-    }
-    let _: Box<ProtoOrIfaceArray> = Box::from_raw(protolist);
 }
 
 /// Trace the resources held by reserved slots of a global object

--- a/components/script/dom/bindings/utils.rs
+++ b/components/script/dom/bindings/utils.rs
@@ -5,36 +5,22 @@
 //! Various utilities to glue JavaScript and the DOM implementation together.
 
 use std::cell::RefCell;
-use std::ffi::CString;
 use std::os::raw::c_char;
-use std::ptr::NonNull;
 use std::thread::LocalKey;
-use std::{ptr, slice, str};
+use std::{ptr, slice};
 
-use js::JS_CALLEE;
 use js::conversions::ToJSValConvertible;
-use js::glue::{
-    CallJitGetterOp, CallJitMethodOp, CallJitSetterOp, IsWrapper,
-    RUST_FUNCTION_VALUE_TO_JITINFO, UnwrapObjectDynamic, UnwrapObjectStatic,
-};
+use js::glue::{IsWrapper, UnwrapObjectDynamic, UnwrapObjectStatic};
 use js::jsapi::{
-    AtomToLinearString, CallArgs, DOMCallbacks, ExceptionStackBehavior, GetLinearStringCharAt,
-    GetLinearStringLength, GetNonCCWObjectGlobal, HandleId as RawHandleId,
-    HandleObject as RawHandleObject, Heap, JS_ClearPendingException,
+    CallArgs, DOMCallbacks, HandleId as RawHandleId,
+    HandleObject as RawHandleObject, Heap,
     JS_DeprecatedStringHasLatin1Chars, JS_EnumerateStandardClasses, JS_FreezeObject,
-    JS_GetLatin1StringCharsAndLength, JS_IsExceptionPending, JS_IsGlobalObject,
-    JS_ResolveStandardClass, JSAtom, JSContext, JSJitInfo, JSObject, JSTracer,
-    MutableHandleIdVector as RawMutableHandleIdVector, MutableHandleValue as RawMutableHandleValue,
-    ObjectOpResult, StringIsArrayIndex,
-};
-use js::jsval::{JSVal, UndefinedValue};
-use js::rust::wrappers::{
-    CallOriginalPromiseReject, JS_DeletePropertyById, JS_ForwardGetPropertyTo,
-    JS_GetPendingException, JS_GetProperty, JS_GetPrototype, JS_HasProperty, JS_HasPropertyById,
-    JS_SetPendingException, JS_SetProperty,
+    JS_GetLatin1StringCharsAndLength, JS_IsGlobalObject,
+    JS_ResolveStandardClass, JSContext, JSObject, JSTracer,
+    MutableHandleIdVector as RawMutableHandleIdVector,
 };
 use js::rust::{
-    Handle, HandleId, HandleObject, HandleValue, MutableHandleValue, ToString,
+    Handle, HandleObject, MutableHandleValue,
     get_object_class, is_dom_class,
 };
 
@@ -42,13 +28,10 @@ use crate::DomTypes;
 use crate::dom::bindings::codegen::InterfaceObjectMap;
 use crate::dom::bindings::codegen::PrototypeList;
 use crate::dom::bindings::constructor::call_html_constructor;
-use crate::dom::bindings::conversions::{
-    DerivedFrom, PrototypeCheck, jsstring_to_str, private_from_proto_check,
-};
-use crate::dom::bindings::error::{Error, throw_dom_exception, throw_invalid_this};
+use crate::dom::bindings::conversions::DerivedFrom;
+use crate::dom::bindings::error::{Error, throw_dom_exception};
 use crate::dom::bindings::reflector::DomObject;
 use crate::dom::bindings::settings_stack::{self, StackEntry};
-use crate::dom::bindings::str::DOMString;
 use crate::dom::bindings::trace::trace_object;
 use crate::dom::windowproxy::WindowProxyHandler;
 use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
@@ -83,118 +66,6 @@ pub(crate) fn to_frozen_array<T: ToJSValConvertible>(
 
     rooted!(in(*cx) let obj = rval.to_object());
     unsafe { JS_FreezeObject(*cx, RawHandleObject::from(obj.handle())) };
-}
-
-/// Gets the property `id` on  `proxy`'s prototype. If it exists, `*found` is
-/// set to true and `*vp` to the value, otherwise `*found` is set to false.
-///
-/// Returns false on JSAPI failure.
-pub(crate) unsafe fn get_property_on_prototype(
-    cx: *mut JSContext,
-    proxy: HandleObject,
-    receiver: HandleValue,
-    id: HandleId,
-    found: *mut bool,
-    vp: MutableHandleValue,
-) -> bool {
-    rooted!(in(cx) let mut proto = ptr::null_mut::<JSObject>());
-    if !JS_GetPrototype(cx, proxy, proto.handle_mut()) || proto.is_null() {
-        *found = false;
-        return true;
-    }
-    let mut has_property = false;
-    if !JS_HasPropertyById(cx, proto.handle(), id, &mut has_property) {
-        return false;
-    }
-    *found = has_property;
-    if !has_property {
-        return true;
-    }
-
-    JS_ForwardGetPropertyTo(cx, proto.handle(), id, receiver, vp)
-}
-
-/// Get an array index from the given `jsid`. Returns `None` if the given
-/// `jsid` is not an integer.
-pub(crate) unsafe fn get_array_index_from_id(_cx: *mut JSContext, id: HandleId) -> Option<u32> {
-    let raw_id = *id;
-    if raw_id.is_int() {
-        return Some(raw_id.to_int() as u32);
-    }
-
-    if raw_id.is_void() || !raw_id.is_string() {
-        return None;
-    }
-
-    let atom = raw_id.to_string() as *mut JSAtom;
-    let s = AtomToLinearString(atom);
-    if GetLinearStringLength(s) == 0 {
-        return None;
-    }
-
-    let chars = [GetLinearStringCharAt(s, 0)];
-    let first_char = char::decode_utf16(chars.iter().cloned())
-        .next()
-        .map_or('\0', |r| r.unwrap_or('\0'));
-    if first_char.is_ascii_lowercase() {
-        return None;
-    }
-
-    let mut i = 0;
-    if StringIsArrayIndex(s, &mut i) {
-        Some(i)
-    } else {
-        None
-    }
-
-    /*let s = jsstr_to_string(cx, RUST_JSID_TO_STRING(raw_id));
-    if s.len() == 0 {
-        return None;
-    }
-
-    let first = s.chars().next().unwrap();
-    if first.is_ascii_lowercase() {
-        return None;
-    }
-
-    let mut i: u32 = 0;
-    let is_array = if s.is_ascii() {
-        let chars = s.as_bytes();
-        StringIsArrayIndex1(chars.as_ptr() as *const _, chars.len() as u32, &mut i)
-    } else {
-        let chars = s.encode_utf16().collect::<Vec<u16>>();
-        let slice = chars.as_slice();
-        StringIsArrayIndex2(slice.as_ptr(), chars.len() as u32, &mut i)
-    };
-
-    if is_array {
-        Some(i)
-    } else {
-        None
-    }*/
-}
-
-/// Find the enum equivelent of a string given by `v` in `pairs`.
-/// Returns `Err(())` on JSAPI failure (there is a pending exception), and
-/// `Ok((None, value))` if there was no matching string.
-pub(crate) unsafe fn find_enum_value<'a, T>(
-    cx: *mut JSContext,
-    v: HandleValue,
-    pairs: &'a [(&'static str, T)],
-) -> Result<(Option<&'a T>, DOMString), ()> {
-    match ptr::NonNull::new(ToString(cx, v)) {
-        Some(jsstr) => {
-            let search = jsstring_to_str(cx, jsstr);
-            Ok((
-                pairs
-                    .iter()
-                    .find(|&&(key, _)| search == *key)
-                    .map(|(_, ev)| ev),
-                search,
-            ))
-        },
-        None => Err(()),
-    }
 }
 
 /// Returns wether `obj` is a platform object using dynamic unwrap
@@ -233,92 +104,6 @@ fn is_platform_object(
         // TODO also check if JS_IsArrayBufferObject
         is_dom_class(&*clasp)
     }
-}
-
-/// Get the property with name `property` from `object`.
-/// Returns `Err(())` on JSAPI failure (there is a pending exception), and
-/// `Ok(false)` if there was no property with the given name.
-pub(crate) fn get_dictionary_property(
-    cx: *mut JSContext,
-    object: HandleObject,
-    property: &str,
-    rval: MutableHandleValue,
-    _can_gc: CanGc,
-) -> Result<bool, ()> {
-    fn has_property(
-        cx: *mut JSContext,
-        object: HandleObject,
-        property: &CString,
-        found: &mut bool,
-    ) -> bool {
-        unsafe { JS_HasProperty(cx, object, property.as_ptr(), found) }
-    }
-    fn get_property(
-        cx: *mut JSContext,
-        object: HandleObject,
-        property: &CString,
-        value: MutableHandleValue,
-    ) -> bool {
-        unsafe { JS_GetProperty(cx, object, property.as_ptr(), value) }
-    }
-
-    let property = CString::new(property).unwrap();
-    if object.get().is_null() {
-        return Ok(false);
-    }
-
-    let mut found = false;
-    if !has_property(cx, object, &property, &mut found) {
-        return Err(());
-    }
-
-    if !found {
-        return Ok(false);
-    }
-
-    if !get_property(cx, object, &property, rval) {
-        return Err(());
-    }
-
-    Ok(true)
-}
-
-/// Set the property with name `property` from `object`.
-/// Returns `Err(())` on JSAPI failure, or null object,
-/// and Ok(()) otherwise
-pub(crate) fn set_dictionary_property(
-    cx: *mut JSContext,
-    object: HandleObject,
-    property: &str,
-    value: HandleValue,
-) -> Result<(), ()> {
-    if object.get().is_null() {
-        return Err(());
-    }
-
-    let property = CString::new(property).unwrap();
-    unsafe {
-        if !JS_SetProperty(cx, object, property.as_ptr(), value) {
-            return Err(());
-        }
-    }
-
-    Ok(())
-}
-
-/// Returns whether `proxy` has a property `id` on its prototype.
-pub(crate) unsafe fn has_property_on_prototype(
-    cx: *mut JSContext,
-    proxy: HandleObject,
-    id: HandleId,
-    found: &mut bool,
-) -> bool {
-    rooted!(in(cx) let mut proto = ptr::null_mut::<JSObject>());
-    if !JS_GetPrototype(cx, proxy, proto.handle_mut()) {
-        return false;
-    }
-    assert!(!proto.is_null());
-    JS_HasPropertyById(cx, proto.handle(), id, found)
 }
 
 /// Trace the resources held by reserved slots of a global object
@@ -390,141 +175,6 @@ pub(crate) unsafe extern "C" fn resolve_global(
     true
 }
 
-/// Deletes the property `id` from `object`.
-pub(crate) unsafe fn delete_property_by_id(
-    cx: *mut JSContext,
-    object: HandleObject,
-    id: HandleId,
-    bp: *mut ObjectOpResult,
-) -> bool {
-    JS_DeletePropertyById(cx, object, id, bp)
-}
-
-unsafe fn generic_call<const EXCEPTION_TO_REJECTION: bool>(
-    cx: *mut JSContext,
-    argc: libc::c_uint,
-    vp: *mut JSVal,
-    is_lenient: bool,
-    call: unsafe extern "C" fn(
-        *const JSJitInfo,
-        *mut JSContext,
-        RawHandleObject,
-        *mut libc::c_void,
-        u32,
-        *mut JSVal,
-    ) -> bool,
-    can_gc: CanGc,
-) -> bool {
-    let args = CallArgs::from_vp(vp, argc);
-
-    let info = RUST_FUNCTION_VALUE_TO_JITINFO(JS_CALLEE(cx, vp));
-    let proto_id = (*info).__bindgen_anon_2.protoID;
-    let cx = SafeJSContext::from_ptr(cx);
-
-    let thisobj = args.thisv();
-    if !thisobj.get().is_null_or_undefined() && !thisobj.get().is_object() {
-        throw_invalid_this(cx, proto_id);
-        return if EXCEPTION_TO_REJECTION {
-            exception_to_promise(*cx, args.rval(), can_gc)
-        } else {
-            false
-        };
-    }
-
-    rooted!(in(*cx) let obj = if thisobj.get().is_object() {
-        thisobj.get().to_object()
-    } else {
-        GetNonCCWObjectGlobal(JS_CALLEE(*cx, vp).to_object_or_null())
-    });
-    let depth = (*info).__bindgen_anon_3.depth as usize;
-    let proto_check = PrototypeCheck::Depth { depth, proto_id };
-    let this = match private_from_proto_check(obj.get(), *cx, proto_check) {
-        Ok(val) => val,
-        Err(()) => {
-            if is_lenient {
-                debug_assert!(!JS_IsExceptionPending(*cx));
-                *vp = UndefinedValue();
-                return true;
-            } else {
-                throw_invalid_this(cx, proto_id);
-                return if EXCEPTION_TO_REJECTION {
-                    exception_to_promise(*cx, args.rval(), can_gc)
-                } else {
-                    false
-                };
-            }
-        },
-    };
-    call(
-        info,
-        *cx,
-        obj.handle().into(),
-        this as *mut libc::c_void,
-        argc,
-        vp,
-    )
-}
-
-/// Generic method of IDL interface.
-pub(crate) unsafe extern "C" fn generic_method<const EXCEPTION_TO_REJECTION: bool>(
-    cx: *mut JSContext,
-    argc: libc::c_uint,
-    vp: *mut JSVal,
-) -> bool {
-    generic_call::<EXCEPTION_TO_REJECTION>(cx, argc, vp, false, CallJitMethodOp, CanGc::note())
-}
-
-/// Generic getter of IDL interface.
-pub(crate) unsafe extern "C" fn generic_getter<const EXCEPTION_TO_REJECTION: bool>(
-    cx: *mut JSContext,
-    argc: libc::c_uint,
-    vp: *mut JSVal,
-) -> bool {
-    generic_call::<EXCEPTION_TO_REJECTION>(cx, argc, vp, false, CallJitGetterOp, CanGc::note())
-}
-
-/// Generic lenient getter of IDL interface.
-pub(crate) unsafe extern "C" fn generic_lenient_getter<const EXCEPTION_TO_REJECTION: bool>(
-    cx: *mut JSContext,
-    argc: libc::c_uint,
-    vp: *mut JSVal,
-) -> bool {
-    generic_call::<EXCEPTION_TO_REJECTION>(cx, argc, vp, true, CallJitGetterOp, CanGc::note())
-}
-
-unsafe extern "C" fn call_setter(
-    info: *const JSJitInfo,
-    cx: *mut JSContext,
-    handle: RawHandleObject,
-    this: *mut libc::c_void,
-    argc: u32,
-    vp: *mut JSVal,
-) -> bool {
-    if !CallJitSetterOp(info, cx, handle, this, argc, vp) {
-        return false;
-    }
-    *vp = UndefinedValue();
-    true
-}
-
-/// Generic setter of IDL interface.
-pub(crate) unsafe extern "C" fn generic_setter(
-    cx: *mut JSContext,
-    argc: libc::c_uint,
-    vp: *mut JSVal,
-) -> bool {
-    generic_call::<false>(cx, argc, vp, false, call_setter, CanGc::note())
-}
-
-/// Generic lenient setter of IDL interface.
-pub(crate) unsafe extern "C" fn generic_lenient_setter(
-    cx: *mut JSContext,
-    argc: libc::c_uint,
-    vp: *mut JSVal,
-) -> bool {
-    generic_call::<false>(cx, argc, vp, true, call_setter, CanGc::note())
-}
-
 unsafe extern "C" fn instance_class_has_proto_at_depth(
     clasp: *const js::jsapi::JSClass,
     proto_id: u32,
@@ -558,48 +208,6 @@ pub(crate) trait AsCCharPtrPtr {
 impl AsCCharPtrPtr for [u8] {
     fn as_c_char_ptr(&self) -> *const c_char {
         self as *const [u8] as *const c_char
-    }
-}
-
-/// <https://searchfox.org/mozilla-central/rev/7279a1df13a819be254fd4649e07c4ff93e4bd45/dom/bindings/BindingUtils.cpp#3300>
-pub(crate) unsafe extern "C" fn generic_static_promise_method(
-    cx: *mut JSContext,
-    argc: libc::c_uint,
-    vp: *mut JSVal,
-) -> bool {
-    let args = CallArgs::from_vp(vp, argc);
-
-    let info = RUST_FUNCTION_VALUE_TO_JITINFO(JS_CALLEE(cx, vp));
-    assert!(!info.is_null());
-    // TODO: we need safe wrappers for this in mozjs!
-    //assert_eq!((*info)._bitfield_1, JSJitInfo_OpType::StaticMethod as u8)
-    let static_fn = (*info).__bindgen_anon_1.staticMethod.unwrap();
-    if static_fn(cx, argc, vp) {
-        return true;
-    }
-    exception_to_promise(cx, args.rval(), CanGc::note())
-}
-
-/// Coverts exception to promise rejection
-///
-/// <https://searchfox.org/mozilla-central/rev/b220e40ff2ee3d10ce68e07d8a8a577d5558e2a2/dom/bindings/BindingUtils.cpp#3315>
-pub(crate) unsafe fn exception_to_promise(
-    cx: *mut JSContext,
-    rval: RawMutableHandleValue,
-    _can_gc: CanGc,
-) -> bool {
-    rooted!(in(cx) let mut exception = UndefinedValue());
-    if !JS_GetPendingException(cx, exception.handle_mut()) {
-        return false;
-    }
-    JS_ClearPendingException(cx);
-    if let Some(promise) = NonNull::new(CallOriginalPromiseReject(cx, exception.handle())) {
-        promise.to_jsval(cx, MutableHandleValue::from_raw(rval));
-        true
-    } else {
-        // We just give up.  Put the exception back.
-        JS_SetPendingException(cx, exception.handle(), ExceptionStackBehavior::Capture);
-        false
     }
 }
 

--- a/components/script/dom/bindings/utils.rs
+++ b/components/script/dom/bindings/utils.rs
@@ -12,21 +12,15 @@ use std::{ptr, slice};
 use js::conversions::ToJSValConvertible;
 use js::glue::{IsWrapper, UnwrapObjectDynamic, UnwrapObjectStatic};
 use js::jsapi::{
-    CallArgs, DOMCallbacks, HandleId as RawHandleId,
-    HandleObject as RawHandleObject, Heap,
+    CallArgs, DOMCallbacks, HandleId as RawHandleId, HandleObject as RawHandleObject, Heap,
     JS_DeprecatedStringHasLatin1Chars, JS_EnumerateStandardClasses, JS_FreezeObject,
-    JS_GetLatin1StringCharsAndLength, JS_IsGlobalObject,
-    JS_ResolveStandardClass, JSContext, JSObject, JSTracer,
-    MutableHandleIdVector as RawMutableHandleIdVector,
+    JS_GetLatin1StringCharsAndLength, JS_IsGlobalObject, JS_ResolveStandardClass, JSContext,
+    JSObject, JSTracer, MutableHandleIdVector as RawMutableHandleIdVector,
 };
-use js::rust::{
-    Handle, HandleObject, MutableHandleValue,
-    get_object_class, is_dom_class,
-};
+use js::rust::{Handle, HandleObject, MutableHandleValue, get_object_class, is_dom_class};
 
 use crate::DomTypes;
-use crate::dom::bindings::codegen::InterfaceObjectMap;
-use crate::dom::bindings::codegen::PrototypeList;
+use crate::dom::bindings::codegen::{InterfaceObjectMap, PrototypeList};
 use crate::dom::bindings::constructor::call_html_constructor;
 use crate::dom::bindings::conversions::DerivedFrom;
 use crate::dom::bindings::error::{Error, throw_dom_exception};

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -51,6 +51,7 @@ use num_traits::ToPrimitive;
 use percent_encoding::percent_decode;
 use profile_traits::ipc as profile_ipc;
 use profile_traits::time::TimerMetadataFrameType;
+use script_bindings::interfaces::DocumentHelpers;
 use script_layout_interface::{PendingRestyle, TrustedNodeAddress};
 use script_traits::{
     AnimationState, ConstellationInputEvent, DocumentActivity, ProgressiveWebMetricType, ScriptMsg,
@@ -78,7 +79,6 @@ use super::bindings::codegen::Bindings::XPathEvaluatorBinding::XPathEvaluatorMet
 use super::canvasrenderingcontext2d::CanvasRenderingContext2D;
 use super::clipboardevent::ClipboardEventType;
 use super::performancepainttiming::PerformancePaintTiming;
-use crate::DomTypes;
 use crate::animation_timeline::AnimationTimeline;
 use crate::animations::Animations;
 use crate::canvas_context::CanvasContext as _;
@@ -6398,11 +6398,7 @@ fn is_named_element_with_id_attribute(elem: &Element) -> bool {
     elem.is::<HTMLImageElement>() && elem.get_name().is_some_and(|name| !name.is_empty())
 }
 
-pub(crate) trait DocumentHelpers<D: DomTypes> {
-    fn ensure_safe_to_run_script_or_layout(&self);
-}
-
-impl DocumentHelpers<crate::DomTypeHolder> for Document {
+impl DocumentHelpers for Document {
     fn ensure_safe_to_run_script_or_layout(&self) {
         Document::ensure_safe_to_run_script_or_layout(self)
     }

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -3348,6 +3348,8 @@ pub(crate) trait GlobalScopeHelpers<D: crate::DomTypes> {
     fn perform_a_microtask_checkpoint(&self, can_gc: CanGc);
 
     fn get_url(&self) -> ServoUrl;
+
+    fn is_secure_context(&self) -> bool;
 }
 
 #[allow(unsafe_code)]
@@ -3386,5 +3388,9 @@ impl GlobalScopeHelpers<crate::DomTypeHolder> for GlobalScope {
 
     fn get_url(&self) -> ServoUrl {
         self.get_url()
+    }
+
+    fn is_secure_context(&self) -> bool {
+        self.is_secure_context()
     }
 }

--- a/components/script/dom/servointernals.rs
+++ b/components/script/dom/servointernals.rs
@@ -5,7 +5,10 @@
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
+use js::rust::HandleObject;
 use profile_traits::mem::MemoryReportResult;
+use script_bindings::interfaces::ServoInternalsHelpers;
+use script_bindings::script_runtime::JSContext;
 use script_traits::ScriptMsg;
 
 use crate::dom::bindings::codegen::Bindings::ServoInternalsBinding::ServoInternalsMethods;
@@ -14,7 +17,7 @@ use crate::dom::bindings::reflector::{DomGlobal, Reflector, reflect_dom_object};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
-use crate::realms::InRealm;
+use crate::realms::{AlreadyInRealm, InRealm};
 use crate::routed_promise::{RoutedPromiseListener, route_promise};
 use crate::script_runtime::CanGc;
 
@@ -55,5 +58,18 @@ impl ServoInternalsMethods<crate::DomTypeHolder> for ServoInternals {
 impl RoutedPromiseListener<MemoryReportResult> for ServoInternals {
     fn handle_response(&self, response: MemoryReportResult, promise: &Rc<Promise>, can_gc: CanGc) {
         promise.resolve_native(&response.content, can_gc);
+    }
+}
+
+impl ServoInternalsHelpers for ServoInternals {
+    /// The navigator.servo api is only exposed to about: pages except about:blank
+    #[allow(unsafe_code)]
+    fn is_servo_internal(cx: JSContext, _global: HandleObject) -> bool {
+        unsafe {
+            let in_realm_proof = AlreadyInRealm::assert_for_cx(cx);
+            let global_scope = GlobalScope::from_context(*cx, InRealm::Already(&in_realm_proof));
+            let url = global_scope.get_url();
+            url.scheme() == "about" && url.as_str() != "about:blank"
+        }
     }
 }

--- a/components/script/dom/testbinding.rs
+++ b/components/script/dom/testbinding.rs
@@ -14,6 +14,7 @@ use js::jsapi::{Heap, JS_NewPlainObject, JSObject};
 use js::jsval::JSVal;
 use js::rust::{CustomAutoRooterGuard, HandleObject, HandleValue, MutableHandleValue};
 use js::typedarray::{self, Uint8ClampedArray};
+use script_bindings::interfaces::TestBindingHelpers;
 use script_bindings::record::Record;
 use script_traits::serializable::BlobImpl;
 use servo_config::prefs;
@@ -1169,5 +1170,14 @@ impl TestBindingCallback {
         self.promise
             .root()
             .resolve_native(&self.value, CanGc::note());
+    }
+}
+
+impl TestBindingHelpers for TestBinding {
+    fn condition_satisfied(cx: SafeJSContext, global: HandleObject) -> bool {
+        Self::condition_satisfied(cx, global)
+    }
+    fn condition_unsatisfied(cx: SafeJSContext, global: HandleObject) -> bool {
+        Self::condition_unsatisfied(cx, global)
     }
 }

--- a/components/script/dom/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl2renderingcontext.rs
@@ -21,6 +21,7 @@ use js::jsapi::{JSObject, Type};
 use js::jsval::{BooleanValue, DoubleValue, Int32Value, NullValue, ObjectValue, UInt32Value};
 use js::rust::{CustomAutoRooterGuard, HandleObject, MutableHandleValue};
 use js::typedarray::{ArrayBufferView, CreateWith, Float32, Int32Array, Uint32, Uint32Array};
+use script_bindings::interfaces::WebGL2RenderingContextHelpers;
 use script_layout_interface::HTMLCanvasDataSource;
 use servo_config::pref;
 use url::Host;
@@ -4707,5 +4708,11 @@ impl LayoutCanvasRenderingContextHelpers for LayoutDom<'_, WebGL2RenderingContex
     fn canvas_data_source(self) -> HTMLCanvasDataSource {
         let this = self.unsafe_get();
         unsafe { (*this.base.to_layout().unsafe_get()).layout_handle() }
+    }
+}
+
+impl WebGL2RenderingContextHelpers for WebGL2RenderingContext {
+    fn is_webgl2_enabled(cx: JSContext, global: HandleObject) -> bool {
+        Self::is_webgl2_enabled(cx, global)
     }
 }

--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -852,7 +852,7 @@ unsafe fn GetSubframeWindowProxy(
     proxy: RawHandleObject,
     id: RawHandleId,
 ) -> Option<(DomRoot<WindowProxy>, u32)> {
-    let index = get_array_index_from_id(cx, Handle::from_raw(id));
+    let index = get_array_index_from_id(Handle::from_raw(id));
     if let Some(index) = index {
         let mut slot = UndefinedValue();
         GetProxyPrivate(*proxy, &mut slot);
@@ -934,7 +934,7 @@ unsafe extern "C" fn defineProperty(
     desc: RawHandle<PropertyDescriptor>,
     res: *mut ObjectOpResult,
 ) -> bool {
-    if get_array_index_from_id(cx, Handle::from_raw(id)).is_some() {
+    if get_array_index_from_id(Handle::from_raw(id)).is_some() {
         // Spec says to Reject whether this is a supported index or not,
         // since we have no indexed setter or indexed creator.  That means
         // throwing in strict mode (FIXME: Bug 828137), doing nothing in
@@ -1003,7 +1003,7 @@ unsafe extern "C" fn set(
     receiver: RawHandleValue,
     res: *mut ObjectOpResult,
 ) -> bool {
-    if get_array_index_from_id(cx, Handle::from_raw(id)).is_some() {
+    if get_array_index_from_id(Handle::from_raw(id)).is_some() {
         // Reject (which means throw if and only if strict) the set.
         (*res).code_ = JSErrNum::JSMSG_READ_ONLY as ::libc::uintptr_t;
         return true;

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -224,7 +224,7 @@ pub(crate) unsafe fn jsval_to_webdriver(
         });
         let _ac = JSAutoRealm::new(cx, *object);
 
-        if is_array_like(cx, val) || is_arguments_object(cx, val) {
+        if is_array_like::<crate::DomTypeHolder>(cx, val) || is_arguments_object(cx, val) {
             let mut result: Vec<WebDriverJSValue> = Vec::new();
 
             let length = match get_property::<u32>(

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -137,7 +137,7 @@ DOMInterfaces = {
 },
 
 'Document': {
-    'additionalTraits': ["crate::dom::document::DocumentHelpers<Self>"],
+    'additionalTraits': ["script_bindings::interfaces::DocumentHelpers"],
     'canGc': ['Close', 'CreateElement', 'CreateElementNS', 'ImportNode', 'SetTitle', 'Write', 'Writeln', 'CreateEvent', 'CreateRange', 'Open', 'Open_', 'CreateComment', 'CreateAttribute', 'CreateAttributeNS', 'CreateDocumentFragment', 'CreateTextNode', 'CreateCDATASection', 'CreateProcessingInstruction', 'Prepend', 'Append', 'ReplaceChildren', 'SetBgColor', 'SetFgColor', 'Fonts', 'ElementFromPoint', 'ElementsFromPoint', 'ExitFullscreen', 'CreateExpression', 'CreateNSResolver', 'Evaluate'],
 },
 
@@ -527,6 +527,7 @@ DOMInterfaces = {
 'ServoInternals': {
     'inRealms': ['ReportMemory'],
     'canGc': ['ReportMemory'],
+    'additionalTraits': ['script_bindings::interfaces::ServoInternalsHelpers'],
 },
 
 'ShadowRoot': {
@@ -550,6 +551,7 @@ DOMInterfaces = {
 'TestBinding': {
     'inRealms': ['PromiseAttribute', 'PromiseNativeHandler'],
     'canGc': ['InterfaceAttribute', 'GetInterfaceAttributeNullable', 'ReceiveInterface', 'ReceiveInterfaceSequence', 'ReceiveNullableInterface', 'PromiseAttribute', 'PromiseNativeHandler', 'PromiseResolveNative', 'PromiseRejectNative', 'PromiseRejectWithTypeError'],
+    'additionalTraits': ['script_bindings::interfaces::TestBindingHelpers'],
 },
 
 'TestWorklet': {
@@ -580,6 +582,7 @@ DOMInterfaces = {
 
 'WebGL2RenderingContext': {
     'canGc': ['MakeXRCompatible'],
+    'additionalTraits': ['script_bindings::interfaces::WebGL2RenderingContextHelpers'],
 },
 
 'Window': {

--- a/components/script_bindings/codegen/CodegenRust.py
+++ b/components/script_bindings/codegen/CodegenRust.py
@@ -3004,8 +3004,8 @@ def InitLegacyUnforgeablePropertiesOnHolder(descriptor, properties):
     """
     unforgeables = []
 
-    defineLegacyUnforgeableAttrs = "define_guarded_properties(cx, unforgeable_holder.handle(), %s, global);"
-    defineLegacyUnforgeableMethods = "define_guarded_methods(cx, unforgeable_holder.handle(), %s, global);"
+    defineLegacyUnforgeableAttrs = "define_guarded_properties::<D>(cx, unforgeable_holder.handle(), %s, global);"
+    defineLegacyUnforgeableMethods = "define_guarded_methods::<D>(cx, unforgeable_holder.handle(), %s, global);"
 
     unforgeableMembers = [
         (defineLegacyUnforgeableAttrs, properties.unforgeable_attrs),
@@ -3175,7 +3175,7 @@ class CGWrapGlobalMethod(CGAbstractMethod):
             ("define_guarded_methods", self.properties.methods),
             ("define_guarded_constants", self.properties.consts)
         ]
-        members = [f"{function}(cx, obj.handle(), {array.variableName()}.get(), obj.handle());"
+        members = [f"{function}::<D>(cx, obj.handle(), {array.variableName()}.get(), obj.handle());"
                    for (function, array) in pairs if array.length() > 0]
         membersStr = "\n".join(members)
 
@@ -3413,7 +3413,7 @@ let global = incumbent_global.reflector().get_jsobject();\n"""
                     """
                     let conditions = ${conditions};
                     let is_satisfied = conditions.iter().any(|c|
-                         c.is_satisfied(
+                         c.is_satisfied::<D>(
                            SafeJSContext::from_ptr(cx),
                            HandleObject::from_raw(obj),
                            global));
@@ -3469,7 +3469,7 @@ class CGCreateInterfaceObjectsMethod(CGAbstractMethod):
 rooted!(in(*cx) let proto = {proto});
 assert!(!proto.is_null());
 rooted!(in(*cx) let mut namespace = ptr::null_mut::<JSObject>());
-create_namespace_object(cx, global, proto.handle(), &NAMESPACE_OBJECT_CLASS,
+create_namespace_object::<D>(cx, global, proto.handle(), &NAMESPACE_OBJECT_CLASS,
                         {methods}, {constants}, {str_to_cstr(name)}, namespace.handle_mut());
 assert!(!namespace.is_null());
 assert!((*cache)[PrototypeList::Constructor::{id} as usize].is_null());
@@ -3483,7 +3483,7 @@ assert!((*cache)[PrototypeList::Constructor::{id} as usize].is_null());
             cName = str_to_cstr(name)
             return CGGeneric(f"""
 rooted!(in(*cx) let mut interface = ptr::null_mut::<JSObject>());
-create_callback_interface_object(cx, global, sConstants.get(), {cName}, interface.handle_mut());
+create_callback_interface_object::<D>(cx, global, sConstants.get(), {cName}, interface.handle_mut());
 assert!(!interface.is_null());
 assert!((*cache)[PrototypeList::Constructor::{name} as usize].is_null());
 (*cache)[PrototypeList::Constructor::{name} as usize] = interface.get();
@@ -3544,7 +3544,7 @@ assert!(!prototype_proto.is_null());"""))
 
         code.append(CGGeneric(f"""
 rooted!(in(*cx) let mut prototype = ptr::null_mut::<JSObject>());
-create_interface_prototype_object(cx,
+create_interface_prototype_object::<D>(cx,
                                   global,
                                   prototype_proto.handle(),
                                   &PrototypeClass,
@@ -3579,7 +3579,7 @@ assert!((*cache)[PrototypeList::ID::{proto_properties['id']} as usize].is_null()
 assert!(!interface_proto.is_null());
 
 rooted!(in(*cx) let mut interface = ptr::null_mut::<JSObject>());
-create_noncallback_interface_object(cx,
+create_noncallback_interface_object::<D>(cx,
                                     global,
                                     interface_proto.handle(),
                                     INTERFACE_OBJECT_CLASS.get(),

--- a/components/script_bindings/codegen/CodegenRust.py
+++ b/components/script_bindings/codegen/CodegenRust.py
@@ -5928,7 +5928,7 @@ class CGDOMJSProxyHandler_getOwnPropertyDescriptor(CGAbstractExternMethod):
                 """)
 
         if indexedGetter:
-            get += "let index = get_array_index_from_id(*cx, Handle::from_raw(id));\n"
+            get += "let index = get_array_index_from_id(Handle::from_raw(id));\n"
 
             attrs = "JSPROP_ENUMERATE"
             if self.descriptor.operations['IndexedSetter'] is None:
@@ -6043,7 +6043,7 @@ class CGDOMJSProxyHandler_defineProperty(CGAbstractExternMethod):
 
         indexedSetter = self.descriptor.operations['IndexedSetter']
         if indexedSetter:
-            set += ("let index = get_array_index_from_id(*cx, Handle::from_raw(id));\n"
+            set += ("let index = get_array_index_from_id(Handle::from_raw(id));\n"
                     "if let Some(index) = index {\n"
                     "    let this = UnwrapProxy::<D>(proxy);\n"
                     "    let this = &*this;\n"
@@ -6051,7 +6051,7 @@ class CGDOMJSProxyHandler_defineProperty(CGAbstractExternMethod):
                     "    return (*opresult).succeed();\n"
                     "}\n")
         elif self.descriptor.operations['IndexedGetter']:
-            set += ("if get_array_index_from_id(*cx, Handle::from_raw(id)).is_some() {\n"
+            set += ("if get_array_index_from_id(Handle::from_raw(id)).is_some() {\n"
                     "    return (*opresult).failNoIndexedSetter();\n"
                     "}\n")
 
@@ -6266,7 +6266,7 @@ class CGDOMJSProxyHandler_hasOwn(CGAbstractExternMethod):
                 """)
 
         if indexedGetter:
-            indexed += ("let index = get_array_index_from_id(*cx, Handle::from_raw(id));\n"
+            indexed += ("let index = get_array_index_from_id(Handle::from_raw(id));\n"
                         "if let Some(index) = index {\n"
                         "    let this = UnwrapProxy::<D>(proxy);\n"
                         "    let this = &*this;\n"
@@ -6358,7 +6358,7 @@ if !expando.is_null() {
 
         indexedGetter = self.descriptor.operations['IndexedGetter']
         if indexedGetter:
-            getIndexedOrExpando = ("let index = get_array_index_from_id(*cx, id_lt);\n"
+            getIndexedOrExpando = ("let index = get_array_index_from_id(id_lt);\n"
                                    "if let Some(index) = index {\n"
                                    "    let this = UnwrapProxy::<D>(proxy);\n"
                                    "    let this = &*this;\n"

--- a/components/script_bindings/codegen/CodegenRust.py
+++ b/components/script_bindings/codegen/CodegenRust.py
@@ -498,7 +498,7 @@ class CGMethodCall(CGThing):
             # XXXbz Now we're supposed to check for distinguishingArg being
             # an array or a platform object that supports indexed
             # properties... skip that last for now.  It's a bit of a pain.
-            pickFirstSignature(f"{distinguishingArg}.get().is_object() && is_array_like(*cx, {distinguishingArg})",
+            pickFirstSignature(f"{distinguishingArg}.get().is_object() && is_array_like::<D>(*cx, {distinguishingArg})",
                                lambda s:
                                    (s[1][distinguishingIndex].type.isSequence()
                                     or s[1][distinguishingIndex].type.isObject()))

--- a/components/script_bindings/conversions.rs
+++ b/components/script_bindings/conversions.rs
@@ -468,23 +468,29 @@ unsafe fn private_from_proto_check_static(
 
 /// Get a `*const T` for a DOM object accessible from a `JSObject`, where the DOM object
 /// is guaranteed not to be a wrapper.
+///
+/// # Safety
+/// `obj` must point to a valid, non-null JSObject.
 #[allow(clippy::result_unit_err)]
-pub fn native_from_object_static<T>(obj: *mut JSObject) -> Result<*const T, ()>
+pub unsafe fn native_from_object_static<T>(obj: *mut JSObject) -> Result<*const T, ()>
 where
     T: DomObject + IDLInterface,
 {
-    unsafe { private_from_proto_check_static(obj, T::derives).map(|ptr| ptr as *const T) }
+    private_from_proto_check_static(obj, T::derives).map(|ptr| ptr as *const T)
 }
 
 /// Get a `*const T` for a DOM object accessible from a `HandleValue`.
 /// Caller is responsible for throwing a JS exception if needed in case of error.
+///
+/// # Safety
+/// `cx` must point to a valid, non-null JSContext.
 #[allow(clippy::result_unit_err)]
-pub fn native_from_handlevalue<T>(v: HandleValue, cx: *mut JSContext) -> Result<*const T, ()>
+pub unsafe fn native_from_handlevalue<T>(v: HandleValue, cx: *mut JSContext) -> Result<*const T, ()>
 where
     T: DomObject + IDLInterface,
 {
     if !v.get().is_object() {
         return Err(());
     }
-    unsafe { native_from_object(v.get().to_object(), cx) }
+    native_from_object(v.get().to_object(), cx)
 }

--- a/components/script_bindings/conversions.rs
+++ b/components/script_bindings/conversions.rs
@@ -444,3 +444,47 @@ impl<T: Float + FromJSValConvertible<Config = ()>> FromJSValConvertible for Fini
         }
     }
 }
+
+/// Get a `*const libc::c_void` for the given DOM object, unless it is a DOM
+/// wrapper, and checking if the object is of the correct type.
+///
+/// Returns Err(()) if `obj` is a wrapper or if the object is not an object
+/// for a DOM object of the given type (as defined by the proto_id and proto_depth).
+#[inline]
+#[allow(clippy::result_unit_err)]
+unsafe fn private_from_proto_check_static(
+    obj: *mut JSObject,
+    proto_check: fn(&'static DOMClass) -> bool,
+) -> Result<*const libc::c_void, ()> {
+    let dom_class = get_dom_class(obj).map_err(|_| ())?;
+    if proto_check(dom_class) {
+        trace!("good prototype");
+        Ok(private_from_object(obj))
+    } else {
+        trace!("bad prototype");
+        Err(())
+    }
+}
+
+/// Get a `*const T` for a DOM object accessible from a `JSObject`, where the DOM object
+/// is guaranteed not to be a wrapper.
+#[allow(clippy::result_unit_err)]
+pub fn native_from_object_static<T>(obj: *mut JSObject) -> Result<*const T, ()>
+where
+    T: DomObject + IDLInterface,
+{
+    unsafe { private_from_proto_check_static(obj, T::derives).map(|ptr| ptr as *const T) }
+}
+
+/// Get a `*const T` for a DOM object accessible from a `HandleValue`.
+/// Caller is responsible for throwing a JS exception if needed in case of error.
+#[allow(clippy::result_unit_err)]
+pub fn native_from_handlevalue<T>(v: HandleValue, cx: *mut JSContext) -> Result<*const T, ()>
+where
+    T: DomObject + IDLInterface,
+{
+    if !v.get().is_object() {
+        return Err(());
+    }
+    unsafe { native_from_object(v.get().to_object(), cx) }
+}

--- a/components/script_bindings/error.rs
+++ b/components/script_bindings/error.rs
@@ -6,7 +6,7 @@ use js::error::throw_type_error;
 use js::jsapi::JS_IsExceptionPending;
 
 use crate::codegen::PrototypeList::proto_id_to_name;
-use crate::script_runtime::{JSContext as SafeJSContext};
+use crate::script_runtime::JSContext as SafeJSContext;
 
 /// DOM exceptions that can be thrown by a native DOM method.
 #[derive(Clone, Debug, MallocSizeOf)]

--- a/components/script_bindings/error.rs
+++ b/components/script_bindings/error.rs
@@ -2,6 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use js::error::throw_type_error;
+use js::jsapi::JS_IsExceptionPending;
+
+use crate::codegen::PrototypeList::proto_id_to_name;
+use crate::script_runtime::{JSContext as SafeJSContext};
+
 /// DOM exceptions that can be thrown by a native DOM method.
 #[derive(Clone, Debug, MallocSizeOf)]
 pub enum Error {
@@ -69,3 +75,20 @@ pub type Fallible<T> = Result<T, Error>;
 /// The return type for IDL operations that can throw DOM exceptions and
 /// return `()`.
 pub type ErrorResult = Fallible<()>;
+
+/// Throw an exception to signal that a `JSObject` can not be converted to a
+/// given DOM type.
+pub fn throw_invalid_this(cx: SafeJSContext, proto_id: u16) {
+    debug_assert!(unsafe { !JS_IsExceptionPending(*cx) });
+    let error = format!(
+        "\"this\" object does not implement interface {}.",
+        proto_id_to_name(proto_id)
+    );
+    unsafe { throw_type_error(*cx, &error) };
+}
+
+pub fn throw_constructor_without_new(cx: SafeJSContext, name: &str) {
+    debug_assert!(unsafe { !JS_IsExceptionPending(*cx) });
+    let error = format!("{} constructor: 'new' is required", name);
+    unsafe { throw_type_error(*cx, &error) };
+}

--- a/components/script_bindings/finalize.rs
+++ b/components/script_bindings/finalize.rs
@@ -28,6 +28,8 @@ unsafe fn do_finalize_global(obj: *mut JSObject) {
     let _: Box<ProtoOrIfaceArray> = Box::from_raw(protolist);
 }
 
+/// # Safety
+/// `this` must point to a valid, non-null instance of T.
 pub unsafe fn finalize_common<T>(this: *const T) {
     if !this.is_null() {
         // The pointer can be null if the object is the unforgeable holder of that interface.
@@ -36,11 +38,17 @@ pub unsafe fn finalize_common<T>(this: *const T) {
     debug!("{} finalize: {:p}", type_name::<T>(), this);
 }
 
+/// # Safety
+/// `obj` must point to a valid, non-null JS object.
+/// `this` must point to a valid, non-null instance of T.
 pub unsafe fn finalize_global<T>(obj: *mut JSObject, this: *const T) {
     do_finalize_global(obj);
     finalize_common::<T>(this);
 }
 
+/// # Safety
+/// `obj` must point to a valid, non-null JS object.
+/// `this` must point to a valid, non-null instance of T.
 pub unsafe fn finalize_weak_referenceable<T: WeakReferenceable>(
     obj: *mut JSObject,
     this: *const T,

--- a/components/script_bindings/finalize.rs
+++ b/components/script_bindings/finalize.rs
@@ -5,8 +5,7 @@
 //! Generic finalizer implementations for DOM binding implementations.
 
 use std::any::type_name;
-use std::mem;
-use std::ptr;
+use std::{mem, ptr};
 
 use js::glue::JS_GetReservedSlot;
 use js::jsapi::JSObject;
@@ -14,7 +13,7 @@ use js::jsval::UndefinedValue;
 use js::rust::GCMethods;
 
 use crate::codegen::PrototypeList::PROTO_OR_IFACE_LENGTH;
-use crate::utils::{get_proto_or_iface_array, ProtoOrIfaceArray};
+use crate::utils::{ProtoOrIfaceArray, get_proto_or_iface_array};
 use crate::weakref::{DOM_WEAK_SLOT, WeakBox, WeakReferenceable};
 
 /// Drop the resources held by reserved slots of a global object

--- a/components/script_bindings/interfaces.rs
+++ b/components/script_bindings/interfaces.rs
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use js::rust::HandleObject;
+
+use crate::script_runtime::JSContext;
+
+pub trait DocumentHelpers {
+    fn ensure_safe_to_run_script_or_layout(&self);
+}
+
+pub trait ServoInternalsHelpers {
+    fn is_servo_internal(cx: JSContext, global: HandleObject) -> bool;
+}
+
+pub trait TestBindingHelpers {
+    fn condition_satisfied(cx: JSContext, global: HandleObject) -> bool;
+    fn condition_unsatisfied(cx: JSContext, global: HandleObject) -> bool;
+}
+
+pub trait WebGL2RenderingContextHelpers {
+    fn is_webgl2_enabled(cx: JSContext, global: HandleObject) -> bool;
+}

--- a/components/script_bindings/lib.rs
+++ b/components/script_bindings/lib.rs
@@ -21,6 +21,7 @@ pub mod callback;
 pub mod constant;
 pub mod conversions;
 pub mod error;
+pub mod finalize;
 pub mod inheritance;
 pub mod iterable;
 pub mod like;

--- a/components/script_bindings/lib.rs
+++ b/components/script_bindings/lib.rs
@@ -24,6 +24,7 @@ pub mod error;
 pub mod inheritance;
 pub mod iterable;
 pub mod like;
+pub mod num;
 pub mod record;
 pub mod reflector;
 pub mod root;

--- a/components/script_bindings/lib.rs
+++ b/components/script_bindings/lib.rs
@@ -24,6 +24,7 @@ pub mod error;
 pub mod inheritance;
 pub mod iterable;
 pub mod like;
+pub mod lock;
 pub mod num;
 pub mod record;
 pub mod reflector;

--- a/components/script_bindings/lib.rs
+++ b/components/script_bindings/lib.rs
@@ -23,6 +23,7 @@ pub mod conversions;
 pub mod error;
 pub mod finalize;
 pub mod inheritance;
+pub mod interfaces;
 pub mod iterable;
 pub mod like;
 pub mod lock;

--- a/components/script_bindings/lock.rs
+++ b/components/script_bindings/lock.rs
@@ -13,6 +13,7 @@ use std::sync::OnceLock;
 pub struct ThreadUnsafeOnceLock<T>(OnceLock<T>);
 
 impl<T> ThreadUnsafeOnceLock<T> {
+    #[allow(clippy::new_without_default)]
     pub const fn new() -> Self {
         Self(OnceLock::new())
     }
@@ -24,7 +25,7 @@ impl<T> ThreadUnsafeOnceLock<T> {
 
     /// Get a reference to the value inside this lock. Panics if the lock has not been initialized.
     ///
-    /// SAFETY:
+    /// # Safety
     ///   The caller must ensure that it does not mutate value contained inside this lock
     ///   (using interior mutability).
     pub unsafe fn get(&self) -> &T {

--- a/components/script_bindings/lock.rs
+++ b/components/script_bindings/lock.rs
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::sync::OnceLock;
+
+/// A OnceLock wrapping a type that is not considered threadsafe by the Rust compiler, but
+/// will be used in a threadsafe manner (it will not be mutated, after being initialized).
+///
+/// This is needed to allow using JS API types (which usually involve raw pointers) in static initializers,
+/// when Servo guarantees through the use of OnceLock that only one thread will ever initialize
+/// the value.
+pub struct ThreadUnsafeOnceLock<T>(OnceLock<T>);
+
+impl<T> ThreadUnsafeOnceLock<T> {
+    pub const fn new() -> Self {
+        Self(OnceLock::new())
+    }
+
+    /// Initialize the value inside this lock. Panics if the lock has been previously initialized.
+    pub fn set(&self, val: T) {
+        assert!(self.0.set(val).is_ok());
+    }
+
+    /// Get a reference to the value inside this lock. Panics if the lock has not been initialized.
+    ///
+    /// SAFETY:
+    ///   The caller must ensure that it does not mutate value contained inside this lock
+    ///   (using interior mutability).
+    pub unsafe fn get(&self) -> &T {
+        self.0.get().unwrap()
+    }
+}
+
+unsafe impl<T> Sync for ThreadUnsafeOnceLock<T> {}
+unsafe impl<T> Send for ThreadUnsafeOnceLock<T> {}

--- a/components/script_bindings/num.rs
+++ b/components/script_bindings/num.rs
@@ -12,11 +12,11 @@ use num_traits::Float;
 
 /// Encapsulates the IDL restricted float type.
 #[derive(Clone, Copy, Eq, JSTraceable, PartialEq)]
-pub(crate) struct Finite<T: Float>(T);
+pub struct Finite<T: Float>(T);
 
 impl<T: Float> Finite<T> {
     /// Create a new `Finite<T: Float>` safely.
-    pub(crate) fn new(value: T) -> Option<Finite<T>> {
+    pub fn new(value: T) -> Option<Finite<T>> {
         if value.is_finite() {
             Some(Finite(value))
         } else {
@@ -26,7 +26,7 @@ impl<T: Float> Finite<T> {
 
     /// Create a new `Finite<T: Float>`.
     #[inline]
-    pub(crate) fn wrap(value: T) -> Finite<T> {
+    pub fn wrap(value: T) -> Finite<T> {
         assert!(
             value.is_finite(),
             "Finite<T> doesn't encapsulate unrestricted value."

--- a/components/script_bindings/utils.rs
+++ b/components/script_bindings/utils.rs
@@ -6,27 +6,36 @@ use std::ffi::CString;
 use std::os::raw::c_void;
 use std::ptr::{self, NonNull};
 
-use js::JS_CALLEE;
 use js::conversions::ToJSValConvertible;
-use js::glue::{JS_GetReservedSlot, RUST_FUNCTION_VALUE_TO_JITINFO, CallJitMethodOp, CallJitGetterOp, CallJitSetterOp};
-use js::jsapi::{JSAtom, JSContext, JSObject, GetLinearStringLength, GetLinearStringCharAt, StringIsArrayIndex, ObjectOpResult, JSJitInfo, HandleObject as RawHandleObject, CallArgs, JS_IsExceptionPending, MutableHandleValue as RawMutableHandleValue, JS_ClearPendingException, ExceptionStackBehavior, AtomToLinearString, GetNonCCWObjectGlobal};
+use js::glue::{
+    CallJitGetterOp, CallJitMethodOp, CallJitSetterOp, JS_GetReservedSlot,
+    RUST_FUNCTION_VALUE_TO_JITINFO,
+};
+use js::jsapi::{
+    AtomToLinearString, CallArgs, ExceptionStackBehavior, GetLinearStringCharAt,
+    GetLinearStringLength, GetNonCCWObjectGlobal, HandleObject as RawHandleObject,
+    JS_ClearPendingException, JS_IsExceptionPending, JSAtom, JSContext, JSJitInfo, JSObject,
+    MutableHandleValue as RawMutableHandleValue, ObjectOpResult, StringIsArrayIndex,
+};
 use js::jsval::{JSVal, UndefinedValue};
-use js::rooted;
-use js::rust::{HandleId, HandleObject, HandleValue, MutableHandleValue, get_object_class, ToString};
 use js::rust::wrappers::{
     CallOriginalPromiseReject, JS_DeletePropertyById, JS_ForwardGetPropertyTo,
     JS_GetPendingException, JS_GetProperty, JS_GetPrototype, JS_HasProperty, JS_HasPropertyById,
     JS_SetPendingException, JS_SetProperty,
 };
+use js::rust::{
+    HandleId, HandleObject, HandleValue, MutableHandleValue, ToString, get_object_class,
+};
+use js::{JS_CALLEE, rooted};
 use malloc_size_of::MallocSizeOfOps;
 
 use crate::codegen::Globals::Globals;
 use crate::codegen::InheritTypes::TopTypeId;
 use crate::codegen::PrototypeList::{self, MAX_PROTO_CHAIN_LENGTH, PROTO_OR_IFACE_LENGTH};
-use crate::conversions::{PrototypeCheck, private_from_proto_check, jsstring_to_str};
+use crate::conversions::{PrototypeCheck, jsstring_to_str, private_from_proto_check};
 use crate::error::throw_invalid_this;
-use crate::str::DOMString;
 use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
+use crate::str::DOMString;
 
 /// The struct that holds inheritance information for DOM object reflectors.
 #[derive(Clone, Copy)]

--- a/components/script_bindings/utils.rs
+++ b/components/script_bindings/utils.rs
@@ -2,17 +2,31 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::ffi::CString;
 use std::os::raw::c_void;
+use std::ptr::{self, NonNull};
 
-use js::glue::JS_GetReservedSlot;
-use js::jsapi::JSObject;
-use js::jsval::UndefinedValue;
-use js::rust::get_object_class;
+use js::JS_CALLEE;
+use js::conversions::ToJSValConvertible;
+use js::glue::{JS_GetReservedSlot, RUST_FUNCTION_VALUE_TO_JITINFO, CallJitMethodOp, CallJitGetterOp, CallJitSetterOp};
+use js::jsapi::{JSAtom, JSContext, JSObject, GetLinearStringLength, GetLinearStringCharAt, StringIsArrayIndex, ObjectOpResult, JSJitInfo, HandleObject as RawHandleObject, CallArgs, JS_IsExceptionPending, MutableHandleValue as RawMutableHandleValue, JS_ClearPendingException, ExceptionStackBehavior, AtomToLinearString, GetNonCCWObjectGlobal};
+use js::jsval::{JSVal, UndefinedValue};
+use js::rooted;
+use js::rust::{HandleId, HandleObject, HandleValue, MutableHandleValue, get_object_class, ToString};
+use js::rust::wrappers::{
+    CallOriginalPromiseReject, JS_DeletePropertyById, JS_ForwardGetPropertyTo,
+    JS_GetPendingException, JS_GetProperty, JS_GetPrototype, JS_HasProperty, JS_HasPropertyById,
+    JS_SetPendingException, JS_SetProperty,
+};
 use malloc_size_of::MallocSizeOfOps;
 
 use crate::codegen::Globals::Globals;
 use crate::codegen::InheritTypes::TopTypeId;
 use crate::codegen::PrototypeList::{self, MAX_PROTO_CHAIN_LENGTH, PROTO_OR_IFACE_LENGTH};
+use crate::conversions::{PrototypeCheck, private_from_proto_check, jsstring_to_str};
+use crate::error::throw_invalid_this;
+use crate::str::DOMString;
+use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
 
 /// The struct that holds inheritance information for DOM object reflectors.
 #[derive(Clone, Copy)]
@@ -78,3 +92,378 @@ pub fn get_proto_or_iface_array(global: *mut JSObject) -> *mut ProtoOrIfaceArray
 
 /// An array of *mut JSObject of size PROTO_OR_IFACE_LENGTH.
 pub type ProtoOrIfaceArray = [*mut JSObject; PROTO_OR_IFACE_LENGTH];
+
+/// Gets the property `id` on  `proxy`'s prototype. If it exists, `*found` is
+/// set to true and `*vp` to the value, otherwise `*found` is set to false.
+///
+/// Returns false on JSAPI failure.
+pub unsafe fn get_property_on_prototype(
+    cx: *mut JSContext,
+    proxy: HandleObject,
+    receiver: HandleValue,
+    id: HandleId,
+    found: *mut bool,
+    vp: MutableHandleValue,
+) -> bool {
+    rooted!(in(cx) let mut proto = ptr::null_mut::<JSObject>());
+    if !JS_GetPrototype(cx, proxy, proto.handle_mut()) || proto.is_null() {
+        *found = false;
+        return true;
+    }
+    let mut has_property = false;
+    if !JS_HasPropertyById(cx, proto.handle(), id, &mut has_property) {
+        return false;
+    }
+    *found = has_property;
+    if !has_property {
+        return true;
+    }
+
+    JS_ForwardGetPropertyTo(cx, proto.handle(), id, receiver, vp)
+}
+
+/// Get an array index from the given `jsid`. Returns `None` if the given
+/// `jsid` is not an integer.
+pub unsafe fn get_array_index_from_id(_cx: *mut JSContext, id: HandleId) -> Option<u32> {
+    let raw_id = *id;
+    if raw_id.is_int() {
+        return Some(raw_id.to_int() as u32);
+    }
+
+    if raw_id.is_void() || !raw_id.is_string() {
+        return None;
+    }
+
+    let atom = raw_id.to_string() as *mut JSAtom;
+    let s = AtomToLinearString(atom);
+    if GetLinearStringLength(s) == 0 {
+        return None;
+    }
+
+    let chars = [GetLinearStringCharAt(s, 0)];
+    let first_char = char::decode_utf16(chars.iter().cloned())
+        .next()
+        .map_or('\0', |r| r.unwrap_or('\0'));
+    if first_char.is_ascii_lowercase() {
+        return None;
+    }
+
+    let mut i = 0;
+    if StringIsArrayIndex(s, &mut i) {
+        Some(i)
+    } else {
+        None
+    }
+
+    /*let s = jsstr_to_string(cx, RUST_JSID_TO_STRING(raw_id));
+    if s.len() == 0 {
+        return None;
+    }
+
+    let first = s.chars().next().unwrap();
+    if first.is_ascii_lowercase() {
+        return None;
+    }
+
+    let mut i: u32 = 0;
+    let is_array = if s.is_ascii() {
+        let chars = s.as_bytes();
+        StringIsArrayIndex1(chars.as_ptr() as *const _, chars.len() as u32, &mut i)
+    } else {
+        let chars = s.encode_utf16().collect::<Vec<u16>>();
+        let slice = chars.as_slice();
+        StringIsArrayIndex2(slice.as_ptr(), chars.len() as u32, &mut i)
+    };
+
+    if is_array {
+        Some(i)
+    } else {
+        None
+    }*/
+}
+
+/// Find the enum equivelent of a string given by `v` in `pairs`.
+/// Returns `Err(())` on JSAPI failure (there is a pending exception), and
+/// `Ok((None, value))` if there was no matching string.
+pub unsafe fn find_enum_value<'a, T>(
+    cx: *mut JSContext,
+    v: HandleValue,
+    pairs: &'a [(&'static str, T)],
+) -> Result<(Option<&'a T>, DOMString), ()> {
+    match ptr::NonNull::new(ToString(cx, v)) {
+        Some(jsstr) => {
+            let search = jsstring_to_str(cx, jsstr);
+            Ok((
+                pairs
+                    .iter()
+                    .find(|&&(key, _)| search == *key)
+                    .map(|(_, ev)| ev),
+                search,
+            ))
+        },
+        None => Err(()),
+    }
+}
+
+/// Get the property with name `property` from `object`.
+/// Returns `Err(())` on JSAPI failure (there is a pending exception), and
+/// `Ok(false)` if there was no property with the given name.
+pub fn get_dictionary_property(
+    cx: *mut JSContext,
+    object: HandleObject,
+    property: &str,
+    rval: MutableHandleValue,
+    _can_gc: CanGc,
+) -> Result<bool, ()> {
+    fn has_property(
+        cx: *mut JSContext,
+        object: HandleObject,
+        property: &CString,
+        found: &mut bool,
+    ) -> bool {
+        unsafe { JS_HasProperty(cx, object, property.as_ptr(), found) }
+    }
+    fn get_property(
+        cx: *mut JSContext,
+        object: HandleObject,
+        property: &CString,
+        value: MutableHandleValue,
+    ) -> bool {
+        unsafe { JS_GetProperty(cx, object, property.as_ptr(), value) }
+    }
+
+    let property = CString::new(property).unwrap();
+    if object.get().is_null() {
+        return Ok(false);
+    }
+
+    let mut found = false;
+    if !has_property(cx, object, &property, &mut found) {
+        return Err(());
+    }
+
+    if !found {
+        return Ok(false);
+    }
+
+    if !get_property(cx, object, &property, rval) {
+        return Err(());
+    }
+
+    Ok(true)
+}
+
+/// Set the property with name `property` from `object`.
+/// Returns `Err(())` on JSAPI failure, or null object,
+/// and Ok(()) otherwise
+pub fn set_dictionary_property(
+    cx: *mut JSContext,
+    object: HandleObject,
+    property: &str,
+    value: HandleValue,
+) -> Result<(), ()> {
+    if object.get().is_null() {
+        return Err(());
+    }
+
+    let property = CString::new(property).unwrap();
+    unsafe {
+        if !JS_SetProperty(cx, object, property.as_ptr(), value) {
+            return Err(());
+        }
+    }
+
+    Ok(())
+}
+
+/// Returns whether `proxy` has a property `id` on its prototype.
+pub unsafe fn has_property_on_prototype(
+    cx: *mut JSContext,
+    proxy: HandleObject,
+    id: HandleId,
+    found: &mut bool,
+) -> bool {
+    rooted!(in(cx) let mut proto = ptr::null_mut::<JSObject>());
+    if !JS_GetPrototype(cx, proxy, proto.handle_mut()) {
+        return false;
+    }
+    assert!(!proto.is_null());
+    JS_HasPropertyById(cx, proto.handle(), id, found)
+}
+
+/// Deletes the property `id` from `object`.
+pub unsafe fn delete_property_by_id(
+    cx: *mut JSContext,
+    object: HandleObject,
+    id: HandleId,
+    bp: *mut ObjectOpResult,
+) -> bool {
+    JS_DeletePropertyById(cx, object, id, bp)
+}
+
+unsafe fn generic_call<const EXCEPTION_TO_REJECTION: bool>(
+    cx: *mut JSContext,
+    argc: libc::c_uint,
+    vp: *mut JSVal,
+    is_lenient: bool,
+    call: unsafe extern "C" fn(
+        *const JSJitInfo,
+        *mut JSContext,
+        RawHandleObject,
+        *mut libc::c_void,
+        u32,
+        *mut JSVal,
+    ) -> bool,
+    can_gc: CanGc,
+) -> bool {
+    let args = CallArgs::from_vp(vp, argc);
+
+    let info = RUST_FUNCTION_VALUE_TO_JITINFO(JS_CALLEE(cx, vp));
+    let proto_id = (*info).__bindgen_anon_2.protoID;
+    let cx = SafeJSContext::from_ptr(cx);
+
+    let thisobj = args.thisv();
+    if !thisobj.get().is_null_or_undefined() && !thisobj.get().is_object() {
+        throw_invalid_this(cx, proto_id);
+        return if EXCEPTION_TO_REJECTION {
+            exception_to_promise(*cx, args.rval(), can_gc)
+        } else {
+            false
+        };
+    }
+
+    rooted!(in(*cx) let obj = if thisobj.get().is_object() {
+        thisobj.get().to_object()
+    } else {
+        GetNonCCWObjectGlobal(JS_CALLEE(*cx, vp).to_object_or_null())
+    });
+    let depth = (*info).__bindgen_anon_3.depth as usize;
+    let proto_check = PrototypeCheck::Depth { depth, proto_id };
+    let this = match private_from_proto_check(obj.get(), *cx, proto_check) {
+        Ok(val) => val,
+        Err(()) => {
+            if is_lenient {
+                debug_assert!(!JS_IsExceptionPending(*cx));
+                *vp = UndefinedValue();
+                return true;
+            } else {
+                throw_invalid_this(cx, proto_id);
+                return if EXCEPTION_TO_REJECTION {
+                    exception_to_promise(*cx, args.rval(), can_gc)
+                } else {
+                    false
+                };
+            }
+        },
+    };
+    call(
+        info,
+        *cx,
+        obj.handle().into(),
+        this as *mut libc::c_void,
+        argc,
+        vp,
+    )
+}
+
+/// Generic method of IDL interface.
+pub unsafe extern "C" fn generic_method<const EXCEPTION_TO_REJECTION: bool>(
+    cx: *mut JSContext,
+    argc: libc::c_uint,
+    vp: *mut JSVal,
+) -> bool {
+    generic_call::<EXCEPTION_TO_REJECTION>(cx, argc, vp, false, CallJitMethodOp, CanGc::note())
+}
+
+/// Generic getter of IDL interface.
+pub unsafe extern "C" fn generic_getter<const EXCEPTION_TO_REJECTION: bool>(
+    cx: *mut JSContext,
+    argc: libc::c_uint,
+    vp: *mut JSVal,
+) -> bool {
+    generic_call::<EXCEPTION_TO_REJECTION>(cx, argc, vp, false, CallJitGetterOp, CanGc::note())
+}
+
+/// Generic lenient getter of IDL interface.
+pub unsafe extern "C" fn generic_lenient_getter<const EXCEPTION_TO_REJECTION: bool>(
+    cx: *mut JSContext,
+    argc: libc::c_uint,
+    vp: *mut JSVal,
+) -> bool {
+    generic_call::<EXCEPTION_TO_REJECTION>(cx, argc, vp, true, CallJitGetterOp, CanGc::note())
+}
+
+unsafe extern "C" fn call_setter(
+    info: *const JSJitInfo,
+    cx: *mut JSContext,
+    handle: RawHandleObject,
+    this: *mut libc::c_void,
+    argc: u32,
+    vp: *mut JSVal,
+) -> bool {
+    if !CallJitSetterOp(info, cx, handle, this, argc, vp) {
+        return false;
+    }
+    *vp = UndefinedValue();
+    true
+}
+
+/// Generic setter of IDL interface.
+pub unsafe extern "C" fn generic_setter(
+    cx: *mut JSContext,
+    argc: libc::c_uint,
+    vp: *mut JSVal,
+) -> bool {
+    generic_call::<false>(cx, argc, vp, false, call_setter, CanGc::note())
+}
+
+/// Generic lenient setter of IDL interface.
+pub unsafe extern "C" fn generic_lenient_setter(
+    cx: *mut JSContext,
+    argc: libc::c_uint,
+    vp: *mut JSVal,
+) -> bool {
+    generic_call::<false>(cx, argc, vp, true, call_setter, CanGc::note())
+}
+
+/// <https://searchfox.org/mozilla-central/rev/7279a1df13a819be254fd4649e07c4ff93e4bd45/dom/bindings/BindingUtils.cpp#3300>
+pub unsafe extern "C" fn generic_static_promise_method(
+    cx: *mut JSContext,
+    argc: libc::c_uint,
+    vp: *mut JSVal,
+) -> bool {
+    let args = CallArgs::from_vp(vp, argc);
+
+    let info = RUST_FUNCTION_VALUE_TO_JITINFO(JS_CALLEE(cx, vp));
+    assert!(!info.is_null());
+    // TODO: we need safe wrappers for this in mozjs!
+    //assert_eq!((*info)._bitfield_1, JSJitInfo_OpType::StaticMethod as u8)
+    let static_fn = (*info).__bindgen_anon_1.staticMethod.unwrap();
+    if static_fn(cx, argc, vp) {
+        return true;
+    }
+    exception_to_promise(cx, args.rval(), CanGc::note())
+}
+
+/// Coverts exception to promise rejection
+///
+/// <https://searchfox.org/mozilla-central/rev/b220e40ff2ee3d10ce68e07d8a8a577d5558e2a2/dom/bindings/BindingUtils.cpp#3315>
+pub unsafe fn exception_to_promise(
+    cx: *mut JSContext,
+    rval: RawMutableHandleValue,
+    _can_gc: CanGc,
+) -> bool {
+    rooted!(in(cx) let mut exception = UndefinedValue());
+    if !JS_GetPendingException(cx, exception.handle_mut()) {
+        return false;
+    }
+    JS_ClearPendingException(cx);
+    if let Some(promise) = NonNull::new(CallOriginalPromiseReject(cx, exception.handle())) {
+        promise.to_jsval(cx, MutableHandleValue::from_raw(rval));
+        true
+    } else {
+        // We just give up.  Put the exception back.
+        JS_SetPendingException(cx, exception.handle(), ExceptionStackBehavior::Capture);
+        false
+    }
+}

--- a/components/script_bindings/utils.rs
+++ b/components/script_bindings/utils.rs
@@ -4,11 +4,15 @@
 
 use std::os::raw::c_void;
 
+use js::glue::JS_GetReservedSlot;
+use js::jsapi::JSObject;
+use js::jsval::UndefinedValue;
+use js::rust::get_object_class;
 use malloc_size_of::MallocSizeOfOps;
 
 use crate::codegen::Globals::Globals;
 use crate::codegen::InheritTypes::TopTypeId;
-use crate::codegen::PrototypeList::{self, MAX_PROTO_CHAIN_LENGTH};
+use crate::codegen::PrototypeList::{self, MAX_PROTO_CHAIN_LENGTH, PROTO_OR_IFACE_LENGTH};
 
 /// The struct that holds inheritance information for DOM object reflectors.
 #[derive(Clone, Copy)]
@@ -46,3 +50,31 @@ impl Clone for DOMJSClass {
     }
 }
 unsafe impl Sync for DOMJSClass {}
+
+/// The index of the slot where the object holder of that interface's
+/// unforgeable members are defined.
+pub const DOM_PROTO_UNFORGEABLE_HOLDER_SLOT: u32 = 0;
+
+/// The index of the slot that contains a reference to the ProtoOrIfaceArray.
+// All DOM globals must have a slot at DOM_PROTOTYPE_SLOT.
+pub const DOM_PROTOTYPE_SLOT: u32 = js::JSCLASS_GLOBAL_SLOT_COUNT;
+
+/// The flag set on the `JSClass`es for DOM global objects.
+// NOTE: This is baked into the Ion JIT as 0 in codegen for LGetDOMProperty and
+// LSetDOMProperty. Those constants need to be changed accordingly if this value
+// changes.
+pub const JSCLASS_DOM_GLOBAL: u32 = js::JSCLASS_USERBIT1;
+
+/// Returns the ProtoOrIfaceArray for the given global object.
+/// Fails if `global` is not a DOM global object.
+pub fn get_proto_or_iface_array(global: *mut JSObject) -> *mut ProtoOrIfaceArray {
+    unsafe {
+        assert_ne!(((*get_object_class(global)).flags & JSCLASS_DOM_GLOBAL), 0);
+        let mut slot = UndefinedValue();
+        JS_GetReservedSlot(global, DOM_PROTOTYPE_SLOT, &mut slot);
+        slot.to_private() as *mut ProtoOrIfaceArray
+    }
+}
+
+/// An array of *mut JSObject of size PROTO_OR_IFACE_LENGTH.
+pub type ProtoOrIfaceArray = [*mut JSObject; PROTO_OR_IFACE_LENGTH];

--- a/components/script_bindings/webidls/ServoInternals.webidl
+++ b/components/script_bindings/webidls/ServoInternals.webidl
@@ -8,12 +8,12 @@
 // This interface is entirely internal to Servo, and should not be accessible to
 // web pages.
 [Exposed=Window,
-Func="dom::bindings::interface::is_servo_internal"]
+Func="ServoInternals::is_servo_internal"]
 interface ServoInternals {
     Promise<object> reportMemory();
 };
 
 partial interface Navigator {
-    [Func="dom::bindings::interface::is_servo_internal"]
+    [Func="ServoInternals::is_servo_internal"]
     readonly attribute ServoInternals servo;
 };


### PR DESCRIPTION
A grab bag of changes needed for #1799; mostly moving code from script to script_bindings, with some conversions to make some code in script/dom/bindings more generic mixed in.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #1799
- [x] There are tests for these changes (existing WPT coverage)