### PR TITLE
Fixed an incorrect touchmove event triggered when the second finger is pressed.

### DIFF
--- a/components/compositing/touch.rs
+++ b/components/compositing/touch.rs
@@ -329,10 +329,7 @@ impl TouchHandler {
                 .active_touch_points
                 .push(TouchPoint::new(id, point));
             match touch_sequence.active_touch_points.len() {
-                2 => {
-                    touch_sequence.state = Pinching;
-                },
-                3.. => {
+                2.. => {
                     touch_sequence.state = MultiTouch;
                 },
                 0..2 => {


### PR DESCRIPTION
Fixed an incorrect touchmove event triggered when the second finger is pressed.

When touchdown is enabled, if the number of touch points is 2, the touch status should not be set to Pinching. A pinching operation is performed only when both fingers are pressed and the moving distance of one finger exceeds a certain threshold.
<!-- Please describe your changes on the following line: -->
When touchdown is set to two or more touch points, the status is set to MultiTouch. If the moving distance exceeds a certain value during touchmove, the status is set to Pinching.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
