### PR TITLE
fetch: Refuse to provide partial response from earlier ranged request to API that did not make a range request

### DIFF
--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -26,7 +26,7 @@ use headers::{
 };
 use http::header::{
     self, ACCEPT, AUTHORIZATION, CONTENT_ENCODING, CONTENT_LANGUAGE, CONTENT_LOCATION,
-    CONTENT_TYPE, HeaderValue,
+    CONTENT_TYPE, HeaderValue, RANGE,
 };
 use http::{HeaderMap, Method, Request as HyperRequest, StatusCode};
 use http_body_util::combinators::BoxBody;
@@ -1123,7 +1123,7 @@ pub async fn http_redirect_fetch(
     fetch_response
 }
 
-/// [HTTP network or cache fetch](https://fetch.spec.whatwg.org#http-network-or-cache-fetch)
+/// [HTTP network or cache fetch](https://fetch.spec.whatwg.org/#concept-http-network-or-cache-fetch)
 #[async_recursion]
 async fn http_network_or_cache_fetch(
     fetch_params: &mut FetchParams,
@@ -1598,8 +1598,12 @@ async fn http_network_or_cache_fetch(
     }
 
     // TODO(#33616): Step 11. Set response’s URL list to a clone of httpRequest’s URL list.
-    // TODO(#33616): Step 12. If httpRequest’s header list contains `Range`,
-    // then set response’s range-requested flag.
+
+    // Step 12. If httpRequest’s header list contains `Range`, then set response’s range-requested flag.
+    if http_request.headers.contains_key(RANGE) {
+        response.range_requested = true;
+    }
+
     // TODO(#33616): Step 13 Set response’s request-includes-credentials to includeCredentials.
 
     // Step 14. If response’s status is 401, httpRequest’s response tainting is not "cors",

--- a/components/net/protocols/blob.rs
+++ b/components/net/protocols/blob.rs
@@ -54,6 +54,7 @@ impl ProtocolHandler for BlobProtocolHander {
         response.status = HttpStatus::default();
 
         if is_range_request {
+            response.range_requested = true;
             partial_content(&mut response);
         }
 

--- a/components/shared/net/response.rs
+++ b/components/shared/net/response.rs
@@ -120,6 +120,9 @@ pub struct Response {
     /// track network metrics
     #[ignore_malloc_size_of = "Mutex heap size undefined"]
     pub resource_timing: Arc<Mutex<ResourceFetchTiming>>,
+
+    /// <https://fetch.spec.whatwg.org/#concept-response-range-requested-flag>
+    pub range_requested: bool,
 }
 
 impl Response {
@@ -142,6 +145,7 @@ impl Response {
             return_internal: true,
             aborted: Arc::new(AtomicBool::new(false)),
             resource_timing: Arc::new(Mutex::new(resource_timing)),
+            range_requested: false,
         }
     }
 
@@ -175,6 +179,7 @@ impl Response {
             resource_timing: Arc::new(Mutex::new(ResourceFetchTiming::new(
                 ResourceTimingType::Error,
             ))),
+            range_requested: false,
         }
     }
 


### PR DESCRIPTION
Part of https://github.com/servo/servo/issues/33616

It appears that there is no web platform test for this change (at least I couldn't find any). The flag itself is used to prevent an attack involving service workers - I only implemented it because it was getting in the way somewhere else.

To quote the spec:
> The above steps prevent the following attack:
A media element is used to request a range of a cross-origin HTML resource. Although this is invalid media, a reference to a clone of the response can be retained in a service worker. This can later be used as the response to a script element’s fetch. If the partial response is valid JavaScript (even though the whole resource is not), executing it would leak private data. 

There *might* be a passing test after https://github.com/servo/servo/pull/36221.

[try run](https://github.com/simonwuelker/servo/actions/runs/14160034812/job/39664607755)