### PR TITLE
Fixed the crash issue when the openharmony web component is adapted.

### DIFF
--- a/components/compositing/touch.rs
+++ b/components/compositing/touch.rs
@@ -378,7 +378,8 @@ impl TouchHandler {
         {
             Some(i) => i,
             None => {
-                unreachable!("Got a touchmove event for a non-active touch point");
+                error!("Got a touchmove event for a non-active touch point");
+                return TouchMoveAction::NoAction;
             },
         };
         let old_point = touch_sequence.active_touch_points[idx].point;


### PR DESCRIPTION
When the OpenHarmony web component is adapted, touchmove events with the same ID may exist after touchup. Therefore, only error logs are printed and no exception is thrown.

