### PR TITLE
script: Fix resize observer depth calculation for Shadow DOM.

### DIFF
--- a/components/script/dom/resizeobserver.rs
+++ b/components/script/dom/resizeobserver.rs
@@ -297,7 +297,7 @@ impl ResizeObservation {
 /// <https://drafts.csswg.org/resize-observer/#calculate-depth-for-node>
 fn calculate_depth_for_node(target: &Element) -> ResizeObservationDepth {
     let node = target.upcast::<Node>();
-    let depth = node.ancestors().count();
+    let depth = node.inclusive_ancestors_in_flat_tree().count() - 1;
     ResizeObservationDepth(depth)
 }
 

--- a/tests/wpt/meta/resize-observer/calculate-depth-for-node.html.ini
+++ b/tests/wpt/meta/resize-observer/calculate-depth-for-node.html.ini
@@ -1,5 +1,0 @@
-[calculate-depth-for-node.html]
-  expected: ERROR
-
-  ["Calculate depth for node" algorithm with Shadow DOM]
-    expected: FAIL


### PR DESCRIPTION
Follow the specification more closely by using the flat tree when calculating depth for the resize observer.

Testing: Newly passing WPT test.
Fixes: #36092
