### PR TITLE
dom: Set "composed" flag on construction for some event types

### DIFF
--- a/components/script/dom/customevent.rs
+++ b/components/script/dom/customevent.rs
@@ -93,7 +93,7 @@ impl CustomEventMethods<crate::DomTypeHolder> for CustomEvent {
         type_: DOMString,
         init: RootedTraceableBox<CustomEventBinding::CustomEventInit>,
     ) -> DomRoot<CustomEvent> {
-        CustomEvent::new(
+        let event = CustomEvent::new(
             global,
             proto,
             Atom::from(type_),
@@ -101,7 +101,9 @@ impl CustomEventMethods<crate::DomTypeHolder> for CustomEvent {
             init.parent.cancelable,
             init.detail.handle(),
             can_gc,
-        )
+        );
+        event.upcast::<Event>().set_composed(init.parent.composed);
+        event
     }
 
     // https://dom.spec.whatwg.org/#dom-customevent-detail

--- a/components/script/dom/errorevent.rs
+++ b/components/script/dom/errorevent.rs
@@ -142,6 +142,7 @@ impl ErrorEventMethods<crate::DomTypeHolder> for ErrorEvent {
             init.error.handle(),
             can_gc,
         );
+        event.upcast::<Event>().set_composed(init.parent.composed);
         Ok(event)
     }
 

--- a/components/script/dom/focusevent.rs
+++ b/components/script/dom/focusevent.rs
@@ -15,7 +15,7 @@ use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::reflect_dom_object_with_proto;
 use crate::dom::bindings::root::{DomRoot, MutNullableDom};
 use crate::dom::bindings::str::DOMString;
-use crate::dom::event::{EventBubbles, EventCancelable};
+use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::uievent::UIEvent;
 use crate::dom::window::Window;
@@ -118,6 +118,9 @@ impl FocusEventMethods<crate::DomTypeHolder> for FocusEvent {
             init.relatedTarget.as_deref(),
             can_gc,
         );
+        event
+            .upcast::<Event>()
+            .set_composed(init.parent.parent.composed);
         Ok(event)
     }
 

--- a/components/script/dom/mouseevent.rs
+++ b/components/script/dom/mouseevent.rs
@@ -342,6 +342,9 @@ impl MouseEventMethods<crate::DomTypeHolder> for MouseEvent {
             None,
             can_gc,
         );
+        event
+            .upcast::<Event>()
+            .set_composed(init.parent.parent.parent.composed);
         Ok(event)
     }
 

--- a/tests/wpt/meta/dom/events/Event-dispatch-listener-order.window.js.ini
+++ b/tests/wpt/meta/dom/events/Event-dispatch-listener-order.window.js.ini
@@ -1,3 +1,0 @@
-[Event-dispatch-listener-order.window.html]
-  [Event-dispatch-listener-order]
-    expected: FAIL

--- a/tests/wpt/meta/dom/events/event-global.html.ini
+++ b/tests/wpt/meta/dom/events/event-global.html.ini
@@ -1,3 +1,0 @@
-[event-global.html]
-  [window.event is undefined inside window.onerror if the target is in a shadow tree (ErrorEvent dispatched inside shadow tree)]
-    expected: FAIL

--- a/tests/wpt/meta/shadow-dom/event-composed-path-with-related-target.html.ini
+++ b/tests/wpt/meta/shadow-dom/event-composed-path-with-related-target.html.ini
@@ -1,4 +1,10 @@
 [event-composed-path-with-related-target.html]
+  [Event path for an event with a relatedTarget. Event should stop at the shadow root]
+    expected: FAIL
+
+  [Event path for an event with a relatedTarget which is identical to target. Event should be dispatched and should stop at the shadow root.]
+    expected: FAIL
+
   [Event path for an event with a relatedTarget. target and relaterTarget do not share any shadow-including ancestor. target is in a shadow tree.]
     expected: FAIL
 
@@ -15,9 +21,6 @@
     expected: FAIL
 
   [Event path for an event with a relatedTarget. target is assigned to a slot.]
-    expected: FAIL
-
-  [Event path for an event with a relatedTarget. relatedTarget is assigned to a slot.]
     expected: FAIL
 
   [Event path for an event with a relatedTarget. Event should be dispatched at every slots.]

--- a/tests/wpt/meta/shadow-dom/event-composed.html.ini
+++ b/tests/wpt/meta/shadow-dom/event-composed.html.ini
@@ -1,9 +1,3 @@
 [event-composed.html]
-  [A synthetic MouseEvent with composed=true should not be scoped]
-    expected: FAIL
-
-  [A synthetic FocusEvent with composed=true should not be scoped]
-    expected: FAIL
-
   [A UA click event should not be scoped]
     expected: FAIL

--- a/tests/wpt/meta/shadow-dom/event-post-dispatch.html.ini
+++ b/tests/wpt/meta/shadow-dom/event-post-dispatch.html.ini
@@ -5,9 +5,6 @@
   [Event properties post dispatch with relatedTarget in the same shadow tree. (composed: false)]
     expected: FAIL
 
-  [Event properties post dispatch with relatedTarget in the document tree and the shadow tree. (composed: true)]
-    expected: FAIL
-
   [Event properties post dispatch with relatedTarget in the document tree and the shadow tree. (composed: false)]
     expected: FAIL
 

--- a/tests/wpt/meta/shadow-dom/event-with-related-target.html.ini
+++ b/tests/wpt/meta/shadow-dom/event-with-related-target.html.ini
@@ -1,4 +1,10 @@
 [event-with-related-target.html]
+  [Firing an event at B1a with relatedNode at B1 with open mode shadow trees]
+    expected: FAIL
+
+  [Firing an event at B1a with relatedNode at B1 with closed mode shadow trees]
+    expected: FAIL
+
   [Firing an event at B1a with relatedNode at B1b1 with open mode shadow trees]
     expected: FAIL
 


### PR DESCRIPTION
"Composed" flag (https://dom.spec.whatwg.org/#composed-flag) should be properly set on event construction phase from optional "EventInit" dictionary
(https://dom.spec.whatwg.org/#dom-eventinit-composed).

The limited set of event types (Custom/Error/Focus/Mouse) will be affected by this CL (used in WPT tests).

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

- [X] There are WPT shadow-dom tests which have new issues related to event "relatedTarget" property
  tests/wpt/tests/shadow-dom/event-composed-path-with-related-target.html
  tests/wpt/tests/shadow-dom/event-with-related-target.html
