### PR TITLE
Enable CSS parent selector (`&`)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6515,7 +6515,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.27.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-15#bc4717c7842ad59243f00ae76ba23f998c749b94"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#600b5c42970fdbe301f18c013a0f0ca4ed5f08db"
 dependencies = [
  "bitflags 2.9.0",
  "cssparser",
@@ -6800,7 +6800,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-15#bc4717c7842ad59243f00ae76ba23f998c749b94"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#600b5c42970fdbe301f18c013a0f0ca4ed5f08db"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -7252,7 +7252,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-15#bc4717c7842ad59243f00ae76ba23f998c749b94"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#600b5c42970fdbe301f18c013a0f0ca4ed5f08db"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -7310,7 +7310,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-15#bc4717c7842ad59243f00ae76ba23f998c749b94"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#600b5c42970fdbe301f18c013a0f0ca4ed5f08db"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -7319,12 +7319,12 @@ dependencies = [
 [[package]]
 name = "stylo_config"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-15#bc4717c7842ad59243f00ae76ba23f998c749b94"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#600b5c42970fdbe301f18c013a0f0ca4ed5f08db"
 
 [[package]]
 name = "stylo_derive"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-15#bc4717c7842ad59243f00ae76ba23f998c749b94"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#600b5c42970fdbe301f18c013a0f0ca4ed5f08db"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -7336,7 +7336,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-15#bc4717c7842ad59243f00ae76ba23f998c749b94"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#600b5c42970fdbe301f18c013a0f0ca4ed5f08db"
 dependencies = [
  "bitflags 2.9.0",
  "stylo_malloc_size_of",
@@ -7345,7 +7345,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-15#bc4717c7842ad59243f00ae76ba23f998c749b94"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#600b5c42970fdbe301f18c013a0f0ca4ed5f08db"
 dependencies = [
  "app_units",
  "cssparser",
@@ -7362,12 +7362,12 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-15#bc4717c7842ad59243f00ae76ba23f998c749b94"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#600b5c42970fdbe301f18c013a0f0ca4ed5f08db"
 
 [[package]]
 name = "stylo_traits"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-15#bc4717c7842ad59243f00ae76ba23f998c749b94"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#600b5c42970fdbe301f18c013a0f0ca4ed5f08db"
 dependencies = [
  "app_units",
  "bitflags 2.9.0",
@@ -7750,7 +7750,7 @@ dependencies = [
 [[package]]
 name = "to_shmem"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-15#bc4717c7842ad59243f00ae76ba23f998c749b94"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#600b5c42970fdbe301f18c013a0f0ca4ed5f08db"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -7763,7 +7763,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-15#bc4717c7842ad59243f00ae76ba23f998c749b94"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#600b5c42970fdbe301f18c013a0f0ca4ed5f08db"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/tests/wpt/meta/css/css-nesting/cssom.html.ini
+++ b/tests/wpt/meta/css/css-nesting/cssom.html.ini
@@ -26,13 +26,7 @@
   [Simple CSSOM manipulation of subrules 7]
     expected: FAIL
 
-  [Simple CSSOM manipulation of subrules 8]
-    expected: FAIL
-
   [Simple CSSOM manipulation of subrules 9]
-    expected: FAIL
-
-  [Mutating the selectorText of outer rule invalidates inner rules]
     expected: FAIL
 
   [Manipulation of nested declarations through CSSOM]

--- a/tests/wpt/meta/css/css-nesting/host-nesting-005.html.ini
+++ b/tests/wpt/meta/css/css-nesting/host-nesting-005.html.ini
@@ -1,2 +1,0 @@
-[host-nesting-005.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-nesting/invalid-inner-rules.html.ini
+++ b/tests/wpt/meta/css/css-nesting/invalid-inner-rules.html.ini
@@ -1,6 +1,3 @@
 [invalid-inner-rules.html]
-  [Simple CSSOM manipulation of subrules]
-    expected: FAIL
-
   [Simple CSSOM manipulation of subrules 1]
     expected: FAIL

--- a/tests/wpt/meta/css/css-nesting/invalidation-001.html.ini
+++ b/tests/wpt/meta/css/css-nesting/invalidation-001.html.ini
@@ -1,3 +1,0 @@
-[invalidation-001.html]
-  [CSS Selectors nested invalidation on changed parent]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-nesting/invalidation-002.html.ini
+++ b/tests/wpt/meta/css/css-nesting/invalidation-002.html.ini
@@ -1,3 +1,0 @@
-[invalidation-002.html]
-  [CSS Selectors nested invalidation on changed child]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-nesting/nested-declarations-matching.html.ini
+++ b/tests/wpt/meta/css/css-nesting/nested-declarations-matching.html.ini
@@ -1,17 +1,5 @@
 [nested-declarations-matching.html]
-  [Nested declarations rule has same specificity as outer selector]
-    expected: FAIL
-
-  [Nested declarations rule has top-level specificity behavior]
-    expected: FAIL
-
   [Bare declartaion in nested grouping rule can match pseudo-element]
-    expected: FAIL
-
-  [Nested @scope rules behave like :where(:scope)]
-    expected: FAIL
-
-  [Nested @scope rules behave like :where(:scope) (trailing)]
     expected: FAIL
 
   [Nested declarations rule responds to parent selector text change]

--- a/tests/wpt/meta/css/css-nesting/nesting-layer.html.ini
+++ b/tests/wpt/meta/css/css-nesting/nesting-layer.html.ini
@@ -1,3 +1,0 @@
-[nesting-layer.html]
-  [@layer can be nested]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-nesting/set-selector-text.html.ini
+++ b/tests/wpt/meta/css/css-nesting/set-selector-text.html.ini
@@ -1,21 +1,6 @@
 [set-selector-text.html]
-  [Outer selectorText text mutation with inner style rule]
-    expected: FAIL
-
-  [Outer selectorText text mutation with inner @media rule]
-    expected: FAIL
-
-  [Outer selectorText text mutation with inner @supports rule]
-    expected: FAIL
-
-  [Outer selectorText text mutation with inner @layer rule]
-    expected: FAIL
-
   [Outer selectorText text mutation with inner @container rule]
     expected: FAIL
 
   [Outer selectorText text mutation with inner @scope rule]
-    expected: FAIL
-
-  [Outer selectorText text mutation with inner nested decl. rule]
     expected: FAIL

--- a/tests/wpt/meta/css/css-nesting/top-level-is-scope.html.ini
+++ b/tests/wpt/meta/css/css-nesting/top-level-is-scope.html.ini
@@ -1,6 +1,3 @@
 [top-level-is-scope.html]
-  [& as direct ancestor]
-    expected: FAIL
-
   [& matches scoped element only, not everything]
     expected: FAIL

--- a/tests/wpt/meta/css/css-nesting/top-level-parent-pseudo-specificity.html.ini
+++ b/tests/wpt/meta/css/css-nesting/top-level-parent-pseudo-specificity.html.ini
@@ -1,3 +1,0 @@
-[top-level-parent-pseudo-specificity.html]
-  [CSS Nesting: Specificity of top-level '&']
-    expected: FAIL


### PR DESCRIPTION
Bumps Stylo to servo/stylo#164
Changelog: https://github.com/servo/stylo/compare/bc4717c7842ad59243f00ae76ba23f998c749b94...600b5c42970fdbe301f18c013a0f0ca4ed5f08db

Testing: covered by WPT
This is part of https://github.com/servo/servo/issues/36245
