### PR TITLE
Fix radio group validity update when removing or selecting an input

### DIFF
--- a/components/script/dom/activation.rs
+++ b/components/script/dom/activation.rs
@@ -16,12 +16,17 @@ pub(crate) trait Activatable {
     fn is_instance_activatable(&self) -> bool;
 
     // https://dom.spec.whatwg.org/#eventtarget-legacy-pre-activation-behavior
-    fn legacy_pre_activation_behavior(&self) -> Option<InputActivationState> {
+    fn legacy_pre_activation_behavior(&self, _can_gc: CanGc) -> Option<InputActivationState> {
         None
     }
 
     // https://dom.spec.whatwg.org/#eventtarget-legacy-canceled-activation-behavior
-    fn legacy_canceled_activation_behavior(&self, _state_before: Option<InputActivationState>) {}
+    fn legacy_canceled_activation_behavior(
+        &self,
+        _state_before: Option<InputActivationState>,
+        _can_gc: CanGc,
+    ) {
+    }
 
     // https://dom.spec.whatwg.org/#eventtarget-activation-behavior
     // event and target are used only by HTMLAnchorElement, in the case

--- a/components/script/dom/event.rs
+++ b/components/script/dom/event.rs
@@ -507,7 +507,7 @@ impl Event {
                 // corresponding pre-activation behavior.
                 pre_activation_result = activation_target
                     .as_maybe_activatable()
-                    .and_then(|activatable| activatable.legacy_pre_activation_behavior());
+                    .and_then(|activatable| activatable.legacy_pre_activation_behavior(can_gc));
             }
 
             let timeline_window = DomRoot::downcast::<Window>(target.global())
@@ -623,7 +623,7 @@ impl Event {
                 // Step 11.2 Otherwise, if activationTarget has legacy-canceled-activation behavior, then run
                 // activationTarget’s legacy-canceled-activation behavior.
                 else {
-                    activatable.legacy_canceled_activation_behavior(pre_activation_result);
+                    activatable.legacy_canceled_activation_behavior(pre_activation_result, can_gc);
                 }
             }
         }

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -1275,7 +1275,7 @@ impl HTMLFormElement {
                 NodeTypeId::Element(ElementTypeId::HTMLElement(
                     HTMLElementTypeId::HTMLInputElement,
                 )) => {
-                    child.downcast::<HTMLInputElement>().unwrap().reset();
+                    child.downcast::<HTMLInputElement>().unwrap().reset(can_gc);
                 },
                 NodeTypeId::Element(ElementTypeId::HTMLElement(
                     HTMLElementTypeId::HTMLSelectElement,

--- a/tests/wpt/tests/html/semantics/forms/constraints/radio-group-valueMissing.html
+++ b/tests/wpt/tests/html/semantics/forms/constraints/radio-group-valueMissing.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<title>
+  The constraint validation API Test: element.validity.valueMissing for radio
+  group
+</title>
+<link rel="author" title="Emmanuel Elom" href="mailto:elomemmanuel007@gmail.com">
+<link
+  rel="help"
+  href="https://html.spec.whatwg.org/multipage/#dom-validitystate-valuemissing"
+/>
+<link
+  rel="help"
+  href="https://html.spec.whatwg.org/multipage/#the-constraint-validation-api"
+/>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/validator.js"></script>
+<div id="log"></div>
+
+<input type="radio" id="first" required name="group" />
+<input type="radio" id="second" checked name="group" />
+<input type="radio" id="third" required name="group1" />
+<input type="radio" id="fourth" name="group1" />
+
+<script>
+  const first = document.getElementById("first");
+  const second = document.getElementById("second");
+  const third = document.getElementById("third");
+  const fourth = document.getElementById("fourth");
+
+  test(() => {
+    assert_equals(first.validity.valueMissing, false);
+    assert_equals(second.validity.valueMissing, false);
+    second.remove();
+    assert_equals(first.validity.valueMissing, true);
+  }, "valueMissing is true for all group members when checked group member is removed");
+
+  test(() => {
+    assert_equals(third.validity.valueMissing, true);
+    assert_equals(fourth.validity.valueMissing, true);
+    fourth.click();
+    assert_equals(third.validity.valueMissing, false);
+    assert_equals(fourth.validity.valueMissing, false);
+  }, "valueMissing is false for all group members when any group member is checked");
+</script>


### PR DESCRIPTION
This PR fixes an issue where radio inputs in the same group failed to correctly update their `validity.valueMissing` state when:

- A **checked radio button was removed** from the DOM.
- A **different radio button was selected** by user interaction.

This behavior caused mismatches with how browsers like Firefox handle radio group validation.

---

### Changes in This PR

#### Radio group revalidation on DOM removal
- Updated `unbind_from_tree()` to revalidate other radio buttons in the same group when a checked input is removed.
- Uses `UnbindContext::parent` as the DOM root to ensure the correct context is used during traversal.

#### New helper: `find_related_radios()`
- Encapsulates logic for finding other inputs in the same group.
- Used during both removal and attribute changes for consistency.

#### Validation on `checked`/`value` updates
- Introduced `update_related_validity_states()` to revalidate all group members when a radio's `checked` or `value` is changed.

#### Web Platform Test (WPT) coverage
- Created a new WPT file: `radio-group-valueMissing.html`.
- Tests follow recommended `test()` pattern:
  - **Precondition**: Assert initial `valueMissing`.
  - **Action**: Remove or select a radio.
  - **Postcondition**: Assert expected `valueMissing`.

#### Manifest updated
- The WPT manifest now includes the new test.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #36110

<!-- Either: -->
- [X] There are tests for these changes 