### PR TITLE
Add SimulateColorScheme command and script thread handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1618,6 +1618,7 @@ version = "0.0.1"
 dependencies = [
  "base",
  "bitflags 2.9.0",
+ "embedder_traits",
  "http 1.3.1",
  "ipc-channel",
  "malloc_size_of_derive",

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2063,10 +2063,9 @@ impl ScriptThread {
             DevtoolScriptControlMsg::GetCssDatabase(reply) => {
                 devtools::handle_get_css_database(reply)
             },
-            DevtoolScriptControlMsg::SimulateColorScheme(id, is_light) => {
+            DevtoolScriptControlMsg::SimulateColorScheme(id, theme) => {
                 match documents.find_window(id) {
                     Some(window) => {
-                        let theme = if is_light { "light" } else { "dark" };
                         window.handle_theme_change(theme);
                     },
                     None => warn!("Message sent to closed pipeline {}.", id),

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2063,6 +2063,15 @@ impl ScriptThread {
             DevtoolScriptControlMsg::GetCssDatabase(reply) => {
                 devtools::handle_get_css_database(reply)
             },
+            DevtoolScriptControlMsg::SimulateColorScheme(id, is_light) => {
+                match documents.find_window(id) {
+                    Some(window) => {
+                        let theme = if is_light { "light" } else { "dark" };
+                        window.handle_theme_change(theme);
+                    },
+                    None => warn!("Message sent to closed pipeline {}.", id),
+                }
+            },
         }
     }
 

--- a/components/shared/devtools/Cargo.toml
+++ b/components/shared/devtools/Cargo.toml
@@ -22,3 +22,4 @@ net_traits = { workspace = true }
 serde = { workspace = true }
 servo_url = { path = "../../url" }
 uuid = { workspace = true, features = ["serde"] }
+embedder_traits = { workspace = true }

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -258,6 +258,8 @@ pub enum DevtoolScriptControlMsg {
     Reload(PipelineId),
     /// Gets the list of all allowed CSS rules and possible values.
     GetCssDatabase(IpcSender<HashMap<String, CssDatabaseProperty>>),
+    /// Simulates a light or dark color scheme for the given pipeline (true for light, false for dark)
+    SimulateColorScheme(PipelineId, bool),
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -18,6 +18,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use base::cross_process_instant::CrossProcessInstant;
 use base::id::{BrowsingContextId, PipelineId, WebViewId};
 use bitflags::bitflags;
+use embedder_traits::Theme;
 use http::{HeaderMap, Method};
 use ipc_channel::ipc::IpcSender;
 use malloc_size_of_derive::MallocSizeOf;
@@ -258,8 +259,8 @@ pub enum DevtoolScriptControlMsg {
     Reload(PipelineId),
     /// Gets the list of all allowed CSS rules and possible values.
     GetCssDatabase(IpcSender<HashMap<String, CssDatabaseProperty>>),
-    /// Simulates a light or dark color scheme for the given pipeline (true for light, false for dark)
-    SimulateColorScheme(PipelineId, bool),
+    /// Simulates a light or dark color scheme for the given pipeline
+    SimulateColorScheme(PipelineId, Theme),
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]


### PR DESCRIPTION
Implements Steps 2-3 of #35867:
- Adds `SimulateColorScheme` to `DevtoolScriptControlMsg` for light/dark mode simulation.
- Handles it in `ScriptThread` with `handle_theme_change` to toggle themes.

Testing: This PR does not require testing because it only adds infrastructure (command and handler) but doesn’t yet integrate with devtools actors.
Fixes: Part of #35867 (https://github.com/servo/servo/issues/35867)
