### PR TITLE
Turn `CSSStyleRule` into a `CSSGroupingRule` subclass

### DIFF
--- a/components/script/dom/cssconditionrule.rs
+++ b/components/script/dom/cssconditionrule.rs
@@ -18,6 +18,9 @@ use crate::dom::csssupportsrule::CSSSupportsRule;
 #[dom_struct]
 pub(crate) struct CSSConditionRule {
     cssgroupingrule: CSSGroupingRule,
+    #[ignore_malloc_size_of = "Arc"]
+    #[no_trace]
+    rules: Arc<Locked<StyleCssRules>>,
 }
 
 impl CSSConditionRule {
@@ -26,7 +29,8 @@ impl CSSConditionRule {
         rules: Arc<Locked<StyleCssRules>>,
     ) -> CSSConditionRule {
         CSSConditionRule {
-            cssgroupingrule: CSSGroupingRule::new_inherited(parent_stylesheet, rules),
+            cssgroupingrule: CSSGroupingRule::new_inherited(parent_stylesheet),
+            rules,
         }
     }
 
@@ -36,6 +40,10 @@ impl CSSConditionRule {
 
     pub(crate) fn shared_lock(&self) -> &SharedRwLock {
         self.cssgroupingrule.shared_lock()
+    }
+
+    pub(crate) fn clone_rules(&self) -> Arc<Locked<StyleCssRules>> {
+        self.rules.clone()
     }
 }
 

--- a/components/script/dom/csslayerblockrule.rs
+++ b/components/script/dom/csslayerblockrule.rs
@@ -4,8 +4,8 @@
 
 use dom_struct::dom_struct;
 use servo_arc::Arc;
-use style::shared_lock::ToCssWithGuard;
-use style::stylesheets::{CssRuleType, LayerBlockRule};
+use style::shared_lock::{Locked, ToCssWithGuard};
+use style::stylesheets::{CssRuleType, CssRules, LayerBlockRule};
 use style_traits::ToCss;
 
 use crate::dom::bindings::codegen::Bindings::CSSLayerBlockRuleBinding::CSSLayerBlockRuleMethods;
@@ -32,10 +32,7 @@ impl CSSLayerBlockRule {
         layerblockrule: Arc<LayerBlockRule>,
     ) -> CSSLayerBlockRule {
         CSSLayerBlockRule {
-            cssgroupingrule: CSSGroupingRule::new_inherited(
-                parent_stylesheet,
-                layerblockrule.rules.clone(),
-            ),
+            cssgroupingrule: CSSGroupingRule::new_inherited(parent_stylesheet),
             layerblockrule,
         }
     }
@@ -55,6 +52,10 @@ impl CSSLayerBlockRule {
             window,
             can_gc,
         )
+    }
+
+    pub(crate) fn clone_rules(&self) -> Arc<Locked<CssRules>> {
+        self.layerblockrule.rules.clone()
     }
 }
 

--- a/components/script/dom/cssstylerule.rs
+++ b/components/script/dom/cssstylerule.rs
@@ -10,14 +10,15 @@ use selectors::parser::{ParseRelative, SelectorList};
 use servo_arc::Arc;
 use style::selector_parser::SelectorParser;
 use style::shared_lock::{Locked, ToCssWithGuard};
-use style::stylesheets::{CssRuleType, Origin, StyleRule};
+use style::stylesheets::{CssRuleType, CssRules, Origin, StyleRule};
 
 use crate::dom::bindings::codegen::Bindings::CSSStyleRuleBinding::CSSStyleRuleMethods;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::{DomGlobal, reflect_dom_object};
 use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
 use crate::dom::bindings::str::DOMString;
-use crate::dom::cssrule::{CSSRule, SpecificCSSRule};
+use crate::dom::cssgroupingrule::CSSGroupingRule;
+use crate::dom::cssrule::SpecificCSSRule;
 use crate::dom::cssstyledeclaration::{CSSModificationAccess, CSSStyleDeclaration, CSSStyleOwner};
 use crate::dom::cssstylesheet::CSSStyleSheet;
 use crate::dom::node::NodeTraits;
@@ -26,7 +27,7 @@ use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct CSSStyleRule {
-    cssrule: CSSRule,
+    cssgroupingrule: CSSGroupingRule,
     #[ignore_malloc_size_of = "Arc"]
     #[no_trace]
     stylerule: Arc<Locked<StyleRule>>,
@@ -39,7 +40,7 @@ impl CSSStyleRule {
         stylerule: Arc<Locked<StyleRule>>,
     ) -> CSSStyleRule {
         CSSStyleRule {
-            cssrule: CSSRule::new_inherited(parent_stylesheet),
+            cssgroupingrule: CSSGroupingRule::new_inherited(parent_stylesheet),
             stylerule,
             style_decl: Default::default(),
         }
@@ -58,6 +59,16 @@ impl CSSStyleRule {
             can_gc,
         )
     }
+
+    pub(crate) fn ensure_rules(&self) -> Arc<Locked<CssRules>> {
+        let lock = self.cssgroupingrule.shared_lock();
+        let mut guard = lock.write();
+        self.stylerule
+            .write_with(&mut guard)
+            .rules
+            .get_or_insert_with(|| CssRules::new(vec![], lock))
+            .clone()
+    }
 }
 
 impl SpecificCSSRule for CSSStyleRule {
@@ -66,7 +77,7 @@ impl SpecificCSSRule for CSSStyleRule {
     }
 
     fn get_css(&self) -> DOMString {
-        let guard = self.cssrule.shared_lock().read();
+        let guard = self.cssgroupingrule.shared_lock().read();
         self.stylerule
             .read_with(&guard)
             .to_css_string(&guard)
@@ -78,7 +89,7 @@ impl CSSStyleRuleMethods<crate::DomTypeHolder> for CSSStyleRule {
     // https://drafts.csswg.org/cssom/#dom-cssstylerule-style
     fn Style(&self) -> DomRoot<CSSStyleDeclaration> {
         self.style_decl.or_init(|| {
-            let guard = self.cssrule.shared_lock().read();
+            let guard = self.cssgroupingrule.shared_lock().read();
             CSSStyleDeclaration::new(
                 self.global().as_window(),
                 CSSStyleOwner::CSSRule(
@@ -94,14 +105,18 @@ impl CSSStyleRuleMethods<crate::DomTypeHolder> for CSSStyleRule {
 
     // https://drafts.csswg.org/cssom/#dom-cssstylerule-selectortext
     fn SelectorText(&self) -> DOMString {
-        let guard = self.cssrule.shared_lock().read();
+        let guard = self.cssgroupingrule.shared_lock().read();
         let stylerule = self.stylerule.read_with(&guard);
         DOMString::from_string(stylerule.selectors.to_css_string())
     }
 
     // https://drafts.csswg.org/cssom/#dom-cssstylerule-selectortext
     fn SetSelectorText(&self, value: DOMString) {
-        let contents = &self.cssrule.parent_stylesheet().style_stylesheet().contents;
+        let contents = &self
+            .cssgroupingrule
+            .parent_stylesheet()
+            .style_stylesheet()
+            .contents;
         // It's not clear from the spec if we should use the stylesheet's namespaces.
         // https://github.com/w3c/csswg-drafts/issues/1511
         let namespaces = contents.namespaces.read();
@@ -118,10 +133,10 @@ impl CSSStyleRuleMethods<crate::DomTypeHolder> for CSSStyleRule {
         // rule?
         if let Ok(mut s) = SelectorList::parse(&parser, &mut css_parser, ParseRelative::No) {
             // This mirrors what we do in CSSStyleOwner::mutate_associated_block.
-            let mut guard = self.cssrule.shared_lock().write();
+            let mut guard = self.cssgroupingrule.shared_lock().write();
             let stylerule = self.stylerule.write_with(&mut guard);
             mem::swap(&mut stylerule.selectors, &mut s);
-            if let Some(owner) = self.cssrule.parent_stylesheet().get_owner() {
+            if let Some(owner) = self.cssgroupingrule.parent_stylesheet().get_owner() {
                 owner.stylesheet_list_owner().invalidate_stylesheets();
             }
         }

--- a/components/script_bindings/webidls/CSSStyleRule.webidl
+++ b/components/script_bindings/webidls/CSSStyleRule.webidl
@@ -4,7 +4,7 @@
 
 // https://drafts.csswg.org/cssom/#the-cssstylerule-interface
 [Exposed=Window]
-interface CSSStyleRule : CSSRule {
+interface CSSStyleRule : CSSGroupingRule {
   attribute DOMString selectorText;
   [SameObject, PutForwards=cssText] readonly attribute CSSStyleDeclaration style;
 };

--- a/tests/wpt/meta/css/css-nesting/cssom.html.ini
+++ b/tests/wpt/meta/css/css-nesting/cssom.html.ini
@@ -1,32 +1,5 @@
 [cssom.html]
-  [CSSStyleRule is a CSSGroupingRule]
-    expected: FAIL
-
-  [Simple CSSOM manipulation of subrules]
-    expected: FAIL
-
-  [Simple CSSOM manipulation of subrules 1]
-    expected: FAIL
-
-  [Simple CSSOM manipulation of subrules 2]
-    expected: FAIL
-
-  [Simple CSSOM manipulation of subrules 3]
-    expected: FAIL
-
-  [Simple CSSOM manipulation of subrules 4]
-    expected: FAIL
-
-  [Simple CSSOM manipulation of subrules 5]
-    expected: FAIL
-
-  [Simple CSSOM manipulation of subrules 6]
-    expected: FAIL
-
   [Simple CSSOM manipulation of subrules 7]
-    expected: FAIL
-
-  [Simple CSSOM manipulation of subrules 9]
     expected: FAIL
 
   [Manipulation of nested declarations through CSSOM]

--- a/tests/wpt/meta/css/cssom/idlharness.html.ini
+++ b/tests/wpt/meta/css/cssom/idlharness.html.ini
@@ -497,12 +497,6 @@
   [CSSImportRule interface: sheet.cssRules[0\] must inherit property "supportsText" with the proper type]
     expected: FAIL
 
-  [CSSStyleRule interface: existence and properties of interface object]
-    expected: FAIL
-
-  [CSSStyleRule interface: existence and properties of interface prototype object]
-    expected: FAIL
-
   [CSSGroupingRule interface: sheet.cssRules[4\] must inherit property "cssRules" with the proper type]
     expected: FAIL
 


### PR DESCRIPTION
Note that `StyleRule` may not have the `CssRules` readily available, they may need to be created. So the previous approach of providing `CSSGroupingRule` with the `CssRules` is no good: it would require writing them in advance, just in case they end up being used.

Therefore, this removes the `CSSGroupingRule::rules` field. Instead, they are lazily obtained in `CSSGroupingRule::rulelist()` by downcasting and calling the appropriate method for the subclass.

Testing: covered by WPT
Fixes: #36245
