### PR TITLE
Fix null realm assertion when activating a service worker

### DIFF
--- a/components/script/dom/serviceworkerglobalscope.rs
+++ b/components/script/dom/serviceworkerglobalscope.rs
@@ -376,11 +376,11 @@ impl ServiceWorkerGlobalScope {
 
                 {
                     // TODO: use AutoWorkerReset as in dedicated worker?
-                    let _ac = enter_realm(scope);
+                    let realm = enter_realm(scope);
                     scope.execute_script(DOMString::from(source), CanGc::note());
+                    global.dispatch_activate(CanGc::note(), InRealm::entered(&realm));
                 }
 
-                global.dispatch_activate(CanGc::note());
                 let reporter_name = format!("service-worker-reporter-{}", random::<u64>());
                 scope
                     .upcast::<GlobalScope>()
@@ -476,7 +476,7 @@ impl ServiceWorkerGlobalScope {
         ScriptEventLoopSender::ServiceWorker(self.own_sender.clone())
     }
 
-    fn dispatch_activate(&self, can_gc: CanGc) {
+    fn dispatch_activate(&self, can_gc: CanGc, _realm: InRealm) {
         let event = ExtendableEvent::new(self, atom!("activate"), false, false, can_gc);
         let event = (*event).upcast::<Event>();
         self.upcast::<EventTarget>().dispatch_event(event, can_gc);

--- a/tests/wpt/meta/fetch/api/abort/serviceworker-intercepted.https.html.ini
+++ b/tests/wpt/meta/fetch/api/abort/serviceworker-intercepted.https.html.ini
@@ -1,37 +1,37 @@
 [serviceworker-intercepted.https.html]
-  expected: CRASH
+  expected: TIMEOUT
   [Already aborted request does not land in service worker]
-    expected: FAIL
+    expected: TIMEOUT
 
   [response.arrayBuffer() rejects if already aborted]
-    expected: FAIL
+    expected: NOTRUN
 
   [response.blob() rejects if already aborted]
-    expected: FAIL
+    expected: NOTRUN
 
   [response.formData() rejects if already aborted]
-    expected: FAIL
+    expected: NOTRUN
 
   [response.json() rejects if already aborted]
-    expected: FAIL
+    expected: NOTRUN
 
   [response.text() rejects if already aborted]
-    expected: FAIL
+    expected: NOTRUN
 
   [Stream errors once aborted.]
-    expected: FAIL
+    expected: NOTRUN
 
   [fetch() rejects with abort reason]
-    expected: FAIL
+    expected: NOTRUN
 
   [fetch() response body has abort reason]
-    expected: FAIL
+    expected: NOTRUN
 
   [Service Worker can observe the fetch abort and associated abort reason]
-    expected: FAIL
+    expected: NOTRUN
 
   [Abort reason serialization happens on abort]
-    expected: FAIL
+    expected: NOTRUN
 
   [response.bytes() rejects if already aborted]
-    expected: FAIL
+    expected: NOTRUN

--- a/tests/wpt/meta/fetch/fetch-later/quota/same-origin-iframe/oversized-payload.tentative.https.window.js.ini
+++ b/tests/wpt/meta/fetch/fetch-later/quota/same-origin-iframe/oversized-payload.tentative.https.window.js.ini
@@ -1,4 +1,5 @@
 [oversized-payload.tentative.https.window.html]
+  expected: ERROR
   [fetchLater() does not accept payload[size=65537\] exceeding per-origin quota in a POST request body of String in same-origin iframe.]
     expected: FAIL
 

--- a/tests/wpt/meta/fetch/metadata/generated/css-font-face.https.sub.tentative.html.ini
+++ b/tests/wpt/meta/fetch/metadata/generated/css-font-face.https.sub.tentative.html.ini
@@ -52,6 +52,3 @@
 
   [sec-fetch-storage-access - Cross-site]
     expected: FAIL
-
-  [sec-fetch-user]
-    expected: FAIL

--- a/tests/wpt/meta/fetch/private-network-access/service-worker-background-fetch.tentative.https.window.js.ini
+++ b/tests/wpt/meta/fetch/private-network-access/service-worker-background-fetch.tentative.https.window.js.ini
@@ -1,28 +1,27 @@
 [service-worker-background-fetch.tentative.https.window.html]
-  expected: CRASH
   [local to local: success.]
-    expected: TIMEOUT
+    expected: FAIL
 
   [private to local: success.]
-    expected: NOTRUN
+    expected: FAIL
 
   [private to private: success.]
-    expected: NOTRUN
+    expected: FAIL
 
   [public to local: success.]
-    expected: NOTRUN
+    expected: FAIL
 
   [public to private: success.]
-    expected: NOTRUN
+    expected: FAIL
 
   [public to public: success.]
-    expected: NOTRUN
+    expected: FAIL
 
   [treat-as-public to local: success.]
-    expected: NOTRUN
+    expected: FAIL
 
   [treat-as-public to private: success.]
-    expected: NOTRUN
+    expected: FAIL
 
   [treat-as-public to public: success.]
-    expected: NOTRUN
+    expected: FAIL

--- a/tests/wpt/meta/fetch/private-network-access/service-worker-fetch-document-treat-as-public.tentative.https.window.js.ini
+++ b/tests/wpt/meta/fetch/private-network-access/service-worker-fetch-document-treat-as-public.tentative.https.window.js.ini
@@ -1,5 +1,5 @@
 [service-worker-fetch-document-treat-as-public.tentative.https.window.html]
-  expected: CRASH
+  expected: TIMEOUT
   [treat-as-public to local: failed preflight.]
     expected: TIMEOUT
 

--- a/tests/wpt/meta/fetch/private-network-access/service-worker-fetch-document.tentative.https.window.js.ini
+++ b/tests/wpt/meta/fetch/private-network-access/service-worker-fetch-document.tentative.https.window.js.ini
@@ -1,5 +1,5 @@
 [service-worker-fetch-document.tentative.https.window.html]
-  expected: CRASH
+  expected: TIMEOUT
   [local to local: success.]
     expected: TIMEOUT
 

--- a/tests/wpt/meta/fetch/private-network-access/service-worker-fetch.tentative.https.window.js.ini
+++ b/tests/wpt/meta/fetch/private-network-access/service-worker-fetch.tentative.https.window.js.ini
@@ -1,5 +1,5 @@
 [service-worker-fetch.tentative.https.window.html?9-last]
-  expected: CRASH
+  expected: TIMEOUT
   [public to public: success.]
     expected: TIMEOUT
 
@@ -23,7 +23,7 @@
 
 
 [service-worker-fetch.tentative.https.window.html?1-8]
-  expected: CRASH
+  expected: TIMEOUT
   [local to local: success.]
     expected: TIMEOUT
 

--- a/tests/wpt/meta/fetch/private-network-access/service-worker-update.tentative.https.window.js.ini
+++ b/tests/wpt/meta/fetch/private-network-access/service-worker-update.tentative.https.window.js.ini
@@ -1,5 +1,5 @@
 [service-worker-update.tentative.https.window.html]
-  expected: CRASH
+  expected: TIMEOUT
   [update public to local: success.]
     expected: TIMEOUT
 

--- a/tests/wpt/meta/fetch/private-network-access/service-worker.tentative.https.window.js.ini
+++ b/tests/wpt/meta/fetch/private-network-access/service-worker.tentative.https.window.js.ini
@@ -1,10 +1,9 @@
 [service-worker.tentative.https.window.html]
-  expected: CRASH
   [treat-as-public to local: success.]
-    expected: TIMEOUT
+    expected: FAIL
 
   [treat-as-public to private: success.]
-    expected: NOTRUN
+    expected: FAIL
 
   [public to public: success.]
-    expected: NOTRUN
+    expected: FAIL

--- a/tests/wpt/meta/fetch/security/dangling-markup/dangling-markup-mitigation-allowed-apis.tentative.https.html.ini
+++ b/tests/wpt/meta/fetch/security/dangling-markup/dangling-markup-mitigation-allowed-apis.tentative.https.html.ini
@@ -1,4 +1,18 @@
 [dangling-markup-mitigation-allowed-apis.tentative.https.html]
-  expected: CRASH
   [Does not block window.open(`resources/empty.html?\n<`,'_self')]
+    expected: FAIL
+
+  [Does not block xhr]
+    expected: FAIL
+
+  [Does not block EventSource]
+    expected: FAIL
+
+  [Does not block fetch]
+    expected: FAIL
+
+  [Does not block Worker]
+    expected: FAIL
+
+  [Does not block importScripts]
     expected: FAIL

--- a/tests/wpt/meta/fetch/security/dangling-markup/dangling-markup-mitigation.tentative.https.html.ini
+++ b/tests/wpt/meta/fetch/security/dangling-markup/dangling-markup-mitigation.tentative.https.html.ini
@@ -1,4 +1,4 @@
 [dangling-markup-mitigation.tentative.https.html]
-  expected: CRASH
+  expected: ERROR
   [Only blocks dangling markup requests]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/fetch/stale-while-revalidate/fetch-sw.https.html.ini
+++ b/tests/wpt/meta/fetch/stale-while-revalidate/fetch-sw.https.html.ini
@@ -1,4 +1,4 @@
 [fetch-sw.https.html]
-  expected: CRASH
+  expected: TIMEOUT
   [Second fetch returns same response]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/html/anonymous-iframe/serviceworker-partitioning.tentative.https.window.js.ini
+++ b/tests/wpt/meta/html/anonymous-iframe/serviceworker-partitioning.tentative.https.window.js.ini
@@ -1,7 +1,7 @@
 [serviceworker-partitioning.tentative.https.window.html]
-  expected: CRASH
+  expected: TIMEOUT
   [Anonymous iframes get partitioned service workers.]
     expected: FAIL
 
   [credentialless iframes get partitioned service workers.]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/html/anonymous-iframe/worker-cookies.tentative.https.window.js.ini
+++ b/tests/wpt/meta/html/anonymous-iframe/worker-cookies.tentative.https.window.js.ini
@@ -13,9 +13,5 @@
 
 
 [worker-cookies.tentative.https.window.html?worker=service_worker]
-  expected: CRASH
-  [Worker spawned from normal iframe can access global cookies]
-    expected: TIMEOUT
-
   [Worker spawned from credentialless iframe can't access global cookies]
-    expected: NOTRUN
+    expected: FAIL

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/iframe-src-aboutblank-navigate-immediately.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/iframe-src-aboutblank-navigate-immediately.html.ini
@@ -1,6 +1,3 @@
 [iframe-src-aboutblank-navigate-immediately.html]
   [Navigating to a different document with window.open]
     expected: FAIL
-
-  [Navigating to a different document with form submission]
-    expected: FAIL

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/navigation-unload-cross-origin.sub.window.js.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/navigation-unload-cross-origin.sub.window.js.ini
@@ -1,3 +1,0 @@
-[navigation-unload-cross-origin.sub.window.html]
-  [Cross-origin navigation started from unload handler must be ignored]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/canvas-host/2d.canvas.host.size.large.html.ini
+++ b/tests/wpt/meta/html/canvas/element/canvas-host/2d.canvas.host.size.large.html.ini
@@ -1,2 +1,0 @@
-[2d.canvas.host.size.large.html]
-  expected: CRASH

--- a/tests/wpt/meta/html/infrastructure/urls/base-url/document-base-url-window-initiator-is-not-opener.https.window.js.ini
+++ b/tests/wpt/meta/html/infrastructure/urls/base-url/document-base-url-window-initiator-is-not-opener.https.window.js.ini
@@ -1,4 +1,3 @@
 [document-base-url-window-initiator-is-not-opener.https.window.html]
-  expected: TIMEOUT
   [window.open() gets base url from initiator not opener.]
     expected: [FAIL, PASS, TIMEOUT]

--- a/tests/wpt/meta/html/interaction/focus/the-autofocus-attribute/document-with-fragment-valid.html.ini
+++ b/tests/wpt/meta/html/interaction/focus/the-autofocus-attribute/document-with-fragment-valid.html.ini
@@ -1,3 +1,0 @@
-[document-with-fragment-valid.html]
-  [Autofocus elements in top-level browsing context's documents with URL fragments should be skipped.]
-    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_popups_escaping-1.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_popups_escaping-1.html.ini
@@ -1,4 +1,4 @@
 [iframe_sandbox_popups_escaping-1.html]
   expected: TIMEOUT
   [Check that popups from a sandboxed iframe escape the sandbox if\n       allow-popups-to-escape-sandbox is used]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_popups_escaping-2.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_popups_escaping-2.html.ini
@@ -1,3 +1,4 @@
 [iframe_sandbox_popups_escaping-2.html]
+  expected: TIMEOUT
   [Check that popups from a sandboxed iframe escape the sandbox if\n       allow-popups-to-escape-sandbox is used]
     expected: TIMEOUT

--- a/tests/wpt/meta/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_popups_escaping-3.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_popups_escaping-3.html.ini
@@ -1,4 +1,4 @@
 [iframe_sandbox_popups_escaping-3.html]
   expected: TIMEOUT
   [Check that popups from a sandboxed iframe escape the sandbox if\n       allow-popups-to-escape-sandbox is used]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_popups_nonescaping-1.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_popups_nonescaping-1.html.ini
@@ -1,4 +1,4 @@
 [iframe_sandbox_popups_nonescaping-1.html]
   expected: TIMEOUT
   [Check that popups from a sandboxed iframe do not escape the sandbox]
-    expected: NOTRUN
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_popups_nonescaping-3.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_popups_nonescaping-3.html.ini
@@ -1,3 +1,4 @@
 [iframe_sandbox_popups_nonescaping-3.html]
+  expected: TIMEOUT
   [Check that popups from a sandboxed iframe do not escape the sandbox]
-    expected: FAIL
+    expected: NOTRUN

--- a/tests/wpt/meta/service-workers/service-worker/ServiceWorkerGlobalScope/error-message-event.https.html.ini
+++ b/tests/wpt/meta/service-workers/service-worker/ServiceWorkerGlobalScope/error-message-event.https.html.ini
@@ -1,2 +1,4 @@
 [error-message-event.https.html]
-  expected: CRASH
+  expected: TIMEOUT
+  [Verify error event is received]
+    expected: TIMEOUT

--- a/tests/wpt/meta/service-workers/service-worker/ServiceWorkerGlobalScope/message-event-ports.https.html.ini
+++ b/tests/wpt/meta/service-workers/service-worker/ServiceWorkerGlobalScope/message-event-ports.https.html.ini
@@ -1,2 +1,4 @@
 [message-event-ports.https.html]
-  expected: CRASH
+  expected: TIMEOUT
+  [Verify MessageEvent.ports getter returns the same object]
+    expected: TIMEOUT

--- a/tests/wpt/meta/service-workers/service-worker/claim-affect-other-registration.https.html.ini
+++ b/tests/wpt/meta/service-workers/service-worker/claim-affect-other-registration.https.html.ini
@@ -1,2 +1,4 @@
 [claim-affect-other-registration.https.html]
-  expected: CRASH
+  expected: TIMEOUT
+  [claim() should affect the originally controlling registration.]
+    expected: TIMEOUT

--- a/tests/wpt/meta/service-workers/service-worker/claim-not-using-registration.https.html.ini
+++ b/tests/wpt/meta/service-workers/service-worker/claim-not-using-registration.https.html.ini
@@ -1,2 +1,7 @@
 [claim-not-using-registration.https.html]
-  expected: CRASH
+  expected: TIMEOUT
+  [Test claim client which is not using registration]
+    expected: FAIL
+
+  [Test claim client when there's a longer-matched registration not already used by the page]
+    expected: TIMEOUT

--- a/tests/wpt/meta/service-workers/service-worker/claim-with-redirect.https.html.ini
+++ b/tests/wpt/meta/service-workers/service-worker/claim-with-redirect.https.html.ini
@@ -1,2 +1,2 @@
 [claim-with-redirect.https.html]
-  expected: CRASH
+  expected: ERROR

--- a/tests/wpt/meta/service-workers/service-worker/controlled-dedicatedworker-postMessage.https.html.ini
+++ b/tests/wpt/meta/service-workers/service-worker/controlled-dedicatedworker-postMessage.https.html.ini
@@ -1,2 +1,10 @@
 [controlled-dedicatedworker-postMessage.https.html]
-  expected: CRASH
+  expected: TIMEOUT
+  [Register service worker]
+    expected: TIMEOUT
+
+  [Verify dedicated worker gets messages if setting event listener early]
+    expected: NOTRUN
+
+  [Verify dedicated worker does not get all messages if not setting event listener early]
+    expected: NOTRUN

--- a/tests/wpt/meta/service-workers/service-worker/controlled-iframe-postMessage.https.html.ini
+++ b/tests/wpt/meta/service-workers/service-worker/controlled-iframe-postMessage.https.html.ini
@@ -1,2 +1,13 @@
 [controlled-iframe-postMessage.https.html]
-  expected: CRASH
+  expected: TIMEOUT
+  [Register service worker]
+    expected: TIMEOUT
+
+  [Verify frame gets early messages if setting synchronously message event listener]
+    expected: NOTRUN
+
+  [Verify frame does not get all messages if not setting event listener early]
+    expected: NOTRUN
+
+  [Verify frame does get messages in order]
+    expected: NOTRUN

--- a/tests/wpt/meta/service-workers/service-worker/fetch-event-within-sw.https.html.ini
+++ b/tests/wpt/meta/service-workers/service-worker/fetch-event-within-sw.https.html.ini
@@ -1,2 +1,7 @@
 [fetch-event-within-sw.https.html]
-  expected: CRASH
+  expected: TIMEOUT
+  [Service worker intercepts requests from window]
+    expected: TIMEOUT
+
+  [Service worker does not intercept fetch/cache requests within service worker]
+    expected: NOTRUN

--- a/tests/wpt/meta/service-workers/service-worker/immutable-prototype-serviceworker.https.html.ini
+++ b/tests/wpt/meta/service-workers/service-worker/immutable-prototype-serviceworker.https.html.ini
@@ -1,2 +1,4 @@
 [immutable-prototype-serviceworker.https.html]
-  expected: CRASH
+  expected: TIMEOUT
+  [worker prototype chain should be immutable]
+    expected: TIMEOUT

--- a/tests/wpt/meta/service-workers/service-worker/multi-globals/url-parsing.https.html.ini
+++ b/tests/wpt/meta/service-workers/service-worker/multi-globals/url-parsing.https.html.ini
@@ -1,2 +1,10 @@
 [url-parsing.https.html]
-  expected: CRASH
+  expected: TIMEOUT
+  [register should use the relevant global of the object it was called on to resolve the script URL and the default scope URL]
+    expected: TIMEOUT
+
+  [register should use the relevant global of the object it was called on to resolve the script URL and the given scope URL]
+    expected: NOTRUN
+
+  [getRegistration should use the relevant global of the object it was called on to resolve the script URL]
+    expected: NOTRUN

--- a/tests/wpt/meta/service-workers/service-worker/navigation-sets-cookie.https.html.ini
+++ b/tests/wpt/meta/service-workers/service-worker/navigation-sets-cookie.https.html.ini
@@ -1,2 +1,49 @@
 [navigation-sets-cookie.https.html]
-  expected: CRASH
+  expected: TIMEOUT
+  [Setup service workers]
+    expected: TIMEOUT
+
+  [Same-site top-level navigation with fallback service worker should be able to set SameSite=* cookies.]
+    expected: NOTRUN
+
+  [Cross-site top-level navigation with fallback service worker should be able to set SameSite=* cookies.]
+    expected: NOTRUN
+
+  [Same-site top-level POST with fallback service worker should be able to set SameSite=* cookies.]
+    expected: NOTRUN
+
+  [Cross-site top-level with fallback service worker POST should be able to set SameSite=* cookies.]
+    expected: NOTRUN
+
+  [Same-site top-level navigation with passthrough service worker should be able to set SameSite=* cookies.]
+    expected: NOTRUN
+
+  [Cross-site top-level navigation with passthrough service worker should be able to set SameSite=* cookies.]
+    expected: NOTRUN
+
+  [Same-site top-level POST with passthrough service worker should be able to set SameSite=* cookies.]
+    expected: NOTRUN
+
+  [Cross-site top-level with passthrough service worker POST should be able to set SameSite=* cookies.]
+    expected: NOTRUN
+
+  [Same-site top-level navigation with navpreload service worker should be able to set SameSite=* cookies.]
+    expected: NOTRUN
+
+  [Cross-site top-level navigation with navpreload service worker should be able to set SameSite=* cookies.]
+    expected: NOTRUN
+
+  [Same-site top-level navigation with change-request service worker should be able to set SameSite=* cookies.]
+    expected: NOTRUN
+
+  [Cross-site top-level navigation with change-request service worker should be able to set SameSite=* cookies.]
+    expected: NOTRUN
+
+  [Same-site top-level POST with change-request service worker should be able to set SameSite=* cookies.]
+    expected: NOTRUN
+
+  [Cross-site top-level with change-request service worker POST should be able to set SameSite=* cookies.]
+    expected: NOTRUN
+
+  [Cleanup service workers]
+    expected: NOTRUN

--- a/tests/wpt/meta/service-workers/service-worker/register-wait-forever-in-install-worker.https.html.ini
+++ b/tests/wpt/meta/service-workers/service-worker/register-wait-forever-in-install-worker.https.html.ini
@@ -1,4 +1,4 @@
 [register-wait-forever-in-install-worker.https.html]
-  expected: CRASH
+  expected: ERROR
   [register worker that calls waitUntil with a promise that never resolves in oninstall]
     expected: FAIL

--- a/tests/wpt/meta/service-workers/service-worker/registration-mime-types.https.html.ini
+++ b/tests/wpt/meta/service-workers/service-worker/registration-mime-types.https.html.ini
@@ -1,2 +1,108 @@
 [registration-mime-types.https.html]
-  expected: CRASH
+  [Registering script with no MIME type]
+    expected: FAIL
+
+  [Registering script with bad MIME type]
+    expected: FAIL
+
+  [Registering script that imports script with no MIME type]
+    expected: FAIL
+
+  [Registering script that imports script with bad MIME type]
+    expected: FAIL
+
+  [Registering script with good MIME type application/ecmascript]
+    expected: FAIL
+
+  [Registering script that imports script with good MIME type application/ecmascript]
+    expected: FAIL
+
+  [Registering script with good MIME type application/javascript]
+    expected: FAIL
+
+  [Registering script that imports script with good MIME type application/javascript]
+    expected: FAIL
+
+  [Registering script with good MIME type application/x-ecmascript]
+    expected: FAIL
+
+  [Registering script that imports script with good MIME type application/x-ecmascript]
+    expected: FAIL
+
+  [Registering script with good MIME type application/x-javascript]
+    expected: FAIL
+
+  [Registering script that imports script with good MIME type application/x-javascript]
+    expected: FAIL
+
+  [Registering script with good MIME type text/ecmascript]
+    expected: FAIL
+
+  [Registering script that imports script with good MIME type text/ecmascript]
+    expected: FAIL
+
+  [Registering script with good MIME type text/javascript]
+    expected: FAIL
+
+  [Registering script that imports script with good MIME type text/javascript]
+    expected: FAIL
+
+  [Registering script with good MIME type text/javascript1.0]
+    expected: FAIL
+
+  [Registering script that imports script with good MIME type text/javascript1.0]
+    expected: FAIL
+
+  [Registering script with good MIME type text/javascript1.1]
+    expected: FAIL
+
+  [Registering script that imports script with good MIME type text/javascript1.1]
+    expected: FAIL
+
+  [Registering script with good MIME type text/javascript1.2]
+    expected: FAIL
+
+  [Registering script that imports script with good MIME type text/javascript1.2]
+    expected: FAIL
+
+  [Registering script with good MIME type text/javascript1.3]
+    expected: FAIL
+
+  [Registering script that imports script with good MIME type text/javascript1.3]
+    expected: FAIL
+
+  [Registering script with good MIME type text/javascript1.4]
+    expected: FAIL
+
+  [Registering script that imports script with good MIME type text/javascript1.4]
+    expected: FAIL
+
+  [Registering script with good MIME type text/javascript1.5]
+    expected: FAIL
+
+  [Registering script that imports script with good MIME type text/javascript1.5]
+    expected: FAIL
+
+  [Registering script with good MIME type text/jscript]
+    expected: FAIL
+
+  [Registering script that imports script with good MIME type text/jscript]
+    expected: FAIL
+
+  [Registering script with good MIME type text/livescript]
+    expected: FAIL
+
+  [Registering script that imports script with good MIME type text/livescript]
+    expected: FAIL
+
+  [Registering script with good MIME type text/x-ecmascript]
+    expected: FAIL
+
+  [Registering script that imports script with good MIME type text/x-ecmascript]
+    expected: FAIL
+
+  [Registering script with good MIME type text/x-javascript]
+    expected: FAIL
+
+  [Registering script that imports script with good MIME type text/x-javascript]
+    expected: FAIL

--- a/tests/wpt/meta/service-workers/service-worker/registration-scope.https.html.ini
+++ b/tests/wpt/meta/service-workers/service-worker/registration-scope.https.html.ini
@@ -1,2 +1,15 @@
 [registration-scope.https.html]
-  expected: CRASH
+  [Scope including URL-encoded multibyte characters]
+    expected: FAIL
+
+  [Scope including non-escaped multibyte characters]
+    expected: FAIL
+
+  [Scope including self-reference]
+    expected: FAIL
+
+  [Scope including parent-reference]
+    expected: FAIL
+
+  [Scope including consecutive slashes]
+    expected: FAIL

--- a/tests/wpt/meta/service-workers/service-worker/registration-script-module.https.html.ini
+++ b/tests/wpt/meta/service-workers/service-worker/registration-script-module.https.html.ini
@@ -1,2 +1,30 @@
 [registration-script-module.https.html]
-  expected: CRASH
+  [Registering invalid chunked encoding script]
+    expected: FAIL
+
+  [Registering invalid chunked encoding script with flush]
+    expected: FAIL
+
+  [Registering script including parse error]
+    expected: FAIL
+
+  [Registering script including undefined error]
+    expected: FAIL
+
+  [Registering script including uncaught exception]
+    expected: FAIL
+
+  [Registering script with top-level await]
+    expected: FAIL
+
+  [Registering script with module instantiation error]
+    expected: FAIL
+
+  [Registering script with module instantiation error and top-level await]
+    expected: FAIL
+
+  [Registering non-existent script]
+    expected: FAIL
+
+  [Registering script including caught exception]
+    expected: FAIL

--- a/tests/wpt/meta/service-workers/service-worker/registration-script-url.https.html.ini
+++ b/tests/wpt/meta/service-workers/service-worker/registration-script-url.https.html.ini
@@ -1,2 +1,6 @@
 [registration-script-url.https.html]
-  expected: CRASH
+  [Script URL including self-reference]
+    expected: FAIL
+
+  [Script URL including parent-reference]
+    expected: FAIL

--- a/tests/wpt/meta/service-workers/service-worker/registration-script.https.html.ini
+++ b/tests/wpt/meta/service-workers/service-worker/registration-script.https.html.ini
@@ -1,2 +1,27 @@
 [registration-script.https.html]
-  expected: CRASH
+  [Registering invalid chunked encoding script]
+    expected: FAIL
+
+  [Registering invalid chunked encoding script with flush]
+    expected: FAIL
+
+  [Registering script including parse error]
+    expected: FAIL
+
+  [Registering script including undefined error]
+    expected: FAIL
+
+  [Registering script including uncaught exception]
+    expected: FAIL
+
+  [Registering script importing malformed script]
+    expected: FAIL
+
+  [Registering non-existent script]
+    expected: FAIL
+
+  [Registering script importing non-existent script]
+    expected: FAIL
+
+  [Registering script including caught exception]
+    expected: FAIL

--- a/tests/wpt/meta/service-workers/service-worker/registration-security-error.https.html.ini
+++ b/tests/wpt/meta/service-workers/service-worker/registration-security-error.https.html.ini
@@ -1,2 +1,25 @@
 [registration-security-error.https.html]
-  expected: CRASH
+  expected: TIMEOUT
+  [Registering same scope as the script directory without the last slash]
+    expected: FAIL
+
+  [Registration scope outside the script directory]
+    expected: FAIL
+
+  [Registering scope outside domain]
+    expected: TIMEOUT
+
+  [Registering script outside domain]
+    expected: NOTRUN
+
+  [Registering redirected script]
+    expected: NOTRUN
+
+  [Scope including parent-reference and not under the script directory]
+    expected: NOTRUN
+
+  [Script URL including consecutive slashes]
+    expected: NOTRUN
+
+  [Script URL is same-origin filesystem: URL]
+    expected: NOTRUN

--- a/tests/wpt/meta/service-workers/service-worker/same-site-cookies.https.html.ini
+++ b/tests/wpt/meta/service-workers/service-worker/same-site-cookies.https.html.ini
@@ -1,2 +1,199 @@
 [same-site-cookies.https.html]
-  expected: CRASH
+  expected: TIMEOUT
+  [Setup service workers]
+    expected: TIMEOUT
+
+  [same-origin, window.open with no service worker]
+    expected: NOTRUN
+
+  [same-origin, window.open with fallback]
+    expected: NOTRUN
+
+  [same-origin, window.open with passthrough]
+    expected: NOTRUN
+
+  [same-origin, window.open with change-request]
+    expected: NOTRUN
+
+  [same-origin, window.open with navpreload]
+    expected: NOTRUN
+
+  [same-site, window.open with no service worker]
+    expected: NOTRUN
+
+  [same-site, window.open with fallback]
+    expected: NOTRUN
+
+  [same-site, window.open with passthrough]
+    expected: NOTRUN
+
+  [same-site, window.open with change-request]
+    expected: NOTRUN
+
+  [same-site, window.open with navpreload]
+    expected: NOTRUN
+
+  [cross-site, window.open with no service worker]
+    expected: NOTRUN
+
+  [cross-site, window.open with fallback]
+    expected: NOTRUN
+
+  [cross-site, window.open with passthrough]
+    expected: NOTRUN
+
+  [cross-site, window.open with change-request]
+    expected: NOTRUN
+
+  [cross-site, window.open with navpreload]
+    expected: NOTRUN
+
+  [same-origin, window.open with no service worker and same-site redirect]
+    expected: NOTRUN
+
+  [same-origin, window.open with fallback and same-site redirect]
+    expected: NOTRUN
+
+  [same-origin, window.open with passthrough and same-site redirect]
+    expected: NOTRUN
+
+  [same-origin, window.open with change-request and same-site redirect]
+    expected: NOTRUN
+
+  [same-origin, window.open with navpreload and same-site redirect]
+    expected: NOTRUN
+
+  [same-origin, window.open with no service worker and cross-site redirect]
+    expected: NOTRUN
+
+  [same-origin, window.open with fallback and cross-site redirect]
+    expected: NOTRUN
+
+  [same-origin, window.open with passthrough and cross-site redirect]
+    expected: NOTRUN
+
+  [same-origin, window.open with change-request and cross-site redirect]
+    expected: NOTRUN
+
+  [same-origin, window.open with navpreload and cross-site redirect]
+    expected: NOTRUN
+
+  [same-origin, window.open with no service worker, cross-site redirect, and same-origin redirect]
+    expected: NOTRUN
+
+  [same-origin, window.open with fallback, cross-site redirect, and same-origin redirect]
+    expected: NOTRUN
+
+  [same-origin, window.open with passthrough, cross-site redirect, and same-origin redirect]
+    expected: NOTRUN
+
+  [same-origin, window.open with change-request, cross-site redirect, and same-origin redirect]
+    expected: NOTRUN
+
+  [same-origin, window.open with navpreload, cross-site redirect, and same-origin redirect]
+    expected: NOTRUN
+
+  [same-origin, nested window.open with cross-site middle frame and no service worker]
+    expected: NOTRUN
+
+  [same-origin, nested window.open with cross-site middle frame and fallback service worker]
+    expected: NOTRUN
+
+  [same-origin, nested window.open with cross-site middle frame and passthrough service worker]
+    expected: NOTRUN
+
+  [same-origin, nested window.open with cross-site middle frame and change-request service worker]
+    expected: NOTRUN
+
+  [same-origin, nested window.open with cross-site middle frame and navpreload service worker]
+    expected: NOTRUN
+
+  [same-origin, nested set location with cross-site middle frame and no service worker]
+    expected: NOTRUN
+
+  [same-origin, nested set location with cross-site middle frame and fallback service worker]
+    expected: NOTRUN
+
+  [same-origin, nested set location with cross-site middle frame and passthrough service worker]
+    expected: NOTRUN
+
+  [same-origin, nested set location with cross-site middle frame and change-request service worker]
+    expected: NOTRUN
+
+  [same-origin, nested set location with cross-site middle frame and navpreload service worker]
+    expected: NOTRUN
+
+  [same-origin, form post with no service worker]
+    expected: NOTRUN
+
+  [same-origin, form post with fallback]
+    expected: NOTRUN
+
+  [same-origin, form post with passthrough]
+    expected: NOTRUN
+
+  [same-origin, form post with change-request]
+    expected: NOTRUN
+
+  [same-site, form post with no service worker]
+    expected: NOTRUN
+
+  [same-site, form post with fallback]
+    expected: NOTRUN
+
+  [same-site, form post with passthrough]
+    expected: NOTRUN
+
+  [same-site, form post with change-request]
+    expected: NOTRUN
+
+  [cross-site, form post with no service worker]
+    expected: NOTRUN
+
+  [cross-site, form post with fallback]
+    expected: NOTRUN
+
+  [cross-site, form post with passthrough]
+    expected: NOTRUN
+
+  [cross-site, form post with change-request]
+    expected: NOTRUN
+
+  [same-origin, form post with no service worker and same-site redirect]
+    expected: NOTRUN
+
+  [same-origin, form post with fallback and same-site redirect]
+    expected: NOTRUN
+
+  [same-origin, form post with passthrough and same-site redirect]
+    expected: NOTRUN
+
+  [same-origin, form post with change-request and same-site redirect]
+    expected: NOTRUN
+
+  [same-origin, form post with no service worker and cross-site redirect]
+    expected: NOTRUN
+
+  [same-origin, form post with fallback and cross-site redirect]
+    expected: NOTRUN
+
+  [same-origin, form post with passthrough and cross-site redirect]
+    expected: NOTRUN
+
+  [same-origin, form post with change-request and cross-site redirect]
+    expected: NOTRUN
+
+  [same-origin, form post with no service worker, cross-site redirect, and same-origin redirect]
+    expected: NOTRUN
+
+  [same-origin, form post with fallback, cross-site redirect, and same-origin redirect]
+    expected: NOTRUN
+
+  [same-origin, form post with passthrough, cross-site redirect, and same-origin redirect]
+    expected: NOTRUN
+
+  [same-origin, form post with change-request, cross-site redirect, and same-origin redirect]
+    expected: NOTRUN
+
+  [Cleanup service workers]
+    expected: NOTRUN

--- a/tests/wpt/meta/service-workers/service-worker/svg-target-reftest.https.html.ini
+++ b/tests/wpt/meta/service-workers/service-worker/svg-target-reftest.https.html.ini
@@ -1,2 +1,2 @@
 [svg-target-reftest.https.html]
-  expected: CRASH
+  expected: TIMEOUT

--- a/tests/wpt/meta/service-workers/service-worker/unregister.https.html.ini
+++ b/tests/wpt/meta/service-workers/service-worker/unregister.https.html.ini
@@ -1,5 +1,4 @@
 [unregister.https.html]
-  expected: CRASH
   [Unregister twice]
     expected: FAIL
 

--- a/tests/wpt/meta/service-workers/service-worker/update-result.https.html.ini
+++ b/tests/wpt/meta/service-workers/service-worker/update-result.https.html.ini
@@ -1,2 +1,4 @@
 [update-result.https.html]
-  expected: CRASH
+  expected: TIMEOUT
+  [ServiceWorkerRegistration.update() should resolve a registration object]
+    expected: TIMEOUT

--- a/tests/wpt/meta/service-workers/service-worker/worker-client-id.https.html.ini
+++ b/tests/wpt/meta/service-workers/service-worker/worker-client-id.https.html.ini
@@ -1,2 +1,4 @@
 [worker-client-id.https.html]
-  expected: CRASH
+  expected: TIMEOUT
+  [Verify workers have a unique client id separate from their owning documents window]
+    expected: TIMEOUT

--- a/tests/wpt/meta/webmessaging/broadcastchannel/service-worker.https.html.ini
+++ b/tests/wpt/meta/webmessaging/broadcastchannel/service-worker.https.html.ini
@@ -1,4 +1,2 @@
 [service-worker.https.html]
-  expected: CRASH
-  [BroadcastChannel works in service workers]
-    expected: FAIL
+  expected: ERROR

--- a/tests/wpt/mozilla/meta/mozilla/service-workers/service-worker-registration.https.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/service-workers/service-worker-registration.https.html.ini
@@ -1,30 +1,8 @@
 [service-worker-registration.https.html]
-  expected: CRASH
-  [Test: Asserts Installing Service Worker and its Registration]
-    expected: FAIL
-
-  [Test: Installing Service Worker ScriptURL property]
-    expected: FAIL
-
-  [Test: Throws Error when Invalid Scope]
-    expected: FAIL
-
   [Test: Asserts Active Service Worker and its Registration]
     expected: FAIL
 
   [Test: Active Service Worker ScriptURL property]
-    expected: FAIL
-
-  [Test: Asserts ServiceWorkerContainer in Navigator]
-    expected: FAIL
-
-  [Test: Throws Error when Invalid Url Path]
-    expected: FAIL
-
-  [Test: Service Worker Registration property scope Url when no scope]
-    expected: FAIL
-
-  [Test: Service Worker Registration property scope when provided a scope]
     expected: FAIL
 
   [Test: Asserts Active Service Worker and its Registration]


### PR DESCRIPTION
Ensure there is an active realm when dispatching the `activation` DOM event to the ServiceWorker global.

Testing: Existing WPT coverage.
Fixes: #36114
Fixes: #36235
Fixes: #36231
