### PR TITLE
dom: Firing "click" event as synthetic pointer event

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -171,7 +171,7 @@ use crate::dom::nodeiterator::NodeIterator;
 use crate::dom::nodelist::NodeList;
 use crate::dom::pagetransitionevent::PageTransitionEvent;
 use crate::dom::performanceentry::PerformanceEntry;
-use crate::dom::pointerevent::PointerEvent;
+use crate::dom::pointerevent::{PointerEvent, PointerId};
 use crate::dom::processinginstruction::ProcessingInstruction;
 use crate::dom::promise::Promise;
 use crate::dom::range::Range;
@@ -1402,7 +1402,6 @@ impl Document {
         // <https://w3c.github.io/uievents/#contextmenu>
         let menu_event = PointerEvent::new(
             &self.window,                   // window
-            None,                           // proto
             DOMString::from("contextmenu"), // type
             EventBubbles::Bubbles,          // can_bubble
             EventCancelable::Cancelable,    // cancelable
@@ -1420,22 +1419,20 @@ impl Document {
             pressed_mouse_buttons,          // buttons
             None,                           // related_target
             None,                           // point_in_target
-            // TODO: decide generic pointer id
-            // <https://www.w3.org/TR/pointerevents3/#dom-pointerevent-pointerid>
-            0,                        // pointer_id
-            1,                        // width
-            1,                        // height
-            0.5,                      // pressure
-            0.0,                      // tangential_pressure
-            0,                        // tilt_x
-            0,                        // tilt_y
-            0,                        // twist
-            PI / 2.0,                 // altitude_angle
-            0.0,                      // azimuth_angle
-            DOMString::from("mouse"), // pointer_type
-            true,                     // is_primary
-            vec![],                   // coalesced_events
-            vec![],                   // predicted_events
+            PointerId::Mouse as i32,        // pointer_id
+            1,                              // width
+            1,                              // height
+            0.5,                            // pressure
+            0.0,                            // tangential_pressure
+            0,                              // tilt_x
+            0,                              // tilt_y
+            0,                              // twist
+            PI / 2.0,                       // altitude_angle
+            0.0,                            // azimuth_angle
+            DOMString::from("mouse"),       // pointer_type
+            true,                           // is_primary
+            vec![],                         // coalesced_events
+            vec![],                         // predicted_events
             can_gc,
         );
         let event = menu_event.upcast::<Event>();
@@ -2186,7 +2183,7 @@ impl Document {
             {
                 if let Some(elem) = target.downcast::<Element>() {
                     elem.upcast::<Node>()
-                        .fire_synthetic_mouse_event_not_trusted(DOMString::from("click"), can_gc);
+                        .fire_synthetic_pointer_event_not_trusted(DOMString::from("click"), can_gc);
                 }
             }
         }

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -395,7 +395,7 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
         Some(item_attr_values.into_iter().collect())
     }
 
-    // https://html.spec.whatwg.org/multipage/#dom-click
+    /// <https://html.spec.whatwg.org/multipage/#dom-click>
     fn Click(&self, can_gc: CanGc) {
         let element = self.as_element();
         if element.disabled_state() {
@@ -407,7 +407,7 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
         element.set_click_in_progress(true);
 
         self.upcast::<Node>()
-            .fire_synthetic_mouse_event_not_trusted(DOMString::from("click"), can_gc);
+            .fire_synthetic_pointer_event_not_trusted(DOMString::from("click"), can_gc);
         element.set_click_in_progress(false);
     }
 

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -2149,7 +2149,7 @@ impl HTMLInputElement {
                     // but we can get here from synthetic keydown events
                     button
                         .upcast::<Node>()
-                        .fire_synthetic_mouse_event_not_trusted(DOMString::from("click"), can_gc);
+                        .fire_synthetic_pointer_event_not_trusted(DOMString::from("click"), can_gc);
                 }
             },
             None => {

--- a/components/script/dom/pointerevent.rs
+++ b/components/script/dom/pointerevent.rs
@@ -23,6 +23,13 @@ use crate::dom::mouseevent::MouseEvent;
 use crate::dom::window::Window;
 use crate::script_runtime::CanGc;
 
+/// <https://w3c.github.io/pointerevents/#dom-pointerevent-pointerid>
+#[derive(Clone, Copy, MallocSizeOf, PartialEq)]
+pub(crate) enum PointerId {
+    NonPointerDevice = -1,
+    Mouse,
+}
+
 #[dom_struct]
 pub(crate) struct PointerEvent {
     mouseevent: MouseEvent,
@@ -83,7 +90,6 @@ impl PointerEvent {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         window: &Window,
-        proto: Option<HandleObject>,
         type_: DOMString,
         can_bubble: EventBubbles,
         cancelable: EventCancelable,
@@ -119,7 +125,7 @@ impl PointerEvent {
     ) -> DomRoot<PointerEvent> {
         Self::new_with_proto(
             window,
-            proto,
+            None,
             type_,
             can_bubble,
             cancelable,

--- a/tests/wpt/meta/shadow-dom/event-composed.html.ini
+++ b/tests/wpt/meta/shadow-dom/event-composed.html.ini
@@ -1,3 +1,0 @@
-[event-composed.html]
-  [A UA click event should not be scoped]
-    expected: FAIL

--- a/tests/wpt/meta/uievents/interface/click-event.htm.ini
+++ b/tests/wpt/meta/uievents/interface/click-event.htm.ini
@@ -1,4 +1,0 @@
-[click-event.htm]
-  [synthetic click event is a PointerEvent]
-    expected: FAIL
-


### PR DESCRIPTION
According to specification
https://html.spec.whatwg.org/multipage/webappapis.html#fire-a-click-event "Firing a click event at target means firing a synthetic pointer event named click at target"

So need to replace synthetic mouse event with "click" type to pointer event.
https://w3c.github.io/pointerevents/#the-click-auxclick-and-contextmenu-events
https://www.w3.org/TR/uievents/#event-type-click

Firing "click" event could be triggered from script or by UA:
- element.click() (https://html.spec.whatwg.org/multipage/interaction.html#dom-click)
- form implicit submission (https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#implicit-submission)
- keyboard activation (space)

---
- [x] ./mach build -d does not report any errors
- [x] ./mach test-tidy does not report any errors
- [x] There are tests for these changes
tests/wpt/tests/shadow-dom/event-composed.html
tests/wpt/tests/uievents/interface/click-event.htm