### PR TITLE
libservo: Remove a couple `EmbedderMethods`

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -5,8 +5,7 @@
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::env;
-use std::fs::{File, create_dir_all};
-use std::io::Write;
+use std::fs::create_dir_all;
 use std::iter::once;
 use std::mem::take;
 use std::rc::Rc;
@@ -113,10 +112,6 @@ pub struct ServoRenderer {
 
     /// The GL bindings for webrender
     webrender_gl: Rc<dyn gleam::gl::Gl>,
-
-    /// The string representing the version of Servo that is running. This is used to tag
-    /// WebRender capture output.
-    version_string: String,
 
     #[cfg(feature = "webxr")]
     /// Some XR devices want to run on the main thread.
@@ -429,7 +424,6 @@ impl IOCompositor {
         window: Rc<dyn WindowMethods>,
         state: InitialCompositorState,
         convert_mouse_to_touch: bool,
-        version_string: String,
     ) -> Self {
         let compositor = IOCompositor {
             global: Rc::new(RefCell::new(ServoRenderer {
@@ -441,7 +435,6 @@ impl IOCompositor {
                 webrender_api: state.webrender_api,
                 webrender_document: state.webrender_document,
                 webrender_gl: state.webrender_gl,
-                version_string,
                 #[cfg(feature = "webxr")]
                 webxr_main_thread: state.webxr_main_thread,
                 convert_mouse_to_touch,
@@ -1773,13 +1766,6 @@ impl IOCompositor {
             .borrow()
             .webrender_api
             .save_capture(capture_path.clone(), CaptureBits::all());
-
-        let version_file_path = capture_path.join("servo-version.txt");
-        if let Err(error) = File::create(version_file_path)
-            .and_then(|mut file| write!(file, "{}", self.global.borrow().version_string))
-        {
-            eprintln!("Unable to write servo version for WebRender Capture: {error:?}");
-        }
     }
 
     fn add_font_instance(

--- a/components/compositing/windowing.rs
+++ b/components/compositing/windowing.rs
@@ -59,16 +59,6 @@ pub trait EmbedderMethods {
     ) {
     }
 
-    /// Returns the user agent string to report in network requests.
-    fn get_user_agent_string(&self) -> Option<String> {
-        None
-    }
-
-    /// Returns the version string of this embedder.
-    fn get_version_string(&self) -> Option<String> {
-        None
-    }
-
     /// Returns the protocol handlers implemented by that embedder.
     /// They will be merged with the default internal ones.
     fn get_protocol_handlers(&self) -> ProtocolRegistry {

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -84,7 +84,7 @@
 //!
 //! See <https://github.com/servo/servo/issues/14704>
 
-use std::borrow::{Cow, ToOwned};
+use std::borrow::ToOwned;
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::marker::PhantomData;
@@ -465,9 +465,6 @@ pub struct Constellation<STF, SWF> {
     /// Pipeline ID of the active media session.
     active_media_session: Option<PipelineId>,
 
-    /// User agent string to report in network requests.
-    user_agent: Cow<'static, str>,
-
     /// The image bytes associated with the RippyPNG embedder resource.
     /// Read during startup and provided to image caches that are created
     /// on an as-needed basis, rather than retrieving it every time.
@@ -521,9 +518,6 @@ pub struct InitialConstellationState {
 
     /// The XR device registry
     pub webxr_registry: Option<webxr_api::Registry>,
-
-    /// User agent string to report in network requests.
-    pub user_agent: Cow<'static, str>,
 
     #[cfg(feature = "webgpu")]
     pub wgpu_image_map: WGPUImageMap,
@@ -744,7 +738,6 @@ where
                     active_keyboard_modifiers: Modifiers::empty(),
                     hard_fail,
                     active_media_session: None,
-                    user_agent: state.user_agent,
                     rippy_data,
                     user_content_manager: state.user_content_manager,
                 };
@@ -988,7 +981,6 @@ where
                 .map(|threads| threads.pipeline()),
             webxr_registry: self.webxr_registry.clone(),
             player_context: WindowGLContext::get(),
-            user_agent: self.user_agent.clone(),
             rippy_data: self.rippy_data.clone(),
             user_content_manager: self.user_content_manager.clone(),
         });

--- a/components/constellation/pipeline.rs
+++ b/components/constellation/pipeline.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::borrow::Cow;
 use std::collections::HashSet;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -192,9 +191,6 @@ pub struct InitialPipelineState {
     /// Application window's GL Context for Media player
     pub player_context: WindowGLContext,
 
-    /// User agent string to report in network requests.
-    pub user_agent: Cow<'static, str>,
-
     /// The image bytes associated with the RippyPNG embedder resource.
     pub rippy_data: Vec<u8>,
 
@@ -294,7 +290,6 @@ impl Pipeline {
                     webgl_chan: state.webgl_chan,
                     webxr_registry: state.webxr_registry,
                     player_context: state.player_context,
-                    user_agent: state.user_agent,
                     rippy_data: state.rippy_data,
                     user_content_manager: state.user_content_manager,
                 };
@@ -501,7 +496,6 @@ pub struct UnprivilegedPipelineContent {
     webgl_chan: Option<WebGLPipeline>,
     webxr_registry: Option<webxr_api::Registry>,
     player_context: WindowGLContext,
-    user_agent: Cow<'static, str>,
     rippy_data: Vec<u8>,
     user_content_manager: UserContentManager,
 }
@@ -554,7 +548,6 @@ impl UnprivilegedPipelineContent {
             layout_factory,
             Arc::new(self.system_font_service.to_proxy()),
             self.load_data.clone(),
-            self.user_agent,
         );
 
         if wait_for_completion {

--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::borrow::Cow;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::{io, mem, str};
@@ -61,7 +60,7 @@ pub enum Data {
 
 pub struct FetchContext {
     pub state: Arc<HttpState>,
-    pub user_agent: Cow<'static, str>,
+    pub user_agent: String,
     pub devtools_chan: Option<Arc<Mutex<Sender<DevtoolsControlMsg>>>>,
     pub filemanager: Arc<Mutex<FileManager>>,
     pub file_token: FileTokenCheck,

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -1255,10 +1255,9 @@ async fn http_network_or_cache_fetch(
     // Step 8.15: If httpRequest’s header list does not contain `User-Agent`, then user agents
     // should append (`User-Agent`, default `User-Agent` value) to httpRequest’s header list.
     if !http_request.headers.contains_key(header::USER_AGENT) {
-        let user_agent = context.user_agent.clone().into_owned();
         http_request
             .headers
-            .typed_insert::<UserAgent>(user_agent.parse().unwrap());
+            .typed_insert::<UserAgent>(context.user_agent.parse().unwrap());
     }
 
     // Steps 8.16 to 8.18

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -4,7 +4,7 @@
 
 //! A thread that takes a URL and streams back the binary data.
 
-use std::borrow::{Cow, ToOwned};
+use std::borrow::ToOwned;
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::prelude::*;
@@ -71,7 +71,6 @@ fn load_root_cert_store_from_file(file_path: String) -> io::Result<RootCertStore
 /// Returns a tuple of (public, private) senders to the new threads.
 #[allow(clippy::too_many_arguments)]
 pub fn new_resource_threads(
-    user_agent: Cow<'static, str>,
     devtools_sender: Option<Sender<DevtoolsControlMsg>>,
     time_profiler_chan: ProfilerChan,
     mem_profiler_chan: MemProfilerChan,
@@ -93,7 +92,6 @@ pub fn new_resource_threads(
     };
 
     let (public_core, private_core) = new_core_resource_thread(
-        user_agent,
         devtools_sender,
         time_profiler_chan,
         mem_profiler_chan,
@@ -113,7 +111,6 @@ pub fn new_resource_threads(
 /// Create a CoreResourceThread
 #[allow(clippy::too_many_arguments)]
 pub fn new_core_resource_thread(
-    user_agent: Cow<'static, str>,
     devtools_sender: Option<Sender<DevtoolsControlMsg>>,
     time_profiler_chan: ProfilerChan,
     mem_profiler_chan: MemProfilerChan,
@@ -131,7 +128,6 @@ pub fn new_core_resource_thread(
         .name("ResourceManager".to_owned())
         .spawn(move || {
             let resource_manager = CoreResourceManager::new(
-                user_agent,
                 devtools_sender,
                 time_profiler_chan,
                 embedder_proxy.clone(),
@@ -549,7 +545,6 @@ pub struct AuthCache {
 }
 
 pub struct CoreResourceManager {
-    user_agent: Cow<'static, str>,
     devtools_sender: Option<Sender<DevtoolsControlMsg>>,
     sw_managers: HashMap<ImmutableOrigin, IpcSender<CustomResponseMediator>>,
     filemanager: FileManager,
@@ -691,7 +686,6 @@ impl CoreResourceThreadPool {
 
 impl CoreResourceManager {
     pub fn new(
-        user_agent: Cow<'static, str>,
         devtools_sender: Option<Sender<DevtoolsControlMsg>>,
         _profiler_chan: ProfilerChan,
         embedder_proxy: EmbedderProxy,
@@ -705,7 +699,6 @@ impl CoreResourceManager {
         let pool = CoreResourceThreadPool::new(num_threads, "CoreResourceThreadPool".to_string());
         let pool_handle = Arc::new(pool);
         CoreResourceManager {
-            user_agent,
             devtools_sender,
             sw_managers: Default::default(),
             filemanager: FileManager::new(embedder_proxy.clone(), Arc::downgrade(&pool_handle)),
@@ -749,7 +742,6 @@ impl CoreResourceManager {
         protocols: Arc<ProtocolRegistry>,
     ) {
         let http_state = http_state.clone();
-        let ua = self.user_agent.clone();
         let dc = self.devtools_sender.clone();
         let filemanager = self.filemanager.clone();
         let request_interceptor = self.request_interceptor.clone();
@@ -790,7 +782,7 @@ impl CoreResourceManager {
             // todo service worker stuff
             let context = FetchContext {
                 state: http_state,
-                user_agent: ua,
+                user_agent: servo_config::pref!(user_agent),
                 devtools_chan: dc.map(|dc| Arc::new(Mutex::new(dc))),
                 filemanager: Arc::new(Mutex::new(filemanager)),
                 file_token,

--- a/components/net/tests/resource_thread.rs
+++ b/components/net/tests/resource_thread.rs
@@ -25,7 +25,6 @@ fn test_exit() {
     let (mtx, _mrx) = ipc::channel().unwrap();
     let (sender, receiver) = ipc::channel().unwrap();
     let (resource_thread, _private_resource_thread) = new_core_resource_thread(
-        "".into(),
         None,
         ProfilerChan(tx),
         MemProfilerChan(mtx),

--- a/components/script/dom/dissimilaroriginwindow.rs
+++ b/components/script/dom/dissimilaroriginwindow.rs
@@ -64,7 +64,6 @@ impl DissimilarOriginWindow {
                 // FIXME(nox): The microtask queue is probably not important
                 // here, but this whole DOM interface is a hack anyway.
                 global_to_clone_from.microtask_queue().clone(),
-                global_to_clone_from.get_user_agent(),
                 #[cfg(feature = "webgpu")]
                 global_to_clone_from.wgpu_id_hub(),
                 Some(global_to_clone_from.is_secure_context()),

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::borrow::Cow;
 use std::cell::{Cell, OnceCell};
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, VecDeque};
@@ -318,9 +317,6 @@ pub(crate) struct GlobalScope {
     // (that is, they cannot be moved).
     #[allow(clippy::vec_box)]
     consumed_rejections: DomRefCell<Vec<Box<Heap<*mut JSObject>>>>,
-
-    /// An optional string allowing the user agent to be set for testing.
-    user_agent: Cow<'static, str>,
 
     /// Identity Manager for WebGPU resources
     #[ignore_malloc_size_of = "defined in wgpu"]
@@ -720,7 +716,6 @@ impl GlobalScope {
         origin: MutableOrigin,
         creation_url: Option<ServoUrl>,
         microtask_queue: Rc<MicrotaskQueue>,
-        user_agent: Cow<'static, str>,
         #[cfg(feature = "webgpu")] gpu_id_hub: Arc<IdentityHub>,
         inherited_secure_context: Option<bool>,
         unminify_js: bool,
@@ -754,7 +749,6 @@ impl GlobalScope {
             event_source_tracker: DOMTracker::new(),
             uncaught_rejections: Default::default(),
             consumed_rejections: Default::default(),
-            user_agent,
             #[cfg(feature = "webgpu")]
             gpu_id_hub,
             #[cfg(feature = "webgpu")]
@@ -2918,10 +2912,6 @@ impl GlobalScope {
             retval,
             can_gc,
         );
-    }
-
-    pub(crate) fn get_user_agent(&self) -> Cow<'static, str> {
-        self.user_agent.clone()
     }
 
     pub(crate) fn get_https_state(&self) -> HttpsState {

--- a/components/script/dom/navigator.rs
+++ b/components/script/dom/navigator.rs
@@ -8,6 +8,7 @@ use std::sync::LazyLock;
 
 use dom_struct::dom_struct;
 use js::rust::MutableHandleValue;
+use servo_config::pref;
 
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::NavigatorBinding::NavigatorMethods;
@@ -192,7 +193,7 @@ impl NavigatorMethods<crate::DomTypeHolder> for Navigator {
 
     // https://html.spec.whatwg.org/multipage/#dom-navigator-useragent
     fn UserAgent(&self) -> DOMString {
-        navigatorinfo::UserAgent(self.global().get_user_agent())
+        navigatorinfo::UserAgent(&pref!(user_agent))
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-navigator-appversion

--- a/components/script/dom/navigatorinfo.rs
+++ b/components/script/dom/navigatorinfo.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::borrow::Cow;
-
 use crate::dom::bindings::str::DOMString;
 
 #[allow(non_snake_case)]
@@ -66,8 +64,8 @@ pub(crate) fn Platform() -> DOMString {
 }
 
 #[allow(non_snake_case)]
-pub(crate) fn UserAgent(user_agent: Cow<'static, str>) -> DOMString {
-    DOMString::from(&*user_agent)
+pub(crate) fn UserAgent(user_agent: &str) -> DOMString {
+    DOMString::from(user_agent)
 }
 
 #[allow(non_snake_case)]

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::borrow::{Cow, ToOwned};
+use std::borrow::ToOwned;
 use std::cell::{Cell, RefCell, RefMut};
 use std::cmp;
 use std::collections::hash_map::Entry;
@@ -2804,7 +2804,6 @@ impl Window {
         unminify_css: bool,
         local_script_source: Option<String>,
         user_content_manager: UserContentManager,
-        user_agent: Cow<'static, str>,
         player_context: WindowGLContext,
         #[cfg(feature = "webgpu")] gpu_id_hub: Arc<IdentityHub>,
         inherited_secure_context: Option<bool>,
@@ -2831,7 +2830,6 @@ impl Window {
                 origin,
                 Some(creator_url),
                 microtask_queue,
-                user_agent,
                 #[cfg(feature = "webgpu")]
                 gpu_id_hub,
                 inherited_secure_context,

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -79,7 +79,6 @@ pub(crate) fn prepare_workerscope_init(
         pipeline_id: global.pipeline_id(),
         origin: global.origin().immutable().clone(),
         creation_url: global.creation_url().clone(),
-        user_agent: global.get_user_agent(),
         inherited_secure_context: Some(global.is_secure_context()),
     };
 
@@ -164,7 +163,6 @@ impl WorkerGlobalScope {
                 MutableOrigin::new(init.origin),
                 init.creation_url,
                 runtime.microtask_queue.clone(),
-                init.user_agent,
                 #[cfg(feature = "webgpu")]
                 gpu_id_hub,
                 init.inherited_secure_context,

--- a/components/script/dom/workernavigator.rs
+++ b/components/script/dom/workernavigator.rs
@@ -4,6 +4,7 @@
 
 use dom_struct::dom_struct;
 use js::rust::MutableHandleValue;
+use servo_config::pref;
 
 use crate::dom::bindings::codegen::Bindings::WorkerNavigatorBinding::WorkerNavigatorMethods;
 use crate::dom::bindings::reflector::{DomGlobal, Reflector, reflect_dom_object};
@@ -85,7 +86,7 @@ impl WorkerNavigatorMethods<crate::DomTypeHolder> for WorkerNavigator {
 
     // https://html.spec.whatwg.org/multipage/#dom-navigator-useragent
     fn UserAgent(&self) -> DOMString {
-        navigatorinfo::UserAgent(self.global().get_user_agent())
+        navigatorinfo::UserAgent(&pref!(user_agent))
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-navigator-appversion

--- a/components/script/dom/workletglobalscope.rs
+++ b/components/script/dom/workletglobalscope.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::borrow::Cow;
 use std::sync::Arc;
 
 use base::id::PipelineId;
@@ -96,7 +95,6 @@ impl WorkletGlobalScope {
                 MutableOrigin::new(ImmutableOrigin::new_opaque()),
                 None,
                 Default::default(),
-                init.user_agent.clone(),
                 #[cfg(feature = "webgpu")]
                 init.gpu_id_hub.clone(),
                 init.inherited_secure_context,
@@ -185,8 +183,6 @@ pub(crate) struct WorkletGlobalScopeInit {
     pub(crate) to_constellation_sender: IpcSender<(PipelineId, ScriptMsg)>,
     /// The image cache
     pub(crate) image_cache: Arc<dyn ImageCache>,
-    /// An optional string allowing the user agent to be set for testing
-    pub(crate) user_agent: Cow<'static, str>,
     /// Identity manager for WebGPU resources
     #[cfg(feature = "webgpu")]
     pub(crate) gpu_id_hub: Arc<IdentityHub>,

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -17,7 +17,6 @@
 //! a page runs its course and the script thread returns to processing events in the main event
 //! loop.
 
-use std::borrow::Cow;
 use std::cell::{Cell, RefCell};
 use std::collections::{HashMap, HashSet};
 use std::default::Default;
@@ -308,9 +307,6 @@ pub struct ScriptThread {
     #[no_trace]
     user_content_manager: UserContentManager,
 
-    /// An optional string allowing the user agent to be set for testing.
-    user_agent: Cow<'static, str>,
-
     /// Application window's GL Context for Media player
     #[no_trace]
     player_context: WindowGLContext,
@@ -390,7 +386,6 @@ impl ScriptThreadFactory for ScriptThread {
         layout_factory: Arc<dyn LayoutFactory>,
         system_font_service: Arc<SystemFontServiceProxy>,
         load_data: LoadData,
-        user_agent: Cow<'static, str>,
     ) {
         thread::Builder::new()
             .name(format!("Script{:?}", state.id))
@@ -408,8 +403,7 @@ impl ScriptThreadFactory for ScriptThread {
                 let memory_profiler_sender = state.memory_profiler_sender.clone();
                 let window_size = state.window_size;
 
-                let script_thread =
-                    ScriptThread::new(state, layout_factory, system_font_service, user_agent);
+                let script_thread = ScriptThread::new(state, layout_factory, system_font_service);
 
                 SCRIPT_THREAD_ROOT.with(|root| {
                     root.set(Some(&script_thread as *const _));
@@ -736,7 +730,6 @@ impl ScriptThread {
                             .pipeline_to_constellation_sender
                             .clone(),
                         image_cache: script_thread.image_cache.clone(),
-                        user_agent: script_thread.user_agent.clone(),
                         #[cfg(feature = "webgpu")]
                         gpu_id_hub: script_thread.gpu_id_hub.clone(),
                         inherited_secure_context: script_thread.inherited_secure_context,
@@ -826,7 +819,6 @@ impl ScriptThread {
         state: InitialScriptState,
         layout_factory: Arc<dyn LayoutFactory>,
         system_font_service: Arc<SystemFontServiceProxy>,
-        user_agent: Cow<'static, str>,
     ) -> ScriptThread {
         let (self_sender, self_receiver) = unbounded();
         let runtime = Runtime::new(Some(SendableTaskSource {
@@ -938,7 +930,6 @@ impl ScriptThread {
             unminify_js: opts.unminify_js,
             local_script_source: opts.local_script_source.clone(),
             unminify_css: opts.unminify_css,
-            user_agent,
             user_content_manager: state.user_content_manager,
             player_context: state.player_context,
             node_ids: Default::default(),
@@ -3109,7 +3100,6 @@ impl ScriptThread {
             self.unminify_css,
             self.local_script_source.clone(),
             self.user_content_manager.clone(),
-            self.user_agent.clone(),
             self.player_context.clone(),
             #[cfg(feature = "webgpu")]
             self.gpu_id_hub.clone(),

--- a/components/servo/examples/winit_minimal.rs
+++ b/components/servo/examples/winit_minimal.rs
@@ -102,7 +102,6 @@ impl ApplicationHandler<WakerEvent> for App {
                 }),
                 window_delegate.clone(),
                 Default::default(),
-                Default::default(),
             );
             servo.setup_logging();
 

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -13,7 +13,6 @@ mod script_msg;
 pub mod serializable;
 pub mod transferable;
 
-use std::borrow::Cow;
 use std::collections::{HashMap, VecDeque};
 use std::fmt;
 use std::sync::Arc;
@@ -564,8 +563,6 @@ pub struct WorkerGlobalScopeInit {
     pub origin: ImmutableOrigin,
     /// The creation URL
     pub creation_url: Option<ServoUrl>,
-    /// An optional string allowing the user agnet to be set for testing.
-    pub user_agent: Cow<'static, str>,
     /// True if secure context
     pub inherited_secure_context: Option<bool>,
 }

--- a/components/shared/script_layout/lib.rs
+++ b/components/shared/script_layout/lib.rs
@@ -11,7 +11,6 @@
 pub mod wrapper_traits;
 
 use std::any::Any;
-use std::borrow::Cow;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicIsize, AtomicU64, Ordering};
 
@@ -280,7 +279,6 @@ pub trait ScriptThreadFactory {
         layout_factory: Arc<dyn LayoutFactory>,
         system_font_service: Arc<SystemFontServiceProxy>,
         load_data: LoadData,
-        user_agent: Cow<'static, str>,
     );
 }
 #[derive(Clone, Default)]

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -161,7 +161,6 @@ impl App {
             window.rendering_context(),
             embedder,
             Rc::new(UpcastedWindow(window.clone())),
-            self.servoshell_preferences.user_agent.clone(),
             user_content_manager,
         );
         servo.setup_logging();

--- a/ports/servoshell/desktop/embedder.rs
+++ b/ports/servoshell/desktop/embedder.rs
@@ -68,8 +68,4 @@ impl EmbedderMethods for EmbedderCallbacks {
         registry.register("resource", resource::ResourceProtocolHandler::default());
         registry
     }
-
-    fn get_version_string(&self) -> Option<String> {
-        crate::servo_version().into()
-    }
 }

--- a/ports/servoshell/egl/android/simpleservo.rs
+++ b/ports/servoshell/egl/android/simpleservo.rs
@@ -98,7 +98,6 @@ pub fn init(
         rendering_context.clone(),
         embedder_callbacks,
         window_callbacks.clone(),
-        None,
         Default::default(),
     );
 

--- a/ports/servoshell/egl/ohos/simpleservo.rs
+++ b/ports/servoshell/egl/ohos/simpleservo.rs
@@ -130,7 +130,6 @@ pub fn init(
         rendering_context.clone(),
         embedder_callbacks,
         window_callbacks.clone(),
-        None, /* user_agent */
         Default::default(),
     );
 

--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -23,8 +23,6 @@ use url::Url;
 #[cfg_attr(any(target_os = "android", target_env = "ohos"), allow(dead_code))]
 #[derive(Clone)]
 pub(crate) struct ServoShellPreferences {
-    /// The user agent to use for servoshell.
-    pub user_agent: Option<String>,
     /// A URL to load when starting servoshell.
     pub url: Option<String>,
     /// An override value for the device pixel ratio.
@@ -74,7 +72,6 @@ impl Default for ServoShellPreferences {
             searchpage: "https://duckduckgo.com/html/?q=%s".into(),
             tracing_filter: None,
             url: None,
-            user_agent: None,
             output_image_path: None,
             exit_after_stable_image: false,
             userscripts_directory: None,
@@ -615,7 +612,6 @@ pub(crate) fn parse_command_line_arguments(args: Vec<String>) -> ArgumentParsing
     let exit_after_load = opt_match.opt_present("x") || output_image_path.is_some();
     let wait_for_stable_image = exit_after_load;
     let servoshell_preferences = ServoShellPreferences {
-        user_agent: opt_match.opt_str("u"),
         url,
         no_native_titlebar,
         device_pixel_ratio_override,


### PR DESCRIPTION
- Remove `EmbedderMethods::get_user_agent_string`. This is now part of
  the `Preferences` data structure, which should allow it to be
  per-`WebView` in the future.
- Remove `EmbedderMethods::get_version_string`. This was used to include
  some data along with WebRender captures about the Servo version. This
  isn't really necessary and it was done to replace code in the past
  that output the WebRender version, so also isn't what the original
  code did. I think we can just remove this entirely.

The idea with these changes is that `EmbedderMethods` can be removed
in a followup and the rest of the methods can be added to
`ServoDelegate`. These two methods are ones that cannot be added to a
delegate as they are used during `Servo` initialization.

Testing: There is currently no testing for libservo. These changes are meant
as preparation for adding a suite of `WebView` unit tests.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

