### PR TITLE
Remove meta-legacy-layout wpt tests

### DIFF
--- a/tests/wpt/meta-legacy-layout/html/canvas/element/layers/2d.layer.nested.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/element/layers/2d.layer.nested.html.ini
@@ -1,2 +1,0 @@
-[2d.layer.nested.html]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/element/layers/2d.layer.shadow-from-outside-canvas.long-distance-with-clipping.ctx-filter.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/element/layers/2d.layer.shadow-from-outside-canvas.long-distance-with-clipping.ctx-filter.html.ini
@@ -1,2 +1,0 @@
-[2d.layer.shadow-from-outside-canvas.long-distance-with-clipping.ctx-filter.html]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/element/layers/2d.layer.shadow-from-outside-canvas.long-distance-with-clipping.layer-filter.tentative.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/element/layers/2d.layer.shadow-from-outside-canvas.long-distance-with-clipping.layer-filter.tentative.html.ini
@@ -1,2 +1,0 @@
-[2d.layer.shadow-from-outside-canvas.long-distance-with-clipping.layer-filter.tentative.html]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/element/layers/2d.layer.shadow-from-outside-canvas.short-distance-with-clipping.ctx-filter.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/element/layers/2d.layer.shadow-from-outside-canvas.short-distance-with-clipping.ctx-filter.html.ini
@@ -1,2 +1,0 @@
-[2d.layer.shadow-from-outside-canvas.short-distance-with-clipping.ctx-filter.html]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/element/layers/2d.layer.shadow-from-outside-canvas.short-distance-with-clipping.layer-filter.tentative.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/element/layers/2d.layer.shadow-from-outside-canvas.short-distance-with-clipping.layer-filter.tentative.html.ini
@@ -1,2 +1,0 @@
-[2d.layer.shadow-from-outside-canvas.short-distance-with-clipping.layer-filter.tentative.html]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/offscreen/layers/2d.layer.nested.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/offscreen/layers/2d.layer.nested.html.ini
@@ -1,2 +1,0 @@
-[2d.layer.nested.html]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/offscreen/layers/2d.layer.shadow-from-outside-canvas.long-distance-with-clipping.ctx-filter.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/offscreen/layers/2d.layer.shadow-from-outside-canvas.long-distance-with-clipping.ctx-filter.html.ini
@@ -1,2 +1,0 @@
-[2d.layer.shadow-from-outside-canvas.long-distance-with-clipping.ctx-filter.html]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/offscreen/layers/2d.layer.shadow-from-outside-canvas.long-distance-with-clipping.layer-filter.tentative.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/offscreen/layers/2d.layer.shadow-from-outside-canvas.long-distance-with-clipping.layer-filter.tentative.html.ini
@@ -1,2 +1,0 @@
-[2d.layer.shadow-from-outside-canvas.long-distance-with-clipping.layer-filter.tentative.html]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/offscreen/layers/2d.layer.shadow-from-outside-canvas.short-distance-with-clipping.ctx-filter.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/offscreen/layers/2d.layer.shadow-from-outside-canvas.short-distance-with-clipping.ctx-filter.html.ini
@@ -1,2 +1,0 @@
-[2d.layer.shadow-from-outside-canvas.short-distance-with-clipping.ctx-filter.html]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/offscreen/layers/2d.layer.shadow-from-outside-canvas.short-distance-with-clipping.layer-filter.tentative.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/offscreen/layers/2d.layer.shadow-from-outside-canvas.short-distance-with-clipping.layer-filter.tentative.html.ini
@@ -1,2 +1,0 @@
-[2d.layer.shadow-from-outside-canvas.short-distance-with-clipping.layer-filter.tentative.html]
-  expected: FAIL


### PR DESCRIPTION
These tests were related to the legacy layout engine which has been removed.
Therefore, they are considered leftover and can be removed.

Fixes #36277