### PR TITLE
layout: Restrict stretch alignment to flex items with computed auto size

### DIFF
--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -1215,6 +1215,7 @@ impl IndependentNonReplacedContents {
             content_box_sizes,
             pbm,
             depends_on_block_constraints,
+            ..
         } = self
             .layout_style(base)
             .content_box_sizes_and_padding_border_margin(&containing_block.into());
@@ -1696,6 +1697,7 @@ fn solve_containing_block_padding_and_border_for_in_flow_box<'a>(
         content_box_sizes,
         pbm,
         depends_on_block_constraints,
+        ..
     } = layout_style.content_box_sizes_and_padding_border_margin(&containing_block.into());
 
     let pbm_sums = pbm.sums_auto_is_zero(ignore_block_margins_for_stretch);

--- a/components/layout_2020/sizing.rs
+++ b/components/layout_2020/sizing.rs
@@ -130,6 +130,7 @@ pub(crate) fn outer_inline(
         content_box_sizes,
         pbm,
         mut depends_on_block_constraints,
+        preferred_size_computes_to_auto,
     } = layout_style.content_box_sizes_and_padding_border_margin(containing_block);
     let margin = pbm.margin.map(|v| v.auto_is(Au::zero));
     let pbm_sums = LogicalVec2 {
@@ -143,7 +144,7 @@ pub(crate) fn outer_inline(
                 .size
                 .block
                 .map(|v| Au::zero().max(v - pbm_sums.block));
-            let automatic_size = if content_box_sizes.block.preferred.is_initial() &&
+            let automatic_size = if preferred_size_computes_to_auto.block &&
                 auto_block_size_stretches_to_containing_block
             {
                 depends_on_block_constraints = true;

--- a/components/layout_2020/style_ext.rs
+++ b/components/layout_2020/style_ext.rs
@@ -235,6 +235,7 @@ pub(crate) struct ContentBoxSizesAndPBM {
     pub content_box_sizes: LogicalVec2<Sizes>,
     pub pbm: PaddingBorderMargin,
     pub depends_on_block_constraints: bool,
+    pub preferred_size_computes_to_auto: LogicalVec2<bool>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -994,6 +995,8 @@ impl LayoutStyle<'_> {
         let box_size = style.box_size(writing_mode);
         let min_size = style.min_box_size(writing_mode);
         let max_size = style.max_box_size(writing_mode);
+        let preferred_size_computes_to_auto = box_size.map(|size| size.is_initial());
+
         let depends_on_block_constraints = |size: &Size<LengthPercentage>| {
             match size {
                 // fit-content is like clamp(min-content, stretch, max-content), but currently
@@ -1008,7 +1011,6 @@ impl LayoutStyle<'_> {
                 _ => false,
             }
         };
-
         let depends_on_block_constraints = depends_on_block_constraints(&box_size.block) ||
             depends_on_block_constraints(&min_size.block) ||
             depends_on_block_constraints(&max_size.block) ||
@@ -1039,6 +1041,7 @@ impl LayoutStyle<'_> {
             },
             pbm,
             depends_on_block_constraints,
+            preferred_size_computes_to_auto,
         }
     }
 

--- a/tests/wpt/meta/css/css-flexbox/quirks-auto-block-size-with-percentage-item.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/quirks-auto-block-size-with-percentage-item.html.ini
@@ -1,3 +1,0 @@
-[quirks-auto-block-size-with-percentage-item.html]
-  [#container 1]
-    expected: FAIL

--- a/tests/wpt/tests/css/css-flexbox/stretch-requires-computed-auto-size.html
+++ b/tests/wpt/tests/css/css-flexbox/stretch-requires-computed-auto-size.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<title>Stretch alignment with percentage that behaves as auto</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://www.w3.org/TR/css-flexbox-1/#valdef-align-items-stretch">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/4525">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="
+  Stretch alignment requires a computed cross size of `auto`.
+  So a cyclic percentage that only behaves as `auto` doesn't stretch.
+">
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div style="display: flex">
+  <div style="width: 100px; height: 100px; background: green"></div>
+  <div style="width: 100px; height: 50%; background: red"></div>
+</div>


### PR DESCRIPTION
We were allowing `align-self: stretch` to stretch flex items whose cross size behaves as `auto`, including cyclic percentages.

However, https://github.com/w3c/csswg-drafts/issues/4525 resolved that stretching should only happen when the cross size computes to `auto`.

So this patch exposes this information in `ContentBoxSizesAndPBM`, and refactors the flexbox stretching logic.

Fixes: #36285

Testing:
 - `/css/css-flexbox/quirks-auto-block-size-with-percentage-item.html`
 - `/css/css-flexbox/stretch-requires-computed-auto-size.html`
