### PR TITLE
Fix:  `display: inline-grid` considered an atomic inline

### DIFF
--- a/components/layout_2020/display_list/stacking_context.rs
+++ b/components/layout_2020/display_list/stacking_context.rs
@@ -986,7 +986,7 @@ impl BoxFragment {
             return Some(StackingContextType::FloatStackingContainer);
         }
 
-        if box_style.display.is_atomic_inline_level() {
+        if self.is_atomic_inline_level() {
             return Some(StackingContextType::AtomicInlineStackingContainer);
         }
 

--- a/components/layout_2020/fragment_tree/box_fragment.rs
+++ b/components/layout_2020/fragment_tree/box_fragment.rs
@@ -12,6 +12,7 @@ use style::computed_values::overflow_x::T as ComputedOverflow;
 use style::computed_values::position::T as ComputedPosition;
 use style::logical_geometry::WritingMode;
 use style::properties::ComputedValues;
+use style::values::specified::box_::DisplayOutside;
 
 use super::{BaseFragment, BaseFragmentInfo, CollapsedBlockMargins, Fragment};
 use crate::formatting_contexts::Baselines;
@@ -346,6 +347,12 @@ impl BoxFragment {
     /// <https://drafts.csswg.org/css-display-3/#inline-box>
     pub(crate) fn is_inline_box(&self) -> bool {
         self.style.is_inline_box(self.base.flags)
+    }
+
+    /// Whether this is an atomic inline-level box.
+    /// <https://drafts.csswg.org/css-display-3/#atomic-inline>
+    pub(crate) fn is_atomic_inline_level(&self) -> bool {
+        self.style.get_box().display.outside() == DisplayOutside::Inline && !self.is_inline_box()
     }
 
     /// Whether this is a table wrapper box.

--- a/tests/wpt/meta/css/css-grid/alignment/grid-gutters-015.html.ini
+++ b/tests/wpt/meta/css/css-grid/alignment/grid-gutters-015.html.ini
@@ -1,2 +1,0 @@
-[grid-gutters-015.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-grid/grid-container-baseline-synthesized-001.html.ini
+++ b/tests/wpt/meta/css/css-grid/grid-container-baseline-synthesized-001.html.ini
@@ -1,2 +1,0 @@
-[grid-container-baseline-synthesized-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-grid/grid-container-baseline-synthesized-002.html.ini
+++ b/tests/wpt/meta/css/css-grid/grid-container-baseline-synthesized-002.html.ini
@@ -1,2 +1,0 @@
-[grid-container-baseline-synthesized-002.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-grid/grid-container-baseline-synthesized-003.html.ini
+++ b/tests/wpt/meta/css/css-grid/grid-container-baseline-synthesized-003.html.ini
@@ -1,2 +1,0 @@
-[grid-container-baseline-synthesized-003.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-grid/grid-container-baseline-synthesized-004.html.ini
+++ b/tests/wpt/meta/css/css-grid/grid-container-baseline-synthesized-004.html.ini
@@ -1,2 +1,0 @@
-[grid-container-baseline-synthesized-004.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-grid/grid-model/grid-container-scrollbars-sizing-002.html.ini
+++ b/tests/wpt/meta/css/css-grid/grid-model/grid-container-scrollbars-sizing-002.html.ini
@@ -1,2 +1,0 @@
-[grid-container-scrollbars-sizing-002.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-grid/subgrid/independent-tracks-from-parent-grid.html.ini
+++ b/tests/wpt/meta/css/css-grid/subgrid/independent-tracks-from-parent-grid.html.ini
@@ -1,2 +1,0 @@
-[independent-tracks-from-parent-grid.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-grid/subgrid/repeat-auto-fill-005.html.ini
+++ b/tests/wpt/meta/css/css-grid/subgrid/repeat-auto-fill-005.html.ini
@@ -1,2 +1,2 @@
 [repeat-auto-fill-005.html]
-  expected: TIMEOUT
+  expected: FAIL

--- a/tests/wpt/meta/css/css-grid/subgrid/repeat-auto-fill-005.html.ini
+++ b/tests/wpt/meta/css/css-grid/subgrid/repeat-auto-fill-005.html.ini
@@ -1,0 +1,2 @@
+[repeat-auto-fill-005.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta/css/css-grid/subgrid/subgrid-baseline-012.html.ini
+++ b/tests/wpt/meta/css/css-grid/subgrid/subgrid-baseline-012.html.ini
@@ -1,2 +1,0 @@
-[subgrid-baseline-012.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-grid/subgrid/subgrid-no-items-on-edges-001.html.ini
+++ b/tests/wpt/meta/css/css-grid/subgrid/subgrid-no-items-on-edges-001.html.ini
@@ -1,2 +1,0 @@
-[subgrid-no-items-on-edges-001.html]
-  expected: FAIL


### PR DESCRIPTION
This change ensures that `display: inline-grid` is considered an atomic inline

- Add `is_atomic_inline_level()` logic to `box_fragment.rs` to improve accuracy.
- Update `stacking_context.rs` to use the new `is_atomic_inline_level()` method instead of the one from stylo.
- Update `repeat-auto-fill-005.html` test expectation.
- Remove .ini expectations for tests that are no longer failing.

Testing: covered by WPT
Fixes:  #35310 
