### PR TITLE
Implement TestUtils

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -114,6 +114,8 @@ pub struct Preferences {
     pub dom_testing_element_activation_enabled: bool,
     pub dom_testing_html_input_element_select_files_enabled: bool,
     pub dom_testperf_enabled: bool,
+    // https://testutils.spec.whatwg.org#availability
+    pub dom_testutils_enabled: bool,
     /// Enable the [URLPattern] API.
     ///
     /// [URLPattern]: https://developer.mozilla.org/en-US/docs/Web/API/URLPattern
@@ -287,6 +289,7 @@ impl Preferences {
             dom_testing_element_activation_enabled: false,
             dom_testing_html_input_element_select_files_enabled: false,
             dom_testperf_enabled: false,
+            dom_testutils_enabled: false,
             dom_urlpattern_enabled: false,
             dom_webgl2_enabled: false,
             dom_webgpu_enabled: false,

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -555,6 +555,7 @@ pub(crate) mod testbindingproxy;
 pub(crate) mod testbindingsetlikewithinterface;
 pub(crate) mod testbindingsetlikewithprimitive;
 pub(crate) mod testns;
+pub(crate) mod testutils;
 pub(crate) mod testworklet;
 pub(crate) mod testworkletglobalscope;
 pub(crate) mod text;

--- a/components/script/dom/testutils.rs
+++ b/components/script/dom/testutils.rs
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::rc::Rc;
+
+use dom_struct::dom_struct;
+use js::jsapi::{GCReason, JS_GC};
+use script_bindings::reflector::Reflector;
+use script_bindings::script_runtime::CanGc;
+
+use super::globalscope::GlobalScope;
+use crate::dom::bindings::codegen::Bindings::TestUtilsBinding::TestUtilsMethods;
+use crate::dom::promise::Promise;
+use crate::test::TrustedPromise;
+
+#[dom_struct]
+pub(crate) struct TestUtils {
+    reflector_: Reflector,
+}
+
+impl TestUtilsMethods<crate::DomTypeHolder> for TestUtils {
+    /// <https://testutils.spec.whatwg.org/#dom-testutils-gc>
+    #[allow(unsafe_code)]
+    fn Gc(global: &GlobalScope) -> Rc<Promise> {
+        // 1. Let p be a new promise.
+        let promise = Promise::new(global, CanGc::note());
+        let trusted = TrustedPromise::new(promise.clone());
+        // 2. Run the following in parallel:
+        // 2.1 Run implementation-defined steps to perform a garbage collection covering at least the entry Realm.
+        // 2.2 Resolve p.
+        // We need to spin the event-loop in order get the GC to actually run.
+        // We do this by queuing a task that calls the GC and then resolves the promise.
+        let task = task!(testutils_gc: move || {
+            unsafe {
+                JS_GC(*GlobalScope::get_cx(), GCReason::API);
+            }
+            let promise = trusted.root();
+            promise.resolve_native(&(), CanGc::note());
+        });
+
+        global
+            .task_manager()
+            .dom_manipulation_task_source()
+            .queue(task);
+
+        promise
+    }
+}

--- a/components/script/dom/testutils.rs
+++ b/components/script/dom/testutils.rs
@@ -33,7 +33,7 @@ impl TestUtilsMethods<crate::DomTypeHolder> for TestUtils {
         // We do this by queuing a task that calls the GC and then resolves the promise.
         let task = task!(testutils_gc: move || {
             unsafe {
-                JS_GC(*GlobalScope::get_cx(), GCReason::API);
+                JS_GC(*GlobalScope::get_cx(), GCReason::DOM_TESTUTILS);
             }
             let promise = trusted.root();
             promise.resolve_native(&(), CanGc::note());

--- a/components/script_bindings/webidls/TestUtils.webidl
+++ b/components/script_bindings/webidls/TestUtils.webidl
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// https://testutils.spec.whatwg.org/
+
+[Exposed=(Window,Worker), Pref="dom_testutils_enabled"]
+namespace TestUtils {
+  [NewObject] Promise<undefined> gc();
+};

--- a/python/tidy/tidy.py
+++ b/python/tidy/tidy.py
@@ -103,6 +103,7 @@ WEBIDL_STANDARDS = [
     b"//github.com/immersive-web/webxr-hands-input/",
     b"//gpuweb.github.io",
     b"//notifications.spec.whatwg.org",
+    b"//testutils.spec.whatwg.org/",
     # Not a URL
     b"// This interface is entirely internal to Servo, and should not be"
     + b" accessible to\n// web pages."

--- a/resources/wpt-prefs.json
+++ b/resources/wpt-prefs.json
@@ -1,4 +1,5 @@
 {
   "dom_webxr_test": true,
-  "gfx_text_antialiasing_enabled": false
+  "gfx_text_antialiasing_enabled": false,
+  "dom_testutils_enabled": true
 }

--- a/tests/wpt/meta/__dir__.ini
+++ b/tests/wpt/meta/__dir__.ini
@@ -6,6 +6,7 @@ prefs: [
   "dom_offscreen_canvas_enabled:true",
   "dom_resize_observer_enabled:true",
   "dom_serviceworker_enabled:true",
+  "dom_testutils_enabled:true",
   "dom_urlpattern_enabled:true",
   "dom_xpath_enabled:true",
   "layout_grid_enabled:true",

--- a/tests/wpt/mozilla/meta/mozilla/interfaces.https.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/interfaces.https.html.ini
@@ -1,1 +1,1 @@
-prefs: [dom_webxr_test: false, dom_notification_enabled: true]
+prefs: [dom_webxr_test: false, dom_notification_enabled: true, dom_testutils_enabled: false]

--- a/tests/wpt/mozilla/meta/mozilla/interfaces.worker.js.ini
+++ b/tests/wpt/mozilla/meta/mozilla/interfaces.worker.js.ini
@@ -1,1 +1,1 @@
-prefs: [dom_notification_enabled: true]
+prefs: [dom_notification_enabled: true, dom_testutils_enabled: false]


### PR DESCRIPTION
Implement the TestUtils namespace from https://testutils.spec.whatwg.org/.
This should make the `js/builtins/weakrefs` tests run faster and more consistently.

This change will enable other WPT tests but no tests exist currently for TestUtils itself.
Fixes: #36290 
