### PR TITLE
localStorage: track changes instead of overwrite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4858,6 +4858,7 @@ dependencies = [
  "rustls-pemfile",
  "rustls-pki-types",
  "serde",
+ "serde-jsonlines",
  "serde_json",
  "servo_allocator",
  "servo_arc",
@@ -6520,6 +6521,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-jsonlines"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "013e069239d98648ea43a9c01845b381445e88de08b5a895ef9302e3bffde03d"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -57,6 +57,7 @@ rustls-pemfile = { workspace = true }
 rustls-pki-types = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde-jsonlines = "0.7.0"
 servo_allocator = { path = "../allocator" }
 servo_arc = { workspace = true }
 servo_config = { path = "../config" }

--- a/components/net/storage_thread.rs
+++ b/components/net/storage_thread.rs
@@ -4,16 +4,27 @@
 
 use std::borrow::ToOwned;
 use std::collections::{BTreeMap, HashMap};
+use std::fs::File;
 use std::path::PathBuf;
 use std::thread;
 
 use ipc_channel::ipc::{self, IpcReceiver, IpcSender};
+use log::warn;
 use net_traits::storage_thread::{StorageThreadMsg, StorageType};
+use serde::{Deserialize, Serialize};
 use servo_url::ServoUrl;
 
 use crate::resource_thread;
 
 const QUOTA_SIZE_LIMIT: usize = 5 * 1024 * 1024;
+
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct LocalStorageRecord {
+    pub operation: String,
+    pub origin: String,
+    pub name: String,
+    pub value: String,
+}
 
 pub trait StorageThreadFactory {
     fn new(config_dir: Option<PathBuf>) -> Self;
@@ -41,11 +52,24 @@ struct StorageManager {
 }
 
 impl StorageManager {
+    /// When the local data is updated, we append the change as a single line in tracking file. At exit, we store the
+    /// data to a json file and delete the tracking file. The tracking file is checked at the start of the program in
+    /// case the changes from previous run is not properly stored in the json (e.g. caused by crash).
+    /// TODO: Implement proper storage mechanism based on <https://storage.spec.whatwg.org/> and use proper key-value
+    /// store mechanism.
+    const LOCAL_DATA_FILENAME: &str = "local_data.json";
+    const TRACK_CHANGES_FILENAME: &str = "track_changes.jsonl";
+
     fn new(port: IpcReceiver<StorageThreadMsg>, config_dir: Option<PathBuf>) -> StorageManager {
         let mut local_data = HashMap::new();
         if let Some(ref config_dir) = config_dir {
-            resource_thread::read_json_from_file(&mut local_data, config_dir, "local_data.json");
+            resource_thread::read_json_from_file(
+                &mut local_data,
+                config_dir,
+                Self::LOCAL_DATA_FILENAME,
+            );
         }
+
         StorageManager {
             port,
             session_data: HashMap::new(),
@@ -59,6 +83,7 @@ impl StorageManager {
     fn start(&mut self) {
         loop {
             match self.port.recv().unwrap() {
+                StorageThreadMsg::Initialize(sender) => self.handle_tracking_file(sender),
                 StorageThreadMsg::Length(sender, url, storage_type) => {
                     self.length(sender, url, storage_type)
                 },
@@ -69,22 +94,34 @@ impl StorageManager {
                     self.keys(sender, url, storage_type)
                 },
                 StorageThreadMsg::SetItem(sender, url, storage_type, name, value) => {
-                    self.set_item(sender, url, storage_type, name, value);
-                    self.save_state()
+                    self.set_item(
+                        sender,
+                        url.clone(),
+                        storage_type,
+                        name.clone(),
+                        value.clone(),
+                    );
+                    if matches!(storage_type, StorageType::Local) {
+                        self.append_change(url, "SET", &name, &value);
+                    }
                 },
                 StorageThreadMsg::GetItem(sender, url, storage_type, name) => {
                     self.request_item(sender, url, storage_type, name)
                 },
                 StorageThreadMsg::RemoveItem(sender, url, storage_type, name) => {
-                    self.remove_item(sender, url, storage_type, name);
-                    self.save_state()
+                    self.remove_item(sender, url.clone(), storage_type, name.clone());
+                    if matches!(storage_type, StorageType::Local) {
+                        self.append_change(url, "REMOVE", &name, "");
+                    }
                 },
                 StorageThreadMsg::Clear(sender, url, storage_type) => {
-                    self.clear(sender, url, storage_type);
-                    self.save_state()
+                    self.clear(sender, url.clone(), storage_type);
+                    if matches!(storage_type, StorageType::Local) {
+                        self.append_change(url, "CLEAR", "", "");
+                    }
                 },
                 StorageThreadMsg::Exit(sender) => {
-                    // Nothing to do since we save localstorage set eagerly.
+                    let _ = self.save_state();
                     let _ = sender.send(());
                     break;
                 },
@@ -92,10 +129,95 @@ impl StorageManager {
         }
     }
 
-    fn save_state(&self) {
-        if let Some(ref config_dir) = self.config_dir {
-            resource_thread::write_json_to_file(&self.local_data, config_dir, "local_data.json");
+    fn update_from_record(&mut self, track_item: LocalStorageRecord) {
+        match track_item.operation.as_str() {
+            "SET" => {
+                let storage_size = self
+                    .local_data
+                    .get(&track_item.origin)
+                    .map_or(0, |&(total, _)| total);
+
+                if !self.local_data.contains_key(&track_item.origin) {
+                    self.local_data
+                        .insert(track_item.origin.clone(), (0, BTreeMap::new()));
+                }
+
+                if let Some((total, entry)) = self.local_data.get_mut(&track_item.origin) {
+                    let mut new_total_size = storage_size + track_item.value.len();
+                    if let Some(old_value) = entry.get(&track_item.name) {
+                        new_total_size -= old_value.len();
+                    } else {
+                        new_total_size += track_item.name.len();
+                    }
+
+                    entry.insert(track_item.name.clone(), track_item.value.clone());
+
+                    *total = new_total_size;
+                }
+            },
+            "REMOVE" => {
+                self.local_data.get_mut(&track_item.origin).and_then(
+                    |&mut (ref mut total, ref mut entry)| {
+                        entry.remove(&track_item.name).inspect(|old| {
+                            *total -= track_item.name.len() + old.len();
+                        })
+                    },
+                );
+            },
+            "CLEAR" => {
+                if let Some((total, entry)) = self.local_data.get_mut(&track_item.origin) {
+                    *total = 0;
+                    entry.clear();
+                }
+            },
+            _ => warn!("Invalid operation at tracking file"),
         }
+    }
+
+    // Merge local data with the change in TRACK_CHANGES_FILENAME,
+    // then clear the file (or create the file if it did not exist).
+    fn handle_tracking_file(&mut self, sender: IpcSender<Result<(), ()>>) {
+        let track_list = if let Some(ref config_dir) = self.config_dir {
+            resource_thread::read_jsonl_file(config_dir, Self::TRACK_CHANGES_FILENAME)
+        } else {
+            return;
+        };
+        for track_elem in track_list {
+            self.update_from_record(track_elem);
+        }
+
+        // Before clearing TRACK_CHANGES_FILENAME, make sure we write the data to LOCAL_DATA_FILENAME first.
+        // This ensures the data from previous session is saved in the JSON file even if the current session crashes.
+        sender.send(self.save_state()).unwrap();
+    }
+
+    // Append every change to TRACK_CHANGES_FILENAME instead of overwriting LOCAL_DATA_FILENAME.
+    fn append_change(&self, url: ServoUrl, operation: &str, name: &str, value: &str) {
+        if let Some(ref config_dir) = self.config_dir {
+            let origin = self.origin_as_string(url);
+            let change = LocalStorageRecord {
+                operation: operation.to_string(),
+                origin,
+                name: name.to_string(),
+                value: value.to_string(),
+            };
+            resource_thread::append_to_jsonl_file(change, config_dir, Self::TRACK_CHANGES_FILENAME);
+        }
+    }
+
+    fn save_state(&self) -> Result<(), ()> {
+        if let Some(ref config_dir) = self.config_dir {
+            let path = config_dir.join(Self::TRACK_CHANGES_FILENAME);
+            if File::create(path).is_err() {
+                return Err(());
+            }
+            return resource_thread::write_json_to_file(
+                &self.local_data,
+                config_dir,
+                Self::LOCAL_DATA_FILENAME,
+            );
+        }
+        Err(())
     }
 
     fn select_data(

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2872,7 +2872,13 @@ impl ScriptThread {
         };
 
         let storage = match storage_type {
-            StorageType::Local => window.LocalStorage(),
+            StorageType::Local => match window.GetLocalStorage() {
+                Ok(root) => match root {
+                    Some(storage) => storage,
+                    None => return,
+                },
+                Err(_) => return,
+            },
             StorageType::Session => window.SessionStorage(),
         };
 

--- a/components/script_bindings/webidls/Window.webidl
+++ b/components/script_bindings/webidls/Window.webidl
@@ -159,7 +159,7 @@ Window includes WindowSessionStorage;
 
 // https://html.spec.whatwg.org/multipage/#dom-localstorage
 interface mixin WindowLocalStorage {
-  readonly attribute Storage localStorage;
+  [Throws] readonly attribute Storage? localStorage;
 };
 Window includes WindowLocalStorage;
 

--- a/components/shared/net/storage_thread.rs
+++ b/components/shared/net/storage_thread.rs
@@ -16,6 +16,9 @@ pub enum StorageType {
 /// Request operations on the storage data associated with a particular url
 #[derive(Debug, Deserialize, Serialize)]
 pub enum StorageThreadMsg {
+    /// special method to avoid panics in Rust code in case we have fs problems
+    Initialize(IpcSender<Result<(), ()>>),
+
     /// gets the number of key/value pairs present in the associated storage data
     Length(IpcSender<usize>, ServoUrl, StorageType),
 

--- a/tests/wpt/meta/webstorage/storage_local_setitem_quotaexceedederr.window.js.ini
+++ b/tests/wpt/meta/webstorage/storage_local_setitem_quotaexceedederr.window.js.ini
@@ -1,2 +1,0 @@
-[storage_local_setitem_quotaexceedederr.window.html]
-    expected: TIMEOUT


### PR DESCRIPTION
When updating the content of local data, only append a single line to tracking file instead of overwriting the local data JSON.

Testing: `/webstorage/storage_local_setitem_quotaexceedederr.window.html`
Fixes: #36034

cc: @d-desiatkin 