### PR TITLE
Webdriver delete cookie

### DIFF
--- a/components/net/cookie_storage.rs
+++ b/components/net/cookie_storage.rs
@@ -94,11 +94,22 @@ impl CookieStorage {
             Ok(None)
         }
     }
+
     pub fn clear_storage(&mut self, url: &ServoUrl) {
         let domain = reg_host(url.host_str().unwrap_or(""));
         let cookies = self.cookies_map.entry(domain).or_default();
         for cookie in cookies.iter_mut() {
             cookie.set_expiry_time_in_past();
+        }
+    }
+
+    pub fn delete_cookie_with_name(&mut self, url: &ServoUrl, name: String) {
+        let domain = reg_host(url.host_str().unwrap_or(""));
+        let cookies = self.cookies_map.entry(domain).or_default();
+        for cookie in cookies.iter_mut() {
+            if cookie.cookie.name() == name {
+                cookie.set_expiry_time_in_past();
+            }
         }
     }
 

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -379,6 +379,14 @@ impl ResourceChannelManager {
                     .clear_storage(&request);
                 return true;
             },
+            CoreResourceMsg::DeleteCookie(request, name) => {
+                http_state
+                    .cookie_jar
+                    .write()
+                    .unwrap()
+                    .delete_cookie_with_name(&request, name);
+                return true;
+            },
             CoreResourceMsg::FetchRedirect(request_builder, res_init, sender) => {
                 let cancellation_listener =
                     self.get_or_create_cancellation_listener(request_builder.id);

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2104,6 +2104,9 @@ impl ScriptThread {
             WebDriverScriptCommand::DeleteCookies(reply) => {
                 webdriver_handlers::handle_delete_cookies(&documents, pipeline_id, reply)
             },
+            WebDriverScriptCommand::DeleteCookie(name, reply) => {
+                webdriver_handlers::handle_delete_cookie(&documents, pipeline_id, name, reply)
+            },
             WebDriverScriptCommand::FindElementCSS(selector, reply) => {
                 webdriver_handlers::handle_find_element_css(
                     &documents,

--- a/components/shared/embedder/webdriver.rs
+++ b/components/shared/embedder/webdriver.rs
@@ -78,6 +78,7 @@ pub enum WebDriverScriptCommand {
         IpcSender<Result<(), WebDriverCookieError>>,
     ),
     DeleteCookies(IpcSender<Result<(), ErrorStatus>>),
+    DeleteCookie(String, IpcSender<Result<(), ErrorStatus>>),
     ExecuteScript(String, IpcSender<WebDriverJSResult>),
     ExecuteAsyncScript(String, IpcSender<WebDriverJSResult>),
     FindElementCSS(String, IpcSender<Result<Option<String>, ErrorStatus>>),

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -493,6 +493,7 @@ pub enum CoreResourceMsg {
         CookieSource,
     ),
     DeleteCookies(ServoUrl),
+    DeleteCookie(ServoUrl, String),
     /// Get a history state by a given history state id
     GetHistoryState(HistoryStateId, IpcSender<Option<Vec<u8>>>),
     /// Set a history state for a given history state id

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -1298,9 +1298,9 @@ impl Handler {
         Ok(WebDriverResponse::Cookies(CookiesResponse(response)))
     }
 
-    fn handle_get_cookie(&self, name: &str) -> WebDriverResult<WebDriverResponse> {
+    fn handle_get_cookie(&self, name: String) -> WebDriverResult<WebDriverResponse> {
         let (sender, receiver) = ipc::channel().unwrap();
-        let cmd = WebDriverScriptCommand::GetCookie(name.to_owned(), sender);
+        let cmd = WebDriverScriptCommand::GetCookie(name, sender);
         self.browsing_context_script_command(cmd)?;
         let cookies = receiver.recv().unwrap();
         let response = cookies
@@ -1832,7 +1832,7 @@ impl WebDriverHandler<ServoExtensionRoute> for Handler {
             WebDriverCommand::FindElementElements(ref element, ref parameters) => {
                 self.handle_find_elements_from_element(element, parameters)
             },
-            WebDriverCommand::GetNamedCookie(ref name) => self.handle_get_cookie(name),
+            WebDriverCommand::GetNamedCookie(name) => self.handle_get_cookie(name),
             WebDriverCommand::GetCookies => self.handle_get_cookies(),
             WebDriverCommand::GetActiveElement => self.handle_active_element(),
             WebDriverCommand::GetElementRect(ref element) => self.handle_element_rect(element),

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -1346,6 +1346,16 @@ impl Handler {
         }
     }
 
+    fn handle_delete_cookie(&self, name: String) -> WebDriverResult<WebDriverResponse> {
+        let (sender, receiver) = ipc::channel().unwrap();
+        let cmd = WebDriverScriptCommand::DeleteCookie(name, sender);
+        self.browsing_context_script_command(cmd)?;
+        match receiver.recv().unwrap() {
+            Ok(_) => Ok(WebDriverResponse::Void),
+            Err(error) => Err(WebDriverError::new(error, "")),
+        }
+    }
+
     fn handle_delete_cookies(&self) -> WebDriverResult<WebDriverResponse> {
         let (sender, receiver) = ipc::channel().unwrap();
         let cmd = WebDriverScriptCommand::DeleteCookies(sender);
@@ -1860,6 +1870,7 @@ impl WebDriverHandler<ServoExtensionRoute> for Handler {
             WebDriverCommand::ElementClick(ref element) => self.handle_element_click(element),
             WebDriverCommand::DismissAlert => self.handle_dismiss_alert(),
             WebDriverCommand::DeleteCookies => self.handle_delete_cookies(),
+            WebDriverCommand::DeleteCookie(name) => self.handle_delete_cookie(name),
             WebDriverCommand::GetTimeouts => self.handle_get_timeouts(),
             WebDriverCommand::SetTimeouts(ref x) => self.handle_set_timeouts(x),
             WebDriverCommand::TakeScreenshot => self.handle_take_screenshot(),


### PR DESCRIPTION
1. Implement `WebDriverCommand::DeleteCookie`
2. Remove unnecessary clone for `WebDriverCommand::GetNamedCookie`

Fixes: #36287