### PR TITLE
layout: Improve style conversion for Taffy

### DIFF
--- a/components/layout_2020/taffy/stylo_taffy/convert.rs
+++ b/components/layout_2020/taffy/stylo_taffy/convert.rs
@@ -138,7 +138,7 @@ pub fn position(input: stylo::Position) -> taffy::Position {
         // TODO: support position:fixed and sticky
         stylo::Position::Absolute => taffy::Position::Absolute,
         stylo::Position::Fixed => taffy::Position::Absolute,
-        stylo::Position::Sticky => taffy::Position::Absolute,
+        stylo::Position::Sticky => taffy::Position::Relative,
     }
 }
 
@@ -170,6 +170,8 @@ pub fn content_alignment(input: stylo::ContentDistribution) -> Option<taffy::Ali
         stylo::AlignFlags::AUTO => None,
         stylo::AlignFlags::START => Some(taffy::AlignContent::Start),
         stylo::AlignFlags::END => Some(taffy::AlignContent::End),
+        stylo::AlignFlags::LEFT => Some(taffy::AlignContent::Start),
+        stylo::AlignFlags::RIGHT => Some(taffy::AlignContent::End),
         stylo::AlignFlags::FLEX_START => Some(taffy::AlignContent::FlexStart),
         stylo::AlignFlags::STRETCH => Some(taffy::AlignContent::Stretch),
         stylo::AlignFlags::FLEX_END => Some(taffy::AlignContent::FlexEnd),
@@ -185,13 +187,17 @@ pub fn content_alignment(input: stylo::ContentDistribution) -> Option<taffy::Ali
 #[inline]
 pub fn item_alignment(input: stylo::AlignFlags) -> Option<taffy::AlignItems> {
     match input.value() {
-        stylo::AlignFlags::NORMAL => None,
         stylo::AlignFlags::AUTO => None,
+        stylo::AlignFlags::NORMAL => Some(taffy::AlignItems::Stretch),
         stylo::AlignFlags::STRETCH => Some(taffy::AlignItems::Stretch),
         stylo::AlignFlags::FLEX_START => Some(taffy::AlignItems::FlexStart),
         stylo::AlignFlags::FLEX_END => Some(taffy::AlignItems::FlexEnd),
+        stylo::AlignFlags::SELF_START => Some(taffy::AlignItems::Start),
+        stylo::AlignFlags::SELF_END => Some(taffy::AlignItems::End),
         stylo::AlignFlags::START => Some(taffy::AlignItems::Start),
         stylo::AlignFlags::END => Some(taffy::AlignItems::End),
+        stylo::AlignFlags::LEFT => Some(taffy::AlignItems::Start),
+        stylo::AlignFlags::RIGHT => Some(taffy::AlignItems::End),
         stylo::AlignFlags::CENTER => Some(taffy::AlignItems::Center),
         stylo::AlignFlags::BASELINE => Some(taffy::AlignItems::Baseline),
         // Should never be hit. But no real reason to panic here.

--- a/tests/wpt/meta/css/css-grid/alignment/grid-align-justify-margin-border-padding.html.ini
+++ b/tests/wpt/meta/css/css-grid/alignment/grid-align-justify-margin-border-padding.html.ini
@@ -1,14 +1,8 @@
 [grid-align-justify-margin-border-padding.html]
-  [.grid 5]
-    expected: FAIL
-
   [.grid 6]
     expected: FAIL
 
   [.grid 7]
-    expected: FAIL
-
-  [.grid 9]
     expected: FAIL
 
   [.grid 10]

--- a/tests/wpt/meta/css/css-grid/alignment/grid-align.html.ini
+++ b/tests/wpt/meta/css/css-grid/alignment/grid-align.html.ini
@@ -1,17 +1,8 @@
 [grid-align.html]
-  [.grid 2]
-    expected: FAIL
-
-  [.grid 3]
-    expected: FAIL
-
   [.grid 5]
     expected: FAIL
 
   [.grid 6]
-    expected: FAIL
-
-  [.grid 8]
     expected: FAIL
 
   [.grid 9]

--- a/tests/wpt/meta/css/css-grid/alignment/grid-column-axis-alignment-sticky-positioned-items-001.html.ini
+++ b/tests/wpt/meta/css/css-grid/alignment/grid-column-axis-alignment-sticky-positioned-items-001.html.ini
@@ -1,6 +1,0 @@
-[grid-column-axis-alignment-sticky-positioned-items-001.html]
-  [.grid 1]
-    expected: FAIL
-
-  [.grid 2]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-grid/alignment/grid-gutters-and-alignment.html.ini
+++ b/tests/wpt/meta/css/css-grid/alignment/grid-gutters-and-alignment.html.ini
@@ -1,7 +1,4 @@
 [grid-gutters-and-alignment.html]
-  [.grid 1]
-    expected: FAIL
-
   [.grid 2]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-grid/alignment/grid-item-alignment-with-orthogonal-flows.html.ini
+++ b/tests/wpt/meta/css/css-grid/alignment/grid-item-alignment-with-orthogonal-flows.html.ini
@@ -11,9 +11,6 @@
   [.grid 4]
     expected: FAIL
 
-  [.grid 5]
-    expected: FAIL
-
   [.grid 6]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-grid/alignment/grid-row-axis-alignment-sticky-positioned-items-001.html.ini
+++ b/tests/wpt/meta/css/css-grid/alignment/grid-row-axis-alignment-sticky-positioned-items-001.html.ini
@@ -1,6 +1,0 @@
-[grid-row-axis-alignment-sticky-positioned-items-001.html]
-  [.grid 1]
-    expected: FAIL
-
-  [.grid 2]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-grid/alignment/grid-self-alignment.html.ini
+++ b/tests/wpt/meta/css/css-grid/alignment/grid-self-alignment.html.ini
@@ -1,14 +1,8 @@
 [grid-self-alignment.html]
-  [.child 2]
-    expected: FAIL
-
   [.child 3]
     expected: FAIL
 
   [.child 4]
-    expected: FAIL
-
-  [.child 6]
     expected: FAIL
 
   [.child 7]
@@ -26,13 +20,7 @@
   [.child 11]
     expected: FAIL
 
-  [.child 14]
-    expected: FAIL
-
   [.child 16]
-    expected: FAIL
-
-  [.child 18]
     expected: FAIL
 
   [.child 19]
@@ -44,16 +32,10 @@
   [.child 23]
     expected: FAIL
 
-  [.child 26]
-    expected: FAIL
-
   [.child 27]
     expected: FAIL
 
   [.child 28]
-    expected: FAIL
-
-  [.child 30]
     expected: FAIL
 
   [.child 31]
@@ -71,13 +53,7 @@
   [.child 35]
     expected: FAIL
 
-  [.child 38]
-    expected: FAIL
-
   [.child 40]
-    expected: FAIL
-
-  [.child 42]
     expected: FAIL
 
   [.child 43]
@@ -89,16 +65,10 @@
   [.child 47]
     expected: FAIL
 
-  [.child 50]
-    expected: FAIL
-
   [.child 51]
     expected: FAIL
 
   [.child 52]
-    expected: FAIL
-
-  [.child 54]
     expected: FAIL
 
   [.child 55]
@@ -116,13 +86,7 @@
   [.child 59]
     expected: FAIL
 
-  [.child 62]
-    expected: FAIL
-
   [.child 64]
-    expected: FAIL
-
-  [.child 66]
     expected: FAIL
 
   [.child 67]
@@ -159,4 +123,22 @@
     expected: FAIL
 
   [.child 69]
+    expected: FAIL
+
+  [.child 12]
+    expected: FAIL
+
+  [.child 24]
+    expected: FAIL
+
+  [.child 36]
+    expected: FAIL
+
+  [.child 48]
+    expected: FAIL
+
+  [.child 60]
+    expected: FAIL
+
+  [.child 72]
     expected: FAIL


### PR DESCRIPTION
This imports the following changes from Blitz:
- Map position:sticky to relative rather than absolute position https://github.com/DioxusLabs/blitz/commit/16a7c1654455bee62e83854f83304a2931b29a0d
- Map left and right alignment from Stylo https://github.com/DioxusLabs/blitz/commit/c71cc681d8c877dbd30853b3c4a2a7449c6450e4
- Improve mapping of align-items/self https://github.com/DioxusLabs/blitz/commit/7bf2a25e756c1310a9e4603b4757e20548b961e2

Fixes: #35998

Testing:
- `/css/css-grid/alignment/grid-align-justify-margin-border-padding.html`
- `/css/css-grid/alignment/grid-align.html`
- `/css/css-grid/alignment/grid-column-axis-alignment-sticky-positioned-items-001.html`
- `/css/css-grid/alignment/grid-gutters-and-alignment.html`
- `/css/css-grid/alignment/grid-item-alignment-with-orthogonal-flows.html`
- `/css/css-grid/alignment/grid-row-axis-alignment-sticky-positioned-items-001.html`
- `/css/css-grid/alignment/grid-self-alignment.html`