### PR TITLE
constellation: Stop assuming that the viewport is shared by all WebViews

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6430,6 +6430,7 @@ dependencies = [
  "base",
  "canvas_traits",
  "constellation_traits",
+ "embedder_traits",
  "euclid",
  "fnv",
  "fonts",

--- a/components/constellation/browsingcontext.rs
+++ b/components/constellation/browsingcontext.rs
@@ -5,9 +5,8 @@
 use std::collections::{HashMap, HashSet};
 
 use base::id::{BrowsingContextGroupId, BrowsingContextId, PipelineId, WebViewId};
-use euclid::Size2D;
+use embedder_traits::ViewportDetails;
 use log::warn;
-use style_traits::CSSPixel;
 
 use crate::pipeline::Pipeline;
 
@@ -50,8 +49,8 @@ pub struct BrowsingContext {
     /// The top-level browsing context ancestor
     pub top_level_id: WebViewId,
 
-    /// The size of the frame.
-    pub size: Size2D<f32, CSSPixel>,
+    /// The [`ViewportDetails`] of the frame that this [`BrowsingContext`] represents.
+    pub viewport_details: ViewportDetails,
 
     /// Whether this browsing context is in private browsing mode.
     pub is_private: bool,
@@ -85,7 +84,7 @@ impl BrowsingContext {
         top_level_id: WebViewId,
         pipeline_id: PipelineId,
         parent_pipeline_id: Option<PipelineId>,
-        size: Size2D<f32, CSSPixel>,
+        viewport_details: ViewportDetails,
         is_private: bool,
         inherited_secure_context: Option<bool>,
         throttled: bool,
@@ -96,7 +95,7 @@ impl BrowsingContext {
             bc_group_id,
             id,
             top_level_id,
-            size,
+            viewport_details,
             is_private,
             inherited_secure_context,
             throttled,

--- a/components/constellation/pipeline.rs
+++ b/components/constellation/pipeline.rs
@@ -19,9 +19,9 @@ use base::id::{
 use bluetooth_traits::BluetoothRequest;
 use canvas_traits::webgl::WebGLPipeline;
 use compositing_traits::{CompositionPipeline, CompositorMsg, CompositorProxy};
-use constellation_traits::WindowSizeData;
 use crossbeam_channel::{Sender, unbounded};
 use devtools_traits::{DevtoolsControlMsg, ScriptToDevtoolsControlMsg};
+use embedder_traits::ViewportDetails;
 use embedder_traits::user_content_manager::UserContentManager;
 use fonts::{SystemFontServiceProxy, SystemFontServiceProxySender};
 use ipc_channel::Error;
@@ -161,8 +161,8 @@ pub struct InitialPipelineState {
     /// A channel to the memory profiler thread.
     pub mem_profiler_chan: profile_mem::ProfilerChan,
 
-    /// Information about the initial window size.
-    pub window_size: WindowSizeData,
+    /// The initial [`ViewportDetails`] to use when starting this new [`Pipeline`].
+    pub viewport_details: ViewportDetails,
 
     /// The ID of the pipeline namespace for this script thread.
     pub pipeline_namespace_id: PipelineNamespaceId,
@@ -219,7 +219,7 @@ impl Pipeline {
                     webview_id: state.webview_id,
                     opener: state.opener,
                     load_data: state.load_data.clone(),
-                    window_size: state.window_size,
+                    viewport_details: state.viewport_details,
                 };
 
                 if let Err(e) = script_chan.send(ScriptThreadMessage::AttachLayout(new_layout_info))
@@ -275,7 +275,7 @@ impl Pipeline {
                     resource_threads: state.resource_threads,
                     time_profiler_chan: state.time_profiler_chan,
                     mem_profiler_chan: state.mem_profiler_chan,
-                    window_size: state.window_size,
+                    viewport_details: state.viewport_details,
                     script_chan: script_chan.clone(),
                     load_data: state.load_data.clone(),
                     script_port,
@@ -484,7 +484,7 @@ pub struct UnprivilegedPipelineContent {
     resource_threads: ResourceThreads,
     time_profiler_chan: time::ProfilerChan,
     mem_profiler_chan: profile_mem::ProfilerChan,
-    window_size: WindowSizeData,
+    viewport_details: ViewportDetails,
     script_chan: IpcSender<ScriptThreadMessage>,
     load_data: LoadData,
     script_port: IpcReceiver<ScriptThreadMessage>,
@@ -534,7 +534,7 @@ impl UnprivilegedPipelineContent {
                 time_profiler_sender: self.time_profiler_chan.clone(),
                 memory_profiler_sender: self.mem_profiler_chan.clone(),
                 devtools_server_sender: self.devtools_ipc_sender,
-                window_size: self.window_size,
+                viewport_details: self.viewport_details,
                 pipeline_namespace_id: self.pipeline_namespace_id,
                 content_process_shutdown_sender: content_process_shutdown_chan,
                 webgl_chan: self.webgl_chan,

--- a/components/constellation/session_history.rs
+++ b/components/constellation/session_history.rs
@@ -6,11 +6,10 @@ use std::cmp::PartialEq;
 use std::fmt;
 
 use base::id::{BrowsingContextId, HistoryStateId, PipelineId, WebViewId};
-use euclid::Size2D;
+use embedder_traits::ViewportDetails;
 use log::debug;
 use script_traits::LoadData;
 use servo_url::ServoUrl;
-use style_traits::CSSPixel;
 
 use crate::browsingcontext::NewBrowsingContextInfo;
 
@@ -127,8 +126,8 @@ pub struct SessionHistoryChange {
     /// easily available when they need to be constructed.
     pub new_browsing_context_info: Option<NewBrowsingContextInfo>,
 
-    /// The size of the viewport for the browsing context.
-    pub window_size: Size2D<f32, CSSPixel>,
+    /// The size and hidpi scale factor of the viewport for the browsing context.
+    pub viewport_details: ViewportDetails,
 }
 
 /// Represents a pipeline or discarded pipeline in a history entry.

--- a/components/constellation/tracing.rs
+++ b/components/constellation/tracing.rs
@@ -58,7 +58,7 @@ mod from_compositor {
                 Self::LoadUrl(..) => target!("LoadUrl"),
                 Self::ClearCache => target!("ClearCache"),
                 Self::TraverseHistory(..) => target!("TraverseHistory"),
-                Self::WindowSize(..) => target!("WindowSize"),
+                Self::ChangeViewportDetails(..) => target!("ChangeViewportDetails"),
                 Self::ThemeChange(..) => target!("ThemeChange"),
                 Self::TickAnimation(..) => target!("TickAnimation"),
                 Self::WebDriverCommand(..) => target!("WebDriverCommand"),

--- a/components/layout_2020/replaced.rs
+++ b/components/layout_2020/replaced.rs
@@ -9,7 +9,8 @@ use std::sync::Arc;
 use app_units::Au;
 use base::id::{BrowsingContextId, PipelineId};
 use data_url::DataUrl;
-use euclid::Size2D;
+use embedder_traits::ViewportDetails;
+use euclid::{Scale, Size2D};
 use net_traits::image_cache::{ImageOrMetadataAvailable, UsePlaceholder};
 use pixels::Image;
 use script_layout_interface::IFrameSize;
@@ -358,12 +359,17 @@ impl ReplacedContents {
             },
             ReplacedContentKind::IFrame(iframe) => {
                 let size = Size2D::new(rect.size.width.to_f32_px(), rect.size.height.to_f32_px());
+                let hidpi_scale_factor = layout_context.shared_context().device_pixel_ratio();
+
                 layout_context.iframe_sizes.lock().insert(
                     iframe.browsing_context_id,
                     IFrameSize {
                         browsing_context_id: iframe.browsing_context_id,
                         pipeline_id: iframe.pipeline_id,
-                        size,
+                        viewport_details: ViewportDetails {
+                            size,
+                            hidpi_scale_factor: Scale::new(hidpi_scale_factor.0),
+                        },
                     },
                 );
                 vec![Fragment::IFrame(ArcRefCell::new(IFrameFragment {

--- a/components/script/dom/documentorshadowroot.rs
+++ b/components/script/dom/documentorshadowroot.rs
@@ -128,7 +128,7 @@ impl DocumentOrShadowRoot {
         let x = *x as f32;
         let y = *y as f32;
         let point = &Point2D::new(x, y);
-        let viewport = self.window.window_size().initial_viewport;
+        let viewport = self.window.viewport_details().size;
 
         if !has_browsing_context {
             return None;
@@ -176,7 +176,7 @@ impl DocumentOrShadowRoot {
         let x = *x as f32;
         let y = *y as f32;
         let point = &Point2D::new(x, y);
-        let viewport = self.window.window_size().initial_viewport;
+        let viewport = self.window.viewport_details().size;
 
         if !has_browsing_context {
             return vec![];

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -4344,7 +4344,7 @@ impl Element {
         if (in_quirks_mode && doc.GetBody().as_deref() == self.downcast::<HTMLElement>()) ||
             (!in_quirks_mode && *self.root_element() == *self)
         {
-            let viewport_dimensions = doc.window().window_size().initial_viewport.round().to_i32();
+            let viewport_dimensions = doc.window().viewport_details().size.round().to_i32();
             rect.size = Size2D::<i32>::new(viewport_dimensions.width, viewport_dimensions.height);
         }
 

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -808,8 +808,8 @@ impl HTMLImageElement {
         let device_pixel_ratio = self
             .owner_document()
             .window()
-            .window_size()
-            .device_pixel_ratio
+            .viewport_details()
+            .hidpi_scale_factor
             .get() as f64;
         for (index, image_source) in img_sources.iter().enumerate() {
             let current_den = image_source.descriptor.density.unwrap();

--- a/components/script/dom/intersectionobserver.rs
+++ b/components/script/dom/intersectionobserver.rs
@@ -444,7 +444,7 @@ impl IntersectionObserver {
                 // > (note that this processing step can only be reached if the document is fully active).
                 // TODO: viewport should consider native scrollbar if exist. Recheck Servo's scrollbar approach.
                 document.map(|document| {
-                    let viewport = document.window().window_size().initial_viewport;
+                    let viewport = document.window().viewport_details().size;
                     Rect::from_size(Size2D::new(
                         Au::from_f32_px(viewport.width),
                         Au::from_f32_px(viewport.height),

--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -326,7 +326,7 @@ impl WindowProxy {
             webview_id: response.new_webview_id,
             opener: Some(self.browsing_context_id),
             load_data,
-            window_size: window.window_size(),
+            viewport_details: window.viewport_details(),
         };
         ScriptThread::process_attach_layout(new_layout_info, document.origin().clone());
         // TODO: if noopener is false, copy the sessionStorage storage area of the creator origin.

--- a/components/script/iframe_collection.rs
+++ b/components/script/iframe_collection.rs
@@ -6,13 +6,11 @@ use std::cell::Cell;
 use std::default::Default;
 
 use base::id::BrowsingContextId;
-use constellation_traits::{WindowSizeData, WindowSizeType};
-use euclid::{Scale, Size2D};
+use constellation_traits::WindowSizeType;
+use embedder_traits::ViewportDetails;
 use fnv::FnvHashMap;
 use script_layout_interface::IFrameSizes;
 use script_traits::IFrameSizeMsg;
-use style_traits::CSSPixel;
-use webrender_api::units::DevicePixel;
 
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::{Dom, DomRoot};
@@ -26,7 +24,7 @@ use crate::script_thread::with_script_thread;
 pub(crate) struct IFrame {
     pub(crate) element: Dom<HTMLIFrameElement>,
     #[no_trace]
-    pub(crate) size: Option<Size2D<f32, CSSPixel>>,
+    pub(crate) size: Option<ViewportDetails>,
 }
 
 #[derive(Default, JSTraceable, MallocSizeOf)]
@@ -98,11 +96,11 @@ impl IFrameCollection {
 
     /// Set the size of an `<iframe>` in the collection given its `BrowsingContextId` and
     /// the new size. Returns the old size.
-    pub(crate) fn set_size(
+    pub(crate) fn set_viewport_details(
         &mut self,
         browsing_context_id: BrowsingContextId,
-        new_size: Size2D<f32, CSSPixel>,
-    ) -> Option<Size2D<f32, CSSPixel>> {
+        new_size: ViewportDetails,
+    ) -> Option<ViewportDetails> {
         self.get_mut(browsing_context_id)
             .expect("Tried to set a size for an unknown <iframe>")
             .size
@@ -115,7 +113,6 @@ impl IFrameCollection {
     pub(crate) fn handle_new_iframe_sizes_after_layout(
         &mut self,
         new_iframe_sizes: IFrameSizes,
-        device_pixel_ratio: Scale<f32, CSSPixel, DevicePixel>,
     ) -> Vec<IFrameSizeMsg> {
         if new_iframe_sizes.is_empty() {
             return vec![];
@@ -123,37 +120,35 @@ impl IFrameCollection {
 
         new_iframe_sizes
             .into_iter()
-            .filter_map(|(browsing_context_id, size)| {
+            .filter_map(|(browsing_context_id, iframe_size)| {
                 // Batch resize message to any local `Pipeline`s now, rather than waiting for them
                 // to filter asynchronously through the `Constellation`. This allows the new value
                 // to be reflected immediately in layout.
-                let new_size = size.size;
+                let viewport_details = iframe_size.viewport_details;
                 with_script_thread(|script_thread| {
                     script_thread.handle_resize_message(
-                        size.pipeline_id,
-                        WindowSizeData {
-                            initial_viewport: new_size,
-                            device_pixel_ratio,
-                        },
+                        iframe_size.pipeline_id,
+                        viewport_details,
                         WindowSizeType::Resize,
                     );
                 });
 
-                let old_size = self.set_size(browsing_context_id, new_size);
+                let old_viewport_details =
+                    self.set_viewport_details(browsing_context_id, viewport_details);
                 // The `Constellation` should be up-to-date even when the in-ScriptThread pipelines
                 // might not be.
-                if old_size == Some(size.size) {
+                if old_viewport_details == Some(viewport_details) {
                     return None;
                 }
 
-                let size_type = match old_size {
+                let size_type = match old_viewport_details {
                     Some(_) => WindowSizeType::Resize,
                     None => WindowSizeType::Initial,
                 };
 
                 Some(IFrameSizeMsg {
                     browsing_context_id,
-                    size: new_size,
+                    size: viewport_details,
                     type_: size_type,
                 })
             })

--- a/components/script/navigation.rs
+++ b/components/script/navigation.rs
@@ -10,9 +10,9 @@ use std::cell::Cell;
 
 use base::cross_process_instant::CrossProcessInstant;
 use base::id::{BrowsingContextId, PipelineId, WebViewId};
-use constellation_traits::WindowSizeData;
 use content_security_policy::Destination;
 use crossbeam_channel::Sender;
+use embedder_traits::ViewportDetails;
 use http::header;
 use net_traits::request::{
     CredentialsMode, InsecureRequestsPolicy, RedirectMode, RequestBuilder, RequestMode,
@@ -138,7 +138,7 @@ pub(crate) struct InProgressLoad {
     pub(crate) opener: Option<BrowsingContextId>,
     /// The current window size associated with this pipeline.
     #[no_trace]
-    pub(crate) window_size: WindowSizeData,
+    pub(crate) viewport_details: ViewportDetails,
     /// The activity level of the document (inactive, active or fully active).
     #[no_trace]
     pub(crate) activity: DocumentActivity,
@@ -170,7 +170,7 @@ impl InProgressLoad {
         webview_id: WebViewId,
         parent_info: Option<PipelineId>,
         opener: Option<BrowsingContextId>,
-        window_size: WindowSizeData,
+        viewport_details: ViewportDetails,
         origin: MutableOrigin,
         load_data: LoadData,
     ) -> InProgressLoad {
@@ -181,7 +181,7 @@ impl InProgressLoad {
             webview_id,
             parent_info,
             opener,
-            window_size,
+            viewport_details,
             activity: DocumentActivity::FullyActive,
             throttled: false,
             origin,

--- a/components/shared/script/script_msg.rs
+++ b/components/shared/script/script_msg.rs
@@ -13,8 +13,9 @@ use base::id::{
 use canvas_traits::canvas::{CanvasId, CanvasMsg};
 use constellation_traits::{LogEntry, TraversalDirection};
 use devtools_traits::{ScriptToDevtoolsControlMsg, WorkerId};
-use embedder_traits::{EmbedderMsg, MediaSessionEvent, TouchEventType, TouchSequenceId};
-use euclid::Size2D;
+use embedder_traits::{
+    EmbedderMsg, MediaSessionEvent, TouchEventType, TouchSequenceId, ViewportDetails,
+};
 use euclid::default::Size2D as UntypedSize2D;
 use ipc_channel::ipc::{IpcReceiver, IpcSender};
 use net_traits::CoreResourceMsg;
@@ -22,7 +23,6 @@ use net_traits::storage_thread::StorageType;
 use serde::{Deserialize, Serialize};
 use servo_url::{ImmutableOrigin, ServoUrl};
 use strum_macros::IntoStaticStr;
-use style_traits::CSSPixel;
 #[cfg(feature = "webgpu")]
 use webgpu::{WebGPU, WebGPUAdapterResponse, wgc};
 use webrender_api::ImageKey;
@@ -39,8 +39,8 @@ use crate::{
 pub struct IFrameSizeMsg {
     /// The child browsing context for this iframe.
     pub browsing_context_id: BrowsingContextId,
-    /// The size of the iframe.
-    pub size: Size2D<f32, CSSPixel>,
+    /// The size and scale factor of the iframe.
+    pub size: ViewportDetails,
     /// The kind of sizing operation.
     pub type_: WindowSizeType,
 }

--- a/components/shared/script_layout/Cargo.toml
+++ b/components/shared/script_layout/Cargo.toml
@@ -17,6 +17,7 @@ app_units = { workspace = true }
 atomic_refcell = { workspace = true }
 canvas_traits = { workspace = true }
 constellation_traits = { workspace = true }
+embedder_traits = { workspace = true }
 euclid = { workspace = true }
 fnv = { workspace = true }
 fonts = { path = "../../fonts" }

--- a/components/shared/script_layout/lib.rs
+++ b/components/shared/script_layout/lib.rs
@@ -18,8 +18,8 @@ use app_units::Au;
 use atomic_refcell::AtomicRefCell;
 use base::Epoch;
 use base::id::{BrowsingContextId, PipelineId, WebViewId};
-use constellation_traits::{ScrollState, UntrustedNodeAddress, WindowSizeData};
-use euclid::Size2D;
+use constellation_traits::{ScrollState, UntrustedNodeAddress};
+use embedder_traits::ViewportDetails;
 use euclid::default::{Point2D, Rect};
 use fnv::FnvHashMap;
 use fonts::{FontContext, SystemFontServiceProxy};
@@ -47,7 +47,6 @@ use style::properties::style_structs::Font;
 use style::queries::values::PrefersColorScheme;
 use style::selector_parser::{PseudoElement, RestyleDamage, Snapshot};
 use style::stylesheets::Stylesheet;
-use style_traits::CSSPixel;
 use webrender_api::ImageKey;
 use webrender_traits::CrossProcessCompositorApi;
 
@@ -185,7 +184,7 @@ pub struct LayoutConfig {
     pub font_context: Arc<FontContext>,
     pub time_profiler_chan: time::ProfilerChan,
     pub compositor_api: CrossProcessCompositorApi,
-    pub window_size: WindowSizeData,
+    pub viewport_details: ViewportDetails,
 }
 
 pub trait LayoutFactory: Send + Sync {
@@ -386,7 +385,7 @@ pub struct Reflow {
 pub struct IFrameSize {
     pub browsing_context_id: BrowsingContextId,
     pub pipeline_id: PipelineId,
-    pub size: Size2D<f32, CSSPixel>,
+    pub viewport_details: ViewportDetails,
 }
 
 pub type IFrameSizes = FnvHashMap<BrowsingContextId, IFrameSize>;
@@ -415,8 +414,8 @@ pub struct ReflowRequest {
     pub dirty_root: Option<TrustedNodeAddress>,
     /// Whether the document's stylesheets have changed since the last script reflow.
     pub stylesheets_changed: bool,
-    /// The current window size.
-    pub window_size: WindowSizeData,
+    /// The current [`ViewportDetails`] to use for this reflow.
+    pub viewport_details: ViewportDetails,
     /// The goal of this reflow.
     pub reflow_goal: ReflowGoal,
     /// The number of objects in the dom #10110


### PR DESCRIPTION
The `Constellation` previously held a `window_size` member, but this
assumes that all `WebView`s have the same size. This change removes that
assumption as well as making sure that all `WebView`s pass their size
and HiDIP scaling to the `Constellation` when they are created.

In addition

- `WindowSizeData` is renamed to `ViewportDetails`, as it was
  holding more than just the size and it didn't necessarily correspond to
  a "window." It's used for tracking viewport data, whether for an
  `<iframe>` or the main `WebView` viewport.
- `ViewportDetails` is stored more consistently so that conceptually an
  `<iframe>` can also have its own HiDPI scaling. This isn't something
  we necessarily want, but it makes everything conceptually simpler.

The goal with this change is to work toward allowing per-`WebView` HiDPI
scaling and sizing. There are still some corresponding changes in the
compositor to make that happen, but they will in a subsequent change.

Testing: This is covered by existing tests. There should be no behavior changes.
Fixes: This is part of #36232.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

