### PR TITLE
wpt: Unskip css/css-text/i18n as many tests are passing there

### DIFF
--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -107,8 +107,6 @@ skip: true
     skip: true
   [css-text]
     skip: false
-    [i18n]
-      skip: true
   [css-typed-om]
     skip: true
   [css-view-transitions]

--- a/tests/wpt/meta/css/css-text/i18n/css3-text-line-break-opclns-201.html.ini
+++ b/tests/wpt/meta/css/css-text/i18n/css3-text-line-break-opclns-201.html.ini
@@ -1,0 +1,2 @@
+[css3-text-line-break-opclns-201.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/i18n/ja/css-text-line-break-ja-cj-loose.html.ini
+++ b/tests/wpt/meta/css/css-text/i18n/ja/css-text-line-break-ja-cj-loose.html.ini
@@ -1,0 +1,153 @@
+[css-text-line-break-ja-cj-loose.html]
+  [3041  HIRAGANA LETTER SMALL A may appear at line start if ja and loose]
+    expected: FAIL
+
+  [3043  HIRAGANA LETTER SMALL I may appear at line start if ja and loose]
+    expected: FAIL
+
+  [3045  HIRAGANA LETTER SMALL U may appear at line start if ja and loose]
+    expected: FAIL
+
+  [3047  HIRAGANA LETTER SMALL E may appear at line start if ja and loose]
+    expected: FAIL
+
+  [3049  HIRAGANA LETTER SMALL O may appear at line start if ja and loose]
+    expected: FAIL
+
+  [3063  HIRAGANA LETTER SMALL TU may appear at line start if ja and loose]
+    expected: FAIL
+
+  [3083  HIRAGANA LETTER SMALL YA may appear at line start if ja and loose]
+    expected: FAIL
+
+  [3085  HIRAGANA LETTER SMALL YU may appear at line start if ja and loose]
+    expected: FAIL
+
+  [3087  HIRAGANA LETTER SMALL YO may appear at line start if ja and loose]
+    expected: FAIL
+
+  [308E  HIRAGANA LETTER SMALL WA may appear at line start if ja and loose]
+    expected: FAIL
+
+  [3095  HIRAGANA LETTER SMALL KA may appear at line start if ja and loose]
+    expected: FAIL
+
+  [3096  HIRAGANA LETTER SMALL KE may appear at line start if ja and loose]
+    expected: FAIL
+
+  [30A1  KATAKANA LETTER SMALL A may appear at line start if ja and loose]
+    expected: FAIL
+
+  [30A3  KATAKANA LETTER SMALL I may appear at line start if ja and loose]
+    expected: FAIL
+
+  [30A5  KATAKANA LETTER SMALL U may appear at line start if ja and loose]
+    expected: FAIL
+
+  [30A7  KATAKANA LETTER SMALL E may appear at line start if ja and loose]
+    expected: FAIL
+
+  [30A9  KATAKANA LETTER SMALL O may appear at line start if ja and loose]
+    expected: FAIL
+
+  [30C3  KATAKANA LETTER SMALL TU may appear at line start if ja and loose]
+    expected: FAIL
+
+  [30E3  KATAKANA LETTER SMALL YA may appear at line start if ja and loose]
+    expected: FAIL
+
+  [30E5  KATAKANA LETTER SMALL YU may appear at line start if ja and loose]
+    expected: FAIL
+
+  [30E7  KATAKANA LETTER SMALL YO may appear at line start if ja and loose]
+    expected: FAIL
+
+  [30EE  KATAKANA LETTER SMALL WA may appear at line start if ja and loose]
+    expected: FAIL
+
+  [30F5  KATAKANA LETTER SMALL KA may appear at line start if ja and loose]
+    expected: FAIL
+
+  [30F6  KATAKANA LETTER SMALL KE may appear at line start if ja and loose]
+    expected: FAIL
+
+  [30FC  KATAKANA-HIRAGANA PROLONGED SOUND MARK may appear at line start if ja and loose]
+    expected: FAIL
+
+  [31F0  KATAKANA LETTER SMALL KU may appear at line start if ja and loose]
+    expected: FAIL
+
+  [31F1  KATAKANA LETTER SMALL SI may appear at line start if ja and loose]
+    expected: FAIL
+
+  [31F2  KATAKANA LETTER SMALL SU may appear at line start if ja and loose]
+    expected: FAIL
+
+  [31F3  KATAKANA LETTER SMALL TO may appear at line start if ja and loose]
+    expected: FAIL
+
+  [31F4  KATAKANA LETTER SMALL NU may appear at line start if ja and loose]
+    expected: FAIL
+
+  [31F5  KATAKANA LETTER SMALL HA may appear at line start if ja and loose]
+    expected: FAIL
+
+  [31F6  KATAKANA LETTER SMALL HI may appear at line start if ja and loose]
+    expected: FAIL
+
+  [31F7  KATAKANA LETTER SMALL HU may appear at line start if ja and loose]
+    expected: FAIL
+
+  [31F8  KATAKANA LETTER SMALL HE may appear at line start if ja and loose]
+    expected: FAIL
+
+  [31F9  KATAKANA LETTER SMALL HO may appear at line start if ja and loose]
+    expected: FAIL
+
+  [31FA  KATAKANA LETTER SMALL MU may appear at line start if ja and loose]
+    expected: FAIL
+
+  [31FB  KATAKANA LETTER SMALL RA may appear at line start if ja and loose]
+    expected: FAIL
+
+  [31FC  KATAKANA LETTER SMALL RI may appear at line start if ja and loose]
+    expected: FAIL
+
+  [31FD  KATAKANA LETTER SMALL RU may appear at line start if ja and loose]
+    expected: FAIL
+
+  [31FE  KATAKANA LETTER SMALL RE may appear at line start if ja and loose]
+    expected: FAIL
+
+  [31FF  KATAKANA LETTER SMALL RO may appear at line start if ja and loose]
+    expected: FAIL
+
+  [FF67  HALFWIDTH KATAKANA LETTER SMALL A may appear at line start if ja and loose]
+    expected: FAIL
+
+  [FF68  HALFWIDTH KATAKANA LETTER SMALL I may appear at line start if ja and loose]
+    expected: FAIL
+
+  [FF69  HALFWIDTH KATAKANA LETTER SMALL U may appear at line start if ja and loose]
+    expected: FAIL
+
+  [FF6A  HALFWIDTH KATAKANA LETTER SMALL E may appear at line start if ja and loose]
+    expected: FAIL
+
+  [FF6B  HALFWIDTH KATAKANA LETTER SMALL O may appear at line start if ja and loose]
+    expected: FAIL
+
+  [FF6C  HALFWIDTH KATAKANA LETTER SMALL YA may appear at line start if ja and loose]
+    expected: FAIL
+
+  [FF6D  HALFWIDTH KATAKANA LETTER SMALL YU may appear at line start if ja and loose]
+    expected: FAIL
+
+  [FF6E  HALFWIDTH KATAKANA LETTER SMALL YO may appear at line start if ja and loose]
+    expected: FAIL
+
+  [FF6F  HALFWIDTH KATAKANA LETTER SMALL TU may appear at line start if ja and loose]
+    expected: FAIL
+
+  [FF70  HALFWIDTH KATAKANA-HIRAGANA PROLONGED SOUND MARK may appear at line start if ja and loose]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-text/i18n/ja/css-text-line-break-ja-cj-normal.html.ini
+++ b/tests/wpt/meta/css/css-text/i18n/ja/css-text-line-break-ja-cj-normal.html.ini
@@ -1,0 +1,153 @@
+[css-text-line-break-ja-cj-normal.html]
+  [3041  HIRAGANA LETTER SMALL A may appear at line start if ja and normal]
+    expected: FAIL
+
+  [3043  HIRAGANA LETTER SMALL I may appear at line start if ja and normal]
+    expected: FAIL
+
+  [3045  HIRAGANA LETTER SMALL U may appear at line start if ja and normal]
+    expected: FAIL
+
+  [3047  HIRAGANA LETTER SMALL E may appear at line start if ja and normal]
+    expected: FAIL
+
+  [3049  HIRAGANA LETTER SMALL O may appear at line start if ja and normal]
+    expected: FAIL
+
+  [3063  HIRAGANA LETTER SMALL TU may appear at line start if ja and normal]
+    expected: FAIL
+
+  [3083  HIRAGANA LETTER SMALL YA may appear at line start if ja and normal]
+    expected: FAIL
+
+  [3085  HIRAGANA LETTER SMALL YU may appear at line start if ja and normal]
+    expected: FAIL
+
+  [3087  HIRAGANA LETTER SMALL YO may appear at line start if ja and normal]
+    expected: FAIL
+
+  [308E  HIRAGANA LETTER SMALL WA may appear at line start if ja and normal]
+    expected: FAIL
+
+  [3095  HIRAGANA LETTER SMALL KA may appear at line start if ja and normal]
+    expected: FAIL
+
+  [3096  HIRAGANA LETTER SMALL KE may appear at line start if ja and normal]
+    expected: FAIL
+
+  [30A1  KATAKANA LETTER SMALL A may appear at line start if ja and normal]
+    expected: FAIL
+
+  [30A3  KATAKANA LETTER SMALL I may appear at line start if ja and normal]
+    expected: FAIL
+
+  [30A5  KATAKANA LETTER SMALL U may appear at line start if ja and normal]
+    expected: FAIL
+
+  [30A7  KATAKANA LETTER SMALL E may appear at line start if ja and normal]
+    expected: FAIL
+
+  [30A9  KATAKANA LETTER SMALL O may appear at line start if ja and normal]
+    expected: FAIL
+
+  [30C3  KATAKANA LETTER SMALL TU may appear at line start if ja and normal]
+    expected: FAIL
+
+  [30E3  KATAKANA LETTER SMALL YA may appear at line start if ja and normal]
+    expected: FAIL
+
+  [30E5  KATAKANA LETTER SMALL YU may appear at line start if ja and normal]
+    expected: FAIL
+
+  [30E7  KATAKANA LETTER SMALL YO may appear at line start if ja and normal]
+    expected: FAIL
+
+  [30EE  KATAKANA LETTER SMALL WA may appear at line start if ja and normal]
+    expected: FAIL
+
+  [30F5  KATAKANA LETTER SMALL KA may appear at line start if ja and normal]
+    expected: FAIL
+
+  [30F6  KATAKANA LETTER SMALL KE may appear at line start if ja and normal]
+    expected: FAIL
+
+  [30FC  KATAKANA-HIRAGANA PROLONGED SOUND MARK may appear at line start if ja and normal]
+    expected: FAIL
+
+  [31F0  KATAKANA LETTER SMALL KU may appear at line start if ja and normal]
+    expected: FAIL
+
+  [31F1  KATAKANA LETTER SMALL SI may appear at line start if ja and normal]
+    expected: FAIL
+
+  [31F2  KATAKANA LETTER SMALL SU may appear at line start if ja and normal]
+    expected: FAIL
+
+  [31F3  KATAKANA LETTER SMALL TO may appear at line start if ja and normal]
+    expected: FAIL
+
+  [31F4  KATAKANA LETTER SMALL NU may appear at line start if ja and normal]
+    expected: FAIL
+
+  [31F5  KATAKANA LETTER SMALL HA may appear at line start if ja and normal]
+    expected: FAIL
+
+  [31F6  KATAKANA LETTER SMALL HI may appear at line start if ja and normal]
+    expected: FAIL
+
+  [31F7  KATAKANA LETTER SMALL HU may appear at line start if ja and normal]
+    expected: FAIL
+
+  [31F8  KATAKANA LETTER SMALL HE may appear at line start if ja and normal]
+    expected: FAIL
+
+  [31F9  KATAKANA LETTER SMALL HO may appear at line start if ja and normal]
+    expected: FAIL
+
+  [31FA  KATAKANA LETTER SMALL MU may appear at line start if ja and normal]
+    expected: FAIL
+
+  [31FB  KATAKANA LETTER SMALL RA may appear at line start if ja and normal]
+    expected: FAIL
+
+  [31FC  KATAKANA LETTER SMALL RI may appear at line start if ja and normal]
+    expected: FAIL
+
+  [31FD  KATAKANA LETTER SMALL RU may appear at line start if ja and normal]
+    expected: FAIL
+
+  [31FE  KATAKANA LETTER SMALL RE may appear at line start if ja and normal]
+    expected: FAIL
+
+  [31FF  KATAKANA LETTER SMALL RO may appear at line start if ja and normal]
+    expected: FAIL
+
+  [FF67  HALFWIDTH KATAKANA LETTER SMALL A may appear at line start if ja and normal]
+    expected: FAIL
+
+  [FF68  HALFWIDTH KATAKANA LETTER SMALL I may appear at line start if ja and normal]
+    expected: FAIL
+
+  [FF69  HALFWIDTH KATAKANA LETTER SMALL U may appear at line start if ja and normal]
+    expected: FAIL
+
+  [FF6A  HALFWIDTH KATAKANA LETTER SMALL E may appear at line start if ja and normal]
+    expected: FAIL
+
+  [FF6B  HALFWIDTH KATAKANA LETTER SMALL O may appear at line start if ja and normal]
+    expected: FAIL
+
+  [FF6C  HALFWIDTH KATAKANA LETTER SMALL YA may appear at line start if ja and normal]
+    expected: FAIL
+
+  [FF6D  HALFWIDTH KATAKANA LETTER SMALL YU may appear at line start if ja and normal]
+    expected: FAIL
+
+  [FF6E  HALFWIDTH KATAKANA LETTER SMALL YO may appear at line start if ja and normal]
+    expected: FAIL
+
+  [FF6F  HALFWIDTH KATAKANA LETTER SMALL TU may appear at line start if ja and normal]
+    expected: FAIL
+
+  [FF70  HALFWIDTH KATAKANA-HIRAGANA PROLONGED SOUND MARK may appear at line start if ja and normal]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-text/i18n/ja/css-text-line-break-ja-cpm-loose.html.ini
+++ b/tests/wpt/meta/css/css-text/i18n/ja/css-text-line-break-ja-cpm-loose.html.ini
@@ -1,0 +1,30 @@
+[css-text-line-break-ja-cpm-loose.html]
+  [30FB  KATAKANA MIDDLE DOT may appear at line start if ja and loose]
+    expected: FAIL
+
+  [FF1A  FULLWIDTH COLON may appear at line start if ja and loose]
+    expected: FAIL
+
+  [FF1B  FULLWIDTH SEMICOLON may appear at line start if ja and loose]
+    expected: FAIL
+
+  [FF65  HALFWIDTH KATAKANA MIDDLE DOT may appear at line start if ja and loose]
+    expected: FAIL
+
+  [203C  DOUBLE EXCLAMATION MARK may appear at line start if ja and loose]
+    expected: FAIL
+
+  [2047  DOUBLE QUESTION MARK may appear at line start if ja and loose]
+    expected: FAIL
+
+  [2048  QUESTION EXCLAMATION MARK may appear at line start if ja and loose]
+    expected: FAIL
+
+  [2049  EXCLAMATION QUESTION MARK may appear at line start if ja and loose]
+    expected: FAIL
+
+  [FF01  FULLWIDTH EXCLAMATION MARK may appear at line start if ja and loose]
+    expected: FAIL
+
+  [FF1F  FULLWIDTH QUESTION MARK may appear at line start if ja and loose]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-text/i18n/ja/css-text-line-break-ja-hyphens-loose.html.ini
+++ b/tests/wpt/meta/css/css-text/i18n/ja/css-text-line-break-ja-hyphens-loose.html.ini
@@ -1,0 +1,6 @@
+[css-text-line-break-ja-hyphens-loose.html]
+  [301C WAVE DASH may appear at line start if ja and loose]
+    expected: FAIL
+
+  [30A0 KATAKANA-HIRAGANA DOUBLE HYPHEN may appear at line start if ja and loose]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-text/i18n/ja/css-text-line-break-ja-hyphens-normal.html.ini
+++ b/tests/wpt/meta/css/css-text/i18n/ja/css-text-line-break-ja-hyphens-normal.html.ini
@@ -1,0 +1,6 @@
+[css-text-line-break-ja-hyphens-normal.html]
+  [301C WAVE DASH may appear at line start if ja and normal]
+    expected: FAIL
+
+  [30A0 KATAKANA-HIRAGANA DOUBLE HYPHEN may appear at line start if ja and normal]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-text/i18n/ja/css-text-line-break-ja-in-loose.html.ini
+++ b/tests/wpt/meta/css/css-text/i18n/ja/css-text-line-break-ja-in-loose.html.ini
@@ -1,0 +1,15 @@
+[css-text-line-break-ja-in-loose.html]
+  [2024  ONE DOT LEADER may appear at line start if ja and loose]
+    expected: FAIL
+
+  [2025  TWO DOT LEADER may appear at line start if ja and loose]
+    expected: FAIL
+
+  [2026  HORIZONTAL ELLIPSIS may appear at line start if ja and loose]
+    expected: FAIL
+
+  [22EF  MIDLINE HORIZONTAL ELLIPSIS may appear at line start if ja and loose]
+    expected: FAIL
+
+  [FE19  PRESENTATION FORM FOR VERTICAL HORIZONTAL ELLIPSIS may appear at line start if ja and loose]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-text/i18n/ja/css-text-line-break-ja-iteration-loose.html.ini
+++ b/tests/wpt/meta/css/css-text/i18n/ja/css-text-line-break-ja-iteration-loose.html.ini
@@ -1,0 +1,18 @@
+[css-text-line-break-ja-iteration-loose.html]
+  [3005  IDEOGRAPHIC ITERATION MARK may appear at line start if ja and loose]
+    expected: FAIL
+
+  [303B  VERTICAL IDEOGRAPHIC ITERATION MARK may appear at line start if ja and loose]
+    expected: FAIL
+
+  [309D  HIRAGANA ITERATION MARK may appear at line start if ja and loose]
+    expected: FAIL
+
+  [309E  HIRAGANA VOICED ITERATION MARK may appear at line start if ja and loose]
+    expected: FAIL
+
+  [30FD  KATAKANA ITERATION MARK may appear at line start if ja and loose]
+    expected: FAIL
+
+  [30FE  KATAKANA VOICED ITERATION MARK may appear at line start if ja and loose]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-text/i18n/ja/css-text-line-break-ja-po-loose.html.ini
+++ b/tests/wpt/meta/css/css-text/i18n/ja/css-text-line-break-ja-po-loose.html.ini
@@ -1,0 +1,30 @@
+[css-text-line-break-ja-po-loose.html]
+  [00B0  DEGREE SIGN may appear at line start if ja and loose]
+    expected: FAIL
+
+  [2030  PER MILLE SIGN may appear at line start if ja and loose]
+    expected: FAIL
+
+  [2032  PRIME may appear at line start if ja and loose]
+    expected: FAIL
+
+  [2033  DOUBLE PRIME may appear at line start if ja and loose]
+    expected: FAIL
+
+  [2035  REVERSED PRIME may appear at line start if ja and loose]
+    expected: FAIL
+
+  [2103  DEGREE CELSIUS may appear at line start if ja and loose]
+    expected: FAIL
+
+  [2109  DEGREE FAHRENHEIT may appear at line start if ja and loose]
+    expected: FAIL
+
+  [FE6A  SMALL PERCENT SIGN may appear at line start if ja and loose]
+    expected: FAIL
+
+  [FF05  FULLWIDTH PERCENT SIGN may appear at line start if ja and loose]
+    expected: FAIL
+
+  [FFE0  FULLWIDTH CENT SIGN may appear at line start if ja and loose]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-text/i18n/ja/css-text-line-break-ja-pr-normal.html.ini
+++ b/tests/wpt/meta/css/css-text/i18n/ja/css-text-line-break-ja-pr-normal.html.ini
@@ -1,0 +1,24 @@
+[css-text-line-break-ja-pr-normal.html]
+  [00B1  PLUS-MINUS SIGN may NOT appear at line start if ja and normal]
+    expected: FAIL
+
+  [20AC  EURO SIGN may NOT appear at line start if ja and normal]
+    expected: FAIL
+
+  [2116  NUMERO SIGN may NOT appear at line start if ja and normal]
+    expected: FAIL
+
+  [FE69  SMALL DOLLAR SIGN may NOT appear at line start if ja and normal]
+    expected: FAIL
+
+  [FF04  FULLWIDTH DOLLAR SIGN may NOT appear at line start if ja and normal]
+    expected: FAIL
+
+  [FFE1  FULLWIDTH POUND SIGN may NOT appear at line start if ja and normal]
+    expected: FAIL
+
+  [FFE5  FULLWIDTH YEN SIGN may NOT appear at line start if ja and normal]
+    expected: FAIL
+
+  [FFE6  FULLWIDTH WON SIGN may NOT appear at line start if ja and normal]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-text/i18n/ja/css-text-line-break-ja-pr-strict.html.ini
+++ b/tests/wpt/meta/css/css-text/i18n/ja/css-text-line-break-ja-pr-strict.html.ini
@@ -1,0 +1,24 @@
+[css-text-line-break-ja-pr-strict.html]
+  [00B1  PLUS-MINUS SIGN may NOT appear at line start if ja and strict]
+    expected: FAIL
+
+  [20AC  EURO SIGN may NOT appear at line start if ja and strict]
+    expected: FAIL
+
+  [2116  NUMERO SIGN may NOT appear at line start if ja and strict]
+    expected: FAIL
+
+  [FE69  SMALL DOLLAR SIGN may NOT appear at line start if ja and strict]
+    expected: FAIL
+
+  [FF04  FULLWIDTH DOLLAR SIGN may NOT appear at line start if ja and strict]
+    expected: FAIL
+
+  [FFE1  FULLWIDTH POUND SIGN may NOT appear at line start if ja and strict]
+    expected: FAIL
+
+  [FFE5  FULLWIDTH YEN SIGN may NOT appear at line start if ja and strict]
+    expected: FAIL
+
+  [FFE6  FULLWIDTH WON SIGN may NOT appear at line start if ja and strict]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-text/i18n/other-lang/css-text-line-break-de-cj-loose.html.ini
+++ b/tests/wpt/meta/css/css-text/i18n/other-lang/css-text-line-break-de-cj-loose.html.ini
@@ -1,0 +1,153 @@
+[css-text-line-break-de-cj-loose.html]
+  [3041  HIRAGANA LETTER SMALL A may appear at line start if de and loose]
+    expected: FAIL
+
+  [3043  HIRAGANA LETTER SMALL I may appear at line start if de and loose]
+    expected: FAIL
+
+  [3045  HIRAGANA LETTER SMALL U may appear at line start if de and loose]
+    expected: FAIL
+
+  [3047  HIRAGANA LETTER SMALL E may appear at line start if de and loose]
+    expected: FAIL
+
+  [3049  HIRAGANA LETTER SMALL O may appear at line start if de and loose]
+    expected: FAIL
+
+  [3063  HIRAGANA LETTER SMALL TU may appear at line start if de and loose]
+    expected: FAIL
+
+  [3083  HIRAGANA LETTER SMALL YA may appear at line start if de and loose]
+    expected: FAIL
+
+  [3085  HIRAGANA LETTER SMALL YU may appear at line start if de and loose]
+    expected: FAIL
+
+  [3087  HIRAGANA LETTER SMALL YO may appear at line start if de and loose]
+    expected: FAIL
+
+  [308E  HIRAGANA LETTER SMALL WA may appear at line start if de and loose]
+    expected: FAIL
+
+  [3095  HIRAGANA LETTER SMALL KA may appear at line start if de and loose]
+    expected: FAIL
+
+  [3096  HIRAGANA LETTER SMALL KE may appear at line start if de and loose]
+    expected: FAIL
+
+  [30A1  KATAKANA LETTER SMALL A may appear at line start if de and loose]
+    expected: FAIL
+
+  [30A3  KATAKANA LETTER SMALL I may appear at line start if de and loose]
+    expected: FAIL
+
+  [30A5  KATAKANA LETTER SMALL U may appear at line start if de and loose]
+    expected: FAIL
+
+  [30A7  KATAKANA LETTER SMALL E may appear at line start if de and loose]
+    expected: FAIL
+
+  [30A9  KATAKANA LETTER SMALL O may appear at line start if de and loose]
+    expected: FAIL
+
+  [30C3  KATAKANA LETTER SMALL TU may appear at line start if de and loose]
+    expected: FAIL
+
+  [30E3  KATAKANA LETTER SMALL YA may appear at line start if de and loose]
+    expected: FAIL
+
+  [30E5  KATAKANA LETTER SMALL YU may appear at line start if de and loose]
+    expected: FAIL
+
+  [30E7  KATAKANA LETTER SMALL YO may appear at line start if de and loose]
+    expected: FAIL
+
+  [30EE  KATAKANA LETTER SMALL WA may appear at line start if de and loose]
+    expected: FAIL
+
+  [30F5  KATAKANA LETTER SMALL KA may appear at line start if de and loose]
+    expected: FAIL
+
+  [30F6  KATAKANA LETTER SMALL KE may appear at line start if de and loose]
+    expected: FAIL
+
+  [30FC  KATAKANA-HIRAGANA PROLONGED SOUND MARK may appear at line start if de and loose]
+    expected: FAIL
+
+  [31F0  KATAKANA LETTER SMALL KU may appear at line start if de and loose]
+    expected: FAIL
+
+  [31F1  KATAKANA LETTER SMALL SI may appear at line start if de and loose]
+    expected: FAIL
+
+  [31F2  KATAKANA LETTER SMALL SU may appear at line start if de and loose]
+    expected: FAIL
+
+  [31F3  KATAKANA LETTER SMALL TO may appear at line start if de and loose]
+    expected: FAIL
+
+  [31F4  KATAKANA LETTER SMALL NU may appear at line start if de and loose]
+    expected: FAIL
+
+  [31F5  KATAKANA LETTER SMALL HA may appear at line start if de and loose]
+    expected: FAIL
+
+  [31F6  KATAKANA LETTER SMALL HI may appear at line start if de and loose]
+    expected: FAIL
+
+  [31F7  KATAKANA LETTER SMALL HU may appear at line start if de and loose]
+    expected: FAIL
+
+  [31F8  KATAKANA LETTER SMALL HE may appear at line start if de and loose]
+    expected: FAIL
+
+  [31F9  KATAKANA LETTER SMALL HO may appear at line start if de and loose]
+    expected: FAIL
+
+  [31FA  KATAKANA LETTER SMALL MU may appear at line start if de and loose]
+    expected: FAIL
+
+  [31FB  KATAKANA LETTER SMALL RA may appear at line start if de and loose]
+    expected: FAIL
+
+  [31FC  KATAKANA LETTER SMALL RI may appear at line start if de and loose]
+    expected: FAIL
+
+  [31FD  KATAKANA LETTER SMALL RU may appear at line start if de and loose]
+    expected: FAIL
+
+  [31FE  KATAKANA LETTER SMALL RE may appear at line start if de and loose]
+    expected: FAIL
+
+  [31FF  KATAKANA LETTER SMALL RO may appear at line start if de and loose]
+    expected: FAIL
+
+  [FF67  HALFWIDTH KATAKANA LETTER SMALL A may appear at line start if de and loose]
+    expected: FAIL
+
+  [FF68  HALFWIDTH KATAKANA LETTER SMALL I may appear at line start if de and loose]
+    expected: FAIL
+
+  [FF69  HALFWIDTH KATAKANA LETTER SMALL U may appear at line start if de and loose]
+    expected: FAIL
+
+  [FF6A  HALFWIDTH KATAKANA LETTER SMALL E may appear at line start if de and loose]
+    expected: FAIL
+
+  [FF6B  HALFWIDTH KATAKANA LETTER SMALL O may appear at line start if de and loose]
+    expected: FAIL
+
+  [FF6C  HALFWIDTH KATAKANA LETTER SMALL YA may appear at line start if de and loose]
+    expected: FAIL
+
+  [FF6D  HALFWIDTH KATAKANA LETTER SMALL YU may appear at line start if de and loose]
+    expected: FAIL
+
+  [FF6E  HALFWIDTH KATAKANA LETTER SMALL YO may appear at line start if de and loose]
+    expected: FAIL
+
+  [FF6F  HALFWIDTH KATAKANA LETTER SMALL TU may appear at line start if de and loose]
+    expected: FAIL
+
+  [FF70  HALFWIDTH KATAKANA-HIRAGANA PROLONGED SOUND MARK may appear at line start if de and loose]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-text/i18n/other-lang/css-text-line-break-de-cj-normal.html.ini
+++ b/tests/wpt/meta/css/css-text/i18n/other-lang/css-text-line-break-de-cj-normal.html.ini
@@ -1,0 +1,153 @@
+[css-text-line-break-de-cj-normal.html]
+  [3041  HIRAGANA LETTER SMALL A may appear at line start if de and normal]
+    expected: FAIL
+
+  [3043  HIRAGANA LETTER SMALL I may appear at line start if de and normal]
+    expected: FAIL
+
+  [3045  HIRAGANA LETTER SMALL U may appear at line start if de and normal]
+    expected: FAIL
+
+  [3047  HIRAGANA LETTER SMALL E may appear at line start if de and normal]
+    expected: FAIL
+
+  [3049  HIRAGANA LETTER SMALL O may appear at line start if de and normal]
+    expected: FAIL
+
+  [3063  HIRAGANA LETTER SMALL TU may appear at line start if de and normal]
+    expected: FAIL
+
+  [3083  HIRAGANA LETTER SMALL YA may appear at line start if de and normal]
+    expected: FAIL
+
+  [3085  HIRAGANA LETTER SMALL YU may appear at line start if de and normal]
+    expected: FAIL
+
+  [3087  HIRAGANA LETTER SMALL YO may appear at line start if de and normal]
+    expected: FAIL
+
+  [308E  HIRAGANA LETTER SMALL WA may appear at line start if de and normal]
+    expected: FAIL
+
+  [3095  HIRAGANA LETTER SMALL KA may appear at line start if de and normal]
+    expected: FAIL
+
+  [3096  HIRAGANA LETTER SMALL KE may appear at line start if de and normal]
+    expected: FAIL
+
+  [30A1  KATAKANA LETTER SMALL A may appear at line start if de and normal]
+    expected: FAIL
+
+  [30A3  KATAKANA LETTER SMALL I may appear at line start if de and normal]
+    expected: FAIL
+
+  [30A5  KATAKANA LETTER SMALL U may appear at line start if de and normal]
+    expected: FAIL
+
+  [30A7  KATAKANA LETTER SMALL E may appear at line start if de and normal]
+    expected: FAIL
+
+  [30A9  KATAKANA LETTER SMALL O may appear at line start if de and normal]
+    expected: FAIL
+
+  [30C3  KATAKANA LETTER SMALL TU may appear at line start if de and normal]
+    expected: FAIL
+
+  [30E3  KATAKANA LETTER SMALL YA may appear at line start if de and normal]
+    expected: FAIL
+
+  [30E5  KATAKANA LETTER SMALL YU may appear at line start if de and normal]
+    expected: FAIL
+
+  [30E7  KATAKANA LETTER SMALL YO may appear at line start if de and normal]
+    expected: FAIL
+
+  [30EE  KATAKANA LETTER SMALL WA may appear at line start if de and normal]
+    expected: FAIL
+
+  [30F5  KATAKANA LETTER SMALL KA may appear at line start if de and normal]
+    expected: FAIL
+
+  [30F6  KATAKANA LETTER SMALL KE may appear at line start if de and normal]
+    expected: FAIL
+
+  [30FC  KATAKANA-HIRAGANA PROLONGED SOUND MARK may appear at line start if de and normal]
+    expected: FAIL
+
+  [31F0  KATAKANA LETTER SMALL KU may appear at line start if de and normal]
+    expected: FAIL
+
+  [31F1  KATAKANA LETTER SMALL SI may appear at line start if de and normal]
+    expected: FAIL
+
+  [31F2  KATAKANA LETTER SMALL SU may appear at line start if de and normal]
+    expected: FAIL
+
+  [31F3  KATAKANA LETTER SMALL TO may appear at line start if de and normal]
+    expected: FAIL
+
+  [31F4  KATAKANA LETTER SMALL NU may appear at line start if de and normal]
+    expected: FAIL
+
+  [31F5  KATAKANA LETTER SMALL HA may appear at line start if de and normal]
+    expected: FAIL
+
+  [31F6  KATAKANA LETTER SMALL HI may appear at line start if de and normal]
+    expected: FAIL
+
+  [31F7  KATAKANA LETTER SMALL HU may appear at line start if de and normal]
+    expected: FAIL
+
+  [31F8  KATAKANA LETTER SMALL HE may appear at line start if de and normal]
+    expected: FAIL
+
+  [31F9  KATAKANA LETTER SMALL HO may appear at line start if de and normal]
+    expected: FAIL
+
+  [31FA  KATAKANA LETTER SMALL MU may appear at line start if de and normal]
+    expected: FAIL
+
+  [31FB  KATAKANA LETTER SMALL RA may appear at line start if de and normal]
+    expected: FAIL
+
+  [31FC  KATAKANA LETTER SMALL RI may appear at line start if de and normal]
+    expected: FAIL
+
+  [31FD  KATAKANA LETTER SMALL RU may appear at line start if de and normal]
+    expected: FAIL
+
+  [31FE  KATAKANA LETTER SMALL RE may appear at line start if de and normal]
+    expected: FAIL
+
+  [31FF  KATAKANA LETTER SMALL RO may appear at line start if de and normal]
+    expected: FAIL
+
+  [FF67  HALFWIDTH KATAKANA LETTER SMALL A may appear at line start if de and normal]
+    expected: FAIL
+
+  [FF68  HALFWIDTH KATAKANA LETTER SMALL I may appear at line start if de and normal]
+    expected: FAIL
+
+  [FF69  HALFWIDTH KATAKANA LETTER SMALL U may appear at line start if de and normal]
+    expected: FAIL
+
+  [FF6A  HALFWIDTH KATAKANA LETTER SMALL E may appear at line start if de and normal]
+    expected: FAIL
+
+  [FF6B  HALFWIDTH KATAKANA LETTER SMALL O may appear at line start if de and normal]
+    expected: FAIL
+
+  [FF6C  HALFWIDTH KATAKANA LETTER SMALL YA may appear at line start if de and normal]
+    expected: FAIL
+
+  [FF6D  HALFWIDTH KATAKANA LETTER SMALL YU may appear at line start if de and normal]
+    expected: FAIL
+
+  [FF6E  HALFWIDTH KATAKANA LETTER SMALL YO may appear at line start if de and normal]
+    expected: FAIL
+
+  [FF6F  HALFWIDTH KATAKANA LETTER SMALL TU may appear at line start if de and normal]
+    expected: FAIL
+
+  [FF70  HALFWIDTH KATAKANA-HIRAGANA PROLONGED SOUND MARK may appear at line start if de and normal]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-text/i18n/other-lang/css-text-line-break-de-in-loose.html.ini
+++ b/tests/wpt/meta/css/css-text/i18n/other-lang/css-text-line-break-de-in-loose.html.ini
@@ -1,0 +1,15 @@
+[css-text-line-break-de-in-loose.html]
+  [2024  ONE DOT LEADER may appear at line start if de and loose]
+    expected: FAIL
+
+  [2025  TWO DOT LEADER may appear at line start if de and loose]
+    expected: FAIL
+
+  [2026  HORIZONTAL ELLIPSIS may appear at line start if de and loose]
+    expected: FAIL
+
+  [22EF  MIDLINE HORIZONTAL ELLIPSIS may appear at line start if de and loose]
+    expected: FAIL
+
+  [FE19  PRESENTATION FORM FOR VERTICAL HORIZONTAL ELLIPSIS may appear at line start if de and loose]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-text/i18n/other-lang/css-text-line-break-de-iteration-loose.html.ini
+++ b/tests/wpt/meta/css/css-text/i18n/other-lang/css-text-line-break-de-iteration-loose.html.ini
@@ -1,0 +1,18 @@
+[css-text-line-break-de-iteration-loose.html]
+  [3005  IDEOGRAPHIC ITERATION MARK may appear at line start if de and loose]
+    expected: FAIL
+
+  [303B  VERTICAL IDEOGRAPHIC ITERATION MARK may appear at line start if de and loose]
+    expected: FAIL
+
+  [309D  HIRAGANA ITERATION MARK may appear at line start if de and loose]
+    expected: FAIL
+
+  [309E  HIRAGANA VOICED ITERATION MARK may appear at line start if de and loose]
+    expected: FAIL
+
+  [30FD  KATAKANA ITERATION MARK may appear at line start if de and loose]
+    expected: FAIL
+
+  [30FE  KATAKANA VOICED ITERATION MARK may appear at line start if de and loose]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-text/i18n/unknown-lang/css-text-line-break-cj-loose.html.ini
+++ b/tests/wpt/meta/css/css-text/i18n/unknown-lang/css-text-line-break-cj-loose.html.ini
@@ -1,0 +1,153 @@
+[css-text-line-break-cj-loose.html]
+  [3041  HIRAGANA LETTER SMALL A may appear at line start if loose]
+    expected: FAIL
+
+  [3043  HIRAGANA LETTER SMALL I may appear at line start if loose]
+    expected: FAIL
+
+  [3045  HIRAGANA LETTER SMALL U may appear at line start if loose]
+    expected: FAIL
+
+  [3047  HIRAGANA LETTER SMALL E may appear at line start if loose]
+    expected: FAIL
+
+  [3049  HIRAGANA LETTER SMALL O may appear at line start if loose]
+    expected: FAIL
+
+  [3063  HIRAGANA LETTER SMALL TU may appear at line start if loose]
+    expected: FAIL
+
+  [3083  HIRAGANA LETTER SMALL YA may appear at line start if loose]
+    expected: FAIL
+
+  [3085  HIRAGANA LETTER SMALL YU may appear at line start if loose]
+    expected: FAIL
+
+  [3087  HIRAGANA LETTER SMALL YO may appear at line start if loose]
+    expected: FAIL
+
+  [308E  HIRAGANA LETTER SMALL WA may appear at line start if loose]
+    expected: FAIL
+
+  [3095  HIRAGANA LETTER SMALL KA may appear at line start if loose]
+    expected: FAIL
+
+  [3096  HIRAGANA LETTER SMALL KE may appear at line start if loose]
+    expected: FAIL
+
+  [30A1  KATAKANA LETTER SMALL A may appear at line start if loose]
+    expected: FAIL
+
+  [30A3  KATAKANA LETTER SMALL I may appear at line start if loose]
+    expected: FAIL
+
+  [30A5  KATAKANA LETTER SMALL U may appear at line start if loose]
+    expected: FAIL
+
+  [30A7  KATAKANA LETTER SMALL E may appear at line start if loose]
+    expected: FAIL
+
+  [30A9  KATAKANA LETTER SMALL O may appear at line start if loose]
+    expected: FAIL
+
+  [30C3  KATAKANA LETTER SMALL TU may appear at line start if loose]
+    expected: FAIL
+
+  [30E3  KATAKANA LETTER SMALL YA may appear at line start if loose]
+    expected: FAIL
+
+  [30E5  KATAKANA LETTER SMALL YU may appear at line start if loose]
+    expected: FAIL
+
+  [30E7  KATAKANA LETTER SMALL YO may appear at line start if loose]
+    expected: FAIL
+
+  [30EE  KATAKANA LETTER SMALL WA may appear at line start if loose]
+    expected: FAIL
+
+  [30F5  KATAKANA LETTER SMALL KA may appear at line start if loose]
+    expected: FAIL
+
+  [30F6  KATAKANA LETTER SMALL KE may appear at line start if loose]
+    expected: FAIL
+
+  [30FC  KATAKANA-HIRAGANA PROLONGED SOUND MARK may appear at line start if loose]
+    expected: FAIL
+
+  [31F0  KATAKANA LETTER SMALL KU may appear at line start if loose]
+    expected: FAIL
+
+  [31F1  KATAKANA LETTER SMALL SI may appear at line start if loose]
+    expected: FAIL
+
+  [31F2  KATAKANA LETTER SMALL SU may appear at line start if loose]
+    expected: FAIL
+
+  [31F3  KATAKANA LETTER SMALL TO may appear at line start if loose]
+    expected: FAIL
+
+  [31F4  KATAKANA LETTER SMALL NU may appear at line start if loose]
+    expected: FAIL
+
+  [31F5  KATAKANA LETTER SMALL HA may appear at line start if loose]
+    expected: FAIL
+
+  [31F6  KATAKANA LETTER SMALL HI may appear at line start if loose]
+    expected: FAIL
+
+  [31F7  KATAKANA LETTER SMALL HU may appear at line start if loose]
+    expected: FAIL
+
+  [31F8  KATAKANA LETTER SMALL HE may appear at line start if loose]
+    expected: FAIL
+
+  [31F9  KATAKANA LETTER SMALL HO may appear at line start if loose]
+    expected: FAIL
+
+  [31FA  KATAKANA LETTER SMALL MU may appear at line start if loose]
+    expected: FAIL
+
+  [31FB  KATAKANA LETTER SMALL RA may appear at line start if loose]
+    expected: FAIL
+
+  [31FC  KATAKANA LETTER SMALL RI may appear at line start if loose]
+    expected: FAIL
+
+  [31FD  KATAKANA LETTER SMALL RU may appear at line start if loose]
+    expected: FAIL
+
+  [31FE  KATAKANA LETTER SMALL RE may appear at line start if loose]
+    expected: FAIL
+
+  [31FF  KATAKANA LETTER SMALL RO may appear at line start if loose]
+    expected: FAIL
+
+  [FF67  HALFWIDTH KATAKANA LETTER SMALL A may appear at line start if loose]
+    expected: FAIL
+
+  [FF68  HALFWIDTH KATAKANA LETTER SMALL I may appear at line start if loose]
+    expected: FAIL
+
+  [FF69  HALFWIDTH KATAKANA LETTER SMALL U may appear at line start if loose]
+    expected: FAIL
+
+  [FF6A  HALFWIDTH KATAKANA LETTER SMALL E may appear at line start if loose]
+    expected: FAIL
+
+  [FF6B  HALFWIDTH KATAKANA LETTER SMALL O may appear at line start if loose]
+    expected: FAIL
+
+  [FF6C  HALFWIDTH KATAKANA LETTER SMALL YA may appear at line start if loose]
+    expected: FAIL
+
+  [FF6D  HALFWIDTH KATAKANA LETTER SMALL YU may appear at line start if loose]
+    expected: FAIL
+
+  [FF6E  HALFWIDTH KATAKANA LETTER SMALL YO may appear at line start if loose]
+    expected: FAIL
+
+  [FF6F  HALFWIDTH KATAKANA LETTER SMALL TU may appear at line start if loose]
+    expected: FAIL
+
+  [FF70  HALFWIDTH KATAKANA-HIRAGANA PROLONGED SOUND MARK may appear at line start if loose]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-text/i18n/unknown-lang/css-text-line-break-cj-normal.html.ini
+++ b/tests/wpt/meta/css/css-text/i18n/unknown-lang/css-text-line-break-cj-normal.html.ini
@@ -1,0 +1,153 @@
+[css-text-line-break-cj-normal.html]
+  [3041  HIRAGANA LETTER SMALL A may appear at line start if normal]
+    expected: FAIL
+
+  [3043  HIRAGANA LETTER SMALL I may appear at line start if normal]
+    expected: FAIL
+
+  [3045  HIRAGANA LETTER SMALL U may appear at line start if normal]
+    expected: FAIL
+
+  [3047  HIRAGANA LETTER SMALL E may appear at line start if normal]
+    expected: FAIL
+
+  [3049  HIRAGANA LETTER SMALL O may appear at line start if normal]
+    expected: FAIL
+
+  [3063  HIRAGANA LETTER SMALL TU may appear at line start if normal]
+    expected: FAIL
+
+  [3083  HIRAGANA LETTER SMALL YA may appear at line start if normal]
+    expected: FAIL
+
+  [3085  HIRAGANA LETTER SMALL YU may appear at line start if normal]
+    expected: FAIL
+
+  [3087  HIRAGANA LETTER SMALL YO may appear at line start if normal]
+    expected: FAIL
+
+  [308E  HIRAGANA LETTER SMALL WA may appear at line start if normal]
+    expected: FAIL
+
+  [3095  HIRAGANA LETTER SMALL KA may appear at line start if normal]
+    expected: FAIL
+
+  [3096  HIRAGANA LETTER SMALL KE may appear at line start if normal]
+    expected: FAIL
+
+  [30A1  KATAKANA LETTER SMALL A may appear at line start if normal]
+    expected: FAIL
+
+  [30A3  KATAKANA LETTER SMALL I may appear at line start if normal]
+    expected: FAIL
+
+  [30A5  KATAKANA LETTER SMALL U may appear at line start if normal]
+    expected: FAIL
+
+  [30A7  KATAKANA LETTER SMALL E may appear at line start if normal]
+    expected: FAIL
+
+  [30A9  KATAKANA LETTER SMALL O may appear at line start if normal]
+    expected: FAIL
+
+  [30C3  KATAKANA LETTER SMALL TU may appear at line start if normal]
+    expected: FAIL
+
+  [30E3  KATAKANA LETTER SMALL YA may appear at line start if normal]
+    expected: FAIL
+
+  [30E5  KATAKANA LETTER SMALL YU may appear at line start if normal]
+    expected: FAIL
+
+  [30E7  KATAKANA LETTER SMALL YO may appear at line start if normal]
+    expected: FAIL
+
+  [30EE  KATAKANA LETTER SMALL WA may appear at line start if normal]
+    expected: FAIL
+
+  [30F5  KATAKANA LETTER SMALL KA may appear at line start if normal]
+    expected: FAIL
+
+  [30F6  KATAKANA LETTER SMALL KE may appear at line start if normal]
+    expected: FAIL
+
+  [30FC  KATAKANA-HIRAGANA PROLONGED SOUND MARK may appear at line start if normal]
+    expected: FAIL
+
+  [31F0  KATAKANA LETTER SMALL KU may appear at line start if normal]
+    expected: FAIL
+
+  [31F1  KATAKANA LETTER SMALL SI may appear at line start if normal]
+    expected: FAIL
+
+  [31F2  KATAKANA LETTER SMALL SU may appear at line start if normal]
+    expected: FAIL
+
+  [31F3  KATAKANA LETTER SMALL TO may appear at line start if normal]
+    expected: FAIL
+
+  [31F4  KATAKANA LETTER SMALL NU may appear at line start if normal]
+    expected: FAIL
+
+  [31F5  KATAKANA LETTER SMALL HA may appear at line start if normal]
+    expected: FAIL
+
+  [31F6  KATAKANA LETTER SMALL HI may appear at line start if normal]
+    expected: FAIL
+
+  [31F7  KATAKANA LETTER SMALL HU may appear at line start if normal]
+    expected: FAIL
+
+  [31F8  KATAKANA LETTER SMALL HE may appear at line start if normal]
+    expected: FAIL
+
+  [31F9  KATAKANA LETTER SMALL HO may appear at line start if normal]
+    expected: FAIL
+
+  [31FA  KATAKANA LETTER SMALL MU may appear at line start if normal]
+    expected: FAIL
+
+  [31FB  KATAKANA LETTER SMALL RA may appear at line start if normal]
+    expected: FAIL
+
+  [31FC  KATAKANA LETTER SMALL RI may appear at line start if normal]
+    expected: FAIL
+
+  [31FD  KATAKANA LETTER SMALL RU may appear at line start if normal]
+    expected: FAIL
+
+  [31FE  KATAKANA LETTER SMALL RE may appear at line start if normal]
+    expected: FAIL
+
+  [31FF  KATAKANA LETTER SMALL RO may appear at line start if normal]
+    expected: FAIL
+
+  [FF67  HALFWIDTH KATAKANA LETTER SMALL A may appear at line start if normal]
+    expected: FAIL
+
+  [FF68  HALFWIDTH KATAKANA LETTER SMALL I may appear at line start if normal]
+    expected: FAIL
+
+  [FF69  HALFWIDTH KATAKANA LETTER SMALL U may appear at line start if normal]
+    expected: FAIL
+
+  [FF6A  HALFWIDTH KATAKANA LETTER SMALL E may appear at line start if normal]
+    expected: FAIL
+
+  [FF6B  HALFWIDTH KATAKANA LETTER SMALL O may appear at line start if normal]
+    expected: FAIL
+
+  [FF6C  HALFWIDTH KATAKANA LETTER SMALL YA may appear at line start if normal]
+    expected: FAIL
+
+  [FF6D  HALFWIDTH KATAKANA LETTER SMALL YU may appear at line start if normal]
+    expected: FAIL
+
+  [FF6E  HALFWIDTH KATAKANA LETTER SMALL YO may appear at line start if normal]
+    expected: FAIL
+
+  [FF6F  HALFWIDTH KATAKANA LETTER SMALL TU may appear at line start if normal]
+    expected: FAIL
+
+  [FF70  HALFWIDTH KATAKANA-HIRAGANA PROLONGED SOUND MARK may appear at line start if normal]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-text/i18n/unknown-lang/css-text-line-break-in-loose.html.ini
+++ b/tests/wpt/meta/css/css-text/i18n/unknown-lang/css-text-line-break-in-loose.html.ini
@@ -1,0 +1,15 @@
+[css-text-line-break-in-loose.html]
+  [2024  ONE DOT LEADER may appear at line start if loose]
+    expected: FAIL
+
+  [2025  TWO DOT LEADER may appear at line start if loose]
+    expected: FAIL
+
+  [2026  HORIZONTAL ELLIPSIS may appear at line start if loose]
+    expected: FAIL
+
+  [22EF  MIDLINE HORIZONTAL ELLIPSIS may appear at line start if loose]
+    expected: FAIL
+
+  [FE19  PRESENTATION FORM FOR VERTICAL HORIZONTAL ELLIPSIS may appear at line start if loose]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-text/i18n/unknown-lang/css-text-line-break-iteration-loose.html.ini
+++ b/tests/wpt/meta/css/css-text/i18n/unknown-lang/css-text-line-break-iteration-loose.html.ini
@@ -1,0 +1,18 @@
+[css-text-line-break-iteration-loose.html]
+  [3005  IDEOGRAPHIC ITERATION MARK may appear at line start if lang unknown and loose]
+    expected: FAIL
+
+  [303B  VERTICAL IDEOGRAPHIC ITERATION MARK may appear at line start if lang unknown and loose]
+    expected: FAIL
+
+  [309D  HIRAGANA ITERATION MARK may appear at line start if lang unknown and loose]
+    expected: FAIL
+
+  [309E  HIRAGANA VOICED ITERATION MARK may appear at line start if lang unknown and loose]
+    expected: FAIL
+
+  [30FD  KATAKANA ITERATION MARK may appear at line start if lang unknown and loose]
+    expected: FAIL
+
+  [30FE  KATAKANA VOICED ITERATION MARK may appear at line start if lang unknown and loose]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-text/i18n/zh/css-text-line-break-zh-cj-loose.html.ini
+++ b/tests/wpt/meta/css/css-text/i18n/zh/css-text-line-break-zh-cj-loose.html.ini
@@ -1,0 +1,153 @@
+[css-text-line-break-zh-cj-loose.html]
+  [3041  HIRAGANA LETTER SMALL A may appear at line start if zh and loose]
+    expected: FAIL
+
+  [3043  HIRAGANA LETTER SMALL I may appear at line start if zh and loose]
+    expected: FAIL
+
+  [3045  HIRAGANA LETTER SMALL U may appear at line start if zh and loose]
+    expected: FAIL
+
+  [3047  HIRAGANA LETTER SMALL E may appear at line start if zh and loose]
+    expected: FAIL
+
+  [3049  HIRAGANA LETTER SMALL O may appear at line start if zh and loose]
+    expected: FAIL
+
+  [3063  HIRAGANA LETTER SMALL TU may appear at line start if zh and loose]
+    expected: FAIL
+
+  [3083  HIRAGANA LETTER SMALL YA may appear at line start if zh and loose]
+    expected: FAIL
+
+  [3085  HIRAGANA LETTER SMALL YU may appear at line start if zh and loose]
+    expected: FAIL
+
+  [3087  HIRAGANA LETTER SMALL YO may appear at line start if zh and loose]
+    expected: FAIL
+
+  [308E  HIRAGANA LETTER SMALL WA may appear at line start if zh and loose]
+    expected: FAIL
+
+  [3095  HIRAGANA LETTER SMALL KA may appear at line start if zh and loose]
+    expected: FAIL
+
+  [3096  HIRAGANA LETTER SMALL KE may appear at line start if zh and loose]
+    expected: FAIL
+
+  [30A1  KATAKANA LETTER SMALL A may appear at line start if zh and loose]
+    expected: FAIL
+
+  [30A3  KATAKANA LETTER SMALL I may appear at line start if zh and loose]
+    expected: FAIL
+
+  [30A5  KATAKANA LETTER SMALL U may appear at line start if zh and loose]
+    expected: FAIL
+
+  [30A7  KATAKANA LETTER SMALL E may appear at line start if zh and loose]
+    expected: FAIL
+
+  [30A9  KATAKANA LETTER SMALL O may appear at line start if zh and loose]
+    expected: FAIL
+
+  [30C3  KATAKANA LETTER SMALL TU may appear at line start if zh and loose]
+    expected: FAIL
+
+  [30E3  KATAKANA LETTER SMALL YA may appear at line start if zh and loose]
+    expected: FAIL
+
+  [30E5  KATAKANA LETTER SMALL YU may appear at line start if zh and loose]
+    expected: FAIL
+
+  [30E7  KATAKANA LETTER SMALL YO may appear at line start if zh and loose]
+    expected: FAIL
+
+  [30EE  KATAKANA LETTER SMALL WA may appear at line start if zh and loose]
+    expected: FAIL
+
+  [30F5  KATAKANA LETTER SMALL KA may appear at line start if zh and loose]
+    expected: FAIL
+
+  [30F6  KATAKANA LETTER SMALL KE may appear at line start if zh and loose]
+    expected: FAIL
+
+  [30FC  KATAKANA-HIRAGANA PROLONGED SOUND MARK may appear at line start if zh and loose]
+    expected: FAIL
+
+  [31F0  KATAKANA LETTER SMALL KU may appear at line start if zh and loose]
+    expected: FAIL
+
+  [31F1  KATAKANA LETTER SMALL SI may appear at line start if zh and loose]
+    expected: FAIL
+
+  [31F2  KATAKANA LETTER SMALL SU may appear at line start if zh and loose]
+    expected: FAIL
+
+  [31F3  KATAKANA LETTER SMALL TO may appear at line start if zh and loose]
+    expected: FAIL
+
+  [31F4  KATAKANA LETTER SMALL NU may appear at line start if zh and loose]
+    expected: FAIL
+
+  [31F5  KATAKANA LETTER SMALL HA may appear at line start if zh and loose]
+    expected: FAIL
+
+  [31F6  KATAKANA LETTER SMALL HI may appear at line start if zh and loose]
+    expected: FAIL
+
+  [31F7  KATAKANA LETTER SMALL HU may appear at line start if zh and loose]
+    expected: FAIL
+
+  [31F8  KATAKANA LETTER SMALL HE may appear at line start if zh and loose]
+    expected: FAIL
+
+  [31F9  KATAKANA LETTER SMALL HO may appear at line start if zh and loose]
+    expected: FAIL
+
+  [31FA  KATAKANA LETTER SMALL MU may appear at line start if zh and loose]
+    expected: FAIL
+
+  [31FB  KATAKANA LETTER SMALL RA may appear at line start if zh and loose]
+    expected: FAIL
+
+  [31FC  KATAKANA LETTER SMALL RI may appear at line start if zh and loose]
+    expected: FAIL
+
+  [31FD  KATAKANA LETTER SMALL RU may appear at line start if zh and loose]
+    expected: FAIL
+
+  [31FE  KATAKANA LETTER SMALL RE may appear at line start if zh and loose]
+    expected: FAIL
+
+  [31FF  KATAKANA LETTER SMALL RO may appear at line start if zh and loose]
+    expected: FAIL
+
+  [FF67  HALFWIDTH KATAKANA LETTER SMALL A may appear at line start if zh and loose]
+    expected: FAIL
+
+  [FF68  HALFWIDTH KATAKANA LETTER SMALL I may appear at line start if zh and loose]
+    expected: FAIL
+
+  [FF69  HALFWIDTH KATAKANA LETTER SMALL U may appear at line start if zh and loose]
+    expected: FAIL
+
+  [FF6A  HALFWIDTH KATAKANA LETTER SMALL E may appear at line start if zh and loose]
+    expected: FAIL
+
+  [FF6B  HALFWIDTH KATAKANA LETTER SMALL O may appear at line start if zh and loose]
+    expected: FAIL
+
+  [FF6C  HALFWIDTH KATAKANA LETTER SMALL YA may appear at line start if zh and loose]
+    expected: FAIL
+
+  [FF6D  HALFWIDTH KATAKANA LETTER SMALL YU may appear at line start if zh and loose]
+    expected: FAIL
+
+  [FF6E  HALFWIDTH KATAKANA LETTER SMALL YO may appear at line start if zh and loose]
+    expected: FAIL
+
+  [FF6F  HALFWIDTH KATAKANA LETTER SMALL TU may appear at line start if zh and loose]
+    expected: FAIL
+
+  [FF70  HALFWIDTH KATAKANA-HIRAGANA PROLONGED SOUND MARK may appear at line start if zh and loose]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-text/i18n/zh/css-text-line-break-zh-cj-normal.html.ini
+++ b/tests/wpt/meta/css/css-text/i18n/zh/css-text-line-break-zh-cj-normal.html.ini
@@ -1,0 +1,153 @@
+[css-text-line-break-zh-cj-normal.html]
+  [3041  HIRAGANA LETTER SMALL A may appear at line start if zh and normal]
+    expected: FAIL
+
+  [3043  HIRAGANA LETTER SMALL I may appear at line start if zh and normal]
+    expected: FAIL
+
+  [3045  HIRAGANA LETTER SMALL U may appear at line start if zh and normal]
+    expected: FAIL
+
+  [3047  HIRAGANA LETTER SMALL E may appear at line start if zh and normal]
+    expected: FAIL
+
+  [3049  HIRAGANA LETTER SMALL O may appear at line start if zh and normal]
+    expected: FAIL
+
+  [3063  HIRAGANA LETTER SMALL TU may appear at line start if zh and normal]
+    expected: FAIL
+
+  [3083  HIRAGANA LETTER SMALL YA may appear at line start if zh and normal]
+    expected: FAIL
+
+  [3085  HIRAGANA LETTER SMALL YU may appear at line start if zh and normal]
+    expected: FAIL
+
+  [3087  HIRAGANA LETTER SMALL YO may appear at line start if zh and normal]
+    expected: FAIL
+
+  [308E  HIRAGANA LETTER SMALL WA may appear at line start if zh and normal]
+    expected: FAIL
+
+  [3095  HIRAGANA LETTER SMALL KA may appear at line start if zh and normal]
+    expected: FAIL
+
+  [3096  HIRAGANA LETTER SMALL KE may appear at line start if zh and normal]
+    expected: FAIL
+
+  [30A1  KATAKANA LETTER SMALL A may appear at line start if zh and normal]
+    expected: FAIL
+
+  [30A3  KATAKANA LETTER SMALL I may appear at line start if zh and normal]
+    expected: FAIL
+
+  [30A5  KATAKANA LETTER SMALL U may appear at line start if zh and normal]
+    expected: FAIL
+
+  [30A7  KATAKANA LETTER SMALL E may appear at line start if zh and normal]
+    expected: FAIL
+
+  [30A9  KATAKANA LETTER SMALL O may appear at line start if zh and normal]
+    expected: FAIL
+
+  [30C3  KATAKANA LETTER SMALL TU may appear at line start if zh and normal]
+    expected: FAIL
+
+  [30E3  KATAKANA LETTER SMALL YA may appear at line start if zh and normal]
+    expected: FAIL
+
+  [30E5  KATAKANA LETTER SMALL YU may appear at line start if zh and normal]
+    expected: FAIL
+
+  [30E7  KATAKANA LETTER SMALL YO may appear at line start if zh and normal]
+    expected: FAIL
+
+  [30EE  KATAKANA LETTER SMALL WA may appear at line start if zh and normal]
+    expected: FAIL
+
+  [30F5  KATAKANA LETTER SMALL KA may appear at line start if zh and normal]
+    expected: FAIL
+
+  [30F6  KATAKANA LETTER SMALL KE may appear at line start if zh and normal]
+    expected: FAIL
+
+  [30FC  KATAKANA-HIRAGANA PROLONGED SOUND MARK may appear at line start if zh and normal]
+    expected: FAIL
+
+  [31F0  KATAKANA LETTER SMALL KU may appear at line start if zh and normal]
+    expected: FAIL
+
+  [31F1  KATAKANA LETTER SMALL SI may appear at line start if zh and normal]
+    expected: FAIL
+
+  [31F2  KATAKANA LETTER SMALL SU may appear at line start if zh and normal]
+    expected: FAIL
+
+  [31F3  KATAKANA LETTER SMALL TO may appear at line start if zh and normal]
+    expected: FAIL
+
+  [31F4  KATAKANA LETTER SMALL NU may appear at line start if zh and normal]
+    expected: FAIL
+
+  [31F5  KATAKANA LETTER SMALL HA may appear at line start if zh and normal]
+    expected: FAIL
+
+  [31F6  KATAKANA LETTER SMALL HI may appear at line start if zh and normal]
+    expected: FAIL
+
+  [31F7  KATAKANA LETTER SMALL HU may appear at line start if zh and normal]
+    expected: FAIL
+
+  [31F8  KATAKANA LETTER SMALL HE may appear at line start if zh and normal]
+    expected: FAIL
+
+  [31F9  KATAKANA LETTER SMALL HO may appear at line start if zh and normal]
+    expected: FAIL
+
+  [31FA  KATAKANA LETTER SMALL MU may appear at line start if zh and normal]
+    expected: FAIL
+
+  [31FB  KATAKANA LETTER SMALL RA may appear at line start if zh and normal]
+    expected: FAIL
+
+  [31FC  KATAKANA LETTER SMALL RI may appear at line start if zh and normal]
+    expected: FAIL
+
+  [31FD  KATAKANA LETTER SMALL RU may appear at line start if zh and normal]
+    expected: FAIL
+
+  [31FE  KATAKANA LETTER SMALL RE may appear at line start if zh and normal]
+    expected: FAIL
+
+  [31FF  KATAKANA LETTER SMALL RO may appear at line start if zh and normal]
+    expected: FAIL
+
+  [FF67  HALFWIDTH KATAKANA LETTER SMALL A may appear at line start if zh and normal]
+    expected: FAIL
+
+  [FF68  HALFWIDTH KATAKANA LETTER SMALL I may appear at line start if zh and normal]
+    expected: FAIL
+
+  [FF69  HALFWIDTH KATAKANA LETTER SMALL U may appear at line start if zh and normal]
+    expected: FAIL
+
+  [FF6A  HALFWIDTH KATAKANA LETTER SMALL E may appear at line start if zh and normal]
+    expected: FAIL
+
+  [FF6B  HALFWIDTH KATAKANA LETTER SMALL O may appear at line start if zh and normal]
+    expected: FAIL
+
+  [FF6C  HALFWIDTH KATAKANA LETTER SMALL YA may appear at line start if zh and normal]
+    expected: FAIL
+
+  [FF6D  HALFWIDTH KATAKANA LETTER SMALL YU may appear at line start if zh and normal]
+    expected: FAIL
+
+  [FF6E  HALFWIDTH KATAKANA LETTER SMALL YO may appear at line start if zh and normal]
+    expected: FAIL
+
+  [FF6F  HALFWIDTH KATAKANA LETTER SMALL TU may appear at line start if zh and normal]
+    expected: FAIL
+
+  [FF70  HALFWIDTH KATAKANA-HIRAGANA PROLONGED SOUND MARK may appear at line start if zh and normal]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-text/i18n/zh/css-text-line-break-zh-cpm-loose.html.ini
+++ b/tests/wpt/meta/css/css-text/i18n/zh/css-text-line-break-zh-cpm-loose.html.ini
@@ -1,0 +1,30 @@
+[css-text-line-break-zh-cpm-loose.html]
+  [30FB  KATAKANA MIDDLE DOT may appear at line start if zh and loose]
+    expected: FAIL
+
+  [FF1A  FULLWIDTH COLON may appear at line start if zh and loose]
+    expected: FAIL
+
+  [FF1B  FULLWIDTH SEMICOLON may appear at line start if zh and loose]
+    expected: FAIL
+
+  [FF65  HALFWIDTH KATAKANA MIDDLE DOT may appear at line start if zh and loose]
+    expected: FAIL
+
+  [203C  DOUBLE EXCLAMATION MARK may appear at line start if zh and loose]
+    expected: FAIL
+
+  [2047  DOUBLE QUESTION MARK may appear at line start if zh and loose]
+    expected: FAIL
+
+  [2048  QUESTION EXCLAMATION MARK may appear at line start if zh and loose]
+    expected: FAIL
+
+  [2049  EXCLAMATION QUESTION MARK may appear at line start if zh and loose]
+    expected: FAIL
+
+  [FF01  FULLWIDTH EXCLAMATION MARK may appear at line start if zh and loose]
+    expected: FAIL
+
+  [FF1F  FULLWIDTH QUESTION MARK may appear at line start if zh and loose]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-text/i18n/zh/css-text-line-break-zh-hyphens-loose.html.ini
+++ b/tests/wpt/meta/css/css-text/i18n/zh/css-text-line-break-zh-hyphens-loose.html.ini
@@ -1,0 +1,6 @@
+[css-text-line-break-zh-hyphens-loose.html]
+  [301C WAVE DASH may appear at line start if zh and loose]
+    expected: FAIL
+
+  [30A0 KATAKANA-HIRAGANA DOUBLE HYPHEN may appear at line start if zh and loose]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-text/i18n/zh/css-text-line-break-zh-hyphens-normal.html.ini
+++ b/tests/wpt/meta/css/css-text/i18n/zh/css-text-line-break-zh-hyphens-normal.html.ini
@@ -1,0 +1,6 @@
+[css-text-line-break-zh-hyphens-normal.html]
+  [301C WAVE DASH may appear at line start if zh and normal]
+    expected: FAIL
+
+  [30A0 KATAKANA-HIRAGANA DOUBLE HYPHEN may appear at line start if zh and normal]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-text/i18n/zh/css-text-line-break-zh-in-loose.html.ini
+++ b/tests/wpt/meta/css/css-text/i18n/zh/css-text-line-break-zh-in-loose.html.ini
@@ -1,0 +1,15 @@
+[css-text-line-break-zh-in-loose.html]
+  [2024  ONE DOT LEADER may appear at line start if zh and loose]
+    expected: FAIL
+
+  [2025  TWO DOT LEADER may appear at line start if zh and loose]
+    expected: FAIL
+
+  [2026  HORIZONTAL ELLIPSIS may appear at line start if zh and loose]
+    expected: FAIL
+
+  [22EF  MIDLINE HORIZONTAL ELLIPSIS may appear at line start if zh and loose]
+    expected: FAIL
+
+  [FE19  PRESENTATION FORM FOR VERTICAL HORIZONTAL ELLIPSIS may appear at line start if zh and loose]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-text/i18n/zh/css-text-line-break-zh-iteration-loose.html.ini
+++ b/tests/wpt/meta/css/css-text/i18n/zh/css-text-line-break-zh-iteration-loose.html.ini
@@ -1,0 +1,18 @@
+[css-text-line-break-zh-iteration-loose.html]
+  [3005  IDEOGRAPHIC ITERATION MARK may appear at line start if zh and loose]
+    expected: FAIL
+
+  [303B  VERTICAL IDEOGRAPHIC ITERATION MARK may appear at line start if zh and loose]
+    expected: FAIL
+
+  [309D  HIRAGANA ITERATION MARK may appear at line start if zh and loose]
+    expected: FAIL
+
+  [309E  HIRAGANA VOICED ITERATION MARK may appear at line start if zh and loose]
+    expected: FAIL
+
+  [30FD  KATAKANA ITERATION MARK may appear at line start if zh and loose]
+    expected: FAIL
+
+  [30FE  KATAKANA VOICED ITERATION MARK may appear at line start if zh and loose]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-text/i18n/zh/css-text-line-break-zh-po-loose.html.ini
+++ b/tests/wpt/meta/css/css-text/i18n/zh/css-text-line-break-zh-po-loose.html.ini
@@ -1,0 +1,30 @@
+[css-text-line-break-zh-po-loose.html]
+  [00B0  DEGREE SIGN may appear at line start if zh and loose]
+    expected: FAIL
+
+  [2030  PER MILLE SIGN may appear at line start if zh and loose]
+    expected: FAIL
+
+  [2032  PRIME may appear at line start if zh and loose]
+    expected: FAIL
+
+  [2033  DOUBLE PRIME may appear at line start if zh and loose]
+    expected: FAIL
+
+  [2035  REVERSED PRIME may appear at line start if zh and loose]
+    expected: FAIL
+
+  [2103  DEGREE CELSIUS may appear at line start if zh and loose]
+    expected: FAIL
+
+  [2109  DEGREE FAHRENHEIT may appear at line start if zh and loose]
+    expected: FAIL
+
+  [FE6A  SMALL PERCENT SIGN may appear at line start if zh and loose]
+    expected: FAIL
+
+  [FF05  FULLWIDTH PERCENT SIGN may appear at line start if zh and loose]
+    expected: FAIL
+
+  [FFE0  FULLWIDTH CENT SIGN may appear at line start if zh and loose]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-text/i18n/zh/css-text-line-break-zh-pr-normal.html.ini
+++ b/tests/wpt/meta/css/css-text/i18n/zh/css-text-line-break-zh-pr-normal.html.ini
@@ -1,0 +1,24 @@
+[css-text-line-break-zh-pr-normal.html]
+  [00B1  PLUS-MINUS SIGN may NOT appear at line start if zh and normal]
+    expected: FAIL
+
+  [20AC  EURO SIGN may NOT appear at line start if zh and normal]
+    expected: FAIL
+
+  [2116  NUMERO SIGN may NOT appear at line start if zh and normal]
+    expected: FAIL
+
+  [FE69  SMALL DOLLAR SIGN may NOT appear at line start if zh and normal]
+    expected: FAIL
+
+  [FF04  FULLWIDTH DOLLAR SIGN may NOT appear at line start if zh and normal]
+    expected: FAIL
+
+  [FFE1  FULLWIDTH POUND SIGN may NOT appear at line start if zh and normal]
+    expected: FAIL
+
+  [FFE5  FULLWIDTH YEN SIGN may NOT appear at line start if zh and normal]
+    expected: FAIL
+
+  [FFE6  FULLWIDTH WON SIGN may NOT appear at line start if zh and normal]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-text/i18n/zh/css-text-line-break-zh-pr-strict.html.ini
+++ b/tests/wpt/meta/css/css-text/i18n/zh/css-text-line-break-zh-pr-strict.html.ini
@@ -1,0 +1,24 @@
+[css-text-line-break-zh-pr-strict.html]
+  [00B1  PLUS-MINUS SIGN may NOT appear at line start if zh and strict]
+    expected: FAIL
+
+  [20AC  EURO SIGN may NOT appear at line start if zh and strict]
+    expected: FAIL
+
+  [2116  NUMERO SIGN may NOT appear at line start if zh and strict]
+    expected: FAIL
+
+  [FE69  SMALL DOLLAR SIGN may NOT appear at line start if zh and strict]
+    expected: FAIL
+
+  [FF04  FULLWIDTH DOLLAR SIGN may NOT appear at line start if zh and strict]
+    expected: FAIL
+
+  [FFE1  FULLWIDTH POUND SIGN may NOT appear at line start if zh and strict]
+    expected: FAIL
+
+  [FFE5  FULLWIDTH YEN SIGN may NOT appear at line start if zh and strict]
+    expected: FAIL
+
+  [FFE6  FULLWIDTH WON SIGN may NOT appear at line start if zh and strict]
+    expected: FAIL


### PR DESCRIPTION
This patch unskips `css/css-text/i18n` WPT tests as many tests on that folder are already passing in Servo.
