### PR TITLE
layout: Let min/max constraints avoid collapsing bottom margins

### DIFF
--- a/tests/wpt/meta/css/CSS2/margin-padding-clear/margin-collapse-038.xht.ini
+++ b/tests/wpt/meta/css/CSS2/margin-padding-clear/margin-collapse-038.xht.ini
@@ -1,0 +1,2 @@
+[margin-collapse-038.xht]
+  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/max-height-separates-margin.html.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/max-height-separates-margin.html.ini
@@ -1,2 +1,0 @@
-[max-height-separates-margin.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/min-height-separates-margin.html.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/min-height-separates-margin.html.ini
@@ -1,2 +1,0 @@
-[min-height-separates-margin.html]
-  expected: FAIL


### PR DESCRIPTION
When `block-size` was intrinsic and there was no block-end padding or margin, we were allowing the block-end margin of the box to collapse with the block-end margin of its contents.

However, due to `min-block-size` or `max-block-size`, the final size can be different than the intrinsic size of the contents. In that case it didn't make any sense to collapse end margins, only WebKit does it too.

This patch takes the final size into account, like Gecko and Blink. This is under discussion in https://github.com/w3c/csswg-drafts/issues/12218, but for now we will match Blink.

Testing: 2 tests are now passing. There is also 1 new failure, but that test only passes in WebKit and I don't agree with it.

Fixes: #36321
