### PR TITLE
Prevent zombie processes in multi-process mode.

### DIFF
--- a/components/constellation/lib.rs
+++ b/components/constellation/lib.rs
@@ -12,6 +12,7 @@ mod constellation;
 mod event_loop;
 mod logging;
 mod pipeline;
+mod process_manager;
 mod sandboxing;
 mod serviceworker;
 mod session_history;

--- a/components/constellation/process_manager.rs
+++ b/components/constellation/process_manager.rs
@@ -1,0 +1,68 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::process::Child;
+
+use crossbeam_channel::{Receiver, Select};
+use log::{debug, warn};
+
+pub enum Process {
+    Unsandboxed(Child),
+    Sandboxed(u32),
+}
+
+impl Process {
+    fn pid(&self) -> u32 {
+        match self {
+            Self::Unsandboxed(child) => child.id(),
+            Self::Sandboxed(pid) => *pid,
+        }
+    }
+
+    fn wait(&mut self) {
+        match self {
+            Self::Unsandboxed(child) => {
+                let _ = child.wait();
+            },
+            Self::Sandboxed(_pid) => {
+                // TODO: use nix::waitpid() on supported platforms.
+                warn!("wait() is not yet implemented for sandboxed processes.");
+            },
+        }
+    }
+}
+
+type ProcessReceiver = Receiver<Result<(), ipc_channel::Error>>;
+
+pub(crate) struct ProcessManager {
+    processes: Vec<(Process, ProcessReceiver)>,
+}
+
+impl ProcessManager {
+    pub fn new() -> Self {
+        Self { processes: vec![] }
+    }
+
+    pub fn add(&mut self, receiver: ProcessReceiver, process: Process) {
+        debug!("Adding process pid={}", process.pid());
+        self.processes.push((process, receiver));
+    }
+
+    pub fn register<'a>(&'a self, select: &mut Select<'a>) {
+        for (_, receiver) in &self.processes {
+            select.recv(receiver);
+        }
+    }
+
+    pub fn receiver_at(&self, index: usize) -> &ProcessReceiver {
+        let (_, receiver) = &self.processes[index];
+        receiver
+    }
+
+    pub fn remove(&mut self, index: usize) {
+        let (mut process, _) = self.processes.swap_remove(index);
+        debug!("Removing process pid={}", process.pid());
+        process.wait();
+    }
+}

--- a/components/constellation/sandboxing.rs
+++ b/components/constellation/sandboxing.rs
@@ -25,6 +25,7 @@ use servo_config::opts::Opts;
 use servo_config::prefs::Preferences;
 
 use crate::pipeline::UnprivilegedPipelineContent;
+use crate::process_manager::Process;
 use crate::serviceworker::ServiceWorkerUnprivilegedContent;
 
 #[derive(Deserialize, Serialize)]
@@ -146,7 +147,7 @@ pub fn content_process_sandbox_profile() {
     target_arch = "arm",
     all(target_arch = "aarch64", not(target_os = "windows"))
 ))]
-pub fn spawn_multiprocess(content: UnprivilegedContent) -> Result<(), Error> {
+pub fn spawn_multiprocess(content: UnprivilegedContent) -> Result<Process, Error> {
     use ipc_channel::ipc::{IpcOneShotServer, IpcSender};
     // Note that this function can panic, due to process creation,
     // avoiding this panic would require a mechanism for dealing
@@ -158,15 +159,14 @@ pub fn spawn_multiprocess(content: UnprivilegedContent) -> Result<(), Error> {
     let mut child_process = process::Command::new(path_to_self);
     setup_common(&mut child_process, token);
 
-    #[allow(clippy::zombie_processes)]
-    let _ = child_process
+    let child = child_process
         .spawn()
         .expect("Failed to start unsandboxed child process!");
 
     let (_receiver, sender) = server.accept().expect("Server failed to accept.");
     sender.send(content)?;
 
-    Ok(())
+    Ok(Process::Unsandboxed(child))
 }
 
 #[cfg(all(
@@ -177,7 +177,7 @@ pub fn spawn_multiprocess(content: UnprivilegedContent) -> Result<(), Error> {
     not(target_arch = "arm"),
     not(target_arch = "aarch64")
 ))]
-pub fn spawn_multiprocess(content: UnprivilegedContent) -> Result<(), Error> {
+pub fn spawn_multiprocess(content: UnprivilegedContent) -> Result<Process, Error> {
     use gaol::sandbox::{self, Sandbox, SandboxMethods};
     use ipc_channel::ipc::{IpcOneShotServer, IpcSender};
 
@@ -208,33 +208,37 @@ pub fn spawn_multiprocess(content: UnprivilegedContent) -> Result<(), Error> {
         .expect("Failed to create IPC one-shot server.");
 
     // If there is a sandbox, use the `gaol` API to create the child process.
-    if content.opts().sandbox {
+    let process = if content.opts().sandbox {
         let mut command = sandbox::Command::me().expect("Failed to get current sandbox.");
         setup_common(&mut command, token);
 
         let profile = content_process_sandbox_profile();
-        let _ = Sandbox::new(profile)
-            .start(&mut command)
-            .expect("Failed to start sandboxed child process!");
+        Process::Sandboxed(
+            Sandbox::new(profile)
+                .start(&mut command)
+                .expect("Failed to start sandboxed child process!")
+                .pid as u32,
+        )
     } else {
         let path_to_self = env::current_exe().expect("Failed to get current executor.");
         let mut child_process = process::Command::new(path_to_self);
         setup_common(&mut child_process, token);
 
-        #[allow(clippy::zombie_processes)]
-        let _ = child_process
-            .spawn()
-            .expect("Failed to start unsandboxed child process!");
-    }
+        Process::Unsandboxed(
+            child_process
+                .spawn()
+                .expect("Failed to start unsandboxed child process!"),
+        )
+    };
 
     let (_receiver, sender) = server.accept().expect("Server failed to accept.");
     sender.send(content)?;
 
-    Ok(())
+    Ok(process)
 }
 
 #[cfg(any(target_os = "windows", target_os = "ios"))]
-pub fn spawn_multiprocess(_content: UnprivilegedContent) -> Result<(), Error> {
+pub fn spawn_multiprocess(_content: UnprivilegedContent) -> Result<Process, Error> {
     log::error!("Multiprocess is not supported on Windows or iOS.");
     process::exit(1);
 }


### PR DESCRIPTION
This introduces a process manager that holds for each process a "lifeline": this is the receiving end of a ipc channel that is not used to send anything, but only to monitor the process presence. We turn that ipc receiver into a crossbeam one to integrate the monitoring into the constellation run loop. The sender side is made part of the initial "UnprivilegedContent" data structure sent to the new process, both for content and for service worker processes.
When a process dies we currently wait() on it to let the OS do a clean shutdown.
