### PR TITLE
script: Remove dependency on `webgpu`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6378,11 +6378,12 @@ dependencies = [
  "utf-8",
  "uuid",
  "webdriver",
- "webgpu",
  "webgpu_traits",
  "webrender_api",
  "webrender_traits",
  "webxr-api",
+ "wgpu-core",
+ "wgpu-types",
  "xml5ever",
 ]
 

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -132,11 +132,12 @@ url = { workspace = true }
 utf-8 = "0.7"
 uuid = { workspace = true, features = ["serde"] }
 webdriver = { workspace = true }
-webgpu = { path = "../webgpu" }
 webgpu_traits = { workspace = true }
 webrender_api = { workspace = true }
 webrender_traits = { workspace = true }
 webxr-api = { workspace = true, features = ["ipc"], optional = true }
+wgpu-core = { workspace = true }
+wgpu-types = { workspace = true }
 xml5ever = { workspace = true }
 
 [target.'cfg(not(target_os = "ios"))'.dependencies]

--- a/components/script/dom/webgpu/gpu.rs
+++ b/components/script/dom/webgpu/gpu.rs
@@ -7,9 +7,8 @@ use std::rc::Rc;
 use dom_struct::dom_struct;
 use js::jsapi::Heap;
 use script_traits::ScriptMsg;
-use webgpu::wgc;
-use webgpu::wgt::PowerPreference;
 use webgpu_traits::WebGPUAdapterResponse;
+use wgpu_types::PowerPreference;
 
 use super::wgsllanguagefeatures::WGSLLanguageFeatures;
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
@@ -69,7 +68,7 @@ impl GPUMethods<crate::DomTypeHolder> for GPU {
         if script_to_constellation_chan
             .send(ScriptMsg::RequestAdapter(
                 sender,
-                wgc::instance::RequestAdapterOptions {
+                wgpu_core::instance::RequestAdapterOptions {
                     power_preference,
                     compatible_surface: None,
                     force_fallback_adapter: options.forceFallbackAdapter,

--- a/components/script/dom/webgpu/gpuadapter.rs
+++ b/components/script/dom/webgpu/gpuadapter.rs
@@ -6,9 +6,9 @@ use std::rc::Rc;
 
 use dom_struct::dom_struct;
 use js::jsapi::{Heap, JSObject};
-use webgpu::wgc::instance::RequestDeviceError;
-use webgpu::wgt::{self, MemoryHints};
 use webgpu_traits::{WebGPU, WebGPUAdapter, WebGPUDeviceResponse, WebGPURequest};
+use wgpu_core::instance::RequestDeviceError;
+use wgpu_types::{self, MemoryHints};
 
 use super::gpusupportedfeatures::GPUSupportedFeatures;
 use super::gpusupportedlimits::set_limit;
@@ -72,9 +72,9 @@ impl GPUAdapter {
         channel: WebGPU,
         name: DOMString,
         extensions: Heap<*mut JSObject>,
-        features: wgt::Features,
-        limits: wgt::Limits,
-        info: wgt::AdapterInfo,
+        features: wgpu_types::Features,
+        limits: wgpu_types::Limits,
+        info: wgpu_types::AdapterInfo,
         adapter: WebGPUAdapter,
         can_gc: CanGc,
     ) -> DomRoot<Self> {
@@ -117,7 +117,7 @@ impl GPUAdapterMethods<crate::DomTypeHolder> for GPUAdapter {
         // Step 2
         let promise = Promise::new_in_current_realm(comp, can_gc);
         let sender = route_promise(&promise, self);
-        let mut required_features = wgt::Features::empty();
+        let mut required_features = wgpu_types::Features::empty();
         for &ext in descriptor.requiredFeatures.iter() {
             if let Some(feature) = gpu_to_wgt_feature(ext) {
                 required_features.insert(feature);
@@ -130,7 +130,7 @@ impl GPUAdapterMethods<crate::DomTypeHolder> for GPUAdapter {
             }
         }
 
-        let mut required_limits = wgt::Limits::default();
+        let mut required_limits = wgpu_types::Limits::default();
         if let Some(limits) = &descriptor.requiredLimits {
             for (limit, value) in (*limits).iter() {
                 if !set_limit(&mut required_limits, limit.as_ref(), *value) {
@@ -141,7 +141,7 @@ impl GPUAdapterMethods<crate::DomTypeHolder> for GPUAdapter {
             }
         }
 
-        let desc = wgt::DeviceDescriptor {
+        let desc = wgpu_types::DeviceDescriptor {
             required_features,
             required_limits,
             label: Some(descriptor.parent.label.to_string()),
@@ -242,8 +242,8 @@ impl RoutedPromiseListener<WebGPUDeviceResponse> for GPUAdapter {
                     self.channel.clone(),
                     self,
                     Heap::default(),
-                    wgt::Features::default(),
-                    wgt::Limits::default(),
+                    wgpu_types::Features::default(),
+                    wgpu_types::Limits::default(),
                     device_id,
                     queue_id,
                     String::new(),

--- a/components/script/dom/webgpu/gpuadapterinfo.rs
+++ b/components/script/dom/webgpu/gpuadapterinfo.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use webgpu::wgt::AdapterInfo;
+use wgpu_types::AdapterInfo;
 
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::GPUAdapterInfoMethods;
 use crate::dom::bindings::reflector::{Reflector, reflect_dom_object};

--- a/components/script/dom/webgpu/gpubindgroup.rs
+++ b/components/script/dom/webgpu/gpubindgroup.rs
@@ -5,8 +5,8 @@
 use std::borrow::Cow;
 
 use dom_struct::dom_struct;
-use webgpu::wgc::binding_model::BindGroupDescriptor;
 use webgpu_traits::{WebGPU, WebGPUBindGroup, WebGPUDevice, WebGPURequest};
+use wgpu_core::binding_model::BindGroupDescriptor;
 
 use crate::conversions::Convert;
 use crate::dom::bindings::cell::DomRefCell;

--- a/components/script/dom/webgpu/gpubindgrouplayout.rs
+++ b/components/script/dom/webgpu/gpubindgrouplayout.rs
@@ -5,8 +5,8 @@
 use std::borrow::Cow;
 
 use dom_struct::dom_struct;
-use webgpu::wgc::binding_model::BindGroupLayoutDescriptor;
 use webgpu_traits::{WebGPU, WebGPUBindGroupLayout, WebGPURequest};
+use wgpu_core::binding_model::BindGroupLayoutDescriptor;
 
 use crate::conversions::Convert;
 use crate::dom::bindings::cell::DomRefCell;

--- a/components/script/dom/webgpu/gpubuffer.rs
+++ b/components/script/dom/webgpu/gpubuffer.rs
@@ -9,10 +9,9 @@ use std::string::String;
 use dom_struct::dom_struct;
 use ipc_channel::ipc::IpcSharedMemory;
 use js::typedarray::ArrayBuffer;
-use webgpu::wgc::device::HostMap;
-use webgpu::{wgc, wgt};
 use webgpu_traits::{Mapping, WebGPU, WebGPUBuffer, WebGPURequest};
-use wgc::resource::BufferAccessError;
+use wgpu_core::device::HostMap;
+use wgpu_core::resource::BufferAccessError;
 
 use crate::conversions::Convert;
 use crate::dom::bindings::buffer_source::DataBlock;
@@ -141,10 +140,10 @@ impl GPUBuffer {
         descriptor: &GPUBufferDescriptor,
         can_gc: CanGc,
     ) -> Fallible<DomRoot<GPUBuffer>> {
-        let desc = wgt::BufferDescriptor {
+        let desc = wgpu_types::BufferDescriptor {
             label: (&descriptor.parent).convert(),
-            size: descriptor.size as wgt::BufferAddress,
-            usage: wgt::BufferUsages::from_bits_retain(descriptor.usage),
+            size: descriptor.size as wgpu_types::BufferAddress,
+            usage: wgpu_types::BufferUsages::from_bits_retain(descriptor.usage),
             mapped_at_creation: descriptor.mappedAtCreation,
         };
         let id = device.global().wgpu_id_hub().create_buffer_id();
@@ -310,8 +309,8 @@ impl GPUBufferMethods<crate::DomTypeHolder> for GPUBuffer {
         let mut mapping = self.mapping.borrow_mut();
         let mapping = mapping.as_mut().ok_or(Error::Operation)?;
 
-        let valid = offset % wgt::MAP_ALIGNMENT == 0 &&
-            range_size % wgt::COPY_BUFFER_ALIGNMENT == 0 &&
+        let valid = offset % wgpu_types::MAP_ALIGNMENT == 0 &&
+            range_size % wgpu_types::COPY_BUFFER_ALIGNMENT == 0 &&
             offset >= mapping.range.start &&
             offset + range_size <= mapping.range.end;
         if !valid {

--- a/components/script/dom/webgpu/gpucanvascontext.rs
+++ b/components/script/dom/webgpu/gpucanvascontext.rs
@@ -9,13 +9,13 @@ use arrayvec::ArrayVec;
 use dom_struct::dom_struct;
 use ipc_channel::ipc::{self, IpcSharedMemory};
 use script_layout_interface::HTMLCanvasDataSource;
-use webgpu::wgc::id;
 use webgpu_traits::{
     ContextConfiguration, PRESENTATION_BUFFER_COUNT, WebGPU, WebGPUContextId, WebGPURequest,
     WebGPUTexture,
 };
 use webrender_api::ImageKey;
 use webrender_api::units::DeviceIntSize;
+use wgpu_core::id;
 
 use super::gpuconvert::convert_texture_descriptor;
 use super::gputexture::GPUTexture;

--- a/components/script/dom/webgpu/gpucommandencoder.rs
+++ b/components/script/dom/webgpu/gpucommandencoder.rs
@@ -3,12 +3,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use webgpu::wgc::command as wgpu_com;
-use webgpu::wgt;
 use webgpu_traits::{
     WebGPU, WebGPUCommandBuffer, WebGPUCommandEncoder, WebGPUComputePass, WebGPUDevice,
     WebGPURenderPass, WebGPURequest,
 };
+use wgpu_core::command as wgpu_com;
 
 use crate::conversions::{Convert, TryConvert};
 use crate::dom::bindings::cell::DomRefCell;
@@ -98,7 +97,7 @@ impl GPUCommandEncoder {
             .send(WebGPURequest::CreateCommandEncoder {
                 device_id: device.id().0,
                 command_encoder_id,
-                desc: wgt::CommandEncoderDescriptor {
+                desc: wgpu_types::CommandEncoderDescriptor {
                     label: (&descriptor.parent).convert(),
                 },
             })
@@ -313,7 +312,7 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
             .send(WebGPURequest::CommandEncoderFinish {
                 command_encoder_id: self.encoder.0,
                 device_id: self.device.id().0,
-                desc: wgt::CommandBufferDescriptor {
+                desc: wgpu_types::CommandBufferDescriptor {
                     label: (&descriptor.parent).convert(),
                 },
             })

--- a/components/script/dom/webgpu/gpucomputepipeline.rs
+++ b/components/script/dom/webgpu/gpucomputepipeline.rs
@@ -4,11 +4,11 @@
 
 use dom_struct::dom_struct;
 use ipc_channel::ipc::IpcSender;
-use webgpu::wgc::pipeline::ComputePipelineDescriptor;
 use webgpu_traits::{
     WebGPU, WebGPUBindGroupLayout, WebGPUComputePipeline, WebGPUComputePipelineResponse,
     WebGPURequest,
 };
+use wgpu_core::pipeline::ComputePipelineDescriptor;
 
 use crate::conversions::Convert;
 use crate::dom::bindings::cell::DomRefCell;

--- a/components/script/dom/webgpu/gpuconvert.rs
+++ b/components/script/dom/webgpu/gpuconvert.rs
@@ -5,11 +5,11 @@
 use std::borrow::Cow;
 use std::num::NonZeroU64;
 
-use webgpu::wgc::binding_model::{BindGroupEntry, BindingResource, BufferBinding};
-use webgpu::wgc::command as wgpu_com;
-use webgpu::wgc::pipeline::ProgrammableStageDescriptor;
-use webgpu::wgc::resource::TextureDescriptor;
-use webgpu::wgt::{self, AstcBlock, AstcChannel};
+use wgpu_core::binding_model::{BindGroupEntry, BindingResource, BufferBinding};
+use wgpu_core::command as wgpu_com;
+use wgpu_core::pipeline::ProgrammableStageDescriptor;
+use wgpu_core::resource::TextureDescriptor;
+use wgpu_types::{self, AstcBlock, AstcChannel};
 
 use crate::conversions::{Convert, TryConvert};
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
@@ -25,185 +25,191 @@ use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
 use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::types::GPUDevice;
 
-impl Convert<wgt::TextureFormat> for GPUTextureFormat {
-    fn convert(self) -> wgt::TextureFormat {
+impl Convert<wgpu_types::TextureFormat> for GPUTextureFormat {
+    fn convert(self) -> wgpu_types::TextureFormat {
         match self {
-            GPUTextureFormat::R8unorm => wgt::TextureFormat::R8Unorm,
-            GPUTextureFormat::R8snorm => wgt::TextureFormat::R8Snorm,
-            GPUTextureFormat::R8uint => wgt::TextureFormat::R8Uint,
-            GPUTextureFormat::R8sint => wgt::TextureFormat::R8Sint,
-            GPUTextureFormat::R16uint => wgt::TextureFormat::R16Uint,
-            GPUTextureFormat::R16sint => wgt::TextureFormat::R16Sint,
-            GPUTextureFormat::R16float => wgt::TextureFormat::R16Float,
-            GPUTextureFormat::Rg8unorm => wgt::TextureFormat::Rg8Unorm,
-            GPUTextureFormat::Rg8snorm => wgt::TextureFormat::Rg8Snorm,
-            GPUTextureFormat::Rg8uint => wgt::TextureFormat::Rg8Uint,
-            GPUTextureFormat::Rg8sint => wgt::TextureFormat::Rg8Sint,
-            GPUTextureFormat::R32uint => wgt::TextureFormat::R32Uint,
-            GPUTextureFormat::R32sint => wgt::TextureFormat::R32Sint,
-            GPUTextureFormat::R32float => wgt::TextureFormat::R32Float,
-            GPUTextureFormat::Rg16uint => wgt::TextureFormat::Rg16Uint,
-            GPUTextureFormat::Rg16sint => wgt::TextureFormat::Rg16Sint,
-            GPUTextureFormat::Rg16float => wgt::TextureFormat::Rg16Float,
-            GPUTextureFormat::Rgba8unorm => wgt::TextureFormat::Rgba8Unorm,
-            GPUTextureFormat::Rgba8unorm_srgb => wgt::TextureFormat::Rgba8UnormSrgb,
-            GPUTextureFormat::Rgba8snorm => wgt::TextureFormat::Rgba8Snorm,
-            GPUTextureFormat::Rgba8uint => wgt::TextureFormat::Rgba8Uint,
-            GPUTextureFormat::Rgba8sint => wgt::TextureFormat::Rgba8Sint,
-            GPUTextureFormat::Bgra8unorm => wgt::TextureFormat::Bgra8Unorm,
-            GPUTextureFormat::Bgra8unorm_srgb => wgt::TextureFormat::Bgra8UnormSrgb,
-            GPUTextureFormat::Rgb10a2unorm => wgt::TextureFormat::Rgb10a2Unorm,
-            GPUTextureFormat::Rg32uint => wgt::TextureFormat::Rg32Uint,
-            GPUTextureFormat::Rg32sint => wgt::TextureFormat::Rg32Sint,
-            GPUTextureFormat::Rg32float => wgt::TextureFormat::Rg32Float,
-            GPUTextureFormat::Rgba16uint => wgt::TextureFormat::Rgba16Uint,
-            GPUTextureFormat::Rgba16sint => wgt::TextureFormat::Rgba16Sint,
-            GPUTextureFormat::Rgba16float => wgt::TextureFormat::Rgba16Float,
-            GPUTextureFormat::Rgba32uint => wgt::TextureFormat::Rgba32Uint,
-            GPUTextureFormat::Rgba32sint => wgt::TextureFormat::Rgba32Sint,
-            GPUTextureFormat::Rgba32float => wgt::TextureFormat::Rgba32Float,
-            GPUTextureFormat::Depth32float => wgt::TextureFormat::Depth32Float,
-            GPUTextureFormat::Depth24plus => wgt::TextureFormat::Depth24Plus,
-            GPUTextureFormat::Depth24plus_stencil8 => wgt::TextureFormat::Depth24PlusStencil8,
-            GPUTextureFormat::Bc1_rgba_unorm => wgt::TextureFormat::Bc1RgbaUnorm,
-            GPUTextureFormat::Bc1_rgba_unorm_srgb => wgt::TextureFormat::Bc1RgbaUnormSrgb,
-            GPUTextureFormat::Bc2_rgba_unorm => wgt::TextureFormat::Bc2RgbaUnorm,
-            GPUTextureFormat::Bc2_rgba_unorm_srgb => wgt::TextureFormat::Bc2RgbaUnormSrgb,
-            GPUTextureFormat::Bc3_rgba_unorm => wgt::TextureFormat::Bc3RgbaUnorm,
-            GPUTextureFormat::Bc3_rgba_unorm_srgb => wgt::TextureFormat::Bc3RgbaUnormSrgb,
-            GPUTextureFormat::Bc4_r_unorm => wgt::TextureFormat::Bc4RUnorm,
-            GPUTextureFormat::Bc4_r_snorm => wgt::TextureFormat::Bc4RSnorm,
-            GPUTextureFormat::Bc5_rg_unorm => wgt::TextureFormat::Bc5RgUnorm,
-            GPUTextureFormat::Bc5_rg_snorm => wgt::TextureFormat::Bc5RgSnorm,
-            GPUTextureFormat::Bc6h_rgb_ufloat => wgt::TextureFormat::Bc6hRgbUfloat,
-            GPUTextureFormat::Bc7_rgba_unorm => wgt::TextureFormat::Bc7RgbaUnorm,
-            GPUTextureFormat::Bc7_rgba_unorm_srgb => wgt::TextureFormat::Bc7RgbaUnormSrgb,
-            GPUTextureFormat::Bc6h_rgb_float => wgt::TextureFormat::Bc6hRgbFloat,
-            GPUTextureFormat::Rgb9e5ufloat => wgt::TextureFormat::Rgb9e5Ufloat,
-            GPUTextureFormat::Rgb10a2uint => wgt::TextureFormat::Rgb10a2Uint,
-            GPUTextureFormat::Rg11b10ufloat => wgt::TextureFormat::Rg11b10Ufloat,
-            GPUTextureFormat::Stencil8 => wgt::TextureFormat::Stencil8,
-            GPUTextureFormat::Depth16unorm => wgt::TextureFormat::Depth16Unorm,
-            GPUTextureFormat::Depth32float_stencil8 => wgt::TextureFormat::Depth32FloatStencil8,
-            GPUTextureFormat::Etc2_rgb8unorm => wgt::TextureFormat::Etc2Rgb8Unorm,
-            GPUTextureFormat::Etc2_rgb8unorm_srgb => wgt::TextureFormat::Etc2Rgb8UnormSrgb,
-            GPUTextureFormat::Etc2_rgb8a1unorm => wgt::TextureFormat::Etc2Rgb8A1Unorm,
-            GPUTextureFormat::Etc2_rgb8a1unorm_srgb => wgt::TextureFormat::Etc2Rgb8A1UnormSrgb,
-            GPUTextureFormat::Etc2_rgba8unorm => wgt::TextureFormat::Etc2Rgba8Unorm,
-            GPUTextureFormat::Etc2_rgba8unorm_srgb => wgt::TextureFormat::Etc2Rgba8UnormSrgb,
-            GPUTextureFormat::Eac_r11unorm => wgt::TextureFormat::EacR11Unorm,
-            GPUTextureFormat::Eac_r11snorm => wgt::TextureFormat::EacR11Snorm,
-            GPUTextureFormat::Eac_rg11unorm => wgt::TextureFormat::EacRg11Unorm,
-            GPUTextureFormat::Eac_rg11snorm => wgt::TextureFormat::EacRg11Snorm,
-            GPUTextureFormat::Astc_4x4_unorm => wgt::TextureFormat::Astc {
+            GPUTextureFormat::R8unorm => wgpu_types::TextureFormat::R8Unorm,
+            GPUTextureFormat::R8snorm => wgpu_types::TextureFormat::R8Snorm,
+            GPUTextureFormat::R8uint => wgpu_types::TextureFormat::R8Uint,
+            GPUTextureFormat::R8sint => wgpu_types::TextureFormat::R8Sint,
+            GPUTextureFormat::R16uint => wgpu_types::TextureFormat::R16Uint,
+            GPUTextureFormat::R16sint => wgpu_types::TextureFormat::R16Sint,
+            GPUTextureFormat::R16float => wgpu_types::TextureFormat::R16Float,
+            GPUTextureFormat::Rg8unorm => wgpu_types::TextureFormat::Rg8Unorm,
+            GPUTextureFormat::Rg8snorm => wgpu_types::TextureFormat::Rg8Snorm,
+            GPUTextureFormat::Rg8uint => wgpu_types::TextureFormat::Rg8Uint,
+            GPUTextureFormat::Rg8sint => wgpu_types::TextureFormat::Rg8Sint,
+            GPUTextureFormat::R32uint => wgpu_types::TextureFormat::R32Uint,
+            GPUTextureFormat::R32sint => wgpu_types::TextureFormat::R32Sint,
+            GPUTextureFormat::R32float => wgpu_types::TextureFormat::R32Float,
+            GPUTextureFormat::Rg16uint => wgpu_types::TextureFormat::Rg16Uint,
+            GPUTextureFormat::Rg16sint => wgpu_types::TextureFormat::Rg16Sint,
+            GPUTextureFormat::Rg16float => wgpu_types::TextureFormat::Rg16Float,
+            GPUTextureFormat::Rgba8unorm => wgpu_types::TextureFormat::Rgba8Unorm,
+            GPUTextureFormat::Rgba8unorm_srgb => wgpu_types::TextureFormat::Rgba8UnormSrgb,
+            GPUTextureFormat::Rgba8snorm => wgpu_types::TextureFormat::Rgba8Snorm,
+            GPUTextureFormat::Rgba8uint => wgpu_types::TextureFormat::Rgba8Uint,
+            GPUTextureFormat::Rgba8sint => wgpu_types::TextureFormat::Rgba8Sint,
+            GPUTextureFormat::Bgra8unorm => wgpu_types::TextureFormat::Bgra8Unorm,
+            GPUTextureFormat::Bgra8unorm_srgb => wgpu_types::TextureFormat::Bgra8UnormSrgb,
+            GPUTextureFormat::Rgb10a2unorm => wgpu_types::TextureFormat::Rgb10a2Unorm,
+            GPUTextureFormat::Rg32uint => wgpu_types::TextureFormat::Rg32Uint,
+            GPUTextureFormat::Rg32sint => wgpu_types::TextureFormat::Rg32Sint,
+            GPUTextureFormat::Rg32float => wgpu_types::TextureFormat::Rg32Float,
+            GPUTextureFormat::Rgba16uint => wgpu_types::TextureFormat::Rgba16Uint,
+            GPUTextureFormat::Rgba16sint => wgpu_types::TextureFormat::Rgba16Sint,
+            GPUTextureFormat::Rgba16float => wgpu_types::TextureFormat::Rgba16Float,
+            GPUTextureFormat::Rgba32uint => wgpu_types::TextureFormat::Rgba32Uint,
+            GPUTextureFormat::Rgba32sint => wgpu_types::TextureFormat::Rgba32Sint,
+            GPUTextureFormat::Rgba32float => wgpu_types::TextureFormat::Rgba32Float,
+            GPUTextureFormat::Depth32float => wgpu_types::TextureFormat::Depth32Float,
+            GPUTextureFormat::Depth24plus => wgpu_types::TextureFormat::Depth24Plus,
+            GPUTextureFormat::Depth24plus_stencil8 => {
+                wgpu_types::TextureFormat::Depth24PlusStencil8
+            },
+            GPUTextureFormat::Bc1_rgba_unorm => wgpu_types::TextureFormat::Bc1RgbaUnorm,
+            GPUTextureFormat::Bc1_rgba_unorm_srgb => wgpu_types::TextureFormat::Bc1RgbaUnormSrgb,
+            GPUTextureFormat::Bc2_rgba_unorm => wgpu_types::TextureFormat::Bc2RgbaUnorm,
+            GPUTextureFormat::Bc2_rgba_unorm_srgb => wgpu_types::TextureFormat::Bc2RgbaUnormSrgb,
+            GPUTextureFormat::Bc3_rgba_unorm => wgpu_types::TextureFormat::Bc3RgbaUnorm,
+            GPUTextureFormat::Bc3_rgba_unorm_srgb => wgpu_types::TextureFormat::Bc3RgbaUnormSrgb,
+            GPUTextureFormat::Bc4_r_unorm => wgpu_types::TextureFormat::Bc4RUnorm,
+            GPUTextureFormat::Bc4_r_snorm => wgpu_types::TextureFormat::Bc4RSnorm,
+            GPUTextureFormat::Bc5_rg_unorm => wgpu_types::TextureFormat::Bc5RgUnorm,
+            GPUTextureFormat::Bc5_rg_snorm => wgpu_types::TextureFormat::Bc5RgSnorm,
+            GPUTextureFormat::Bc6h_rgb_ufloat => wgpu_types::TextureFormat::Bc6hRgbUfloat,
+            GPUTextureFormat::Bc7_rgba_unorm => wgpu_types::TextureFormat::Bc7RgbaUnorm,
+            GPUTextureFormat::Bc7_rgba_unorm_srgb => wgpu_types::TextureFormat::Bc7RgbaUnormSrgb,
+            GPUTextureFormat::Bc6h_rgb_float => wgpu_types::TextureFormat::Bc6hRgbFloat,
+            GPUTextureFormat::Rgb9e5ufloat => wgpu_types::TextureFormat::Rgb9e5Ufloat,
+            GPUTextureFormat::Rgb10a2uint => wgpu_types::TextureFormat::Rgb10a2Uint,
+            GPUTextureFormat::Rg11b10ufloat => wgpu_types::TextureFormat::Rg11b10Ufloat,
+            GPUTextureFormat::Stencil8 => wgpu_types::TextureFormat::Stencil8,
+            GPUTextureFormat::Depth16unorm => wgpu_types::TextureFormat::Depth16Unorm,
+            GPUTextureFormat::Depth32float_stencil8 => {
+                wgpu_types::TextureFormat::Depth32FloatStencil8
+            },
+            GPUTextureFormat::Etc2_rgb8unorm => wgpu_types::TextureFormat::Etc2Rgb8Unorm,
+            GPUTextureFormat::Etc2_rgb8unorm_srgb => wgpu_types::TextureFormat::Etc2Rgb8UnormSrgb,
+            GPUTextureFormat::Etc2_rgb8a1unorm => wgpu_types::TextureFormat::Etc2Rgb8A1Unorm,
+            GPUTextureFormat::Etc2_rgb8a1unorm_srgb => {
+                wgpu_types::TextureFormat::Etc2Rgb8A1UnormSrgb
+            },
+            GPUTextureFormat::Etc2_rgba8unorm => wgpu_types::TextureFormat::Etc2Rgba8Unorm,
+            GPUTextureFormat::Etc2_rgba8unorm_srgb => wgpu_types::TextureFormat::Etc2Rgba8UnormSrgb,
+            GPUTextureFormat::Eac_r11unorm => wgpu_types::TextureFormat::EacR11Unorm,
+            GPUTextureFormat::Eac_r11snorm => wgpu_types::TextureFormat::EacR11Snorm,
+            GPUTextureFormat::Eac_rg11unorm => wgpu_types::TextureFormat::EacRg11Unorm,
+            GPUTextureFormat::Eac_rg11snorm => wgpu_types::TextureFormat::EacRg11Snorm,
+            GPUTextureFormat::Astc_4x4_unorm => wgpu_types::TextureFormat::Astc {
                 block: AstcBlock::B4x4,
                 channel: AstcChannel::Unorm,
             },
-            GPUTextureFormat::Astc_4x4_unorm_srgb => wgt::TextureFormat::Astc {
+            GPUTextureFormat::Astc_4x4_unorm_srgb => wgpu_types::TextureFormat::Astc {
                 block: AstcBlock::B4x4,
                 channel: AstcChannel::UnormSrgb,
             },
-            GPUTextureFormat::Astc_5x4_unorm => wgt::TextureFormat::Astc {
+            GPUTextureFormat::Astc_5x4_unorm => wgpu_types::TextureFormat::Astc {
                 block: AstcBlock::B5x4,
                 channel: AstcChannel::Unorm,
             },
-            GPUTextureFormat::Astc_5x4_unorm_srgb => wgt::TextureFormat::Astc {
+            GPUTextureFormat::Astc_5x4_unorm_srgb => wgpu_types::TextureFormat::Astc {
                 block: AstcBlock::B5x4,
                 channel: AstcChannel::UnormSrgb,
             },
-            GPUTextureFormat::Astc_5x5_unorm => wgt::TextureFormat::Astc {
+            GPUTextureFormat::Astc_5x5_unorm => wgpu_types::TextureFormat::Astc {
                 block: AstcBlock::B5x5,
                 channel: AstcChannel::Unorm,
             },
-            GPUTextureFormat::Astc_5x5_unorm_srgb => wgt::TextureFormat::Astc {
+            GPUTextureFormat::Astc_5x5_unorm_srgb => wgpu_types::TextureFormat::Astc {
                 block: AstcBlock::B5x5,
                 channel: AstcChannel::UnormSrgb,
             },
-            GPUTextureFormat::Astc_6x5_unorm => wgt::TextureFormat::Astc {
+            GPUTextureFormat::Astc_6x5_unorm => wgpu_types::TextureFormat::Astc {
                 block: AstcBlock::B6x5,
                 channel: AstcChannel::Unorm,
             },
-            GPUTextureFormat::Astc_6x5_unorm_srgb => wgt::TextureFormat::Astc {
+            GPUTextureFormat::Astc_6x5_unorm_srgb => wgpu_types::TextureFormat::Astc {
                 block: AstcBlock::B6x5,
                 channel: AstcChannel::UnormSrgb,
             },
-            GPUTextureFormat::Astc_6x6_unorm => wgt::TextureFormat::Astc {
+            GPUTextureFormat::Astc_6x6_unorm => wgpu_types::TextureFormat::Astc {
                 block: AstcBlock::B6x6,
                 channel: AstcChannel::Unorm,
             },
-            GPUTextureFormat::Astc_6x6_unorm_srgb => wgt::TextureFormat::Astc {
+            GPUTextureFormat::Astc_6x6_unorm_srgb => wgpu_types::TextureFormat::Astc {
                 block: AstcBlock::B6x6,
                 channel: AstcChannel::UnormSrgb,
             },
-            GPUTextureFormat::Astc_8x5_unorm => wgt::TextureFormat::Astc {
+            GPUTextureFormat::Astc_8x5_unorm => wgpu_types::TextureFormat::Astc {
                 block: AstcBlock::B8x5,
                 channel: AstcChannel::Unorm,
             },
-            GPUTextureFormat::Astc_8x5_unorm_srgb => wgt::TextureFormat::Astc {
+            GPUTextureFormat::Astc_8x5_unorm_srgb => wgpu_types::TextureFormat::Astc {
                 block: AstcBlock::B8x5,
                 channel: AstcChannel::UnormSrgb,
             },
-            GPUTextureFormat::Astc_8x6_unorm => wgt::TextureFormat::Astc {
+            GPUTextureFormat::Astc_8x6_unorm => wgpu_types::TextureFormat::Astc {
                 block: AstcBlock::B8x6,
                 channel: AstcChannel::Unorm,
             },
-            GPUTextureFormat::Astc_8x6_unorm_srgb => wgt::TextureFormat::Astc {
+            GPUTextureFormat::Astc_8x6_unorm_srgb => wgpu_types::TextureFormat::Astc {
                 block: AstcBlock::B8x6,
                 channel: AstcChannel::UnormSrgb,
             },
-            GPUTextureFormat::Astc_8x8_unorm => wgt::TextureFormat::Astc {
+            GPUTextureFormat::Astc_8x8_unorm => wgpu_types::TextureFormat::Astc {
                 block: AstcBlock::B8x8,
                 channel: AstcChannel::Unorm,
             },
-            GPUTextureFormat::Astc_8x8_unorm_srgb => wgt::TextureFormat::Astc {
+            GPUTextureFormat::Astc_8x8_unorm_srgb => wgpu_types::TextureFormat::Astc {
                 block: AstcBlock::B8x8,
                 channel: AstcChannel::UnormSrgb,
             },
-            GPUTextureFormat::Astc_10x5_unorm => wgt::TextureFormat::Astc {
+            GPUTextureFormat::Astc_10x5_unorm => wgpu_types::TextureFormat::Astc {
                 block: AstcBlock::B10x5,
                 channel: AstcChannel::Unorm,
             },
-            GPUTextureFormat::Astc_10x5_unorm_srgb => wgt::TextureFormat::Astc {
+            GPUTextureFormat::Astc_10x5_unorm_srgb => wgpu_types::TextureFormat::Astc {
                 block: AstcBlock::B10x5,
                 channel: AstcChannel::UnormSrgb,
             },
-            GPUTextureFormat::Astc_10x6_unorm => wgt::TextureFormat::Astc {
+            GPUTextureFormat::Astc_10x6_unorm => wgpu_types::TextureFormat::Astc {
                 block: AstcBlock::B10x6,
                 channel: AstcChannel::Unorm,
             },
-            GPUTextureFormat::Astc_10x6_unorm_srgb => wgt::TextureFormat::Astc {
+            GPUTextureFormat::Astc_10x6_unorm_srgb => wgpu_types::TextureFormat::Astc {
                 block: AstcBlock::B10x6,
                 channel: AstcChannel::UnormSrgb,
             },
-            GPUTextureFormat::Astc_10x8_unorm => wgt::TextureFormat::Astc {
+            GPUTextureFormat::Astc_10x8_unorm => wgpu_types::TextureFormat::Astc {
                 block: AstcBlock::B10x8,
                 channel: AstcChannel::Unorm,
             },
-            GPUTextureFormat::Astc_10x8_unorm_srgb => wgt::TextureFormat::Astc {
+            GPUTextureFormat::Astc_10x8_unorm_srgb => wgpu_types::TextureFormat::Astc {
                 block: AstcBlock::B10x8,
                 channel: AstcChannel::UnormSrgb,
             },
-            GPUTextureFormat::Astc_10x10_unorm => wgt::TextureFormat::Astc {
+            GPUTextureFormat::Astc_10x10_unorm => wgpu_types::TextureFormat::Astc {
                 block: AstcBlock::B10x10,
                 channel: AstcChannel::Unorm,
             },
-            GPUTextureFormat::Astc_10x10_unorm_srgb => wgt::TextureFormat::Astc {
+            GPUTextureFormat::Astc_10x10_unorm_srgb => wgpu_types::TextureFormat::Astc {
                 block: AstcBlock::B10x10,
                 channel: AstcChannel::UnormSrgb,
             },
-            GPUTextureFormat::Astc_12x10_unorm => wgt::TextureFormat::Astc {
+            GPUTextureFormat::Astc_12x10_unorm => wgpu_types::TextureFormat::Astc {
                 block: AstcBlock::B12x10,
                 channel: AstcChannel::Unorm,
             },
-            GPUTextureFormat::Astc_12x10_unorm_srgb => wgt::TextureFormat::Astc {
+            GPUTextureFormat::Astc_12x10_unorm_srgb => wgpu_types::TextureFormat::Astc {
                 block: AstcBlock::B12x10,
                 channel: AstcChannel::UnormSrgb,
             },
-            GPUTextureFormat::Astc_12x12_unorm => wgt::TextureFormat::Astc {
+            GPUTextureFormat::Astc_12x12_unorm => wgpu_types::TextureFormat::Astc {
                 block: AstcBlock::B12x12,
                 channel: AstcChannel::Unorm,
             },
-            GPUTextureFormat::Astc_12x12_unorm_srgb => wgt::TextureFormat::Astc {
+            GPUTextureFormat::Astc_12x12_unorm_srgb => wgpu_types::TextureFormat::Astc {
                 block: AstcBlock::B12x12,
                 channel: AstcChannel::UnormSrgb,
             },
@@ -211,12 +217,12 @@ impl Convert<wgt::TextureFormat> for GPUTextureFormat {
     }
 }
 
-impl TryConvert<wgt::Extent3d> for &GPUExtent3D {
+impl TryConvert<wgpu_types::Extent3d> for &GPUExtent3D {
     type Error = Error;
 
-    fn try_convert(self) -> Result<wgt::Extent3d, Self::Error> {
+    fn try_convert(self) -> Result<wgpu_types::Extent3d, Self::Error> {
         match *self {
-            GPUExtent3D::GPUExtent3DDict(ref dict) => Ok(wgt::Extent3d {
+            GPUExtent3D::GPUExtent3DDict(ref dict) => Ok(wgpu_types::Extent3d {
                 width: dict.width,
                 height: dict.height,
                 depth_or_array_layers: dict.depthOrArrayLayers,
@@ -228,7 +234,7 @@ impl TryConvert<wgt::Extent3d> for &GPUExtent3D {
                         "GPUExtent3D size must be between 1 and 3 (inclusive)".to_string(),
                     ))
                 } else {
-                    Ok(wgt::Extent3d {
+                    Ok(wgpu_types::Extent3d {
                         width: v[0],
                         height: v.get(1).copied().unwrap_or(1),
                         depth_or_array_layers: v.get(2).copied().unwrap_or(1),
@@ -239,71 +245,71 @@ impl TryConvert<wgt::Extent3d> for &GPUExtent3D {
     }
 }
 
-impl Convert<wgt::TexelCopyBufferLayout> for &GPUImageDataLayout {
-    fn convert(self) -> wgt::TexelCopyBufferLayout {
-        wgt::TexelCopyBufferLayout {
-            offset: self.offset as wgt::BufferAddress,
+impl Convert<wgpu_types::TexelCopyBufferLayout> for &GPUImageDataLayout {
+    fn convert(self) -> wgpu_types::TexelCopyBufferLayout {
+        wgpu_types::TexelCopyBufferLayout {
+            offset: self.offset as wgpu_types::BufferAddress,
             bytes_per_row: self.bytesPerRow,
             rows_per_image: self.rowsPerImage,
         }
     }
 }
 
-impl Convert<wgt::VertexFormat> for GPUVertexFormat {
-    fn convert(self) -> wgt::VertexFormat {
+impl Convert<wgpu_types::VertexFormat> for GPUVertexFormat {
+    fn convert(self) -> wgpu_types::VertexFormat {
         match self {
-            GPUVertexFormat::Uint8x2 => wgt::VertexFormat::Uint8x2,
-            GPUVertexFormat::Uint8x4 => wgt::VertexFormat::Uint8x4,
-            GPUVertexFormat::Sint8x2 => wgt::VertexFormat::Sint8x2,
-            GPUVertexFormat::Sint8x4 => wgt::VertexFormat::Sint8x4,
-            GPUVertexFormat::Unorm8x2 => wgt::VertexFormat::Unorm8x2,
-            GPUVertexFormat::Unorm8x4 => wgt::VertexFormat::Unorm8x4,
-            GPUVertexFormat::Snorm8x2 => wgt::VertexFormat::Unorm8x2,
-            GPUVertexFormat::Snorm8x4 => wgt::VertexFormat::Unorm8x4,
-            GPUVertexFormat::Uint16x2 => wgt::VertexFormat::Uint16x2,
-            GPUVertexFormat::Uint16x4 => wgt::VertexFormat::Uint16x4,
-            GPUVertexFormat::Sint16x2 => wgt::VertexFormat::Sint16x2,
-            GPUVertexFormat::Sint16x4 => wgt::VertexFormat::Sint16x4,
-            GPUVertexFormat::Unorm16x2 => wgt::VertexFormat::Unorm16x2,
-            GPUVertexFormat::Unorm16x4 => wgt::VertexFormat::Unorm16x4,
-            GPUVertexFormat::Snorm16x2 => wgt::VertexFormat::Snorm16x2,
-            GPUVertexFormat::Snorm16x4 => wgt::VertexFormat::Snorm16x4,
-            GPUVertexFormat::Float16x2 => wgt::VertexFormat::Float16x2,
-            GPUVertexFormat::Float16x4 => wgt::VertexFormat::Float16x4,
-            GPUVertexFormat::Float32 => wgt::VertexFormat::Float32,
-            GPUVertexFormat::Float32x2 => wgt::VertexFormat::Float32x2,
-            GPUVertexFormat::Float32x3 => wgt::VertexFormat::Float32x3,
-            GPUVertexFormat::Float32x4 => wgt::VertexFormat::Float32x4,
-            GPUVertexFormat::Uint32 => wgt::VertexFormat::Uint32,
-            GPUVertexFormat::Uint32x2 => wgt::VertexFormat::Uint32x2,
-            GPUVertexFormat::Uint32x3 => wgt::VertexFormat::Uint32x3,
-            GPUVertexFormat::Uint32x4 => wgt::VertexFormat::Uint32x4,
-            GPUVertexFormat::Sint32 => wgt::VertexFormat::Sint32,
-            GPUVertexFormat::Sint32x2 => wgt::VertexFormat::Sint32x2,
-            GPUVertexFormat::Sint32x3 => wgt::VertexFormat::Sint32x3,
-            GPUVertexFormat::Sint32x4 => wgt::VertexFormat::Sint32x4,
+            GPUVertexFormat::Uint8x2 => wgpu_types::VertexFormat::Uint8x2,
+            GPUVertexFormat::Uint8x4 => wgpu_types::VertexFormat::Uint8x4,
+            GPUVertexFormat::Sint8x2 => wgpu_types::VertexFormat::Sint8x2,
+            GPUVertexFormat::Sint8x4 => wgpu_types::VertexFormat::Sint8x4,
+            GPUVertexFormat::Unorm8x2 => wgpu_types::VertexFormat::Unorm8x2,
+            GPUVertexFormat::Unorm8x4 => wgpu_types::VertexFormat::Unorm8x4,
+            GPUVertexFormat::Snorm8x2 => wgpu_types::VertexFormat::Unorm8x2,
+            GPUVertexFormat::Snorm8x4 => wgpu_types::VertexFormat::Unorm8x4,
+            GPUVertexFormat::Uint16x2 => wgpu_types::VertexFormat::Uint16x2,
+            GPUVertexFormat::Uint16x4 => wgpu_types::VertexFormat::Uint16x4,
+            GPUVertexFormat::Sint16x2 => wgpu_types::VertexFormat::Sint16x2,
+            GPUVertexFormat::Sint16x4 => wgpu_types::VertexFormat::Sint16x4,
+            GPUVertexFormat::Unorm16x2 => wgpu_types::VertexFormat::Unorm16x2,
+            GPUVertexFormat::Unorm16x4 => wgpu_types::VertexFormat::Unorm16x4,
+            GPUVertexFormat::Snorm16x2 => wgpu_types::VertexFormat::Snorm16x2,
+            GPUVertexFormat::Snorm16x4 => wgpu_types::VertexFormat::Snorm16x4,
+            GPUVertexFormat::Float16x2 => wgpu_types::VertexFormat::Float16x2,
+            GPUVertexFormat::Float16x4 => wgpu_types::VertexFormat::Float16x4,
+            GPUVertexFormat::Float32 => wgpu_types::VertexFormat::Float32,
+            GPUVertexFormat::Float32x2 => wgpu_types::VertexFormat::Float32x2,
+            GPUVertexFormat::Float32x3 => wgpu_types::VertexFormat::Float32x3,
+            GPUVertexFormat::Float32x4 => wgpu_types::VertexFormat::Float32x4,
+            GPUVertexFormat::Uint32 => wgpu_types::VertexFormat::Uint32,
+            GPUVertexFormat::Uint32x2 => wgpu_types::VertexFormat::Uint32x2,
+            GPUVertexFormat::Uint32x3 => wgpu_types::VertexFormat::Uint32x3,
+            GPUVertexFormat::Uint32x4 => wgpu_types::VertexFormat::Uint32x4,
+            GPUVertexFormat::Sint32 => wgpu_types::VertexFormat::Sint32,
+            GPUVertexFormat::Sint32x2 => wgpu_types::VertexFormat::Sint32x2,
+            GPUVertexFormat::Sint32x3 => wgpu_types::VertexFormat::Sint32x3,
+            GPUVertexFormat::Sint32x4 => wgpu_types::VertexFormat::Sint32x4,
         }
     }
 }
 
-impl Convert<wgt::PrimitiveState> for &GPUPrimitiveState {
-    fn convert(self) -> wgt::PrimitiveState {
-        wgt::PrimitiveState {
+impl Convert<wgpu_types::PrimitiveState> for &GPUPrimitiveState {
+    fn convert(self) -> wgpu_types::PrimitiveState {
+        wgpu_types::PrimitiveState {
             topology: self.topology.convert(),
             strip_index_format: self
                 .stripIndexFormat
                 .map(|index_format| match index_format {
-                    GPUIndexFormat::Uint16 => wgt::IndexFormat::Uint16,
-                    GPUIndexFormat::Uint32 => wgt::IndexFormat::Uint32,
+                    GPUIndexFormat::Uint16 => wgpu_types::IndexFormat::Uint16,
+                    GPUIndexFormat::Uint32 => wgpu_types::IndexFormat::Uint32,
                 }),
             front_face: match self.frontFace {
-                GPUFrontFace::Ccw => wgt::FrontFace::Ccw,
-                GPUFrontFace::Cw => wgt::FrontFace::Cw,
+                GPUFrontFace::Ccw => wgpu_types::FrontFace::Ccw,
+                GPUFrontFace::Cw => wgpu_types::FrontFace::Cw,
             },
             cull_mode: match self.cullMode {
                 GPUCullMode::None => None,
-                GPUCullMode::Front => Some(wgt::Face::Front),
-                GPUCullMode::Back => Some(wgt::Face::Back),
+                GPUCullMode::Front => Some(wgpu_types::Face::Front),
+                GPUCullMode::Back => Some(wgpu_types::Face::Back),
             },
             unclipped_depth: self.clampDepth,
             ..Default::default()
@@ -311,96 +317,96 @@ impl Convert<wgt::PrimitiveState> for &GPUPrimitiveState {
     }
 }
 
-impl Convert<wgt::PrimitiveTopology> for &GPUPrimitiveTopology {
-    fn convert(self) -> wgt::PrimitiveTopology {
+impl Convert<wgpu_types::PrimitiveTopology> for &GPUPrimitiveTopology {
+    fn convert(self) -> wgpu_types::PrimitiveTopology {
         match self {
-            GPUPrimitiveTopology::Point_list => wgt::PrimitiveTopology::PointList,
-            GPUPrimitiveTopology::Line_list => wgt::PrimitiveTopology::LineList,
-            GPUPrimitiveTopology::Line_strip => wgt::PrimitiveTopology::LineStrip,
-            GPUPrimitiveTopology::Triangle_list => wgt::PrimitiveTopology::TriangleList,
-            GPUPrimitiveTopology::Triangle_strip => wgt::PrimitiveTopology::TriangleStrip,
+            GPUPrimitiveTopology::Point_list => wgpu_types::PrimitiveTopology::PointList,
+            GPUPrimitiveTopology::Line_list => wgpu_types::PrimitiveTopology::LineList,
+            GPUPrimitiveTopology::Line_strip => wgpu_types::PrimitiveTopology::LineStrip,
+            GPUPrimitiveTopology::Triangle_list => wgpu_types::PrimitiveTopology::TriangleList,
+            GPUPrimitiveTopology::Triangle_strip => wgpu_types::PrimitiveTopology::TriangleStrip,
         }
     }
 }
 
-impl Convert<wgt::AddressMode> for GPUAddressMode {
-    fn convert(self) -> wgt::AddressMode {
+impl Convert<wgpu_types::AddressMode> for GPUAddressMode {
+    fn convert(self) -> wgpu_types::AddressMode {
         match self {
-            GPUAddressMode::Clamp_to_edge => wgt::AddressMode::ClampToEdge,
-            GPUAddressMode::Repeat => wgt::AddressMode::Repeat,
-            GPUAddressMode::Mirror_repeat => wgt::AddressMode::MirrorRepeat,
+            GPUAddressMode::Clamp_to_edge => wgpu_types::AddressMode::ClampToEdge,
+            GPUAddressMode::Repeat => wgpu_types::AddressMode::Repeat,
+            GPUAddressMode::Mirror_repeat => wgpu_types::AddressMode::MirrorRepeat,
         }
     }
 }
 
-impl Convert<wgt::FilterMode> for GPUFilterMode {
-    fn convert(self) -> wgt::FilterMode {
+impl Convert<wgpu_types::FilterMode> for GPUFilterMode {
+    fn convert(self) -> wgpu_types::FilterMode {
         match self {
-            GPUFilterMode::Nearest => wgt::FilterMode::Nearest,
-            GPUFilterMode::Linear => wgt::FilterMode::Linear,
+            GPUFilterMode::Nearest => wgpu_types::FilterMode::Nearest,
+            GPUFilterMode::Linear => wgpu_types::FilterMode::Linear,
         }
     }
 }
 
-impl Convert<wgt::TextureViewDimension> for GPUTextureViewDimension {
-    fn convert(self) -> wgt::TextureViewDimension {
+impl Convert<wgpu_types::TextureViewDimension> for GPUTextureViewDimension {
+    fn convert(self) -> wgpu_types::TextureViewDimension {
         match self {
-            GPUTextureViewDimension::_1d => wgt::TextureViewDimension::D1,
-            GPUTextureViewDimension::_2d => wgt::TextureViewDimension::D2,
-            GPUTextureViewDimension::_2d_array => wgt::TextureViewDimension::D2Array,
-            GPUTextureViewDimension::Cube => wgt::TextureViewDimension::Cube,
-            GPUTextureViewDimension::Cube_array => wgt::TextureViewDimension::CubeArray,
-            GPUTextureViewDimension::_3d => wgt::TextureViewDimension::D3,
+            GPUTextureViewDimension::_1d => wgpu_types::TextureViewDimension::D1,
+            GPUTextureViewDimension::_2d => wgpu_types::TextureViewDimension::D2,
+            GPUTextureViewDimension::_2d_array => wgpu_types::TextureViewDimension::D2Array,
+            GPUTextureViewDimension::Cube => wgpu_types::TextureViewDimension::Cube,
+            GPUTextureViewDimension::Cube_array => wgpu_types::TextureViewDimension::CubeArray,
+            GPUTextureViewDimension::_3d => wgpu_types::TextureViewDimension::D3,
         }
     }
 }
 
-impl Convert<wgt::CompareFunction> for GPUCompareFunction {
-    fn convert(self) -> wgt::CompareFunction {
+impl Convert<wgpu_types::CompareFunction> for GPUCompareFunction {
+    fn convert(self) -> wgpu_types::CompareFunction {
         match self {
-            GPUCompareFunction::Never => wgt::CompareFunction::Never,
-            GPUCompareFunction::Less => wgt::CompareFunction::Less,
-            GPUCompareFunction::Equal => wgt::CompareFunction::Equal,
-            GPUCompareFunction::Less_equal => wgt::CompareFunction::LessEqual,
-            GPUCompareFunction::Greater => wgt::CompareFunction::Greater,
-            GPUCompareFunction::Not_equal => wgt::CompareFunction::NotEqual,
-            GPUCompareFunction::Greater_equal => wgt::CompareFunction::GreaterEqual,
-            GPUCompareFunction::Always => wgt::CompareFunction::Always,
+            GPUCompareFunction::Never => wgpu_types::CompareFunction::Never,
+            GPUCompareFunction::Less => wgpu_types::CompareFunction::Less,
+            GPUCompareFunction::Equal => wgpu_types::CompareFunction::Equal,
+            GPUCompareFunction::Less_equal => wgpu_types::CompareFunction::LessEqual,
+            GPUCompareFunction::Greater => wgpu_types::CompareFunction::Greater,
+            GPUCompareFunction::Not_equal => wgpu_types::CompareFunction::NotEqual,
+            GPUCompareFunction::Greater_equal => wgpu_types::CompareFunction::GreaterEqual,
+            GPUCompareFunction::Always => wgpu_types::CompareFunction::Always,
         }
     }
 }
 
-impl Convert<wgt::BlendFactor> for &GPUBlendFactor {
-    fn convert(self) -> wgt::BlendFactor {
+impl Convert<wgpu_types::BlendFactor> for &GPUBlendFactor {
+    fn convert(self) -> wgpu_types::BlendFactor {
         match self {
-            GPUBlendFactor::Zero => wgt::BlendFactor::Zero,
-            GPUBlendFactor::One => wgt::BlendFactor::One,
-            GPUBlendFactor::Src => wgt::BlendFactor::Src,
-            GPUBlendFactor::One_minus_src => wgt::BlendFactor::OneMinusSrc,
-            GPUBlendFactor::Src_alpha => wgt::BlendFactor::SrcAlpha,
-            GPUBlendFactor::One_minus_src_alpha => wgt::BlendFactor::OneMinusSrcAlpha,
-            GPUBlendFactor::Dst => wgt::BlendFactor::Dst,
-            GPUBlendFactor::One_minus_dst => wgt::BlendFactor::OneMinusDst,
-            GPUBlendFactor::Dst_alpha => wgt::BlendFactor::DstAlpha,
-            GPUBlendFactor::One_minus_dst_alpha => wgt::BlendFactor::OneMinusDstAlpha,
-            GPUBlendFactor::Src_alpha_saturated => wgt::BlendFactor::SrcAlphaSaturated,
-            GPUBlendFactor::Constant => wgt::BlendFactor::Constant,
-            GPUBlendFactor::One_minus_constant => wgt::BlendFactor::OneMinusConstant,
+            GPUBlendFactor::Zero => wgpu_types::BlendFactor::Zero,
+            GPUBlendFactor::One => wgpu_types::BlendFactor::One,
+            GPUBlendFactor::Src => wgpu_types::BlendFactor::Src,
+            GPUBlendFactor::One_minus_src => wgpu_types::BlendFactor::OneMinusSrc,
+            GPUBlendFactor::Src_alpha => wgpu_types::BlendFactor::SrcAlpha,
+            GPUBlendFactor::One_minus_src_alpha => wgpu_types::BlendFactor::OneMinusSrcAlpha,
+            GPUBlendFactor::Dst => wgpu_types::BlendFactor::Dst,
+            GPUBlendFactor::One_minus_dst => wgpu_types::BlendFactor::OneMinusDst,
+            GPUBlendFactor::Dst_alpha => wgpu_types::BlendFactor::DstAlpha,
+            GPUBlendFactor::One_minus_dst_alpha => wgpu_types::BlendFactor::OneMinusDstAlpha,
+            GPUBlendFactor::Src_alpha_saturated => wgpu_types::BlendFactor::SrcAlphaSaturated,
+            GPUBlendFactor::Constant => wgpu_types::BlendFactor::Constant,
+            GPUBlendFactor::One_minus_constant => wgpu_types::BlendFactor::OneMinusConstant,
         }
     }
 }
 
-impl Convert<wgt::BlendComponent> for &GPUBlendComponent {
-    fn convert(self) -> wgt::BlendComponent {
-        wgt::BlendComponent {
+impl Convert<wgpu_types::BlendComponent> for &GPUBlendComponent {
+    fn convert(self) -> wgpu_types::BlendComponent {
+        wgpu_types::BlendComponent {
             src_factor: self.srcFactor.convert(),
             dst_factor: self.dstFactor.convert(),
             operation: match self.operation {
-                GPUBlendOperation::Add => wgt::BlendOperation::Add,
-                GPUBlendOperation::Subtract => wgt::BlendOperation::Subtract,
-                GPUBlendOperation::Reverse_subtract => wgt::BlendOperation::ReverseSubtract,
-                GPUBlendOperation::Min => wgt::BlendOperation::Min,
-                GPUBlendOperation::Max => wgt::BlendOperation::Max,
+                GPUBlendOperation::Add => wgpu_types::BlendOperation::Add,
+                GPUBlendOperation::Subtract => wgpu_types::BlendOperation::Subtract,
+                GPUBlendOperation::Reverse_subtract => wgpu_types::BlendOperation::ReverseSubtract,
+                GPUBlendOperation::Min => wgpu_types::BlendOperation::Min,
+                GPUBlendOperation::Max => wgpu_types::BlendOperation::Max,
             },
         }
     }
@@ -422,17 +428,17 @@ impl Convert<wgpu_com::StoreOp> for &GPUStoreOp {
     }
 }
 
-impl Convert<wgt::StencilOperation> for GPUStencilOperation {
-    fn convert(self) -> wgt::StencilOperation {
+impl Convert<wgpu_types::StencilOperation> for GPUStencilOperation {
+    fn convert(self) -> wgpu_types::StencilOperation {
         match self {
-            GPUStencilOperation::Keep => wgt::StencilOperation::Keep,
-            GPUStencilOperation::Zero => wgt::StencilOperation::Zero,
-            GPUStencilOperation::Replace => wgt::StencilOperation::Replace,
-            GPUStencilOperation::Invert => wgt::StencilOperation::Invert,
-            GPUStencilOperation::Increment_clamp => wgt::StencilOperation::IncrementClamp,
-            GPUStencilOperation::Decrement_clamp => wgt::StencilOperation::DecrementClamp,
-            GPUStencilOperation::Increment_wrap => wgt::StencilOperation::IncrementWrap,
-            GPUStencilOperation::Decrement_wrap => wgt::StencilOperation::DecrementWrap,
+            GPUStencilOperation::Keep => wgpu_types::StencilOperation::Keep,
+            GPUStencilOperation::Zero => wgpu_types::StencilOperation::Zero,
+            GPUStencilOperation::Replace => wgpu_types::StencilOperation::Replace,
+            GPUStencilOperation::Invert => wgpu_types::StencilOperation::Invert,
+            GPUStencilOperation::Increment_clamp => wgpu_types::StencilOperation::IncrementClamp,
+            GPUStencilOperation::Decrement_clamp => wgpu_types::StencilOperation::DecrementClamp,
+            GPUStencilOperation::Increment_wrap => wgpu_types::StencilOperation::IncrementWrap,
+            GPUStencilOperation::Decrement_wrap => wgpu_types::StencilOperation::DecrementWrap,
         }
     }
 }
@@ -446,10 +452,10 @@ impl Convert<wgpu_com::TexelCopyBufferInfo> for &GPUImageCopyBuffer {
     }
 }
 
-impl TryConvert<wgt::Origin3d> for &GPUOrigin3D {
+impl TryConvert<wgpu_types::Origin3d> for &GPUOrigin3D {
     type Error = Error;
 
-    fn try_convert(self) -> Result<wgt::Origin3d, Self::Error> {
+    fn try_convert(self) -> Result<wgpu_types::Origin3d, Self::Error> {
         match self {
             GPUOrigin3D::RangeEnforcedUnsignedLongSequence(v) => {
                 // https://gpuweb.github.io/gpuweb/#abstract-opdef-validate-gpuorigin3d-shape
@@ -458,14 +464,14 @@ impl TryConvert<wgt::Origin3d> for &GPUOrigin3D {
                         "sequence is too long for GPUOrigin3D".to_string(),
                     ))
                 } else {
-                    Ok(wgt::Origin3d {
+                    Ok(wgpu_types::Origin3d {
                         x: v.first().copied().unwrap_or(0),
                         y: v.get(1).copied().unwrap_or(0),
                         z: v.get(2).copied().unwrap_or(0),
                     })
                 }
             },
-            GPUOrigin3D::GPUOrigin3DDict(d) => Ok(wgt::Origin3d {
+            GPUOrigin3D::GPUOrigin3DDict(d) => Ok(wgpu_types::Origin3d {
                 x: d.x,
                 y: d.y,
                 z: d.z,
@@ -484,13 +490,13 @@ impl TryConvert<wgpu_com::TexelCopyTextureInfo> for &GPUImageCopyTexture {
             origin: self
                 .origin
                 .as_ref()
-                .map(TryConvert::<wgt::Origin3d>::try_convert)
+                .map(TryConvert::<wgpu_types::Origin3d>::try_convert)
                 .transpose()?
                 .unwrap_or_default(),
             aspect: match self.aspect {
-                GPUTextureAspect::All => wgt::TextureAspect::All,
-                GPUTextureAspect::Stencil_only => wgt::TextureAspect::StencilOnly,
-                GPUTextureAspect::Depth_only => wgt::TextureAspect::DepthOnly,
+                GPUTextureAspect::All => wgpu_types::TextureAspect::All,
+                GPUTextureAspect::Stencil_only => wgpu_types::TextureAspect::StencilOnly,
+                GPUTextureAspect::Depth_only => wgpu_types::TextureAspect::DepthOnly,
             },
         })
     }
@@ -509,51 +515,53 @@ impl<'a> Convert<Option<Cow<'a, str>>> for &GPUObjectDescriptorBase {
 pub(crate) fn convert_bind_group_layout_entry(
     bgle: &GPUBindGroupLayoutEntry,
     device: &GPUDevice,
-) -> Fallible<Result<wgt::BindGroupLayoutEntry, webgpu_traits::Error>> {
+) -> Fallible<Result<wgpu_types::BindGroupLayoutEntry, webgpu_traits::Error>> {
     let number_of_provided_bindings = bgle.buffer.is_some() as u8 +
         bgle.sampler.is_some() as u8 +
         bgle.storageTexture.is_some() as u8 +
         bgle.texture.is_some() as u8;
     let ty = if let Some(buffer) = &bgle.buffer {
-        Some(wgt::BindingType::Buffer {
+        Some(wgpu_types::BindingType::Buffer {
             ty: match buffer.type_ {
-                GPUBufferBindingType::Uniform => wgt::BufferBindingType::Uniform,
+                GPUBufferBindingType::Uniform => wgpu_types::BufferBindingType::Uniform,
                 GPUBufferBindingType::Storage => {
-                    wgt::BufferBindingType::Storage { read_only: false }
+                    wgpu_types::BufferBindingType::Storage { read_only: false }
                 },
                 GPUBufferBindingType::Read_only_storage => {
-                    wgt::BufferBindingType::Storage { read_only: true }
+                    wgpu_types::BufferBindingType::Storage { read_only: true }
                 },
             },
             has_dynamic_offset: buffer.hasDynamicOffset,
             min_binding_size: NonZeroU64::new(buffer.minBindingSize),
         })
     } else if let Some(sampler) = &bgle.sampler {
-        Some(wgt::BindingType::Sampler(match sampler.type_ {
-            GPUSamplerBindingType::Filtering => wgt::SamplerBindingType::Filtering,
-            GPUSamplerBindingType::Non_filtering => wgt::SamplerBindingType::NonFiltering,
-            GPUSamplerBindingType::Comparison => wgt::SamplerBindingType::Comparison,
+        Some(wgpu_types::BindingType::Sampler(match sampler.type_ {
+            GPUSamplerBindingType::Filtering => wgpu_types::SamplerBindingType::Filtering,
+            GPUSamplerBindingType::Non_filtering => wgpu_types::SamplerBindingType::NonFiltering,
+            GPUSamplerBindingType::Comparison => wgpu_types::SamplerBindingType::Comparison,
         }))
     } else if let Some(storage) = &bgle.storageTexture {
-        Some(wgt::BindingType::StorageTexture {
+        Some(wgpu_types::BindingType::StorageTexture {
             access: match storage.access {
-                GPUStorageTextureAccess::Write_only => wgt::StorageTextureAccess::WriteOnly,
-                GPUStorageTextureAccess::Read_only => wgt::StorageTextureAccess::ReadOnly,
-                GPUStorageTextureAccess::Read_write => wgt::StorageTextureAccess::ReadWrite,
+                GPUStorageTextureAccess::Write_only => wgpu_types::StorageTextureAccess::WriteOnly,
+                GPUStorageTextureAccess::Read_only => wgpu_types::StorageTextureAccess::ReadOnly,
+                GPUStorageTextureAccess::Read_write => wgpu_types::StorageTextureAccess::ReadWrite,
             },
             format: device.validate_texture_format_required_features(&storage.format)?,
             view_dimension: storage.viewDimension.convert(),
         })
     } else if let Some(texture) = &bgle.texture {
-        Some(wgt::BindingType::Texture {
+        Some(wgpu_types::BindingType::Texture {
             sample_type: match texture.sampleType {
-                GPUTextureSampleType::Float => wgt::TextureSampleType::Float { filterable: true },
-                GPUTextureSampleType::Unfilterable_float => {
-                    wgt::TextureSampleType::Float { filterable: false }
+                GPUTextureSampleType::Float => {
+                    wgpu_types::TextureSampleType::Float { filterable: true }
                 },
-                GPUTextureSampleType::Depth => wgt::TextureSampleType::Depth,
-                GPUTextureSampleType::Sint => wgt::TextureSampleType::Sint,
-                GPUTextureSampleType::Uint => wgt::TextureSampleType::Uint,
+                GPUTextureSampleType::Unfilterable_float => {
+                    wgpu_types::TextureSampleType::Float { filterable: false }
+                },
+                GPUTextureSampleType::Depth => wgpu_types::TextureSampleType::Depth,
+                GPUTextureSampleType::Sint => wgpu_types::TextureSampleType::Sint,
+                GPUTextureSampleType::Uint => wgpu_types::TextureSampleType::Uint,
             },
             view_dimension: texture.viewDimension.convert(),
             multisampled: texture.multisampled,
@@ -573,9 +581,9 @@ pub(crate) fn convert_bind_group_layout_entry(
         "Exactly on entry type must be provided".to_string(),
     ));
 
-    Ok(ty.map(|ty| wgt::BindGroupLayoutEntry {
+    Ok(ty.map(|ty| wgpu_types::BindGroupLayoutEntry {
         binding: bgle.binding,
-        visibility: wgt::ShaderStages::from_bits_retain(bgle.visibility),
+        visibility: wgpu_types::ShaderStages::from_bits_retain(bgle.visibility),
         ty,
         count: None,
     }))
@@ -584,7 +592,7 @@ pub(crate) fn convert_bind_group_layout_entry(
 pub(crate) fn convert_texture_descriptor(
     descriptor: &GPUTextureDescriptor,
     device: &GPUDevice,
-) -> Fallible<(TextureDescriptor<'static>, wgt::Extent3d)> {
+) -> Fallible<(TextureDescriptor<'static>, wgpu_types::Extent3d)> {
     let size = (&descriptor.size).try_convert()?;
     let desc = TextureDescriptor {
         label: (&descriptor.parent).convert(),
@@ -593,7 +601,7 @@ pub(crate) fn convert_texture_descriptor(
         sample_count: descriptor.sampleCount,
         dimension: descriptor.dimension.convert(),
         format: device.validate_texture_format_required_features(&descriptor.format)?,
-        usage: wgt::TextureUsages::from_bits_retain(descriptor.usage),
+        usage: wgpu_types::TextureUsages::from_bits_retain(descriptor.usage),
         view_formats: descriptor
             .viewFormats
             .iter()
@@ -603,17 +611,17 @@ pub(crate) fn convert_texture_descriptor(
     Ok((desc, size))
 }
 
-impl TryConvert<wgt::Color> for &GPUColor {
+impl TryConvert<wgpu_types::Color> for &GPUColor {
     type Error = Error;
 
-    fn try_convert(self) -> Result<wgt::Color, Self::Error> {
+    fn try_convert(self) -> Result<wgpu_types::Color, Self::Error> {
         match self {
             GPUColor::DoubleSequence(s) => {
                 // https://gpuweb.github.io/gpuweb/#abstract-opdef-validate-gpucolor-shape
                 if s.len() != 4 {
                     Err(Error::Type("GPUColor sequence must be len 4".to_string()))
                 } else {
-                    Ok(wgt::Color {
+                    Ok(wgpu_types::Color {
                         r: *s[0],
                         g: *s[1],
                         b: *s[2],
@@ -621,7 +629,7 @@ impl TryConvert<wgt::Color> for &GPUColor {
                     })
                 }
             },
-            GPUColor::GPUColorDict(d) => Ok(wgt::Color {
+            GPUColor::GPUColorDict(d) => Ok(wgpu_types::Color {
                 r: *d.r,
                 g: *d.g,
                 b: *d.b,
@@ -660,7 +668,7 @@ impl<'a> Convert<BindGroupEntry<'a>> for &GPUBindGroupEntry {
                     BindingResource::Buffer(BufferBinding {
                         buffer: b.buffer.id().0,
                         offset: b.offset,
-                        size: b.size.and_then(wgt::BufferSize::new),
+                        size: b.size.and_then(wgpu_types::BufferSize::new),
                     })
                 },
             },
@@ -668,12 +676,12 @@ impl<'a> Convert<BindGroupEntry<'a>> for &GPUBindGroupEntry {
     }
 }
 
-impl Convert<wgt::TextureDimension> for GPUTextureDimension {
-    fn convert(self) -> wgt::TextureDimension {
+impl Convert<wgpu_types::TextureDimension> for GPUTextureDimension {
+    fn convert(self) -> wgpu_types::TextureDimension {
         match self {
-            GPUTextureDimension::_1d => wgt::TextureDimension::D1,
-            GPUTextureDimension::_2d => wgt::TextureDimension::D2,
-            GPUTextureDimension::_3d => wgt::TextureDimension::D3,
+            GPUTextureDimension::_1d => wgpu_types::TextureDimension::D1,
+            GPUTextureDimension::_2d => wgpu_types::TextureDimension::D2,
+            GPUTextureDimension::_3d => wgpu_types::TextureDimension::D3,
         }
     }
 }

--- a/components/script/dom/webgpu/gpudevice.rs
+++ b/components/script/dom/webgpu/gpudevice.rs
@@ -10,15 +10,15 @@ use std::rc::Rc;
 
 use dom_struct::dom_struct;
 use js::jsapi::{Heap, JSObject};
-use webgpu::wgc::id::{BindGroupLayoutId, PipelineLayoutId};
-use webgpu::wgc::pipeline as wgpu_pipe;
-use webgpu::wgc::pipeline::RenderPipelineDescriptor;
-use webgpu::wgt::{self, TextureFormat};
 use webgpu_traits::{
     PopError, WebGPU, WebGPUComputePipeline, WebGPUComputePipelineResponse, WebGPUDevice,
     WebGPUPoppedErrorScopeResponse, WebGPUQueue, WebGPURenderPipeline,
     WebGPURenderPipelineResponse, WebGPURequest,
 };
+use wgpu_core::id::{BindGroupLayoutId, PipelineLayoutId};
+use wgpu_core::pipeline as wgpu_pipe;
+use wgpu_core::pipeline::RenderPipelineDescriptor;
+use wgpu_types::{self, TextureFormat};
 
 use super::gpudevicelostinfo::GPUDeviceLostInfo;
 use super::gpuerror::AsWebGpu;
@@ -143,8 +143,8 @@ impl GPUDevice {
         channel: WebGPU,
         adapter: &GPUAdapter,
         extensions: Heap<*mut JSObject>,
-        features: wgt::Features,
-        limits: wgt::Limits,
+        features: wgpu_types::Features,
+        limits: wgpu_types::Limits,
         device: WebGPUDevice,
         queue: WebGPUQueue,
         label: String,
@@ -274,14 +274,14 @@ impl GPUDevice {
                         .map(|buffer| wgpu_pipe::VertexBufferLayout {
                             array_stride: buffer.arrayStride,
                             step_mode: match buffer.stepMode {
-                                GPUVertexStepMode::Vertex => wgt::VertexStepMode::Vertex,
-                                GPUVertexStepMode::Instance => wgt::VertexStepMode::Instance,
+                                GPUVertexStepMode::Vertex => wgpu_types::VertexStepMode::Vertex,
+                                GPUVertexStepMode::Instance => wgpu_types::VertexStepMode::Instance,
                             },
                             attributes: Cow::Owned(
                                 buffer
                                     .attributes
                                     .iter()
-                                    .map(|att| wgt::VertexAttribute {
+                                    .map(|att| wgpu_types::VertexAttribute {
                                         format: att.format.convert(),
                                         offset: att.offset,
                                         shader_location: att.shaderLocation,
@@ -305,13 +305,14 @@ impl GPUDevice {
                                 .map(|state| {
                                     self.validate_texture_format_required_features(&state.format)
                                         .map(|format| {
-                                            Some(wgt::ColorTargetState {
+                                            Some(wgpu_types::ColorTargetState {
                                                 format,
-                                                write_mask: wgt::ColorWrites::from_bits_retain(
-                                                    state.writeMask,
-                                                ),
+                                                write_mask:
+                                                    wgpu_types::ColorWrites::from_bits_retain(
+                                                        state.writeMask,
+                                                    ),
                                                 blend: state.blend.as_ref().map(|blend| {
-                                                    wgt::BlendState {
+                                                    wgpu_types::BlendState {
                                                         color: (&blend.color).convert(),
                                                         alpha: (&blend.alpha).convert(),
                                                     }
@@ -330,19 +331,19 @@ impl GPUDevice {
                 .as_ref()
                 .map(|dss_desc| {
                     self.validate_texture_format_required_features(&dss_desc.format)
-                        .map(|format| wgt::DepthStencilState {
+                        .map(|format| wgpu_types::DepthStencilState {
                             format,
                             depth_write_enabled: dss_desc.depthWriteEnabled,
                             depth_compare: dss_desc.depthCompare.convert(),
-                            stencil: wgt::StencilState {
-                                front: wgt::StencilFaceState {
+                            stencil: wgpu_types::StencilState {
+                                front: wgpu_types::StencilFaceState {
                                     compare: dss_desc.stencilFront.compare.convert(),
 
                                     fail_op: dss_desc.stencilFront.failOp.convert(),
                                     depth_fail_op: dss_desc.stencilFront.depthFailOp.convert(),
                                     pass_op: dss_desc.stencilFront.passOp.convert(),
                                 },
-                                back: wgt::StencilFaceState {
+                                back: wgpu_types::StencilFaceState {
                                     compare: dss_desc.stencilBack.compare.convert(),
                                     fail_op: dss_desc.stencilBack.failOp.convert(),
                                     depth_fail_op: dss_desc.stencilBack.depthFailOp.convert(),
@@ -351,7 +352,7 @@ impl GPUDevice {
                                 read_mask: dss_desc.stencilReadMask,
                                 write_mask: dss_desc.stencilWriteMask,
                             },
-                            bias: wgt::DepthBiasState {
+                            bias: wgpu_types::DepthBiasState {
                                 constant: dss_desc.depthBias,
                                 slope_scale: *dss_desc.depthBiasSlopeScale,
                                 clamp: *dss_desc.depthBiasClamp,
@@ -359,7 +360,7 @@ impl GPUDevice {
                         })
                 })
                 .transpose()?,
-            multisample: wgt::MultisampleState {
+            multisample: wgpu_types::MultisampleState {
                 count: descriptor.multisample.count,
                 mask: descriptor.multisample.mask as u64,
                 alpha_to_coverage_enabled: descriptor.multisample.alphaToCoverageEnabled,

--- a/components/script/dom/webgpu/gpupipelinelayout.rs
+++ b/components/script/dom/webgpu/gpupipelinelayout.rs
@@ -5,8 +5,8 @@
 use std::borrow::Cow;
 
 use dom_struct::dom_struct;
-use webgpu::wgc::binding_model::PipelineLayoutDescriptor;
 use webgpu_traits::{WebGPU, WebGPUBindGroupLayout, WebGPUPipelineLayout, WebGPURequest};
+use wgpu_core::binding_model::PipelineLayoutDescriptor;
 
 use crate::conversions::Convert;
 use crate::dom::bindings::cell::DomRefCell;

--- a/components/script/dom/webgpu/gpuqueue.rs
+++ b/components/script/dom/webgpu/gpuqueue.rs
@@ -6,7 +6,6 @@ use std::rc::Rc;
 
 use dom_struct::dom_struct;
 use ipc_channel::ipc::IpcSharedMemory;
-use webgpu::wgt;
 use webgpu_traits::{WebGPU, WebGPUQueue, WebGPURequest};
 
 use crate::conversions::{Convert, TryConvert};
@@ -131,7 +130,7 @@ impl GPUQueueMethods<crate::DomTypeHolder> for GPUQueue {
 
         // Step 4
         let valid = data_offset + content_size <= data_size as u64 &&
-            content_size * sizeof_element as u64 % wgt::COPY_BUFFER_ALIGNMENT == 0;
+            content_size * sizeof_element as u64 % wgpu_types::COPY_BUFFER_ALIGNMENT == 0;
         if !valid {
             return Err(Error::Operation);
         }

--- a/components/script/dom/webgpu/gpurenderbundleencoder.rs
+++ b/components/script/dom/webgpu/gpurenderbundleencoder.rs
@@ -5,11 +5,10 @@
 use std::borrow::Cow;
 
 use dom_struct::dom_struct;
-use webgpu::wgc::command::{
+use webgpu_traits::{WebGPU, WebGPURenderBundle, WebGPURequest};
+use wgpu_core::command::{
     RenderBundleEncoder, RenderBundleEncoderDescriptor, bundle_ffi as wgpu_bundle,
 };
-use webgpu::wgt;
-use webgpu_traits::{WebGPU, WebGPURenderBundle, WebGPURequest};
 
 use crate::conversions::Convert;
 use crate::dom::bindings::cell::DomRefCell;
@@ -106,7 +105,7 @@ impl GPURenderBundleEncoder {
                 .map(|dsf| {
                     device
                         .validate_texture_format_required_features(&dsf)
-                        .map(|format| wgt::RenderBundleDepthStencil {
+                        .map(|format| wgpu_types::RenderBundleDepthStencil {
                             format,
                             depth_read_only: descriptor.depthReadOnly,
                             stencil_read_only: descriptor.stencilReadOnly,
@@ -178,11 +177,11 @@ impl GPURenderBundleEncoderMethods<crate::DomTypeHolder> for GPURenderBundleEnco
                 encoder,
                 buffer.id().0,
                 match index_format {
-                    GPUIndexFormat::Uint16 => wgt::IndexFormat::Uint16,
-                    GPUIndexFormat::Uint32 => wgt::IndexFormat::Uint32,
+                    GPUIndexFormat::Uint16 => wgpu_types::IndexFormat::Uint16,
+                    GPUIndexFormat::Uint32 => wgpu_types::IndexFormat::Uint32,
                 },
                 offset,
-                wgt::BufferSize::new(size),
+                wgpu_types::BufferSize::new(size),
             );
         }
     }
@@ -195,7 +194,7 @@ impl GPURenderBundleEncoderMethods<crate::DomTypeHolder> for GPURenderBundleEnco
                 slot,
                 buffer.id().0,
                 offset,
-                wgt::BufferSize::new(size),
+                wgpu_types::BufferSize::new(size),
             );
         }
     }
@@ -258,7 +257,7 @@ impl GPURenderBundleEncoderMethods<crate::DomTypeHolder> for GPURenderBundleEnco
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpurenderbundleencoder-finish>
     fn Finish(&self, descriptor: &GPURenderBundleDescriptor) -> DomRoot<GPURenderBundle> {
-        let desc = wgt::RenderBundleDescriptor {
+        let desc = wgpu_types::RenderBundleDescriptor {
             label: (&descriptor.parent).convert(),
         };
         let encoder = self.render_bundle_encoder.borrow_mut().take().unwrap();

--- a/components/script/dom/webgpu/gpurenderpassencoder.rs
+++ b/components/script/dom/webgpu/gpurenderpassencoder.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use webgpu::wgt;
 use webgpu_traits::{RenderCommand, WebGPU, WebGPURenderPass, WebGPURequest};
 
 use crate::conversions::TryConvert;
@@ -171,11 +170,11 @@ impl GPURenderPassEncoderMethods<crate::DomTypeHolder> for GPURenderPassEncoder 
         self.send_render_command(RenderCommand::SetIndexBuffer {
             buffer_id: buffer.id().0,
             index_format: match index_format {
-                GPUIndexFormat::Uint16 => wgt::IndexFormat::Uint16,
-                GPUIndexFormat::Uint32 => wgt::IndexFormat::Uint32,
+                GPUIndexFormat::Uint16 => wgpu_types::IndexFormat::Uint16,
+                GPUIndexFormat::Uint32 => wgpu_types::IndexFormat::Uint32,
             },
             offset,
-            size: wgt::BufferSize::new(size),
+            size: wgpu_types::BufferSize::new(size),
         })
     }
 
@@ -185,7 +184,7 @@ impl GPURenderPassEncoderMethods<crate::DomTypeHolder> for GPURenderPassEncoder 
             slot,
             buffer_id: buffer.id().0,
             offset,
-            size: wgt::BufferSize::new(size),
+            size: wgpu_types::BufferSize::new(size),
         })
     }
 

--- a/components/script/dom/webgpu/gpurenderpipeline.rs
+++ b/components/script/dom/webgpu/gpurenderpipeline.rs
@@ -4,11 +4,11 @@
 
 use dom_struct::dom_struct;
 use ipc_channel::ipc::IpcSender;
-use webgpu::wgc::pipeline::RenderPipelineDescriptor;
 use webgpu_traits::{
     WebGPU, WebGPUBindGroupLayout, WebGPURenderPipeline, WebGPURenderPipelineResponse,
     WebGPURequest,
 };
+use wgpu_core::pipeline::RenderPipelineDescriptor;
 
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::GPURenderPipelineMethods;

--- a/components/script/dom/webgpu/gpusampler.rs
+++ b/components/script/dom/webgpu/gpusampler.rs
@@ -3,8 +3,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use webgpu::wgc::resource::SamplerDescriptor;
 use webgpu_traits::{WebGPU, WebGPUDevice, WebGPURequest, WebGPUSampler};
+use wgpu_core::resource::SamplerDescriptor;
 
 use crate::conversions::Convert;
 use crate::dom::bindings::cell::DomRefCell;

--- a/components/script/dom/webgpu/gpusupportedfeatures.rs
+++ b/components/script/dom/webgpu/gpusupportedfeatures.rs
@@ -7,7 +7,7 @@
 use dom_struct::dom_struct;
 use indexmap::IndexSet;
 use js::rust::HandleObject;
-use webgpu::wgt::Features;
+use wgpu_types::Features;
 
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{

--- a/components/script/dom/webgpu/gpusupportedlimits.rs
+++ b/components/script/dom/webgpu/gpusupportedlimits.rs
@@ -5,7 +5,7 @@
 use GPUSupportedLimits_Binding::GPUSupportedLimitsMethods;
 use dom_struct::dom_struct;
 use num_traits::bounds::UpperBounded;
-use webgpu::wgt::Limits;
+use wgpu_types::Limits;
 
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::GPUSupportedLimits_Binding;
 use crate::dom::bindings::reflector::{Reflector, reflect_dom_object};

--- a/components/script/dom/webgpu/gputexture.rs
+++ b/components/script/dom/webgpu/gputexture.rs
@@ -5,9 +5,8 @@
 use std::string::String;
 
 use dom_struct::dom_struct;
-use webgpu::wgc::resource;
-use webgpu::wgt;
 use webgpu_traits::{WebGPU, WebGPURequest, WebGPUTexture, WebGPUTextureView};
+use wgpu_core::resource;
 
 use super::gpuconvert::convert_texture_descriptor;
 use crate::conversions::Convert;
@@ -37,7 +36,7 @@ pub(crate) struct GPUTexture {
     channel: WebGPU,
     #[ignore_malloc_size_of = "defined in wgpu"]
     #[no_trace]
-    texture_size: wgt::Extent3d,
+    texture_size: wgpu_types::Extent3d,
     mip_level_count: u32,
     sample_count: u32,
     dimension: GPUTextureDimension,
@@ -51,7 +50,7 @@ impl GPUTexture {
         texture: WebGPUTexture,
         device: &GPUDevice,
         channel: WebGPU,
-        texture_size: wgt::Extent3d,
+        texture_size: wgpu_types::Extent3d,
         mip_level_count: u32,
         sample_count: u32,
         dimension: GPUTextureDimension,
@@ -80,7 +79,7 @@ impl GPUTexture {
         texture: WebGPUTexture,
         device: &GPUDevice,
         channel: WebGPU,
-        texture_size: wgt::Extent3d,
+        texture_size: wgpu_types::Extent3d,
         mip_level_count: u32,
         sample_count: u32,
         dimension: GPUTextureDimension,
@@ -193,12 +192,14 @@ impl GPUTextureMethods<crate::DomTypeHolder> for GPUTexture {
                     .map(|f| self.device.validate_texture_format_required_features(&f))
                     .transpose()?,
                 dimension: descriptor.dimension.map(|dimension| dimension.convert()),
-                usage: Some(wgt::TextureUsages::from_bits_retain(descriptor.usage)),
-                range: wgt::ImageSubresourceRange {
+                usage: Some(wgpu_types::TextureUsages::from_bits_retain(
+                    descriptor.usage,
+                )),
+                range: wgpu_types::ImageSubresourceRange {
                     aspect: match descriptor.aspect {
-                        GPUTextureAspect::All => wgt::TextureAspect::All,
-                        GPUTextureAspect::Stencil_only => wgt::TextureAspect::StencilOnly,
-                        GPUTextureAspect::Depth_only => wgt::TextureAspect::DepthOnly,
+                        GPUTextureAspect::All => wgpu_types::TextureAspect::All,
+                        GPUTextureAspect::Stencil_only => wgpu_types::TextureAspect::StencilOnly,
+                        GPUTextureAspect::Depth_only => wgpu_types::TextureAspect::DepthOnly,
                     },
                     base_mip_level: descriptor.baseMipLevel,
                     mip_level_count: descriptor.mipLevelCount,

--- a/components/script/dom/webgpu/identityhub.rs
+++ b/components/script/dom/webgpu/identityhub.rs
@@ -2,18 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use webgpu::wgc::id::markers::{
+use webgpu_traits::{ComputePass, ComputePassId, RenderPass, RenderPassId};
+use wgpu_core::id::markers::{
     Adapter, BindGroup, BindGroupLayout, Buffer, CommandEncoder, ComputePipeline, Device,
     PipelineLayout, Queue, RenderBundle, RenderPipeline, Sampler, ShaderModule, Texture,
     TextureView,
 };
-use webgpu::wgc::id::{
+use wgpu_core::id::{
     AdapterId, BindGroupId, BindGroupLayoutId, BufferId, CommandEncoderId, ComputePipelineId,
     DeviceId, PipelineLayoutId, QueueId, RenderBundleId, RenderPipelineId, SamplerId,
     ShaderModuleId, TextureId, TextureViewId,
 };
-use webgpu::wgc::identity::IdentityManager;
-use webgpu_traits::{ComputePass, ComputePassId, RenderPass, RenderPassId};
+use wgpu_core::identity::IdentityManager;
 
 #[derive(Debug)]
 pub(crate) struct IdentityHub {

--- a/components/script/dom/webgpu/wgsllanguagefeatures.rs
+++ b/components/script/dom/webgpu/wgsllanguagefeatures.rs
@@ -7,7 +7,7 @@
 use dom_struct::dom_struct;
 use indexmap::IndexSet;
 use js::rust::HandleObject;
-use webgpu::wgc::naga::front::wgsl::ImplementedLanguageExtension;
+use wgpu_core::naga::front::wgsl::ImplementedLanguageExtension;
 
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::WGSLLanguageFeaturesMethods;


### PR DESCRIPTION
After #36320, `script` only depends on `webgpu` for its type aliases to
`wgpu_core` and `wgpu_types`. This change removes the dependency on
`webgpu` in favor of depending directly on the upstream crates. This
makes it so that you can change `webgpu` without recompiling `script`.

Testing: This change is covered by existing WebGPU tests and is mainly
just changing the way dependencies are accessed.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>
