### PR TITLE
Fix: Add support for stylesheet MIME type quirk in quirks mode

### DIFF
--- a/components/script/stylesheet_loader.rs
+++ b/components/script/stylesheet_loader.rs
@@ -165,8 +165,12 @@ impl FetchResponseListener for StylesheetContext {
             let is_css = metadata.content_type.is_some_and(|ct| {
                 let mime: Mime = ct.into_inner().into();
                 mime.type_() == mime::TEXT && mime.subtype() == mime::CSS
-            }) || (document.quirks_mode() == QuirksMode::Quirks &&
-                document.url().origin() == metadata.final_url.origin());
+            }) || (
+                // Quirk: If the document has been set to quirks mode, has the same origin as the URL of the external resource, and the Content-Type metadata of the external resource is not a supported style sheet type, the user agent must instead assume it to be text/css.
+                // <https://html.spec.whatwg.org/multipage/#link-type-stylesheet>
+                document.quirks_mode() == QuirksMode::Quirks &&
+                    document.url().origin() == metadata.final_url.origin()
+            );
 
             let data = if is_css {
                 let data = std::mem::take(&mut self.data);

--- a/components/script/stylesheet_loader.rs
+++ b/components/script/stylesheet_loader.rs
@@ -166,7 +166,11 @@ impl FetchResponseListener for StylesheetContext {
                 let mime: Mime = ct.into_inner().into();
                 mime.type_() == mime::TEXT && mime.subtype() == mime::CSS
             }) || (
-                // Quirk: If the document has been set to quirks mode, has the same origin as the URL of the external resource, and the Content-Type metadata of the external resource is not a supported style sheet type, the user agent must instead assume it to be text/css.
+                // Quirk: If the document has been set to quirks mode,
+                // has the same origin as the URL of the external resource,
+                // and the Content-Type metadata of the external resource
+                // is not a supported style sheet type, the user agent must
+                // instead assume it to be text/css.
                 // <https://html.spec.whatwg.org/multipage/#link-type-stylesheet>
                 document.quirks_mode() == QuirksMode::Quirks &&
                     document.origin().immutable().clone() == metadata.final_url.origin()

--- a/components/script/stylesheet_loader.rs
+++ b/components/script/stylesheet_loader.rs
@@ -169,7 +169,7 @@ impl FetchResponseListener for StylesheetContext {
                 // Quirk: If the document has been set to quirks mode, has the same origin as the URL of the external resource, and the Content-Type metadata of the external resource is not a supported style sheet type, the user agent must instead assume it to be text/css.
                 // <https://html.spec.whatwg.org/multipage/#link-type-stylesheet>
                 document.quirks_mode() == QuirksMode::Quirks &&
-                    document.url().origin() == metadata.final_url.origin()
+                    document.origin().immutable().clone() == metadata.final_url.origin()
             );
 
             let data = if is_css {

--- a/components/script/stylesheet_loader.rs
+++ b/components/script/stylesheet_loader.rs
@@ -15,6 +15,7 @@ use net_traits::{
 };
 use servo_arc::Arc;
 use servo_url::ServoUrl;
+use style::context::QuirksMode;
 use style::media_queries::MediaList;
 use style::parser::ParserContext;
 use style::shared_lock::{Locked, SharedRwLock};
@@ -164,7 +165,8 @@ impl FetchResponseListener for StylesheetContext {
             let is_css = metadata.content_type.is_some_and(|ct| {
                 let mime: Mime = ct.into_inner().into();
                 mime.type_() == mime::TEXT && mime.subtype() == mime::CSS
-            });
+            }) || (document.quirks_mode() == QuirksMode::Quirks &&
+                document.url().origin() == metadata.final_url.origin());
 
             let data = if is_css {
                 let data = std::mem::take(&mut self.data);

--- a/tests/wpt/tests/html/links/stylesheet/quirk-origin-check-positive.html
+++ b/tests/wpt/tests/html/links/stylesheet/quirk-origin-check-positive.html
@@ -1,0 +1,18 @@
+<!-- quirks -->
+<title>Same-origin stylesheet with non-CSS MIME type quirk</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#link-type-stylesheet">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="stylesheet" href="resources/quirk-stylesheet.css.txt">
+<p class="test">This text should be green.</p>
+<script>
+setup({ single_test: true });
+onload = () => {
+  assert_equals(
+    getComputedStyle(document.querySelector('.test')).color, 
+    'rgb(0, 128, 0)',
+    "Same-origin stylesheet with non-CSS MIME type should be applied in quirks mode"
+  );
+  done();
+};
+</script>

--- a/tests/wpt/tests/html/links/stylesheet/quirk-origin-check-positive.html
+++ b/tests/wpt/tests/html/links/stylesheet/quirk-origin-check-positive.html
@@ -9,7 +9,7 @@
 setup({ single_test: true });
 onload = () => {
   assert_equals(
-    getComputedStyle(document.querySelector('.test')).color, 
+    getComputedStyle(document.querySelector('.test')).color,
     'rgb(0, 128, 0)',
     "Same-origin stylesheet with non-CSS MIME type should be applied in quirks mode"
   );

--- a/tests/wpt/tests/html/links/stylesheet/resources/quirk-stylesheet.css.txt
+++ b/tests/wpt/tests/html/links/stylesheet/resources/quirk-stylesheet.css.txt
@@ -1,0 +1,1 @@
+.test { color: green; }


### PR DESCRIPTION
This PR implements the HTML spec quirk for stylesheets: https://html.spec.whatwg.org/multipage/#link-type-stylesheet

The implementation adds a check in `stylesheet_loader.rs` to handle this quirk condition correctly, and adds a new WPT test to verify that same-origin non-CSS MIME type resources are properly treated as CSS in quirks mode.

Testing: Added a new WPT test (`quirk-origin-check-positive.html`) that verifies the positive case for this quirk. 
Fixes: https://github.com/servo/servo/issues/36324