### PR TITLE
Remove layout_writing_mode_enabled from experimental features

### DIFF
--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -564,7 +564,6 @@ pub(crate) fn parse_command_line_arguments(args: Vec<String>) -> ArgumentParsing
             "layout_columns_enabled",
             "layout_container_queries_enabled",
             "layout_grid_enabled",
-            "layout_writing_mode_enabled",
         ]
         .iter()
         .for_each(|pref| preferences.set_value(pref, PrefValue::Bool(true)));


### PR DESCRIPTION
Running tests with --enable-experimental-web-platform-features would make so many of them fail asserts because of this feature.

Testing: No need to test since `--enable-experimental-web-platform-features` isn't used by default
This is part of #36315
