### PR TITLE
constellation: Rename messages sent to the `Constellation`

### DIFF
--- a/components/compositing/lib.rs
+++ b/components/compositing/lib.rs
@@ -8,7 +8,7 @@ use std::cell::Cell;
 use std::rc::Rc;
 
 use compositing_traits::{CompositorProxy, CompositorReceiver};
-use constellation_traits::ConstellationMsg;
+use constellation_traits::EmbedderToConstellationMessage;
 use crossbeam_channel::Sender;
 use embedder_traits::ShutdownState;
 use profile_traits::{mem, time};
@@ -34,7 +34,7 @@ pub struct InitialCompositorState {
     /// A port on which messages inbound to the compositor can be received.
     pub receiver: CompositorReceiver,
     /// A channel to the constellation.
-    pub constellation_chan: Sender<ConstellationMsg>,
+    pub constellation_chan: Sender<EmbedderToConstellationMessage>,
     /// A channel to the time profiler thread.
     pub time_profiler_chan: time::ProfilerChan,
     /// A channel to the memory profiler thread.

--- a/components/constellation/lib.rs
+++ b/components/constellation/lib.rs
@@ -18,6 +18,6 @@ mod session_history;
 mod webview_manager;
 
 pub use crate::constellation::{Constellation, InitialConstellationState};
-pub use crate::logging::{FromCompositorLogger, FromScriptLogger};
+pub use crate::logging::{FromEmbedderLogger, FromScriptLogger};
 pub use crate::pipeline::UnprivilegedPipelineContent;
 pub use crate::sandboxing::{UnprivilegedContent, content_process_sandbox_profile};

--- a/components/constellation/logging.rs
+++ b/components/constellation/logging.rs
@@ -12,11 +12,11 @@ use std::thread;
 
 use backtrace::Backtrace;
 use base::id::WebViewId;
-use constellation_traits::{ConstellationMsg as FromCompositorMsg, LogEntry};
+use constellation_traits::{EmbedderToConstellationMessage, LogEntry};
 use crossbeam_channel::Sender;
 use log::{Level, LevelFilter, Log, Metadata, Record};
 use parking_lot::ReentrantMutex;
-use script_traits::{ScriptMsg as FromScriptMsg, ScriptToConstellationChan};
+use script_traits::{ScriptToConstellationChan, ScriptToConstellationMessage};
 
 /// A logger directed at the constellation from content processes
 /// #[derive(Clone)]
@@ -50,7 +50,7 @@ impl Log for FromScriptLogger {
     fn log(&self, record: &Record) {
         if let Some(entry) = log_entry(record) {
             let thread_name = thread::current().name().map(ToOwned::to_owned);
-            let msg = FromScriptMsg::LogEntry(thread_name, entry);
+            let msg = ScriptToConstellationMessage::LogEntry(thread_name, entry);
             let chan = self.script_to_constellation_chan.lock();
             let _ = chan.send(msg);
         }
@@ -61,15 +61,15 @@ impl Log for FromScriptLogger {
 
 /// A logger directed at the constellation from the compositor
 #[derive(Clone)]
-pub struct FromCompositorLogger {
+pub struct FromEmbedderLogger {
     /// A channel to the constellation
-    pub constellation_chan: Arc<ReentrantMutex<Sender<FromCompositorMsg>>>,
+    pub constellation_chan: Arc<ReentrantMutex<Sender<EmbedderToConstellationMessage>>>,
 }
 
-impl FromCompositorLogger {
+impl FromEmbedderLogger {
     /// Create a new constellation logger.
-    pub fn new(constellation_chan: Sender<FromCompositorMsg>) -> FromCompositorLogger {
-        FromCompositorLogger {
+    pub fn new(constellation_chan: Sender<EmbedderToConstellationMessage>) -> FromEmbedderLogger {
+        FromEmbedderLogger {
             constellation_chan: Arc::new(ReentrantMutex::new(constellation_chan)),
         }
     }
@@ -80,7 +80,7 @@ impl FromCompositorLogger {
     }
 }
 
-impl Log for FromCompositorLogger {
+impl Log for FromEmbedderLogger {
     fn enabled(&self, metadata: &Metadata) -> bool {
         metadata.level() <= Level::Warn
     }
@@ -89,7 +89,7 @@ impl Log for FromCompositorLogger {
         if let Some(entry) = log_entry(record) {
             let top_level_id = WebViewId::installed();
             let thread_name = thread::current().name().map(ToOwned::to_owned);
-            let msg = FromCompositorMsg::LogEntry(top_level_id, thread_name, entry);
+            let msg = EmbedderToConstellationMessage::LogEntry(top_level_id, thread_name, entry);
             let chan = self.constellation_chan.lock();
             let _ = chan.send(msg);
         }

--- a/components/constellation/tracing.rs
+++ b/components/constellation/tracing.rs
@@ -46,7 +46,7 @@ mod from_compositor {
         };
     }
 
-    impl LogTarget for constellation_traits::ConstellationMsg {
+    impl LogTarget for constellation_traits::EmbedderToConstellationMessage {
         fn log_target(&self) -> &'static str {
             match self {
                 Self::Exit => target!("Exit"),
@@ -113,7 +113,7 @@ mod from_script {
         };
     }
 
-    impl LogTarget for script_traits::ScriptMsg {
+    impl LogTarget for script_traits::ScriptToConstellationMessage {
         fn log_target(&self) -> &'static str {
             match self {
                 Self::CompleteMessagePortTransfer(..) => target!("CompleteMessagePortTransfer"),

--- a/components/script/animations.rs
+++ b/components/script/animations.rs
@@ -11,7 +11,7 @@ use constellation_traits::UntrustedNodeAddress;
 use cssparser::ToCss;
 use fxhash::{FxHashMap, FxHashSet};
 use libc::c_void;
-use script_traits::{AnimationState as AnimationsPresentState, ScriptMsg};
+use script_traits::{AnimationState as AnimationsPresentState, ScriptToConstellationMessage};
 use serde::{Deserialize, Serialize};
 use style::animation::{
     Animation, AnimationSetKey, AnimationState, DocumentAnimationSet, ElementAnimationSet,
@@ -186,7 +186,9 @@ impl Animations {
             true => AnimationsPresentState::AnimationsPresent,
             false => AnimationsPresentState::NoAnimationsPresent,
         };
-        window.send_to_constellation(ScriptMsg::ChangeRunningAnimationsState(state));
+        window.send_to_constellation(ScriptToConstellationMessage::ChangeRunningAnimationsState(
+            state,
+        ));
     }
 
     pub(crate) fn running_animation_count(&self) -> usize {

--- a/components/script/canvas_state.rs
+++ b/components/script/canvas_state.rs
@@ -21,7 +21,7 @@ use net_traits::image_cache::{ImageCache, ImageResponse};
 use net_traits::request::CorsSettings;
 use pixels::PixelFormat;
 use profile_traits::ipc as profiled_ipc;
-use script_traits::ScriptMsg;
+use script_traits::ScriptToConstellationMessage;
 use servo_url::{ImmutableOrigin, ServoUrl};
 use style::color::{AbsoluteColor, ColorFlags, ColorSpace};
 use style::context::QuirksMode;
@@ -177,7 +177,9 @@ impl CanvasState {
         let script_to_constellation_chan = global.script_to_constellation_chan();
         debug!("Asking constellation to create new canvas thread.");
         script_to_constellation_chan
-            .send(ScriptMsg::CreateCanvasPaintThread(size, sender))
+            .send(ScriptToConstellationMessage::CreateCanvasPaintThread(
+                size, sender,
+            ))
             .unwrap();
         let (ipc_renderer, canvas_id, image_key) = receiver.recv().unwrap();
         debug!("Done.");

--- a/components/script/clipboard_provider.rs
+++ b/components/script/clipboard_provider.rs
@@ -5,7 +5,7 @@
 use base::id::WebViewId;
 use embedder_traits::EmbedderMsg;
 use ipc_channel::ipc::channel;
-use script_traits::{ScriptMsg, ScriptToConstellationChan};
+use script_traits::{ScriptToConstellationChan, ScriptToConstellationMessage};
 
 /// A trait which abstracts access to the embedder's clipboard in order to allow unit
 /// testing clipboard-dependent parts of `script`.
@@ -25,19 +25,17 @@ impl ClipboardProvider for EmbedderClipboardProvider {
     fn get_text(&mut self) -> Result<String, String> {
         let (tx, rx) = channel().unwrap();
         self.constellation_sender
-            .send(ScriptMsg::ForwardToEmbedder(EmbedderMsg::GetClipboardText(
-                self.webview_id,
-                tx,
-            )))
+            .send(ScriptToConstellationMessage::ForwardToEmbedder(
+                EmbedderMsg::GetClipboardText(self.webview_id, tx),
+            ))
             .unwrap();
         rx.recv().unwrap()
     }
     fn set_text(&mut self, s: String) {
         self.constellation_sender
-            .send(ScriptMsg::ForwardToEmbedder(EmbedderMsg::SetClipboardText(
-                self.webview_id,
-                s,
-            )))
+            .send(ScriptToConstellationMessage::ForwardToEmbedder(
+                EmbedderMsg::SetClipboardText(self.webview_id, s),
+            ))
             .unwrap();
     }
 }

--- a/components/script/dom/dissimilaroriginwindow.rs
+++ b/components/script/dom/dissimilaroriginwindow.rs
@@ -7,7 +7,7 @@ use dom_struct::dom_struct;
 use js::jsapi::{Heap, JSObject};
 use js::jsval::UndefinedValue;
 use js::rust::{CustomAutoRooter, CustomAutoRooterGuard, HandleValue, MutableHandleValue};
-use script_traits::{ScriptMsg, StructuredSerializedData};
+use script_traits::{ScriptToConstellationMessage, StructuredSerializedData};
 use servo_url::ServoUrl;
 
 use crate::dom::bindings::codegen::Bindings::DissimilarOriginWindowBinding;
@@ -236,7 +236,7 @@ impl DissimilarOriginWindow {
                 Err(_) => return Err(Error::Syntax),
             },
         };
-        let msg = ScriptMsg::PostMessage {
+        let msg = ScriptToConstellationMessage::PostMessage {
             target,
             source: incumbent.pipeline_id(),
             source_origin,

--- a/components/script/dom/history.rs
+++ b/components/script/dom/history.rs
@@ -14,7 +14,7 @@ use js::rust::{HandleValue, MutableHandleValue};
 use net_traits::{CoreResourceMsg, IpcSend};
 use profile_traits::ipc;
 use profile_traits::ipc::channel;
-use script_traits::{ScriptMsg, StructuredSerializedData};
+use script_traits::{ScriptToConstellationMessage, StructuredSerializedData};
 use servo_url::ServoUrl;
 
 use crate::dom::bindings::codegen::Bindings::HistoryBinding::HistoryMethods;
@@ -72,7 +72,7 @@ impl History {
         if !self.window.Document().is_fully_active() {
             return Err(Error::Security);
         }
-        let msg = ScriptMsg::TraverseHistory(direction);
+        let msg = ScriptToConstellationMessage::TraverseHistory(direction);
         let _ = self
             .window
             .as_global_scope()
@@ -227,7 +227,7 @@ impl History {
             PushOrReplace::Push => {
                 let state_id = HistoryStateId::new();
                 self.state_id.set(Some(state_id));
-                let msg = ScriptMsg::PushHistoryState(state_id, new_url.clone());
+                let msg = ScriptToConstellationMessage::PushHistoryState(state_id, new_url.clone());
                 let _ = self
                     .window
                     .as_global_scope()
@@ -244,7 +244,8 @@ impl History {
                         state_id
                     },
                 };
-                let msg = ScriptMsg::ReplaceHistoryState(state_id, new_url.clone());
+                let msg =
+                    ScriptToConstellationMessage::ReplaceHistoryState(state_id, new_url.clone());
                 let _ = self
                     .window
                     .as_global_scope()
@@ -339,7 +340,7 @@ impl HistoryMethods<crate::DomTypeHolder> for History {
         }
         let (sender, recv) = channel(self.global().time_profiler_chan().clone())
             .expect("Failed to create channel to send jsh length.");
-        let msg = ScriptMsg::JointSessionHistoryLength(sender);
+        let msg = ScriptToConstellationMessage::JointSessionHistoryLength(sender);
         let _ = self
             .window
             .as_global_scope()

--- a/components/script/dom/htmlcanvaselement.rs
+++ b/components/script/dom/htmlcanvaselement.rs
@@ -21,7 +21,7 @@ use js::error::throw_type_error;
 use js::rust::{HandleObject, HandleValue};
 use script_layout_interface::{HTMLCanvasData, HTMLCanvasDataSource};
 #[cfg(feature = "webgpu")]
-use script_traits::ScriptMsg;
+use script_traits::ScriptToConstellationMessage;
 use script_traits::serializable::BlobImpl;
 use servo_media::streams::MediaStreamType;
 use servo_media::streams::registry::MediaStreamId;
@@ -334,7 +334,7 @@ impl HTMLCanvasElement {
         let global_scope = self.owner_global();
         let _ = global_scope
             .script_to_constellation_chan()
-            .send(ScriptMsg::GetWebGPUChan(sender));
+            .send(ScriptToConstellationMessage::GetWebGPUChan(sender));
         receiver
             .recv()
             .expect("Failed to get WebGPU channel")

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -15,7 +15,7 @@ use profile_traits::ipc as ProfiledIpc;
 use script_traits::IFrameSandboxState::{IFrameSandboxed, IFrameUnsandboxed};
 use script_traits::{
     IFrameLoadInfo, IFrameLoadInfoWithData, JsEvalResult, LoadData, LoadOrigin,
-    NavigationHistoryBehavior, NewLayoutInfo, ScriptMsg, UpdatePipelineIdReason,
+    NavigationHistoryBehavior, NewLayoutInfo, ScriptToConstellationMessage, UpdatePipelineIdReason,
 };
 use servo_url::ServoUrl;
 use style::attr::{AttrValue, LengthOrPercentageOrAuto};
@@ -217,7 +217,7 @@ impl HTMLIFrameElement {
                 window
                     .as_global_scope()
                     .script_to_constellation_chan()
-                    .send(ScriptMsg::ScriptNewIFrame(load_info))
+                    .send(ScriptToConstellationMessage::ScriptNewIFrame(load_info))
                     .unwrap();
 
                 let new_layout_info = NewLayoutInfo {
@@ -244,7 +244,9 @@ impl HTMLIFrameElement {
                 window
                     .as_global_scope()
                     .script_to_constellation_chan()
-                    .send(ScriptMsg::ScriptLoadedURLInIFrame(load_info))
+                    .send(ScriptToConstellationMessage::ScriptLoadedURLInIFrame(
+                        load_info,
+                    ))
                     .unwrap();
             },
         }
@@ -782,7 +784,7 @@ impl VirtualMethods for HTMLIFrameElement {
         };
         debug!("Unbinding frame {}.", browsing_context_id);
 
-        let msg = ScriptMsg::RemoveIFrame(browsing_context_id, sender);
+        let msg = ScriptToConstellationMessage::RemoveIFrame(browsing_context_id, sender);
         window
             .as_global_scope()
             .script_to_constellation_chan()

--- a/components/script/dom/mediasession.rs
+++ b/components/script/dom/mediasession.rs
@@ -8,7 +8,7 @@ use dom_struct::dom_struct;
 use embedder_traits::{
     MediaMetadata as EmbedderMediaMetadata, MediaSessionActionType, MediaSessionEvent,
 };
-use script_traits::ScriptMsg;
+use script_traits::ScriptToConstellationMessage;
 
 use super::bindings::trace::HashMapTracedValues;
 use crate::conversions::Convert;
@@ -106,7 +106,10 @@ impl MediaSession {
         let global = self.global();
         let window = global.as_window();
         let pipeline_id = window.pipeline_id();
-        window.send_to_constellation(ScriptMsg::MediaSessionEvent(pipeline_id, event));
+        window.send_to_constellation(ScriptToConstellationMessage::MediaSessionEvent(
+            pipeline_id,
+            event,
+        ));
     }
 
     pub(crate) fn update_title(&self, title: String) {

--- a/components/script/dom/serviceworker.rs
+++ b/components/script/dom/serviceworker.rs
@@ -8,7 +8,7 @@ use base::id::ServiceWorkerId;
 use dom_struct::dom_struct;
 use js::jsapi::{Heap, JSObject};
 use js::rust::{CustomAutoRooter, CustomAutoRooterGuard, HandleValue};
-use script_traits::{DOMMessage, ScriptMsg};
+use script_traits::{DOMMessage, ScriptToConstellationMessage};
 use servo_url::ServoUrl;
 
 use crate::dom::abstractworker::SimpleWorkerErrorHandler;
@@ -109,13 +109,9 @@ impl ServiceWorker {
             origin: incumbent.origin().immutable().clone(),
             data,
         };
-        let _ = self
-            .global()
-            .script_to_constellation_chan()
-            .send(ScriptMsg::ForwardDOMMessage(
-                msg_vec,
-                self.scope_url.clone(),
-            ));
+        let _ = self.global().script_to_constellation_chan().send(
+            ScriptToConstellationMessage::ForwardDOMMessage(msg_vec, self.scope_url.clone()),
+        );
         Ok(())
     }
 }

--- a/components/script/dom/serviceworkercontainer.rs
+++ b/components/script/dom/serviceworkercontainer.rs
@@ -8,7 +8,9 @@ use std::rc::Rc;
 use dom_struct::dom_struct;
 use ipc_channel::ipc;
 use ipc_channel::router::ROUTER;
-use script_traits::{Job, JobError, JobResult, JobResultValue, JobType, ScriptMsg};
+use script_traits::{
+    Job, JobError, JobResult, JobResultValue, JobType, ScriptToConstellationMessage,
+};
 
 use crate::dom::bindings::codegen::Bindings::ServiceWorkerContainerBinding::{
     RegistrationOptions, ServiceWorkerContainerMethods,
@@ -179,7 +181,7 @@ impl ServiceWorkerContainerMethods<crate::DomTypeHolder> for ServiceWorkerContai
         // B: Step 14: schedule job.
         let _ = global
             .script_to_constellation_chan()
-            .send(ScriptMsg::ScheduleJob(job));
+            .send(ScriptToConstellationMessage::ScheduleJob(job));
 
         // A: Step 7
         promise

--- a/components/script/dom/servointernals.rs
+++ b/components/script/dom/servointernals.rs
@@ -9,7 +9,7 @@ use js::rust::HandleObject;
 use profile_traits::mem::MemoryReportResult;
 use script_bindings::interfaces::ServoInternalsHelpers;
 use script_bindings::script_runtime::JSContext;
-use script_traits::ScriptMsg;
+use script_traits::ScriptToConstellationMessage;
 
 use crate::dom::bindings::codegen::Bindings::ServoInternalsBinding::ServoInternalsMethods;
 use crate::dom::bindings::error::Error;
@@ -46,7 +46,7 @@ impl ServoInternalsMethods<crate::DomTypeHolder> for ServoInternals {
         let sender = route_promise(&promise, self);
         let script_to_constellation_chan = global.script_to_constellation_chan();
         if script_to_constellation_chan
-            .send(ScriptMsg::ReportMemory(sender))
+            .send(ScriptToConstellationMessage::ReportMemory(sender))
             .is_err()
         {
             promise.reject_error(Error::Operation, can_gc);

--- a/components/script/dom/storage.rs
+++ b/components/script/dom/storage.rs
@@ -7,7 +7,7 @@ use ipc_channel::ipc::IpcSender;
 use net_traits::IpcSend;
 use net_traits::storage_thread::{StorageThreadMsg, StorageType};
 use profile_traits::ipc;
-use script_traits::ScriptMsg;
+use script_traits::ScriptToConstellationMessage;
 use servo_url::ServoUrl;
 
 use crate::dom::bindings::codegen::Bindings::StorageBinding::StorageMethods;
@@ -195,7 +195,9 @@ impl Storage {
     ) {
         let storage = self.storage_type;
         let url = self.get_url();
-        let msg = ScriptMsg::BroadcastStorageEvent(storage, url, key, old_value, new_value);
+        let msg = ScriptToConstellationMessage::BroadcastStorageEvent(
+            storage, url, key, old_value, new_value,
+        );
         self.global()
             .script_to_constellation_chan()
             .send(msg)

--- a/components/script/dom/webgpu/gpu.rs
+++ b/components/script/dom/webgpu/gpu.rs
@@ -6,7 +6,7 @@ use std::rc::Rc;
 
 use dom_struct::dom_struct;
 use js::jsapi::Heap;
-use script_traits::ScriptMsg;
+use script_traits::ScriptToConstellationMessage;
 use webgpu_traits::WebGPUAdapterResponse;
 use wgpu_types::PowerPreference;
 
@@ -66,7 +66,7 @@ impl GPUMethods<crate::DomTypeHolder> for GPU {
 
         let script_to_constellation_chan = global.script_to_constellation_chan();
         if script_to_constellation_chan
-            .send(ScriptMsg::RequestAdapter(
+            .send(ScriptToConstellationMessage::RequestAdapter(
                 sender,
                 wgpu_core::instance::RequestAdapterOptions {
                     power_preference,

--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -31,7 +31,7 @@ use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 use net_traits::request::Referrer;
 use script_traits::{
     AuxiliaryWebViewCreationRequest, LoadData, LoadOrigin, NavigationHistoryBehavior,
-    NewLayoutInfo, ScriptMsg,
+    NewLayoutInfo, ScriptToConstellationMessage,
 };
 use serde::{Deserialize, Serialize};
 use servo_url::{ImmutableOrigin, ServoUrl};
@@ -314,7 +314,7 @@ impl WindowProxy {
             opener_pipeline_id: self.currently_active.get().unwrap(),
             response_sender,
         };
-        let constellation_msg = ScriptMsg::CreateAuxiliaryWebView(load_info);
+        let constellation_msg = ScriptToConstellationMessage::CreateAuxiliaryWebView(load_info);
         window.send_to_constellation(constellation_msg);
 
         let response = response_receiver.recv().unwrap()?;
@@ -863,7 +863,7 @@ unsafe fn GetSubframeWindowProxy(
             let (result_sender, result_receiver) = ipc::channel().unwrap();
 
             let _ = win.as_global_scope().script_to_constellation_chan().send(
-                ScriptMsg::GetChildBrowsingContextId(
+                ScriptToConstellationMessage::GetChildBrowsingContextId(
                     browsing_context_id,
                     index as usize,
                     result_sender,
@@ -882,7 +882,7 @@ unsafe fn GetSubframeWindowProxy(
             let (result_sender, result_receiver) = ipc::channel().unwrap();
 
             let _ = win.global().script_to_constellation_chan().send(
-                ScriptMsg::GetChildBrowsingContextId(
+                ScriptToConstellationMessage::GetChildBrowsingContextId(
                     browsing_context_id,
                     index as usize,
                     result_sender,

--- a/components/script/dom/workletglobalscope.rs
+++ b/components/script/dom/workletglobalscope.rs
@@ -14,7 +14,7 @@ use js::rust::Runtime;
 use net_traits::ResourceThreads;
 use net_traits::image_cache::ImageCache;
 use profile_traits::{mem, time};
-use script_traits::{Painter, ScriptMsg, ScriptToConstellationChan};
+use script_traits::{Painter, ScriptToConstellationChan, ScriptToConstellationMessage};
 use servo_url::{ImmutableOrigin, MutableOrigin, ServoUrl};
 use stylo_atoms::Atom;
 
@@ -180,7 +180,7 @@ pub(crate) struct WorkletGlobalScopeInit {
     /// Channel to devtools
     pub(crate) devtools_chan: Option<IpcSender<ScriptToDevtoolsControlMsg>>,
     /// Messages to send to constellation
-    pub(crate) to_constellation_sender: IpcSender<(PipelineId, ScriptMsg)>,
+    pub(crate) to_constellation_sender: IpcSender<(PipelineId, ScriptToConstellationMessage)>,
     /// The image cache
     pub(crate) image_cache: Arc<dyn ImageCache>,
     /// Identity manager for WebGPU resources

--- a/components/script/messaging.rs
+++ b/components/script/messaging.rs
@@ -18,7 +18,7 @@ use net_traits::FetchResponseMsg;
 use net_traits::image_cache::PendingImageResponse;
 use profile_traits::mem::{self as profile_mem, OpaqueSender, ReportsChan};
 use profile_traits::time::{self as profile_time};
-use script_traits::{Painter, ScriptMsg, ScriptThreadMessage};
+use script_traits::{Painter, ScriptThreadMessage, ScriptToConstellationMessage};
 use stylo_atoms::Atom;
 use timers::TimerScheduler;
 #[cfg(feature = "webgpu")]
@@ -315,7 +315,8 @@ pub(crate) struct ScriptThreadSenders {
     /// A [`Sender`] that sends messages to the `Constellation` associated with
     /// particular pipelines.
     #[no_trace]
-    pub(crate) pipeline_to_constellation_sender: IpcSender<(PipelineId, ScriptMsg)>,
+    pub(crate) pipeline_to_constellation_sender:
+        IpcSender<(PipelineId, ScriptToConstellationMessage)>,
 
     /// The shared [`IpcSender`] which is sent to the `ImageCache` when requesting an image. The
     /// messages on this channel are routed to crossbeam [`Sender`] on the router thread, which

--- a/components/servo/proxies.rs
+++ b/components/servo/proxies.rs
@@ -5,18 +5,18 @@
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use constellation_traits::ConstellationMsg;
+use constellation_traits::EmbedderToConstellationMessage;
 use crossbeam_channel::{SendError, Sender};
 use log::warn;
 
 #[derive(Clone)]
 pub(crate) struct ConstellationProxy {
-    sender: Sender<ConstellationMsg>,
+    sender: Sender<EmbedderToConstellationMessage>,
     disconnected: Arc<AtomicBool>,
 }
 
 impl ConstellationProxy {
-    pub fn new(sender: Sender<ConstellationMsg>) -> Self {
+    pub fn new(sender: Sender<EmbedderToConstellationMessage>) -> Self {
         Self {
             sender,
             disconnected: Arc::default(),
@@ -27,13 +27,16 @@ impl ConstellationProxy {
         self.disconnected.load(Ordering::SeqCst)
     }
 
-    pub fn send(&self, msg: ConstellationMsg) {
+    pub fn send(&self, msg: EmbedderToConstellationMessage) {
         if self.try_send(msg).is_err() {
             warn!("Lost connection to Constellation. Will report to embedder.")
         }
     }
 
-    fn try_send(&self, msg: ConstellationMsg) -> Result<(), SendError<ConstellationMsg>> {
+    fn try_send(
+        &self,
+        msg: EmbedderToConstellationMessage,
+    ) -> Result<(), SendError<EmbedderToConstellationMessage>> {
         if self.disconnected() {
             return Err(SendError(msg));
         }
@@ -45,7 +48,7 @@ impl ConstellationProxy {
         Ok(())
     }
 
-    pub fn sender(&self) -> Sender<ConstellationMsg> {
+    pub fn sender(&self) -> Sender<EmbedderToConstellationMessage> {
         self.sender.clone()
     }
 }

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 use base::id::WebViewId;
 use compositing::IOCompositor;
 use compositing::windowing::WebRenderDebugOption;
-use constellation_traits::{ConstellationMsg, TraversalDirection};
+use constellation_traits::{EmbedderToConstellationMessage, TraversalDirection};
 use dpi::PhysicalSize;
 use embedder_traits::{
     Cursor, InputEvent, LoadStatus, MediaSessionActionType, ScreenGeometry, Theme, TouchEventType,
@@ -87,7 +87,7 @@ pub(crate) struct WebViewInner {
 impl Drop for WebViewInner {
     fn drop(&mut self) {
         self.constellation_proxy
-            .send(ConstellationMsg::CloseWebView(self.id));
+            .send(EmbedderToConstellationMessage::CloseWebView(self.id));
     }
 }
 
@@ -256,13 +256,13 @@ impl WebView {
     pub fn focus(&self) {
         self.inner()
             .constellation_proxy
-            .send(ConstellationMsg::FocusWebView(self.id()));
+            .send(EmbedderToConstellationMessage::FocusWebView(self.id()));
     }
 
     pub fn blur(&self) {
         self.inner()
             .constellation_proxy
-            .send(ConstellationMsg::BlurWebView);
+            .send(EmbedderToConstellationMessage::BlurWebView);
     }
 
     pub fn rect(&self) -> DeviceRect {
@@ -308,25 +308,28 @@ impl WebView {
     pub fn notify_theme_change(&self, theme: Theme) {
         self.inner()
             .constellation_proxy
-            .send(ConstellationMsg::ThemeChange(theme))
+            .send(EmbedderToConstellationMessage::ThemeChange(theme))
     }
 
     pub fn load(&self, url: Url) {
         self.inner()
             .constellation_proxy
-            .send(ConstellationMsg::LoadUrl(self.id(), url.into()))
+            .send(EmbedderToConstellationMessage::LoadUrl(
+                self.id(),
+                url.into(),
+            ))
     }
 
     pub fn reload(&self) {
         self.inner()
             .constellation_proxy
-            .send(ConstellationMsg::Reload(self.id()))
+            .send(EmbedderToConstellationMessage::Reload(self.id()))
     }
 
     pub fn go_back(&self, amount: usize) {
         self.inner()
             .constellation_proxy
-            .send(ConstellationMsg::TraverseHistory(
+            .send(EmbedderToConstellationMessage::TraverseHistory(
                 self.id(),
                 TraversalDirection::Back(amount),
             ))
@@ -335,7 +338,7 @@ impl WebView {
     pub fn go_forward(&self, amount: usize) {
         self.inner()
             .constellation_proxy
-            .send(ConstellationMsg::TraverseHistory(
+            .send(EmbedderToConstellationMessage::TraverseHistory(
                 self.id(),
                 TraversalDirection::Forward(amount),
             ))
@@ -367,7 +370,7 @@ impl WebView {
 
         self.inner()
             .constellation_proxy
-            .send(ConstellationMsg::ForwardInputEvent(
+            .send(EmbedderToConstellationMessage::ForwardInputEvent(
                 self.id(),
                 event,
                 None, /* hit_test */
@@ -377,7 +380,7 @@ impl WebView {
     pub fn notify_media_session_action_event(&self, event: MediaSessionActionType) {
         self.inner()
             .constellation_proxy
-            .send(ConstellationMsg::MediaSessionAction(event));
+            .send(EmbedderToConstellationMessage::MediaSessionAction(event));
     }
 
     pub fn notify_vsync(&self) {
@@ -415,13 +418,16 @@ impl WebView {
     pub fn exit_fullscreen(&self) {
         self.inner()
             .constellation_proxy
-            .send(ConstellationMsg::ExitFullScreen(self.id()));
+            .send(EmbedderToConstellationMessage::ExitFullScreen(self.id()));
     }
 
     pub fn set_throttled(&self, throttled: bool) {
         self.inner()
             .constellation_proxy
-            .send(ConstellationMsg::SetWebViewThrottled(self.id(), throttled));
+            .send(EmbedderToConstellationMessage::SetWebViewThrottled(
+                self.id(),
+                throttled,
+            ));
     }
 
     pub fn toggle_webrender_debugging(&self, debugging: WebRenderDebugOption) {
@@ -438,13 +444,19 @@ impl WebView {
     pub fn toggle_sampling_profiler(&self, rate: Duration, max_duration: Duration) {
         self.inner()
             .constellation_proxy
-            .send(ConstellationMsg::ToggleProfiler(rate, max_duration));
+            .send(EmbedderToConstellationMessage::ToggleProfiler(
+                rate,
+                max_duration,
+            ));
     }
 
     pub fn send_error(&self, message: String) {
         self.inner()
             .constellation_proxy
-            .send(ConstellationMsg::SendError(Some(self.id()), message));
+            .send(EmbedderToConstellationMessage::SendError(
+                Some(self.id()),
+                message,
+            ));
     }
 
     /// Paint the contents of this [`WebView`] into its `RenderingContext`. This will

--- a/components/servo/webview_delegate.rs
+++ b/components/servo/webview_delegate.rs
@@ -5,7 +5,7 @@
 use std::path::PathBuf;
 
 use base::id::PipelineId;
-use constellation_traits::ConstellationMsg;
+use constellation_traits::EmbedderToConstellationMessage;
 use embedder_traits::{
     AllowOrDeny, AuthenticationResponse, ContextMenuResult, Cursor, FilterPattern,
     GamepadHapticEffectType, InputMethodType, LoadStatus, MediaSessionEvent, Notification,
@@ -33,7 +33,7 @@ pub struct NavigationRequest {
 impl NavigationRequest {
     pub fn allow(mut self) {
         self.constellation_proxy
-            .send(ConstellationMsg::AllowNavigationResponse(
+            .send(EmbedderToConstellationMessage::AllowNavigationResponse(
                 self.pipeline_id,
                 true,
             ));
@@ -42,7 +42,7 @@ impl NavigationRequest {
 
     pub fn deny(mut self) {
         self.constellation_proxy
-            .send(ConstellationMsg::AllowNavigationResponse(
+            .send(EmbedderToConstellationMessage::AllowNavigationResponse(
                 self.pipeline_id,
                 false,
             ));
@@ -54,7 +54,7 @@ impl Drop for NavigationRequest {
     fn drop(&mut self) {
         if !self.response_sent {
             self.constellation_proxy
-                .send(ConstellationMsg::AllowNavigationResponse(
+                .send(EmbedderToConstellationMessage::AllowNavigationResponse(
                     self.pipeline_id,
                     true,
                 ));

--- a/components/shared/constellation/lib.rs
+++ b/components/shared/constellation/lib.rs
@@ -30,9 +30,10 @@ use strum_macros::IntoStaticStr;
 use webrender_api::ExternalScrollId;
 use webrender_api::units::LayoutPixel;
 
-/// Messages to the constellation.
+/// Messages to the Constellation from the embedding layer, whether from `ServoRenderer` or
+/// from `libservo` itself.
 #[derive(IntoStaticStr)]
-pub enum ConstellationMsg {
+pub enum EmbedderToConstellationMessage {
     /// Exit the constellation.
     Exit,
     /// Request that the constellation send the current focused top-level browsing context id,
@@ -96,7 +97,7 @@ pub enum PaintMetricEvent {
     FirstContentfulPaint(CrossProcessInstant, bool /* first_reflow */),
 }
 
-impl fmt::Debug for ConstellationMsg {
+impl fmt::Debug for EmbedderToConstellationMessage {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         let variant_string: &'static str = self.into();
         write!(formatter, "ConstellationMsg::{variant_string}")

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -62,7 +62,8 @@ use webrender_traits::CrossProcessCompositorApi;
 
 pub use crate::script_msg::{
     DOMMessage, IFrameSizeMsg, Job, JobError, JobResult, JobResultValue, JobType, SWManagerMsg,
-    SWManagerSenders, ScopeThings, ScriptMsg, ServiceWorkerMsg, TouchEventResult,
+    SWManagerSenders, ScopeThings, ScriptToConstellationMessage, ServiceWorkerMsg,
+    TouchEventResult,
 };
 use crate::serializable::{BlobImpl, DomPoint};
 use crate::transferable::MessagePortImpl;
@@ -634,14 +635,14 @@ pub struct DrawAPaintImageResult {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ScriptToConstellationChan {
     /// Sender for communicating with constellation thread.
-    pub sender: IpcSender<(PipelineId, ScriptMsg)>,
+    pub sender: IpcSender<(PipelineId, ScriptToConstellationMessage)>,
     /// Used to identify the origin of the message.
     pub pipeline_id: PipelineId,
 }
 
 impl ScriptToConstellationChan {
     /// Send ScriptMsg and attach the pipeline_id to the message.
-    pub fn send(&self, msg: ScriptMsg) -> Result<(), IpcError> {
+    pub fn send(&self, msg: ScriptToConstellationMessage) -> Result<(), IpcError> {
         self.sender.send((self.pipeline_id, msg))
     }
 }

--- a/components/shared/script/script_msg.rs
+++ b/components/shared/script/script_msg.rs
@@ -54,9 +54,9 @@ pub enum TouchEventResult {
     DefaultPrevented(TouchSequenceId, TouchEventType),
 }
 
-/// Messages from the script to the constellation.
+/// Messages sent from the `ScriptThread` to the `Constellation`.
 #[derive(Deserialize, IntoStaticStr, Serialize)]
-pub enum ScriptMsg {
+pub enum ScriptToConstellationMessage {
     /// Request to complete the transfer of a set of ports to a router.
     CompleteMessagePortTransfer(MessagePortRouterId, Vec<MessagePortId>),
     /// The results of attempting to complete the transfer of a batch of ports.
@@ -219,7 +219,7 @@ pub enum ScriptMsg {
     ReportMemory(IpcSender<MemoryReportResult>),
 }
 
-impl fmt::Debug for ScriptMsg {
+impl fmt::Debug for ScriptToConstellationMessage {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         let variant_string: &'static str = self.into();
         write!(formatter, "ScriptMsg::{variant_string}")

--- a/components/webdriver_server/actions.rs
+++ b/components/webdriver_server/actions.rs
@@ -6,7 +6,7 @@ use std::collections::HashSet;
 use std::time::{Duration, Instant};
 use std::{cmp, thread};
 
-use constellation_traits::ConstellationMsg;
+use constellation_traits::EmbedderToConstellationMessage;
 use embedder_traits::{MouseButtonAction, WebDriverCommandMsg, WebDriverScriptCommand};
 use ipc_channel::ipc;
 use keyboard_types::webdriver::KeyInputState;
@@ -206,7 +206,7 @@ impl Handler {
         let cmd_msg =
             WebDriverCommandMsg::KeyboardAction(session.browsing_context_id, keyboard_event);
         self.constellation_chan
-            .send(ConstellationMsg::WebDriverCommand(cmd_msg))
+            .send(EmbedderToConstellationMessage::WebDriverCommand(cmd_msg))
             .unwrap();
     }
 
@@ -234,7 +234,7 @@ impl Handler {
             let cmd_msg =
                 WebDriverCommandMsg::KeyboardAction(session.browsing_context_id, keyboard_event);
             self.constellation_chan
-                .send(ConstellationMsg::WebDriverCommand(cmd_msg))
+                .send(EmbedderToConstellationMessage::WebDriverCommand(cmd_msg))
                 .unwrap();
         }
     }
@@ -286,7 +286,7 @@ impl Handler {
             pointer_input_state.y as f32,
         );
         self.constellation_chan
-            .send(ConstellationMsg::WebDriverCommand(cmd_msg))
+            .send(EmbedderToConstellationMessage::WebDriverCommand(cmd_msg))
             .unwrap();
     }
 
@@ -333,7 +333,7 @@ impl Handler {
             pointer_input_state.y as f32,
         );
         self.constellation_chan
-            .send(ConstellationMsg::WebDriverCommand(cmd_msg))
+            .send(EmbedderToConstellationMessage::WebDriverCommand(cmd_msg))
             .unwrap();
     }
 
@@ -388,7 +388,7 @@ impl Handler {
         let cmd_msg =
             WebDriverCommandMsg::GetWindowSize(self.session.as_ref().unwrap().webview_id, sender);
         self.constellation_chan
-            .send(ConstellationMsg::WebDriverCommand(cmd_msg))
+            .send(EmbedderToConstellationMessage::WebDriverCommand(cmd_msg))
             .unwrap();
 
         // Steps 7 - 8
@@ -468,7 +468,7 @@ impl Handler {
                 let cmd_msg =
                     WebDriverCommandMsg::MouseMoveAction(session.webview_id, x as f32, y as f32);
                 self.constellation_chan
-                    .send(ConstellationMsg::WebDriverCommand(cmd_msg))
+                    .send(EmbedderToConstellationMessage::WebDriverCommand(cmd_msg))
                     .unwrap();
                 // Step 7.3
                 pointer_input_state.x = x;

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -19,7 +19,7 @@ use std::{env, fmt, mem, process, thread};
 use base::id::{BrowsingContextId, WebViewId};
 use base64::Engine;
 use capabilities::ServoCapabilities;
-use constellation_traits::{ConstellationMsg, TraversalDirection};
+use constellation_traits::{EmbedderToConstellationMessage, TraversalDirection};
 use cookie::{CookieBuilder, Expiration};
 use crossbeam_channel::{Receiver, Sender, after, select, unbounded};
 use embedder_traits::{
@@ -100,7 +100,7 @@ fn cookie_msg_to_cookie(cookie: cookie::Cookie) -> Cookie {
     }
 }
 
-pub fn start_server(port: u16, constellation_chan: Sender<ConstellationMsg>) {
+pub fn start_server(port: u16, constellation_chan: Sender<EmbedderToConstellationMessage>) {
     let handler = Handler::new(constellation_chan);
     thread::Builder::new()
         .name("WebDriverHttpServer".to_owned())
@@ -188,7 +188,7 @@ struct Handler {
     /// will be forwarded to the load_status_receiver.
     load_status_sender: IpcSender<WebDriverLoadStatus>,
     session: Option<WebDriverSession>,
-    constellation_chan: Sender<ConstellationMsg>,
+    constellation_chan: Sender<EmbedderToConstellationMessage>,
     resize_timeout: u32,
 }
 
@@ -400,7 +400,7 @@ impl<'de> Visitor<'de> for TupleVecMapVisitor {
 }
 
 impl Handler {
-    pub fn new(constellation_chan: Sender<ConstellationMsg>) -> Handler {
+    pub fn new(constellation_chan: Sender<EmbedderToConstellationMessage>) -> Handler {
         // Create a pair of both an IPC and a threaded channel,
         // keep the IPC sender to clone and pass to the constellation for each load,
         // and keep a threaded receiver to block on an incoming load-status.
@@ -425,7 +425,8 @@ impl Handler {
         let (sender, receiver) = ipc::channel().unwrap();
 
         for _ in 0..iterations {
-            let msg = ConstellationMsg::GetFocusTopLevelBrowsingContext(sender.clone());
+            let msg =
+                EmbedderToConstellationMessage::GetFocusTopLevelBrowsingContext(sender.clone());
             self.constellation_chan.send(msg).unwrap();
             // Wait until the document is ready before returning the top-level browsing context id.
             if let Some(x) = receiver.recv().unwrap() {
@@ -622,20 +623,18 @@ impl Handler {
         cmd_msg: WebDriverScriptCommand,
     ) -> WebDriverResult<()> {
         let browsing_context_id = self.session()?.browsing_context_id;
-        let msg = ConstellationMsg::WebDriverCommand(WebDriverCommandMsg::ScriptCommand(
-            browsing_context_id,
-            cmd_msg,
-        ));
+        let msg = EmbedderToConstellationMessage::WebDriverCommand(
+            WebDriverCommandMsg::ScriptCommand(browsing_context_id, cmd_msg),
+        );
         self.constellation_chan.send(msg).unwrap();
         Ok(())
     }
 
     fn top_level_script_command(&self, cmd_msg: WebDriverScriptCommand) -> WebDriverResult<()> {
         let browsing_context_id = BrowsingContextId::from(self.session()?.webview_id);
-        let msg = ConstellationMsg::WebDriverCommand(WebDriverCommandMsg::ScriptCommand(
-            browsing_context_id,
-            cmd_msg,
-        ));
+        let msg = EmbedderToConstellationMessage::WebDriverCommand(
+            WebDriverCommandMsg::ScriptCommand(browsing_context_id, cmd_msg),
+        );
         self.constellation_chan.send(msg).unwrap();
         Ok(())
     }
@@ -656,7 +655,7 @@ impl Handler {
         let cmd_msg =
             WebDriverCommandMsg::LoadUrl(webview_id, url, self.load_status_sender.clone());
         self.constellation_chan
-            .send(ConstellationMsg::WebDriverCommand(cmd_msg))
+            .send(EmbedderToConstellationMessage::WebDriverCommand(cmd_msg))
             .unwrap();
 
         self.wait_for_load()
@@ -692,7 +691,7 @@ impl Handler {
         let cmd_msg = WebDriverCommandMsg::GetWindowSize(webview_id, sender);
 
         self.constellation_chan
-            .send(ConstellationMsg::WebDriverCommand(cmd_msg))
+            .send(EmbedderToConstellationMessage::WebDriverCommand(cmd_msg))
             .unwrap();
 
         let window_size = receiver.recv().unwrap();
@@ -724,7 +723,7 @@ impl Handler {
         let cmd_msg = WebDriverCommandMsg::SetWindowSize(webview_id, size.to_i32(), sender.clone());
 
         self.constellation_chan
-            .send(ConstellationMsg::WebDriverCommand(cmd_msg))
+            .send(EmbedderToConstellationMessage::WebDriverCommand(cmd_msg))
             .unwrap();
 
         let timeout = self.resize_timeout;
@@ -735,7 +734,7 @@ impl Handler {
             thread::sleep(Duration::from_millis(timeout as u64));
             let cmd_msg = WebDriverCommandMsg::GetWindowSize(webview_id, sender);
             constellation_chan
-                .send(ConstellationMsg::WebDriverCommand(cmd_msg))
+                .send(EmbedderToConstellationMessage::WebDriverCommand(cmd_msg))
                 .unwrap();
         });
 
@@ -784,7 +783,7 @@ impl Handler {
     fn handle_go_back(&self) -> WebDriverResult<WebDriverResponse> {
         let webview_id = self.session()?.webview_id;
         let direction = TraversalDirection::Back(1);
-        let msg = ConstellationMsg::TraverseHistory(webview_id, direction);
+        let msg = EmbedderToConstellationMessage::TraverseHistory(webview_id, direction);
         self.constellation_chan.send(msg).unwrap();
         Ok(WebDriverResponse::Void)
     }
@@ -792,7 +791,7 @@ impl Handler {
     fn handle_go_forward(&self) -> WebDriverResult<WebDriverResponse> {
         let webview_id = self.session()?.webview_id;
         let direction = TraversalDirection::Forward(1);
-        let msg = ConstellationMsg::TraverseHistory(webview_id, direction);
+        let msg = EmbedderToConstellationMessage::TraverseHistory(webview_id, direction);
         self.constellation_chan.send(msg).unwrap();
         Ok(WebDriverResponse::Void)
     }
@@ -802,7 +801,7 @@ impl Handler {
 
         let cmd_msg = WebDriverCommandMsg::Refresh(webview_id, self.load_status_sender.clone());
         self.constellation_chan
-            .send(ConstellationMsg::WebDriverCommand(cmd_msg))
+            .send(EmbedderToConstellationMessage::WebDriverCommand(cmd_msg))
             .unwrap();
 
         self.wait_for_load()
@@ -892,7 +891,7 @@ impl Handler {
             session.window_handles.remove(&session.webview_id);
             let cmd_msg = WebDriverCommandMsg::CloseWebView(session.webview_id);
             self.constellation_chan
-                .send(ConstellationMsg::WebDriverCommand(cmd_msg))
+                .send(EmbedderToConstellationMessage::WebDriverCommand(cmd_msg))
                 .unwrap();
         }
 
@@ -919,7 +918,7 @@ impl Handler {
             self.load_status_sender.clone(),
         );
         self.constellation_chan
-            .send(ConstellationMsg::WebDriverCommand(cmd_msg))
+            .send(EmbedderToConstellationMessage::WebDriverCommand(cmd_msg))
             .unwrap();
 
         let mut handle = self.session.as_ref().unwrap().id.to_string();
@@ -980,7 +979,7 @@ impl Handler {
             session.webview_id = webview_id;
             session.browsing_context_id = BrowsingContextId::from(webview_id);
 
-            let msg = ConstellationMsg::FocusWebView(webview_id);
+            let msg = EmbedderToConstellationMessage::FocusWebView(webview_id);
             self.constellation_chan.send(msg).unwrap();
             Ok(WebDriverResponse::Void)
         } else {
@@ -1558,7 +1557,7 @@ impl Handler {
         let cmd = WebDriverScriptCommand::FocusElement(element.to_string(), sender);
         let cmd_msg = WebDriverCommandMsg::ScriptCommand(browsing_context_id, cmd);
         self.constellation_chan
-            .send(ConstellationMsg::WebDriverCommand(cmd_msg))
+            .send(EmbedderToConstellationMessage::WebDriverCommand(cmd_msg))
             .unwrap();
 
         // TODO: distinguish the not found and not focusable cases
@@ -1574,7 +1573,7 @@ impl Handler {
         // so the constellation may have changed state between them.
         let cmd_msg = WebDriverCommandMsg::SendKeys(browsing_context_id, input_events);
         self.constellation_chan
-            .send(ConstellationMsg::WebDriverCommand(cmd_msg))
+            .send(EmbedderToConstellationMessage::WebDriverCommand(cmd_msg))
             .unwrap();
 
         Ok(WebDriverResponse::Void)
@@ -1658,7 +1657,7 @@ impl Handler {
             let cmd_msg =
                 WebDriverCommandMsg::TakeScreenshot(self.session()?.webview_id, rect, sender);
             self.constellation_chan
-                .send(ConstellationMsg::WebDriverCommand(cmd_msg))
+                .send(EmbedderToConstellationMessage::WebDriverCommand(cmd_msg))
                 .unwrap();
 
             if let Some(x) = receiver.recv().unwrap() {

--- a/ports/servoshell/lib.rs
+++ b/ports/servoshell/lib.rs
@@ -88,7 +88,7 @@ pub fn init_tracing(filter_directives: Option<&str>) {
         let subscriber = subscriber.with(filter);
 
         // Same as SubscriberInitExt::init, but avoids initialising the tracing-log compat layer,
-        // since it would break Servo’s FromScriptLogger and FromCompositorLogger.
+        // since it would break Servo’s FromScriptLogger and FromEmbederLogger.
         // <https://docs.rs/tracing-subscriber/0.3.18/tracing_subscriber/util/trait.SubscriberInitExt.html#method.init>
         // <https://docs.rs/tracing/0.1.40/tracing/#consuming-log-records>
         tracing::subscriber::set_global_default(subscriber)


### PR DESCRIPTION
Messages that are sent to the `Constellation` have pretty ambiguous names.
This change does two renames:

- `ConstellationMsg` → `EmbedderToConstellationMessage`
- `ScriptMsg` → `ScriptToConstellationMessage`

This naming reflects that the `Constellation` stands in between the
embedding layer and the script layer and can receive messages from both.
Soon both of these message types will live in `constellation_traits`,
reflecting the idea that the `_traits` variant for a crate is
responsible for exposing the API for that crate.

Testing: No new tests are necessary here as this just renames two enums.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>
