### PR TITLE
script: Remove code dealing with `CompositorUntrustedNode`

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -1309,7 +1309,7 @@ impl Document {
             event.action, hit_test_result.point_in_viewport
         );
 
-        let node = unsafe { node::from_untrusted_compositor_node_address(hit_test_result.node) };
+        let node = unsafe { node::from_untrusted_node_address(hit_test_result.node) };
         let Some(el) = node
             .inclusive_ancestors(ShadowIncluding::Yes)
             .filter_map(DomRoot::downcast::<Element>)
@@ -1774,7 +1774,7 @@ impl Document {
             return;
         };
 
-        let node = unsafe { node::from_untrusted_compositor_node_address(hit_test_result.node) };
+        let node = unsafe { node::from_untrusted_node_address(hit_test_result.node) };
         let Some(new_target) = node
             .inclusive_ancestors(ShadowIncluding::No)
             .filter_map(DomRoot::downcast::<Element>)
@@ -1952,7 +1952,7 @@ impl Document {
             return;
         };
 
-        let node = unsafe { node::from_untrusted_compositor_node_address(hit_test_result.node) };
+        let node = unsafe { node::from_untrusted_node_address(hit_test_result.node) };
         let Some(el) = node
             .inclusive_ancestors(ShadowIncluding::No)
             .filter_map(DomRoot::downcast::<Element>)
@@ -2012,7 +2012,7 @@ impl Document {
             TouchEventType::Cancel => "touchcancel",
         };
 
-        let node = unsafe { node::from_untrusted_compositor_node_address(hit_test_result.node) };
+        let node = unsafe { node::from_untrusted_node_address(hit_test_result.node) };
         let Some(el) = node
             .inclusive_ancestors(ShadowIncluding::No)
             .filter_map(DomRoot::downcast::<Element>)

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -16,9 +16,7 @@ use std::{cmp, fmt, iter};
 use app_units::Au;
 use base::id::{BrowsingContextId, PipelineId};
 use bitflags::bitflags;
-use constellation_traits::{
-    UntrustedNodeAddress, UntrustedNodeAddress as CompositorUntrustedNodeAddress,
-};
+use constellation_traits::UntrustedNodeAddress;
 use devtools_traits::NodeInfo;
 use dom_struct::dom_struct;
 use euclid::default::{Rect, Size2D, Vector2D};
@@ -1513,15 +1511,6 @@ pub(crate) unsafe fn from_untrusted_node_address(candidate: UntrustedNodeAddress
     DomRoot::from_ref(Node::from_untrusted_node_address(candidate))
 }
 
-/// If the given untrusted node address represents a valid DOM node in the given runtime,
-/// returns it.
-#[allow(unsafe_code)]
-pub(crate) unsafe fn from_untrusted_compositor_node_address(
-    candidate: CompositorUntrustedNodeAddress,
-) -> DomRoot<Node> {
-    DomRoot::from_ref(Node::from_untrusted_compositor_node_address(candidate))
-}
-
 #[allow(unsafe_code)]
 pub(crate) trait LayoutNodeHelpers<'dom> {
     fn type_id_for_layout(self) -> NodeTypeId;
@@ -2860,26 +2849,6 @@ impl Node {
     #[allow(unsafe_code)]
     pub(crate) unsafe fn from_untrusted_node_address(
         candidate: UntrustedNodeAddress,
-    ) -> &'static Self {
-        // https://github.com/servo/servo/issues/6383
-        let candidate = candidate.0 as usize;
-        let object = candidate as *mut JSObject;
-        if object.is_null() {
-            panic!("Attempted to create a `Node` from an invalid pointer!")
-        }
-        &*(conversions::private_from_object(object) as *const Self)
-    }
-
-    /// If the given untrusted node address represents a valid DOM node in the given runtime,
-    /// returns it.
-    ///
-    /// # Safety
-    ///
-    /// Callers should ensure they pass a [`CompositorUntrustedNodeAddress`] that points
-    /// to a valid [`JSObject`] in memory that represents a [`Node`].
-    #[allow(unsafe_code)]
-    pub(crate) unsafe fn from_untrusted_compositor_node_address(
-        candidate: CompositorUntrustedNodeAddress,
     ) -> &'static Self {
         // https://github.com/servo/servo/issues/6383
         let candidate = candidate.0 as usize;


### PR DESCRIPTION
There used to be two kinds of untrusted nodes, but these have been
unified, so the duplicate methods dealing with them in `script` can be
removed.

Testing: This is covered by existing tests as it shouldn't change
any behavior.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>
