### PR TITLE
Enable layout_container_queries_enabled on all WPT tests

### DIFF
--- a/tests/wpt/meta/__dir__.ini
+++ b/tests/wpt/meta/__dir__.ini
@@ -8,5 +8,6 @@ prefs: [
   "dom_serviceworker_enabled:true",
   "dom_urlpattern_enabled:true",
   "dom_xpath_enabled:true",
+  "layout_container_queries_enabled:true",
   "layout_grid_enabled:true",
 ]

--- a/tests/wpt/meta/css/css-conditional/container-queries/animation-container-size.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/animation-container-size.html.ini
@@ -1,2 +1,3 @@
 [animation-container-size.html]
-  expected: ERROR
+  [Animation affects container query evaluation]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/animation-container-type-dynamic.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/animation-container-type-dynamic.html.ini
@@ -1,2 +1,3 @@
 [animation-container-type-dynamic.html]
-  expected: ERROR
+  [Animated container creating new container]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/animation-nested-animation.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/animation-nested-animation.html.ini
@@ -1,2 +1,3 @@
 [animation-nested-animation.html]
-  expected: ERROR
+  [Animated container can create inner animation]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/animation-nested-transition.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/animation-nested-transition.html.ini
@@ -1,2 +1,3 @@
 [animation-nested-transition.html]
-  expected: ERROR
+  [Animated container size triggers transition]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/aspect-ratio-feature-evaluation.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/aspect-ratio-feature-evaluation.html.ini
@@ -1,2 +1,6 @@
 [aspect-ratio-feature-evaluation.html]
-  expected: ERROR
+  [@container queries with aspect-ratio and size containment]
+    expected: FAIL
+
+  [@container query with aspect-ratio change after resize]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/at-container-parsing.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/at-container-parsing.html.ini
@@ -1,2 +1,255 @@
 [at-container-parsing.html]
-  expected: ERROR
+  [Query condition should be valid: (width)]
+    expected: FAIL
+
+  [Query condition should be valid: (min-width: 0px)]
+    expected: FAIL
+
+  [Query condition should be valid: (max-width: 0px)]
+    expected: FAIL
+
+  [Query condition should be valid: (height)]
+    expected: FAIL
+
+  [Query condition should be valid: (min-height: 0px)]
+    expected: FAIL
+
+  [Query condition should be valid: (max-height: 0px)]
+    expected: FAIL
+
+  [Query condition should be valid: (aspect-ratio)]
+    expected: FAIL
+
+  [Query condition should be valid: (min-aspect-ratio: 1/2)]
+    expected: FAIL
+
+  [Query condition should be valid: (max-aspect-ratio: 1/2)]
+    expected: FAIL
+
+  [Query condition should be valid: (orientation: portrait)]
+    expected: FAIL
+
+  [Query condition should be valid: (inline-size)]
+    expected: FAIL
+
+  [Query condition should be valid: (min-inline-size: 0px)]
+    expected: FAIL
+
+  [Query condition should be valid: (max-inline-size: 0px)]
+    expected: FAIL
+
+  [Query condition should be valid: (block-size)]
+    expected: FAIL
+
+  [Query condition should be valid: (min-block-size: 0px)]
+    expected: FAIL
+
+  [Query condition should be valid: (max-block-size: 0px)]
+    expected: FAIL
+
+  [Query condition should be valid: (width: 100px)]
+    expected: FAIL
+
+  [Query condition should be valid: ((width: 100px))]
+    expected: FAIL
+
+  [Query condition should be valid: (not (width: 100px))]
+    expected: FAIL
+
+  [Query condition should be valid: ((width: 100px) and (height: 100px))]
+    expected: FAIL
+
+  [Query condition should be valid: (((width: 40px) or (width: 50px)) and (height: 100px))]
+    expected: FAIL
+
+  [Query condition should be valid: ((width: 100px) and ((height: 40px) or (height: 50px)))]
+    expected: FAIL
+
+  [Query condition should be valid: (((width: 40px) and (height: 50px)) or (height: 100px))]
+    expected: FAIL
+
+  [Query condition should be valid: ((width: 50px) or ((width: 40px) and (height: 50px)))]
+    expected: FAIL
+
+  [Query condition should be valid: ((width: 100px) and (not (height: 100px)))]
+    expected: FAIL
+
+  [Query condition should be valid: (width < 100px)]
+    expected: FAIL
+
+  [Query condition should be valid: (width <= 100px)]
+    expected: FAIL
+
+  [Query condition should be valid: (width = 100px)]
+    expected: FAIL
+
+  [Query condition should be valid: (width > 100px)]
+    expected: FAIL
+
+  [Query condition should be valid: (width >= 100px)]
+    expected: FAIL
+
+  [Query condition should be valid: (100px < width)]
+    expected: FAIL
+
+  [Query condition should be valid: (100px <= width)]
+    expected: FAIL
+
+  [Query condition should be valid: (100px = width)]
+    expected: FAIL
+
+  [Query condition should be valid: (100px > width)]
+    expected: FAIL
+
+  [Query condition should be valid: (100px >= width)]
+    expected: FAIL
+
+  [Query condition should be valid: (100px < width < 200px)]
+    expected: FAIL
+
+  [Query condition should be valid: (100px < width <= 200px)]
+    expected: FAIL
+
+  [Query condition should be valid: (100px <= width < 200px)]
+    expected: FAIL
+
+  [Query condition should be valid: (100px > width > 200px)]
+    expected: FAIL
+
+  [Query condition should be valid: (100px > width >= 200px)]
+    expected: FAIL
+
+  [Query condition should be valid: (100px >= width > 200px)]
+    expected: FAIL
+
+  [Query condition should be valid: (width: calc(10px))]
+    expected: FAIL
+
+  [Query condition should be valid: (width: calc(10em))]
+    expected: FAIL
+
+  [Query condition should be valid: (width: calc(10px + 10em))]
+    expected: FAIL
+
+  [Query condition should be valid: (width < calc(10px + 10em))]
+    expected: FAIL
+
+  [Query condition should be valid: (width < max(10px, 10em))]
+    expected: FAIL
+
+  [Query condition should be valid: (calc(10px + 10em) < width)]
+    expected: FAIL
+
+  [Query condition should be valid: (calc(10px + 10em) < width < max(30px, 30em))]
+    expected: FAIL
+
+  [Query condition should be valid: (width: 100px) and (height: 100px)]
+    expected: FAIL
+
+  [Query condition should be valid: (width: 100px) or (height: 100px)]
+    expected: FAIL
+
+  [Query condition should be valid: not (width: 100px)]
+    expected: FAIL
+
+  [Query condition should be valid but unknown: foo(width)]
+    expected: FAIL
+
+  [Query condition should be valid but unknown: size(width)]
+    expected: FAIL
+
+  [Query condition should be valid but unknown: (asdf)]
+    expected: FAIL
+
+  [Query condition should be valid but unknown: (resolution > 100dpi)]
+    expected: FAIL
+
+  [Query condition should be valid but unknown: (resolution: 150dpi)]
+    expected: FAIL
+
+  [Query condition should be valid but unknown: (resolution: calc(2x))]
+    expected: FAIL
+
+  [Query condition should be valid but unknown: (color)]
+    expected: FAIL
+
+  [Query condition should be valid but unknown: (min-color: 1)]
+    expected: FAIL
+
+  [Query condition should be valid but unknown: (color-index >= 1)]
+    expected: FAIL
+
+  [Query condition should be valid but unknown: size(grid)]
+    expected: FAIL
+
+  [Query condition should be valid but unknown: (grid)]
+    expected: FAIL
+
+  [Query condition should be valid but unknown: (width == 100px)]
+    expected: FAIL
+
+  [Query condition should be valid but unknown: (100px == width)]
+    expected: FAIL
+
+  [Query condition should be valid but unknown: (100px = width = 200px)]
+    expected: FAIL
+
+  [Query condition should be valid but unknown: (100px < width > 200px)]
+    expected: FAIL
+
+  [Query condition should be valid but unknown: (100px <= width >= 200px)]
+    expected: FAIL
+
+  [Query condition should be valid but unknown: (100px <= width > 200px)]
+    expected: FAIL
+
+  [Query condition should be valid but unknown: (100px < width >= 200px)]
+    expected: FAIL
+
+  [Query condition should be valid but unknown: (100px : width : 200px)]
+    expected: FAIL
+
+  [@container rule should be valid: @container name not (width <= 500px) {} {}]
+    expected: FAIL
+
+  [@container rule should be valid: @container not (width <= 500px) {} {}]
+    expected: FAIL
+
+  [@container rule should be valid: @container (width: 100px), (height: 100px) {} {}]
+    expected: FAIL
+
+  [@container rule should be valid: @container (width),(height)  , (inline-size > 20px) {} {}]
+    expected: FAIL
+
+  [@container rule should be valid: @container (width), name (height) {} {}]
+    expected: FAIL
+
+  [@container rule should be valid: @container --foo {} {}]
+    expected: FAIL
+
+  [@container rule should be valid: @container container {} {}]
+    expected: FAIL
+
+  [@container rule should be valid: @container container, container2 {} {}]
+    expected: FAIL
+
+  [Container name: foo]
+    expected: FAIL
+
+  [Container name:  foo]
+    expected: FAIL
+
+  [Container name:  foo ]
+    expected: FAIL
+
+  [Container name: normal]
+    expected: FAIL
+
+  [Container name: Normal]
+    expected: FAIL
+
+  [Container name: auto]
+    expected: FAIL
+
+  [Container name: Auto]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/at-container-serialization.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/at-container-serialization.html.ini
@@ -1,2 +1,51 @@
 [at-container-serialization.html]
-  expected: ERROR
+  [Serialization of conditionText]
+    expected: FAIL
+
+  [Serialization of inner @container rule]
+    expected: FAIL
+
+  [Serialization of nested @container rule]
+    expected: FAIL
+
+  [@container conditionText serialization: (  wiDTh  )]
+    expected: FAIL
+
+  [@container conditionText serialization: (width:100px)]
+    expected: FAIL
+
+  [@container conditionText serialization: (min-width:  100px)]
+    expected: FAIL
+
+  [@container conditionText serialization: (   MAX-WIDTH:100px  )]
+    expected: FAIL
+
+  [@container conditionText serialization: (width > 100px)]
+    expected: FAIL
+
+  [@container conditionText serialization: (width < 100px)]
+    expected: FAIL
+
+  [@container conditionText serialization: (widTH >= 100px)]
+    expected: FAIL
+
+  [@container conditionText serialization: (width <= 100px)]
+    expected: FAIL
+
+  [@container conditionText serialization: (10px < width < 100px)]
+    expected: FAIL
+
+  [@container conditionText serialization: (10px <=  width  <=  100px)]
+    expected: FAIL
+
+  [@container conditionText serialization: (100px>WIDTH>10px)]
+    expected: FAIL
+
+  [@container conditionText serialization: (  100px >= width >= 10px  )]
+    expected: FAIL
+
+  [@container conditionText serialization: (calc(1em + 1px) >= width >= max(10em, 10px))]
+    expected: FAIL
+
+  [@container conditionText serialization: (width),(height) ,--foo ,--bar]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/auto-scrollbars.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/auto-scrollbars.html.ini
@@ -1,2 +1,0 @@
-[auto-scrollbars.html]
-  expected: ERROR

--- a/tests/wpt/meta/css/css-conditional/container-queries/backdrop-invalidation.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/backdrop-invalidation.html.ini
@@ -1,2 +1,3 @@
 [backdrop-invalidation.html]
-  expected: ERROR
+  [Pseudo-element ::backdrop responds to container size changes]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/calc-evaluation.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/calc-evaluation.html.ini
@@ -1,2 +1,3 @@
 [calc-evaluation.html]
-  expected: ERROR
+  [em relative inline-size]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/canvas-as-container-005.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/canvas-as-container-005.html.ini
@@ -1,2 +1,3 @@
 [canvas-as-container-005.html]
-  expected: ERROR
+  [Initially display:none, not focusable]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/canvas-as-container-006.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/canvas-as-container-006.html.ini
@@ -1,2 +1,3 @@
 [canvas-as-container-006.html]
-  expected: ERROR
+  [Initially display:none, not focusable]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/chrome-legacy-skip-recalc.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/chrome-legacy-skip-recalc.html.ini
@@ -1,2 +1,0 @@
-[chrome-legacy-skip-recalc.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/column-spanner-in-container.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/column-spanner-in-container.html.ini
@@ -1,2 +1,3 @@
 [column-spanner-in-container.html]
-  expected: ERROR
+  [Reducing #multicol width means #spanner no longer gets column-span:all]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/conditional-container-status.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/conditional-container-status.html.ini
@@ -1,2 +1,3 @@
 [conditional-container-status.html]
-  expected: ERROR
+  [Conditionally applying container-type:initial]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/container-computed.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/container-computed.html.ini
@@ -1,2 +1,42 @@
 [container-computed.html]
-  expected: ERROR
+  [Property container value 'initial']
+    expected: FAIL
+
+  [Property container value 'inherit']
+    expected: FAIL
+
+  [Property container value 'unset']
+    expected: FAIL
+
+  [Property container value 'none / inline-size']
+    expected: FAIL
+
+  [Property container value 'none / size']
+    expected: FAIL
+
+  [Property container value 'inline-size / inline-size']
+    expected: FAIL
+
+  [Property container value 'block-size / size']
+    expected: FAIL
+
+  [Property container value 'foo / inline-size']
+    expected: FAIL
+
+  [Property container value 'foo /inline-size']
+    expected: FAIL
+
+  [Property container value 'foo/ inline-size']
+    expected: FAIL
+
+  [Property container value 'foo/inline-size']
+    expected: FAIL
+
+  [Property container value 'FoO / size']
+    expected: FAIL
+
+  [Property container value 'foo bar / size']
+    expected: FAIL
+
+  [Property container value 'foo / normal']
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/container-for-shadow-dom.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/container-for-shadow-dom.html.ini
@@ -1,2 +1,51 @@
 [container-for-shadow-dom.html]
-  expected: ERROR
+  [Match container in outer tree]
+    expected: FAIL
+
+  [Match container in walking flat tree ancestors]
+    expected: FAIL
+
+  [Match container in ::slotted selector's originating element tree]
+    expected: FAIL
+
+  [Match container in outer tree for :host]
+    expected: FAIL
+
+  [Match container in ::part selector's originating element tree]
+    expected: FAIL
+
+  [Match container for ::before in ::slotted selector's originating element tree]
+    expected: FAIL
+
+  [Match container in outer tree for :host::before]
+    expected: FAIL
+
+  [Match container for ::before in ::part selector's originating element tree]
+    expected: FAIL
+
+  [Match container for ::part selector's originating element tree for exportparts]
+    expected: FAIL
+
+  [Match container for slot light tree child fallback]
+    expected: FAIL
+
+  [Should not match container inside shadow tree for ::part()]
+    expected: FAIL
+
+  [A :host::part rule should match containers in the originating element tree]
+    expected: FAIL
+
+  [Container name set inside a shadow tree should not match query using ::part on the outside]
+    expected: FAIL
+
+  [Container name set with a ::part should match query inside the shadow tree]
+    expected: FAIL
+
+  [Container name set inside a shadow tree should match query for a ::slotted() rule inside the tree]
+    expected: FAIL
+
+  [Container name set on :host from inside a shadow tree matching query inside the shadow tree]
+    expected: FAIL
+
+  [Container name set on :host from inside a shadow tree matching query for ::slotted inside the shadow tree]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/container-inheritance.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/container-inheritance.html.ini
@@ -1,2 +1,0 @@
-[container-inheritance.html]
-  expected: ERROR

--- a/tests/wpt/meta/css/css-conditional/container-queries/container-inner-at-rules.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/container-inner-at-rules.html.ini
@@ -1,2 +1,18 @@
 [container-inner-at-rules.html]
-  expected: ERROR
+  [@keyframes is defined regardless of evaluation]
+    expected: FAIL
+
+  [@property is defined regardless of evaluation]
+    expected: FAIL
+
+  [@layer order respected regardless of evaluation]
+    expected: FAIL
+
+  [@font-face is defined regardless of evaluation]
+    expected: FAIL
+
+  [@media works inside @container]
+    expected: FAIL
+
+  [@supports works inside @container]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/container-inside-multicol-with-table.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/container-inside-multicol-with-table.html.ini
@@ -1,2 +1,6 @@
 [container-inside-multicol-with-table.html]
-  expected: ERROR
+  [Matching size container inside table inside multicol]
+    expected: FAIL
+
+  [Matching size container inside multicol with table sibling]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/container-longhand-animation-type.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/container-longhand-animation-type.html.ini
@@ -1,2 +1,3 @@
 [container-longhand-animation-type.html]
-  expected: ERROR
+  [Reference variable is applied]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/container-name-computed.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/container-name-computed.html.ini
@@ -1,2 +1,0 @@
-[container-name-computed.html]
-  expected: ERROR

--- a/tests/wpt/meta/css/css-conditional/container-queries/container-name-invalidation.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/container-name-invalidation.html.ini
@@ -1,2 +1,6 @@
 [container-name-invalidation.html]
-  expected: ERROR
+  [Changing a named container invalidates relevant descendants]
+    expected: FAIL
+
+  [Changing container-name invalidates relevant descendants]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/container-name-parsing.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/container-name-parsing.html.ini
@@ -1,2 +1,0 @@
-[container-name-parsing.html]
-  expected: ERROR

--- a/tests/wpt/meta/css/css-conditional/container-queries/container-name-tree-scoped.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/container-name-tree-scoped.html.ini
@@ -1,2 +1,6 @@
 [container-name-tree-scoped.html]
-  expected: ERROR
+  [Inner scope query should match container-name set by :host rule in shadow tree]
+    expected: FAIL
+
+  [Inner scope query containing ::slotted should match container-name set by :host rule in shadow tree]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/container-nested.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/container-nested.html.ini
@@ -1,2 +1,27 @@
 [container-nested.html]
-  expected: ERROR
+  [Implicit]
+    expected: FAIL
+
+  [Outer named, inner named]
+    expected: FAIL
+
+  [Outer named, inner named (reverse)]
+    expected: FAIL
+
+  [Outer named, inner implicit]
+    expected: FAIL
+
+  [Inner named, outer implicit]
+    expected: FAIL
+
+  [Inner named, outer implicit (reverse)]
+    expected: FAIL
+
+  [Three levels]
+    expected: FAIL
+
+  [Named inner invalidation]
+    expected: FAIL
+
+  [Implicit outer invalidation]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/container-parsing.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/container-parsing.html.ini
@@ -1,2 +1,63 @@
 [container-parsing.html]
-  expected: ERROR
+  [e.style['container'\] = "initial" should set the property value]
+    expected: FAIL
+
+  [e.style['container'\] = "inherit" should set the property value]
+    expected: FAIL
+
+  [e.style['container'\] = "unset" should set the property value]
+    expected: FAIL
+
+  [e.style['container'\] = "revert" should set the property value]
+    expected: FAIL
+
+  [e.style['container'\] = "none" should set the property value]
+    expected: FAIL
+
+  [e.style['container'\] = "none / normal" should set the property value]
+    expected: FAIL
+
+  [e.style['container'\] = "inline-size" should set the property value]
+    expected: FAIL
+
+  [e.style['container'\] = "none / inline-size" should set the property value]
+    expected: FAIL
+
+  [e.style['container'\] = "size" should set the property value]
+    expected: FAIL
+
+  [e.style['container'\] = "block-size / size" should set the property value]
+    expected: FAIL
+
+  [e.style['container'\] = "inline-size / inline-size" should set the property value]
+    expected: FAIL
+
+  [e.style['container'\] = "size / size" should set the property value]
+    expected: FAIL
+
+  [e.style['container'\] = "foo" should set the property value]
+    expected: FAIL
+
+  [e.style['container'\] = "foo / normal" should set the property value]
+    expected: FAIL
+
+  [e.style['container'\] = "foo bar / size" should set the property value]
+    expected: FAIL
+
+  [e.style['container'\] = "foo bar / normal" should set the property value]
+    expected: FAIL
+
+  [e.style['container'\] = "FOO / size" should set the property value]
+    expected: FAIL
+
+  [e.style['container'\] = "FOO/size" should set the property value]
+    expected: FAIL
+
+  [e.style['container'\] = "  FOO  /size" should set the property value]
+    expected: FAIL
+
+  [e.style['container'\] = "normal / size" should set the property value]
+    expected: FAIL
+
+  [e.style['container'\] = "auto / size" should set the property value]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/container-selection.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/container-selection.html.ini
@@ -1,2 +1,48 @@
 [container-selection.html]
-  expected: ERROR
+  [(width: 16px) for .size > .inline > span]
+    expected: FAIL
+
+  [(height: 16px) for .inline > .size > span]
+    expected: FAIL
+
+  [(width: 16px) for .inline > .size > span]
+    expected: FAIL
+
+  [(height: 32px) for .size > .inline > span]
+    expected: FAIL
+
+  [a (width: 32px) for .a-size > .b-size > span]
+    expected: FAIL
+
+  [b (width: 16px) for .a-size > .b-size > span]
+    expected: FAIL
+
+  [a (width: 16px) for .a-size > .a-size > span]
+    expected: FAIL
+
+  [a (width: 32px) for .a-size > .a > span]
+    expected: FAIL
+
+  [a (width: 32px) for .ab-size > .size > span]
+    expected: FAIL
+
+  [b (width: 32px) for .ab-size > .size > span]
+    expected: FAIL
+
+  [a (width: 8px) for .a-size > .b-size > .a-inline > span]
+    expected: FAIL
+
+  [b (width: 16px) for .a-size > .b-size > .a-inline > span]
+    expected: FAIL
+
+  [a (height: 32px) for .a-size > .b-size > .a-inline > span]
+    expected: FAIL
+
+  [a (inline-size: 8px) for .a-size > .b-size > .a-inline > span]
+    expected: FAIL
+
+  [b (inline-size: 16px) for .a-size > .b-size > .a-inline > span]
+    expected: FAIL
+
+  [a (block-size: 32px) for .a-size > .b-size > .a-inline > span]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/container-size-invalidation-after-load.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/container-size-invalidation-after-load.html.ini
@@ -1,2 +1,3 @@
 [container-size-invalidation-after-load.html]
-  expected: ERROR
+  [@container: invalidation of container size after load event]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/container-size-invalidation.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/container-size-invalidation.html.ini
@@ -1,2 +1,6 @@
 [container-size-invalidation.html]
-  expected: ERROR
+  [Children respond to changes in container size]
+    expected: FAIL
+
+  [Descendants respond to changes in container size]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/container-size-nested-invalidation.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/container-size-nested-invalidation.html.ini
@@ -1,2 +1,3 @@
 [container-size-nested-invalidation.html]
-  expected: ERROR
+  [Queries that skip a container are invalidated correctly]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/container-size-shadow-invalidation.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/container-size-shadow-invalidation.html.ini
@@ -1,2 +1,6 @@
 [container-size-shadow-invalidation.html]
-  expected: ERROR
+  [Host container child invalidated with container in shadow tree]
+    expected: FAIL
+
+  [Non-host container child invalidated with container in shadow tree]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/container-type-computed.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/container-type-computed.html.ini
@@ -1,2 +1,0 @@
-[container-type-computed.html]
-  expected: ERROR

--- a/tests/wpt/meta/css/css-conditional/container-queries/container-type-containment.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/container-type-containment.html.ini
@@ -1,2 +1,9 @@
 [container-type-containment.html]
-  expected: ERROR
+  [container-type:inline-size turns on layout containment]
+    expected: FAIL
+
+  [container-type:inline-size turns on inline-size containment]
+    expected: FAIL
+
+  [container-type:size turns on full size containment]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/container-type-invalidation.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/container-type-invalidation.html.ini
@@ -1,2 +1,3 @@
 [container-type-invalidation.html]
-  expected: ERROR
+  [Changing the container type invalidates relevant descendants]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/container-type-layout-invalidation.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/container-type-layout-invalidation.html.ini
@@ -1,2 +1,3 @@
 [container-type-layout-invalidation.html]
-  expected: ERROR
+  [Changing container-type invalidates layout]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/container-type-parsing.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/container-type-parsing.html.ini
@@ -1,2 +1,0 @@
-[container-type-parsing.html]
-  expected: ERROR

--- a/tests/wpt/meta/css/css-conditional/container-queries/container-units-animation.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/container-units-animation.html.ini
@@ -1,2 +1,36 @@
 [container-units-animation.html]
-  expected: ERROR
+  [Animation using cqw unit]
+    expected: FAIL
+
+  [Animation using cqw unit responds to changing container size]
+    expected: FAIL
+
+  [Animation using cqh unit]
+    expected: FAIL
+
+  [Animation using cqh unit responds to changing container size]
+    expected: FAIL
+
+  [Animation using cqi unit]
+    expected: FAIL
+
+  [Animation using cqi unit responds to changing container size]
+    expected: FAIL
+
+  [Animation using cqb unit]
+    expected: FAIL
+
+  [Animation using cqb unit responds to changing container size]
+    expected: FAIL
+
+  [Animation using cqmin unit]
+    expected: FAIL
+
+  [Animation using cqmin unit responds to changing container size]
+    expected: FAIL
+
+  [Animation using cqmax unit]
+    expected: FAIL
+
+  [Animation using cqmax unit responds to changing container size]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/container-units-basic.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/container-units-basic.html.ini
@@ -1,2 +1,6 @@
 [container-units-basic.html]
-  expected: ERROR
+  [Container relative units]
+    expected: FAIL
+
+  [Container relative units in math functions]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/container-units-computational-independence.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/container-units-computational-independence.html.ini
@@ -1,2 +1,18 @@
 [container-units-computational-independence.html]
-  expected: ERROR
+  [Container relative unit cqw is not computationally independent]
+    expected: FAIL
+
+  [Container relative unit cqh is not computationally independent]
+    expected: FAIL
+
+  [Container relative unit cqi is not computationally independent]
+    expected: FAIL
+
+  [Container relative unit cqb is not computationally independent]
+    expected: FAIL
+
+  [Container relative unit cqmin is not computationally independent]
+    expected: FAIL
+
+  [Container relative unit cqmax is not computationally independent]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/container-units-content-box.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/container-units-content-box.html.ini
@@ -1,2 +1,6 @@
 [container-units-content-box.html]
-  expected: ERROR
+  [Container units are relative to the content box of the container]
+    expected: FAIL
+
+  [Container units are relative to the content box of the container (box-sizing: border-box)]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/container-units-in-at-container-dynamic.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/container-units-in-at-container-dynamic.html.ini
@@ -1,2 +1,3 @@
 [container-units-in-at-container-dynamic.html]
-  expected: ERROR
+  [Query with container-relative units are responsive to changes]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/container-units-in-at-container-fallback.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/container-units-in-at-container-fallback.html.ini
@@ -1,2 +1,3 @@
 [container-units-in-at-container-fallback.html]
-  expected: ERROR
+  [Use small viewport size as fallback]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/container-units-in-at-container.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/container-units-in-at-container.html.ini
@@ -1,2 +1,54 @@
 [container-units-in-at-container.html]
-  expected: ERROR
+  [cqw unit resolves against appropriate container]
+    expected: FAIL
+
+  [cqh unit resolves against appropriate container]
+    expected: FAIL
+
+  [cqi unit resolves against appropriate container]
+    expected: FAIL
+
+  [cqb unit resolves against appropriate container]
+    expected: FAIL
+
+  [cqmin unit resolves against appropriate container]
+    expected: FAIL
+
+  [cqmax unit resolves against appropriate container]
+    expected: FAIL
+
+  [cqw unit resolves against appropriate container (vertical writing-mode on subject)]
+    expected: FAIL
+
+  [cqh unit resolves against appropriate container (vertical writing-mode on subject)]
+    expected: FAIL
+
+  [cqi unit resolves against appropriate container (vertical writing-mode on subject)]
+    expected: FAIL
+
+  [cqb unit resolves against appropriate container (vertical writing-mode on subject)]
+    expected: FAIL
+
+  [cqmin unit resolves against appropriate container (vertical writing-mode on subject)]
+    expected: FAIL
+
+  [cqmax unit resolves against appropriate container (vertical writing-mode on subject)]
+    expected: FAIL
+
+  [cqw unit resolves against appropriate container (vertical writing-mode on container)]
+    expected: FAIL
+
+  [cqh unit resolves against appropriate container (vertical writing-mode on container)]
+    expected: FAIL
+
+  [cqi unit resolves against appropriate container (vertical writing-mode on container)]
+    expected: FAIL
+
+  [cqb unit resolves against appropriate container (vertical writing-mode on container)]
+    expected: FAIL
+
+  [cqmin unit resolves against appropriate container (vertical writing-mode on container)]
+    expected: FAIL
+
+  [cqmax unit resolves against appropriate container (vertical writing-mode on container)]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/container-units-ineligible-container.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/container-units-ineligible-container.html.ini
@@ -1,2 +1,27 @@
 [container-units-ineligible-container.html]
-  expected: ERROR
+  [/* basic */]
+    expected: FAIL
+
+  [display: table]
+    expected: FAIL
+
+  [display: table-cell]
+    expected: FAIL
+
+  [display: inline]
+    expected: FAIL
+
+  [display: contents]
+    expected: FAIL
+
+  [display: none]
+    expected: FAIL
+
+  [container-type: normal]
+    expected: FAIL
+
+  [container-type: inline-size]
+    expected: FAIL
+
+  [container-type: inline-size; writing-mode: vertical-lr]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/container-units-invalidation.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/container-units-invalidation.html.ini
@@ -1,2 +1,15 @@
 [container-units-invalidation.html]
-  expected: ERROR
+  [cqi respond when selected container changes type (inline-size -> normal)]
+    expected: FAIL
+
+  [cqb respond when selected container changes type (size -> normal)]
+    expected: FAIL
+
+  [cqb respond when intermediate container changes type (inline-size -> size)]
+    expected: FAIL
+
+  [cqi respond when selected container changes inline-size]
+    expected: FAIL
+
+  [cqb respond when selected container changes block-size]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/container-units-media-queries.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/container-units-media-queries.html.ini
@@ -1,2 +1,18 @@
 [container-units-media-queries.html]
-  expected: ERROR
+  [@media(width:100cqw) applies]
+    expected: FAIL
+
+  [@media(width:100cqi) applies]
+    expected: FAIL
+
+  [@media(width:100cqmax) applies]
+    expected: FAIL
+
+  [@media(height:100cqh) applies]
+    expected: FAIL
+
+  [@media(height:100cqb) applies]
+    expected: FAIL
+
+  [@media(height:100cqmin) applies]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/container-units-selection.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/container-units-selection.html.ini
@@ -1,2 +1,6 @@
 [container-units-selection.html]
-  expected: ERROR
+  [Container units select the proper container]
+    expected: FAIL
+
+  [Units respond to the writing-mode of the element]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/container-units-shadow.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/container-units-shadow.html.ini
@@ -1,2 +1,6 @@
 [container-units-shadow.html]
-  expected: ERROR
+  [Direct slotted child queries flat tree]
+    expected: FAIL
+
+  [Nondirect slotted child queries flat tree ancestors]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/container-units-small-viewport-fallback.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/container-units-small-viewport-fallback.html.ini
@@ -1,2 +1,3 @@
 [container-units-small-viewport-fallback.html]
-  expected: ERROR
+  [Use small viewport size as fallback]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/container-units-svglength.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/container-units-svglength.html.ini
@@ -1,2 +1,22 @@
 [container-units-svglength.html]
   expected: ERROR
+  [unitType with container-relative units]
+    expected: FAIL
+
+  [cqw,cqh can be resolved]
+    expected: FAIL
+
+  [cqi,cqb can be resolved]
+    expected: FAIL
+
+  [cqmin,cqmax can be resolved]
+    expected: FAIL
+
+  [calc() with container-relative units can be resolved]
+    expected: FAIL
+
+  [Can modify value with container-relative units]
+    expected: FAIL
+
+  [CSS Container Queries Test: container-relative units in SVGLength]
+    expected: NOTRUN

--- a/tests/wpt/meta/css/css-conditional/container-queries/container-units-typed-om.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/container-units-typed-om.html.ini
@@ -1,2 +1,72 @@
 [container-units-typed-om.html]
-  expected: ERROR
+  [CSS.cqw function]
+    expected: FAIL
+
+  [Reify value with cqw unit]
+    expected: FAIL
+
+  [Set value with cqw unit (string)]
+    expected: FAIL
+
+  [Set value with cqw unit (CSS.cqw)]
+    expected: FAIL
+
+  [CSS.cqh function]
+    expected: FAIL
+
+  [Reify value with cqh unit]
+    expected: FAIL
+
+  [Set value with cqh unit (string)]
+    expected: FAIL
+
+  [Set value with cqh unit (CSS.cqh)]
+    expected: FAIL
+
+  [CSS.cqi function]
+    expected: FAIL
+
+  [Reify value with cqi unit]
+    expected: FAIL
+
+  [Set value with cqi unit (string)]
+    expected: FAIL
+
+  [Set value with cqi unit (CSS.cqi)]
+    expected: FAIL
+
+  [CSS.cqb function]
+    expected: FAIL
+
+  [Reify value with cqb unit]
+    expected: FAIL
+
+  [Set value with cqb unit (string)]
+    expected: FAIL
+
+  [Set value with cqb unit (CSS.cqb)]
+    expected: FAIL
+
+  [CSS.cqmin function]
+    expected: FAIL
+
+  [Reify value with cqmin unit]
+    expected: FAIL
+
+  [Set value with cqmin unit (string)]
+    expected: FAIL
+
+  [Set value with cqmin unit (CSS.cqmin)]
+    expected: FAIL
+
+  [CSS.cqmax function]
+    expected: FAIL
+
+  [Reify value with cqmax unit]
+    expected: FAIL
+
+  [Set value with cqmax unit (string)]
+    expected: FAIL
+
+  [Set value with cqmax unit (CSS.cqmax)]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/counters-flex-circular.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/counters-flex-circular.html.ini
@@ -1,2 +1,3 @@
 [counters-flex-circular.html]
-  expected: ERROR
+  [The container query should match the layed out width]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/display-contents.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/display-contents.html.ini
@@ -1,2 +1,6 @@
 [display-contents.html]
-  expected: ERROR
+  [getComputedStyle when container becomes display:contents]
+    expected: FAIL
+
+  [getComputedStyle when intermediate container becomes display:contents]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/display-none.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/display-none.html.ini
@@ -1,2 +1,42 @@
 [display-none.html]
-  expected: ERROR
+  [getComputedStyle when element is display:none]
+    expected: FAIL
+
+  [getComputedStyle when parent is display:none]
+    expected: FAIL
+
+  [getComputedStyle when ancestor is display:none]
+    expected: FAIL
+
+  [getComputedStyle when element in nested container is display:none]
+    expected: FAIL
+
+  [getComputedStyle when element becomes display:none]
+    expected: FAIL
+
+  [getComputedStyle when parent becomes display:none]
+    expected: FAIL
+
+  [getComputedStyle when ancestor becomes display:none]
+    expected: FAIL
+
+  [getComputedStyle when container becomes display:none]
+    expected: FAIL
+
+  [getComputedStyle when intermediate container becomes display:none]
+    expected: FAIL
+
+  [getComputedStyle when ::before is display:none]
+    expected: FAIL
+
+  [getComputedStyle when originating element is display:none]
+    expected: FAIL
+
+  [getComputedStyle on ::before when ancestor element is display:none]
+    expected: FAIL
+
+  [getComputedStyle on ::before when container is display:none]
+    expected: FAIL
+
+  [getComputedStyle when in display:none with layout dirty outer element]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/font-relative-calc-dynamic.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/font-relative-calc-dynamic.html.ini
@@ -1,2 +1,3 @@
 [font-relative-calc-dynamic.html]
-  expected: ERROR
+  [font-relative calc() is responsive to container font-size changes]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/font-relative-units-dynamic.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/font-relative-units-dynamic.html.ini
@@ -1,2 +1,36 @@
 [font-relative-units-dynamic.html]
-  expected: ERROR
+  [em units respond to changes]
+    expected: FAIL
+
+  [rem units respond to changes]
+    expected: FAIL
+
+  [ex units respond to changes]
+    expected: FAIL
+
+  [rex units respond to changes]
+    expected: FAIL
+
+  [ch units respond to changes]
+    expected: FAIL
+
+  [cap units respond to changes]
+    expected: FAIL
+
+  [rch units respond to changes]
+    expected: FAIL
+
+  [lh units respond to changes]
+    expected: FAIL
+
+  [rlh units respond to changes]
+    expected: FAIL
+
+  [ic units respond to changes]
+    expected: FAIL
+
+  [ric units respond to changes]
+    expected: FAIL
+
+  [rcap units respond to changes]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/font-relative-units.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/font-relative-units.html.ini
@@ -1,2 +1,36 @@
 [font-relative-units.html]
-  expected: ERROR
+  [em relative inline-size]
+    expected: FAIL
+
+  [rem relative inline-size]
+    expected: FAIL
+
+  [ex relative inline-size]
+    expected: FAIL
+
+  [rex relative inline-size]
+    expected: FAIL
+
+  [ch relative inline-size]
+    expected: FAIL
+
+  [rch relative inline-size]
+    expected: FAIL
+
+  [ic relative inline-size]
+    expected: FAIL
+
+  [ric relative inline-size]
+    expected: FAIL
+
+  [lh relative inline-size]
+    expected: FAIL
+
+  [rlh relative inline-size]
+    expected: FAIL
+
+  [cap relative inline-size]
+    expected: FAIL
+
+  [rcap relative inline-size]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/fragmented-container-001.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/fragmented-container-001.html.ini
@@ -1,2 +1,3 @@
 [fragmented-container-001.html]
-  expected: ERROR
+  [Children of fragmented inline-size container should match inline-size of first fragment]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/get-animations.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/get-animations.html.ini
@@ -1,2 +1,3 @@
 [get-animations.html]
-  expected: ERROR
+  [Calling getAnimations updates layout of parent frame if needed]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/grid-container.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/grid-container.html.ini
@@ -1,2 +1,3 @@
 [grid-container.html]
-  expected: ERROR
+  [Check that grid items can query grid container]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/grid-item-container.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/grid-item-container.html.ini
@@ -1,2 +1,3 @@
 [grid-item-container.html]
-  expected: ERROR
+  [Check that children can query grid item containers]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/iframe-in-container-invalidation.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/iframe-in-container-invalidation.html.ini
@@ -1,2 +1,3 @@
 [iframe-in-container-invalidation.html]
-  expected: ERROR
+  [@container-dependent elements respond to size changes of an @container-dependent iframe]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/iframe-invalidation.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/iframe-invalidation.html.ini
@@ -1,2 +1,3 @@
 [iframe-invalidation.html]
-  expected: ERROR
+  [@container-dependent elements respond to iframe size changes]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/ineligible-containment.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/ineligible-containment.html.ini
@@ -1,2 +1,3 @@
 [ineligible-containment.html]
-  expected: ERROR
+  [Changing containment eligibility invalidates style]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/inheritance-from-container.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/inheritance-from-container.html.ini
@@ -1,2 +1,0 @@
-[inheritance-from-container.html]
-  expected: ERROR

--- a/tests/wpt/meta/css/css-conditional/container-queries/inline-size-and-min-width.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/inline-size-and-min-width.html.ini
@@ -1,2 +1,3 @@
 [inline-size-and-min-width.html]
-  expected: ERROR
+  [min-width of inline-size container affects container size]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/inline-size-containment-vertical-rl.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/inline-size-containment-vertical-rl.html.ini
@@ -1,2 +1,3 @@
 [inline-size-containment-vertical-rl.html]
-  expected: ERROR
+  [inline-size containment only]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/inline-size-containment.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/inline-size-containment.html.ini
@@ -1,2 +1,3 @@
 [inline-size-containment.html]
-  expected: ERROR
+  [inline-size containment only]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/layout-dependent-focus.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/layout-dependent-focus.html.ini
@@ -1,2 +1,3 @@
 [layout-dependent-focus.html]
-  expected: ERROR
+  [Verify that onblur is called on hidden input]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/multicol-container-001.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/multicol-container-001.html.ini
@@ -1,2 +1,3 @@
 [multicol-container-001.html]
-  expected: ERROR
+  [Children of multicol inline-size container should match inline-size of the container]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/multiple-size-containers-comma-separated-queries.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/multiple-size-containers-comma-separated-queries.html.ini
@@ -1,2 +1,3 @@
 [multiple-size-containers-comma-separated-queries.html]
-  expected: ERROR
+  [Should match the named outer container for width > 400px]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/nested-query-containers.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/nested-query-containers.html.ini
@@ -1,97 +1,96 @@
 [nested-query-containers.html]
-  expected: ERROR
   [test1 - inline - 0b000]
-    expected: NOTRUN
+    expected: FAIL
 
   [test2 - inline - 0b001]
-    expected: NOTRUN
+    expected: FAIL
 
   [test3 - inline - 0b010]
-    expected: NOTRUN
+    expected: FAIL
 
   [test4 - inline - 0b011]
-    expected: NOTRUN
+    expected: FAIL
 
   [test5 - inline - 0b100]
-    expected: NOTRUN
+    expected: FAIL
 
   [test6 - inline - 0b101]
-    expected: NOTRUN
+    expected: FAIL
 
   [test7 - inline - 0b110]
-    expected: NOTRUN
+    expected: FAIL
 
   [test8 - inline - 0b111]
-    expected: NOTRUN
+    expected: FAIL
 
   [test9 - contents - 0b000]
-    expected: NOTRUN
+    expected: FAIL
 
   [test10 - contents - 0b001]
-    expected: NOTRUN
+    expected: FAIL
 
   [test11 - contents - 0b010]
-    expected: NOTRUN
+    expected: FAIL
 
   [test12 - contents - 0b011]
-    expected: NOTRUN
+    expected: FAIL
 
   [test13 - contents - 0b100]
-    expected: NOTRUN
+    expected: FAIL
 
   [test14 - contents - 0b101]
-    expected: NOTRUN
+    expected: FAIL
 
   [test15 - contents - 0b110]
-    expected: NOTRUN
+    expected: FAIL
 
   [test16 - contents - 0b111]
-    expected: NOTRUN
+    expected: FAIL
 
   [test17 - table-cell - 0b000]
-    expected: NOTRUN
+    expected: FAIL
 
   [test18 - table-cell - 0b001]
-    expected: NOTRUN
+    expected: FAIL
 
   [test19 - table-cell - 0b010]
-    expected: NOTRUN
+    expected: FAIL
 
   [test20 - table-cell - 0b011]
-    expected: NOTRUN
+    expected: FAIL
 
   [test21 - table-cell - 0b100]
-    expected: NOTRUN
+    expected: FAIL
 
   [test22 - table-cell - 0b101]
-    expected: NOTRUN
+    expected: FAIL
 
   [test23 - table-cell - 0b110]
-    expected: NOTRUN
+    expected: FAIL
 
   [test24 - table-cell - 0b111]
-    expected: NOTRUN
+    expected: FAIL
 
   [test25 - table - 0b000]
-    expected: NOTRUN
+    expected: FAIL
 
   [test26 - table - 0b001]
-    expected: NOTRUN
+    expected: FAIL
 
   [test27 - table - 0b010]
-    expected: NOTRUN
+    expected: FAIL
 
   [test28 - table - 0b011]
-    expected: NOTRUN
+    expected: FAIL
 
   [test29 - table - 0b100]
-    expected: NOTRUN
+    expected: FAIL
 
   [test30 - table - 0b101]
-    expected: NOTRUN
+    expected: FAIL
 
   [test31 - table - 0b110]
-    expected: NOTRUN
+    expected: FAIL
 
   [test32 - table - 0b111]
-    expected: NOTRUN
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/never-match-container.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/never-match-container.html.ini
@@ -1,2 +1,0 @@
-[never-match-container.html]
-  expected: ERROR

--- a/tests/wpt/meta/css/css-conditional/container-queries/orthogonal-wm-container-query.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/orthogonal-wm-container-query.html.ini
@@ -1,2 +1,3 @@
 [orthogonal-wm-container-query.html]
-  expected: ERROR
+  [Orthogonal width]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/percentage-padding-orthogonal.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/percentage-padding-orthogonal.html.ini
@@ -1,2 +1,12 @@
 [percentage-padding-orthogonal.html]
-  expected: ERROR
+  [#container width 400px after padding is applied.]
+    expected: FAIL
+
+  [#container width 400px after padding is applied. #second is removed from the rendering]
+    expected: FAIL
+
+  [#container width 399px after padding is applied. #second is removed from the rendering]
+    expected: FAIL
+
+  [#container width 399x after padding is applied. #second is removed from the rendering]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/pseudo-elements-001.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/pseudo-elements-001.html.ini
@@ -1,2 +1,6 @@
 [pseudo-elements-001.html]
-  expected: ERROR
+  [Pseudo-elements ::before and ::after respond to container size changes]
+    expected: FAIL
+
+  [Pseudo-element ::marker responds to container size changes]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/pseudo-elements-003.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/pseudo-elements-003.html.ini
@@ -1,2 +1,24 @@
 [pseudo-elements-003.html]
-  expected: ERROR
+  [Originating element container for ::before]
+    expected: FAIL
+
+  [Originating element container for ::after]
+    expected: FAIL
+
+  [Originating element container for ::marker]
+    expected: FAIL
+
+  [Originating element container for ::first-line]
+    expected: FAIL
+
+  [Originating element container for ::first-letter]
+    expected: FAIL
+
+  [Originating element container for outer ::first-line]
+    expected: FAIL
+
+  [Originating element container for outer ::first-letter]
+    expected: FAIL
+
+  [Originating element container for ::backdrop]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/pseudo-elements-004.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/pseudo-elements-004.html.ini
@@ -1,2 +1,36 @@
 [pseudo-elements-004.html]
-  expected: ERROR
+  [Initial color for ::before]
+    expected: FAIL
+
+  [Initial color for ::after]
+    expected: FAIL
+
+  [Initial color for ::marker]
+    expected: FAIL
+
+  [Initial color for ::first-line]
+    expected: FAIL
+
+  [Initial color for ::first-letter]
+    expected: FAIL
+
+  [Initial color for ::backdrop]
+    expected: FAIL
+
+  [Color for ::before depending on container]
+    expected: FAIL
+
+  [Color for ::after depending on container]
+    expected: FAIL
+
+  [Color for ::marker depending on container]
+    expected: FAIL
+
+  [Color for ::first-line depending on container]
+    expected: FAIL
+
+  [Color for ::first-letter depending on container]
+    expected: FAIL
+
+  [Color for ::backdrop depending on container]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/pseudo-elements-006.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/pseudo-elements-006.html.ini
@@ -1,2 +1,24 @@
 [pseudo-elements-006.html]
-  expected: ERROR
+  [Originating element container for ::before]
+    expected: FAIL
+
+  [Originating element container for ::after]
+    expected: FAIL
+
+  [Originating element container for ::marker]
+    expected: FAIL
+
+  [Originating element container for ::first-line]
+    expected: FAIL
+
+  [Originating element container for ::first-letter]
+    expected: FAIL
+
+  [Originating element container for outer ::first-line]
+    expected: FAIL
+
+  [Originating element container for outer ::first-letter]
+    expected: FAIL
+
+  [Originating element container for ::backdrop]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/pseudo-elements-007.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/pseudo-elements-007.html.ini
@@ -1,2 +1,36 @@
 [pseudo-elements-007.html]
-  expected: ERROR
+  [Initial font-size for ::before]
+    expected: FAIL
+
+  [Initial font-size for ::after]
+    expected: FAIL
+
+  [Initial font-size for ::marker]
+    expected: FAIL
+
+  [Initial font-size for ::first-line]
+    expected: FAIL
+
+  [Initial font-size for ::first-letter]
+    expected: FAIL
+
+  [Initial font-size for ::backdrop]
+    expected: FAIL
+
+  [font-size for ::before depending on container]
+    expected: FAIL
+
+  [font-size for ::after depending on container]
+    expected: FAIL
+
+  [font-size for ::marker depending on container]
+    expected: FAIL
+
+  [font-size for ::first-line depending on container]
+    expected: FAIL
+
+  [font-size for ::first-letter depending on container]
+    expected: FAIL
+
+  [font-size for ::backdrop depending on container]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/pseudo-elements-008.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/pseudo-elements-008.html.ini
@@ -1,2 +1,27 @@
 [pseudo-elements-008.html]
-  expected: ERROR
+  [Originating element container for ::before]
+    expected: FAIL
+
+  [Originating element container for ::after]
+    expected: FAIL
+
+  [Originating element container for ::marker]
+    expected: FAIL
+
+  [Originating element container for ::first-line]
+    expected: FAIL
+
+  [Originating element container for ::first-letter]
+    expected: FAIL
+
+  [Originating element container  for ::highlight]
+    expected: FAIL
+
+  [Originating element container for outer ::first-line]
+    expected: FAIL
+
+  [Originating element container for outer ::first-letter]
+    expected: FAIL
+
+  [Originating element container for ::backdrop]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/pseudo-elements-013.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/pseudo-elements-013.html.ini
@@ -1,2 +1,9 @@
 [pseudo-elements-013.html]
-  expected: ERROR
+  [Initial text-decoration-thickness for highlight pseudo]
+    expected: FAIL
+
+  [text-decoration-thickness for highlight pseudo depending on container]
+    expected: FAIL
+
+  [text-decoration-thickness for highlight pseudo depending on container only defined in a query]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/query-content-box.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/query-content-box.html.ini
@@ -1,2 +1,18 @@
 [query-content-box.html]
-  expected: ERROR
+  [Size queries with content-box sizing]
+    expected: FAIL
+
+  [Size queries with border-box sizing]
+    expected: FAIL
+
+  [Size queries with content-box sizing and overflow:scroll]
+    expected: FAIL
+
+  [Size queries with border-box sizing and overflow:scroll]
+    expected: FAIL
+
+  [Size queries with content-box sizing and scrollbar-gutter:stable]
+    expected: FAIL
+
+  [Size queries with border-box sizing and scrollbar-gutter:stable]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/query-evaluation-style.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/query-evaluation-style.html.ini
@@ -1,2 +1,33 @@
 [query-evaluation-style.html]
-  expected: ERROR
+  [style((--foo: bar))]
+    expected: FAIL
+
+  [style(not (--baz: qux))]
+    expected: FAIL
+
+  [style((--foo: bar) and (--foo: bar))]
+    expected: FAIL
+
+  [style((--foo: bar) and (--foo: bar) and (--foo: bar))]
+    expected: FAIL
+
+  [style((--foo: bar) or (--foo: bar))]
+    expected: FAIL
+
+  [style((--foo: bar) or (--foo: bar) or (--foo: bar))]
+    expected: FAIL
+
+  [style((--baz: qux) or (--foo: bar) or (--foo: bar))]
+    expected: FAIL
+
+  [style((--foo: bar) or (--baz: qux) or (--foo: bar))]
+    expected: FAIL
+
+  [style((--foo: bar) or (--foo: bar) or (--baz: qux))]
+    expected: FAIL
+
+  [style(not ((--foo: bar) and (--baz: qux)))]
+    expected: FAIL
+
+  [style((--baz: qux) or (not ((--baz: qux) and (--foo: bar))))]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/query-evaluation.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/query-evaluation.html.ini
@@ -1,2 +1,39 @@
 [query-evaluation.html]
-  expected: ERROR
+  [(width)]
+    expected: FAIL
+
+  [((width))]
+    expected: FAIL
+
+  [((((width))))]
+    expected: FAIL
+
+  [(not (height))]
+    expected: FAIL
+
+  [((width) and (width))]
+    expected: FAIL
+
+  [((width) and (width) and (width))]
+    expected: FAIL
+
+  [((width) or (width))]
+    expected: FAIL
+
+  [((width) or (width) or (width))]
+    expected: FAIL
+
+  [((height) or (width) or (width))]
+    expected: FAIL
+
+  [((width) or (height) or (width))]
+    expected: FAIL
+
+  [((width) or (width) or (height))]
+    expected: FAIL
+
+  [(not ((width) and (height)))]
+    expected: FAIL
+
+  [((height) or (not ((height) and (width))))]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/reattach-container-with-dirty-child.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/reattach-container-with-dirty-child.html.ini
@@ -1,2 +1,6 @@
 [reattach-container-with-dirty-child.html]
-  expected: ERROR
+  [Initially wider than 200px]
+    expected: FAIL
+
+  [Container query changed and inner.style applied]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/sibling-layout-dependency.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/sibling-layout-dependency.html.ini
@@ -1,2 +1,12 @@
 [sibling-layout-dependency.html]
-  expected: ERROR
+  [Sibling style mutation]
+    expected: FAIL
+
+  [Sibling style mutation, parent is affected]
+    expected: FAIL
+
+  [Sibling style mutation, ancestor is affected]
+    expected: FAIL
+
+  [Sibling text mutation]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/size-container-no-principal-box.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/size-container-no-principal-box.html.ini
@@ -1,2 +1,6 @@
 [size-container-no-principal-box.html]
-  expected: ERROR
+  [(min-width: 0) can match a container with a principal box]
+    expected: FAIL
+
+  [not (max-width: 0) can match a container with a principal box]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/size-container-writing-mode-change.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/size-container-writing-mode-change.html.ini
@@ -1,2 +1,6 @@
 [size-container-writing-mode-change.html]
-  expected: ERROR
+  [Initial horizontal writing-mode]
+    expected: FAIL
+
+  [Vertical writing-mode changes logical query evaluation]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/size-feature-evaluation.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/size-feature-evaluation.html.ini
@@ -1,2 +1,84 @@
 [size-feature-evaluation.html]
-  expected: ERROR
+  [(width >= 100px) (.horizontal)]
+    expected: FAIL
+
+  [(min-width: 100px) (.horizontal)]
+    expected: FAIL
+
+  [(max-width: 100px) (.horizontal)]
+    expected: FAIL
+
+  [(height >= 200px) (.horizontal)]
+    expected: FAIL
+
+  [(min-height: 200px) (.horizontal)]
+    expected: FAIL
+
+  [(max-height: 200px) (.horizontal)]
+    expected: FAIL
+
+  [(inline-size >= 100px) (.horizontal)]
+    expected: FAIL
+
+  [(min-inline-size: 100px) (.horizontal)]
+    expected: FAIL
+
+  [(max-inline-size: 100px) (.horizontal)]
+    expected: FAIL
+
+  [(block-size >= 200px) (.horizontal)]
+    expected: FAIL
+
+  [(min-block-size: 200px) (.horizontal)]
+    expected: FAIL
+
+  [(max-block-size: 200px) (.horizontal)]
+    expected: FAIL
+
+  [(orientation: portrait) (.horizontal)]
+    expected: FAIL
+
+  [(aspect-ratio: 1/2) (.horizontal)]
+    expected: FAIL
+
+  [(width >= 100px) (.vertical)]
+    expected: FAIL
+
+  [(min-width: 100px) (.vertical)]
+    expected: FAIL
+
+  [(max-width: 100px) (.vertical)]
+    expected: FAIL
+
+  [(height >= 200px) (.vertical)]
+    expected: FAIL
+
+  [(min-height: 200px) (.vertical)]
+    expected: FAIL
+
+  [(max-height: 200px) (.vertical)]
+    expected: FAIL
+
+  [(block-size >= 100px) (.vertical)]
+    expected: FAIL
+
+  [(min-block-size: 100px) (.vertical)]
+    expected: FAIL
+
+  [(max-block-size: 100px) (.vertical)]
+    expected: FAIL
+
+  [(inline-size >= 200px) (.vertical)]
+    expected: FAIL
+
+  [(min-inline-size: 200px) (.vertical)]
+    expected: FAIL
+
+  [(max-inline-size: 200px) (.vertical)]
+    expected: FAIL
+
+  [(orientation: portrait) (.vertical)]
+    expected: FAIL
+
+  [(aspect-ratio: 1/2) (.vertical)]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/size-query-with-var.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/size-query-with-var.html.ini
@@ -1,2 +1,9 @@
 [size-query-with-var.html]
-  expected: ERROR
+  [Matching --match-unknown-fallback]
+    expected: FAIL
+
+  [Matching --match-unregistered]
+    expected: FAIL
+
+  [Matching --match-registered]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/style-change-in-container.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/style-change-in-container.html.ini
@@ -1,2 +1,3 @@
 [style-change-in-container.html]
-  expected: ERROR
+  [Basic test for container query evaluation stability]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/style-not-sharing-float.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/style-not-sharing-float.html.ini
@@ -1,2 +1,3 @@
 [style-not-sharing-float.html]
-  expected: ERROR
+  [Check that style is not sharing in the case of Container Queries]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/svg-foreignobject-child-container.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/svg-foreignobject-child-container.html.ini
@@ -1,2 +1,3 @@
 [svg-foreignobject-child-container.html]
-  expected: ERROR
+  [#inner querying #container inside foreignObject]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/svg-root-size-container.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/svg-root-size-container.html.ini
@@ -1,2 +1,6 @@
 [svg-root-size-container.html]
-  expected: ERROR
+  [SVG text querying SVG root size container]
+    expected: FAIL
+
+  [div in foreignObject querying SVG root size container]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/table-inside-container-changing-display.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/table-inside-container-changing-display.html.ini
@@ -1,2 +1,0 @@
-[table-inside-container-changing-display.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/top-layer-dialog-container.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/top-layer-dialog-container.html.ini
@@ -1,2 +1,3 @@
 [top-layer-dialog-container.html]
-  expected: ERROR
+  [#dialog sized by viewport]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/top-layer-dialog.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/top-layer-dialog.html.ini
@@ -1,2 +1,9 @@
 [top-layer-dialog.html]
-  expected: ERROR
+  [#container changed to 200px]
+    expected: FAIL
+
+  [Modal dialog still has parent as query container while in top layer]
+    expected: FAIL
+
+  [Container changes width while dialog is in top layer]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/top-layer-nested-dialog.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/top-layer-nested-dialog.html.ini
@@ -1,2 +1,6 @@
 [top-layer-nested-dialog.html]
-  expected: ERROR
+  [Dialogs still not matching after showModal]
+    expected: FAIL
+
+  [@container queries start matching]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/transition-scrollbars.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/transition-scrollbars.html.ini
@@ -1,2 +1,3 @@
 [transition-scrollbars.html]
-  expected: ERROR
+  [Scrollbars do not cause a transition of background-color]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/transition-style-change-event-002.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/transition-style-change-event-002.html.ini
@@ -1,2 +1,0 @@
-[transition-style-change-event-002.html]
-  expected: ERROR

--- a/tests/wpt/meta/css/css-conditional/container-queries/transition-style-change-event.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/transition-style-change-event.html.ini
@@ -1,2 +1,3 @@
 [transition-style-change-event.html]
-  expected: ERROR
+  [Container Queries - Style Change Event for transitions]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/unsupported-axis.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/unsupported-axis.html.ini
@@ -1,2 +1,12 @@
 [unsupported-axis.html]
-  expected: ERROR
+  [(width > 0px)]
+    expected: FAIL
+
+  [(inline-size > 0px)]
+    expected: FAIL
+
+  [not (width < 0px)]
+    expected: FAIL
+
+  [not (inline-size < 0px)]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/var-evaluation.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/var-evaluation.html.ini
@@ -1,2 +1,3 @@
 [var-evaluation.html]
-  expected: ERROR
+  [inline-size with var-substitution]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/viewport-units-dynamic.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/viewport-units-dynamic.html.ini
@@ -1,2 +1,3 @@
 [viewport-units-dynamic.html]
-  expected: ERROR
+  [CSS Container Queries Test: @container-dependent elements respond to viewport unit changes]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/viewport-units.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/viewport-units.html.ini
@@ -1,2 +1,6 @@
 [viewport-units.html]
-  expected: ERROR
+  [Match width with vw]
+    expected: FAIL
+
+  [Match width with vh]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/whitespace-update-after-removal.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/whitespace-update-after-removal.html.ini
@@ -1,2 +1,0 @@
-[whitespace-update-after-removal.html]
-  expected: FAIL


### PR DESCRIPTION
This feature is part of --enable-experimental-web-platform-features, so it should be enabled on all tests.

It's not really implemented beyond parsing, but it should be safe to enable. It mostly changes test results from ERROR to FAIL.

This is part of #36315
