### PR TITLE
Run Trusted Types tests

### DIFF
--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -251,6 +251,8 @@ skip: true
   skip: false
 [touch-events]
   skip: false
+[trusted-types]
+  skip: false
 [uievents]
   skip: false
 [upgrade-insecure-requests]

--- a/tests/wpt/meta/trusted-types/DOMParser-parseFromString.html.ini
+++ b/tests/wpt/meta/trusted-types/DOMParser-parseFromString.html.ini
@@ -1,0 +1,3 @@
+[DOMParser-parseFromString.html]
+  [document.innerText assigned via policy (successful HTML transformation).]
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/DedicatedWorker-block-eval-function-constructor.html.ini
+++ b/tests/wpt/meta/trusted-types/DedicatedWorker-block-eval-function-constructor.html.ini
@@ -1,0 +1,2 @@
+[DedicatedWorker-block-eval-function-constructor.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/DedicatedWorker-constructor-from-DedicatedWorker.html.ini
+++ b/tests/wpt/meta/trusted-types/DedicatedWorker-constructor-from-DedicatedWorker.html.ini
@@ -1,0 +1,2 @@
+[DedicatedWorker-constructor-from-DedicatedWorker.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta/trusted-types/DedicatedWorker-constructor-from-SharedWorker.html.ini
+++ b/tests/wpt/meta/trusted-types/DedicatedWorker-constructor-from-SharedWorker.html.ini
@@ -1,0 +1,2 @@
+[DedicatedWorker-constructor-from-SharedWorker.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/DedicatedWorker-constructor.https.html.ini
+++ b/tests/wpt/meta/trusted-types/DedicatedWorker-constructor.https.html.ini
@@ -1,0 +1,2 @@
+[DedicatedWorker-constructor.https.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/DedicatedWorker-eval.html.ini
+++ b/tests/wpt/meta/trusted-types/DedicatedWorker-eval.html.ini
@@ -1,0 +1,2 @@
+[DedicatedWorker-eval.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/DedicatedWorker-importScripts.html.ini
+++ b/tests/wpt/meta/trusted-types/DedicatedWorker-importScripts.html.ini
@@ -1,0 +1,2 @@
+[DedicatedWorker-importScripts.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/DedicatedWorker-setTimeout-setInterval.html.ini
+++ b/tests/wpt/meta/trusted-types/DedicatedWorker-setTimeout-setInterval.html.ini
@@ -1,0 +1,2 @@
+[DedicatedWorker-setTimeout-setInterval.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/Document-execCommand.html.ini
+++ b/tests/wpt/meta/trusted-types/Document-execCommand.html.ini
@@ -1,0 +1,6 @@
+[Document-execCommand.html]
+  [Document.execCommand("insertHTML") works as usual.]
+    expected: FAIL
+
+  [Document.execCommand("paste") works as usual.]
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/Document-write-appending-line-feed.html.ini
+++ b/tests/wpt/meta/trusted-types/Document-write-appending-line-feed.html.ini
@@ -1,0 +1,2 @@
+[Document-write-appending-line-feed.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/Document-write-exception-order.xhtml.ini
+++ b/tests/wpt/meta/trusted-types/Document-write-exception-order.xhtml.ini
@@ -1,0 +1,4 @@
+[Document-write-exception-order.xhtml]
+  expected: ERROR
+  [`document.write(string)` throws TypeError]
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/Document-write.html.ini
+++ b/tests/wpt/meta/trusted-types/Document-write.html.ini
@@ -1,0 +1,18 @@
+[Document-write.html]
+  [document.write with html assigned via policy (successful transformation).]
+    expected: FAIL
+
+  [document.writeln with html assigned via policy (successful transformation).]
+    expected: FAIL
+
+  [document.write(TrustedHTML, TrustedHTML)]
+    expected: FAIL
+
+  [document.writeln(TrustedHTML, TrustedHTML)]
+    expected: FAIL
+
+  [document.write(TrustedHTML, String)]
+    expected: FAIL
+
+  [document.writeln(TrustedHTML, String)]
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/Element-insertAdjacentHTML.html.ini
+++ b/tests/wpt/meta/trusted-types/Element-insertAdjacentHTML.html.ini
@@ -1,0 +1,3 @@
+[Element-insertAdjacentHTML.html]
+  [insertAdjacentHTML with html assigned via policy (successful HTML transformation).]
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/Element-outerHTML.html.ini
+++ b/tests/wpt/meta/trusted-types/Element-outerHTML.html.ini
@@ -1,0 +1,3 @@
+[Element-outerHTML.html]
+  [outerHTML with html assigned via policy (successful HTML transformation).]
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/Element-setAttribute-respects-Elements-node-documents-globals-CSP-after-adoption-from-TT-realm.html.ini
+++ b/tests/wpt/meta/trusted-types/Element-setAttribute-respects-Elements-node-documents-globals-CSP-after-adoption-from-TT-realm.html.ini
@@ -1,0 +1,3 @@
+[Element-setAttribute-respects-Elements-node-documents-globals-CSP-after-adoption-from-TT-realm.html]
+  [Trusted types are not enforced for setAttributeNode and\n              setAttributeNS after moving the target node from a TT-realm to a\n              non-TT realm for script.xlink:href]
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/Element-setAttribute-respects-Elements-node-documents-globals-CSP-after-adoption-from-non-TT-realm.html.ini
+++ b/tests/wpt/meta/trusted-types/Element-setAttribute-respects-Elements-node-documents-globals-CSP-after-adoption-from-non-TT-realm.html.ini
@@ -1,0 +1,2 @@
+[Element-setAttribute-respects-Elements-node-documents-globals-CSP-after-adoption-from-non-TT-realm.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/Element-setAttribute-setAttributeNS-sinks.tentative.html.ini
+++ b/tests/wpt/meta/trusted-types/Element-setAttribute-setAttributeNS-sinks.tentative.html.ini
@@ -1,0 +1,2 @@
+[Element-setAttribute-setAttributeNS-sinks.tentative.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/Element-setAttribute.html.ini
+++ b/tests/wpt/meta/trusted-types/Element-setAttribute.html.ini
@@ -1,0 +1,9 @@
+[Element-setAttribute.html]
+  [script.src assigned via policy (successful ScriptURL transformation)]
+    expected: FAIL
+
+  [iframe.srcdoc assigned via policy (successful HTML transformation)]
+    expected: FAIL
+
+  [script.src assigned via policy (successful script transformation)]
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/Element-setAttributeNS.html.ini
+++ b/tests/wpt/meta/trusted-types/Element-setAttributeNS.html.ini
@@ -1,0 +1,12 @@
+[Element-setAttributeNS.html]
+  [Element.setAttributeNS assigned via policy (successful HTML transformation)]
+    expected: FAIL
+
+  [Element.setAttributeNS assigned via policy (successful Script transformation)]
+    expected: FAIL
+
+  [Element.setAttributeNS assigned via policy (successful ScriptURL transformation)]
+    expected: FAIL
+
+  [Element.setAttributeNS accepts a URL on <svg:image xlink:href/>]
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/GlobalEventHandlers-onclick.html.ini
+++ b/tests/wpt/meta/trusted-types/GlobalEventHandlers-onclick.html.ini
@@ -1,0 +1,2 @@
+[GlobalEventHandlers-onclick.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/HTMLElement-generic.html.ini
+++ b/tests/wpt/meta/trusted-types/HTMLElement-generic.html.ini
@@ -1,0 +1,2 @@
+[HTMLElement-generic.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/HTMLScriptElement-internal-slot.html.ini
+++ b/tests/wpt/meta/trusted-types/HTMLScriptElement-internal-slot.html.ini
@@ -1,0 +1,2 @@
+[HTMLScriptElement-internal-slot.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/Node-multiple-arguments-tt-enforced.html.ini
+++ b/tests/wpt/meta/trusted-types/Node-multiple-arguments-tt-enforced.html.ini
@@ -1,0 +1,2 @@
+[Node-multiple-arguments-tt-enforced.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/Node-multiple-arguments.html.ini
+++ b/tests/wpt/meta/trusted-types/Node-multiple-arguments.html.ini
@@ -1,0 +1,2 @@
+[Node-multiple-arguments.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/Range-createContextualFragment.html.ini
+++ b/tests/wpt/meta/trusted-types/Range-createContextualFragment.html.ini
@@ -1,0 +1,3 @@
+[Range-createContextualFragment.html]
+  [range.createContextualFragment assigned via policy (successful HTML transformation).]
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/SVGScriptElement-internal-slot.html.ini
+++ b/tests/wpt/meta/trusted-types/SVGScriptElement-internal-slot.html.ini
@@ -1,0 +1,2 @@
+[SVGScriptElement-internal-slot.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/ServiceWorker-block-eval-function-constructor.https.html.ini
+++ b/tests/wpt/meta/trusted-types/ServiceWorker-block-eval-function-constructor.https.html.ini
@@ -1,0 +1,2 @@
+[ServiceWorker-block-eval-function-constructor.https.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/ServiceWorker-eval.https.html.ini
+++ b/tests/wpt/meta/trusted-types/ServiceWorker-eval.https.html.ini
@@ -1,0 +1,2 @@
+[ServiceWorker-eval.https.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/ServiceWorker-importScripts.https.html.ini
+++ b/tests/wpt/meta/trusted-types/ServiceWorker-importScripts.https.html.ini
@@ -1,0 +1,2 @@
+[ServiceWorker-importScripts.https.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/ServiceWorkerContainer-register-from-DedicatedWorker.https.html.ini
+++ b/tests/wpt/meta/trusted-types/ServiceWorkerContainer-register-from-DedicatedWorker.https.html.ini
@@ -1,0 +1,2 @@
+[ServiceWorkerContainer-register-from-DedicatedWorker.https.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/ServiceWorkerContainer-register-from-ServiceWorker.https.html.ini
+++ b/tests/wpt/meta/trusted-types/ServiceWorkerContainer-register-from-ServiceWorker.https.html.ini
@@ -1,0 +1,2 @@
+[ServiceWorkerContainer-register-from-ServiceWorker.https.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/ServiceWorkerContainer-register-from-SharedWorker.https.html.ini
+++ b/tests/wpt/meta/trusted-types/ServiceWorkerContainer-register-from-SharedWorker.https.html.ini
@@ -1,0 +1,2 @@
+[ServiceWorkerContainer-register-from-SharedWorker.https.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/ServiceWorkerContainer-register.https.html.ini
+++ b/tests/wpt/meta/trusted-types/ServiceWorkerContainer-register.https.html.ini
@@ -1,0 +1,2 @@
+[ServiceWorkerContainer-register.https.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/SharedWorker-block-eval-function-constructor.html.ini
+++ b/tests/wpt/meta/trusted-types/SharedWorker-block-eval-function-constructor.html.ini
@@ -1,0 +1,2 @@
+[SharedWorker-block-eval-function-constructor.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/SharedWorker-constructor.https.html.ini
+++ b/tests/wpt/meta/trusted-types/SharedWorker-constructor.https.html.ini
@@ -1,0 +1,2 @@
+[SharedWorker-constructor.https.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/SharedWorker-eval.html.ini
+++ b/tests/wpt/meta/trusted-types/SharedWorker-eval.html.ini
@@ -1,0 +1,2 @@
+[SharedWorker-eval.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/SharedWorker-importScripts.html.ini
+++ b/tests/wpt/meta/trusted-types/SharedWorker-importScripts.html.ini
@@ -1,0 +1,2 @@
+[SharedWorker-importScripts.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/SharedWorker-setTimeout-setInterval.html.ini
+++ b/tests/wpt/meta/trusted-types/SharedWorker-setTimeout-setInterval.html.ini
@@ -1,0 +1,2 @@
+[SharedWorker-setTimeout-setInterval.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/TrustedType-AttributeNodes.html.ini
+++ b/tests/wpt/meta/trusted-types/TrustedType-AttributeNodes.html.ini
@@ -1,0 +1,2 @@
+[TrustedType-AttributeNodes.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/TrustedTypePolicy-CSP-wildcard.html.ini
+++ b/tests/wpt/meta/trusted-types/TrustedTypePolicy-CSP-wildcard.html.ini
@@ -1,0 +1,3 @@
+[TrustedTypePolicy-CSP-wildcard.html]
+  [CSP supports wildcards.]
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/TrustedTypePolicy-createXXX.html.ini
+++ b/tests/wpt/meta/trusted-types/TrustedTypePolicy-createXXX.html.ini
@@ -1,0 +1,10 @@
+[TrustedTypePolicy-createXXX.html]
+  expected: ERROR
+  [calling undefined callbacks throws]
+    expected: FAIL
+
+  [Attributes without type constraints will work as before.]
+    expected: FAIL
+
+  [trustedTypes.createPolicy(.., null) creates empty policy.]
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/TrustedTypePolicyFactory-blocking.tentative.html.ini
+++ b/tests/wpt/meta/trusted-types/TrustedTypePolicyFactory-blocking.tentative.html.ini
@@ -1,0 +1,12 @@
+[TrustedTypePolicyFactory-blocking.tentative.html]
+  [Block Trusted Type policy creation by event listener.]
+    expected: FAIL
+
+  [Trusted Type policy creation.]
+    expected: FAIL
+
+  [Block only default Trusted Type policy creation.]
+    expected: FAIL
+
+  [Policy creation called before addEventListener function will not reached the listener.]
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/TrustedTypePolicyFactory-constants.html.ini
+++ b/tests/wpt/meta/trusted-types/TrustedTypePolicyFactory-constants.html.ini
@@ -1,0 +1,18 @@
+[TrustedTypePolicyFactory-constants.html]
+  [trustedTypes.emptyHTML returns the intended value.]
+    expected: FAIL
+
+  [trustedTypes.emptyHTML cannot be redefined.]
+    expected: FAIL
+
+  [trustedTypes.emptyHTML cannot be redefined via defineProperty.]
+    expected: FAIL
+
+  [trustedTypes.emptyScript returns the intended value.]
+    expected: FAIL
+
+  [trustedTypes.emptyScript cannot be redefined.]
+    expected: FAIL
+
+  [trustedTypes.emptyScript cannot be redefined via defineProperty.]
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/TrustedTypePolicyFactory-createPolicy-createXYZTests.html.ini
+++ b/tests/wpt/meta/trusted-types/TrustedTypePolicyFactory-createPolicy-createXYZTests.html.ini
@@ -1,0 +1,84 @@
+[TrustedTypePolicyFactory-createPolicy-createXYZTests.html]
+  [html = identity function]
+    expected: FAIL
+
+  [html = null]
+    expected: FAIL
+
+  [html = string + global string]
+    expected: FAIL
+
+  [html = identity function, global string changed]
+    expected: FAIL
+
+  [html = callback that throws]
+    expected: FAIL
+
+  [html = this bound to an object]
+    expected: FAIL
+
+  [html = this without bind]
+    expected: FAIL
+
+  [html - calling undefined callback throws]
+    expected: FAIL
+
+  [createHTML defined - calling undefined callbacks throws]
+    expected: FAIL
+
+  [script = identity function]
+    expected: FAIL
+
+  [script = null]
+    expected: FAIL
+
+  [script = string + global string]
+    expected: FAIL
+
+  [script = identity function, global string changed]
+    expected: FAIL
+
+  [script = callback that throws]
+    expected: FAIL
+
+  [script = this bound to an object]
+    expected: FAIL
+
+  [script = this without bind]
+    expected: FAIL
+
+  [script - calling undefined callback throws]
+    expected: FAIL
+
+  [createScript defined - calling undefined callbacks throws]
+    expected: FAIL
+
+  [script_url = identity function]
+    expected: FAIL
+
+  [script_url = null]
+    expected: FAIL
+
+  [script_url = string + global string]
+    expected: FAIL
+
+  [script_url = identity function, global string changed]
+    expected: FAIL
+
+  [script_url = callback that throws]
+    expected: FAIL
+
+  [script_url = this bound to an object]
+    expected: FAIL
+
+  [script_url = this without bind]
+    expected: FAIL
+
+  [script_url - calling undefined callback throws]
+    expected: FAIL
+
+  [createScriptURL defined - calling undefined callbacks throws]
+    expected: FAIL
+
+  [Arbitrary number of arguments]
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/TrustedTypePolicyFactory-createPolicy-cspTests-none-none-name.html.ini
+++ b/tests/wpt/meta/trusted-types/TrustedTypePolicyFactory-createPolicy-cspTests-none-none-name.html.ini
@@ -1,0 +1,3 @@
+[TrustedTypePolicyFactory-createPolicy-cspTests-none-none-name.html]
+  [Can create policy with name 'SomeName']
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/TrustedTypePolicyFactory-createPolicy-cspTests-none-skip.html.ini
+++ b/tests/wpt/meta/trusted-types/TrustedTypePolicyFactory-createPolicy-cspTests-none-skip.html.ini
@@ -1,0 +1,9 @@
+[TrustedTypePolicyFactory-createPolicy-cspTests-none-skip.html]
+  [Can create policy with name 'SomeName']
+    expected: FAIL
+
+  [Can create a second policy with name 'SomeName']
+    expected: FAIL
+
+  [Can create policy with name 'default']
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/TrustedTypePolicyFactory-createPolicy-cspTests-none.html.ini
+++ b/tests/wpt/meta/trusted-types/TrustedTypePolicyFactory-createPolicy-cspTests-none.html.ini
@@ -1,0 +1,7 @@
+[TrustedTypePolicyFactory-createPolicy-cspTests-none.html]
+  expected: TIMEOUT
+  [Cannot create policy with name 'SomeName' - policy creation throws]
+    expected: TIMEOUT
+
+  [Cannot create policy with name 'default' - policy creation throws]
+    expected: NOTRUN

--- a/tests/wpt/meta/trusted-types/TrustedTypePolicyFactory-createPolicy-cspTests-wildcard.html.ini
+++ b/tests/wpt/meta/trusted-types/TrustedTypePolicyFactory-createPolicy-cspTests-wildcard.html.ini
@@ -1,0 +1,3 @@
+[TrustedTypePolicyFactory-createPolicy-cspTests-wildcard.html]
+  [Wildcard given - policy creation works]
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/TrustedTypePolicyFactory-createPolicy-cspTests.html.ini
+++ b/tests/wpt/meta/trusted-types/TrustedTypePolicyFactory-createPolicy-cspTests.html.ini
@@ -1,0 +1,13 @@
+[TrustedTypePolicyFactory-createPolicy-cspTests.html]
+  expected: TIMEOUT
+  [Allowed-name policy creation works.]
+    expected: FAIL
+
+  [Another allowed-name policy creation works.]
+    expected: FAIL
+
+  [Non-allowed name policy creation throws.]
+    expected: TIMEOUT
+
+  [Duplicate name policy creation throws.]
+    expected: NOTRUN

--- a/tests/wpt/meta/trusted-types/TrustedTypePolicyFactory-createPolicy-unenforced.html.ini
+++ b/tests/wpt/meta/trusted-types/TrustedTypePolicyFactory-createPolicy-unenforced.html.ini
@@ -1,0 +1,3 @@
+[TrustedTypePolicyFactory-createPolicy-unenforced.html]
+  [Duplicate policy names should be tolerated (unless in enforcing mode)]
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/TrustedTypePolicyFactory-defaultPolicy.html.ini
+++ b/tests/wpt/meta/trusted-types/TrustedTypePolicyFactory-defaultPolicy.html.ini
@@ -1,0 +1,9 @@
+[TrustedTypePolicyFactory-defaultPolicy.html]
+  [defaultPolicy with no default created is not an error]
+    expected: FAIL
+
+  [defaultPolicy returns the correct default policy]
+    expected: FAIL
+
+  [defaultPolicy is a read-only property]
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/TrustedTypePolicyFactory-getAttributeType-event-handler-content-attributes.tentative.html.ini
+++ b/tests/wpt/meta/trusted-types/TrustedTypePolicyFactory-getAttributeType-event-handler-content-attributes.tentative.html.ini
@@ -1,0 +1,2 @@
+[TrustedTypePolicyFactory-getAttributeType-event-handler-content-attributes.tentative.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/TrustedTypePolicyFactory-getAttributeType-namespace.html.ini
+++ b/tests/wpt/meta/trusted-types/TrustedTypePolicyFactory-getAttributeType-namespace.html.ini
@@ -1,0 +1,63 @@
+[TrustedTypePolicyFactory-getAttributeType-namespace.html]
+  [0: getAttributeType with full namespace info.]
+    expected: FAIL
+
+  [0: getAttributeType with element namespace and empty attribute namespace]
+    expected: FAIL
+
+  [0: getAttributeType without namespaces.]
+    expected: FAIL
+
+  [0: getAttributeType with undefined and empty namespace.]
+    expected: FAIL
+
+  [0: getAttributeType with empty and undefined namespace.]
+    expected: FAIL
+
+  [0: getAttributeType with empty namespaces.]
+    expected: FAIL
+
+  [0: getAttributeType with element namespace and empty attribute namespace.]
+    expected: FAIL
+
+  [1: getAttributeType with full namespace info.]
+    expected: FAIL
+
+  [1: getAttributeType with element namespace and empty attribute namespace]
+    expected: FAIL
+
+  [1: getAttributeType without namespaces.]
+    expected: FAIL
+
+  [1: getAttributeType with undefined and empty namespace.]
+    expected: FAIL
+
+  [1: getAttributeType with empty and undefined namespace.]
+    expected: FAIL
+
+  [1: getAttributeType with empty namespaces.]
+    expected: FAIL
+
+  [1: getAttributeType with element namespace and empty attribute namespace.]
+    expected: FAIL
+
+  [2: getAttributeType with full namespace info.]
+    expected: FAIL
+
+  [2: getAttributeType with element namespace and empty attribute namespace]
+    expected: FAIL
+
+  [2: getAttributeType without namespaces.]
+    expected: FAIL
+
+  [2: getAttributeType with undefined and empty namespace.]
+    expected: FAIL
+
+  [2: getAttributeType with empty and undefined namespace.]
+    expected: FAIL
+
+  [2: getAttributeType with empty namespaces.]
+    expected: FAIL
+
+  [2: getAttributeType with element namespace and empty attribute namespace.]
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/TrustedTypePolicyFactory-getAttributeType-svg.html.ini
+++ b/tests/wpt/meta/trusted-types/TrustedTypePolicyFactory-getAttributeType-svg.html.ini
@@ -1,0 +1,12 @@
+[TrustedTypePolicyFactory-getAttributeType-svg.html]
+  [trustedTypes.getAttributeType html script[href\]]
+    expected: FAIL
+
+  [trustedTypes.getAttributeType svg script[href\]]
+    expected: FAIL
+
+  [trustedTypes.getAttributeType svg script[href\] xlink href]
+    expected: FAIL
+
+  [trustedTypes.getAttributeType svg script[href\] other href]
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/TrustedTypePolicyFactory-getAttributeType.html.ini
+++ b/tests/wpt/meta/trusted-types/TrustedTypePolicyFactory-getAttributeType.html.ini
@@ -1,0 +1,2 @@
+[TrustedTypePolicyFactory-getAttributeType.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/TrustedTypePolicyFactory-getPropertyType.tentative.html.ini
+++ b/tests/wpt/meta/trusted-types/TrustedTypePolicyFactory-getPropertyType.tentative.html.ini
@@ -1,0 +1,84 @@
+[TrustedTypePolicyFactory-getPropertyType.tentative.html]
+  [sanity check trustedTypes.getPropertyType for the HTML script element.]
+    expected: FAIL
+
+  [sanity check trustedTypes.getAttributeType.]
+    expected: FAIL
+
+  [getPropertyType tests adapted from w3c/trusted-types polyfill]
+    expected: FAIL
+
+  [getAttributeType tests adapted from w3c/trusted-types polyfill]
+    expected: FAIL
+
+  [iframe[srcDoc\] is defined]
+    expected: FAIL
+
+  [iframe.srcDoc is maybe defined]
+    expected: FAIL
+
+  [IFRAME[srcDoc\] is defined]
+    expected: FAIL
+
+  [IFRAME.srcDoc is maybe defined]
+    expected: FAIL
+
+  [iFrAmE[srcDoc\] is defined]
+    expected: FAIL
+
+  [iFrAmE.srcDoc is maybe defined]
+    expected: FAIL
+
+  [iframe[SRCDOC\] is defined]
+    expected: FAIL
+
+  [iframe.SRCDOC is maybe defined]
+    expected: FAIL
+
+  [IFRAME[SRCDOC\] is defined]
+    expected: FAIL
+
+  [IFRAME.SRCDOC is maybe defined]
+    expected: FAIL
+
+  [iFrAmE[SRCDOC\] is defined]
+    expected: FAIL
+
+  [iFrAmE.SRCDOC is maybe defined]
+    expected: FAIL
+
+  [iframe[srcdoc\] is defined]
+    expected: FAIL
+
+  [iframe.srcdoc is maybe defined]
+    expected: FAIL
+
+  [IFRAME[srcdoc\] is defined]
+    expected: FAIL
+
+  [IFRAME.srcdoc is maybe defined]
+    expected: FAIL
+
+  [iFrAmE[srcdoc\] is defined]
+    expected: FAIL
+
+  [iFrAmE.srcdoc is maybe defined]
+    expected: FAIL
+
+  [getPropertyType vs getAttributeType for event handler.]
+    expected: FAIL
+
+  [ASCII case-insensitivity of tag name and attribute parameters]
+    expected: FAIL
+
+  [getPropertyType with an explicit elementNs parameter]
+    expected: FAIL
+
+  [getAttributeType with explicit elementNs and attrNs parameters]
+    expected: FAIL
+
+  [getAttributeType with qualified attribute name]
+    expected: FAIL
+
+  [getPropertyType/getAttributeType with explicit null elementNs/attrNs]
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/TrustedTypePolicyFactory-isXXX.html.ini
+++ b/tests/wpt/meta/trusted-types/TrustedTypePolicyFactory-isXXX.html.ini
@@ -1,0 +1,12 @@
+[TrustedTypePolicyFactory-isXXX.html]
+  [TrustedTypePolicyFactory.isHTML requires the object to be created via policy.]
+    expected: FAIL
+
+  [TrustedTypePolicyFactory.isScript requires the object to be created via policy.]
+    expected: FAIL
+
+  [TrustedTypePolicyFactory.isScriptURL requires the object to be created via policy.]
+    expected: FAIL
+
+  [TrustedTypePolicyFactory.isXXX should accept anything without throwing.]
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/TrustedTypePolicyFactory-metadata.tentative.html.ini
+++ b/tests/wpt/meta/trusted-types/TrustedTypePolicyFactory-metadata.tentative.html.ini
@@ -1,0 +1,2 @@
+[TrustedTypePolicyFactory-metadata.tentative.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/Window-TrustedTypes.html.ini
+++ b/tests/wpt/meta/trusted-types/Window-TrustedTypes.html.ini
@@ -1,0 +1,6 @@
+[Window-TrustedTypes.html]
+  [factory = window.trustedTypes]
+    expected: FAIL
+
+  [factory construction fails]
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/Window-block-eval-function-constructor.html.ini
+++ b/tests/wpt/meta/trusted-types/Window-block-eval-function-constructor.html.ini
@@ -1,0 +1,2 @@
+[Window-block-eval-function-constructor.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/Window-setTimeout-setInterval.html.ini
+++ b/tests/wpt/meta/trusted-types/Window-setTimeout-setInterval.html.ini
@@ -1,0 +1,7 @@
+[Window-setTimeout-setInterval.html]
+  expected: ERROR
+  [Window.setTimeout assigned via policy (successful Script transformation).]
+    expected: FAIL
+
+  [Window.setInterval assigned via policy (successful Script transformation).]
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/block-Document-execCommand.html.ini
+++ b/tests/wpt/meta/trusted-types/block-Document-execCommand.html.ini
@@ -1,0 +1,2 @@
+[block-Document-execCommand.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/block-string-assignment-to-DOMParser-parseFromString.html.ini
+++ b/tests/wpt/meta/trusted-types/block-string-assignment-to-DOMParser-parseFromString.html.ini
@@ -1,0 +1,12 @@
+[block-string-assignment-to-DOMParser-parseFromString.html]
+  [document.innerText assigned via policy (successful HTML transformation).]
+    expected: FAIL
+
+  [`document.innerText = string` throws.]
+    expected: FAIL
+
+  ['document.innerText = null' throws]
+    expected: FAIL
+
+  ['document.innerText = string' assigned via default policy (successful HTML transformation).]
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/block-string-assignment-to-DedicatedWorker-setTimeout-setInterval.html.ini
+++ b/tests/wpt/meta/trusted-types/block-string-assignment-to-DedicatedWorker-setTimeout-setInterval.html.ini
@@ -1,0 +1,2 @@
+[block-string-assignment-to-DedicatedWorker-setTimeout-setInterval.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/block-string-assignment-to-Document-parseHTMLUnsafe.html.ini
+++ b/tests/wpt/meta/trusted-types/block-string-assignment-to-Document-parseHTMLUnsafe.html.ini
@@ -1,0 +1,9 @@
+[block-string-assignment-to-Document-parseHTMLUnsafe.html]
+  [Document.parseHTMLUnsafe assigned via policy (successful HTML transformation).]
+    expected: FAIL
+
+  ['Document.parseHTMLUnsafe(string)' assigned via default policy (successful HTML transformation).]
+    expected: FAIL
+
+  ['Document.parseHTMLUnsafe(null)' assigned via default policy does not throw]
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/block-string-assignment-to-Document-write.html.ini
+++ b/tests/wpt/meta/trusted-types/block-string-assignment-to-Document-write.html.ini
@@ -1,0 +1,2 @@
+[block-string-assignment-to-Document-write.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/block-string-assignment-to-Element-insertAdjacentHTML.html.ini
+++ b/tests/wpt/meta/trusted-types/block-string-assignment-to-Element-insertAdjacentHTML.html.ini
@@ -1,0 +1,18 @@
+[block-string-assignment-to-Element-insertAdjacentHTML.html]
+  [insertAdjacentHTML with html assigned via policy (successful HTML transformation).]
+    expected: FAIL
+
+  [insertAdjacentHTML(TrustedHTML) throws SyntaxError DOMException when position invalid.]
+    expected: FAIL
+
+  [`insertAdjacentHTML(string)` throws.]
+    expected: FAIL
+
+  [`insertAdjacentHTML(string)` still throws TypeError when position invalid.]
+    expected: FAIL
+
+  [`insertAdjacentHTML(null)` throws.]
+    expected: FAIL
+
+  [`insertAdjacentHTML(string)` assigned via default policy (successful HTML transformation).]
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/block-string-assignment-to-Element-outerHTML.html.ini
+++ b/tests/wpt/meta/trusted-types/block-string-assignment-to-Element-outerHTML.html.ini
@@ -1,0 +1,21 @@
+[block-string-assignment-to-Element-outerHTML.html]
+  [outerHTML with html assigned via policy (successful HTML transformation).]
+    expected: FAIL
+
+  [`outerHTML = TrustedHTML` throws NoModificationAllowedError when parent is a document.]
+    expected: FAIL
+
+  [`outerHTML = string` throws.]
+    expected: FAIL
+
+  [`outerHTML = string` throws TypeError even when parent is a document.]
+    expected: FAIL
+
+  [`outerHTML = null` throws.]
+    expected: FAIL
+
+  [`outerHTML = string` assigned via default policy (successful HTML transformation).]
+    expected: FAIL
+
+  [`outerHTML = null` assigned via default policy does not throw]
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/block-string-assignment-to-Element-setAttribute.html.ini
+++ b/tests/wpt/meta/trusted-types/block-string-assignment-to-Element-setAttribute.html.ini
@@ -1,0 +1,2 @@
+[block-string-assignment-to-Element-setAttribute.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/block-string-assignment-to-Element-setAttributeNS.html.ini
+++ b/tests/wpt/meta/trusted-types/block-string-assignment-to-Element-setAttributeNS.html.ini
@@ -1,0 +1,10 @@
+[block-string-assignment-to-Element-setAttributeNS.html]
+  expected: ERROR
+  [Element.setAttributeNS assigned via policy (successful HTML transformation)]
+    expected: FAIL
+
+  [Element.setAttributeNS assigned via policy (successful Script transformation)]
+    expected: FAIL
+
+  [Element.setAttributeNS assigned via policy (successful ScriptURL transformation)]
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/block-string-assignment-to-Element-setHTMLUnsafe.html.ini
+++ b/tests/wpt/meta/trusted-types/block-string-assignment-to-Element-setHTMLUnsafe.html.ini
@@ -1,0 +1,15 @@
+[block-string-assignment-to-Element-setHTMLUnsafe.html]
+  [element.setHTMLUnsafe(html) assigned via policy (successful HTML transformation).]
+    expected: FAIL
+
+  [`element.setHTMLUnsafe(string)` throws.]
+    expected: FAIL
+
+  [`element.setHTMLUnsafe(null)` throws.]
+    expected: FAIL
+
+  [`element.setHTMLUnsafe(string)` assigned via default policy (successful HTML transformation).]
+    expected: FAIL
+
+  [`element.setHTMLUnsafe(string)` assigned via default policy does not throw]
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/block-string-assignment-to-HTMLElement-generic.html.ini
+++ b/tests/wpt/meta/trusted-types/block-string-assignment-to-HTMLElement-generic.html.ini
@@ -1,0 +1,10 @@
+[block-string-assignment-to-HTMLElement-generic.html]
+  expected: ERROR
+  [script.src accepts only TrustedScriptURL]
+    expected: FAIL
+
+  [div.innerHTML accepts only TrustedHTML]
+    expected: FAIL
+
+  [iframe.srcdoc accepts only TrustedHTML]
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/block-string-assignment-to-HTMLIFrameElement-srcdoc.html.ini
+++ b/tests/wpt/meta/trusted-types/block-string-assignment-to-HTMLIFrameElement-srcdoc.html.ini
@@ -1,0 +1,12 @@
+[block-string-assignment-to-HTMLIFrameElement-srcdoc.html]
+  [iframe.srcdoc assigned via policy (successful HTML transformation).]
+    expected: FAIL
+
+  [`iframe.srcdoc = string` throws.]
+    expected: FAIL
+
+  [`iframe.srcdoc = null` throws.]
+    expected: FAIL
+
+  [`iframe.srcdoc = string` assigned via default policy (successful HTML transformation).]
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/block-string-assignment-to-Range-createContextualFragment.html.ini
+++ b/tests/wpt/meta/trusted-types/block-string-assignment-to-Range-createContextualFragment.html.ini
@@ -1,0 +1,12 @@
+[block-string-assignment-to-Range-createContextualFragment.html]
+  [range.createContextualFragment assigned via policy (successful HTML transformation).]
+    expected: FAIL
+
+  [`range.createContextualFragment(string)` throws.]
+    expected: FAIL
+
+  [`range.createContextualFragment(null)` throws.]
+    expected: FAIL
+
+  [`range.createContextualFragment(string)` assigned via default policy (successful HTML transformation).]
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/block-string-assignment-to-ShadowRoot-innerHTML.html.ini
+++ b/tests/wpt/meta/trusted-types/block-string-assignment-to-ShadowRoot-innerHTML.html.ini
@@ -1,0 +1,2 @@
+[block-string-assignment-to-ShadowRoot-innerHTML.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/block-string-assignment-to-ShadowRoot-setHTMLUnsafe.html.ini
+++ b/tests/wpt/meta/trusted-types/block-string-assignment-to-ShadowRoot-setHTMLUnsafe.html.ini
@@ -1,0 +1,2 @@
+[block-string-assignment-to-ShadowRoot-setHTMLUnsafe.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/block-string-assignment-to-SharedWorker-setTimeout-setInterval.html.ini
+++ b/tests/wpt/meta/trusted-types/block-string-assignment-to-SharedWorker-setTimeout-setInterval.html.ini
@@ -1,0 +1,2 @@
+[block-string-assignment-to-SharedWorker-setTimeout-setInterval.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/block-string-assignment-to-Window-setTimeout-setInterval.html.ini
+++ b/tests/wpt/meta/trusted-types/block-string-assignment-to-Window-setTimeout-setInterval.html.ini
@@ -1,0 +1,19 @@
+[block-string-assignment-to-Window-setTimeout-setInterval.html]
+  expected: ERROR
+  [Window.setTimeout assigned via policy (successful Script transformation).]
+    expected: FAIL
+
+  [`Window.setTimeout(string)` throws.]
+    expected: FAIL
+
+  [`Window.setTimeout(null)` throws.]
+    expected: FAIL
+
+  [Window.setInterval assigned via policy (successful Script transformation).]
+    expected: FAIL
+
+  [`Window.setInterval(string)` throws.]
+    expected: FAIL
+
+  [`Window.setInterval(null)` throws.]
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/block-string-assignment-to-attribute-via-attribute-node.html.ini
+++ b/tests/wpt/meta/trusted-types/block-string-assignment-to-attribute-via-attribute-node.html.ini
@@ -1,0 +1,18 @@
+[block-string-assignment-to-attribute-via-attribute-node.html]
+  [Set script.src via textContent]
+    expected: FAIL
+
+  [Set script.src via nodeValue]
+    expected: FAIL
+
+  [Set iframe.srcdoc via textContent]
+    expected: FAIL
+
+  [Set iframe.srcdoc via nodeValue]
+    expected: FAIL
+
+  [Set div.onclick via textContent]
+    expected: FAIL
+
+  [Set div.onclick via nodeValue]
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/block-string-assignment-to-text-and-url-sinks.html.ini
+++ b/tests/wpt/meta/trusted-types/block-string-assignment-to-text-and-url-sinks.html.ini
@@ -1,0 +1,2 @@
+[block-string-assignment-to-text-and-url-sinks.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/block-text-node-insertion-into-script-element.html.ini
+++ b/tests/wpt/meta/trusted-types/block-text-node-insertion-into-script-element.html.ini
@@ -1,0 +1,2 @@
+[block-text-node-insertion-into-script-element.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/block-text-node-insertion-into-svg-script-element.html.ini
+++ b/tests/wpt/meta/trusted-types/block-text-node-insertion-into-svg-script-element.html.ini
@@ -1,0 +1,2 @@
+[block-text-node-insertion-into-svg-script-element.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/csp-block-eval.html.ini
+++ b/tests/wpt/meta/trusted-types/csp-block-eval.html.ini
@@ -1,0 +1,2 @@
+[csp-block-eval.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/default-policy-callback-arguments.html.ini
+++ b/tests/wpt/meta/trusted-types/default-policy-callback-arguments.html.ini
@@ -1,0 +1,2 @@
+[default-policy-callback-arguments.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/default-policy-report-only.html.ini
+++ b/tests/wpt/meta/trusted-types/default-policy-report-only.html.ini
@@ -1,0 +1,4 @@
+[default-policy-report-only.html]
+  expected: ERROR
+  [Count SecurityPolicyViolation events.]
+    expected: TIMEOUT

--- a/tests/wpt/meta/trusted-types/default-policy.html.ini
+++ b/tests/wpt/meta/trusted-types/default-policy.html.ini
@@ -1,0 +1,13 @@
+[default-policy.html]
+  expected: ERROR
+  [Count SecurityPolicyViolation events.]
+    expected: TIMEOUT
+
+  [script.src no default policy]
+    expected: FAIL
+
+  [div.innerHTML no default policy]
+    expected: FAIL
+
+  [script.text no default policy]
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/empty-default-policy-report-only.html.ini
+++ b/tests/wpt/meta/trusted-types/empty-default-policy-report-only.html.ini
@@ -1,0 +1,4 @@
+[empty-default-policy-report-only.html]
+  expected: ERROR
+  [Count SecurityPolicyViolation events.]
+    expected: TIMEOUT

--- a/tests/wpt/meta/trusted-types/empty-default-policy.html.ini
+++ b/tests/wpt/meta/trusted-types/empty-default-policy.html.ini
@@ -1,0 +1,4 @@
+[empty-default-policy.html]
+  expected: ERROR
+  [Count SecurityPolicyViolation events.]
+    expected: TIMEOUT

--- a/tests/wpt/meta/trusted-types/eval-csp-no-tt.html.ini
+++ b/tests/wpt/meta/trusted-types/eval-csp-no-tt.html.ini
@@ -1,0 +1,2 @@
+[eval-csp-no-tt.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/eval-csp-tt-default-policy-mutate.html.ini
+++ b/tests/wpt/meta/trusted-types/eval-csp-tt-default-policy-mutate.html.ini
@@ -1,0 +1,2 @@
+[eval-csp-tt-default-policy-mutate.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/eval-csp-tt-default-policy.html.ini
+++ b/tests/wpt/meta/trusted-types/eval-csp-tt-default-policy.html.ini
@@ -1,0 +1,2 @@
+[eval-csp-tt-default-policy.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/eval-csp-tt-no-default-policy.html.ini
+++ b/tests/wpt/meta/trusted-types/eval-csp-tt-no-default-policy.html.ini
@@ -1,0 +1,2 @@
+[eval-csp-tt-no-default-policy.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/eval-function-constructor-untrusted-arguments-and-applying-default-policy.html.ini
+++ b/tests/wpt/meta/trusted-types/eval-function-constructor-untrusted-arguments-and-applying-default-policy.html.ini
@@ -1,0 +1,2 @@
+[eval-function-constructor-untrusted-arguments-and-applying-default-policy.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/eval-function-constructor-untrusted-arguments-and-default-policy-throwing.html.ini
+++ b/tests/wpt/meta/trusted-types/eval-function-constructor-untrusted-arguments-and-default-policy-throwing.html.ini
@@ -1,0 +1,2 @@
+[eval-function-constructor-untrusted-arguments-and-default-policy-throwing.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/eval-function-constructor.html.ini
+++ b/tests/wpt/meta/trusted-types/eval-function-constructor.html.ini
@@ -1,0 +1,2 @@
+[eval-function-constructor.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/eval-no-csp-no-tt-default-policy.html.ini
+++ b/tests/wpt/meta/trusted-types/eval-no-csp-no-tt-default-policy.html.ini
@@ -1,0 +1,2 @@
+[eval-no-csp-no-tt-default-policy.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/eval-no-csp-no-tt.html.ini
+++ b/tests/wpt/meta/trusted-types/eval-no-csp-no-tt.html.ini
@@ -1,0 +1,2 @@
+[eval-no-csp-no-tt.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/eval-with-permissive-csp.html.ini
+++ b/tests/wpt/meta/trusted-types/eval-with-permissive-csp.html.ini
@@ -1,0 +1,2 @@
+[eval-with-permissive-csp.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/get-trusted-types-compliant-attribute-value.html.ini
+++ b/tests/wpt/meta/trusted-types/get-trusted-types-compliant-attribute-value.html.ini
@@ -1,0 +1,2 @@
+[get-trusted-types-compliant-attribute-value.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/idlharness.window.js.ini
+++ b/tests/wpt/meta/trusted-types/idlharness.window.js.ini
@@ -1,0 +1,264 @@
+[idlharness.window.html]
+  [TrustedHTML interface: existence and properties of interface object]
+    expected: FAIL
+
+  [TrustedHTML interface object length]
+    expected: FAIL
+
+  [TrustedHTML interface object name]
+    expected: FAIL
+
+  [TrustedHTML interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [TrustedHTML interface: existence and properties of interface prototype object's "constructor" property]
+    expected: FAIL
+
+  [TrustedHTML interface: existence and properties of interface prototype object's @@unscopables property]
+    expected: FAIL
+
+  [TrustedHTML interface: stringifier]
+    expected: FAIL
+
+  [TrustedHTML interface: operation toJSON()]
+    expected: FAIL
+
+  [TrustedHTML must be primary interface of window.trustedTypes.createPolicy("SomeName1", { createHTML: s => s }).createHTML("A string")]
+    expected: FAIL
+
+  [Stringification of window.trustedTypes.createPolicy("SomeName1", { createHTML: s => s }).createHTML("A string")]
+    expected: FAIL
+
+  [TrustedHTML interface: window.trustedTypes.createPolicy("SomeName1", { createHTML: s => s }).createHTML("A string") must inherit property "toJSON()" with the proper type]
+    expected: FAIL
+
+  [TrustedHTML interface: toJSON operation on window.trustedTypes.createPolicy("SomeName1", { createHTML: s => s }).createHTML("A string")]
+    expected: FAIL
+
+  [TrustedScript interface: existence and properties of interface object]
+    expected: FAIL
+
+  [TrustedScript interface object length]
+    expected: FAIL
+
+  [TrustedScript interface object name]
+    expected: FAIL
+
+  [TrustedScript interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [TrustedScript interface: existence and properties of interface prototype object's "constructor" property]
+    expected: FAIL
+
+  [TrustedScript interface: existence and properties of interface prototype object's @@unscopables property]
+    expected: FAIL
+
+  [TrustedScript interface: stringifier]
+    expected: FAIL
+
+  [TrustedScript interface: operation toJSON()]
+    expected: FAIL
+
+  [TrustedScript must be primary interface of window.trustedTypes.createPolicy("SomeName2", { createScript: s => s }).createScript("A string")]
+    expected: FAIL
+
+  [Stringification of window.trustedTypes.createPolicy("SomeName2", { createScript: s => s }).createScript("A string")]
+    expected: FAIL
+
+  [TrustedScript interface: window.trustedTypes.createPolicy("SomeName2", { createScript: s => s }).createScript("A string") must inherit property "toJSON()" with the proper type]
+    expected: FAIL
+
+  [TrustedScript interface: toJSON operation on window.trustedTypes.createPolicy("SomeName2", { createScript: s => s }).createScript("A string")]
+    expected: FAIL
+
+  [TrustedScriptURL interface: existence and properties of interface object]
+    expected: FAIL
+
+  [TrustedScriptURL interface object length]
+    expected: FAIL
+
+  [TrustedScriptURL interface object name]
+    expected: FAIL
+
+  [TrustedScriptURL interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [TrustedScriptURL interface: existence and properties of interface prototype object's "constructor" property]
+    expected: FAIL
+
+  [TrustedScriptURL interface: existence and properties of interface prototype object's @@unscopables property]
+    expected: FAIL
+
+  [TrustedScriptURL interface: stringifier]
+    expected: FAIL
+
+  [TrustedScriptURL interface: operation toJSON()]
+    expected: FAIL
+
+  [TrustedScriptURL must be primary interface of window.trustedTypes.createPolicy("SomeName3", { createScriptURL: s => s }).createScriptURL("A string")]
+    expected: FAIL
+
+  [Stringification of window.trustedTypes.createPolicy("SomeName3", { createScriptURL: s => s }).createScriptURL("A string")]
+    expected: FAIL
+
+  [TrustedScriptURL interface: window.trustedTypes.createPolicy("SomeName3", { createScriptURL: s => s }).createScriptURL("A string") must inherit property "toJSON()" with the proper type]
+    expected: FAIL
+
+  [TrustedScriptURL interface: toJSON operation on window.trustedTypes.createPolicy("SomeName3", { createScriptURL: s => s }).createScriptURL("A string")]
+    expected: FAIL
+
+  [TrustedTypePolicyFactory interface: existence and properties of interface object]
+    expected: FAIL
+
+  [TrustedTypePolicyFactory interface object length]
+    expected: FAIL
+
+  [TrustedTypePolicyFactory interface object name]
+    expected: FAIL
+
+  [TrustedTypePolicyFactory interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [TrustedTypePolicyFactory interface: existence and properties of interface prototype object's "constructor" property]
+    expected: FAIL
+
+  [TrustedTypePolicyFactory interface: existence and properties of interface prototype object's @@unscopables property]
+    expected: FAIL
+
+  [TrustedTypePolicyFactory interface: operation createPolicy(DOMString, optional TrustedTypePolicyOptions)]
+    expected: FAIL
+
+  [TrustedTypePolicyFactory interface: operation isHTML(any)]
+    expected: FAIL
+
+  [TrustedTypePolicyFactory interface: operation isScript(any)]
+    expected: FAIL
+
+  [TrustedTypePolicyFactory interface: operation isScriptURL(any)]
+    expected: FAIL
+
+  [TrustedTypePolicyFactory interface: attribute emptyHTML]
+    expected: FAIL
+
+  [TrustedTypePolicyFactory interface: attribute emptyScript]
+    expected: FAIL
+
+  [TrustedTypePolicyFactory interface: operation getAttributeType(DOMString, DOMString, optional DOMString?, optional DOMString?)]
+    expected: FAIL
+
+  [TrustedTypePolicyFactory interface: operation getPropertyType(DOMString, DOMString, optional DOMString?)]
+    expected: FAIL
+
+  [TrustedTypePolicyFactory interface: attribute defaultPolicy]
+    expected: FAIL
+
+  [TrustedTypePolicyFactory must be primary interface of window.trustedTypes]
+    expected: FAIL
+
+  [Stringification of window.trustedTypes]
+    expected: FAIL
+
+  [TrustedTypePolicyFactory interface: window.trustedTypes must inherit property "createPolicy(DOMString, optional TrustedTypePolicyOptions)" with the proper type]
+    expected: FAIL
+
+  [TrustedTypePolicyFactory interface: calling createPolicy(DOMString, optional TrustedTypePolicyOptions) on window.trustedTypes with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [TrustedTypePolicyFactory interface: window.trustedTypes must inherit property "isHTML(any)" with the proper type]
+    expected: FAIL
+
+  [TrustedTypePolicyFactory interface: calling isHTML(any) on window.trustedTypes with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [TrustedTypePolicyFactory interface: window.trustedTypes must inherit property "isScript(any)" with the proper type]
+    expected: FAIL
+
+  [TrustedTypePolicyFactory interface: calling isScript(any) on window.trustedTypes with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [TrustedTypePolicyFactory interface: window.trustedTypes must inherit property "isScriptURL(any)" with the proper type]
+    expected: FAIL
+
+  [TrustedTypePolicyFactory interface: calling isScriptURL(any) on window.trustedTypes with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [TrustedTypePolicyFactory interface: window.trustedTypes must inherit property "emptyHTML" with the proper type]
+    expected: FAIL
+
+  [TrustedTypePolicyFactory interface: window.trustedTypes must inherit property "emptyScript" with the proper type]
+    expected: FAIL
+
+  [TrustedTypePolicyFactory interface: window.trustedTypes must inherit property "getAttributeType(DOMString, DOMString, optional DOMString?, optional DOMString?)" with the proper type]
+    expected: FAIL
+
+  [TrustedTypePolicyFactory interface: calling getAttributeType(DOMString, DOMString, optional DOMString?, optional DOMString?) on window.trustedTypes with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [TrustedTypePolicyFactory interface: window.trustedTypes must inherit property "getPropertyType(DOMString, DOMString, optional DOMString?)" with the proper type]
+    expected: FAIL
+
+  [TrustedTypePolicyFactory interface: calling getPropertyType(DOMString, DOMString, optional DOMString?) on window.trustedTypes with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [TrustedTypePolicyFactory interface: window.trustedTypes must inherit property "defaultPolicy" with the proper type]
+    expected: FAIL
+
+  [TrustedTypePolicy interface: existence and properties of interface object]
+    expected: FAIL
+
+  [TrustedTypePolicy interface object length]
+    expected: FAIL
+
+  [TrustedTypePolicy interface object name]
+    expected: FAIL
+
+  [TrustedTypePolicy interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [TrustedTypePolicy interface: existence and properties of interface prototype object's "constructor" property]
+    expected: FAIL
+
+  [TrustedTypePolicy interface: existence and properties of interface prototype object's @@unscopables property]
+    expected: FAIL
+
+  [TrustedTypePolicy interface: attribute name]
+    expected: FAIL
+
+  [TrustedTypePolicy interface: operation createHTML(DOMString, any...)]
+    expected: FAIL
+
+  [TrustedTypePolicy interface: operation createScript(DOMString, any...)]
+    expected: FAIL
+
+  [TrustedTypePolicy interface: operation createScriptURL(DOMString, any...)]
+    expected: FAIL
+
+  [TrustedTypePolicy must be primary interface of window.trustedTypes.createPolicy("SomeName", { createHTML: s => s })]
+    expected: FAIL
+
+  [Stringification of window.trustedTypes.createPolicy("SomeName", { createHTML: s => s })]
+    expected: FAIL
+
+  [TrustedTypePolicy interface: window.trustedTypes.createPolicy("SomeName", { createHTML: s => s }) must inherit property "name" with the proper type]
+    expected: FAIL
+
+  [TrustedTypePolicy interface: window.trustedTypes.createPolicy("SomeName", { createHTML: s => s }) must inherit property "createHTML(DOMString, any...)" with the proper type]
+    expected: FAIL
+
+  [TrustedTypePolicy interface: calling createHTML(DOMString, any...) on window.trustedTypes.createPolicy("SomeName", { createHTML: s => s }) with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [TrustedTypePolicy interface: window.trustedTypes.createPolicy("SomeName", { createHTML: s => s }) must inherit property "createScript(DOMString, any...)" with the proper type]
+    expected: FAIL
+
+  [TrustedTypePolicy interface: calling createScript(DOMString, any...) on window.trustedTypes.createPolicy("SomeName", { createHTML: s => s }) with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [TrustedTypePolicy interface: window.trustedTypes.createPolicy("SomeName", { createHTML: s => s }) must inherit property "createScriptURL(DOMString, any...)" with the proper type]
+    expected: FAIL
+
+  [TrustedTypePolicy interface: calling createScriptURL(DOMString, any...) on window.trustedTypes.createPolicy("SomeName", { createHTML: s => s }) with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [Window interface: attribute trustedTypes]
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/inheriting-csp-for-local-schemes.html.ini
+++ b/tests/wpt/meta/trusted-types/inheriting-csp-for-local-schemes.html.ini
@@ -1,0 +1,2 @@
+[inheriting-csp-for-local-schemes.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/legacy-trusted-script-urls.html.ini
+++ b/tests/wpt/meta/trusted-types/legacy-trusted-script-urls.html.ini
@@ -1,0 +1,6 @@
+[legacy-trusted-script-urls.html]
+  [getPropertyType() with legacy TrustedScriptURLs properties return null.]
+    expected: FAIL
+
+  [getAttributeType() with legacy TrustedScriptURLs attributes return null.]
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/modify-attributes-in-callback.html.ini
+++ b/tests/wpt/meta/trusted-types/modify-attributes-in-callback.html.ini
@@ -1,0 +1,2 @@
+[modify-attributes-in-callback.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/no-require-trusted-types-for-report-only.html.ini
+++ b/tests/wpt/meta/trusted-types/no-require-trusted-types-for-report-only.html.ini
@@ -1,0 +1,2 @@
+[no-require-trusted-types-for-report-only.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/no-require-trusted-types-for.html.ini
+++ b/tests/wpt/meta/trusted-types/no-require-trusted-types-for.html.ini
@@ -1,0 +1,2 @@
+[no-require-trusted-types-for.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/require-trusted-types-for-TypeError-belongs-to-the-global-object-realm.html.ini
+++ b/tests/wpt/meta/trusted-types/require-trusted-types-for-TypeError-belongs-to-the-global-object-realm.html.ini
@@ -1,0 +1,6 @@
+[require-trusted-types-for-TypeError-belongs-to-the-global-object-realm.html]
+  [Setting innerHTML on a node inserted by the parser.]
+    expected: FAIL
+
+  [Setting innerHTML on a node adopted from a subframe.]
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/require-trusted-types-for-report-only.html.ini
+++ b/tests/wpt/meta/trusted-types/require-trusted-types-for-report-only.html.ini
@@ -1,0 +1,13 @@
+[require-trusted-types-for-report-only.html]
+  expected: TIMEOUT
+  [Require trusted types for 'script' block create HTML.]
+    expected: TIMEOUT
+
+  [Require trusted types for 'script' block create script.]
+    expected: NOTRUN
+
+  [Require trusted types for 'script' block create script URL.]
+    expected: NOTRUN
+
+  [Set require trusted types for 'script' without CSP for trusted types don't block policy creation and using.]
+    expected: NOTRUN

--- a/tests/wpt/meta/trusted-types/require-trusted-types-for.html.ini
+++ b/tests/wpt/meta/trusted-types/require-trusted-types-for.html.ini
@@ -1,0 +1,13 @@
+[require-trusted-types-for.html]
+  expected: TIMEOUT
+  [Require trusted types for 'script' block create HTML.]
+    expected: TIMEOUT
+
+  [Require trusted types for 'script' block create script.]
+    expected: NOTRUN
+
+  [Require trusted types for 'script' block create script URL.]
+    expected: NOTRUN
+
+  [Set require trusted types for 'script' without CSP for trusted types don't block policy creation and using.]
+    expected: NOTRUN

--- a/tests/wpt/meta/trusted-types/set-attributes-mutations-in-callback.tentative.html.ini
+++ b/tests/wpt/meta/trusted-types/set-attributes-mutations-in-callback.tentative.html.ini
@@ -1,0 +1,2 @@
+[set-attributes-mutations-in-callback.tentative.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/set-attributes-no-require-trusted-types.html.ini
+++ b/tests/wpt/meta/trusted-types/set-attributes-no-require-trusted-types.html.ini
@@ -1,0 +1,2 @@
+[set-attributes-no-require-trusted-types.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/set-attributes-require-trusted-types-default-policy.html.ini
+++ b/tests/wpt/meta/trusted-types/set-attributes-require-trusted-types-default-policy.html.ini
@@ -1,0 +1,2 @@
+[set-attributes-require-trusted-types-default-policy.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/set-attributes-require-trusted-types-no-default-policy.html.ini
+++ b/tests/wpt/meta/trusted-types/set-attributes-require-trusted-types-no-default-policy.html.ini
@@ -1,0 +1,2 @@
+[set-attributes-require-trusted-types-no-default-policy.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/set-event-handlers-content-attributes.tentative.html.ini
+++ b/tests/wpt/meta/trusted-types/set-event-handlers-content-attributes.tentative.html.ini
@@ -1,0 +1,2 @@
+[set-event-handlers-content-attributes.tentative.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/should-sink-type-mismatch-violation-be-blocked-by-csp-001.html.ini
+++ b/tests/wpt/meta/trusted-types/should-sink-type-mismatch-violation-be-blocked-by-csp-001.html.ini
@@ -1,0 +1,31 @@
+[should-sink-type-mismatch-violation-be-blocked-by-csp-001.html]
+  expected: TIMEOUT
+  [Multiple enforce require-trusted-types-for directives.]
+    expected: TIMEOUT
+
+  [Multiple report-only require-trusted-types-for directives.]
+    expected: NOTRUN
+
+  [One violated report-only require-trusted-types-for directive followed by multiple enforce directives]
+    expected: NOTRUN
+
+  [One violated enforce require-trusted-types-for directive followed by multiple report-only directives]
+    expected: NOTRUN
+
+  [Mixing enforce and report-only require-trusted-types-for directives.]
+    expected: NOTRUN
+
+  [directive "require-trusted-types-for 'script'%09'script'%0A'script'%0C'script'%0D'script'%20'script'" (required-ascii-whitespace)]
+    expected: NOTRUN
+
+  [invalid directive "require-trusted-types-for 'script''script'" (no ascii-whitespace)]
+    expected: NOTRUN
+
+  [directive "require-trusted-types-for 'script' 'invalid'" (unknown sink group)]
+    expected: NOTRUN
+
+  [directive "require-trusted-types-for 'invalid' 'script'" (unknown sink group)]
+    expected: NOTRUN
+
+  [directive "require-trusted-types-for 'invalid' 'script' 'also-invalid" (unknown sink group)]
+    expected: NOTRUN

--- a/tests/wpt/meta/trusted-types/should-sink-type-mismatch-violation-be-blocked-by-csp-002-worker.html.ini
+++ b/tests/wpt/meta/trusted-types/should-sink-type-mismatch-violation-be-blocked-by-csp-002-worker.html.ini
@@ -1,0 +1,2 @@
+[should-sink-type-mismatch-violation-be-blocked-by-csp-002-worker.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta/trusted-types/should-sink-type-mismatch-violation-be-blocked-by-csp-003.html.ini
+++ b/tests/wpt/meta/trusted-types/should-sink-type-mismatch-violation-be-blocked-by-csp-003.html.ini
@@ -1,0 +1,4 @@
+[should-sink-type-mismatch-violation-be-blocked-by-csp-003.html]
+  expected: TIMEOUT
+  [Location of required-trusted-types-for violations.]
+    expected: TIMEOUT

--- a/tests/wpt/meta/trusted-types/should-trusted-type-policy-creation-be-blocked-by-csp-001.html.ini
+++ b/tests/wpt/meta/trusted-types/should-trusted-type-policy-creation-be-blocked-by-csp-001.html.ini
@@ -1,0 +1,73 @@
+[should-trusted-type-policy-creation-be-blocked-by-csp-001.html]
+  expected: TIMEOUT
+  [single enforce policy with directive "trusted-type tt-policy-name"]
+    expected: TIMEOUT
+
+  [single report-only policy with directive "trusted-type tt-policy-name"]
+    expected: NOTRUN
+
+  [single enforce policy with directive "trusted-type *"]
+    expected: NOTRUN
+
+  [single report-only policy with directive "trusted-type *"]
+    expected: NOTRUN
+
+  [single enforce policy with directive "trusted-type 'none'"]
+    expected: NOTRUN
+
+  [single report-only policy with directive "trusted-type 'none'"]
+    expected: NOTRUN
+
+  [single enforce policy with directive "trusted-type 'allow-duplicates'"]
+    expected: NOTRUN
+
+  [single report-only policy with directive "trusted-type 'allow-duplicates'"]
+    expected: NOTRUN
+
+  [single enforce policy with directive "trusted-type tt-policy-name 'allow-duplicates'"]
+    expected: NOTRUN
+
+  [single report-only policy with directive "trusted-type tt-policy-name 'allow-duplicates'"]
+    expected: NOTRUN
+
+  [single enforce policy with directive "trusted-type * 'allow-duplicates'"]
+    expected: NOTRUN
+
+  [single report-only policy with directive "trusted-type * 'allow-duplicates'"]
+    expected: NOTRUN
+
+  [single enforce policy with directive "trusted-type 'none' 'allow-duplicates'"]
+    expected: NOTRUN
+
+  [single report-only policy with directive "trusted-type 'none' 'allow-duplicates'"]
+    expected: NOTRUN
+
+  [single enforce policy with directive "trusted-type 'none' tt-policy-name"]
+    expected: NOTRUN
+
+  [single report-only policy with directive "trusted-type 'none' tt-policy-name"]
+    expected: NOTRUN
+
+  [single enforce policy with directive "trusted-type 'none' *"]
+    expected: NOTRUN
+
+  [single report-only policy with directive "trusted-type 'none' *"]
+    expected: NOTRUN
+
+  [single enforce policy with directive "trusted-type tt-policy-name *"]
+    expected: NOTRUN
+
+  [single report-only policy with directive "trusted-type tt-policy-name *"]
+    expected: NOTRUN
+
+  [single enforce policy with directive "trusted-type tt-policy-name1 tt-policy-name2 tt-policy-name3"]
+    expected: NOTRUN
+
+  [single report-only policy with directive "trusted-type tt-policy-name1 tt-policy-name2 tt-policy-name3"]
+    expected: NOTRUN
+
+  [Single enforce policy with directive "trusted-type none"]
+    expected: NOTRUN
+
+  [Single enforce policy with directive "trusted-type allow-duplicates"]
+    expected: NOTRUN

--- a/tests/wpt/meta/trusted-types/should-trusted-type-policy-creation-be-blocked-by-csp-002.html.ini
+++ b/tests/wpt/meta/trusted-types/should-trusted-type-policy-creation-be-blocked-by-csp-002.html.ini
@@ -1,0 +1,61 @@
+[should-trusted-type-policy-creation-be-blocked-by-csp-002.html]
+  expected: TIMEOUT
+  [valid tt-policy-name name "1"]
+    expected: TIMEOUT
+
+  [valid tt-policy-name name "abcdefghijklmnopqrstuvwxyz"]
+    expected: NOTRUN
+
+  [valid tt-policy-name name "ABCDEFGHIJKLMNOPQRSTUVWXYZ"]
+    expected: NOTRUN
+
+  [valid tt-policy-name name "0123456789"]
+    expected: NOTRUN
+
+  [valid tt-policy-name name "policy-name"]
+    expected: NOTRUN
+
+  [valid tt-policy-name name "policy=name"]
+    expected: NOTRUN
+
+  [valid tt-policy-name name "policy_name"]
+    expected: NOTRUN
+
+  [valid tt-policy-name name "policy/name"]
+    expected: NOTRUN
+
+  [valid tt-policy-name name "policy@name"]
+    expected: NOTRUN
+
+  [valid tt-policy-name name "policy.name"]
+    expected: NOTRUN
+
+  [valid tt-policy-name name "policy%name"]
+    expected: NOTRUN
+
+  [valid tt-policy-name name "policy#name"]
+    expected: NOTRUN
+
+  [valid tt-policy-name name "6xY/2x=3Y..."]
+    expected: NOTRUN
+
+  [invalid tt-policy-name name "policy name"]
+    expected: NOTRUN
+
+  [invalid tt-policy-name name "policy*name"]
+    expected: NOTRUN
+
+  [invalid tt-policy-name name "policy$name"]
+    expected: NOTRUN
+
+  [invalid tt-policy-name name "policy?name"]
+    expected: NOTRUN
+
+  [invalid tt-policy-name name "policy!name"]
+    expected: NOTRUN
+
+  [directive "trusted-type _TTP1_%09_TTP2_%0C_TTP3_%0D_TTP4_%20_TTP5_" (required-ascii-whitespace)]
+    expected: NOTRUN
+
+  [invalid directive "trusted-type _TTP" (no ascii whitespace)]
+    expected: NOTRUN

--- a/tests/wpt/meta/trusted-types/should-trusted-type-policy-creation-be-blocked-by-csp-003.html.ini
+++ b/tests/wpt/meta/trusted-types/should-trusted-type-policy-creation-be-blocked-by-csp-003.html.ini
@@ -1,0 +1,19 @@
+[should-trusted-type-policy-creation-be-blocked-by-csp-003.html]
+  expected: TIMEOUT
+  [Multiple non-violated enforce trusted-types directives.]
+    expected: TIMEOUT
+
+  [Multiple report-only trusted-types directives.]
+    expected: NOTRUN
+
+  [One violated report-only trusted-types directive followed by multiple enforce directives.]
+    expected: NOTRUN
+
+  [One violated enforce trusted-types directive followed by multiple report-only directives.]
+    expected: NOTRUN
+
+  [Mixing enforce and report-only policies with trusted-types directives]
+    expected: NOTRUN
+
+  [Mixing enforce and report-only policies with trusted-types directives (duplicate policy)]
+    expected: NOTRUN

--- a/tests/wpt/meta/trusted-types/should-trusted-type-policy-creation-be-blocked-by-csp-004-worker.html.ini
+++ b/tests/wpt/meta/trusted-types/should-trusted-type-policy-creation-be-blocked-by-csp-004-worker.html.ini
@@ -1,0 +1,10 @@
+[should-trusted-type-policy-creation-be-blocked-by-csp-004-worker.html]
+  expected: TIMEOUT
+  [No violation/exception for allowed policy names (tt-policy-name-1 tt-policy-name-2 tt-policy-name-3).]
+    expected: TIMEOUT
+
+  [Violation and exception for duplicate policy names (tt-policy-name-1 tt-policy-name-2 tt-policy-name-3).]
+    expected: NOTRUN
+
+  [Violation and exception for forbidden policy name (tt-policy-name-1 tt-policy-name-2 tt-policy-name-3).]
+    expected: NOTRUN

--- a/tests/wpt/meta/trusted-types/should-trusted-type-policy-creation-be-blocked-by-csp-005.html.ini
+++ b/tests/wpt/meta/trusted-types/should-trusted-type-policy-creation-be-blocked-by-csp-005.html.ini
@@ -1,0 +1,4 @@
+[should-trusted-type-policy-creation-be-blocked-by-csp-005.html]
+  expected: TIMEOUT
+  [Location of trusted-types violations.]
+    expected: TIMEOUT

--- a/tests/wpt/meta/trusted-types/trusted-types-createHTMLDocument.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-createHTMLDocument.html.ini
@@ -1,0 +1,39 @@
+[trusted-types-createHTMLDocument.html]
+  [Trusted Type assignment is blocked. (document)]
+    expected: FAIL
+
+  [Trusted Type instances created in the main doc can be used. (document)]
+    expected: FAIL
+
+  [Trusted Type assignment is blocked. (createHTMLDocument)]
+    expected: FAIL
+
+  [Trusted Type instances created in the main doc can be used. (createHTMLDocument)]
+    expected: FAIL
+
+  [Trusted Type assignment is blocked. (DOMParser)]
+    expected: FAIL
+
+  [Trusted Type instances created in the main doc can be used. (DOMParser)]
+    expected: FAIL
+
+  [Trusted Type assignment is blocked. (XHR)]
+    expected: FAIL
+
+  [Trusted Type instances created in the main doc can be used. (XHR)]
+    expected: FAIL
+
+  [Install default policy.]
+    expected: FAIL
+
+  [Default policy applies. (document)]
+    expected: FAIL
+
+  [Default policy applies. (createHTMLDocument)]
+    expected: FAIL
+
+  [Default policy applies. (DOMParser)]
+    expected: FAIL
+
+  [Default policy applies. (XHR)]
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/trusted-types-duplicate-names-list-report-only.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-duplicate-names-list-report-only.html.ini
@@ -1,0 +1,3 @@
+[trusted-types-duplicate-names-list-report-only.html]
+  [TrustedTypePolicyFactory and policy list in CSP.]
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/trusted-types-duplicate-names-list.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-duplicate-names-list.html.ini
@@ -1,0 +1,3 @@
+[trusted-types-duplicate-names-list.html]
+  [TrustedTypePolicyFactory and policy list in CSP.]
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/trusted-types-duplicate-names-without-enforcement.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-duplicate-names-without-enforcement.html.ini
@@ -1,0 +1,6 @@
+[trusted-types-duplicate-names-without-enforcement.html]
+  [createPolicy - duplicate policies are allowed when Trusted Types are not enforced.]
+    expected: FAIL
+
+  [createPolicy - duplicate "default" policy is never allowed.]
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/trusted-types-duplicate-names.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-duplicate-names.html.ini
@@ -1,0 +1,3 @@
+[trusted-types-duplicate-names.html]
+  [policy - duplicate names]
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/trusted-types-eval-reporting-no-unsafe-eval.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-eval-reporting-no-unsafe-eval.html.ini
@@ -1,0 +1,2 @@
+[trusted-types-eval-reporting-no-unsafe-eval.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/trusted-types-eval-reporting-report-only.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-eval-reporting-report-only.html.ini
@@ -1,0 +1,2 @@
+[trusted-types-eval-reporting-report-only.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/trusted-types-event-handlers.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-event-handlers.html.ini
@@ -1,0 +1,231 @@
+[trusted-types-event-handlers.html]
+  [Event handler onclick should be blocked.]
+    expected: FAIL
+
+  [Event handler onchange should be blocked.]
+    expected: FAIL
+
+  [Event handler onfocus should be blocked.]
+    expected: FAIL
+
+  [Event handler oNclick should be blocked.]
+    expected: FAIL
+
+  [Event handler OnClIcK should be blocked.]
+    expected: FAIL
+
+  [Event handler div.oncopy should be blocked.]
+    expected: FAIL
+
+  [Event handler div.oncut should be blocked.]
+    expected: FAIL
+
+  [Event handler div.onpaste should be blocked.]
+    expected: FAIL
+
+  [Event handler div.onabort should be blocked.]
+    expected: FAIL
+
+  [Event handler div.onblur should be blocked.]
+    expected: FAIL
+
+  [Event handler div.oncancel should be blocked.]
+    expected: FAIL
+
+  [Event handler div.oncanplay should be blocked.]
+    expected: FAIL
+
+  [Event handler div.oncanplaythrough should be blocked.]
+    expected: FAIL
+
+  [Event handler div.onchange should be blocked.]
+    expected: FAIL
+
+  [Event handler div.onclick should be blocked.]
+    expected: FAIL
+
+  [Event handler div.onclose should be blocked.]
+    expected: FAIL
+
+  [Event handler div.oncontextmenu should be blocked.]
+    expected: FAIL
+
+  [Event handler div.oncuechange should be blocked.]
+    expected: FAIL
+
+  [Event handler div.ondblclick should be blocked.]
+    expected: FAIL
+
+  [Event handler div.ondrag should be blocked.]
+    expected: FAIL
+
+  [Event handler div.ondragend should be blocked.]
+    expected: FAIL
+
+  [Event handler div.ondragenter should be blocked.]
+    expected: FAIL
+
+  [Event handler div.ondragexit should be blocked.]
+    expected: FAIL
+
+  [Event handler div.ondragleave should be blocked.]
+    expected: FAIL
+
+  [Event handler div.ondragover should be blocked.]
+    expected: FAIL
+
+  [Event handler div.ondragstart should be blocked.]
+    expected: FAIL
+
+  [Event handler div.ondrop should be blocked.]
+    expected: FAIL
+
+  [Event handler div.ondurationchange should be blocked.]
+    expected: FAIL
+
+  [Event handler div.onemptied should be blocked.]
+    expected: FAIL
+
+  [Event handler div.onended should be blocked.]
+    expected: FAIL
+
+  [Event handler div.onerror should be blocked.]
+    expected: FAIL
+
+  [Event handler div.onfocus should be blocked.]
+    expected: FAIL
+
+  [Event handler div.onformdata should be blocked.]
+    expected: FAIL
+
+  [Event handler div.oninput should be blocked.]
+    expected: FAIL
+
+  [Event handler div.oninvalid should be blocked.]
+    expected: FAIL
+
+  [Event handler div.onkeydown should be blocked.]
+    expected: FAIL
+
+  [Event handler div.onkeypress should be blocked.]
+    expected: FAIL
+
+  [Event handler div.onkeyup should be blocked.]
+    expected: FAIL
+
+  [Event handler div.onload should be blocked.]
+    expected: FAIL
+
+  [Event handler div.onloadeddata should be blocked.]
+    expected: FAIL
+
+  [Event handler div.onloadedmetadata should be blocked.]
+    expected: FAIL
+
+  [Event handler div.onloadstart should be blocked.]
+    expected: FAIL
+
+  [Event handler div.onmousedown should be blocked.]
+    expected: FAIL
+
+  [Event handler div.onmouseenter should be blocked.]
+    expected: FAIL
+
+  [Event handler div.onmouseleave should be blocked.]
+    expected: FAIL
+
+  [Event handler div.onmousemove should be blocked.]
+    expected: FAIL
+
+  [Event handler div.onmouseout should be blocked.]
+    expected: FAIL
+
+  [Event handler div.onmouseover should be blocked.]
+    expected: FAIL
+
+  [Event handler div.onmouseup should be blocked.]
+    expected: FAIL
+
+  [Event handler div.onwheel should be blocked.]
+    expected: FAIL
+
+  [Event handler div.onpause should be blocked.]
+    expected: FAIL
+
+  [Event handler div.onplay should be blocked.]
+    expected: FAIL
+
+  [Event handler div.onplaying should be blocked.]
+    expected: FAIL
+
+  [Event handler div.onprogress should be blocked.]
+    expected: FAIL
+
+  [Event handler div.onratechange should be blocked.]
+    expected: FAIL
+
+  [Event handler div.onreset should be blocked.]
+    expected: FAIL
+
+  [Event handler div.onresize should be blocked.]
+    expected: FAIL
+
+  [Event handler div.onscroll should be blocked.]
+    expected: FAIL
+
+  [Event handler div.onsecuritypolicyviolation should be blocked.]
+    expected: FAIL
+
+  [Event handler div.onseeked should be blocked.]
+    expected: FAIL
+
+  [Event handler div.onseeking should be blocked.]
+    expected: FAIL
+
+  [Event handler div.onselect should be blocked.]
+    expected: FAIL
+
+  [Event handler div.onshow should be blocked.]
+    expected: FAIL
+
+  [Event handler div.onstalled should be blocked.]
+    expected: FAIL
+
+  [Event handler div.onsubmit should be blocked.]
+    expected: FAIL
+
+  [Event handler div.onsuspend should be blocked.]
+    expected: FAIL
+
+  [Event handler div.ontimeupdate should be blocked.]
+    expected: FAIL
+
+  [Event handler div.ontoggle should be blocked.]
+    expected: FAIL
+
+  [Event handler div.onvolumechange should be blocked.]
+    expected: FAIL
+
+  [Event handler div.onwaiting should be blocked.]
+    expected: FAIL
+
+  [Event handler div.onanimationend should be blocked.]
+    expected: FAIL
+
+  [Event handler div.onanimationiteration should be blocked.]
+    expected: FAIL
+
+  [Event handler div.ontransitionrun should be blocked.]
+    expected: FAIL
+
+  [Event handler div.ontransitionend should be blocked.]
+    expected: FAIL
+
+  [Event handler div.ontransitioncancel should be blocked.]
+    expected: FAIL
+
+  [Event handler div.onselectstart should be blocked.]
+    expected: FAIL
+
+  [Event handler div.onselectionchange should be blocked.]
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/trusted-types-from-literal.tentative.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-from-literal.tentative.html.ini
@@ -1,0 +1,2 @@
+[trusted-types-from-literal.tentative.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/trusted-types-navigation.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-navigation.html.ini
@@ -1,0 +1,49 @@
+[trusted-types-navigation.html]
+  expected: TIMEOUT
+  [Navigate a window via anchor with javascript:-urls in enforcing mode.]
+    expected: TIMEOUT
+
+  [Navigate a window via anchor with javascript:-urls w/ default policy in enforcing mode.]
+    expected: NOTRUN
+
+  [Navigate a window via anchor with javascript:-urls in report-only mode.]
+    expected: NOTRUN
+
+  [Navigate a window via anchor with javascript:-urls w/ default policy in report-only mode.]
+    expected: NOTRUN
+
+  [Navigate a frame via anchor with javascript:-urls in enforcing mode.]
+    expected: NOTRUN
+
+  [Navigate a frame via anchor with javascript:-urls w/ default policy in enforcing mode.]
+    expected: NOTRUN
+
+  [Navigate a frame via anchor with javascript:-urls in report-only mode.]
+    expected: NOTRUN
+
+  [Navigate a frame via anchor with javascript:-urls w/ default policy in report-only mode.]
+    expected: NOTRUN
+
+  [Navigate a window via form-submission with javascript:-urls in enforcing mode.]
+    expected: NOTRUN
+
+  [Navigate a window via form-submission with javascript:-urls w/ default policy in enforcing mode.]
+    expected: NOTRUN
+
+  [Navigate a window via form-submission with javascript:-urls in report-only mode.]
+    expected: NOTRUN
+
+  [Navigate a window via form-submission with javascript:-urls w/ default policy in report-only mode.]
+    expected: NOTRUN
+
+  [Navigate a frame via form-submission with javascript:-urls in enforcing mode.]
+    expected: NOTRUN
+
+  [Navigate a frame via form-submission with javascript:-urls w/ default policy in enforcing mode.]
+    expected: NOTRUN
+
+  [Navigate a frame via form-submission with javascript:-urls in report-only mode.]
+    expected: NOTRUN
+
+  [Navigate a frame via form-submission with javascript:-urls w/ default policy in report-only mode.]
+    expected: NOTRUN

--- a/tests/wpt/meta/trusted-types/trusted-types-report-only.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-report-only.html.ini
@@ -1,0 +1,2 @@
+[trusted-types-report-only.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/trusted-types-reporting-check-report-DedicatedWorker-create-policy.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-reporting-check-report-DedicatedWorker-create-policy.html.ini
@@ -1,0 +1,12 @@
+[trusted-types-reporting-check-report-DedicatedWorker-create-policy.html]
+  [Creating policy works for policy in the allowlist.]
+    expected: FAIL
+
+  [Creating policy works for policy in the blocklist, since it's report-only.]
+    expected: FAIL
+
+  [Test report-uri works with trusted-types violation.]
+    expected: FAIL
+
+  [Test number of sent reports.]
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/trusted-types-reporting-check-report-DedicatedWorker-sink-mismatch.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-reporting-check-report-DedicatedWorker-sink-mismatch.html.ini
@@ -1,0 +1,2 @@
+[trusted-types-reporting-check-report-DedicatedWorker-sink-mismatch.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta/trusted-types/trusted-types-reporting-check-report-Window-create-policy.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-reporting-check-report-Window-create-policy.html.ini
@@ -1,0 +1,12 @@
+[trusted-types-reporting-check-report-Window-create-policy.html]
+  [Creating policy works for policy in the allowlist.]
+    expected: FAIL
+
+  [Creating policy works for policy in the blocklist, since it's report-only.]
+    expected: FAIL
+
+  [Test report-uri works with trusted-types violation.]
+    expected: FAIL
+
+  [Test number of sent reports.]
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/trusted-types-reporting-check-report-Window-sink-mismatch.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-reporting-check-report-Window-sink-mismatch.html.ini
@@ -1,0 +1,9 @@
+[trusted-types-reporting-check-report-Window-sink-mismatch.html]
+  [Passing a TrustedScript to setTimeout works.]
+    expected: FAIL
+
+  [Test report-uri works with require-trusted-types-for violation.]
+    expected: FAIL
+
+  [Test number of sent reports.]
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/trusted-types-reporting-for-DOMParser-parseFromString.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-reporting-for-DOMParser-parseFromString.html.ini
@@ -1,0 +1,2 @@
+[trusted-types-reporting-for-DOMParser-parseFromString.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/trusted-types-reporting-for-DedicatedWorker-DedicatedWorker-constructor.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-reporting-for-DedicatedWorker-DedicatedWorker-constructor.html.ini
@@ -1,0 +1,2 @@
+[trusted-types-reporting-for-DedicatedWorker-DedicatedWorker-constructor.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta/trusted-types/trusted-types-reporting-for-DedicatedWorker-ServiceWorkerContainer-register.https.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-reporting-for-DedicatedWorker-ServiceWorkerContainer-register.https.html.ini
@@ -1,0 +1,2 @@
+[trusted-types-reporting-for-DedicatedWorker-ServiceWorkerContainer-register.https.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta/trusted-types/trusted-types-reporting-for-DedicatedWorker-eval.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-reporting-for-DedicatedWorker-eval.html.ini
@@ -1,0 +1,2 @@
+[trusted-types-reporting-for-DedicatedWorker-eval.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta/trusted-types/trusted-types-reporting-for-DedicatedWorker-function-constructor.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-reporting-for-DedicatedWorker-function-constructor.html.ini
@@ -1,0 +1,2 @@
+[trusted-types-reporting-for-DedicatedWorker-function-constructor.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta/trusted-types/trusted-types-reporting-for-DedicatedWorker-importScripts.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-reporting-for-DedicatedWorker-importScripts.html.ini
@@ -1,0 +1,2 @@
+[trusted-types-reporting-for-DedicatedWorker-importScripts.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta/trusted-types/trusted-types-reporting-for-DedicatedWorker-setTimeout-setInterval.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-reporting-for-DedicatedWorker-setTimeout-setInterval.html.ini
@@ -1,0 +1,2 @@
+[trusted-types-reporting-for-DedicatedWorker-setTimeout-setInterval.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta/trusted-types/trusted-types-reporting-for-Document-execCommand.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-reporting-for-Document-execCommand.html.ini
@@ -1,0 +1,2 @@
+[trusted-types-reporting-for-Document-execCommand.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/trusted-types-reporting-for-Document-parseHTMLUnsafe.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-reporting-for-Document-parseHTMLUnsafe.html.ini
@@ -1,0 +1,2 @@
+[trusted-types-reporting-for-Document-parseHTMLUnsafe.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/trusted-types-reporting-for-Document-write.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-reporting-for-Document-write.html.ini
@@ -1,0 +1,2 @@
+[trusted-types-reporting-for-Document-write.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/trusted-types-reporting-for-Element-innerHTML.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-reporting-for-Element-innerHTML.html.ini
@@ -1,0 +1,2 @@
+[trusted-types-reporting-for-Element-innerHTML.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/trusted-types-reporting-for-Element-insertAdjacentHTML.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-reporting-for-Element-insertAdjacentHTML.html.ini
@@ -1,0 +1,2 @@
+[trusted-types-reporting-for-Element-insertAdjacentHTML.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/trusted-types-reporting-for-Element-outerHTML.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-reporting-for-Element-outerHTML.html.ini
@@ -1,0 +1,2 @@
+[trusted-types-reporting-for-Element-outerHTML.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/trusted-types-reporting-for-Element-setAttribute.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-reporting-for-Element-setAttribute.html.ini
@@ -1,0 +1,2 @@
+[trusted-types-reporting-for-Element-setAttribute.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/trusted-types-reporting-for-Element-setHTMLUnsafe.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-reporting-for-Element-setHTMLUnsafe.html.ini
@@ -1,0 +1,2 @@
+[trusted-types-reporting-for-Element-setHTMLUnsafe.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/trusted-types-reporting-for-HTMLIFrameElement-srcdoc.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-reporting-for-HTMLIFrameElement-srcdoc.html.ini
@@ -1,0 +1,2 @@
+[trusted-types-reporting-for-HTMLIFrameElement-srcdoc.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/trusted-types-reporting-for-HTMLScriptElement-innerHTML.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-reporting-for-HTMLScriptElement-innerHTML.html.ini
@@ -1,0 +1,2 @@
+[trusted-types-reporting-for-HTMLScriptElement-innerHTML.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/trusted-types-reporting-for-HTMLScriptElement.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-reporting-for-HTMLScriptElement.html.ini
@@ -1,0 +1,2 @@
+[trusted-types-reporting-for-HTMLScriptElement.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/trusted-types-reporting-for-Range-createContextualFragment.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-reporting-for-Range-createContextualFragment.html.ini
@@ -1,0 +1,2 @@
+[trusted-types-reporting-for-Range-createContextualFragment.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/trusted-types-reporting-for-SVGScriptElement-innerHTML.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-reporting-for-SVGScriptElement-innerHTML.html.ini
@@ -1,0 +1,2 @@
+[trusted-types-reporting-for-SVGScriptElement-innerHTML.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/trusted-types-reporting-for-ServiceWorker-ServiceWorkerContainer-register.https.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-reporting-for-ServiceWorker-ServiceWorkerContainer-register.https.html.ini
@@ -1,0 +1,2 @@
+[trusted-types-reporting-for-ServiceWorker-ServiceWorkerContainer-register.https.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/trusted-types-reporting-for-ServiceWorker-eval.https.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-reporting-for-ServiceWorker-eval.https.html.ini
@@ -1,0 +1,2 @@
+[trusted-types-reporting-for-ServiceWorker-eval.https.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/trusted-types-reporting-for-ServiceWorker-function-constructor.https.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-reporting-for-ServiceWorker-function-constructor.https.html.ini
@@ -1,0 +1,2 @@
+[trusted-types-reporting-for-ServiceWorker-function-constructor.https.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/trusted-types-reporting-for-ServiceWorker-importScripts.https.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-reporting-for-ServiceWorker-importScripts.https.html.ini
@@ -1,0 +1,2 @@
+[trusted-types-reporting-for-ServiceWorker-importScripts.https.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/trusted-types-reporting-for-ServiceWorker-setTimeout-setInterval.https.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-reporting-for-ServiceWorker-setTimeout-setInterval.https.html.ini
@@ -1,0 +1,2 @@
+[trusted-types-reporting-for-ServiceWorker-setTimeout-setInterval.https.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/trusted-types-reporting-for-ShadowRoot-innerHTML.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-reporting-for-ShadowRoot-innerHTML.html.ini
@@ -1,0 +1,2 @@
+[trusted-types-reporting-for-ShadowRoot-innerHTML.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/trusted-types-reporting-for-ShadowRoot-setHTMLUnsafe.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-reporting-for-ShadowRoot-setHTMLUnsafe.html.ini
@@ -1,0 +1,2 @@
+[trusted-types-reporting-for-ShadowRoot-setHTMLUnsafe.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/trusted-types-reporting-for-SharedWorker-DedicatedWorker-constructor.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-reporting-for-SharedWorker-DedicatedWorker-constructor.html.ini
@@ -1,0 +1,2 @@
+[trusted-types-reporting-for-SharedWorker-DedicatedWorker-constructor.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/trusted-types-reporting-for-SharedWorker-ServiceWorkerContainer-register.https.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-reporting-for-SharedWorker-ServiceWorkerContainer-register.https.html.ini
@@ -1,0 +1,2 @@
+[trusted-types-reporting-for-SharedWorker-ServiceWorkerContainer-register.https.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/trusted-types-reporting-for-SharedWorker-eval.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-reporting-for-SharedWorker-eval.html.ini
@@ -1,0 +1,2 @@
+[trusted-types-reporting-for-SharedWorker-eval.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/trusted-types-reporting-for-SharedWorker-function-constructor.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-reporting-for-SharedWorker-function-constructor.html.ini
@@ -1,0 +1,2 @@
+[trusted-types-reporting-for-SharedWorker-function-constructor.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/trusted-types-reporting-for-SharedWorker-importScripts.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-reporting-for-SharedWorker-importScripts.html.ini
@@ -1,0 +1,2 @@
+[trusted-types-reporting-for-SharedWorker-importScripts.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/trusted-types-reporting-for-SharedWorker-setTimeout-setInterval.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-reporting-for-SharedWorker-setTimeout-setInterval.html.ini
@@ -1,0 +1,2 @@
+[trusted-types-reporting-for-SharedWorker-setTimeout-setInterval.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/trusted-types-reporting-for-Window-DedicatedWorker-constructor.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-reporting-for-Window-DedicatedWorker-constructor.html.ini
@@ -1,0 +1,2 @@
+[trusted-types-reporting-for-Window-DedicatedWorker-constructor.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/trusted-types-reporting-for-Window-ServiceWorkerContainer-register.https.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-reporting-for-Window-ServiceWorkerContainer-register.https.html.ini
@@ -1,0 +1,2 @@
+[trusted-types-reporting-for-Window-ServiceWorkerContainer-register.https.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/trusted-types-reporting-for-Window-SharedWorker-constructor.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-reporting-for-Window-SharedWorker-constructor.html.ini
@@ -1,0 +1,2 @@
+[trusted-types-reporting-for-Window-SharedWorker-constructor.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/trusted-types-reporting-for-Window-eval.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-reporting-for-Window-eval.html.ini
@@ -1,0 +1,2 @@
+[trusted-types-reporting-for-Window-eval.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/trusted-types-reporting-for-Window-function-constructor.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-reporting-for-Window-function-constructor.html.ini
@@ -1,0 +1,2 @@
+[trusted-types-reporting-for-Window-function-constructor.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/trusted-types-reporting-for-Window-setTimeout-setInterval.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-reporting-for-Window-setTimeout-setInterval.html.ini
@@ -1,0 +1,2 @@
+[trusted-types-reporting-for-Window-setTimeout-setInterval.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/trusted-types-reporting.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-reporting.html.ini
@@ -1,0 +1,25 @@
+[trusted-types-reporting.html]
+  expected: TIMEOUT
+  [Trusted Type violation report: creating a forbidden policy.]
+    expected: TIMEOUT
+
+  [Trusted Type violation report: creating a report-only-forbidden policy.]
+    expected: NOTRUN
+
+  [Trusted Type violation report: creating a forbidden-but-not-reported policy.]
+    expected: NOTRUN
+
+  [Trusted Type violation report: sample for SVGScriptElement href assignment]
+    expected: NOTRUN
+
+  [Trusted Type violation report: sample for SVGScriptElement href assignment by setAttribute]
+    expected: NOTRUN
+
+  [Trusted Type violation report: sample for eval]
+    expected: NOTRUN
+
+  [Trusted Type violation report: sample for custom element assignment]
+    expected: NOTRUN
+
+  [Trusted Type violation report: Worker constructor]
+    expected: NOTRUN

--- a/tests/wpt/meta/trusted-types/trusted-types-sandbox-allow-scripts.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-sandbox-allow-scripts.html.ini
@@ -1,0 +1,6 @@
+[trusted-types-sandbox-allow-scripts.html]
+  [window.trustedTypes.createPolicy() in a sandboxed page with allow-scripts.]
+    expected: FAIL
+
+  [Default Trusted Types policy in a sandboxed page with allow-scripts.]
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/trusted-types-sandbox-no-allow-scripts.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-sandbox-no-allow-scripts.html.ini
@@ -1,0 +1,3 @@
+[trusted-types-sandbox-no-allow-scripts.html]
+  [Trusted Types CSP directives don't affect the behavior of sandboxed page without allow-scripts.]
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/trusted-types-source-file-path.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-source-file-path.html.ini
@@ -1,0 +1,2 @@
+[trusted-types-source-file-path.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/trusted-types-svg-script-set-href.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-svg-script-set-href.html.ini
@@ -1,0 +1,2 @@
+[trusted-types-svg-script-set-href.html]
+  expected: ERROR

--- a/tests/wpt/meta/trusted-types/trusted-types-tojson.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-tojson.html.ini
@@ -1,0 +1,3 @@
+[trusted-types-tojson.html]
+  [toJSON]
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/tt-block-eval.html.ini
+++ b/tests/wpt/meta/trusted-types/tt-block-eval.html.ini
@@ -1,0 +1,2 @@
+[tt-block-eval.html]
+  expected: ERROR


### PR DESCRIPTION
To set a baseline of test expectations prior to implementation.

Part of #36258
