### PR TITLE
layout: Check if root before establishing containing block

### DIFF
--- a/components/layout/flexbox/layout.rs
+++ b/components/layout/flexbox/layout.rs
@@ -1774,19 +1774,17 @@ impl FlexItem<'_> {
         non_stretch_layout_result: Option<&mut FlexItemLayoutResult>,
     ) -> Option<FlexItemLayoutResult> {
         let containing_block = flex_context.containing_block;
-        let mut positioning_context = PositioningContext::new_for_style(
-            self.box_.style(),
-            &self.box_.base_fragment_info().flags,
-        )
-        .unwrap_or_else(|| {
-            PositioningContext::new_for_subtree(
-                flex_context
-                    .positioning_context
-                    .collects_for_nearest_positioned_ancestor(),
-            )
-        });
-
         let independent_formatting_context = &self.box_.independent_formatting_context;
+        let mut positioning_context = independent_formatting_context
+            .new_positioning_context()
+            .unwrap_or_else(|| {
+                PositioningContext::new_for_subtree(
+                    flex_context
+                        .positioning_context
+                        .collects_for_nearest_positioned_ancestor(),
+                )
+            });
+
         let item_writing_mode = independent_formatting_context.style().writing_mode;
         let item_is_horizontal = item_writing_mode.is_horizontal();
         let flex_axis = flex_context.config.flex_axis;
@@ -2619,15 +2617,16 @@ impl FlexItemBox {
         cross_size_stretches_to_container_size: bool,
         intrinsic_sizing_mode: IntrinsicSizingMode,
     ) -> Au {
-        let mut positioning_context =
-            PositioningContext::new_for_style(self.style(), &&self.base_fragment_info().flags)
-                .unwrap_or_else(|| {
-                    PositioningContext::new_for_subtree(
-                        flex_context
-                            .positioning_context
-                            .collects_for_nearest_positioned_ancestor(),
-                    )
-                });
+        let mut positioning_context = self
+            .independent_formatting_context
+            .new_positioning_context()
+            .unwrap_or_else(|| {
+                PositioningContext::new_for_subtree(
+                    flex_context
+                        .positioning_context
+                        .collects_for_nearest_positioned_ancestor(),
+                )
+            });
 
         let style = self.independent_formatting_context.style();
         match &self.independent_formatting_context.contents {

--- a/components/layout/flexbox/layout.rs
+++ b/components/layout/flexbox/layout.rs
@@ -1774,14 +1774,17 @@ impl FlexItem<'_> {
         non_stretch_layout_result: Option<&mut FlexItemLayoutResult>,
     ) -> Option<FlexItemLayoutResult> {
         let containing_block = flex_context.containing_block;
-        let mut positioning_context = PositioningContext::new_for_style(self.box_.style())
-            .unwrap_or_else(|| {
-                PositioningContext::new_for_subtree(
-                    flex_context
-                        .positioning_context
-                        .collects_for_nearest_positioned_ancestor(),
-                )
-            });
+        let mut positioning_context = PositioningContext::new_for_style(
+            self.box_.style(),
+            &self.box_.base_fragment_info().flags,
+        )
+        .unwrap_or_else(|| {
+            PositioningContext::new_for_subtree(
+                flex_context
+                    .positioning_context
+                    .collects_for_nearest_positioned_ancestor(),
+            )
+        });
 
         let independent_formatting_context = &self.box_.independent_formatting_context;
         let item_writing_mode = independent_formatting_context.style().writing_mode;
@@ -2616,14 +2619,15 @@ impl FlexItemBox {
         cross_size_stretches_to_container_size: bool,
         intrinsic_sizing_mode: IntrinsicSizingMode,
     ) -> Au {
-        let mut positioning_context = PositioningContext::new_for_style(self.style())
-            .unwrap_or_else(|| {
-                PositioningContext::new_for_subtree(
-                    flex_context
-                        .positioning_context
-                        .collects_for_nearest_positioned_ancestor(),
-                )
-            });
+        let mut positioning_context =
+            PositioningContext::new_for_style(self.style(), &&self.base_fragment_info().flags)
+                .unwrap_or_else(|| {
+                    PositioningContext::new_for_subtree(
+                        flex_context
+                            .positioning_context
+                            .collects_for_nearest_positioned_ancestor(),
+                    )
+                });
 
         let style = self.independent_formatting_context.style();
         match &self.independent_formatting_context.contents {

--- a/components/layout/flow/float.rs
+++ b/components/layout/flow/float.rs
@@ -918,6 +918,7 @@ impl FloatBox {
             layout_context,
             containing_block,
             &style,
+            &self.contents.base.base_fragment_info.flags,
             |positioning_context| {
                 self.contents
                     .layout_float_or_atomic_inline(

--- a/components/layout/flow/float.rs
+++ b/components/layout/flow/float.rs
@@ -913,12 +913,10 @@ impl FloatBox {
         positioning_context: &mut PositioningContext,
         containing_block: &ContainingBlock,
     ) -> BoxFragment {
-        let style = self.contents.style().clone();
         positioning_context.layout_maybe_position_relative_fragment(
             layout_context,
             containing_block,
-            &style,
-            &self.contents.base.base_fragment_info.flags,
+            &self.contents.base,
             |positioning_context| {
                 self.contents
                     .layout_float_or_atomic_inline(

--- a/components/layout/flow/inline/line.rs
+++ b/components/layout/flow/inline/line.rs
@@ -326,13 +326,12 @@ impl LineItemLayout<'_, '_> {
         let inline_box = self.layout.ifc.inline_boxes.get(identifier);
         let inline_box = &*(inline_box.borrow());
 
-        let style = &inline_box.base.style;
         let space_above_baseline = inline_box_state.calculate_space_above_baseline();
         let block_start_offset =
             self.calculate_inline_box_block_start(inline_box_state, space_above_baseline);
 
         let positioning_context_or_start_offset_in_parent =
-            match PositioningContext::new_for_style(style, &inline_box.base_fragment_info.flags) {
+            match inline_box.base.new_positioning_context() {
                 Some(positioning_context) => Either::Left(positioning_context),
                 None => Either::Right(self.current_positioning_context_mut().len()),
             };

--- a/components/layout/flow/inline/line.rs
+++ b/components/layout/flow/inline/line.rs
@@ -332,7 +332,7 @@ impl LineItemLayout<'_, '_> {
             self.calculate_inline_box_block_start(inline_box_state, space_above_baseline);
 
         let positioning_context_or_start_offset_in_parent =
-            match PositioningContext::new_for_style(style) {
+            match PositioningContext::new_for_style(style, &inline_box.base_fragment_info.flags) {
                 Some(positioning_context) => Either::Left(positioning_context),
                 None => Either::Right(self.current_positioning_context_mut().len()),
             };

--- a/components/layout/flow/inline/mod.rs
+++ b/components/layout/flow/inline/mod.rs
@@ -2004,8 +2004,9 @@ impl IndependentFormattingContext {
         bidi_level: Level,
     ) {
         // We need to know the inline size of the atomic before deciding whether to do the line break.
-        let mut child_positioning_context = PositioningContext::new_for_style(self.style())
-            .unwrap_or_else(|| PositioningContext::new_for_subtree(true));
+        let mut child_positioning_context =
+            PositioningContext::new_for_style(self.style(), &self.base_fragment_info().flags)
+                .unwrap_or_else(|| PositioningContext::new_for_subtree(true));
         let IndependentFloatOrAtomicLayoutResult {
             mut fragment,
             baselines,

--- a/components/layout/flow/inline/mod.rs
+++ b/components/layout/flow/inline/mod.rs
@@ -2004,9 +2004,9 @@ impl IndependentFormattingContext {
         bidi_level: Level,
     ) {
         // We need to know the inline size of the atomic before deciding whether to do the line break.
-        let mut child_positioning_context =
-            PositioningContext::new_for_style(self.style(), &self.base_fragment_info().flags)
-                .unwrap_or_else(|| PositioningContext::new_for_subtree(true));
+        let mut child_positioning_context = self
+            .new_positioning_context()
+            .unwrap_or_else(|| PositioningContext::new_for_subtree(true));
         let IndependentFloatOrAtomicLayoutResult {
             mut fragment,
             baselines,

--- a/components/layout/flow/mod.rs
+++ b/components/layout/flow/mod.rs
@@ -779,8 +779,7 @@ impl BlockLevelBox {
                 ArcRefCell::new(positioning_context.layout_maybe_position_relative_fragment(
                     layout_context,
                     containing_block,
-                    &base.style,
-                    &base.base_fragment_info.flags,
+                    base,
                     |positioning_context| {
                         layout_in_flow_non_replaced_block_level_same_formatting_context(
                             layout_context,
@@ -799,8 +798,7 @@ impl BlockLevelBox {
                 positioning_context.layout_maybe_position_relative_fragment(
                     layout_context,
                     containing_block,
-                    independent.style(),
-                    &independent.base_fragment_info().flags,
+                    &independent.base,
                     |positioning_context| {
                         independent.layout_in_flow_block_level(
                             layout_context,

--- a/components/layout/flow/mod.rs
+++ b/components/layout/flow/mod.rs
@@ -780,6 +780,7 @@ impl BlockLevelBox {
                     layout_context,
                     containing_block,
                     &base.style,
+                    &base.base_fragment_info.flags,
                     |positioning_context| {
                         layout_in_flow_non_replaced_block_level_same_formatting_context(
                             layout_context,
@@ -799,6 +800,7 @@ impl BlockLevelBox {
                     layout_context,
                     containing_block,
                     independent.style(),
+                    &independent.base_fragment_info().flags,
                     |positioning_context| {
                         independent.layout_in_flow_block_level(
                             layout_context,

--- a/components/layout/style_ext.rs
+++ b/components/layout/style_ext.rs
@@ -845,9 +845,9 @@ impl ComputedValuesExt for ComputedValues {
         // > A value other than none for the filter property results in the creation of a containing
         // > block for absolute and fixed positioned descendants unless the element it applies to is
         // > a document root element in the current browsing context.
-        // FIXME(#35391): Need to check if this is the root element.
-        if !self.get_effects().filter.0.is_empty() ||
-            will_change_bits.intersects(WillChangeBits::FIXPOS_CB_NON_SVG)
+        if !fragment_flags.contains(FragmentFlags::IS_ROOT_ELEMENT) &&
+            (!self.get_effects().filter.0.is_empty() ||
+                will_change_bits.intersects(WillChangeBits::FIXPOS_CB_NON_SVG))
         {
             return true;
         }

--- a/components/layout/table/layout.rs
+++ b/components/layout/table/layout.rs
@@ -1503,7 +1503,8 @@ impl<'a> TableLayout<'a> {
         layout_context: &LayoutContext,
         parent_positioning_context: &mut PositioningContext,
     ) -> BoxFragment {
-        let mut positioning_context = PositioningContext::new_for_style(caption.context.style());
+        let mut positioning_context =
+            PositioningContext::new_for_style(caption.context.style(), &context.base_fragment_info().flags);
         let containing_block = &ContainingBlock {
             size: ContainingBlockSize {
                 inline: self.table_width + self.pbm.padding_border_sums.inline,
@@ -2325,7 +2326,10 @@ impl<'a> RowFragmentLayout<'a> {
         Self {
             row: table_row,
             rect,
-            positioning_context: PositioningContext::new_for_style(&table_row.base.style),
+            positioning_context: PositioningContext::new_for_style(
+                &table_row.base.style,
+                &table_row.base.base_fragment_info.flags,
+            ),
             containing_block,
             fragments: Vec::new(),
         }
@@ -2416,7 +2420,10 @@ impl RowGroupFragmentLayout {
         Self {
             row_group,
             rect,
-            positioning_context,
+            positioning_context: PositioningContext::new_for_style(
+                &row_group.base.style,
+                &row_group.base.base_fragment_info.flags,
+            ),
             index,
             fragments: Vec::new(),
         }

--- a/components/layout/table/layout.rs
+++ b/components/layout/table/layout.rs
@@ -1503,8 +1503,7 @@ impl<'a> TableLayout<'a> {
         layout_context: &LayoutContext,
         parent_positioning_context: &mut PositioningContext,
     ) -> BoxFragment {
-        let mut positioning_context =
-            PositioningContext::new_for_style(caption.context.style(), &context.base_fragment_info().flags);
+        let mut positioning_context = caption.context.new_positioning_context();
         let containing_block = &ContainingBlock {
             size: ContainingBlockSize {
                 inline: self.table_width + self.pbm.padding_border_sums.inline,
@@ -2326,10 +2325,7 @@ impl<'a> RowFragmentLayout<'a> {
         Self {
             row: table_row,
             rect,
-            positioning_context: PositioningContext::new_for_style(
-                &table_row.base.style,
-                &table_row.base.base_fragment_info.flags,
-            ),
+            positioning_context: table_row.base.new_positioning_context(),
             containing_block,
             fragments: Vec::new(),
         }
@@ -2414,16 +2410,13 @@ impl RowGroupFragmentLayout {
             let row_group = row_group.borrow();
             (
                 dimensions.get_row_group_rect(&row_group),
-                PositioningContext::new_for_style(&row_group.base.style),
+                row_group.base.new_positioning_context(),
             )
         };
         Self {
             row_group,
             rect,
-            positioning_context: PositioningContext::new_for_style(
-                &row_group.base.style,
-                &row_group.base.base_fragment_info.flags,
-            ),
+            positioning_context,
             index,
             fragments: Vec::new(),
         }

--- a/components/layout/taffy/layout.rs
+++ b/components/layout/taffy/layout.rs
@@ -136,6 +136,7 @@ impl taffy::LayoutPartialTree for TaffyContainerContext<'_> {
                 // TODO: re-evaluate sizing constraint conversions in light of recent layout changes
                 let containing_block = &self.content_box_size_override;
                 let style = independent_context.style();
+                let flags = &independent_context.base_fragment_info().flags;
 
                 // Adjust known_dimensions from border box to content box
                 let pbm = independent_context
@@ -251,13 +252,15 @@ impl taffy::LayoutPartialTree for TaffyContainerContext<'_> {
                             style,
                         };
                         let layout = {
-                            let mut child_positioning_context =
-                                PositioningContext::new_for_style(style).unwrap_or_else(|| {
-                                    PositioningContext::new_for_subtree(
-                                        self.positioning_context
-                                            .collects_for_nearest_positioned_ancestor(),
-                                    )
-                                });
+                            let mut child_positioning_context = PositioningContext::new_for_style(
+                                style, flags,
+                            )
+                            .unwrap_or_else(|| {
+                                PositioningContext::new_for_subtree(
+                                    self.positioning_context
+                                        .collects_for_nearest_positioned_ancestor(),
+                                )
+                            });
 
                             let layout = non_replaced.layout_without_caching(
                                 self.layout_context,

--- a/components/layout/taffy/layout.rs
+++ b/components/layout/taffy/layout.rs
@@ -136,7 +136,6 @@ impl taffy::LayoutPartialTree for TaffyContainerContext<'_> {
                 // TODO: re-evaluate sizing constraint conversions in light of recent layout changes
                 let containing_block = &self.content_box_size_override;
                 let style = independent_context.style();
-                let flags = &independent_context.base_fragment_info().flags;
 
                 // Adjust known_dimensions from border box to content box
                 let pbm = independent_context
@@ -252,15 +251,14 @@ impl taffy::LayoutPartialTree for TaffyContainerContext<'_> {
                             style,
                         };
                         let layout = {
-                            let mut child_positioning_context = PositioningContext::new_for_style(
-                                style, flags,
-                            )
-                            .unwrap_or_else(|| {
-                                PositioningContext::new_for_subtree(
-                                    self.positioning_context
-                                        .collects_for_nearest_positioned_ancestor(),
-                                )
-                            });
+                            let mut child_positioning_context = independent_context
+                                .new_positioning_context()
+                                .unwrap_or_else(|| {
+                                    PositioningContext::new_for_subtree(
+                                        self.positioning_context
+                                            .collects_for_nearest_positioned_ancestor(),
+                                    )
+                                });
 
                             let layout = non_replaced.layout_without_caching(
                                 self.layout_context,

--- a/tests/wpt/meta/css/css-will-change/will-change-fixedpos-cb-003.html.ini
+++ b/tests/wpt/meta/css/css-will-change/will-change-fixedpos-cb-003.html.ini
@@ -1,2 +1,0 @@
-[will-change-fixedpos-cb-003.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/filter-effects/filtered-html-is-not-container.html.ini
+++ b/tests/wpt/meta/css/filter-effects/filtered-html-is-not-container.html.ini
@@ -1,2 +1,0 @@
-[filtered-html-is-not-container.html]
-  expected: FAIL


### PR DESCRIPTION
As per [w3.org/TR/filter-effects-1#FilterProperty](https://www.w3.org/TR/filter-effects-1/#FilterProperty), `filter` shouldn't make the root element establish a containing block for absolute and fixed positioned descendants. `will-change: filter` has matching behavior.

This PR adds a check for if we are the root element before establishing such a block.

To know if we are the root element, we look at the `FragmentFlags` passed in. Previously for our function, these were dummy flags, always constructed as empty. Thus, this PR also makes sure the correct FragmentFlags are passed down the chain to the function `establishes_containing_block_for_all_descendants`.

Testing:
- `/css/filter-effects/filtered-html-is-not-container.html` now passes
- `/css/css-will-change/will-change-fixedpos-cb-003.html` now passes
- Manual tests are working

Fixes: #35391 
