### PR TITLE
Implement CSP check for Trusted Types

### DIFF
--- a/tests/wpt/meta/trusted-types/TrustedTypePolicy-CSP-no-name.html.ini
+++ b/tests/wpt/meta/trusted-types/TrustedTypePolicy-CSP-no-name.html.ini
@@ -1,3 +1,0 @@
-[TrustedTypePolicy-CSP-no-name.html]
-  [No name list given - policy creation fails.]
-    expected: FAIL

--- a/tests/wpt/meta/trusted-types/TrustedTypePolicyFactory-createPolicy-cspTests-noNamesGiven.html.ini
+++ b/tests/wpt/meta/trusted-types/TrustedTypePolicyFactory-createPolicy-cspTests-noNamesGiven.html.ini
@@ -1,3 +1,0 @@
-[TrustedTypePolicyFactory-createPolicy-cspTests-noNamesGiven.html]
-  [No name list given - policy creation throws]
-    expected: FAIL

--- a/tests/wpt/meta/trusted-types/TrustedTypePolicyFactory-createPolicy-cspTests-none-none-name.html.ini
+++ b/tests/wpt/meta/trusted-types/TrustedTypePolicyFactory-createPolicy-cspTests-none-none-name.html.ini
@@ -1,3 +1,0 @@
-[TrustedTypePolicyFactory-createPolicy-cspTests-none-none-name.html]
-  [Cannot create policy with name 'default' - policy creation throws]
-    expected: FAIL

--- a/tests/wpt/meta/trusted-types/TrustedTypePolicyFactory-createPolicy-cspTests-none-none.html.ini
+++ b/tests/wpt/meta/trusted-types/TrustedTypePolicyFactory-createPolicy-cspTests-none-none.html.ini
@@ -1,6 +1,0 @@
-[TrustedTypePolicyFactory-createPolicy-cspTests-none-none.html]
-  [Cannot create policy with name 'SomeName' - policy creation throws]
-    expected: FAIL
-
-  [Cannot create policy with name 'default' - policy creation throws]
-    expected: FAIL

--- a/tests/wpt/meta/trusted-types/should-trusted-type-policy-creation-be-blocked-by-csp-001.html.ini
+++ b/tests/wpt/meta/trusted-types/should-trusted-type-policy-creation-be-blocked-by-csp-001.html.ini
@@ -1,66 +1,30 @@
 [should-trusted-type-policy-creation-be-blocked-by-csp-001.html]
-  [single enforce policy with directive "trusted-type tt-policy-name"]
-    expected: FAIL
-
   [single report-only policy with directive "trusted-type tt-policy-name"]
-    expected: FAIL
-
-  [single enforce policy with directive "trusted-type *"]
     expected: FAIL
 
   [single report-only policy with directive "trusted-type *"]
     expected: FAIL
 
-  [single enforce policy with directive "trusted-type 'none'"]
-    expected: FAIL
-
   [single report-only policy with directive "trusted-type 'none'"]
-    expected: FAIL
-
-  [single enforce policy with directive "trusted-type 'allow-duplicates'"]
     expected: FAIL
 
   [single report-only policy with directive "trusted-type 'allow-duplicates'"]
     expected: FAIL
 
-  [single enforce policy with directive "trusted-type tt-policy-name 'allow-duplicates'"]
-    expected: FAIL
-
   [single report-only policy with directive "trusted-type tt-policy-name 'allow-duplicates'"]
-    expected: FAIL
-
-  [single enforce policy with directive "trusted-type 'none' 'allow-duplicates'"]
     expected: FAIL
 
   [single report-only policy with directive "trusted-type 'none' 'allow-duplicates'"]
     expected: FAIL
 
-  [single enforce policy with directive "trusted-type 'none' tt-policy-name"]
-    expected: FAIL
-
   [single report-only policy with directive "trusted-type 'none' tt-policy-name"]
-    expected: FAIL
-
-  [single enforce policy with directive "trusted-type 'none' *"]
     expected: FAIL
 
   [single report-only policy with directive "trusted-type 'none' *"]
     expected: FAIL
 
-  [single enforce policy with directive "trusted-type tt-policy-name *"]
-    expected: FAIL
-
   [single report-only policy with directive "trusted-type tt-policy-name *"]
     expected: FAIL
 
-  [single enforce policy with directive "trusted-type tt-policy-name1 tt-policy-name2 tt-policy-name3"]
-    expected: FAIL
-
   [single report-only policy with directive "trusted-type tt-policy-name1 tt-policy-name2 tt-policy-name3"]
-    expected: FAIL
-
-  [Single enforce policy with directive "trusted-type none"]
-    expected: FAIL
-
-  [Single enforce policy with directive "trusted-type allow-duplicates"]
     expected: FAIL

--- a/tests/wpt/meta/trusted-types/trusted-types-duplicate-names-list.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-duplicate-names-list.html.ini
@@ -1,3 +1,0 @@
-[trusted-types-duplicate-names-list.html]
-  [TrustedTypePolicyFactory and policy list in CSP.]
-    expected: FAIL

--- a/tests/wpt/meta/trusted-types/trusted-types-reporting-clipping-of-sample.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-reporting-clipping-of-sample.html.ini
@@ -1,4 +1,5 @@
 [trusted-types-reporting-clipping-of-sample.html]
+  expected: CRASH
   [Clipping of violation sample for createPolicy(AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA)]
     expected: FAIL
 

--- a/tests/wpt/meta/trusted-types/trusted-types-reporting-clipping-of-sample.tentative.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-reporting-clipping-of-sample.tentative.html.ini
@@ -1,4 +1,5 @@
 [trusted-types-reporting-clipping-of-sample.tentative.html]
+  expected: CRASH
   [Clipping of violation sample for createPolicy(𝐆𝐆𝐆𝐆𝐆𝐆𝐆𝐆𝐆𝐆𝐆𝐆𝐆𝐆𝐆𝐆𝐆𝐆𝐆𝐆)]
     expected: FAIL
 

--- a/tests/wpt/meta/trusted-types/trusted-types-sandbox-allow-scripts.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-sandbox-allow-scripts.html.ini
@@ -1,6 +1,3 @@
 [trusted-types-sandbox-allow-scripts.html]
-  [window.trustedTypes.createPolicy() in a sandboxed page with allow-scripts.]
-    expected: FAIL
-
   [Default Trusted Types policy in a sandboxed page with allow-scripts.]
     expected: FAIL


### PR DESCRIPTION
The algorithm [1] is implemented in the content-security-policy
package.

Requires https://github.com/rust-ammonia/rust-content-security-policy/pull/56
This is part of #36258

[1]: https://w3c.github.io/trusted-types/dist/spec/#abstract-opdef-should-trusted-type-policy-creation-be-blocked-by-content-security-policy