### PR TITLE
Improve the display of top-level images

### DIFF
--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -41,7 +41,6 @@ use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::DocumentBinding::{
     DocumentMethods, DocumentReadyState,
 };
-use crate::dom::bindings::codegen::Bindings::HTMLImageElementBinding::HTMLImageElementMethods;
 use crate::dom::bindings::codegen::Bindings::HTMLTemplateElementBinding::HTMLTemplateElementMethods;
 use crate::dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
 use crate::dom::bindings::codegen::Bindings::ShadowRootBinding::{
@@ -52,7 +51,7 @@ use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::{DomGlobal, Reflector, reflect_dom_object};
 use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
 use crate::dom::bindings::settings_stack::is_execution_stack_empty;
-use crate::dom::bindings::str::{DOMString, USVString};
+use crate::dom::bindings::str::DOMString;
 use crate::dom::characterdata::CharacterData;
 use crate::dom::comment::Comment;
 use crate::dom::document::{Document, DocumentSource, HasBrowsingContext, IsHTMLDocument};
@@ -60,7 +59,6 @@ use crate::dom::documentfragment::DocumentFragment;
 use crate::dom::documenttype::DocumentType;
 use crate::dom::element::{CustomElementCreationMode, Element, ElementCreator};
 use crate::dom::htmlformelement::{FormControlElementHelpers, HTMLFormElement};
-use crate::dom::htmlimageelement::HTMLImageElement;
 use crate::dom::htmlinputelement::HTMLInputElement;
 use crate::dom::htmlscriptelement::{HTMLScriptElement, ScriptResult};
 use crate::dom::htmltemplateelement::HTMLTemplateElement;
@@ -904,17 +902,9 @@ impl FetchResponseListener for ParserContext {
         ) {
             (mime::IMAGE, _, _) => {
                 self.is_synthesized_document = true;
-                let page = "<html><body></body></html>".into();
+                let page = resources::read_string(Resource::ImageDocumentHTML);
                 parser.push_string_input_chunk(page);
                 parser.parse_sync(CanGc::note());
-
-                let doc = &parser.document;
-                let doc_body = DomRoot::upcast::<Node>(doc.GetBody().unwrap());
-                let img = HTMLImageElement::new(local_name!("img"), None, doc, None, CanGc::note());
-                img.SetSrc(USVString(self.url.to_string()));
-                doc_body
-                    .AppendChild(&DomRoot::upcast::<Node>(img), CanGc::note())
-                    .expect("Appending failed");
             },
             (mime::TEXT, mime::PLAIN, _) => {
                 // https://html.spec.whatwg.org/multipage/#read-text

--- a/components/shared/embedder/resources.rs
+++ b/components/shared/embedder/resources.rs
@@ -115,6 +115,8 @@ pub enum Resource {
     DirectoryListingHTML,
     /// A HTML page that is used for the about:memory url.
     AboutMemoryHTML,
+    /// A HTML page used when loading an image as the top-level content.
+    ImageDocumentHTML,
 }
 
 impl Resource {
@@ -135,6 +137,7 @@ impl Resource {
             Resource::CrashHTML => "crash.html",
             Resource::DirectoryListingHTML => "directory-listing.html",
             Resource::AboutMemoryHTML => "about-memory.html",
+            Resource::ImageDocumentHTML => "image-document.html",
         }
     }
 }
@@ -194,6 +197,9 @@ fn resources_for_tests() -> Box<dyn ResourceReaderMethods + Sync + Send> {
                 },
                 Resource::AboutMemoryHTML => {
                     &include_bytes!("../../../resources/about-memory.html")[..]
+                },
+                Resource::ImageDocumentHTML => {
+                    &include_bytes!("../../../resources/image-document.html")[..]
                 },
             }
             .to_owned()

--- a/ports/servoshell/egl/android/resources.rs
+++ b/ports/servoshell/egl/android/resources.rs
@@ -45,6 +45,9 @@ impl ResourceReaderMethods for ResourceReaderInstance {
             Resource::AboutMemoryHTML => {
                 &include_bytes!("../../../../resources/about-memory.html")[..]
             },
+            Resource::ImageDocumentHTML => {
+                &include_bytes!("../../../../resources/image-document.html")[..]
+            },
         })
     }
 

--- a/resources/image-document.html
+++ b/resources/image-document.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title></title>
+    <style>
+      html,
+      body {
+        background-color: white;
+        margin: 0;
+        width: 100%;
+        height: 100%;
+      }
+
+      body {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+      }
+
+      body.zoomed-in img {
+        cursor: zoom-out;
+      }
+
+      body.zoomed-out img {
+        cursor: zoom-in;
+        max-width: 100vw;
+        max-height: 100vh;
+      }
+
+      img {
+        /* Creates a checkerboard background for transparent images */
+        background: repeating-conic-gradient(#ccc 0% 25%, white 0% 50%);
+        background-size: 40px 40px;
+      }
+    </style>
+    <script>
+      // true if we try to adjust the image size to fit the viewport,
+      // false if we let it scroll when it's larger.
+      var adjustSize = true;
+
+      var img;
+
+      function configureImage() {
+        const body = document.body;
+        body.classList.remove("zoomed-in");
+        body.classList.remove("zoomed-out");
+
+        if (
+          img.naturalWidth > window.innerWidth ||
+          img.naturalHeight > window.innerHeight
+        ) {
+          body.classList.add(adjustSize ? "zoomed-out" : "zoomed-in");
+        }
+      }
+
+      document.addEventListener("DOMContentLoaded", () => {
+        img = document.body.firstElementChild;
+        window.onresize = img.onload = configureImage;
+
+        img.onclick = () => {
+          adjustSize = !adjustSize;
+          configureImage();
+        };
+
+        img.src = location.href;
+
+        // Set the page title based on the image url.
+        try {
+          const path = location.pathname;
+          const segments = path.split('/');
+          document.title = segments.pop() || url.toString();
+        } catch (error) {
+          console.error('Invalid URL:', error);
+        }
+      });
+    </script>
+  </head>
+  <body><img src="#"></body>
+</html>


### PR DESCRIPTION
Instead of just synthesizing an img tag, this uses a resource document. This provides:
- zoom in / zoom out when needed.
- checkerboard when the image has transparency.
