### PR TITLE
Add CanGc as arguments in methods in Attr and Node

### DIFF
--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -105,7 +105,7 @@ pub(crate) fn handle_get_root_node(
 ) {
     let info = documents
         .find_document(pipeline)
-        .map(|document| document.upcast::<Node>().summarize());
+        .map(|document| document.upcast::<Node>().summarize(CanGc::note()));
     reply.send(info).unwrap();
 }
 
@@ -117,7 +117,7 @@ pub(crate) fn handle_get_document_element(
     let info = documents
         .find_document(pipeline)
         .and_then(|document| document.GetDocumentElement())
-        .map(|element| element.upcast::<Node>().summarize());
+        .map(|element| element.upcast::<Node>().summarize(CanGc::note()));
     reply.send(info).unwrap();
 }
 
@@ -166,7 +166,7 @@ pub(crate) fn handle_get_children(
                 if !shadow_root.is_user_agent_widget() ||
                     pref!(inspector_show_servo_internal_shadow_roots)
                 {
-                    children.push(shadow_root.upcast::<Node>().summarize());
+                    children.push(shadow_root.upcast::<Node>().summarize(CanGc::note()));
                 }
             }
             let children_iter = parent.children().enumerate().filter_map(|(i, child)| {
@@ -175,7 +175,7 @@ pub(crate) fn handle_get_children(
                 let prev_inline = i > 0 && inline[i - 1];
                 let next_inline = i < inline.len() - 1 && inline[i + 1];
 
-                let info = child.summarize();
+                let info = child.summarize(CanGc::note());
                 if !is_whitespace(&info) {
                     return Some(info);
                 }

--- a/components/script/dom/attr.rs
+++ b/components/script/dom/attr.rs
@@ -112,10 +112,10 @@ impl AttrMethods<crate::DomTypeHolder> for Attr {
     }
 
     // https://dom.spec.whatwg.org/#dom-attr-value
-    fn SetValue(&self, value: DOMString) {
+    fn SetValue(&self, value: DOMString, can_gc: CanGc) {
         if let Some(owner) = self.owner() {
             let value = owner.parse_attribute(self.namespace(), self.local_name(), value);
-            self.set_value(value, &owner, CanGc::note());
+            self.set_value(value, &owner, can_gc);
         } else {
             *self.value.borrow_mut() = AttrValue::String(value.into());
         }

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -2249,13 +2249,13 @@ impl Document {
             for node in nodes {
                 match node {
                     NodeOrString::Node(node) => {
-                        fragment.AppendChild(&node)?;
+                        fragment.AppendChild(&node, can_gc)?;
                     },
                     NodeOrString::String(string) => {
                         let node = DomRoot::upcast::<Node>(self.CreateTextNode(string, can_gc));
                         // No try!() here because appending a text node
                         // should not fail.
-                        fragment.AppendChild(&node).unwrap();
+                        fragment.AppendChild(&node, can_gc).unwrap();
                     },
                 }
             }
@@ -5404,7 +5404,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
                     let parent = root.upcast::<Node>();
                     let child = elem.upcast::<Node>();
                     parent
-                        .InsertBefore(child, parent.GetFirstChild().as_deref())
+                        .InsertBefore(child, parent.GetFirstChild().as_deref(), can_gc)
                         .unwrap()
                 },
             }
@@ -5427,7 +5427,9 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
                             None,
                             can_gc,
                         );
-                        head.upcast::<Node>().AppendChild(elem.upcast()).unwrap()
+                        head.upcast::<Node>()
+                            .AppendChild(elem.upcast(), can_gc)
+                            .unwrap()
                     },
                     None => return,
                 },
@@ -5500,7 +5502,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
             // Step 3.
             (Some(ref root), Some(child)) => {
                 let root = root.upcast::<Node>();
-                root.ReplaceChild(new_body.upcast(), child.upcast())
+                root.ReplaceChild(new_body.upcast(), child.upcast(), CanGc::note())
                     .unwrap();
             },
 
@@ -5510,7 +5512,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
             // Step 5.
             (Some(ref root), &None) => {
                 let root = root.upcast::<Node>();
-                root.AppendChild(new_body.upcast()).unwrap();
+                root.AppendChild(new_body.upcast(), CanGc::note()).unwrap();
             },
         }
         Ok(())

--- a/components/script/dom/domimplementation.rs
+++ b/components/script/dom/domimplementation.rs
@@ -138,12 +138,12 @@ impl DOMImplementationMethods<crate::DomTypeHolder> for DOMImplementation {
 
             // Step 4.
             if let Some(doc_type) = maybe_doctype {
-                doc_node.AppendChild(doc_type.upcast()).unwrap();
+                doc_node.AppendChild(doc_type.upcast(), can_gc).unwrap();
             }
 
             // Step 5.
             if let Some(ref elem) = maybe_elem {
-                doc_node.AppendChild(elem.upcast()).unwrap();
+                doc_node.AppendChild(elem.upcast(), can_gc).unwrap();
             }
         }
 
@@ -185,7 +185,7 @@ impl DOMImplementationMethods<crate::DomTypeHolder> for DOMImplementation {
             // Step 3.
             let doc_node = doc.upcast::<Node>();
             let doc_type = DocumentType::new(DOMString::from("html"), None, None, &doc, can_gc);
-            doc_node.AppendChild(doc_type.upcast()).unwrap();
+            doc_node.AppendChild(doc_type.upcast(), can_gc).unwrap();
         }
 
         {
@@ -198,7 +198,9 @@ impl DOMImplementationMethods<crate::DomTypeHolder> for DOMImplementation {
                 None,
                 can_gc,
             ));
-            doc_node.AppendChild(&doc_html).expect("Appending failed");
+            doc_node
+                .AppendChild(&doc_html, can_gc)
+                .expect("Appending failed");
 
             {
                 // Step 5.
@@ -209,7 +211,7 @@ impl DOMImplementationMethods<crate::DomTypeHolder> for DOMImplementation {
                     None,
                     can_gc,
                 ));
-                doc_html.AppendChild(&doc_head).unwrap();
+                doc_html.AppendChild(&doc_head, can_gc).unwrap();
 
                 // Step 6.
                 if let Some(title_str) = title {
@@ -221,17 +223,17 @@ impl DOMImplementationMethods<crate::DomTypeHolder> for DOMImplementation {
                         None,
                         can_gc,
                     ));
-                    doc_head.AppendChild(&doc_title).unwrap();
+                    doc_head.AppendChild(&doc_title, can_gc).unwrap();
 
                     // Step 6.2.
                     let title_text = Text::new(title_str, &doc, can_gc);
-                    doc_title.AppendChild(title_text.upcast()).unwrap();
+                    doc_title.AppendChild(title_text.upcast(), can_gc).unwrap();
                 }
             }
 
             // Step 7.
             let doc_body = HTMLBodyElement::new(local_name!("body"), None, &doc, None, can_gc);
-            doc_html.AppendChild(doc_body.upcast()).unwrap();
+            doc_html.AppendChild(doc_body.upcast(), can_gc).unwrap();
         }
 
         // Step 8.

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -2170,7 +2170,10 @@ impl Element {
         let fragment = DocumentFragment::new(&context_document, can_gc);
         // Step 4.
         for child in new_children {
-            fragment.upcast::<Node>().AppendChild(&child).unwrap();
+            fragment
+                .upcast::<Node>()
+                .AppendChild(&child, can_gc)
+                .unwrap();
         }
         // Step 5.
         Ok(fragment)
@@ -2973,7 +2976,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
 
         // For each node in newChildren, append node to fragment.
         for child in new_children {
-            frag.upcast::<Node>().AppendChild(&child).unwrap();
+            frag.upcast::<Node>().AppendChild(&child, can_gc).unwrap();
         }
 
         // Replace all with fragment within target.
@@ -3093,7 +3096,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         // Step 5.
         let frag = parent.parse_fragment(value, can_gc)?;
         // Step 6.
-        context_parent.ReplaceChild(frag.upcast(), context_node)?;
+        context_parent.ReplaceChild(frag.upcast(), context_node, can_gc)?;
         Ok(())
     }
 

--- a/components/script/dom/htmldetailselement.rs
+++ b/components/script/dom/htmldetailselement.rs
@@ -118,7 +118,7 @@ impl HTMLDetailsElement {
 
         let summary = HTMLSlotElement::new(local_name!("slot"), None, &document, None, can_gc);
         root.upcast::<Node>()
-            .AppendChild(summary.upcast::<Node>())
+            .AppendChild(summary.upcast::<Node>(), can_gc)
             .unwrap();
 
         let fallback_summary =
@@ -128,12 +128,12 @@ impl HTMLDetailsElement {
             .SetTextContent(Some(DEFAULT_SUMMARY.into()), can_gc);
         summary
             .upcast::<Node>()
-            .AppendChild(fallback_summary.upcast::<Node>())
+            .AppendChild(fallback_summary.upcast::<Node>(), can_gc)
             .unwrap();
 
         let descendants = HTMLSlotElement::new(local_name!("slot"), None, &document, None, can_gc);
         root.upcast::<Node>()
-            .AppendChild(descendants.upcast::<Node>())
+            .AppendChild(descendants.upcast::<Node>(), can_gc)
             .unwrap();
 
         let _ = self.shadow_tree.borrow_mut().insert(ShadowTree {

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -532,11 +532,13 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
         if fragment.upcast::<Node>().children_count() == 0 {
             let text_node = Text::new(DOMString::from("".to_owned()), &document, can_gc);
 
-            fragment.upcast::<Node>().AppendChild(text_node.upcast())?;
+            fragment
+                .upcast::<Node>()
+                .AppendChild(text_node.upcast(), can_gc)?;
         }
 
         // Step 6: Replace this with fragment within this's parent.
-        parent.ReplaceChild(fragment.upcast(), node)?;
+        parent.ReplaceChild(fragment.upcast(), node, can_gc)?;
 
         // Step 7: If next is non-null and next's previous sibling is a Text node, then merge with
         // the next text node given next's previous sibling.
@@ -670,7 +672,7 @@ fn append_text_node_to_fragment(
     let text = Text::new(DOMString::from(text), document, can_gc);
     fragment
         .upcast::<Node>()
-        .AppendChild(text.upcast())
+        .AppendChild(text.upcast(), can_gc)
         .unwrap();
 }
 
@@ -1016,7 +1018,10 @@ impl HTMLElement {
                     }
 
                     let br = HTMLBRElement::new(local_name!("br"), None, &document, None, can_gc);
-                    fragment.upcast::<Node>().AppendChild(br.upcast()).unwrap();
+                    fragment
+                        .upcast::<Node>()
+                        .AppendChild(br.upcast(), can_gc)
+                        .unwrap();
                 },
                 _ => {
                     // Collect a sequence of code points that are not U+000A LF or U+000D CR from

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -1928,7 +1928,7 @@ impl HTMLMediaElement {
             .SetTextContent(Some(DOMString::from(media_controls_script)), can_gc);
         if let Err(e) = shadow_root
             .upcast::<Node>()
-            .AppendChild(script.upcast::<Node>())
+            .AppendChild(script.upcast::<Node>(), can_gc)
         {
             warn!("Could not render media controls {:?}", e);
             return;
@@ -1949,7 +1949,7 @@ impl HTMLMediaElement {
 
         if let Err(e) = shadow_root
             .upcast::<Node>()
-            .AppendChild(style.upcast::<Node>())
+            .AppendChild(style.upcast::<Node>(), can_gc)
         {
             warn!("Could not render media controls {:?}", e);
         }

--- a/components/script/dom/htmlmeterelement.rs
+++ b/components/script/dom/htmlmeterelement.rs
@@ -94,7 +94,7 @@ impl HTMLMeterElement {
 
         let meter_value = HTMLDivElement::new(local_name!("div"), None, &document, None, can_gc);
         root.upcast::<Node>()
-            .AppendChild(meter_value.upcast::<Node>())
+            .AppendChild(meter_value.upcast::<Node>(), can_gc)
             .unwrap();
 
         let _ = self.shadow_tree.borrow_mut().insert(ShadowTree {

--- a/components/script/dom/htmloptionscollection.rs
+++ b/components/script/dom/htmloptionscollection.rs
@@ -64,7 +64,7 @@ impl HTMLOptionsCollection {
             let element =
                 HTMLOptionElement::new(local_name!("option"), None, &document, None, can_gc);
             let node = element.upcast::<Node>();
-            root.AppendChild(node)?;
+            root.AppendChild(node, can_gc)?;
         }
         Ok(())
     }
@@ -122,7 +122,7 @@ impl HTMLOptionsCollectionMethods<crate::DomTypeHolder> for HTMLOptionsCollectio
                 let child = self.upcast().IndexedGetter(index).unwrap();
                 let child_node = child.upcast::<Node>();
 
-                root.ReplaceChild(node, child_node).map(|_| ())
+                root.ReplaceChild(node, child_node, can_gc).map(|_| ())
             }
         } else {
             // Step 1

--- a/components/script/dom/htmlprogresselement.rs
+++ b/components/script/dom/htmlprogresselement.rs
@@ -96,7 +96,7 @@ impl HTMLProgressElement {
             .upcast::<Element>()
             .SetId("-servo-progress-bar".into(), can_gc);
         root.upcast::<Node>()
-            .AppendChild(progress_bar.upcast::<Node>())
+            .AppendChild(progress_bar.upcast::<Node>(), can_gc)
             .unwrap();
 
         let _ = self.shadow_tree.borrow_mut().insert(ShadowTree {

--- a/components/script/dom/htmlselectelement.rs
+++ b/components/script/dom/htmlselectelement.rs
@@ -286,7 +286,7 @@ impl HTMLSelectElement {
         );
         select_box
             .upcast::<Node>()
-            .AppendChild(text_container.upcast::<Node>())
+            .AppendChild(text_container.upcast::<Node>(), can_gc)
             .unwrap();
 
         let text = Text::new(DOMString::new(), &document, can_gc);
@@ -295,7 +295,7 @@ impl HTMLSelectElement {
         });
         text_container
             .upcast::<Node>()
-            .AppendChild(text.upcast::<Node>())
+            .AppendChild(text.upcast::<Node>(), can_gc)
             .unwrap();
 
         let chevron_container =
@@ -310,11 +310,11 @@ impl HTMLSelectElement {
             .SetTextContent(Some("▾".into()), can_gc);
         select_box
             .upcast::<Node>()
-            .AppendChild(chevron_container.upcast::<Node>())
+            .AppendChild(chevron_container.upcast::<Node>(), can_gc)
             .unwrap();
 
         root.upcast::<Node>()
-            .AppendChild(select_box.upcast::<Node>())
+            .AppendChild(select_box.upcast::<Node>(), can_gc)
             .unwrap();
     }
 

--- a/components/script/dom/htmltableelement.rs
+++ b/components/script/dom/htmltableelement.rs
@@ -133,7 +133,7 @@ impl HTMLTableElement {
             let reference_element = node.child_elements().find(reference_predicate);
             let reference_node = reference_element.as_ref().map(|e| e.upcast());
 
-            node.InsertBefore(section.upcast(), reference_node)?;
+            node.InsertBefore(section.upcast(), reference_node, can_gc)?;
         }
 
         Ok(())
@@ -212,7 +212,11 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
 
         if let Some(caption) = new_caption {
             let node = self.upcast::<Node>();
-            node.InsertBefore(caption.upcast(), node.GetFirstChild().as_deref())?;
+            node.InsertBefore(
+                caption.upcast(),
+                node.GetFirstChild().as_deref(),
+                CanGc::note(),
+            )?;
         }
 
         Ok(())
@@ -339,7 +343,7 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
             .find(|n| n.is::<HTMLTableSectionElement>() && n.local_name() == &local_name!("tbody"));
         let reference_element = last_tbody.and_then(|t| t.upcast::<Node>().GetNextSibling());
 
-        node.InsertBefore(tbody.upcast(), reference_element.as_deref())
+        node.InsertBefore(tbody.upcast(), reference_element.as_deref(), can_gc)
             .expect("Insertion failed");
         tbody
     }
@@ -373,16 +377,16 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
             {
                 last_tbody
                     .upcast::<Node>()
-                    .AppendChild(new_row.upcast::<Node>())
+                    .AppendChild(new_row.upcast::<Node>(), can_gc)
                     .expect("InsertRow failed to append first row.");
             } else {
                 let tbody = self.CreateTBody(can_gc);
-                node.AppendChild(tbody.upcast())
+                node.AppendChild(tbody.upcast(), can_gc)
                     .expect("InsertRow failed to append new tbody.");
 
                 tbody
                     .upcast::<Node>()
-                    .AppendChild(new_row.upcast::<Node>())
+                    .AppendChild(new_row.upcast::<Node>(), can_gc)
                     .expect("InsertRow failed to append first row.");
             }
         } else if index == number_of_row_elements as i32 || index == -1 {
@@ -398,7 +402,7 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
 
             last_row_parent
                 .upcast::<Node>()
-                .AppendChild(new_row.upcast::<Node>())
+                .AppendChild(new_row.upcast::<Node>(), can_gc)
                 .expect("InsertRow failed to append last row.");
         } else {
             // insert new row before the index-th row in rows using the same parent
@@ -413,7 +417,11 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
 
             ith_row_parent
                 .upcast::<Node>()
-                .InsertBefore(new_row.upcast::<Node>(), Some(ith_row.upcast::<Node>()))
+                .InsertBefore(
+                    new_row.upcast::<Node>(),
+                    Some(ith_row.upcast::<Node>()),
+                    can_gc,
+                )
                 .expect("InsertRow failed to append row");
         }
 

--- a/components/script/dom/htmltemplateelement.rs
+++ b/components/script/dom/htmltemplateelement.rs
@@ -149,7 +149,7 @@ impl VirtualMethods for HTMLTemplateElement {
                 CloneChildrenFlag::CloneChildren,
                 CanGc::note(),
             );
-            copy_contents.AppendChild(&copy_child).unwrap();
+            copy_contents.AppendChild(&copy_child, can_gc).unwrap();
         }
     }
 }

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -596,7 +596,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
                     .unwrap();
                 let clone = cdata.clone_with_data(data, &start_node.owner_doc(), can_gc);
                 // Step 4.3.
-                fragment.upcast::<Node>().AppendChild(&clone)?;
+                fragment.upcast::<Node>().AppendChild(&clone, can_gc)?;
                 // Step 4.4
                 return Ok(fragment);
             }
@@ -619,12 +619,12 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
                     .unwrap();
                 let clone = cdata.clone_with_data(data, &start_node.owner_doc(), can_gc);
                 // Step 13.3.
-                fragment.upcast::<Node>().AppendChild(&clone)?;
+                fragment.upcast::<Node>().AppendChild(&clone, can_gc)?;
             } else {
                 // Step 14.1.
                 let clone = child.CloneNode(/* deep */ false, can_gc)?;
                 // Step 14.2.
-                fragment.upcast::<Node>().AppendChild(&clone)?;
+                fragment.upcast::<Node>().AppendChild(&clone, can_gc)?;
                 // Step 14.3.
                 let subrange = Range::new(
                     &clone.owner_doc(),
@@ -637,7 +637,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
                 // Step 14.4.
                 let subfragment = subrange.CloneContents(can_gc)?;
                 // Step 14.5.
-                clone.AppendChild(subfragment.upcast())?;
+                clone.AppendChild(subfragment.upcast(), can_gc)?;
             }
         }
 
@@ -646,7 +646,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
             // Step 15.1.
             let clone = child.CloneNode(/* deep */ true, can_gc)?;
             // Step 15.2.
-            fragment.upcast::<Node>().AppendChild(&clone)?;
+            fragment.upcast::<Node>().AppendChild(&clone, can_gc)?;
         }
 
         if let Some(child) = last_partially_contained_child {
@@ -657,19 +657,19 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
                 let data = cdata.SubstringData(0, end_offset).unwrap();
                 let clone = cdata.clone_with_data(data, &start_node.owner_doc(), can_gc);
                 // Step 16.3.
-                fragment.upcast::<Node>().AppendChild(&clone)?;
+                fragment.upcast::<Node>().AppendChild(&clone, can_gc)?;
             } else {
                 // Step 17.1.
                 let clone = child.CloneNode(/* deep */ false, can_gc)?;
                 // Step 17.2.
-                fragment.upcast::<Node>().AppendChild(&clone)?;
+                fragment.upcast::<Node>().AppendChild(&clone, can_gc)?;
                 // Step 17.3.
                 let subrange =
                     Range::new(&clone.owner_doc(), &child, 0, &end_node, end_offset, can_gc);
                 // Step 17.4.
                 let subfragment = subrange.CloneContents(can_gc)?;
                 // Step 17.5.
-                clone.AppendChild(subfragment.upcast())?;
+                clone.AppendChild(subfragment.upcast(), can_gc)?;
             }
         }
 
@@ -705,7 +705,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
                     .unwrap()
                     .SetData(text.unwrap());
                 // Step 4.3.
-                fragment.upcast::<Node>().AppendChild(&clone)?;
+                fragment.upcast::<Node>().AppendChild(&clone, can_gc)?;
                 // Step 4.4.
                 end_data.ReplaceData(start_offset, end_offset - start_offset, DOMString::new())?;
                 // Step 4.5.
@@ -749,7 +749,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
                     .unwrap()
                     .SetData(text.unwrap());
                 // Step 15.3.
-                fragment.upcast::<Node>().AppendChild(&clone)?;
+                fragment.upcast::<Node>().AppendChild(&clone, can_gc)?;
                 // Step 15.4.
                 start_data.ReplaceData(
                     start_offset,
@@ -760,7 +760,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
                 // Step 16.1.
                 let clone = child.CloneNode(/* deep */ false, can_gc)?;
                 // Step 16.2.
-                fragment.upcast::<Node>().AppendChild(&clone)?;
+                fragment.upcast::<Node>().AppendChild(&clone, can_gc)?;
                 // Step 16.3.
                 let subrange = Range::new(
                     &clone.owner_doc(),
@@ -773,13 +773,13 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
                 // Step 16.4.
                 let subfragment = subrange.ExtractContents(can_gc)?;
                 // Step 16.5.
-                clone.AppendChild(subfragment.upcast())?;
+                clone.AppendChild(subfragment.upcast(), can_gc)?;
             }
         }
 
         // Step 17.
         for child in contained_children {
-            fragment.upcast::<Node>().AppendChild(&child)?;
+            fragment.upcast::<Node>().AppendChild(&child, can_gc)?;
         }
 
         if let Some(child) = last_partially_contained_child {
@@ -794,21 +794,21 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
                     .unwrap()
                     .SetData(text.unwrap());
                 // Step 18.3.
-                fragment.upcast::<Node>().AppendChild(&clone)?;
+                fragment.upcast::<Node>().AppendChild(&clone, can_gc)?;
                 // Step 18.4.
                 end_data.ReplaceData(0, end_offset, DOMString::new())?;
             } else {
                 // Step 19.1.
                 let clone = child.CloneNode(/* deep */ false, can_gc)?;
                 // Step 19.2.
-                fragment.upcast::<Node>().AppendChild(&clone)?;
+                fragment.upcast::<Node>().AppendChild(&clone, can_gc)?;
                 // Step 19.3.
                 let subrange =
                     Range::new(&clone.owner_doc(), &child, 0, &end_node, end_offset, can_gc);
                 // Step 19.4.
                 let subfragment = subrange.ExtractContents(can_gc)?;
                 // Step 19.5.
-                clone.AppendChild(subfragment.upcast())?;
+                clone.AppendChild(subfragment.upcast(), can_gc)?;
             }
         }
 
@@ -856,7 +856,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
             },
             _ => {
                 // Steps 4-5.
-                let child = start_node.ChildNodes().Item(start_offset);
+                let child = start_node.ChildNodes(can_gc).Item(start_offset);
                 (child, DomRoot::from_ref(&*start_node))
             },
         };
@@ -1029,7 +1029,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
         self.InsertNode(new_parent, can_gc)?;
 
         // Step 6.
-        new_parent.AppendChild(fragment.upcast())?;
+        new_parent.AppendChild(fragment.upcast(), can_gc)?;
 
         // Step 7.
         self.SelectNode(new_parent)

--- a/components/script/dom/servoparser/async_html.rs
+++ b/components/script/dom/servoparser/async_html.rs
@@ -484,7 +484,7 @@ impl Tokenizer {
 
                 document
                     .upcast::<Node>()
-                    .AppendChild(doctype.upcast())
+                    .AppendChild(doctype.upcast(), can_gc)
                     .expect("Appending failed");
             },
             ParseOperation::AddAttrsIfMissing { target, attrs } => {
@@ -503,7 +503,7 @@ impl Tokenizer {
             },
             ParseOperation::RemoveFromParent { target } => {
                 if let Some(ref parent) = self.get_node(&target).GetParentNode() {
-                    parent.RemoveChild(&self.get_node(&target)).unwrap();
+                    parent.RemoveChild(&self.get_node(&target), can_gc).unwrap();
                 }
             },
             ParseOperation::MarkScriptAlreadyStarted { node } => {
@@ -517,7 +517,7 @@ impl Tokenizer {
                 let parent = self.get_node(&parent);
                 let new_parent = self.get_node(&new_parent);
                 while let Some(child) = parent.GetFirstChild() {
-                    new_parent.AppendChild(&child).unwrap();
+                    new_parent.AppendChild(&child, can_gc).unwrap();
                 }
             },
             ParseOperation::AssociateWithForm {

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -913,7 +913,7 @@ impl FetchResponseListener for ParserContext {
                 let img = HTMLImageElement::new(local_name!("img"), None, doc, None, CanGc::note());
                 img.SetSrc(USVString(self.url.to_string()));
                 doc_body
-                    .AppendChild(&DomRoot::upcast::<Node>(img))
+                    .AppendChild(&DomRoot::upcast::<Node>(img), CanGc::note())
                     .expect("Appending failed");
             },
             (mime::TEXT, mime::PLAIN, _) => {
@@ -1095,7 +1095,7 @@ fn insert(
             if element_in_non_fragment {
                 ScriptThread::push_new_element_queue();
             }
-            parent.InsertBefore(&n, reference_child).unwrap();
+            parent.InsertBefore(&n, reference_child, can_gc).unwrap();
             if element_in_non_fragment {
                 ScriptThread::pop_current_element_queue(can_gc);
             }
@@ -1111,7 +1111,9 @@ fn insert(
                 text.upcast::<CharacterData>().append_data(&t);
             } else {
                 let text = Text::new(String::from(t).into(), &parent.owner_doc(), can_gc);
-                parent.InsertBefore(text.upcast(), reference_child).unwrap();
+                parent
+                    .InsertBefore(text.upcast(), reference_child, can_gc)
+                    .unwrap();
             }
         },
     }
@@ -1323,7 +1325,7 @@ impl TreeSink for Sink {
             CanGc::note(),
         );
         doc.upcast::<Node>()
-            .AppendChild(doctype.upcast())
+            .AppendChild(doctype.upcast(), CanGc::note())
             .expect("Appending failed");
     }
 
@@ -1343,7 +1345,7 @@ impl TreeSink for Sink {
 
     fn remove_from_parent(&self, target: &Dom<Node>) {
         if let Some(ref parent) = target.GetParentNode() {
-            parent.RemoveChild(target).unwrap();
+            parent.RemoveChild(target, CanGc::note()).unwrap();
         }
     }
 
@@ -1365,7 +1367,7 @@ impl TreeSink for Sink {
 
     fn reparent_children(&self, node: &Dom<Node>, new_parent: &Dom<Node>) {
         while let Some(ref child) = node.GetFirstChild() {
-            new_parent.AppendChild(child).unwrap();
+            new_parent.AppendChild(child, CanGc::note()).unwrap();
         }
     }
 

--- a/components/script/dom/text.rs
+++ b/components/script/dom/text.rs
@@ -89,7 +89,7 @@ impl TextMethods<crate::DomTypeHolder> for Text {
         if let Some(ref parent) = parent {
             // Step 7.1.
             parent
-                .InsertBefore(new_node.upcast(), node.GetNextSibling().as_deref())
+                .InsertBefore(new_node.upcast(), node.GetNextSibling().as_deref(), can_gc)
                 .unwrap();
             // Steps 7.2-3.
             node.ranges()

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -18,6 +18,10 @@ DOMInterfaces = {
     'weakReferenceable': True,
 },
 
+'Attr': {
+    'canGc':['SetValue'],
+},
+
 'AudioBuffer': {
     'canGc':['CopyToChannel', 'GetChannelData'],
 },
@@ -452,7 +456,7 @@ DOMInterfaces = {
 },
 
 'Node': {
-    'canGc': ['CloneNode', 'SetTextContent'],
+    'canGc': ['AppendChild', 'ChildNodes', 'CloneNode', 'InsertBefore', 'Normalize', 'SetNodeValue', 'SetTextContent', 'RemoveChild', 'ReplaceChild'],
 },
 
 'NodeIterator': {


### PR DESCRIPTION
Add CanGc as argument to methods in `Attr` and `Node`.

Addressed part of https://github.com/servo/servo/issues/34573.

---

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they are a refactor.
