### PR TITLE
Add CanGc as arguments in methods in devtools.rs, CharacterData, CSSStyleRule, CSSStyleSheet

### DIFF
--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -243,7 +243,7 @@ pub(crate) fn handle_get_stylesheet_style(
         let owner = node.stylesheet_list_owner();
 
         let stylesheet = owner.stylesheet_at(stylesheet)?;
-        let list = stylesheet.GetCssRules().ok()?;
+        let list = stylesheet.GetCssRules(can_gc).ok()?;
 
         let styles = (0..list.Length())
             .filter_map(move |i| {
@@ -252,7 +252,7 @@ pub(crate) fn handle_get_stylesheet_style(
                 if *selector != *style.SelectorText() {
                     return None;
                 };
-                Some(style.Style())
+                Some(style.Style(can_gc))
             })
             .flat_map(|style| {
                 (0..style.Length()).map(move |i| {
@@ -290,7 +290,7 @@ pub(crate) fn handle_get_selectors(
         let rules = (0..owner.stylesheet_count())
             .filter_map(|i| {
                 let stylesheet = owner.stylesheet_at(i)?;
-                let list = stylesheet.GetCssRules().ok()?;
+                let list = stylesheet.GetCssRules(can_gc).ok()?;
                 let elem = node.downcast::<Element>()?;
 
                 Some((0..list.Length()).filter_map(move |j| {

--- a/components/script/dom/characterdata.rs
+++ b/components/script/dom/characterdata.rs
@@ -260,9 +260,9 @@ impl CharacterDataMethods<crate::DomTypeHolder> for CharacterData {
     }
 
     // https://dom.spec.whatwg.org/#dom-childnode-remove
-    fn Remove(&self) {
+    fn Remove(&self, can_gc: CanGc) {
         let node = self.upcast::<Node>();
-        node.remove_self(CanGc::note());
+        node.remove_self(can_gc);
     }
 
     // https://dom.spec.whatwg.org/#dom-nondocumenttypechildnode-previouselementsibling

--- a/components/script/dom/cssstylerule.rs
+++ b/components/script/dom/cssstylerule.rs
@@ -87,7 +87,7 @@ impl SpecificCSSRule for CSSStyleRule {
 
 impl CSSStyleRuleMethods<crate::DomTypeHolder> for CSSStyleRule {
     // https://drafts.csswg.org/cssom/#dom-cssstylerule-style
-    fn Style(&self) -> DomRoot<CSSStyleDeclaration> {
+    fn Style(&self, can_gc: CanGc) -> DomRoot<CSSStyleDeclaration> {
         self.style_decl.or_init(|| {
             let guard = self.cssgroupingrule.shared_lock().read();
             CSSStyleDeclaration::new(
@@ -98,7 +98,7 @@ impl CSSStyleRuleMethods<crate::DomTypeHolder> for CSSStyleRule {
                 ),
                 None,
                 CSSModificationAccess::ReadWrite,
-                CanGc::note(),
+                can_gc,
             )
         })
     }

--- a/components/script/dom/cssstylesheet.rs
+++ b/components/script/dom/cssstylesheet.rs
@@ -70,14 +70,14 @@ impl CSSStyleSheet {
         )
     }
 
-    fn rulelist(&self) -> DomRoot<CSSRuleList> {
+    fn rulelist(&self, can_gc: CanGc) -> DomRoot<CSSRuleList> {
         self.rulelist.or_init(|| {
             let rules = self.style_stylesheet.contents.rules.clone();
             CSSRuleList::new(
                 self.global().as_window(),
                 self,
                 RulesSource::Rules(rules),
-                CanGc::note(),
+                can_gc,
             )
         })
     }
@@ -127,38 +127,38 @@ impl CSSStyleSheet {
 
 impl CSSStyleSheetMethods<crate::DomTypeHolder> for CSSStyleSheet {
     /// <https://drafts.csswg.org/cssom/#dom-cssstylesheet-cssrules>
-    fn GetCssRules(&self) -> Fallible<DomRoot<CSSRuleList>> {
+    fn GetCssRules(&self, can_gc: CanGc) -> Fallible<DomRoot<CSSRuleList>> {
         if !self.origin_clean.get() {
             return Err(Error::Security);
         }
-        Ok(self.rulelist())
+        Ok(self.rulelist(can_gc))
     }
 
     /// <https://drafts.csswg.org/cssom/#dom-cssstylesheet-insertrule>
-    fn InsertRule(&self, rule: DOMString, index: u32) -> Fallible<u32> {
+    fn InsertRule(&self, rule: DOMString, index: u32, can_gc: CanGc) -> Fallible<u32> {
         if !self.origin_clean.get() {
             return Err(Error::Security);
         }
-        self.rulelist()
-            .insert_rule(&rule, index, CssRuleTypes::default(), None, CanGc::note())
+        self.rulelist(can_gc)
+            .insert_rule(&rule, index, CssRuleTypes::default(), None, can_gc)
     }
 
     /// <https://drafts.csswg.org/cssom/#dom-cssstylesheet-deleterule>
-    fn DeleteRule(&self, index: u32) -> ErrorResult {
+    fn DeleteRule(&self, index: u32, can_gc: CanGc) -> ErrorResult {
         if !self.origin_clean.get() {
             return Err(Error::Security);
         }
-        self.rulelist().remove_rule(index)
+        self.rulelist(can_gc).remove_rule(index)
     }
 
     /// <https://drafts.csswg.org/cssom/#dom-cssstylesheet-rules>
-    fn GetRules(&self) -> Fallible<DomRoot<CSSRuleList>> {
-        self.GetCssRules()
+    fn GetRules(&self, can_gc: CanGc) -> Fallible<DomRoot<CSSRuleList>> {
+        self.GetCssRules(can_gc)
     }
 
     /// <https://drafts.csswg.org/cssom/#dom-cssstylesheet-removerule>
-    fn RemoveRule(&self, index: u32) -> ErrorResult {
-        self.DeleteRule(index)
+    fn RemoveRule(&self, index: u32, can_gc: CanGc) -> ErrorResult {
+        self.DeleteRule(index, can_gc)
     }
 
     /// <https://drafts.csswg.org/cssom/#dom-cssstylesheet-addrule>
@@ -167,6 +167,7 @@ impl CSSStyleSheetMethods<crate::DomTypeHolder> for CSSStyleSheet {
         selector: DOMString,
         block: DOMString,
         optional_index: Option<u32>,
+        can_gc: CanGc,
     ) -> Fallible<i32> {
         // > 1. Let *rule* be an empty string.
         // > 2. Append *selector* to *rule*.
@@ -184,10 +185,10 @@ impl CSSStyleSheetMethods<crate::DomTypeHolder> for CSSStyleSheet {
         };
 
         // > 6. Let *index* be *optionalIndex* if provided, or the number of CSS rules in the stylesheet otherwise.
-        let index = optional_index.unwrap_or_else(|| self.rulelist().Length());
+        let index = optional_index.unwrap_or_else(|| self.rulelist(can_gc).Length());
 
         // > 7. Call `insertRule()`, with *rule* and *index* as arguments.
-        self.InsertRule(rule, index)?;
+        self.InsertRule(rule, index, can_gc)?;
 
         // > 8. Return -1.
         Ok(-1)

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2006,13 +2006,13 @@ impl ScriptThread {
                 None => warn!("Message sent to closed pipeline {}.", id),
             },
             DevtoolScriptControlMsg::GetRootNode(id, reply) => {
-                devtools::handle_get_root_node(&documents, id, reply)
+                devtools::handle_get_root_node(&documents, id, reply, can_gc)
             },
             DevtoolScriptControlMsg::GetDocumentElement(id, reply) => {
-                devtools::handle_get_document_element(&documents, id, reply)
+                devtools::handle_get_document_element(&documents, id, reply, can_gc)
             },
             DevtoolScriptControlMsg::GetChildren(id, node_id, reply) => {
-                devtools::handle_get_children(&documents, id, node_id, reply)
+                devtools::handle_get_children(&documents, id, node_id, reply, can_gc)
             },
             DevtoolScriptControlMsg::GetAttributeStyle(id, node_id, reply) => {
                 devtools::handle_get_attribute_style(&documents, id, node_id, reply, can_gc)

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -84,7 +84,7 @@ DOMInterfaces = {
 },
 
 'CharacterData': {
-    'canGc': ['Before', 'After', 'ReplaceWith']
+    'canGc': ['Before', 'After', 'Remove', 'ReplaceWith']
 },
 
 'CountQueuingStrategy': {
@@ -117,6 +117,14 @@ DOMInterfaces = {
 
 'CSSRuleList': {
     'canGc': ['Item', 'IndexedGetter'],
+},
+
+'CSSStyleRule': {
+    'canGc': ['Style'],
+},
+
+'CSSStyleSheet': {
+   'canGc': ['AddRule', 'DeleteRule', 'GetCssRules', 'GetRules', 'InsertRule', 'RemoveRule'],
 },
 
 'Crypto': {


### PR DESCRIPTION
Add CanGc as arguments in methods in devtools.rs, CharacterData, CSSStyleRule, CSSStyleSheet

Testing: These changes do not require tests because they are a refactor.
Addressed part of https://github.com/servo/servo/issues/34573.
