### PR TITLE
Remove trailing space in CSSStyleSheet::AddRule()

### DIFF
--- a/components/script/dom/cssstylesheet.rs
+++ b/components/script/dom/cssstylesheet.rs
@@ -181,7 +181,7 @@ impl CSSStyleSheetMethods<crate::DomTypeHolder> for CSSStyleSheet {
         } else {
             rule.push_str(" { ");
             rule.push_str(block.str());
-            rule.push_str(" } ");
+            rule.push_str(" }");
         };
 
         // > 6. Let *index* be *optionalIndex* if provided, or the number of CSS rules in the stylesheet otherwise.


### PR DESCRIPTION
-Remove trailing space in CSSStyleSheet::AddRule()

Testing: The change made does not require testing
Fixes: https://github.com/servo/servo/issues/36380
