### PR TITLE
fix: meta referrer updating to follow spec

### DIFF
--- a/components/script/dom/htmlheadelement.rs
+++ b/components/script/dom/htmlheadelement.rs
@@ -10,7 +10,7 @@ use js::rust::HandleObject;
 use crate::dom::bindings::codegen::Bindings::DocumentBinding::DocumentMethods;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::DomRoot;
-use crate::dom::document::{Document, determine_policy_for_token};
+use crate::dom::document::Document;
 use crate::dom::element::Element;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::htmlmetaelement::HTMLMetaElement;
@@ -52,42 +52,6 @@ impl HTMLHeadElement {
 
         n.upcast::<Node>().set_weird_parser_insertion_mode();
         n
-    }
-
-    /// <https://html.spec.whatwg.org/multipage/#meta-referrer>
-    pub(crate) fn set_document_referrer(&self, most_recent: &HTMLMetaElement) {
-        let doc = self.owner_document();
-
-        if doc.GetHead().as_deref() != Some(self) {
-            return;
-        }
-
-        // From spec: For historical reasons, unlike other standard metadata names, the processing model for referrer
-        // is not responsive to element removals, and does not use tree order. Only the most-recently-inserted or
-        // most-recently-modified meta element in this state has an effect.
-        // 1. If element is not in a document tree, then return.
-        let meta_node = most_recent.upcast::<Node>();
-        if !meta_node.is_in_a_document_tree() {
-            return;
-        }
-
-        // 2. If element does not have a name attribute whose value is an ASCII case-insensitive match for "referrer",
-        // then return.
-        if most_recent.upcast::<Element>().get_name() != Some(atom!("referrer")) {
-            return;
-        }
-
-        // 3. If element does not have a content attribute, or that attribute's value is the empty string, then return.
-        let content = most_recent
-            .upcast::<Element>()
-            .get_attribute(&ns!(), &local_name!("content"));
-        if let Some(attr) = content {
-            let attr = attr.value();
-            let attr_val = attr.trim();
-            if !attr_val.is_empty() {
-                doc.set_referrer_policy(determine_policy_for_token(attr_val));
-            }
-        }
     }
 
     /// <https://html.spec.whatwg.org/multipage/#attr-meta-http-equiv-content-security-policy>

--- a/components/script/dom/htmlmetaelement.rs
+++ b/components/script/dom/htmlmetaelement.rs
@@ -117,7 +117,7 @@ impl HTMLMetaElement {
     fn apply_referrer(&self) {
         if let Some(parent) = self.upcast::<Node>().GetParentElement() {
             if let Some(head) = parent.downcast::<HTMLHeadElement>() {
-                head.set_document_referrer();
+                head.set_document_referrer(self);
             }
         }
     }

--- a/tests/wpt/meta/referrer-policy/generic/first-meta-changed-after-second-added.http.html.ini
+++ b/tests/wpt/meta/referrer-policy/generic/first-meta-changed-after-second-added.http.html.ini
@@ -1,3 +1,0 @@
-[first-meta-changed-after-second-added.http.html]
-  [document referrer policy is the value of the most recently modified <meta name="referrer"]
-    expected: FAIL

--- a/tests/wpt/meta/referrer-policy/generic/meta-referrer-outofhead-fetch.http.html.ini
+++ b/tests/wpt/meta/referrer-policy/generic/meta-referrer-outofhead-fetch.http.html.ini
@@ -1,3 +1,0 @@
-[meta-referrer-outofhead-fetch.http.html]
-  [Referer header was not send]
-    expected: FAIL

--- a/tests/wpt/meta/referrer-policy/generic/meta-referrer-removed-2.http.html.ini
+++ b/tests/wpt/meta/referrer-policy/generic/meta-referrer-removed-2.http.html.ini
@@ -1,3 +1,0 @@
-[meta-referrer-removed-2.http.html]
-  [referrer policy does not change when second <meta name="referrer"> is removed]
-    expected: FAIL


### PR DESCRIPTION
Previously the referrer policy used tree order but the spec only cares about the most-recently-updated or most-recently-added meta referrer.

Testing: change has existing WPT tests
