### PR TITLE
refactor: add CanGc as argument to methods in Document

### DIFF
--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -360,7 +360,7 @@ fn finish_fetching_a_classic_script(
         },
         ExternalScriptKind::Deferred => {
             document = elem.parser_document.as_rooted();
-            document.deferred_script_loaded(elem, load);
+            document.deferred_script_loaded(elem, load, can_gc);
         },
         ExternalScriptKind::ParsingBlocking => {
             document = elem.parser_document.as_rooted();

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1523,7 +1523,9 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
 
     // https://w3c.github.io/selection-api/#dom-window-getselection
     fn GetSelection(&self) -> Option<DomRoot<Selection>> {
-        self.document.get().and_then(|d| d.GetSelection())
+        self.document
+            .get()
+            .and_then(|d| d.GetSelection(CanGc::note()))
     }
 
     // https://dom.spec.whatwg.org/#dom-window-event

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -992,7 +992,7 @@ impl ModuleOwner {
                     .has_attribute(&local_name!("async"));
 
                 if !asynch && (*script.root()).get_parser_inserted() {
-                    document.deferred_script_loaded(&script.root(), load);
+                    document.deferred_script_loaded(&script.root(), load, can_gc);
                 } else if !asynch && !(*script.root()).get_non_blocking() {
                     document.asap_in_order_script_loaded(&script.root(), load, can_gc);
                 } else {

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -553,7 +553,7 @@ pub(crate) fn handle_find_element_tag_name(
     pipeline: PipelineId,
     selector: String,
     reply: IpcSender<Result<Option<String>, ErrorStatus>>,
-    _can_gc: CanGc,
+    can_gc: CanGc,
 ) {
     reply
         .send(
@@ -562,7 +562,7 @@ pub(crate) fn handle_find_element_tag_name(
                 .ok_or(ErrorStatus::UnknownError)
                 .map(|document| {
                     document
-                        .GetElementsByTagName(DOMString::from(selector))
+                        .GetElementsByTagName(DOMString::from(selector), can_gc)
                         .elements_iter()
                         .next()
                 })
@@ -621,14 +621,14 @@ pub(crate) fn handle_find_elements_tag_name(
     pipeline: PipelineId,
     selector: String,
     reply: IpcSender<Result<Vec<String>, ErrorStatus>>,
-    _can_gc: CanGc,
+    can_gc: CanGc,
 ) {
     reply
         .send(
             documents
                 .find_document(pipeline)
                 .ok_or(ErrorStatus::UnknownError)
-                .map(|document| document.GetElementsByTagName(DOMString::from(selector)))
+                .map(|document| document.GetElementsByTagName(DOMString::from(selector), can_gc))
                 .map(|nodes| {
                     nodes
                         .elements_iter()

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -158,7 +158,7 @@ DOMInterfaces = {
 
 'Document': {
     'additionalTraits': ["crate::interfaces::DocumentHelpers"],
-    'canGc': ['Close', 'CreateElement', 'CreateElementNS', 'ImportNode', 'SetTitle', 'Write', 'Writeln', 'CreateEvent', 'CreateRange', 'Open', 'Open_', 'CreateComment', 'CreateAttribute', 'CreateAttributeNS', 'CreateDocumentFragment', 'CreateTextNode', 'CreateCDATASection', 'CreateProcessingInstruction', 'Prepend', 'Append', 'ReplaceChildren', 'SetBgColor', 'SetFgColor', 'Fonts', 'ElementFromPoint', 'ElementsFromPoint', 'ExitFullscreen', 'CreateExpression', 'CreateNSResolver', 'Evaluate'],
+    'canGc': ['Close', 'CreateElement', 'CreateElementNS', 'ImportNode', 'SetTitle', 'Write', 'Writeln', 'CreateEvent', 'CreateRange', 'Open', 'Open_', 'CreateComment', 'CreateAttribute', 'CreateAttributeNS', 'CreateDocumentFragment', 'CreateTextNode', 'CreateCDATASection', 'CreateProcessingInstruction', 'Prepend', 'Append', 'ReplaceChildren', 'SetBgColor', 'SetFgColor', 'Fonts', 'ElementFromPoint', 'ElementsFromPoint', 'ExitFullscreen', 'CreateExpression', 'CreateNSResolver', 'Evaluate', 'StyleSheets', 'Implementation', 'GetElementsByTagName', 'GetElementsByTagNameNS', 'GetElementsByClassName', 'AdoptNode', 'CreateNodeIterator', 'SetBody', 'GetElementsByName', 'Images', 'Embeds', 'Plugins', 'Links', 'Forms', 'Scripts', 'Anchors', 'Applets', 'Children', 'GetSelection'],
 },
 
 'DocumentFragment': {


### PR DESCRIPTION
Add CanGc as arguments in methods in Document

Testing: These changes do not require tests because they are a refactor.
Addressed part of https://github.com/servo/servo/issues/34573.
