### PR TITLE
add CanGc as argument to methods in DissimilarOriginWindow, DocumentFragment, DocumentType, DOMRect, DOMRectReadOnly, DOMStringMap

### DIFF
--- a/components/script/dom/dissimilaroriginwindow.rs
+++ b/components/script/dom/dissimilaroriginwindow.rs
@@ -190,9 +190,9 @@ impl DissimilarOriginWindowMethods<crate::DomTypeHolder> for DissimilarOriginWin
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-location
-    fn Location(&self) -> DomRoot<DissimilarOriginLocation> {
+    fn Location(&self, can_gc: CanGc) -> DomRoot<DissimilarOriginLocation> {
         self.location
-            .or_init(|| DissimilarOriginLocation::new(self, CanGc::note()))
+            .or_init(|| DissimilarOriginLocation::new(self, can_gc))
     }
 }
 

--- a/components/script/dom/documentfragment.rs
+++ b/components/script/dom/documentfragment.rs
@@ -76,9 +76,9 @@ impl DocumentFragmentMethods<crate::DomTypeHolder> for DocumentFragment {
     }
 
     // https://dom.spec.whatwg.org/#dom-parentnode-children
-    fn Children(&self) -> DomRoot<HTMLCollection> {
+    fn Children(&self, can_gc: CanGc) -> DomRoot<HTMLCollection> {
         let window = self.owner_window();
-        HTMLCollection::children(&window, self.upcast(), CanGc::note())
+        HTMLCollection::children(&window, self.upcast(), can_gc)
     }
 
     // https://dom.spec.whatwg.org/#dom-nonelementparentnode-getelementbyid

--- a/components/script/dom/documenttype.rs
+++ b/components/script/dom/documenttype.rs
@@ -103,7 +103,7 @@ impl DocumentTypeMethods<crate::DomTypeHolder> for DocumentType {
     }
 
     // https://dom.spec.whatwg.org/#dom-childnode-remove
-    fn Remove(&self) {
-        self.upcast::<Node>().remove_self(CanGc::note());
+    fn Remove(&self, can_gc: CanGc) {
+        self.upcast::<Node>().remove_self(can_gc);
     }
 }

--- a/components/script/dom/domrect.rs
+++ b/components/script/dom/domrect.rs
@@ -75,10 +75,10 @@ impl DOMRectMethods<crate::DomTypeHolder> for DOMRect {
 
     // https://drafts.fxtf.org/geometry/#dom-domrect-fromrect
     #[cfg_attr(crown, allow(crown::unrooted_must_root))]
-    fn FromRect(global: &GlobalScope, other: &DOMRectInit) -> DomRoot<DOMRect> {
+    fn FromRect(global: &GlobalScope, other: &DOMRectInit, can_gc: CanGc) -> DomRoot<DOMRect> {
         let rect = create_a_domrectreadonly_from_the_dictionary(other);
 
-        reflect_dom_object(Box::new(Self { rect }), global, CanGc::note())
+        reflect_dom_object(Box::new(Self { rect }), global, can_gc)
     }
 
     // https://drafts.fxtf.org/geometry/#dom-domrect-x

--- a/components/script/dom/domrectreadonly.rs
+++ b/components/script/dom/domrectreadonly.rs
@@ -104,10 +104,14 @@ impl DOMRectReadOnlyMethods<crate::DomTypeHolder> for DOMRectReadOnly {
 
     // https://drafts.fxtf.org/geometry/#dom-domrectreadonly-fromrect
     #[cfg_attr(crown, allow(crown::unrooted_must_root))]
-    fn FromRect(global: &GlobalScope, other: &DOMRectInit) -> DomRoot<DOMRectReadOnly> {
+    fn FromRect(
+        global: &GlobalScope,
+        other: &DOMRectInit,
+        can_gc: CanGc,
+    ) -> DomRoot<DOMRectReadOnly> {
         let dom_rect = create_a_domrectreadonly_from_the_dictionary(other);
 
-        reflect_dom_object(Box::new(dom_rect), global, CanGc::note())
+        reflect_dom_object(Box::new(dom_rect), global, can_gc)
     }
 
     // https://drafts.fxtf.org/geometry/#dom-domrectreadonly-x

--- a/components/script/dom/domstringmap.rs
+++ b/components/script/dom/domstringmap.rs
@@ -39,8 +39,8 @@ impl DOMStringMap {
 // https://html.spec.whatwg.org/multipage/#domstringmap
 impl DOMStringMapMethods<crate::DomTypeHolder> for DOMStringMap {
     // https://html.spec.whatwg.org/multipage/#dom-domstringmap-removeitem
-    fn NamedDeleter(&self, name: DOMString) {
-        self.element.delete_custom_attr(name, CanGc::note())
+    fn NamedDeleter(&self, name: DOMString, can_gc: CanGc) {
+        self.element.delete_custom_attr(name, can_gc)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-domstringmap-setitem

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -161,12 +161,16 @@ DOMInterfaces = {
     'canGc': ['Close', 'CreateElement', 'CreateElementNS', 'ImportNode', 'SetTitle', 'Write', 'Writeln', 'CreateEvent', 'CreateRange', 'Open', 'Open_', 'CreateComment', 'CreateAttribute', 'CreateAttributeNS', 'CreateDocumentFragment', 'CreateTextNode', 'CreateCDATASection', 'CreateProcessingInstruction', 'Prepend', 'Append', 'ReplaceChildren', 'SetBgColor', 'SetFgColor', 'Fonts', 'ElementFromPoint', 'ElementsFromPoint', 'ExitFullscreen', 'CreateExpression', 'CreateNSResolver', 'Evaluate', 'StyleSheets', 'Implementation', 'GetElementsByTagName', 'GetElementsByTagNameNS', 'GetElementsByClassName', 'AdoptNode', 'CreateNodeIterator', 'SetBody', 'GetElementsByName', 'Images', 'Embeds', 'Plugins', 'Links', 'Forms', 'Scripts', 'Anchors', 'Applets', 'Children', 'GetSelection'],
 },
 
+'DissimilarOriginWindow': {
+    'canGc': ['Location']
+},
+
 'DocumentFragment': {
-    'canGc': ['Prepend', 'Append', 'ReplaceChildren']
+    'canGc': ['Prepend', 'Append', 'ReplaceChildren', 'Children']
 },
 
 'DocumentType': {
-    'canGc': ['Before', 'After', 'ReplaceWith']
+    'canGc': ['Before', 'After', 'Remove', 'ReplaceWith']
 },
 
 'DOMImplementation': {
@@ -197,8 +201,16 @@ DOMInterfaces = {
     'canGc': ['FromRect', 'FromQuad', 'GetBounds'],
 },
 
+'DOMRect': {
+    'canGc': ['FromRect'],
+},
+
+'DOMRectReadOnly': {
+    'canGc': ['FromRect'],
+},
+
 'DOMStringMap': {
-    'canGc': ['NamedSetter']
+    'canGc': ['NamedDeleter', 'NamedSetter']
 },
 
 "DOMTokenList": {


### PR DESCRIPTION
add CanGc as argument to methods in DissimilarOriginWindow, DocumentFragment, DocumentType, DOMRect, DOMRectReadOnly, DOMStringMap

Testing: These changes do not require tests because they are a refactor.
Addressed part of https://github.com/servo/servo/issues/34573.
