### PR TITLE
libservo: Move animation tracking from `WindowMethods` to delegates

### DIFF
--- a/components/compositing/windowing.rs
+++ b/components/compositing/windowing.rs
@@ -4,8 +4,6 @@
 
 //! Abstract windowing methods. The concrete implementations of these can be found in `platform/`.
 
-use std::fmt::Debug;
-
 use embedder_traits::{EventLoopWaker, MouseButton};
 use euclid::Scale;
 use net::protocols::ProtocolRegistry;
@@ -27,12 +25,6 @@ pub enum WebRenderDebugOption {
     RenderTargetDebug,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub enum AnimationState {
-    Idle,
-    Animating,
-}
-
 // TODO: this trait assumes that the window is responsible
 // for creating the GL context, making it current, buffer
 // swapping, etc. Really that should all be done by surfman.
@@ -40,12 +32,6 @@ pub trait WindowMethods {
     /// Get the HighDPI factor of the native window, the screen and the framebuffer.
     /// TODO(martin): Move this to `RendererWebView` when possible.
     fn hidpi_factor(&self) -> Scale<f32, DeviceIndependentPixel, DevicePixel>;
-    /// Set whether the application is currently animating.
-    /// Typically, when animations are active, the window
-    /// will want to avoid blocking on UI events, and just
-    /// run the event loop at the vsync interval.
-    /// TODO(martin): Move this to `RendererWebView` when possible.
-    fn set_animation_state(&self, _state: AnimationState);
 }
 
 pub trait EmbedderMethods {

--- a/components/servo/examples/winit_minimal.rs
+++ b/components/servo/examples/winit_minimal.rs
@@ -1,11 +1,11 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::cell::{Cell, RefCell};
+use std::cell::RefCell;
 use std::error::Error;
 use std::rc::Rc;
 
-use compositing::windowing::{AnimationState, EmbedderMethods, WindowMethods};
+use compositing::windowing::{EmbedderMethods, WindowMethods};
 use euclid::{Point2D, Scale, Size2D};
 use servo::{RenderingContext, Servo, TouchEventType, WebView, WindowRenderingContext};
 use servo_geometry::DeviceIndependentPixel;
@@ -236,25 +236,17 @@ impl embedder_traits::EventLoopWaker for Waker {
 
 struct WindowDelegate {
     window: Window,
-    animation_state: Cell<AnimationState>,
 }
 
 impl WindowDelegate {
     fn new(window: Window) -> Self {
-        Self {
-            window,
-            animation_state: Cell::new(AnimationState::Idle),
-        }
+        Self { window }
     }
 }
 
 impl WindowMethods for WindowDelegate {
     fn hidpi_factor(&self) -> Scale<f32, DeviceIndependentPixel, DevicePixel> {
         Scale::new(self.window.scale_factor() as f32)
-    }
-
-    fn set_animation_state(&self, state: compositing::windowing::AnimationState) {
-        self.animation_state.set(state);
     }
 }
 

--- a/components/servo/servo_delegate.rs
+++ b/components/servo/servo_delegate.rs
@@ -28,6 +28,11 @@ pub trait ServoDelegate {
     /// Request a DevTools connection from a DevTools client. Typically an embedder application
     /// will show a permissions prompt when this happens to confirm a connection is allowed.
     fn request_devtools_connection(&self, _servo: &Servo, _request: AllowOrDenyRequest) {}
+    /// Any [`WebView`] in this Servo instance has either started to animate or WebXR is
+    /// running. When a [`WebView`] is animating, it is up to the embedding application
+    /// ensure that `Servo::spin_event_loop` is called at regular intervals in order to
+    /// update the painted contents of the [`WebView`].
+    fn notify_animating_changed(&self, _animating: bool) {}
     /// Triggered when Servo will load a web (HTTP/HTTPS) resource. The load may be
     /// intercepted and alternate contents can be loaded by the client by calling
     /// [`WebResourceLoad::intercept`]. If not handled, the load will continue as normal.

--- a/components/servo/webview_delegate.rs
+++ b/components/servo/webview_delegate.rs
@@ -375,6 +375,11 @@ pub trait WebViewDelegate {
     /// This [`WebView`] has either become focused or lost focus. Whether or not the
     /// [`WebView`] is focused can be accessed via [`WebView::focused`].
     fn notify_focus_changed(&self, _webview: WebView, _focused: bool) {}
+    /// This [`WebView`] has either started to animate or stopped animating. When a
+    /// [`WebView`] is animating, it is up to the embedding application ensure that
+    /// `Servo::spin_event_loop` is called at regular intervals in order to update the
+    /// painted contents of the [`WebView`].
+    fn notify_animating_changed(&self, _webview: WebView, _animating: bool) {}
     /// The `LoadStatus` of the currently loading or loaded page in this [`WebView`] has changed. The new
     /// status can accessed via [`WebView::load_status`].
     fn notify_load_status_changed(&self, _webview: WebView, _status: LoadStatus) {}

--- a/components/shared/compositing/lib.rs
+++ b/components/shared/compositing/lib.rs
@@ -590,4 +590,5 @@ impl From<SerializableImageData> for ImageData {
 pub trait RendererWebView {
     fn id(&self) -> WebViewId;
     fn screen_geometry(&self) -> Option<ScreenGeometry>;
+    fn set_animating(&self, new_value: bool);
 }

--- a/ports/servoshell/desktop/events_loop.rs
+++ b/ports/servoshell/desktop/events_loop.rs
@@ -96,7 +96,7 @@ impl EventsLoop {
                     if !app.handle_events_with_headless() {
                         break;
                     }
-                    if !app.is_animating() {
+                    if !app.animating() {
                         *flag.lock().unwrap() = false;
                     }
                 }

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -14,7 +14,7 @@ use euclid::{Angle, Length, Point2D, Rotation3D, Scale, Size2D, UnknownUnit, Vec
 use keyboard_types::{Modifiers, ShortcutMatcher};
 use log::{debug, info};
 use raw_window_handle::{HasDisplayHandle, HasWindowHandle, RawWindowHandle};
-use servo::compositing::windowing::{AnimationState, WebRenderDebugOption, WindowMethods};
+use servo::compositing::windowing::{WebRenderDebugOption, WindowMethods};
 use servo::servo_config::pref;
 use servo::servo_geometry::DeviceIndependentPixel;
 use servo::webrender_api::ScrollLocation;
@@ -62,7 +62,6 @@ pub struct Window {
     /// A map of winit's key codes to key values that are interpreted from
     /// winit's ReceivedChar events.
     keys_down: RefCell<HashMap<LogicalKey, Key>>,
-    animation_state: Cell<AnimationState>,
     fullscreen: Cell<bool>,
     device_pixel_ratio_override: Option<f32>,
     xr_window_poses: RefCell<Vec<Rc<XRWindowPose>>>,
@@ -151,7 +150,6 @@ impl Window {
             webview_relative_mouse_point: Cell::new(Point2D::zero()),
             last_pressed: Cell::new(None),
             keys_down: RefCell::new(HashMap::new()),
-            animation_state: Cell::new(AnimationState::Idle),
             fullscreen: Cell::new(false),
             inner_size: Cell::new(inner_size),
             monitor,
@@ -570,10 +568,6 @@ impl WindowPortsMethods for Window {
         self.winit_window.set_cursor_visible(true);
     }
 
-    fn is_animating(&self) -> bool {
-        self.animation_state.get() == AnimationState::Animating
-    }
-
     fn id(&self) -> winit::window::WindowId {
         self.winit_window.id()
     }
@@ -771,10 +765,6 @@ impl WindowMethods for Window {
     fn hidpi_factor(&self) -> Scale<f32, DeviceIndependentPixel, DevicePixel> {
         self.device_pixel_ratio_override()
             .unwrap_or_else(|| self.device_hidpi_factor())
-    }
-
-    fn set_animation_state(&self, state: AnimationState) {
-        self.animation_state.set(state);
     }
 }
 

--- a/ports/servoshell/desktop/headless_window.rs
+++ b/ports/servoshell/desktop/headless_window.rs
@@ -9,7 +9,7 @@ use std::rc::Rc;
 
 use euclid::num::Zero;
 use euclid::{Length, Scale, Size2D};
-use servo::compositing::windowing::{AnimationState, WindowMethods};
+use servo::compositing::windowing::WindowMethods;
 use servo::servo_geometry::DeviceIndependentPixel;
 use servo::webrender_api::units::{DeviceIntSize, DevicePixel};
 use servo::{RenderingContext, ScreenGeometry, SoftwareRenderingContext};
@@ -20,7 +20,6 @@ use crate::desktop::window_trait::WindowPortsMethods;
 use crate::prefs::ServoShellPreferences;
 
 pub struct Window {
-    animation_state: Cell<AnimationState>,
     fullscreen: Cell<bool>,
     device_pixel_ratio_override: Option<Scale<f32, DeviceIndependentPixel, DevicePixel>>,
     inner_size: Cell<DeviceIntSize>,
@@ -50,7 +49,6 @@ impl Window {
             });
 
         let window = Window {
-            animation_state: Cell::new(AnimationState::Idle),
             fullscreen: Cell::new(false),
             device_pixel_ratio_override,
             inner_size: Cell::new(inner_size),
@@ -120,10 +118,6 @@ impl WindowPortsMethods for Window {
         self.fullscreen.get()
     }
 
-    fn is_animating(&self) -> bool {
-        self.animation_state.get() == AnimationState::Animating
-    }
-
     fn handle_winit_event(&self, _: Rc<RunningAppState>, _: winit::event::WindowEvent) {
         // Not expecting any winit events.
     }
@@ -156,9 +150,5 @@ impl WindowMethods for Window {
     fn hidpi_factor(&self) -> Scale<f32, DeviceIndependentPixel, DevicePixel> {
         self.device_pixel_ratio_override()
             .unwrap_or_else(|| self.device_hidpi_factor())
-    }
-
-    fn set_animation_state(&self, state: AnimationState) {
-        self.animation_state.set(state);
     }
 }

--- a/ports/servoshell/desktop/window_trait.rs
+++ b/ports/servoshell/desktop/window_trait.rs
@@ -28,7 +28,6 @@ pub trait WindowPortsMethods: WindowMethods {
     fn page_height(&self) -> f32;
     fn get_fullscreen(&self) -> bool;
     fn handle_winit_event(&self, state: Rc<RunningAppState>, event: winit::event::WindowEvent);
-    fn is_animating(&self) -> bool;
     fn set_title(&self, _title: &str) {}
     /// Request a new inner size for the window, not including external decorations.
     fn request_resize(&self, webview: &WebView, inner_size: DeviceIntSize)


### PR DESCRIPTION
This changes removes animation tracking from the `WindowMethods` trait
and moves it to `ServoDelegate` and `WebViewDelegate`.

- Animation changes per-`WebView` are now triggered in the compositor
  only when the value is updated there, rather than right after ticking
  animations.
- Both `WebView` and `Servo` now expose an `animation()` method, so
  tracking animation state actually becomes unecessary in many cases,
  such as that of desktop servoshell, which can just read the value
  when the event loop spins.

Testing: No tests necessary as the API layer is still untested. Later,
tests will be added for the `WebView` API and this can be tested then.
Signed-off-by: Martin Robinson <mrobinson@igalia.com>
