### PR TITLE
script: Correctly convert a jsval to a `Promise`

### DIFF
--- a/components/script/dom/promise.rs
+++ b/components/script/dom/promise.rs
@@ -412,13 +412,11 @@ impl FromJSValConvertibleRc for Promise {
         }
         rooted!(in(cx) let obj = value.get().to_object());
 
-        let promise_global = GlobalScope::from_object_maybe_wrapped(obj.handle().get(), cx);
-        let promise = Promise::new_resolved(
-            &promise_global,
-            SafeJSContext::from_ptr(cx),
-            *obj,
-            CanGc::note(),
-        );
+        let cx = SafeJSContext::from_ptr(cx);
+        let in_realm_proof = AlreadyInRealm::assert_for_cx(cx);
+        let global_scope = GlobalScope::from_context(*cx, InRealm::Already(&in_realm_proof));
+
+        let promise = Promise::new_resolved(&global_scope, cx, *obj, CanGc::note());
         Ok(ConversionResult::Success(promise))
     }
 }

--- a/components/script/dom/promise.rs
+++ b/components/script/dom/promise.rs
@@ -411,10 +411,14 @@ impl FromJSValConvertibleRc for Promise {
             return Ok(ConversionResult::Failure("not an object".into()));
         }
         rooted!(in(cx) let obj = value.get().to_object());
-        if !IsPromiseObject(obj.handle()) {
-            return Ok(ConversionResult::Failure("not a promise".into()));
-        }
-        let promise = Promise::new_with_js_promise(obj.handle(), SafeJSContext::from_ptr(cx));
+
+        let promise_global = GlobalScope::from_object_maybe_wrapped(obj.handle().get(), cx);
+        let promise = Promise::new_resolved(
+            &promise_global,
+            SafeJSContext::from_ptr(cx),
+            *obj,
+            CanGc::note(),
+        );
         Ok(ConversionResult::Success(promise))
     }
 }

--- a/tests/wpt/meta/clipboard-apis/clipboard-item.https.html.ini
+++ b/tests/wpt/meta/clipboard-apis/clipboard-item.https.html.ini
@@ -2,9 +2,6 @@
   [ClipboardItem({string, Blob}) succeeds with different types]
     expected: FAIL
 
-  [ClipboardItem() succeeds with empty options]
-    expected: FAIL
-
   [types() returns correct values]
     expected: FAIL
 


### PR DESCRIPTION
Fixes an oversight of #36097, in which converting to a Promise would fail if the value passed wasn't actually a Promise, while in binding code we actually call `Promise::new_resolved` on the value.

Testing: There are wpt tests that should pass now
