### PR TITLE
layout: Enable using cached fragments when there is a BoxTree update point

### DIFF
--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -1934,7 +1934,7 @@ impl FlexItem<'_> {
                     }
                 }
 
-                let layout = non_replaced.layout_with_caching(
+                let layout = non_replaced.layout(
                     flex_context.layout_context,
                     &mut positioning_context,
                     &item_as_containing_block,
@@ -2686,7 +2686,7 @@ impl FlexItemBox {
                 };
                 let mut content_block_size = || {
                     non_replaced
-                        .layout_with_caching(
+                        .layout(
                             flex_context.layout_context,
                             &mut positioning_context,
                             &item_as_containing_block,

--- a/components/layout_2020/flexbox/mod.rs
+++ b/components/layout_2020/flexbox/mod.rs
@@ -143,6 +143,22 @@ pub(crate) enum FlexLevelBox {
     OutOfFlowAbsolutelyPositionedBox(ArcRefCell<AbsolutelyPositionedBox>),
 }
 
+impl FlexLevelBox {
+    pub(crate) fn invalidate_cached_fragment(&self) {
+        match self {
+            FlexLevelBox::FlexItem(flex_item_box) => flex_item_box
+                .independent_formatting_context
+                .base
+                .invalidate_cached_fragment(),
+            FlexLevelBox::OutOfFlowAbsolutelyPositionedBox(positioned_box) => positioned_box
+                .borrow()
+                .context
+                .base
+                .invalidate_cached_fragment(),
+        }
+    }
+}
+
 pub(crate) struct FlexItemBox {
     independent_formatting_context: IndependentFormattingContext,
 }

--- a/components/layout_2020/flow/inline/mod.rs
+++ b/components/layout_2020/flow/inline/mod.rs
@@ -196,6 +196,30 @@ pub(crate) enum InlineItem {
     ),
 }
 
+impl InlineItem {
+    pub(crate) fn invalidate_cached_fragment(&self) {
+        match self {
+            InlineItem::StartInlineBox(..) | InlineItem::EndInlineBox | InlineItem::TextRun(..) => {
+            },
+            InlineItem::OutOfFlowAbsolutelyPositionedBox(positioned_box, ..) => {
+                positioned_box
+                    .borrow()
+                    .context
+                    .base
+                    .invalidate_cached_fragment();
+            },
+            InlineItem::OutOfFlowFloatBox(float_box) => {
+                float_box.contents.base.invalidate_cached_fragment()
+            },
+            InlineItem::Atomic(independent_formatting_context, ..) => {
+                independent_formatting_context
+                    .base
+                    .invalidate_cached_fragment();
+            },
+        }
+    }
+}
+
 /// Information about the current line under construction for a particular
 /// [`InlineFormattingContextLayout`]. This tracks position and size information while
 /// [`LineItem`]s are collected and is used as input when those [`LineItem`]s are

--- a/components/layout_2020/formatting_contexts.rs
+++ b/components/layout_2020/formatting_contexts.rs
@@ -219,7 +219,7 @@ impl IndependentFormattingContext {
 }
 
 impl IndependentNonReplacedContents {
-    pub fn layout(
+    pub(crate) fn layout_without_caching(
         &self,
         layout_context: &LayoutContext,
         positioning_context: &mut PositioningContext,
@@ -265,7 +265,7 @@ impl IndependentNonReplacedContents {
             level = "trace",
         )
     )]
-    pub fn layout_with_caching(
+    pub fn layout(
         &self,
         layout_context: &LayoutContext,
         positioning_context: &mut PositioningContext,
@@ -297,7 +297,7 @@ impl IndependentNonReplacedContents {
             positioning_context.collects_for_nearest_positioned_ancestor(),
         );
 
-        let result = self.layout(
+        let result = self.layout_without_caching(
             layout_context,
             &mut child_positioning_context,
             containing_block_for_children,

--- a/components/layout_2020/layout_box_base.rs
+++ b/components/layout_2020/layout_box_base.rs
@@ -63,6 +63,10 @@ impl LayoutBoxBase {
         *cache = Some((constraint_space.block_size, result));
         result
     }
+
+    pub(crate) fn invalidate_cached_fragment(&self) {
+        let _ = self.cached_layout_result.borrow_mut().take();
+    }
 }
 
 impl Debug for LayoutBoxBase {

--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -629,6 +629,7 @@ impl HoistedAbsolutelyPositionedBox {
                         &mut positioning_context,
                         &containing_block_for_children,
                         containing_block,
+                        &context.base,
                         false, /* depends_on_block_constraints */
                     );
 

--- a/components/layout_2020/taffy/layout.rs
+++ b/components/layout_2020/taffy/layout.rs
@@ -259,7 +259,7 @@ impl taffy::LayoutPartialTree for TaffyContainerContext<'_> {
                                     )
                                 });
 
-                            let layout = non_replaced.layout(
+                            let layout = non_replaced.layout_without_caching(
                                 self.layout_context,
                                 &mut child_positioning_context,
                                 &content_box_size_override,

--- a/components/layout_2020/taffy/mod.rs
+++ b/components/layout_2020/taffy/mod.rs
@@ -111,6 +111,26 @@ impl TaffyItemBox {
             taffy_level_box: inner,
         }
     }
+
+    pub(crate) fn invalidate_cached_fragment(&mut self) {
+        self.taffy_layout = Default::default();
+        self.positioning_context =
+            PositioningContext::new_for_containing_block_for_all_descendants();
+        match self.taffy_level_box {
+            TaffyItemBoxInner::InFlowBox(ref independent_formatting_context) => {
+                independent_formatting_context
+                    .base
+                    .invalidate_cached_fragment()
+            },
+            TaffyItemBoxInner::OutOfFlowAbsolutelyPositionedBox(ref positioned_box) => {
+                positioned_box
+                    .borrow()
+                    .context
+                    .base
+                    .invalidate_cached_fragment()
+            },
+        }
+    }
 }
 
 /// Details from Taffy grid layout that will be stored


### PR DESCRIPTION
This starts to enable the fragment cache for all layout modes, except
grid. The main tricky bit here is that update points are absolutes and
these need to be laid out again in their containing blocks. We punt a
little bit on this, by forcing ancestors of update points to rebuild
their Fragments. This is just the first step.

Testing: We do not currently have layout performance tests, but will try
to run some tests manually later. Behavior is covered by the WPT.

Co-authored-by: Oriol Brufau <obrufau@igalia.com>
Signed-off-by: Martin Robinson <mrobinson@igalia.com>
