### PR TITLE
Add serde and wgsl features to wgpu-core

### DIFF
--- a/components/script/dom/bindings/buffer_source.rs
+++ b/components/script/dom/bindings/buffer_source.rs
@@ -34,9 +34,11 @@ use js::rust::{
     CustomAutoRooterGuard, Handle, MutableHandleObject,
     MutableHandleValue as SafeMutableHandleValue,
 };
+#[cfg(feature = "webgpu")]
+use js::typedarray::{ArrayBuffer, HeapArrayBuffer};
 use js::typedarray::{
-    ArrayBuffer, ArrayBufferU8, ArrayBufferView, ArrayBufferViewU8, CreateWith, HeapArrayBuffer,
-    TypedArray, TypedArrayElement, TypedArrayElementCreator,
+    ArrayBufferU8, ArrayBufferView, ArrayBufferViewU8, CreateWith, TypedArray, TypedArrayElement,
+    TypedArrayElementCreator,
 };
 
 use crate::dom::bindings::error::{Error, Fallible};

--- a/components/shared/webgpu/Cargo.toml
+++ b/components/shared/webgpu/Cargo.toml
@@ -18,5 +18,5 @@ ipc-channel = { workspace = true }
 malloc_size_of = { workspace = true }
 serde = { workspace = true }
 webrender_api = { workspace = true }
-wgpu-core = { workspace = true }
+wgpu-core = { workspace = true, features = ["serde", "wgsl"] }
 wgpu-types = { workspace = true }


### PR DESCRIPTION
This fixes errors when running `./mach clippy -r -p layout_2020` and `./mach clippy -r -p script`.

Also addressing an unused import warning when running the latter.

Testing: These changes do not require tests because it's just a compile error fix.
