### PR TITLE
libservo: Make zooming and HiDPI scaling work per-`WebView`

### DIFF
--- a/components/compositing/webview.rs
+++ b/components/compositing/webview.rs
@@ -9,17 +9,21 @@ use std::rc::Rc;
 
 use base::id::{PipelineId, WebViewId};
 use compositing_traits::{RendererWebView, SendableFrameTree};
-use constellation_traits::{EmbedderToConstellationMessage, ScrollState};
+use constellation_traits::{EmbedderToConstellationMessage, ScrollState, WindowSizeType};
 use embedder_traits::{
     AnimationState, CompositorHitTestResult, InputEvent, MouseButton, MouseButtonAction,
     MouseButtonEvent, MouseMoveEvent, ShutdownState, TouchEvent, TouchEventResult, TouchEventType,
-    TouchId,
+    TouchId, ViewportDetails,
 };
-use euclid::{Point2D, Scale, Vector2D};
+use euclid::{Box2D, Point2D, Scale, Size2D, Vector2D};
 use fnv::FnvHashSet;
 use log::{debug, warn};
+use servo_geometry::DeviceIndependentPixel;
+use style_traits::{CSSPixel, PinchZoomFactor};
 use webrender::Transaction;
-use webrender_api::units::{DeviceIntPoint, DevicePoint, DeviceRect, LayoutVector2D};
+use webrender_api::units::{
+    DeviceIntPoint, DeviceIntRect, DevicePixel, DevicePoint, DeviceRect, LayoutVector2D,
+};
 use webrender_api::{
     ExternalScrollId, HitTestFlags, RenderReasons, SampledScrollOffset, ScrollLocation,
 };
@@ -27,6 +31,10 @@ use webrender_api::{
 use crate::IOCompositor;
 use crate::compositor::{PipelineDetails, ServoRenderer};
 use crate::touch::{TouchHandler, TouchMoveAction, TouchMoveAllowed, TouchSequenceState};
+
+// Default viewport constraints
+const MAX_ZOOM: f32 = 8.0;
+const MIN_ZOOM: f32 = 0.1;
 
 #[derive(Clone, Copy)]
 struct ScrollEvent {
@@ -65,6 +73,16 @@ pub(crate) struct WebView {
     pending_scroll_zoom_events: Vec<ScrollZoomEvent>,
     /// Touch input state machine
     touch_handler: TouchHandler,
+    /// "Desktop-style" zoom that resizes the viewport to fit the window.
+    pub page_zoom: Scale<f32, CSSPixel, DeviceIndependentPixel>,
+    /// "Mobile-style" zoom that does not reflow the page.
+    viewport_zoom: PinchZoomFactor,
+    /// Viewport zoom constraints provided by @viewport.
+    min_viewport_zoom: Option<PinchZoomFactor>,
+    max_viewport_zoom: Option<PinchZoomFactor>,
+    /// The HiDPI scale factor for the `WebView` associated with this renderer. This is controlled
+    /// by the embedding layer.
+    hidpi_scale_factor: Scale<f32, DeviceIndependentPixel, DevicePixel>,
 }
 
 impl Drop for WebView {
@@ -78,19 +96,26 @@ impl Drop for WebView {
 
 impl WebView {
     pub(crate) fn new(
-        renderer_webview: Box<dyn RendererWebView>,
-        rect: DeviceRect,
         global: Rc<RefCell<ServoRenderer>>,
+        renderer_webview: Box<dyn RendererWebView>,
+        viewport_details: ViewportDetails,
     ) -> Self {
+        let hidpi_scale_factor = viewport_details.hidpi_scale_factor;
+        let size = viewport_details.size * viewport_details.hidpi_scale_factor;
         Self {
             id: renderer_webview.id(),
             renderer_webview,
             root_pipeline_id: None,
-            rect,
+            rect: DeviceRect::from_origin_and_size(DevicePoint::origin(), size),
             pipelines: Default::default(),
             touch_handler: TouchHandler::new(),
             global,
             pending_scroll_zoom_events: Default::default(),
+            page_zoom: Scale::new(1.0),
+            viewport_zoom: PinchZoomFactor::new(1.0),
+            min_viewport_zoom: Some(PinchZoomFactor::new(1.0)),
+            max_viewport_zoom: None,
+            hidpi_scale_factor: Scale::new(hidpi_scale_factor.0),
         }
     }
 
@@ -265,7 +290,7 @@ impl WebView {
     }
 
     /// On a Window refresh tick (e.g. vsync)
-    pub fn on_vsync(&mut self) {
+    pub(crate) fn on_vsync(&mut self) {
         if let Some(fling_action) = self.touch_handler.on_vsync() {
             self.on_scroll_window_event(
                 ScrollLocation::Delta(fling_action.delta),
@@ -300,7 +325,7 @@ impl WebView {
         }
     }
 
-    pub fn notify_input_event(&mut self, event: InputEvent) {
+    pub(crate) fn notify_input_event(&mut self, event: InputEvent) {
         if self.global.borrow().shutdown_state() != ShutdownState::NotShuttingDown {
             return;
         }
@@ -365,7 +390,7 @@ impl WebView {
         }
     }
 
-    pub fn on_touch_event(&mut self, event: TouchEvent) {
+    pub(crate) fn on_touch_event(&mut self, event: TouchEvent) {
         if self.global.borrow().shutdown_state() != ShutdownState::NotShuttingDown {
             return;
         }
@@ -644,7 +669,7 @@ impl WebView {
         }));
     }
 
-    pub fn notify_scroll_event(
+    pub(crate) fn notify_scroll_event(
         &mut self,
         scroll_location: ScrollLocation,
         cursor: DeviceIntPoint,
@@ -727,13 +752,12 @@ impl WebView {
             }
         }
 
-        let zoom_changed = compositor
-            .set_pinch_zoom_level(compositor.pinch_zoom_level().get() * combined_magnification);
+        let zoom_changed =
+            self.set_pinch_zoom_level(self.pinch_zoom_level().get() * combined_magnification);
         let scroll_result = combined_scroll_event.and_then(|combined_event| {
             self.scroll_node_at_device_point(
                 combined_event.cursor.to_f32(),
                 combined_event.scroll_location,
-                compositor,
             )
         });
         if !zoom_changed && scroll_result.is_none() {
@@ -769,11 +793,10 @@ impl WebView {
         &mut self,
         cursor: DevicePoint,
         scroll_location: ScrollLocation,
-        compositor: &mut IOCompositor,
     ) -> Option<(PipelineId, ExternalScrollId, LayoutVector2D)> {
         let scroll_location = match scroll_location {
             ScrollLocation::Delta(delta) => {
-                let device_pixels_per_page = compositor.device_pixels_per_page_pixel();
+                let device_pixels_per_page = self.device_pixels_per_page_pixel();
                 let scaled_delta = (Vector2D::from_untyped(delta.to_untyped()) /
                     device_pixels_per_page)
                     .to_untyped();
@@ -818,8 +841,39 @@ impl WebView {
         None
     }
 
+    pub(crate) fn pinch_zoom_level(&self) -> Scale<f32, DevicePixel, DevicePixel> {
+        Scale::new(self.viewport_zoom.get())
+    }
+
+    fn set_pinch_zoom_level(&mut self, mut zoom: f32) -> bool {
+        if let Some(min) = self.min_viewport_zoom {
+            zoom = f32::max(min.get(), zoom);
+        }
+        if let Some(max) = self.max_viewport_zoom {
+            zoom = f32::min(max.get(), zoom);
+        }
+
+        let old_zoom = std::mem::replace(&mut self.viewport_zoom, PinchZoomFactor::new(zoom));
+        old_zoom != self.viewport_zoom
+    }
+
+    pub(crate) fn set_page_zoom(&mut self, magnification: f32) {
+        self.page_zoom =
+            Scale::new((self.page_zoom.get() * magnification).clamp(MIN_ZOOM, MAX_ZOOM));
+    }
+
+    pub(crate) fn device_pixels_per_page_pixel(&self) -> Scale<f32, CSSPixel, DevicePixel> {
+        self.page_zoom * self.hidpi_scale_factor * self.pinch_zoom_level()
+    }
+
+    pub(crate) fn device_pixels_per_page_pixel_not_including_pinch_zoom(
+        &self,
+    ) -> Scale<f32, CSSPixel, DevicePixel> {
+        self.page_zoom * self.hidpi_scale_factor
+    }
+
     /// Simulate a pinch zoom
-    pub fn set_pinch_zoom(&mut self, magnification: f32) {
+    pub(crate) fn set_pinch_zoom(&mut self, magnification: f32) {
         if self.global.borrow().shutdown_state() != ShutdownState::NotShuttingDown {
             return;
         }
@@ -827,6 +881,71 @@ impl WebView {
         // TODO: Scroll to keep the center in view?
         self.pending_scroll_zoom_events
             .push(ScrollZoomEvent::PinchZoom(magnification));
+    }
+
+    fn send_window_size_message(&self) {
+        // The device pixel ratio used by the style system should include the scale from page pixels
+        // to device pixels, but not including any pinch zoom.
+        let device_pixel_ratio = self.device_pixels_per_page_pixel_not_including_pinch_zoom();
+        let initial_viewport = self.rect.size().to_f32() / device_pixel_ratio;
+        let msg = EmbedderToConstellationMessage::ChangeViewportDetails(
+            self.id,
+            ViewportDetails {
+                hidpi_scale_factor: device_pixel_ratio,
+                size: initial_viewport,
+            },
+            WindowSizeType::Resize,
+        );
+        if let Err(e) = self.global.borrow().constellation_sender.send(msg) {
+            warn!("Sending window resize to constellation failed ({:?}).", e);
+        }
+    }
+
+    /// Set the `hidpi_scale_factor` for this renderer, returning `true` if the value actually changed.
+    pub(crate) fn set_hidpi_scale_factor(
+        &mut self,
+        new_scale: Scale<f32, DeviceIndependentPixel, DevicePixel>,
+    ) -> bool {
+        let old_scale_factor = std::mem::replace(&mut self.hidpi_scale_factor, new_scale);
+        if self.hidpi_scale_factor == old_scale_factor {
+            return false;
+        }
+
+        self.send_window_size_message();
+        true
+    }
+
+    /// Set the `rect` for this renderer, returning `true` if the value actually changed.
+    pub(crate) fn set_rect(&mut self, new_rect: DeviceRect) -> bool {
+        let old_rect = std::mem::replace(&mut self.rect, new_rect);
+        if old_rect.size() != self.rect.size() {
+            self.send_window_size_message();
+        }
+        old_rect != self.rect
+    }
+
+    pub(crate) fn client_window_rect(
+        &self,
+        rendering_context_size: Size2D<u32, DevicePixel>,
+    ) -> Box2D<i32, DeviceIndependentPixel> {
+        let screen_geometry = self.renderer_webview.screen_geometry().unwrap_or_default();
+        let rect = DeviceIntRect::from_origin_and_size(
+            screen_geometry.offset,
+            rendering_context_size.to_i32(),
+        )
+        .to_f32() /
+            self.hidpi_scale_factor;
+        rect.to_i32()
+    }
+
+    pub(crate) fn screen_size(&self) -> Size2D<i32, DeviceIndependentPixel> {
+        let screen_geometry = self.renderer_webview.screen_geometry().unwrap_or_default();
+        (screen_geometry.size.to_f32() / self.hidpi_scale_factor).to_i32()
+    }
+
+    pub(crate) fn available_screen_size(&self) -> Size2D<i32, DeviceIndependentPixel> {
+        let screen_geometry = self.renderer_webview.screen_geometry().unwrap_or_default();
+        (screen_geometry.available_size.to_f32() / self.hidpi_scale_factor).to_i32()
     }
 }
 

--- a/components/compositing/windowing.rs
+++ b/components/compositing/windowing.rs
@@ -5,10 +5,8 @@
 //! Abstract windowing methods. The concrete implementations of these can be found in `platform/`.
 
 use embedder_traits::{EventLoopWaker, MouseButton};
-use euclid::Scale;
 use net::protocols::ProtocolRegistry;
-use servo_geometry::DeviceIndependentPixel;
-use webrender_api::units::{DevicePixel, DevicePoint};
+use webrender_api::units::DevicePoint;
 
 #[derive(Clone)]
 pub enum MouseWindowEvent {
@@ -23,15 +21,6 @@ pub enum WebRenderDebugOption {
     Profiler,
     TextureCacheDebug,
     RenderTargetDebug,
-}
-
-// TODO: this trait assumes that the window is responsible
-// for creating the GL context, making it current, buffer
-// swapping, etc. Really that should all be done by surfman.
-pub trait WindowMethods {
-    /// Get the HighDPI factor of the native window, the screen and the framebuffer.
-    /// TODO(martin): Move this to `RendererWebView` when possible.
-    fn hidpi_factor(&self) -> Scale<f32, DeviceIndependentPixel, DevicePixel>;
 }
 
 pub trait EmbedderMethods {

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -4588,9 +4588,12 @@ where
                 self.compositor_proxy
                     .send(CompositorMsg::WebDriverMouseMoveEvent(webview_id, x, y));
             },
-            WebDriverCommandMsg::TakeScreenshot(_, rect, response_sender) => {
-                self.compositor_proxy
-                    .send(CompositorMsg::CreatePng(rect, response_sender));
+            WebDriverCommandMsg::TakeScreenshot(webview_id, rect, response_sender) => {
+                self.compositor_proxy.send(CompositorMsg::CreatePng(
+                    webview_id,
+                    rect,
+                    response_sender,
+                ));
             },
         }
     }

--- a/components/servo/examples/winit_minimal.rs
+++ b/components/servo/examples/winit_minimal.rs
@@ -5,18 +5,17 @@ use std::cell::RefCell;
 use std::error::Error;
 use std::rc::Rc;
 
-use compositing::windowing::{EmbedderMethods, WindowMethods};
-use euclid::{Point2D, Scale, Size2D};
+use compositing::windowing::EmbedderMethods;
+use euclid::{Scale, Size2D};
 use servo::{
     RenderingContext, Servo, TouchEventType, WebView, WebViewBuilder, WindowRenderingContext,
 };
-use servo_geometry::DeviceIndependentPixel;
 use tracing::warn;
 use url::Url;
 use webrender_api::ScrollLocation;
 use webrender_api::units::{DeviceIntPoint, DevicePixel, LayoutVector2D};
 use winit::application::ApplicationHandler;
-use winit::dpi::{PhysicalPosition, PhysicalSize};
+use winit::dpi::PhysicalSize;
 use winit::event::{MouseScrollDelta, WindowEvent};
 use winit::event_loop::EventLoop;
 use winit::raw_window_handle::{HasDisplayHandle, HasWindowHandle};
@@ -43,7 +42,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 }
 
 struct AppState {
-    window_delegate: Rc<WindowDelegate>,
+    window: Window,
     servo: Servo,
     rendering_context: Rc<WindowRenderingContext>,
     webviews: RefCell<Vec<WebView>>,
@@ -51,15 +50,17 @@ struct AppState {
 
 impl ::servo::WebViewDelegate for AppState {
     fn notify_new_frame_ready(&self, _: WebView) {
-        self.window_delegate.window.request_redraw();
+        self.window.request_redraw();
     }
 
     fn request_open_auxiliary_webview(&self, parent_webview: WebView) -> Option<WebView> {
         let webview = WebViewBuilder::new_auxiliary(&self.servo)
+            .hidpi_scale_factor(Scale::new(self.window.scale_factor() as f32))
             .delegate(parent_webview.delegate())
             .build();
         webview.focus();
         webview.raise_to_top(true);
+
         self.webviews.borrow_mut().push(webview.clone());
         Some(webview)
     }
@@ -91,7 +92,6 @@ impl ApplicationHandler<WakerEvent> for App {
                 WindowRenderingContext::new(display_handle, window_handle, window.inner_size())
                     .expect("Could not create RenderingContext for window."),
             );
-            let window_delegate = Rc::new(WindowDelegate::new(window));
 
             let _ = rendering_context.make_current();
 
@@ -102,13 +102,12 @@ impl ApplicationHandler<WakerEvent> for App {
                 Box::new(EmbedderDelegate {
                     waker: waker.clone(),
                 }),
-                window_delegate.clone(),
                 Default::default(),
             );
             servo.setup_logging();
 
             let app_state = Rc::new(AppState {
-                window_delegate,
+                window,
                 servo,
                 rendering_context,
                 webviews: Default::default(),
@@ -120,8 +119,10 @@ impl ApplicationHandler<WakerEvent> for App {
 
             let webview = WebViewBuilder::new(&app_state.servo)
                 .url(url)
+                .hidpi_scale_factor(Scale::new(app_state.window.scale_factor() as f32))
                 .delegate(app_state.clone())
                 .build();
+
             webview.focus();
             webview.raise_to_top(true);
 
@@ -239,26 +240,6 @@ impl embedder_traits::EventLoopWaker for Waker {
     }
 }
 
-struct WindowDelegate {
-    window: Window,
-}
-
-impl WindowDelegate {
-    fn new(window: Window) -> Self {
-        Self { window }
-    }
-}
-
-impl WindowMethods for WindowDelegate {
-    fn hidpi_factor(&self) -> Scale<f32, DeviceIndependentPixel, DevicePixel> {
-        Scale::new(self.window.scale_factor() as f32)
-    }
-}
-
 pub fn winit_size_to_euclid_size<T>(size: PhysicalSize<T>) -> Size2D<T, DevicePixel> {
     Size2D::new(size.width, size.height)
-}
-
-pub fn winit_position_to_euclid_point<T>(position: PhysicalPosition<T>) -> Point2D<T, DevicePixel> {
-    Point2D::new(position.x, position.y)
 }

--- a/components/servo/tests/common/mod.rs
+++ b/components/servo/tests/common/mod.rs
@@ -7,14 +7,12 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
-use compositing::windowing::{EmbedderMethods, WindowMethods};
+use compositing::windowing::EmbedderMethods;
 use compositing_traits::rendering_context::{RenderingContext, SoftwareRenderingContext};
 use dpi::PhysicalSize;
 use embedder_traits::EventLoopWaker;
 use euclid::Scale;
 use servo::Servo;
-use servo_geometry::DeviceIndependentPixel;
-use webrender_api::units::DevicePixel;
 
 pub struct ServoTest {
     servo: Servo,
@@ -39,13 +37,6 @@ impl ServoTest {
             }
         }
 
-        struct WindowMethodsImpl;
-        impl WindowMethods for WindowMethodsImpl {
-            fn hidpi_factor(&self) -> Scale<f32, DeviceIndependentPixel, DevicePixel> {
-                Scale::new(1.0)
-            }
-        }
-
         #[derive(Clone)]
         struct EventLoopWakerImpl(Arc<AtomicBool>);
         impl EventLoopWaker for EventLoopWakerImpl {
@@ -64,7 +55,6 @@ impl ServoTest {
             Default::default(),
             rendering_context.clone(),
             Box::new(EmbedderMethodsImpl(user_event_triggered)),
-            Rc::new(WindowMethodsImpl),
             Default::default(),
         );
         Self { servo }

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -15,10 +15,13 @@ use constellation_traits::{EmbedderToConstellationMessage, TraversalDirection};
 use dpi::PhysicalSize;
 use embedder_traits::{
     Cursor, InputEvent, LoadStatus, MediaSessionActionType, ScreenGeometry, Theme, TouchEventType,
+    ViewportDetails,
 };
+use euclid::{Point2D, Scale, Size2D};
+use servo_geometry::DeviceIndependentPixel;
 use url::Url;
 use webrender_api::ScrollLocation;
-use webrender_api::units::{DeviceIntPoint, DeviceRect};
+use webrender_api::units::{DeviceIntPoint, DevicePixel, DeviceRect};
 
 use crate::clipboard_delegate::{ClipboardDelegate, DefaultClipboardDelegate};
 use crate::webview_delegate::{DefaultWebViewDelegate, WebViewDelegate};
@@ -75,6 +78,7 @@ pub(crate) struct WebViewInner {
     pub(crate) clipboard_delegate: Rc<dyn ClipboardDelegate>,
 
     rect: DeviceRect,
+    hidpi_scale_factor: Scale<f32, DeviceIndependentPixel, DevicePixel>,
     load_status: LoadStatus,
     url: Option<Url>,
     status_text: Option<String>,
@@ -96,6 +100,17 @@ impl WebView {
     pub(crate) fn new(builder: WebViewBuilder) -> Self {
         let id = WebViewId::new();
         let servo = builder.servo;
+        let size = builder.size.map_or_else(
+            || {
+                builder
+                    .servo
+                    .compositor
+                    .borrow()
+                    .rendering_context_size()
+                    .to_f32()
+            },
+            |size| Size2D::new(size.width as f32, size.height as f32),
+        );
 
         let webview = Self(Rc::new(RefCell::new(WebViewInner {
             id,
@@ -103,7 +118,8 @@ impl WebView {
             compositor: servo.compositor.clone(),
             delegate: builder.delegate,
             clipboard_delegate: Rc::new(DefaultClipboardDelegate),
-            rect: DeviceRect::zero(),
+            rect: DeviceRect::from_origin_and_size(Point2D::origin(), size),
+            hidpi_scale_factor: builder.hidpi_scale_factor,
             load_status: LoadStatus::Complete,
             url: None,
             status_text: None,
@@ -114,14 +130,14 @@ impl WebView {
             cursor: Cursor::Pointer,
         })));
 
-        builder
-            .servo
-            .compositor
-            .borrow_mut()
-            .add_webview(Box::new(ServoRendererWebView {
+        let viewport_details = webview.viewport_details();
+        servo.compositor.borrow_mut().add_webview(
+            Box::new(ServoRendererWebView {
                 weak_handle: webview.weak_handle(),
                 id,
-            }));
+            }),
+            viewport_details,
+        );
 
         servo
             .webviews
@@ -133,8 +149,8 @@ impl WebView {
                 Url::parse("about:blank").expect("Should always be able to parse 'about:blank'."),
             );
 
-            let viewport_details = servo.compositor.borrow().default_webview_viewport_details();
-            servo
+            builder
+                .servo
                 .constellation_proxy
                 .send(EmbedderToConstellationMessage::NewWebView(
                     url.into(),
@@ -152,6 +168,17 @@ impl WebView {
 
     fn inner_mut(&self) -> RefMut<'_, WebViewInner> {
         self.0.borrow_mut()
+    }
+
+    pub(crate) fn viewport_details(&self) -> ViewportDetails {
+        // The division by 1 represents the page's default zoom of 100%,
+        // and gives us the appropriate CSSPixel type for the viewport.
+        let inner = self.inner();
+        let scaled_viewport_size = inner.rect.size() / inner.hidpi_scale_factor;
+        ViewportDetails {
+            size: scaled_viewport_size / Scale::new(1.0),
+            hidpi_scale_factor: Scale::new(inner.hidpi_scale_factor.0),
+        }
     }
 
     pub(crate) fn from_weak_handle(inner: &Weak<RefCell<WebViewInner>>) -> Option<Self> {
@@ -320,6 +347,25 @@ impl WebView {
             .move_resize_webview(self.id(), rect);
     }
 
+    pub fn hidpi_scale_factor(&self) -> Scale<f32, DeviceIndependentPixel, DevicePixel> {
+        self.inner().hidpi_scale_factor
+    }
+
+    pub fn set_hidpi_scale_factor(
+        &self,
+        new_scale_factor: Scale<f32, DeviceIndependentPixel, DevicePixel>,
+    ) {
+        if self.inner().hidpi_scale_factor == new_scale_factor {
+            return;
+        }
+
+        self.inner_mut().hidpi_scale_factor = new_scale_factor;
+        self.inner()
+            .compositor
+            .borrow_mut()
+            .set_hidpi_scale_factor(self.id(), new_scale_factor);
+    }
+
     pub fn show(&self, hide_others: bool) {
         self.inner()
             .compositor
@@ -437,14 +483,14 @@ impl WebView {
         self.inner()
             .compositor
             .borrow_mut()
-            .on_zoom_window_event(new_zoom);
+            .on_zoom_window_event(self.id(), new_zoom);
     }
 
     pub fn reset_zoom(&self) {
         self.inner()
             .compositor
             .borrow_mut()
-            .on_zoom_reset_window_event();
+            .on_zoom_reset_window_event(self.id());
     }
 
     pub fn set_pinch_zoom(&self, new_pinch_zoom: f32) {
@@ -535,6 +581,8 @@ pub struct WebViewBuilder<'servo> {
     delegate: Rc<dyn WebViewDelegate>,
     auxiliary: bool,
     url: Option<Url>,
+    size: Option<PhysicalSize<u32>>,
+    hidpi_scale_factor: Scale<f32, DeviceIndependentPixel, DevicePixel>,
 }
 
 impl<'servo> WebViewBuilder<'servo> {
@@ -543,6 +591,8 @@ impl<'servo> WebViewBuilder<'servo> {
             servo,
             auxiliary: false,
             url: None,
+            size: None,
+            hidpi_scale_factor: Scale::new(1.0),
             delegate: Rc::new(DefaultWebViewDelegate),
         }
     }
@@ -560,6 +610,19 @@ impl<'servo> WebViewBuilder<'servo> {
 
     pub fn url(mut self, url: Url) -> Self {
         self.url = Some(url);
+        self
+    }
+
+    pub fn size(mut self, size: PhysicalSize<u32>) -> Self {
+        self.size = Some(size);
+        self
+    }
+
+    pub fn hidpi_scale_factor(
+        mut self,
+        hidpi_scale_factor: Scale<f32, DeviceIndependentPixel, DevicePixel>,
+    ) -> Self {
+        self.hidpi_scale_factor = hidpi_scale_factor;
         self
     }
 

--- a/components/shared/compositing/lib.rs
+++ b/components/shared/compositing/lib.rs
@@ -70,7 +70,11 @@ pub enum CompositorMsg {
     /// Script has handled a touch event, and either prevented or allowed default actions.
     TouchEventProcessed(WebViewId, TouchEventResult),
     /// Composite to a PNG file and return the Image over a passed channel.
-    CreatePng(Option<Rect<f32, CSSPixel>>, IpcSender<Option<Image>>),
+    CreatePng(
+        WebViewId,
+        Option<Rect<f32, CSSPixel>>,
+        IpcSender<Option<Image>>,
+    ),
     /// A reply to the compositor asking if the output image is stable.
     IsReadyToSaveImageReply(bool),
     /// Set whether to use less resources by stopping animations.

--- a/ports/servoshell/desktop/app_state.rs
+++ b/ports/servoshell/desktop/app_state.rs
@@ -109,6 +109,7 @@ impl RunningAppState {
     pub(crate) fn new_toplevel_webview(self: &Rc<Self>, url: Url) {
         let webview = WebViewBuilder::new(self.servo())
             .url(url)
+            .hidpi_scale_factor(self.inner().window.hidpi_scale_factor())
             .delegate(self.clone())
             .build();
 
@@ -128,6 +129,14 @@ impl RunningAppState {
 
     pub(crate) fn servo(&self) -> &Servo {
         &self.servo
+    }
+
+    pub(crate) fn hidpi_scale_factor_changed(&self) {
+        let inner = self.inner();
+        let new_scale_factor = inner.window.hidpi_scale_factor();
+        for webview in inner.webviews.values() {
+            webview.set_hidpi_scale_factor(new_scale_factor);
+        }
     }
 
     pub(crate) fn save_output_image_if_necessary(&self) {
@@ -462,6 +471,7 @@ impl WebViewDelegate for RunningAppState {
         parent_webview: servo::WebView,
     ) -> Option<servo::WebView> {
         let webview = WebViewBuilder::new_auxiliary(&self.servo)
+            .hidpi_scale_factor(self.inner().window.hidpi_scale_factor())
             .delegate(parent_webview.delegate())
             .build();
 

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -14,7 +14,7 @@ use euclid::{Angle, Length, Point2D, Rotation3D, Scale, Size2D, UnknownUnit, Vec
 use keyboard_types::{Modifiers, ShortcutMatcher};
 use log::{debug, info};
 use raw_window_handle::{HasDisplayHandle, HasWindowHandle, RawWindowHandle};
-use servo::compositing::windowing::{WebRenderDebugOption, WindowMethods};
+use servo::compositing::windowing::WebRenderDebugOption;
 use servo::servo_config::pref;
 use servo::servo_geometry::DeviceIndependentPixel;
 use servo::webrender_api::ScrollLocation;
@@ -252,7 +252,7 @@ impl Window {
 
     /// Helper function to handle a click
     fn handle_mouse(&self, webview: &WebView, button: MouseButton, action: ElementState) {
-        let max_pixel_dist = 10.0 * self.hidpi_factor().get();
+        let max_pixel_dist = 10.0 * self.hidpi_scale_factor().get();
         let mouse_button = match &button {
             MouseButton::Left => ServoMouseButton::Left,
             MouseButton::Right => ServoMouseButton::Right,
@@ -443,8 +443,11 @@ impl Window {
 
 impl WindowPortsMethods for Window {
     fn screen_geometry(&self) -> ScreenGeometry {
-        let hidpi_factor = self.hidpi_factor();
-        let toolbar_size = Size2D::new(0.0, (self.toolbar_height.get() * self.hidpi_factor()).0);
+        let hidpi_factor = self.hidpi_scale_factor();
+        let toolbar_size = Size2D::new(
+            0.0,
+            (self.toolbar_height.get() * self.hidpi_scale_factor()).0,
+        );
 
         let screen_size = self.screen_size.to_f32() * hidpi_factor;
         let available_screen_size = screen_size - toolbar_size;
@@ -462,18 +465,18 @@ impl WindowPortsMethods for Window {
         }
     }
 
-    fn device_hidpi_factor(&self) -> Scale<f32, DeviceIndependentPixel, DevicePixel> {
+    fn device_hidpi_scale_factor(&self) -> Scale<f32, DeviceIndependentPixel, DevicePixel> {
         Scale::new(self.winit_window.scale_factor() as f32)
     }
 
-    fn device_pixel_ratio_override(
-        &self,
-    ) -> Option<Scale<f32, DeviceIndependentPixel, DevicePixel>> {
-        self.device_pixel_ratio_override.map(Scale::new)
+    fn hidpi_scale_factor(&self) -> Scale<f32, DeviceIndependentPixel, DevicePixel> {
+        self.device_pixel_ratio_override
+            .map(Scale::new)
+            .unwrap_or_else(|| self.device_hidpi_scale_factor())
     }
 
     fn page_height(&self) -> f32 {
-        let dpr = self.hidpi_factor();
+        let dpr = self.hidpi_scale_factor();
         let size = self.winit_window.inner_size();
         size.height as f32 * dpr.get()
     }
@@ -483,7 +486,7 @@ impl WindowPortsMethods for Window {
     }
 
     fn request_resize(&self, _: &WebView, size: DeviceIntSize) -> Option<DeviceIntSize> {
-        let toolbar_height = self.toolbar_height() * self.hidpi_factor();
+        let toolbar_height = self.toolbar_height() * self.hidpi_scale_factor();
         let toolbar_height = toolbar_height.get().ceil() as i32;
         let total_size = PhysicalSize::new(size.width, size.height + toolbar_height);
         self.winit_window
@@ -587,7 +590,7 @@ impl WindowPortsMethods for Window {
             },
             WindowEvent::CursorMoved { position, .. } => {
                 let mut point = winit_position_to_euclid_point(position).to_f32();
-                point.y -= (self.toolbar_height() * self.hidpi_factor()).0;
+                point.y -= (self.toolbar_height() * self.hidpi_scale_factor()).0;
 
                 self.webview_relative_mouse_point.set(point);
                 webview.notify_input_event(InputEvent::MouseMove(MouseMoveEvent { point }));
@@ -598,7 +601,7 @@ impl WindowPortsMethods for Window {
                         (dx as f64, (dy * LINE_HEIGHT) as f64, WheelMode::DeltaLine)
                     },
                     MouseScrollDelta::PixelDelta(position) => {
-                        let scale_factor = self.device_hidpi_factor().inverse().get() as f64;
+                        let scale_factor = self.device_hidpi_scale_factor().inverse().get() as f64;
                         let position = position.to_logical(scale_factor);
                         (position.x, position.y, WheelMode::DeltaPixel)
                     },
@@ -728,7 +731,7 @@ impl WindowPortsMethods for Window {
         // this prevents a crash in the compositor due to invalid surface size
         self.winit_window.set_min_inner_size(Some(PhysicalSize::new(
             1.0,
-            1.0 + (self.toolbar_height() * self.hidpi_factor()).0,
+            1.0 + (self.toolbar_height() * self.hidpi_scale_factor()).0,
         )));
     }
 
@@ -758,13 +761,6 @@ impl WindowPortsMethods for Window {
 
     fn hide_ime(&self) {
         self.winit_window.set_ime_allowed(false);
-    }
-}
-
-impl WindowMethods for Window {
-    fn hidpi_factor(&self) -> Scale<f32, DeviceIndependentPixel, DevicePixel> {
-        self.device_pixel_ratio_override()
-            .unwrap_or_else(|| self.device_hidpi_factor())
     }
 }
 

--- a/ports/servoshell/desktop/headless_window.rs
+++ b/ports/servoshell/desktop/headless_window.rs
@@ -9,7 +9,6 @@ use std::rc::Rc;
 
 use euclid::num::Zero;
 use euclid::{Length, Scale, Size2D};
-use servo::compositing::windowing::WindowMethods;
 use servo::servo_geometry::DeviceIndependentPixel;
 use servo::webrender_api::units::{DeviceIntSize, DevicePixel};
 use servo::{RenderingContext, ScreenGeometry, SoftwareRenderingContext};
@@ -94,19 +93,18 @@ impl WindowPortsMethods for Window {
         Some(new_size)
     }
 
-    fn device_hidpi_factor(&self) -> Scale<f32, DeviceIndependentPixel, DevicePixel> {
+    fn device_hidpi_scale_factor(&self) -> Scale<f32, DeviceIndependentPixel, DevicePixel> {
         Scale::new(1.0)
     }
 
-    fn device_pixel_ratio_override(
-        &self,
-    ) -> Option<Scale<f32, DeviceIndependentPixel, DevicePixel>> {
+    fn hidpi_scale_factor(&self) -> Scale<f32, DeviceIndependentPixel, DevicePixel> {
         self.device_pixel_ratio_override
+            .unwrap_or_else(|| self.device_hidpi_scale_factor())
     }
 
     fn page_height(&self) -> f32 {
         let height = self.inner_size.get().height;
-        let dpr = self.hidpi_factor();
+        let dpr = self.hidpi_scale_factor();
         height as f32 * dpr.get()
     }
 
@@ -143,12 +141,5 @@ impl WindowPortsMethods for Window {
 
     fn rendering_context(&self) -> Rc<dyn RenderingContext> {
         self.rendering_context.clone()
-    }
-}
-
-impl WindowMethods for Window {
-    fn hidpi_factor(&self) -> Scale<f32, DeviceIndependentPixel, DevicePixel> {
-        self.device_pixel_ratio_override()
-            .unwrap_or_else(|| self.device_hidpi_factor())
     }
 }

--- a/ports/servoshell/desktop/window_trait.rs
+++ b/ports/servoshell/desktop/window_trait.rs
@@ -8,7 +8,6 @@
 use std::rc::Rc;
 
 use euclid::{Length, Scale};
-use servo::compositing::windowing::WindowMethods;
 use servo::servo_geometry::DeviceIndependentPixel;
 use servo::webrender_api::units::{DeviceIntPoint, DeviceIntSize, DevicePixel};
 use servo::{Cursor, RenderingContext, ScreenGeometry, WebView};
@@ -18,13 +17,11 @@ use super::app_state::RunningAppState;
 // This should vary by zoom level and maybe actual text size (focused or under cursor)
 pub const LINE_HEIGHT: f32 = 38.0;
 
-pub trait WindowPortsMethods: WindowMethods {
+pub trait WindowPortsMethods {
     fn id(&self) -> winit::window::WindowId;
     fn screen_geometry(&self) -> ScreenGeometry;
-    fn device_hidpi_factor(&self) -> Scale<f32, DeviceIndependentPixel, DevicePixel>;
-    fn device_pixel_ratio_override(
-        &self,
-    ) -> Option<Scale<f32, DeviceIndependentPixel, DevicePixel>>;
+    fn device_hidpi_scale_factor(&self) -> Scale<f32, DeviceIndependentPixel, DevicePixel>;
+    fn hidpi_scale_factor(&self) -> Scale<f32, DeviceIndependentPixel, DevicePixel>;
     fn page_height(&self) -> f32;
     fn get_fullscreen(&self) -> bool;
     fn handle_winit_event(&self, state: Rc<RunningAppState>, event: winit::event::WindowEvent);

--- a/ports/servoshell/egl/android/simpleservo.rs
+++ b/ports/servoshell/egl/android/simpleservo.rs
@@ -83,7 +83,6 @@ pub fn init(
     let window_callbacks = Rc::new(ServoWindowCallbacks::new(
         callbacks,
         RefCell::new(init_opts.coordinates),
-        init_opts.density,
     ));
 
     let embedder_callbacks = Box::new(ServoEmbedderCallbacks::new(
@@ -97,13 +96,13 @@ pub fn init(
         preferences,
         rendering_context.clone(),
         embedder_callbacks,
-        window_callbacks.clone(),
         Default::default(),
     );
 
     APP.with(|app| {
         let app_state = RunningAppState::new(
             init_opts.url,
+            init_opts.density,
             rendering_context,
             servo,
             window_callbacks,

--- a/ports/servoshell/egl/ohos/simpleservo.rs
+++ b/ports/servoshell/egl/ohos/simpleservo.rs
@@ -124,7 +124,6 @@ pub fn init(
     let window_callbacks = Rc::new(ServoWindowCallbacks::new(
         callbacks,
         RefCell::new(coordinates),
-        options.display_density as f32,
     ));
 
     let embedder_callbacks = Box::new(ServoEmbedderCallbacks::new(
@@ -138,12 +137,12 @@ pub fn init(
         preferences,
         rendering_context.clone(),
         embedder_callbacks,
-        window_callbacks.clone(),
         Default::default(),
     );
 
     let app_state = RunningAppState::new(
         Some(options.url),
+        options.display_density as f32,
         rendering_context,
         servo,
         window_callbacks,


### PR DESCRIPTION
libservo: Make zooming and HiDPI scaling work per-`WebView`

This change moves all zooming and HiDPI scaling to work per-`WebView` in
both libservo and Compositor. This means that you can pinch zoom one
`WebView` and it should now work independently of other `WebView`s.
This is accomplished by making each `WebView` in the WebRender scene
have its own scaling reference frame.

All WebViews are now expected to manage their HiDPI scaling factor and
this can be set independently of other WebViews. Perhaps in the future
this will become a Servo-wide setting.

This allows full removal of the `WindowMethods` trait from Servo.

Testing: There are not yet any tests for the WebView API, but I hope
to add those soon.

Co-authored-by: Shubham Gupta <shubham13297@gmail.com>
Signed-off-by: Martin Robinson <mrobinson@igalia.com>
