### PR TITLE
libservo: Move `EventLooperWaker` from `webxr_traits` to `embedder_traits`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1949,7 +1949,6 @@ dependencies = [
  "url",
  "webdriver",
  "webrender_api",
- "webxr-api",
 ]
 
 [[package]]
@@ -8699,6 +8698,7 @@ dependencies = [
 name = "webxr-api"
 version = "0.0.1"
 dependencies = [
+ "embedder_traits",
  "euclid",
  "ipc-channel",
  "log",

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -46,7 +46,6 @@ webxr = [
     "dep:webxr",
     "dep:webxr-api",
     "compositing/webxr",
-    "embedder_traits/webxr",
     "canvas/webxr",
     "script/webxr",
 ]

--- a/components/shared/embedder/Cargo.toml
+++ b/components/shared/embedder/Cargo.toml
@@ -11,9 +11,6 @@ rust-version.workspace = true
 name = "embedder_traits"
 path = "lib.rs"
 
-[features]
-webxr = ["dep:webxr-api"]
-
 [dependencies]
 base = { workspace = true }
 cfg-if = { workspace = true }
@@ -37,4 +34,3 @@ stylo_traits = { workspace = true }
 url = { workspace = true }
 webdriver = { workspace = true }
 webrender_api = { workspace = true }
-webxr-api = { workspace = true, features = ["ipc"], optional = true }

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -90,21 +90,16 @@ pub enum Cursor {
     ZoomOut,
 }
 
-#[cfg(feature = "webxr")]
-pub use webxr_api::MainThreadWaker as EventLoopWaker;
-#[cfg(not(feature = "webxr"))]
 pub trait EventLoopWaker: 'static + Send {
     fn clone_box(&self) -> Box<dyn EventLoopWaker>;
     fn wake(&self);
 }
 
-#[cfg(not(feature = "webxr"))]
 impl Clone for Box<dyn EventLoopWaker> {
     fn clone(&self) -> Self {
-        EventLoopWaker::clone_box(self.as_ref())
+        self.clone_box()
     }
 }
-
 /// Sends messages to the embedder.
 pub struct EmbedderProxy {
     pub sender: Sender<EmbedderMsg>,

--- a/components/shared/webxr/Cargo.toml
+++ b/components/shared/webxr/Cargo.toml
@@ -19,6 +19,7 @@ path = "lib.rs"
 ipc = ["serde", "ipc-channel", "euclid/serde"]
 
 [dependencies]
+embedder_traits = { workspace = true }
 euclid = { workspace = true }
 ipc-channel = { workspace = true, optional = true }
 log = { workspace = true }

--- a/components/shared/webxr/lib.rs
+++ b/components/shared/webxr/lib.rs
@@ -50,7 +50,7 @@ pub use mock::{
     MockButton, MockButtonType, MockDeviceInit, MockDeviceMsg, MockDiscoveryAPI, MockInputInit,
     MockInputMsg, MockRegion, MockViewInit, MockViewsInit, MockWorld,
 };
-pub use registry::{MainThreadRegistry, MainThreadWaker, Registry};
+pub use registry::{MainThreadRegistry, Registry};
 pub use session::{
     EnvironmentBlendMode, MainThreadSession, Quitter, Session, SessionBuilder, SessionId,
     SessionInit, SessionMode, SessionThread,


### PR DESCRIPTION
Now that `webxr` is integrated into the Servo directory, `webxr` can
depend on `embedder_traits` instead of having it re-export this type
conditionally (and sometimes duplicating it).

Testing: This just moves a data type, so no tests are necessary.
Signed-off-by: Martin Robinson <mrobinson@igalia.com>
