### PR TITLE
Generate pattern strings for URLPattern components

### DIFF
--- a/components/script/dom/urlpattern/preprocessing.rs
+++ b/components/script/dom/urlpattern/preprocessing.rs
@@ -644,7 +644,7 @@ fn escape_a_string(input: &str, to_escape: &[char]) -> String {
 }
 
 /// <https://urlpattern.spec.whatwg.org/#escape-a-pattern-string>
-fn escape_a_pattern_string(input: &str) -> String {
+pub(super) fn escape_a_pattern_string(input: &str) -> String {
     escape_a_string(input, &['+', '*', '?', ':', '{', '}', '(', ')', '\\'])
 }
 

--- a/components/script/dom/urlpattern/tokenizer.rs
+++ b/components/script/dom/urlpattern/tokenizer.rs
@@ -517,7 +517,7 @@ impl Tokenizer<'_> {
 }
 
 /// <https://urlpattern.spec.whatwg.org/#is-a-valid-name-code-point>
-fn is_a_valid_name_code_point(code_point: char, first: bool) -> bool {
+pub(super) fn is_a_valid_name_code_point(code_point: char, first: bool) -> bool {
     // FIXME: implement this check
     _ = first;
     code_point.is_alphabetic()

--- a/tests/wpt/meta/urlpattern/urlpattern.any.js.ini
+++ b/tests/wpt/meta/urlpattern/urlpattern.any.js.ini
@@ -581,9 +581,6 @@
   [Pattern: [{"pathname":"/foo/bar"}\] Inputs: ["./foo/bar","https://example.com"\]]
     expected: FAIL
 
-  [Pattern: [{"pathname":"/foo/bar"}\] Inputs: [{"pathname":"/foo/bar"},"https://example.com"\]]
-    expected: FAIL
-
   [Pattern: ["https://example.com:8080/foo?bar#baz"\] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}\]]
     expected: FAIL
 
@@ -1517,9 +1514,6 @@
     expected: FAIL
 
   [Pattern: [{"pathname":"/foo/bar"}\] Inputs: ["./foo/bar","https://example.com"\]]
-    expected: FAIL
-
-  [Pattern: [{"pathname":"/foo/bar"}\] Inputs: [{"pathname":"/foo/bar"},"https://example.com"\]]
     expected: FAIL
 
   [Pattern: ["https://example.com:8080/foo?bar#baz"\] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}\]]

--- a/tests/wpt/meta/urlpattern/urlpattern.https.any.js.ini
+++ b/tests/wpt/meta/urlpattern/urlpattern.https.any.js.ini
@@ -584,9 +584,6 @@
   [Pattern: [{"pathname":"/foo/bar"}\] Inputs: ["./foo/bar","https://example.com"\]]
     expected: FAIL
 
-  [Pattern: [{"pathname":"/foo/bar"}\] Inputs: [{"pathname":"/foo/bar"},"https://example.com"\]]
-    expected: FAIL
-
   [Pattern: ["https://example.com:8080/foo?bar#baz"\] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}\]]
     expected: FAIL
 
@@ -1517,9 +1514,6 @@
     expected: FAIL
 
   [Pattern: [{"pathname":"/foo/bar"}\] Inputs: ["./foo/bar","https://example.com"\]]
-    expected: FAIL
-
-  [Pattern: [{"pathname":"/foo/bar"}\] Inputs: [{"pathname":"/foo/bar"},"https://example.com"\]]
     expected: FAIL
 
   [Pattern: ["https://example.com:8080/foo?bar#baz"\] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}\]]


### PR DESCRIPTION
This makes the component getters functions (like URLPattern::hostname) actually do what they're supposed to.

It appears that there are no web platform tests for this functionality. The results seem correct when I test the methods locally. I'll mark this as ready for review when I either find existing tests or add new ones.

Testing: *Describe how this pull request is tested or why it doesn't require tests*
Fixes: *Link to an issue this pull requests fixes or remove this line if there is no issue*
