### PR TITLE
Drop vergen_git2 dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1503,7 +1503,6 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
  "syn",
 ]
 
@@ -1563,37 +1562,6 @@ checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
  "serde",
-]
-
-[[package]]
-name = "derive_builder"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
-dependencies = [
- "derive_builder_macro",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "derive_builder_macro"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
-dependencies = [
- "derive_builder_core",
- "syn",
 ]
 
 [[package]]
@@ -2575,19 +2543,6 @@ dependencies = [
  "libc",
  "system-deps",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "git2"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fda788993cc341f69012feba8bf45c0ba4f3291fcc08e214b4d5a7332d88aff"
-dependencies = [
- "bitflags 2.9.0",
- "libc",
- "libgit2-sys",
- "log",
- "url",
 ]
 
 [[package]]
@@ -4309,18 +4264,6 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06085512b750d640299b79be4bad3d2fa90a9c00b1fd9e1b46364f66f0485c72"
 dependencies = [
- "pkg-config",
-]
-
-[[package]]
-name = "libgit2-sys"
-version = "0.18.1+1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1dcb20f84ffcdd825c7a311ae347cce604a6f084a767dec4a4929829645290e"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
  "pkg-config",
 ]
 
@@ -6972,7 +6915,6 @@ dependencies = [
  "tracing-perfetto",
  "tracing-subscriber",
  "url",
- "vergen-git2",
  "windows-sys 0.59.0",
  "winit",
  "winres",
@@ -7225,12 +7167,6 @@ dependencies = [
  "proc-macro2",
  "quote",
 ]
-
-[[package]]
-name = "strsim"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
@@ -8200,45 +8136,6 @@ name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-
-[[package]]
-name = "vergen"
-version = "9.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b2bf58be11fc9414104c6d3a2e464163db5ef74b12296bda593cac37b6e4777"
-dependencies = [
- "anyhow",
- "derive_builder",
- "rustversion",
- "time",
- "vergen-lib",
-]
-
-[[package]]
-name = "vergen-git2"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d86bae87104cb2790cdee615c2bb54729804d307191732ab27b1c5357ea6ddc5"
-dependencies = [
- "anyhow",
- "derive_builder",
- "git2",
- "rustversion",
- "time",
- "vergen",
- "vergen-lib",
-]
-
-[[package]]
-name = "vergen-lib"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b07e6010c0f3e59fcb164e0163834597da68d1f864e2b8ca49f74de01e9c166"
-dependencies = [
- "anyhow",
- "derive_builder",
- "rustversion",
-]
 
 [[package]]
 name = "version-compare"

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -22,7 +22,6 @@ bench = false
 # since build-scripts can't detect the cargo target os at build-time, we
 # must unconditionally add these dependencies. See https://github.com/rust-lang/cargo/issues/4932
 [build-dependencies]
-vergen-git2 = { version = "1.0.5", features = ["build"] }
 # MacOS only
 cc = "1.2"
 

--- a/ports/servoshell/build.rs
+++ b/ports/servoshell/build.rs
@@ -6,18 +6,20 @@ use std::error::Error;
 use std::fs::File;
 use std::io::Write;
 use std::path::Path;
+use std::process::Command;
 
-use vergen_git2::{Emitter, Git2Builder};
-
-fn emit_git_sha() -> Result<(), String> {
-    let git_options = Git2Builder::default()
-        .sha(true /* short */)
-        .build()
+fn git_sha() -> Result<String, String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
         .map_err(|e| e.to_string())?;
-    Emitter::default()
-        .add_instructions(&git_options)
-        .and_then(|emitter| emitter.fail_on_error().emit())
-        .map_err(|e| e.to_string())
+    if output.status.success() {
+        let hash = String::from_utf8(output.stdout).map_err(|e| e.to_string())?;
+        Ok(hash.trim().to_owned())
+    } else {
+        let stderr = String::from_utf8(output.stderr).map_err(|e| e.to_string())?;
+        Err(stderr)
+    }
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -72,12 +74,15 @@ fn main() -> Result<(), Box<dyn Error>> {
         println!("cargo:rustc-link-search=native={}", out.display());
     }
 
-    if let Err(error) = emit_git_sha() {
-        println!(
-            "cargo:warning=Could not generate git version information: {:?}",
-            error
-        );
-        println!("cargo:rustc-env=VERGEN_GIT_SHA=nogit");
+    match git_sha() {
+        Ok(hash) => println!("cargo:rustc-env=GIT_SHA={}", hash),
+        Err(error) => {
+            println!(
+                "cargo:warning=Could not generate git version information: {:?}",
+                error
+            );
+            println!("cargo:rustc-env=GIT_SHA=nogit");
+        },
     }
 
     // On MacOS, all dylib dependencies are shipped along with the binary

--- a/ports/servoshell/lib.rs
+++ b/ports/servoshell/lib.rs
@@ -97,11 +97,7 @@ pub fn init_tracing(filter_directives: Option<&str>) {
 }
 
 pub fn servo_version() -> String {
-    format!(
-        "Servo {}-{}",
-        env!("CARGO_PKG_VERSION"),
-        env!("VERGEN_GIT_SHA")
-    )
+    format!("Servo {}-{}", env!("CARGO_PKG_VERSION"), env!("GIT_SHA"))
 }
 
 /// Plumbs tracing spans into HiTrace, with the following caveats:


### PR DESCRIPTION
Manually call `git rev-parse --short HEAD` to retrieve the commit hash, instead of using Emitter from vergen_git2. This helps remove dependencies and shorten compile time.

Testing: This change is untested, because there is no good way to test that the
version number embedded into Servo is correct currently.

Fixes: #36435 