### PR TITLE
Implement `disabled` attribute for `<link rel="stylesheet">`

### DIFF
--- a/components/script/stylesheet_loader.rs
+++ b/components/script/stylesheet_loader.rs
@@ -214,7 +214,7 @@ impl FetchResponseListener for StylesheetContext {
                             document.quirks_mode(),
                         ));
 
-                        if link.is_alternate() {
+                        if link.is_effectively_disabled() {
                             sheet.set_disabled(true);
                         }
 

--- a/components/script_bindings/webidls/HTMLLinkElement.webidl
+++ b/components/script_bindings/webidls/HTMLLinkElement.webidl
@@ -13,17 +13,24 @@ interface HTMLLinkElement : HTMLElement {
            attribute DOMString? crossOrigin;
   [CEReactions]
            attribute DOMString rel;
+  // [CEReactions] attribute DOMString as;
   [SameObject, PutForwards=value] readonly attribute DOMTokenList relList;
   [CEReactions]
            attribute DOMString media;
   [CEReactions]
+           attribute DOMString integrity;
+  [CEReactions]
            attribute DOMString hreflang;
   [CEReactions]
            attribute DOMString type;
-  [CEReactions]
-           attribute DOMString integrity;
+  // [SameObject, PutForwards=value] readonly attribute DOMTokenList sizes;
+  // [CEReactions] attribute USVString imageSrcset;
+  // [CEReactions] attribute DOMString imageSizes;
   [CEReactions]
            attribute DOMString referrerPolicy;
+  // [SameObject, PutForwards=value] readonly attribute DOMTokenList blocking;
+  [CEReactions] attribute boolean disabled;
+  // [CEReactions] attribute DOMString fetchPriority;
 
   // also has obsolete members
 };

--- a/tests/wpt/meta/css/cssom/HTMLLinkElement-disabled-003.html.ini
+++ b/tests/wpt/meta/css/cssom/HTMLLinkElement-disabled-003.html.ini
@@ -1,4 +1,0 @@
-[HTMLLinkElement-disabled-003.html]
-  [HTMLLinkElement.disabled's explicitly enabled state persists when disconnected and connected again]
-    expected: FAIL
-

--- a/tests/wpt/meta/css/cssom/HTMLLinkElement-disabled-004.html.ini
+++ b/tests/wpt/meta/css/cssom/HTMLLinkElement-disabled-004.html.ini
@@ -1,4 +1,0 @@
-[HTMLLinkElement-disabled-004.html]
-  [HTMLLinkElement.disabled's explicitly enabled state doesn't persist on clones]
-    expected: FAIL
-

--- a/tests/wpt/meta/css/cssom/HTMLLinkElement-disabled-007.html.ini
+++ b/tests/wpt/meta/css/cssom/HTMLLinkElement-disabled-007.html.ini
@@ -1,4 +1,0 @@
-[HTMLLinkElement-disabled-007.html]
-  [HTMLLinkElement.disabled setter sets the explicitly enabled state if toggled back and forth.]
-    expected: FAIL
-

--- a/tests/wpt/meta/css/cssom/HTMLLinkElement-disabled-alternate.html.ini
+++ b/tests/wpt/meta/css/cssom/HTMLLinkElement-disabled-alternate.html.ini
@@ -1,2 +1,0 @@
-[HTMLLinkElement-disabled-alternate.html]
-  expected: FAIL

--- a/tests/wpt/meta/html/dom/idlharness.https.html.ini
+++ b/tests/wpt/meta/html/dom/idlharness.https.html.ini
@@ -6052,9 +6052,6 @@
   [HTMLLinkElement interface: attribute blocking]
     expected: FAIL
 
-  [HTMLLinkElement interface: attribute disabled]
-    expected: FAIL
-
   [HTMLLinkElement interface: attribute fetchPriority]
     expected: FAIL
 
@@ -6071,9 +6068,6 @@
     expected: FAIL
 
   [HTMLLinkElement interface: document.createElement("link") must inherit property "blocking" with the proper type]
-    expected: FAIL
-
-  [HTMLLinkElement interface: document.createElement("link") must inherit property "disabled" with the proper type]
     expected: FAIL
 
   [HTMLLinkElement interface: document.createElement("link") must inherit property "fetchPriority" with the proper type]

--- a/tests/wpt/meta/subresource-integrity/subresource-integrity.html.ini
+++ b/tests/wpt/meta/subresource-integrity/subresource-integrity.html.ini
@@ -1,7 +1,4 @@
 [subresource-integrity.html]
-  [Style: Same-origin with correct sha256 and sha512 hash, rel='alternate stylesheet' enabled]
-    expected: FAIL
-
   [Script: Same-origin with non-Base64 hash.]
     expected: FAIL
 


### PR DESCRIPTION
Adds support for both the content and the IDL attribute.
Note this doesn't cover dynamic updates to `document.styleSheets` and the owner node of the sheet.

Testing: Covered by WPT
Fixes: #26739
