### PR TITLE
fix: File to FormData not correctly handling name and lastModified

### DIFF
--- a/components/script/dom/file.rs
+++ b/components/script/dom/file.rs
@@ -108,6 +108,10 @@ impl File {
     pub(crate) fn file_type(&self) -> String {
         self.blob.type_string()
     }
+
+    pub(crate) fn get_modified(&self) -> SystemTime {
+        self.modified
+    }
 }
 
 impl FileMethods<crate::DomTypeHolder> for File {
@@ -132,15 +136,12 @@ impl FileMethods<crate::DomTypeHolder> for File {
             .map(|modified| OffsetDateTime::UNIX_EPOCH + Duration::milliseconds(modified))
             .map(Into::into);
 
-        // NOTE: Following behaviour might be removed in future,
-        // see https://github.com/w3c/FileAPI/issues/41
-        let replaced_filename = DOMString::from_string(filename.replace('/', ":"));
         let type_string = normalize_type_string(blobPropertyBag.type_.as_ref());
         Ok(File::new_with_proto(
             global,
             proto,
             BlobImpl::new_from_bytes(bytes, type_string),
-            replaced_filename,
+            filename,
             modified,
             can_gc,
         ))

--- a/components/script/dom/formdata.rs
+++ b/components/script/dom/formdata.rs
@@ -275,12 +275,13 @@ impl FormData {
         };
 
         let bytes = blob.get_bytes().unwrap_or_default();
+        let last_modified = blob.downcast::<File>().map(|file| file.get_modified());
 
         File::new(
             &self.global(),
             BlobImpl::new_from_bytes(bytes, blob.type_string()),
             name,
-            None,
+            last_modified,
             can_gc,
         )
     }

--- a/tests/wpt/meta/FileAPI/file/File-constructor.any.js.ini
+++ b/tests/wpt/meta/FileAPI/file/File-constructor.any.js.ini
@@ -1,8 +1,0 @@
-[File-constructor.any.html]
-  [No replacement when using special character in fileName]
-    expected: FAIL
-
-
-[File-constructor.any.worker.html]
-  [No replacement when using special character in fileName]
-    expected: FAIL

--- a/tests/wpt/meta/xhr/formdata/set-blob.any.js.ini
+++ b/tests/wpt/meta/xhr/formdata/set-blob.any.js.ini
@@ -1,8 +1,0 @@
-[set-blob.any.html]
-  [file with lastModified and custom name]
-    expected: FAIL
-
-
-[set-blob.any.worker.html]
-  [file with lastModified and custom name]
-    expected: FAIL


### PR DESCRIPTION
Set File's lastModified when reconstructing from Blob for FormData
Remove special character replacement in fileName (spec removed this step)

Testing: WPT tests exist
Fixes: #22744 (if I undertand the issue correctly the filename issue was already fixed and now this fixes the lastModified part)
