### PR TITLE
Implement WebviewDelegate.screen_geometry for OHOS

### DIFF
--- a/ports/servoshell/egl/app_state.rs
+++ b/ports/servoshell/egl/app_state.rs
@@ -20,8 +20,8 @@ use servo::{
     AllowOrDenyRequest, ContextMenuResult, EmbedderProxy, EventLoopWaker, ImeEvent, InputEvent,
     InputMethodType, Key, KeyState, KeyboardEvent, LoadStatus, MediaSessionActionType,
     MediaSessionEvent, MouseButton, MouseButtonAction, MouseButtonEvent, MouseMoveEvent,
-    NavigationRequest, PermissionRequest, RenderingContext, Servo, ServoDelegate, ServoError,
-    SimpleDialog, TouchEvent, TouchEventType, TouchId, WebView, WebViewDelegate,
+    NavigationRequest, PermissionRequest, RenderingContext, ScreenGeometry, Servo, ServoDelegate,
+    ServoError, SimpleDialog, TouchEvent, TouchEventType, TouchId, WebView, WebViewDelegate,
     WindowRenderingContext,
 };
 use url::Url;
@@ -115,6 +115,16 @@ impl ServoDelegate for ServoShellServoDelegate {
 }
 
 impl WebViewDelegate for RunningAppState {
+    fn screen_geometry(&self, webview: WebView) -> Option<ScreenGeometry> {
+        let coord = self.callbacks.coordinates.borrow();
+        let screen_size = DeviceIntSize::new(coord.viewport.size.width, coord.viewport.size.height);
+        Some(ScreenGeometry {
+            size: screen_size,
+            available_size: screen_size,
+            offset: Point2D::zero(),
+        })
+    }
+
     fn notify_page_title_changed(&self, _webview: servo::WebView, title: Option<String>) {
         self.callbacks.host_callbacks.on_title_changed(title);
     }

--- a/ports/servoshell/egl/ohos/simpleservo.rs
+++ b/ports/servoshell/egl/ohos/simpleservo.rs
@@ -66,6 +66,15 @@ pub fn init(
             );
         });
 
+    // Ensure cache dir exists before copy `prefs.json`
+    let _ = crate::prefs::default_config_dir().inspect(|path| {
+        if !path.exists() {
+            fs::create_dir_all(path).unwrap_or_else(|e| {
+                log::error!("Failed to create config directory at {:?}: {:?}", path, e)
+            })
+        }
+    });
+
     // Try copy `prefs.json` from {this.context.resource_prefsDir}/servo/
     // to `config_dir` if none exist
     let source_prefs = resource_dir.join("prefs.json");


### PR DESCRIPTION
[OHOS]Bugfix: unimplemented WebviewDelegate.sceen_geometry causes failed page loading

this  [PR 36223](https://github.com/servo/servo/pull/36223)  causes that some page can not be loaded on ohos platform. The newly added WebviewDelegate.screen_geometry is unimplemented at ohos platform
Besides, this commit also fix the bug that failed to copy the prefs.json to cache dir when the servo is started at the first time after an ohos application is installed, due to the cache dir is not existed.

@mrobinson @jschwe 

Testing: the ohos platform test demo hap
Fixes: No issue exists i can find
