### PR TITLE
layout: Enforce min-content min main size of flex-level tables

### DIFF
--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -2156,10 +2156,7 @@ impl FlexItem<'_> {
 
     #[inline]
     fn is_table(&self) -> bool {
-        match &self.box_.independent_formatting_context.contents {
-            IndependentFormattingContextContents::NonReplaced(content) => content.is_table(),
-            IndependentFormattingContextContents::Replaced(_) => false,
-        }
+        self.box_.is_table()
     }
 }
 
@@ -2367,6 +2364,7 @@ impl FlexItemBox {
             get_automatic_minimum_size,
             stretch_size.main,
             &main_content_sizes,
+            self.is_table(),
         );
 
         FlexItem {
@@ -2723,6 +2721,14 @@ impl FlexItemBox {
                     IntrinsicSizingMode::Size => content_block_size(),
                 }
             },
+        }
+    }
+
+    #[inline]
+    fn is_table(&self) -> bool {
+        match &self.independent_formatting_context.contents {
+            IndependentFormattingContextContents::NonReplaced(content) => content.is_table(),
+            IndependentFormattingContextContents::Replaced(_) => false,
         }
     }
 }

--- a/tests/wpt/meta/css/css-flexbox/table-as-item-fixed-min-width-3.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/table-as-item-fixed-min-width-3.html.ini
@@ -1,2 +1,0 @@
-[table-as-item-fixed-min-width-3.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/table-as-item-min-content-height-1.tentative.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/table-as-item-min-content-height-1.tentative.html.ini
@@ -1,2 +1,0 @@
-[table-as-item-min-content-height-1.tentative.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/table-as-item-min-content-height-2.tentative.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/table-as-item-min-content-height-2.tentative.html.ini
@@ -1,2 +1,0 @@
-[table-as-item-min-content-height-2.tentative.html]
-  expected: FAIL


### PR DESCRIPTION
Additionally to the minimum specified in min-width or min-height, tables also enforce a `min-content` minimum.

This was handled in `Sizes::resolve()`, but flex items don't use that. So this patch moves the logic into `Size::resolve_for_min()`.

Testing: Covered by WPT
