### PR TITLE
layout: Box `block_margins_collapsed_with_children` member of `BoxFragment`

### DIFF
--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -256,8 +256,6 @@ impl FlexLineItem<'_> {
                 size: item_used_size,
             },
         );
-        let margin = flex_context.sides_to_flow_relative(item_margin);
-        let collapsed_margin = CollapsedBlockMargins::from_margin(&margin);
 
         if let Some(item_baseline) = self.layout_result.baseline_relative_to_margin_box.as_ref() {
             let item_baseline = *item_baseline + item_content_cross_start_position -
@@ -294,9 +292,10 @@ impl FlexLineItem<'_> {
             flex_context
                 .sides_to_flow_relative(self.item.border)
                 .to_physical(container_writing_mode),
-            margin.to_physical(container_writing_mode),
+            flex_context
+                .sides_to_flow_relative(item_margin)
+                .to_physical(container_writing_mode),
             None, /* clearance */
-            collapsed_margin,
         );
 
         // If this flex item establishes a containing block for absolutely-positioned

--- a/components/layout_2020/flow/inline/line.rs
+++ b/components/layout_2020/flow/inline/line.rs
@@ -23,9 +23,7 @@ use webrender_api::FontInstanceKey;
 use super::inline_box::{InlineBoxContainerState, InlineBoxIdentifier, InlineBoxTreePathToken};
 use super::{InlineFormattingContextLayout, LineBlockSizes};
 use crate::cell::ArcRefCell;
-use crate::fragment_tree::{
-    BaseFragmentInfo, BoxFragment, CollapsedBlockMargins, Fragment, TextFragment,
-};
+use crate::fragment_tree::{BaseFragmentInfo, BoxFragment, Fragment, TextFragment};
 use crate::geom::{LogicalRect, LogicalVec2, PhysicalRect, ToLogical};
 use crate::positioned::{
     AbsolutelyPositionedBox, PositioningContext, PositioningContextLength, relative_adjustement,
@@ -465,7 +463,6 @@ impl LineItemLayout<'_, '_> {
             border.to_physical(ifc_writing_mode),
             margin.to_physical(ifc_writing_mode),
             None, /* clearance */
-            CollapsedBlockMargins::zero(),
         );
 
         let offset_from_parent_ifc = LogicalVec2 {

--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -356,7 +356,6 @@ impl OutsideMarker {
             PhysicalSides::zero(),
             PhysicalSides::zero(),
             None,
-            CollapsedBlockMargins::zero(),
         )))
     }
 }
@@ -1106,9 +1105,9 @@ fn layout_in_flow_non_replaced_block_level_same_formatting_context(
         pbm.border.to_physical(containing_block_writing_mode),
         margin.to_physical(containing_block_writing_mode),
         clearance,
-        block_margins_collapsed_with_children,
     )
     .with_baselines(flow_layout.baselines)
+    .with_block_margins_collapsed_with_children(block_margins_collapsed_with_children)
 }
 
 impl IndependentNonReplacedContents {
@@ -1212,10 +1211,10 @@ impl IndependentNonReplacedContents {
             pbm.border.to_physical(containing_block_writing_mode),
             margin.to_physical(containing_block_writing_mode),
             None, /* clearance */
-            block_margins_collapsed_with_children,
         )
         .with_baselines(layout.baselines)
         .with_specific_layout_info(layout.specific_layout_info)
+        .with_block_margins_collapsed_with_children(block_margins_collapsed_with_children)
     }
 
     /// Lay out a normal in flow non-replaced block that establishes an independent
@@ -1517,10 +1516,10 @@ impl IndependentNonReplacedContents {
             pbm.border.to_physical(containing_block_writing_mode),
             margin.to_physical(containing_block_writing_mode),
             clearance,
-            CollapsedBlockMargins::from_margin(&margin),
         )
         .with_baselines(layout.baselines)
         .with_specific_layout_info(layout.specific_layout_info)
+        .with_block_margins_collapsed_with_children(CollapsedBlockMargins::from_margin(&margin))
     }
 }
 
@@ -1654,8 +1653,8 @@ impl ReplacedContents {
             pbm.border.to_physical(containing_block_writing_mode),
             margin.to_physical(containing_block_writing_mode),
             clearance,
-            CollapsedBlockMargins::from_margin(&margin),
         )
+        .with_block_margins_collapsed_with_children(CollapsedBlockMargins::from_margin(&margin))
     }
 }
 
@@ -2039,7 +2038,7 @@ impl<'container> PlacementState<'container> {
                     return;
                 }
 
-                let fragment_block_margins = &fragment.block_margins_collapsed_with_children;
+                let fragment_block_margins = fragment.block_margins_collapsed_with_children();
                 let mut fragment_block_size = fragment
                     .border_rect()
                     .size
@@ -2353,7 +2352,6 @@ impl IndependentFormattingContext {
             // so there's no need to store it explicitly in the fragment.
             // And atomic inlines don't have clearance.
             None, /* clearance */
-            CollapsedBlockMargins::zero(),
         );
 
         IndependentFloatOrAtomicLayoutResult {

--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -21,8 +21,7 @@ use crate::formatting_contexts::{
     IndependentFormattingContext, IndependentFormattingContextContents,
 };
 use crate::fragment_tree::{
-    BoxFragment, CollapsedBlockMargins, Fragment, FragmentFlags, HoistedSharedFragment,
-    SpecificLayoutInfo,
+    BoxFragment, Fragment, FragmentFlags, HoistedSharedFragment, SpecificLayoutInfo,
 };
 use crate::geom::{
     AuOrAuto, LengthPercentageOrAuto, LogicalRect, LogicalSides, LogicalSides1D, LogicalVec2,
@@ -697,9 +696,6 @@ impl HoistedAbsolutelyPositionedBox {
                 pbm.border.to_physical(containing_block_writing_mode),
                 margin.to_physical(containing_block_writing_mode),
                 None, /* clearance */
-                // We do not set the baseline offset, because absolutely positioned
-                // elements are not inflow.
-                CollapsedBlockMargins::zero(),
             )
             .with_specific_layout_info(specific_layout_info)
         };

--- a/components/layout_2020/table/layout.rs
+++ b/components/layout_2020/table/layout.rs
@@ -1785,7 +1785,6 @@ impl<'a> TableLayout<'a> {
                 self.pbm.border.to_physical(table_writing_mode),
                 PhysicalSides::zero(),
                 None, /* clearance */
-                CollapsedBlockMargins::zero(),
             )
             .with_specific_layout_info(self.specific_layout_info_for_grid());
         }
@@ -1911,7 +1910,6 @@ impl<'a> TableLayout<'a> {
             self.pbm.border.to_physical(table_writing_mode),
             PhysicalSides::zero(),
             None, /* clearance */
-            CollapsedBlockMargins::zero(),
         )
         .with_baselines(baselines)
         .with_specific_layout_info(self.specific_layout_info_for_grid())
@@ -2338,7 +2336,6 @@ impl<'a> RowFragmentLayout<'a> {
             PhysicalSides::zero(), /* border */
             PhysicalSides::zero(), /* margin */
             None,                  /* clearance */
-            CollapsedBlockMargins::zero(),
         );
         row_fragment.set_does_not_paint_background();
 
@@ -2404,7 +2401,6 @@ impl RowGroupFragmentLayout {
             PhysicalSides::zero(), /* border */
             PhysicalSides::zero(), /* margin */
             None,                  /* clearance */
-            CollapsedBlockMargins::zero(),
         );
         row_group_fragment.set_does_not_paint_background();
 
@@ -2887,7 +2883,6 @@ impl TableSlotCell {
             layout.border.to_physical(table_style.writing_mode),
             PhysicalSides::zero(), /* margin */
             None,                  /* clearance */
-            CollapsedBlockMargins::zero(),
         )
         .with_baselines(layout.layout.baselines)
         .with_specific_layout_info(specific_layout_info)

--- a/components/layout_2020/taffy/layout.rs
+++ b/components/layout_2020/taffy/layout.rs
@@ -23,8 +23,8 @@ use crate::fragment_tree::{
     BoxFragment, CollapsedBlockMargins, Fragment, FragmentFlags, SpecificLayoutInfo,
 };
 use crate::geom::{
-    LogicalSides, LogicalVec2, PhysicalPoint, PhysicalRect, PhysicalSides, PhysicalSize, Size,
-    SizeConstraint, Sizes,
+    LogicalVec2, PhysicalPoint, PhysicalRect, PhysicalSides, PhysicalSize, Size, SizeConstraint,
+    Sizes,
 };
 use crate::layout_box_base::CacheableLayoutResult;
 use crate::positioned::{AbsolutelyPositionedBox, PositioningContext, PositioningContextLength};
@@ -486,15 +486,6 @@ impl TaffyContainer {
             .map(|child| (**child).borrow_mut())
             .enumerate()
             .map(|(child_id, mut child)| {
-                fn rect_to_logical_sides<T>(rect: taffy::Rect<T>) -> LogicalSides<T> {
-                    LogicalSides {
-                        inline_start: rect.left,
-                        inline_end: rect.right,
-                        block_start: rect.top,
-                        block_end: rect.bottom,
-                    }
-                }
-
                 fn rect_to_physical_sides<T>(rect: taffy::Rect<T>) -> PhysicalSides<T> {
                     PhysicalSides::new(rect.top, rect.right, rect.bottom, rect.left)
                 }
@@ -514,8 +505,6 @@ impl TaffyContainer {
                 let padding = rect_to_physical_sides(layout.padding.map(Au::from_f32_px));
                 let border = rect_to_physical_sides(layout.border.map(Au::from_f32_px));
                 let margin = rect_to_physical_sides(layout.margin.map(Au::from_f32_px));
-                let logical_margin = rect_to_logical_sides(layout.margin.map(Au::from_f32_px));
-                let collapsed_margin = CollapsedBlockMargins::from_margin(&logical_margin);
 
                 // Compute content box size and position.
                 //
@@ -576,7 +565,6 @@ impl TaffyContainer {
                             border,
                             margin,
                             None, /* clearance */
-                            collapsed_margin,
                         )
                         .with_baselines(Baselines {
                             first: output.first_baselines.y.map(Au::from_f32_px),


### PR DESCRIPTION
This reduces the size of `BoxFragment` by around 20 bytes.

Testing: This just changes the layout of a data structure, so is
covered by existing WPT tests.
