### PR TITLE
libservo: Create a `WebViewBuilder` class to construct `WebView`s

### DIFF
--- a/components/servo/examples/winit_minimal.rs
+++ b/components/servo/examples/winit_minimal.rs
@@ -7,7 +7,9 @@ use std::rc::Rc;
 
 use compositing::windowing::{EmbedderMethods, WindowMethods};
 use euclid::{Point2D, Scale, Size2D};
-use servo::{RenderingContext, Servo, TouchEventType, WebView, WindowRenderingContext};
+use servo::{
+    RenderingContext, Servo, TouchEventType, WebView, WebViewBuilder, WindowRenderingContext,
+};
 use servo_geometry::DeviceIndependentPixel;
 use tracing::warn;
 use url::Url;
@@ -53,8 +55,9 @@ impl ::servo::WebViewDelegate for AppState {
     }
 
     fn request_open_auxiliary_webview(&self, parent_webview: WebView) -> Option<WebView> {
-        let webview = self.servo.new_auxiliary_webview();
-        webview.set_delegate(parent_webview.delegate());
+        let webview = WebViewBuilder::new_auxiliary(&self.servo)
+            .delegate(parent_webview.delegate())
+            .build();
         webview.focus();
         webview.raise_to_top(true);
         self.webviews.borrow_mut().push(webview.clone());
@@ -115,8 +118,10 @@ impl ApplicationHandler<WakerEvent> for App {
             let url = Url::parse("https://demo.servo.org/experiments/twgl-tunnel/")
                 .expect("Guaranteed by argument");
 
-            let webview = app_state.servo.new_webview(url);
-            webview.set_delegate(app_state.clone());
+            let webview = WebViewBuilder::new(&app_state.servo)
+                .url(url)
+                .delegate(app_state.clone())
+                .build();
             webview.focus();
             webview.raise_to_top(true);
 

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -119,7 +119,7 @@ pub use {bluetooth, bluetooth_traits};
 use crate::proxies::ConstellationProxy;
 use crate::responders::ServoErrorChannel;
 pub use crate::servo_delegate::{ServoDelegate, ServoError};
-pub use crate::webview::WebView;
+pub use crate::webview::{WebView, WebViewBuilder};
 pub use crate::webview_delegate::{
     AllowOrDenyRequest, AuthenticationRequest, FormControl, NavigationRequest, PermissionRequest,
     SelectElement, WebResourceLoad, WebViewDelegate,
@@ -659,29 +659,6 @@ impl Servo {
 
     pub fn deinit(&self) {
         self.compositor.borrow_mut().deinit();
-    }
-
-    pub fn new_webview(&self, url: url::Url) -> WebView {
-        let webview = WebView::new(&self.constellation_proxy, self.compositor.clone());
-        self.webviews
-            .borrow_mut()
-            .insert(webview.id(), webview.weak_handle());
-        let viewport_details = self.compositor.borrow().default_webview_viewport_details();
-        self.constellation_proxy
-            .send(EmbedderToConstellationMessage::NewWebView(
-                url.into(),
-                webview.id(),
-                viewport_details,
-            ));
-        webview
-    }
-
-    pub fn new_auxiliary_webview(&self) -> WebView {
-        let webview = WebView::new(&self.constellation_proxy, self.compositor.clone());
-        self.webviews
-            .borrow_mut()
-            .insert(webview.id(), webview.weak_handle());
-        webview
     }
 
     fn get_webview_handle(&self, id: WebViewId) -> Option<WebView> {

--- a/ports/servoshell/desktop/app_state.rs
+++ b/ports/servoshell/desktop/app_state.rs
@@ -19,7 +19,7 @@ use servo::webrender_api::units::{DeviceIntPoint, DeviceIntRect, DeviceIntSize};
 use servo::{
     AllowOrDenyRequest, AuthenticationRequest, FilterPattern, FormControl, GamepadHapticEffectType,
     LoadStatus, PermissionRequest, Servo, ServoDelegate, ServoError, SimpleDialog, TouchEventType,
-    WebView, WebViewDelegate,
+    WebView, WebViewBuilder, WebViewDelegate,
 };
 use url::Url;
 
@@ -107,8 +107,10 @@ impl RunningAppState {
     }
 
     pub(crate) fn new_toplevel_webview(self: &Rc<Self>, url: Url) {
-        let webview = self.servo().new_webview(url);
-        webview.set_delegate(self.clone());
+        let webview = WebViewBuilder::new(self.servo())
+            .url(url)
+            .delegate(self.clone())
+            .build();
 
         webview.focus();
         webview.raise_to_top(true);
@@ -459,8 +461,9 @@ impl WebViewDelegate for RunningAppState {
         &self,
         parent_webview: servo::WebView,
     ) -> Option<servo::WebView> {
-        let webview = self.servo.new_auxiliary_webview();
-        webview.set_delegate(parent_webview.delegate());
+        let webview = WebViewBuilder::new_auxiliary(&self.servo)
+            .delegate(parent_webview.delegate())
+            .build();
 
         webview.focus();
         webview.raise_to_top(true);


### PR DESCRIPTION
This exposes a new method of creating `WebView`s using the Rust builder
pattern. This will be more important as we add more kinds of
configuration options for `WebView` such as size and HiDPI scaling.

Testing: The API currently doesn't have tests, but functionality is
ensured by the fact that servoshell is the test harness.
Signed-off-by: Martin Robinson <mrobinson@igalia.com>
