### PR TITLE
compositing: Send `CompositorDisplayListInfo` as bytes to compositor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1089,6 +1089,7 @@ name = "compositing"
 version = "0.0.1"
 dependencies = [
  "base",
+ "bincode",
  "bitflags 2.9.0",
  "compositing_traits",
  "constellation_traits",
@@ -1120,6 +1121,7 @@ name = "compositing_traits"
 version = "0.0.1"
 dependencies = [
  "base",
+ "bincode",
  "crossbeam-channel",
  "dpi",
  "embedder_traits",

--- a/components/compositing/Cargo.toml
+++ b/components/compositing/Cargo.toml
@@ -19,6 +19,7 @@ webxr = ["dep:webxr"]
 
 [dependencies]
 base = { workspace = true }
+bincode = { workspace = true }
 bitflags = { workspace = true }
 compositing_traits = { workspace = true }
 constellation_traits = { workspace = true }

--- a/components/shared/compositing/Cargo.toml
+++ b/components/shared/compositing/Cargo.toml
@@ -16,6 +16,7 @@ no-wgl = ["surfman/sm-angle-default"]
 
 [dependencies]
 base = { workspace = true }
+bincode = { workspace = true }
 crossbeam-channel = { workspace = true }
 dpi = { version = "0.1" }
 embedder_traits = { workspace = true }


### PR DESCRIPTION
`CompositorDisplayListInfo` is a large data structure that scales with
the size of the display list. Serializing it onto the Compositor's IPC
channel can cause deadlocks. This change serializes it with bincode and
sends it alongside the rest of the serialized display list information
on the IPC `bytes_channel`. This should prevent deadlocks when the
compositor API is unified.

Testing: This is covered by existing WPT tests.
Signed-off-by: Martin Robinson <mrobinson@igalia.com>
