### PR TITLE
add CanGc as argument to methods in ElementInternals, GlobalScope, HTMLAnchorElement, HTMLAreaElement, HTMLCanvasElement

### DIFF
--- a/components/script/dom/elementinternals.rs
+++ b/components/script/dom/elementinternals.rs
@@ -234,6 +234,7 @@ impl ElementInternalsMethods<crate::DomTypeHolder> for ElementInternals {
         flags: &ValidityStateFlags,
         message: Option<DOMString>,
         anchor: Option<&HTMLElement>,
+        can_gc: CanGc,
     ) -> ErrorResult {
         // Steps 1-2: Check form-associated custom element
         if !self.is_target_form_associated() {
@@ -253,7 +254,7 @@ impl ElementInternalsMethods<crate::DomTypeHolder> for ElementInternals {
         // Step 4: For each entry `flag` → `value` of `flags`, set element's validity flag with the name
         // `flag` to `value`.
         self.validity_state().update_invalid_flags(bits);
-        self.validity_state().update_pseudo_classes(CanGc::note());
+        self.validity_state().update_pseudo_classes(can_gc);
 
         // Step 5: Set element's validation message to the empty string if message is not given
         // or all of element's validity flags are false, or to message otherwise.
@@ -309,7 +310,7 @@ impl ElementInternalsMethods<crate::DomTypeHolder> for ElementInternals {
     }
 
     /// <https://html.spec.whatwg.org/multipage#dom-elementinternals-labels>
-    fn GetLabels(&self) -> Fallible<DomRoot<NodeList>> {
+    fn GetLabels(&self, can_gc: CanGc) -> Fallible<DomRoot<NodeList>> {
         if !self.is_target_form_associated() {
             return Err(Error::NotSupported);
         }
@@ -317,7 +318,7 @@ impl ElementInternalsMethods<crate::DomTypeHolder> for ElementInternals {
             NodeList::new_labels_list(
                 self.target_element.upcast::<Node>().owner_doc().window(),
                 &self.target_element,
-                CanGc::note(),
+                can_gc,
             )
         }))
     }

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -2126,8 +2126,8 @@ impl GlobalScope {
         unsafe { SafeJSContext::from_ptr(cx) }
     }
 
-    pub(crate) fn crypto(&self) -> DomRoot<Crypto> {
-        self.crypto.or_init(|| Crypto::new(self, CanGc::note()))
+    pub(crate) fn crypto(&self, can_gc: CanGc) -> DomRoot<Crypto> {
+        self.crypto.or_init(|| Crypto::new(self, can_gc))
     }
 
     pub(crate) fn live_devtools_updates(&self) -> bool {
@@ -2994,6 +2994,7 @@ impl GlobalScope {
         device: WebGPUDevice,
         reason: DeviceLostReason,
         msg: String,
+        can_gc: CanGc,
     ) {
         let reason = match reason {
             DeviceLostReason::Unknown => GPUDeviceLostReason::Unknown,
@@ -3007,7 +3008,7 @@ impl GlobalScope {
             .expect("GPUDevice should still be in devices hashmap")
             .root()
         {
-            device.lose(reason, msg, CanGc::note());
+            device.lose(reason, msg, can_gc);
         }
     }
 

--- a/components/script/dom/htmlanchorelement.rs
+++ b/components/script/dom/htmlanchorelement.rs
@@ -145,7 +145,7 @@ impl HTMLAnchorElementMethods<crate::DomTypeHolder> for HTMLAnchorElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-a-rellist
-    fn RelList(&self) -> DomRoot<DOMTokenList> {
+    fn RelList(&self, can_gc: CanGc) -> DomRoot<DOMTokenList> {
         self.rel_list.or_init(|| {
             DOMTokenList::new(
                 self.upcast(),
@@ -155,7 +155,7 @@ impl HTMLAnchorElementMethods<crate::DomTypeHolder> for HTMLAnchorElement {
                     Atom::from("noreferrer"),
                     Atom::from("opener"),
                 ]),
-                CanGc::note(),
+                can_gc,
             )
         })
     }

--- a/components/script/dom/htmlareaelement.rs
+++ b/components/script/dom/htmlareaelement.rs
@@ -362,7 +362,7 @@ impl HTMLAreaElementMethods<crate::DomTypeHolder> for HTMLAreaElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-area-rellist>
-    fn RelList(&self) -> DomRoot<DOMTokenList> {
+    fn RelList(&self, can_gc: CanGc) -> DomRoot<DOMTokenList> {
         self.rel_list.or_init(|| {
             DOMTokenList::new(
                 self.upcast(),
@@ -372,7 +372,7 @@ impl HTMLAreaElementMethods<crate::DomTypeHolder> for HTMLAreaElement {
                     Atom::from("noreferrer"),
                     Atom::from("opener"),
                 ]),
-                CanGc::note(),
+                can_gc,
             )
         })
     }

--- a/components/script/dom/htmlbuttonelement.rs
+++ b/components/script/dom/htmlbuttonelement.rs
@@ -261,7 +261,7 @@ impl VirtualMethods for HTMLButtonElement {
                         el.check_ancestors_disabled_state_for_form_control();
                     },
                 }
-                el.update_sequentially_focusable_status(CanGc::note());
+                el.update_sequentially_focusable_status(can_gc);
                 self.validity_state()
                     .perform_validation_and_update(ValidationFlags::all(), can_gc);
             },

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -954,7 +954,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
 
     // https://dvcs.w3.org/hg/webcrypto-api/raw-file/tip/spec/Overview.html#dfn-GlobalCrypto
     fn Crypto(&self) -> DomRoot<Crypto> {
-        self.as_global_scope().crypto()
+        self.as_global_scope().crypto(CanGc::note())
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-frameelement

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -351,7 +351,7 @@ impl WorkerGlobalScopeMethods<crate::DomTypeHolder> for WorkerGlobalScope {
 
     // https://html.spec.whatwg.org/multipage/#dfn-Crypto
     fn Crypto(&self) -> DomRoot<Crypto> {
-        self.upcast::<GlobalScope>().crypto()
+        self.upcast::<GlobalScope>().crypto(CanGc::note())
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-windowbase64-btoa

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1948,7 +1948,7 @@ impl ScriptThread {
                 msg,
             } => {
                 let global = self.documents.borrow().find_global(pipeline_id).unwrap();
-                global.gpu_device_lost(device, reason, msg);
+                global.gpu_device_lost(device, reason, msg, can_gc);
             },
             WebGPUMsg::UncapturedError {
                 device,

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -226,7 +226,7 @@ DOMInterfaces = {
 },
 
 'ElementInternals': {
-    'canGc': ['CheckValidity', 'ReportValidity'],
+    'canGc': ['CheckValidity', 'GetLabels', 'SetValidity', 'ReportValidity'],
 },
 
 'EventSource': {
@@ -319,11 +319,11 @@ DOMInterfaces = {
 },
 
 "HTMLAnchorElement": {
-    "canGc": ["SetText","SetRel","SetHref", 'SetHash', 'SetHost', 'SetHostname', 'SetPassword', 'SetPathname', 'SetPort', 'SetProtocol', 'SetSearch', 'SetUsername']
+    "canGc": ["SetText","SetRel","SetHref", 'SetHash', 'SetHost', 'SetHostname', 'SetPassword', 'SetPathname', 'SetPort', 'SetProtocol', 'SetSearch', 'SetUsername', 'RelList']
 },
 
 "HTMLAreaElement": {
-     "canGc": ['SetText', 'SetRel', 'SetHref', 'SetHash', 'SetHost', 'SetHostname', 'SetPassword', 'SetPathname', 'SetPort', 'SetProtocol', 'SetSearch', 'SetUsername']
+     "canGc": ['SetText', 'SetRel', 'SetHref', 'SetHash', 'SetHost', 'SetHostname', 'SetPassword', 'SetPathname', 'SetPort', 'SetProtocol', 'SetSearch', 'SetUsername', 'RelList']
 },
 
 "HTMLBodyElement": {
@@ -335,7 +335,7 @@ DOMInterfaces = {
 },
 
 'HTMLCanvasElement': {
-    'canGc': ['CaptureStream', 'GetContext'],
+    'canGc': ['CaptureStream', 'GetContext', 'SetHeight', 'SetWidth', 'TransferControlToOffscreen'],
 },
 
 'HTMLDialogElement': {


### PR DESCRIPTION
add CanGc as argument to methods in ElementInternals, GlobalScope, HTMLAnchorElement, HTMLAreaElement, HTMLCanvasElement

Testing: These changes do not require tests because they are a refactor.
Addresses part of https://github.com/servo/servo/issues/34573.