### PR TITLE
Remove HTMLStyleElement::line_number

### DIFF
--- a/components/script/dom/htmlstyleelement.rs
+++ b/components/script/dom/htmlstyleelement.rs
@@ -44,7 +44,6 @@ pub(crate) struct HTMLStyleElement {
     in_stack_of_open_elements: Cell<bool>,
     pending_loads: Cell<u32>,
     any_failed_load: Cell<bool>,
-    line_number: u64,
 }
 
 impl HTMLStyleElement {
@@ -62,7 +61,6 @@ impl HTMLStyleElement {
             in_stack_of_open_elements: Cell::new(creator.is_parser_created()),
             pending_loads: Cell::new(0),
             any_failed_load: Cell::new(false),
-            line_number: creator.return_line_number(),
         }
     }
 


### PR DESCRIPTION
This field is unused.
