### PR TITLE
script: `LoadBlocker`'s drop impl shouldn't run after termination.

### DIFF
--- a/components/script/document_loader.rs
+++ b/components/script/document_loader.rs
@@ -50,10 +50,18 @@ impl LoadBlocker {
 
     /// Remove this load from the associated document's list of blocking loads.
     pub(crate) fn terminate(blocker: &DomRefCell<Option<LoadBlocker>>, can_gc: CanGc) {
-        if let Some(this) = blocker.borrow().as_ref() {
-            let load_data = this.load.clone().unwrap();
-            this.doc.finish_load(load_data, can_gc);
+        let Some(load) = blocker
+            .borrow_mut()
+            .as_mut()
+            .and_then(|blocker| blocker.load.take())
+        else {
+            return;
+        };
+
+        if let Some(blocker) = blocker.borrow().as_ref() {
+            blocker.doc.finish_load(load, can_gc);
         }
+
         *blocker.borrow_mut() = None;
     }
 }

--- a/tests/wpt/meta/dom/ranges/Range-cloneContents.html.ini
+++ b/tests/wpt/meta/dom/ranges/Range-cloneContents.html.ini
@@ -1,0 +1,3 @@
+[Range-cloneContents.html]
+  bug: https://github.com/servo/servo/issues/36561
+  expected: ERROR

--- a/tests/wpt/meta/dom/ranges/Range-deleteContents.html.ini
+++ b/tests/wpt/meta/dom/ranges/Range-deleteContents.html.ini
@@ -1,0 +1,3 @@
+[Range-deleteContents.html]
+  bug: https://github.com/servo/servo/issues/36561
+  expected: ERROR

--- a/tests/wpt/meta/dom/ranges/Range-extractContents.html.ini
+++ b/tests/wpt/meta/dom/ranges/Range-extractContents.html.ini
@@ -1,0 +1,3 @@
+[Range-extractContents.html]
+  bug: https://github.com/servo/servo/issues/36561
+  expected: ERROR

--- a/tests/wpt/meta/dom/ranges/Range-insertNode.html.ini
+++ b/tests/wpt/meta/dom/ranges/Range-insertNode.html.ini
@@ -1,0 +1,3 @@
+[Range-insertNode.html]
+  bug: https://github.com/servo/servo/issues/36561
+  expected: ERROR

--- a/tests/wpt/meta/dom/ranges/Range-surroundContents.html.ini
+++ b/tests/wpt/meta/dom/ranges/Range-surroundContents.html.ini
@@ -1,0 +1,3 @@
+[Range-surroundContents.html]
+  bug: https://github.com/servo/servo/issues/36561
+  expected: ERROR

--- a/tests/wpt/meta/mimesniff/media/media-sniff.window.js.ini
+++ b/tests/wpt/meta/mimesniff/media/media-sniff.window.js.ini
@@ -1,0 +1,3 @@
+[media-sniff.window.html]
+  bug: https://github.com/servo/servo/issues/36626
+  expected: TIMEOUT


### PR DESCRIPTION
The logic in LoadBlocker::terminate was modified in #34122 to `clone`
the LoadBlocker's inner `load` member instead of `take`ing it. However,
this member serves as a flag so that `LoadBlocker`'s Drop impl can avoid
calling `doc.finish_load` on already terminated loads. The change results in
unnecessary 'unknown completed load' warnings when Servo is run with
logging enabled.

Signed-off-by: Mukilan Thiyagarajan <mukilan@igalia.com>
