### PR TITLE
Gate `window.trustedTypes` behind flag

### DIFF
--- a/components/script_bindings/webidls/WindowOrWorkerGlobalScope.webidl
+++ b/components/script_bindings/webidls/WindowOrWorkerGlobalScope.webidl
@@ -47,6 +47,7 @@ partial interface mixin WindowOrWorkerGlobalScope {
 
 // https://www.w3.org/TR/trusted-types/#extensions-to-the-windoworworkerglobalscope-interface
 partial interface mixin WindowOrWorkerGlobalScope {
+  [Pref="dom_trusted_types_enabled"]
   readonly attribute TrustedTypePolicyFactory trustedTypes;
 };
 


### PR DESCRIPTION
This was missed in #36355 and should have also been gated by the flag. With these, the wpt.fyi tests should now no longer pass, as the flag hasn't been removed yet.
