### PR TITLE
layout: Add a `LayoutBoxBase` to inline boxes

### DIFF
--- a/components/layout_2020/flow/inline/construct.rs
+++ b/components/layout_2020/flow/inline/construct.rs
@@ -163,7 +163,7 @@ impl InlineFormattingContextBuilder {
     }
 
     pub(crate) fn start_inline_box(&mut self, inline_box: InlineBox) -> ArcRefCell<InlineItem> {
-        self.push_control_character_string(inline_box.style.bidi_control_chars().0);
+        self.push_control_character_string(inline_box.base.style.bidi_control_chars().0);
 
         let (identifier, inline_box) = self.inline_boxes.start_inline_box(inline_box);
         let inline_level_box = ArcRefCell::new(InlineItem::StartInlineBox(inline_box));
@@ -177,7 +177,9 @@ impl InlineFormattingContextBuilder {
         let inline_level_box = self.inline_boxes.get(&identifier);
         inline_level_box.borrow_mut().is_last_fragment = true;
 
-        self.push_control_character_string(inline_level_box.borrow().style.bidi_control_chars().1);
+        self.push_control_character_string(
+            inline_level_box.borrow().base.style.bidi_control_chars().1,
+        );
 
         inline_level_box
     }

--- a/components/layout_2020/flow/inline/line.rs
+++ b/components/layout_2020/flow/inline/line.rs
@@ -326,7 +326,7 @@ impl LineItemLayout<'_, '_> {
         let inline_box = self.layout.ifc.inline_boxes.get(identifier);
         let inline_box = &*(inline_box.borrow());
 
-        let style = &inline_box.style;
+        let style = &inline_box.base.style;
         let space_above_baseline = inline_box_state.calculate_space_above_baseline();
         let block_start_offset =
             self.calculate_inline_box_block_start(inline_box_state, space_above_baseline);
@@ -378,7 +378,7 @@ impl LineItemLayout<'_, '_> {
 
         let containing_block_writing_mode = self.layout.containing_block.style.writing_mode;
         if containing_block_writing_mode.is_bidi_ltr() !=
-            inline_box.style.writing_mode.is_bidi_ltr()
+            inline_box.base.style.writing_mode.is_bidi_ltr()
         {
             std::mem::swap(&mut had_start, &mut had_end)
         }
@@ -418,7 +418,7 @@ impl LineItemLayout<'_, '_> {
 
         // Relative adjustment should not affect the rest of line layout, so we can
         // do it right before creating the Fragment.
-        let style = &inline_box.style;
+        let style = &inline_box.base.style;
         if style.get_box().position == Position::Relative {
             content_rect.start_corner += relative_adjustement(style, self.layout.containing_block);
         }
@@ -455,7 +455,7 @@ impl LineItemLayout<'_, '_> {
         // but they need to be made relative to this fragment.
         let physical_content_rect = content_rect.as_physical(Some(self.layout.containing_block));
         let mut fragment = BoxFragment::new(
-            inline_box.base_fragment_info,
+            inline_box.base.base_fragment_info,
             style.clone(),
             fragments,
             physical_content_rect,

--- a/components/layout_2020/formatting_contexts.rs
+++ b/components/layout_2020/formatting_contexts.rs
@@ -275,6 +275,7 @@ impl IndependentNonReplacedContents {
         depends_on_block_constraints: bool,
     ) -> CacheableLayoutResult {
         if let Some(cache) = base.cached_layout_result.borrow().as_ref() {
+            let cache = &**cache;
             if cache.containing_block_for_children_size.inline ==
                 containing_block_for_children.size.inline &&
                 (cache.containing_block_for_children_size.block ==
@@ -305,11 +306,11 @@ impl IndependentNonReplacedContents {
             depends_on_block_constraints,
         );
 
-        *base.cached_layout_result.borrow_mut() = Some(CacheableLayoutResultAndInputs {
+        *base.cached_layout_result.borrow_mut() = Some(Box::new(CacheableLayoutResultAndInputs {
             result: result.clone(),
             positioning_context: child_positioning_context.clone(),
             containing_block_for_children_size: containing_block_for_children.size.clone(),
-        });
+        }));
         positioning_context.append(child_positioning_context);
 
         result

--- a/components/layout_2020/layout_box_base.rs
+++ b/components/layout_2020/layout_box_base.rs
@@ -27,8 +27,8 @@ pub(crate) struct LayoutBoxBase {
     pub base_fragment_info: BaseFragmentInfo,
     pub style: Arc<ComputedValues>,
     pub cached_inline_content_size:
-        AtomicRefCell<Option<(SizeConstraint, InlineContentSizesResult)>>,
-    pub cached_layout_result: AtomicRefCell<Option<CacheableLayoutResultAndInputs>>,
+        AtomicRefCell<Option<Box<(SizeConstraint, InlineContentSizesResult)>>>,
+    pub cached_layout_result: AtomicRefCell<Option<Box<CacheableLayoutResultAndInputs>>>,
 }
 
 impl LayoutBoxBase {
@@ -50,7 +50,8 @@ impl LayoutBoxBase {
         layout_box: &impl ComputeInlineContentSizes,
     ) -> InlineContentSizesResult {
         let mut cache = self.cached_inline_content_size.borrow_mut();
-        if let Some((previous_cb_block_size, result)) = *cache {
+        if let Some(cached_inline_content_size) = cache.as_ref() {
+            let (previous_cb_block_size, result) = **cached_inline_content_size;
             if !result.depends_on_block_constraints ||
                 previous_cb_block_size == constraint_space.block_size
             {
@@ -60,7 +61,7 @@ impl LayoutBoxBase {
         }
 
         let result = layout_box.compute_inline_content_sizes(layout_context, constraint_space);
-        *cache = Some((constraint_space.block_size, result));
+        *cache = Some(Box::new((constraint_space.block_size, result)));
         result
     }
 


### PR DESCRIPTION
`LayoutBoxBase` will soon contain laid out `Fragment`s of a box tree
node in order to facilitate incremental layout and also layout queries.
This is currently missing for inline boxes, so this change adds a
`LayoutBoxBase` to them.

Testing: This should not change any observable behavior, so existing
WPT suites should suffice for testing.
