### PR TITLE
Unify media query and media query list parsing

### DIFF
--- a/components/script/dom/medialist.rs
+++ b/components/script/dom/medialist.rs
@@ -9,7 +9,7 @@ use style::media_queries::{MediaList as StyleMediaList, MediaQuery};
 use style::parser::ParserContext;
 use style::shared_lock::{Locked, SharedRwLock};
 use style::stylesheets::{CssRuleType, Origin, UrlExtraData};
-use style_traits::{ParsingMode, ToCss};
+use style_traits::{ParseError, ParsingMode, ToCss};
 
 use crate::dom::bindings::codegen::Bindings::MediaListBinding::MediaListMethods;
 use crate::dom::bindings::codegen::Bindings::WindowBinding::Window_Binding::WindowMethods;
@@ -59,30 +59,39 @@ impl MediaList {
     fn shared_lock(&self) -> &SharedRwLock {
         &self.parent_stylesheet.style_stylesheet().shared_lock
     }
-}
 
-impl MediaListMethods<crate::DomTypeHolder> for MediaList {
-    /// <https://drafts.csswg.org/cssom/#dom-medialist-mediatext>
-    fn MediaText(&self) -> DOMString {
-        let guard = self.shared_lock().read();
-        DOMString::from(self.media_queries.read_with(&guard).to_css_string())
+    /// <https://drafts.csswg.org/cssom/#parse-a-media-query-list>
+    pub(crate) fn parse_media_list(value: &str, window: &Window) -> StyleMediaList {
+        if value.is_empty() {
+            return StyleMediaList::empty();
+        }
+        let mut input = ParserInput::new(value);
+        let mut parser = Parser::new(&mut input);
+        let url_data = UrlExtraData(window.get_url().get_arc());
+        let quirks_mode = window.Document().quirks_mode();
+        // FIXME(emilio): This looks somewhat fishy, since we use the context
+        // only to parse the media query list, CssRuleType::Media doesn't make
+        // much sense.
+        let context = ParserContext::new(
+            Origin::Author,
+            &url_data,
+            Some(CssRuleType::Media),
+            ParsingMode::DEFAULT,
+            quirks_mode,
+            /* namespaces = */ Default::default(),
+            window.css_error_reporter(),
+            None,
+        );
+        StyleMediaList::parse(&context, &mut parser)
     }
 
-    /// <https://drafts.csswg.org/cssom/#dom-medialist-mediatext>
-    fn SetMediaText(&self, value: DOMString) {
-        let mut guard = self.shared_lock().write();
-        let media_queries = self.media_queries.write_with(&mut guard);
-        // Step 2
-        if value.is_empty() {
-            // Step 1
-            *media_queries = StyleMediaList::empty();
-            return;
-        }
-        // Step 3
-        let mut input = ParserInput::new(&value);
+    /// <https://drafts.csswg.org/cssom/#parse-a-media-query>
+    pub(crate) fn parse_media_query<'i>(
+        value: &'i str,
+        window: &Window,
+    ) -> Result<MediaQuery, ParseError<'i>> {
+        let mut input = ParserInput::new(value);
         let mut parser = Parser::new(&mut input);
-        let global = self.global();
-        let window = global.as_window();
         let url_data = UrlExtraData(window.get_url().get_arc());
         let quirks_mode = window.Document().quirks_mode();
         let context = ParserContext::new(
@@ -95,7 +104,23 @@ impl MediaListMethods<crate::DomTypeHolder> for MediaList {
             window.css_error_reporter(),
             None,
         );
-        *media_queries = StyleMediaList::parse(&context, &mut parser);
+        MediaQuery::parse(&context, &mut parser)
+    }
+}
+
+impl MediaListMethods<crate::DomTypeHolder> for MediaList {
+    /// <https://drafts.csswg.org/cssom/#dom-medialist-mediatext>
+    fn MediaText(&self) -> DOMString {
+        let guard = self.shared_lock().read();
+        DOMString::from(self.media_queries.read_with(&guard).to_css_string())
+    }
+
+    /// <https://drafts.csswg.org/cssom/#dom-medialist-mediatext>
+    fn SetMediaText(&self, value: DOMString) {
+        let global = self.global();
+        let mut guard = self.shared_lock().write();
+        let media_queries = self.media_queries.write_with(&mut guard);
+        *media_queries = Self::parse_media_list(&value, global.as_window());
     }
 
     // https://drafts.csswg.org/cssom/#dom-medialist-length
@@ -122,23 +147,8 @@ impl MediaListMethods<crate::DomTypeHolder> for MediaList {
     /// <https://drafts.csswg.org/cssom/#dom-medialist-appendmedium>
     fn AppendMedium(&self, medium: DOMString) {
         // Step 1
-        let mut input = ParserInput::new(&medium);
-        let mut parser = Parser::new(&mut input);
         let global = self.global();
-        let win = global.as_window();
-        let url_data = UrlExtraData(win.get_url().get_arc());
-        let quirks_mode = win.Document().quirks_mode();
-        let context = ParserContext::new(
-            Origin::Author,
-            &url_data,
-            Some(CssRuleType::Media),
-            ParsingMode::DEFAULT,
-            quirks_mode,
-            /* namespaces = */ Default::default(),
-            win.css_error_reporter(),
-            None,
-        );
-        let m = MediaQuery::parse(&context, &mut parser);
+        let m = Self::parse_media_query(&medium, global.as_window());
         // Step 2
         if m.is_err() {
             return;
@@ -161,23 +171,8 @@ impl MediaListMethods<crate::DomTypeHolder> for MediaList {
     /// <https://drafts.csswg.org/cssom/#dom-medialist-deletemedium>
     fn DeleteMedium(&self, medium: DOMString) {
         // Step 1
-        let mut input = ParserInput::new(&medium);
-        let mut parser = Parser::new(&mut input);
         let global = self.global();
-        let win = global.as_window();
-        let url_data = UrlExtraData(win.get_url().get_arc());
-        let quirks_mode = win.Document().quirks_mode();
-        let context = ParserContext::new(
-            Origin::Author,
-            &url_data,
-            Some(CssRuleType::Media),
-            ParsingMode::DEFAULT,
-            quirks_mode,
-            /* namespaces = */ Default::default(),
-            win.css_error_reporter(),
-            None,
-        );
-        let m = MediaQuery::parse(&context, &mut parser);
+        let m = Self::parse_media_query(&medium, global.as_window());
         // Step 2
         if m.is_err() {
             return;

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -27,7 +27,7 @@ use constellation_traits::{
     ScriptToConstellationMessage, ScrollState, StructuredSerializedData, WindowSizeType,
 };
 use crossbeam_channel::{Sender, unbounded};
-use cssparser::{Parser, ParserInput, SourceLocation};
+use cssparser::SourceLocation;
 use devtools_traits::{ScriptToDevtoolsControlMsg, TimelineMarker, TimelineMarkerType};
 use dom_struct::dom_struct;
 use embedder_traits::user_content_manager::{UserContentManager, UserScript};
@@ -74,15 +74,13 @@ use servo_geometry::{DeviceIndependentIntRect, MaxRect, f32_rect_to_au_rect};
 use servo_url::{ImmutableOrigin, MutableOrigin, ServoUrl};
 use style::dom::OpaqueNode;
 use style::error_reporting::{ContextualParseError, ParseErrorReporter};
-use style::media_queries;
-use style::parser::ParserContext as CssParserContext;
 use style::properties::PropertyId;
 use style::properties::style_structs::Font;
 use style::queries::values::PrefersColorScheme;
 use style::selector_parser::PseudoElement;
 use style::str::HTML_SPACE_CHARACTERS;
-use style::stylesheets::{CssRuleType, Origin, UrlExtraData};
-use style_traits::{CSSPixel, ParsingMode};
+use style::stylesheets::UrlExtraData;
+use style_traits::CSSPixel;
 use stylo_atoms::Atom;
 use url::Position;
 use webrender_api::units::{DevicePixel, LayoutPixel};
@@ -133,6 +131,7 @@ use crate::dom::history::History;
 use crate::dom::htmlcollection::{CollectionFilter, HTMLCollection};
 use crate::dom::htmliframeelement::HTMLIFrameElement;
 use crate::dom::location::Location;
+use crate::dom::medialist::MediaList;
 use crate::dom::mediaquerylist::{MediaQueryList, MediaQueryListMatchState};
 use crate::dom::mediaquerylistevent::MediaQueryListEvent;
 use crate::dom::messageevent::MessageEvent;
@@ -1457,21 +1456,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
 
     // https://drafts.csswg.org/cssom-view/#dom-window-matchmedia
     fn MatchMedia(&self, query: DOMString) -> DomRoot<MediaQueryList> {
-        let mut input = ParserInput::new(&query);
-        let mut parser = Parser::new(&mut input);
-        let url_data = UrlExtraData(self.get_url().get_arc());
-        let quirks_mode = self.Document().quirks_mode();
-        let context = CssParserContext::new(
-            Origin::Author,
-            &url_data,
-            Some(CssRuleType::Media),
-            ParsingMode::DEFAULT,
-            quirks_mode,
-            /* namespaces = */ Default::default(),
-            self.css_error_reporter(),
-            None,
-        );
-        let media_query_list = media_queries::MediaList::parse(&context, &mut parser);
+        let media_query_list = MediaList::parse_media_list(&query, self);
         let document = self.Document();
         let mql = MediaQueryList::new(&document, media_query_list, CanGc::note());
         self.media_query_lists.track(&*mql);


### PR DESCRIPTION
Several places were using identical logic in order to parse a media queries or media query lists.

This patch centralizes the logic into 2 new helper methods in MediaList.

Testing: not needed (no behavior change)
