### PR TITLE
Switch to data_url::mime for document content type

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -27,6 +27,7 @@ use constellation_traits::{
 use content_security_policy::{self as csp, CspList, PolicyDisposition};
 use cookie::Cookie;
 use cssparser::match_ignore_ascii_case;
+use data_url::mime::Mime;
 use devtools_traits::ScriptToDevtoolsControlMsg;
 use dom_struct::dom_struct;
 use embedder_traits::{
@@ -42,7 +43,6 @@ use ipc_channel::ipc;
 use js::rust::{HandleObject, HandleValue};
 use keyboard_types::{Code, Key, KeyState, Modifiers};
 use metrics::{InteractiveFlag, InteractiveWindow, ProgressiveWebMetrics};
-use mime::{self, Mime};
 use net_traits::CookieSource::NonHTTP;
 use net_traits::CoreResourceMsg::{GetCookiesForUrl, SetCookiesForUrl};
 use net_traits::policy_container::PolicyContainer;
@@ -201,6 +201,7 @@ use crate::fetch::FetchCanceller;
 use crate::iframe_collection::IFrameCollection;
 use crate::image_animation::ImageAnimationManager;
 use crate::messaging::{CommonScriptMsg, MainThreadScriptMsg};
+use crate::mime::{APPLICATION, CHARSET, MimeExt};
 use crate::network_listener::{NetworkListener, PreInvoke};
 use crate::realms::{AlreadyInRealm, InRealm, enter_realm};
 use crate::script_runtime::{CanGc, ScriptThreadEventCategory};
@@ -717,9 +718,7 @@ impl Document {
     }
 
     pub(crate) fn is_xhtml_document(&self) -> bool {
-        self.content_type.type_() == mime::APPLICATION &&
-            self.content_type.subtype().as_str() == "xhtml" &&
-            self.content_type.suffix() == Some(mime::XML)
+        self.content_type.matches(APPLICATION, "xhtml+xml")
     }
 
     pub(crate) fn set_https_state(&self, https_state: HttpsState) {
@@ -3787,15 +3786,17 @@ impl Document {
         let content_type = content_type.unwrap_or_else(|| {
             match is_html_document {
                 // https://dom.spec.whatwg.org/#dom-domimplementation-createhtmldocument
-                IsHTMLDocument::HTMLDocument => mime::TEXT_HTML,
+                IsHTMLDocument::HTMLDocument => "text/html",
                 // https://dom.spec.whatwg.org/#concept-document-content-type
-                IsHTMLDocument::NonHTMLDocument => "application/xml".parse().unwrap(),
+                IsHTMLDocument::NonHTMLDocument => "application/xml",
             }
+            .parse()
+            .unwrap()
         });
 
         let encoding = content_type
-            .get_param(mime::CHARSET)
-            .and_then(|charset| Encoding::for_label(charset.as_str().as_bytes()))
+            .get_parameter(CHARSET)
+            .and_then(|charset| Encoding::for_label(charset.as_bytes()))
             .unwrap_or(UTF_8);
 
         let has_browsing_context = has_browsing_context == HasBrowsingContext::Yes;

--- a/components/script/dom/domimplementation.rs
+++ b/components/script/dom/domimplementation.rs
@@ -92,10 +92,12 @@ impl DOMImplementationMethods<crate::DomTypeHolder> for DOMImplementation {
         let namespace = namespace_from_domstring(maybe_namespace.to_owned());
 
         let content_type = match namespace {
-            ns!(html) => "application/xhtml+xml".parse().unwrap(),
-            ns!(svg) => mime::IMAGE_SVG,
-            _ => "application/xml".parse().unwrap(),
-        };
+            ns!(html) => "application/xhtml+xml",
+            ns!(svg) => "image/svg+xml",
+            _ => "application/xml",
+        }
+        .parse()
+        .unwrap();
 
         // Step 1.
         let doc = XMLDocument::new(

--- a/components/script/dom/xmldocument.rs
+++ b/components/script/dom/xmldocument.rs
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use data_url::mime::Mime;
 use dom_struct::dom_struct;
-use mime::Mime;
 use net_traits::request::InsecureRequestsPolicy;
 use script_traits::DocumentActivity;
 use servo_url::{MutableOrigin, ServoUrl};

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -48,6 +48,7 @@ pub mod layout_dom;
 #[allow(unsafe_code)]
 pub(crate) mod messaging;
 mod microtask;
+pub(crate) mod mime;
 mod navigation;
 mod network_listener;
 mod realms;

--- a/components/script/mime.rs
+++ b/components/script/mime.rs
@@ -1,0 +1,62 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use data_url::mime::Mime;
+use headers::ContentType;
+
+pub(crate) static APPLICATION: &str = "application";
+pub(crate) static CHARSET: &str = "charset";
+pub(crate) static HTML: &str = "html";
+pub(crate) static TEXT: &str = "text";
+pub(crate) static XML: &str = "xml";
+
+/// Convenience methods to make the data_url Mime type more ergonomic.
+pub(crate) trait MimeExt {
+    /// Creates a new Mime from type and subtype, without any parameter.
+    fn new(type_: &str, subtype: &str) -> Self;
+
+    /// Checks that this Mime matches a given type and subtype, ignoring
+    /// parameters.
+    fn matches(&self, type_: &str, subtype: &str) -> bool;
+
+    /// Checks that the subtype has a given suffix.
+    /// Eg. image/svg+xml has the the xml suffix.
+    fn has_suffix(&self, suffix: &str) -> bool;
+
+    /// TODO: replace by a derive on data_url.
+    fn clone(&self) -> Self;
+
+    /// Build a Mime from the value of a Content-Type header.
+    fn from_ct(ct: ContentType) -> Self;
+}
+
+impl MimeExt for Mime {
+    fn new(type_: &str, subtype: &str) -> Self {
+        Mime {
+            type_: type_.into(),
+            subtype: subtype.into(),
+            parameters: vec![],
+        }
+    }
+
+    fn matches(&self, type_: &str, subtype: &str) -> bool {
+        self.type_ == type_ && self.subtype == subtype
+    }
+
+    fn has_suffix(&self, suffix: &str) -> bool {
+        self.subtype.ends_with(&format!("+{}", suffix))
+    }
+
+    fn clone(&self) -> Self {
+        Self {
+            type_: self.type_.clone(),
+            subtype: self.subtype.clone(),
+            parameters: self.parameters.clone(),
+        }
+    }
+
+    fn from_ct(ct: ContentType) -> Self {
+        ct.to_string().parse().unwrap()
+    }
+}

--- a/tests/wpt/meta/mimesniff/mime-types/charset-parameter.window.js.ini
+++ b/tests/wpt/meta/mimesniff/mime-types/charset-parameter.window.js.ini
@@ -35,12 +35,6 @@
   [text/html;charset="gbk]
     expected: FAIL
 
-  [text/html;charset="\\ gbk"]
-    expected: FAIL
-
-  [text/html;charset="\\g\\b\\k"]
-    expected: FAIL
-
   [text/html;charset="gbk"x]
     expected: FAIL
 

--- a/tests/wpt/meta/xhr/overridemimetype-blob.html.ini
+++ b/tests/wpt/meta/xhr/overridemimetype-blob.html.ini
@@ -2,103 +2,13 @@
   [2) MIME types need to be parsed and serialized: TEXT/HTML;CHARSET=GBK]
     expected: FAIL
 
-  [3) MIME types need to be parsed and serialized: text/html;charset=gbk(]
-    expected: FAIL
-
-  [4) MIME types need to be parsed and serialized: text/html;x=(;charset=gbk]
-    expected: FAIL
-
-  [5) MIME types need to be parsed and serialized: text/html;charset=gbk;charset=windows-1255]
-    expected: FAIL
-
-  [6) MIME types need to be parsed and serialized: text/html;charset=();charset=GBK]
-    expected: FAIL
-
-  [7) MIME types need to be parsed and serialized: text/html;charset =gbk]
-    expected: FAIL
-
-  [8) MIME types need to be parsed and serialized: text/html ;charset=gbk]
-    expected: FAIL
-
-  [9) MIME types need to be parsed and serialized: text/html; charset=gbk]
-    expected: FAIL
-
-  [10) MIME types need to be parsed and serialized: text/html;charset= gbk]
-    expected: FAIL
-
-  [11) MIME types need to be parsed and serialized: text/html;charset= "gbk"]
-    expected: FAIL
-
-  [12) MIME types need to be parsed and serialized: text/html;charset=\x0bgbk]
-    expected: FAIL
-
-  [13) MIME types need to be parsed and serialized: text/html;charset=\x0cgbk]
-    expected: FAIL
-
-  [14) MIME types need to be parsed and serialized: text/html;\x0bcharset=gbk]
-    expected: FAIL
-
-  [15) MIME types need to be parsed and serialized: text/html;\x0ccharset=gbk]
-    expected: FAIL
-
-  [19) MIME types need to be parsed and serialized: text/html;charset=';charset=GBK]
-    expected: FAIL
-
-  [20) MIME types need to be parsed and serialized: text/html;test;charset=gbk]
-    expected: FAIL
-
-  [21) MIME types need to be parsed and serialized: text/html;test=;charset=gbk]
-    expected: FAIL
-
-  [22) MIME types need to be parsed and serialized: text/html;';charset=gbk]
-    expected: FAIL
-
-  [23) MIME types need to be parsed and serialized: text/html;";charset=gbk]
-    expected: FAIL
-
-  [24) MIME types need to be parsed and serialized: text/html ; ; charset=gbk]
-    expected: FAIL
-
-  [25) MIME types need to be parsed and serialized: text/html;;;;charset=gbk]
-    expected: FAIL
-
   [26) MIME types need to be parsed and serialized: text/html;charset= ";charset=GBK]
     expected: FAIL
 
   [27) MIME types need to be parsed and serialized: text/html;charset=";charset=foo";charset=GBK]
     expected: FAIL
 
-  [28) MIME types need to be parsed and serialized: text/html;charset="gbk"]
-    expected: FAIL
-
-  [29) MIME types need to be parsed and serialized: text/html;charset="gbk]
-    expected: FAIL
-
-  [30) MIME types need to be parsed and serialized: text/html;charset=gbk"]
-    expected: FAIL
-
-  [33) MIME types need to be parsed and serialized: text/html;charset="\\ gbk"]
-    expected: FAIL
-
-  [34) MIME types need to be parsed and serialized: text/html;charset="\\g\\b\\k"]
-    expected: FAIL
-
-  [35) MIME types need to be parsed and serialized: text/html;charset="gbk"x]
-    expected: FAIL
-
-  [36) MIME types need to be parsed and serialized: text/html;charset="";charset=GBK]
-    expected: FAIL
-
   [37) MIME types need to be parsed and serialized: text/html;charset=";charset=GBK]
-    expected: FAIL
-
-  [38) MIME types need to be parsed and serialized: text/html;charset={gbk}]
-    expected: FAIL
-
-  [41) MIME types need to be parsed and serialized: text/html;a\]=bar;b[=bar;c=bar]
-    expected: FAIL
-
-  [43) MIME types need to be parsed and serialized: text/html;in\]valid=";asd=foo";foo=bar]
     expected: FAIL
 
   [44) MIME types need to be parsed and serialized: !#$%&'*+-.^_`|~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz/!#$%&'*+-.^_`|~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz;!#$%&'*+-.^_`|~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz=!#$%&'*+-.^_`|~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz]
@@ -107,32 +17,5 @@
   [45) MIME types need to be parsed and serialized: x/x;x="\t !\\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\\\\]^_`abcdefghijklmnopqrstuvwxyz{|}~ ¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿ"]
     expected: FAIL
 
-  [46) MIME types need to be parsed and serialized: x/x;test]
-    expected: FAIL
-
-  [47) MIME types need to be parsed and serialized: x/x;test="\\]
-    expected: FAIL
-
-  [48) MIME types need to be parsed and serialized: x/x;x= ]
-    expected: FAIL
-
-  [49) MIME types need to be parsed and serialized: x/x;x=\t]
-    expected: FAIL
-
-  [50) MIME types need to be parsed and serialized: x/x\n\r\t ;x=x]
-    expected: FAIL
-
-  [51) MIME types need to be parsed and serialized: \n\r\t x/x;x=x\n\r\t ]
-    expected: FAIL
-
-  [52) MIME types need to be parsed and serialized: x/x;\n\r\t x=x\n\r\t ;x=y]
-    expected: FAIL
-
   [53) MIME types need to be parsed and serialized: text/html;test=ÿ;charset=gbk]
-    expected: FAIL
-
-  [54) MIME types need to be parsed and serialized: x/x;test=�;x=x]
-    expected: FAIL
-
-  [63) MIME types need to be parsed and serialized: bogus/]
     expected: FAIL

--- a/tests/wpt/meta/xhr/send-content-type-charset.htm.ini
+++ b/tests/wpt/meta/xhr/send-content-type-charset.htm.ini
@@ -2,9 +2,6 @@
   [charset given but wrong, fix it (unknown MIME, bogus charset)]
     expected: FAIL
 
-  [If charset= param is UTF-8 (case-insensitive), it should not be changed (bogus charset)]
-    expected: FAIL
-
   [charset given but wrong, fix it (known MIME, actual charset)]
     expected: FAIL
 
@@ -15,9 +12,6 @@
     expected: FAIL
 
   [charset in double quotes with space]
-    expected: FAIL
-
-  [charset in double quotes with backslashes that is UTF-8 does not change]
     expected: FAIL
 
   [unknown parameters need to be preserved]


### PR DESCRIPTION
The data_url Mime parser has a more conformant behavior in most cases, including dealing with charsets.

Testing: wpt expectations with new passes are updated.

