### PR TITLE
Force the event loop to spin when polling.

### DIFF
--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -395,6 +395,9 @@ impl ApplicationHandler<WakerEvent> for App {
             event_loop.set_control_flow(ControlFlow::Wait);
         } else {
             event_loop.set_control_flow(ControlFlow::Poll);
+            // Even when using polling, we still need to ensure there's an event in the queue
+            // that will make us spin the event loop.
+            window.winit_window().unwrap().request_redraw();
         }
 
         // Consume and handle any events from the servoshell UI.
@@ -427,6 +430,9 @@ impl ApplicationHandler<WakerEvent> for App {
             event_loop.set_control_flow(ControlFlow::Wait);
         } else {
             event_loop.set_control_flow(ControlFlow::Poll);
+            // Even when using polling, we still need to ensure there's an event in the queue
+            // that will make us spin the event loop.
+            window.winit_window().unwrap().request_redraw();
         }
 
         // Consume and handle any events from the Minibrowser.


### PR DESCRIPTION
Pages that animate will freeze if no window events are triggered (eg. moving the mouse), despite using winit's polling control flow correctly. By requesting a redraw, we ensure that there is always an event ready to be received by winit, consequently making servoshell spin the Servo event loop.

Testing: Manual testing on https://madebyevan.com/shaders/fast-rounded-rectangle-shadows/
