### PR TITLE
Enable the zstd decoder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1543,6 +1543,8 @@ dependencies = [
  "compression-core",
  "flate2",
  "memchr",
+ "zstd",
+ "zstd-safe",
 ]
 
 [[package]]
@@ -10948,6 +10950,34 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]
 
 [[package]]

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -15,7 +15,7 @@ test = false
 doctest = false
 
 [dependencies]
-async-compression = { version = "0.4.12", default-features = false, features = ["tokio", "brotli", "gzip", "zlib"] }
+async-compression = { version = "0.4.12", default-features = false, features = ["tokio", "brotli", "gzip", "zlib", "zstd"] }
 async-recursion = "1.1"
 async-tungstenite = { workspace = true }
 base = { workspace = true }

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -184,7 +184,7 @@ fn set_default_accept_encoding(headers: &mut HeaderMap) {
     // TODO(eijebong): Change this once typed headers are done
     headers.insert(
         header::ACCEPT_ENCODING,
-        HeaderValue::from_static("gzip, deflate, br"),
+        HeaderValue::from_static("gzip, deflate, br, zstd"),
     );
 }
 

--- a/components/net/tests/fetch.rs
+++ b/components/net/tests/fetch.rs
@@ -1313,7 +1313,7 @@ fn test_fetch_with_devtools() {
 
     headers.insert(
         header::ACCEPT_ENCODING,
-        HeaderValue::from_static("gzip, deflate, br"),
+        HeaderValue::from_static("gzip, deflate, br, zstd"),
     );
 
     // Append fetch metadata headers

--- a/components/net/tests/http_loader.rs
+++ b/components/net/tests/http_loader.rs
@@ -189,7 +189,7 @@ fn test_check_default_headers_loaded_in_every_request() {
 
     headers.insert(
         header::ACCEPT_ENCODING,
-        HeaderValue::from_static("gzip, deflate, br"),
+        HeaderValue::from_static("gzip, deflate, br, zstd"),
     );
 
     headers.typed_insert(Host::from(
@@ -369,7 +369,7 @@ fn test_request_and_response_data_with_network_messages() {
 
     headers.insert(
         header::ACCEPT_ENCODING,
-        HeaderValue::from_static("gzip, deflate, br"),
+        HeaderValue::from_static("gzip, deflate, br, zstd"),
     );
 
     // Append fetch metadata headers
@@ -1128,7 +1128,7 @@ fn test_load_sets_default_accept_encoding_to_gzip_and_deflate() {
                     .unwrap()
                     .to_str()
                     .unwrap(),
-                "gzip, deflate, br"
+                "gzip, deflate, br, zstd"
             );
             *response.body_mut() = make_body(b"Yay!".to_vec());
         };

--- a/tests/wpt/meta/fetch/content-encoding/zstd/big-zstd-body.https.any.js.ini
+++ b/tests/wpt/meta/fetch/content-encoding/zstd/big-zstd-body.https.any.js.ini
@@ -2,17 +2,11 @@
   expected: ERROR
 
 [big-zstd-body.https.any.worker.html]
-  [large zstd data should be decompressed successfully]
-    expected: FAIL
-
   [large zstd data should be decompressed successfully with byte stream]
     expected: FAIL
 
 
 [big-zstd-body.https.any.html]
-  [large zstd data should be decompressed successfully]
-    expected: FAIL
-
   [large zstd data should be decompressed successfully with byte stream]
     expected: FAIL
 

--- a/tests/wpt/meta/fetch/content-encoding/zstd/zstd-body.https.any.js.ini
+++ b/tests/wpt/meta/fetch/content-encoding/zstd/zstd-body.https.any.js.ini
@@ -2,19 +2,8 @@
   expected: ERROR
 
 [zstd-body.https.any.html]
-  [fetched zstd data with content type text should be decompressed.]
-    expected: FAIL
-
-  [fetched zstd data with content type octetstream should be decompressed.]
-    expected: FAIL
-
 
 [zstd-body.https.any.sharedworker.html]
   expected: ERROR
 
 [zstd-body.https.any.worker.html]
-  [fetched zstd data with content type text should be decompressed.]
-    expected: FAIL
-
-  [fetched zstd data with content type octetstream should be decompressed.]
-    expected: FAIL

--- a/tests/wpt/meta/fetch/content-encoding/zstd/zstd-navigation.https.window.js.ini
+++ b/tests/wpt/meta/fetch/content-encoding/zstd/zstd-navigation.https.window.js.ini
@@ -1,3 +1,0 @@
-[zstd-navigation.https.window.html]
-  [Naigation to zstd encoded page]
-    expected: FAIL


### PR DESCRIPTION
Uses the `zstd` support from `async-compression` to support zstd Content-Encoding.

Testing: Covered by wpt tests.

