### PR TITLE
touch: Fix panic with -Zconvert-mouse-to-touch

### DIFF
--- a/components/compositing/touch.rs
+++ b/components/compositing/touch.rs
@@ -282,6 +282,10 @@ impl TouchHandler {
         debug_assert!(old.is_some(), "Sequence already removed?");
     }
 
+    pub fn try_get_current_touch_sequence(&self) -> Option<&TouchSequenceInfo> {
+        self.touch_sequence_map.get(&self.current_sequence_id)
+    }
+
     pub fn get_current_touch_sequence_mut(&mut self) -> &mut TouchSequenceInfo {
         self.touch_sequence_map
             .get_mut(&self.current_sequence_id)

--- a/components/compositing/webview.rs
+++ b/components/compositing/webview.rs
@@ -338,27 +338,53 @@ impl WebView {
         if self.global.borrow().convert_mouse_to_touch {
             match event {
                 InputEvent::MouseButton(event) => {
-                    match event.action {
-                        MouseButtonAction::Click => {},
-                        MouseButtonAction::Down => self.on_touch_down(TouchEvent::new(
-                            TouchEventType::Down,
-                            TouchId(0),
-                            event.point,
-                        )),
-                        MouseButtonAction::Up => self.on_touch_up(TouchEvent::new(
-                            TouchEventType::Up,
-                            TouchId(0),
-                            event.point,
-                        )),
+                    match (event.button, event.action) {
+                        (MouseButton::Left, MouseButtonAction::Down) => self.on_touch_down(
+                            TouchEvent::new(TouchEventType::Down, TouchId(0), event.point),
+                        ),
+                        (MouseButton::Left, MouseButtonAction::Up) => self.on_touch_up(
+                            TouchEvent::new(TouchEventType::Up, TouchId(0), event.point),
+                        ),
+                        _ => {},
                     }
                     return;
                 },
                 InputEvent::MouseMove(event) => {
-                    self.on_touch_move(TouchEvent::new(
-                        TouchEventType::Move,
-                        TouchId(0),
-                        event.point,
-                    ));
+                    if let Some(state) = self.touch_handler.try_get_current_touch_sequence() {
+                        // We assume that the debug option `-Z convert-mouse-to-touch` will only
+                        // be used on devices without native touch input, so we can directly
+                        // reuse the touch handler for tracking the state of pressed buttons.
+                        match state.state {
+                            TouchSequenceState::Touching | TouchSequenceState::Panning { .. } => {
+                                self.on_touch_move(TouchEvent::new(
+                                    TouchEventType::Move,
+                                    TouchId(0),
+                                    event.point,
+                                ));
+                            },
+                            TouchSequenceState::MultiTouch => {
+                                // Multitouch simulation currently is not implemented.
+                                // Since we only get one mouse move event, we would need to
+                                // dispatch one mouse move event per currently pressed mouse button.
+                            },
+                            TouchSequenceState::Pinching => {
+                                // We only have one mouse button, so Pinching should be impossible.
+                                #[cfg(debug_assertions)]
+                                log::error!(
+                                    "Touch handler is in Pinching state, which should be unreachable with \
+                                -Z convert-mouse-to-touch debug option."
+                                );
+                            },
+                            TouchSequenceState::PendingFling { .. } |
+                            TouchSequenceState::Flinging { .. } |
+                            TouchSequenceState::PendingClick(_) |
+                            TouchSequenceState::Finished => {
+                                // Mouse movement without a button being pressed is not
+                                // translated to touch events.
+                            },
+                        }
+                    }
+                    // We don't want to (directly) dispatch mouse events when simulating touch input.
                     return;
                 },
                 _ => {},


### PR DESCRIPTION
- We previously converted all mouse move events to touch events, but we should only be doing that while a mouse button is pressed (a finger always does touch-down -> move -> up / cancel)
- Only consider Left mouse button for mouse-to-touch. We currently already hardcode TouchId 0, which we would need to change in order to properly support Multi-touch. Since we don't have any Multi-touch gestures at the moment, we leave this unimplemented and simply only evaluate the left mouse button.

Testing:  Manual testing. We don't have servodriver support yet.
Fixes: #36526
