### PR TITLE
Make DOMException serializable

### DIFF
--- a/components/shared/base/id.rs
+++ b/components/shared/base/id.rs
@@ -196,6 +196,7 @@ impl PipelineNamespace {
     self, ServiceWorkerRegistrationIndex}
     namespace_id_method! {next_blob_id, BlobId, self, BlobIndex}
     namespace_id_method! {next_dom_point_id, DomPointId, self, DomPointIndex}
+    namespace_id_method! {next_dom_exception_id, DomExceptionId, self, DomExceptionIndex}
 }
 
 thread_local!(pub static PIPELINE_NAMESPACE: Cell<Option<PipelineNamespace>> = const { Cell::new(None) });
@@ -421,6 +422,19 @@ impl DomPointId {
             let next_point_id = namespace.next_dom_point_id();
             tls.set(Some(namespace));
             next_point_id
+        })
+    }
+}
+
+namespace_id! {DomExceptionId, DomExceptionIndex, "DomException"}
+
+impl DomExceptionId {
+    pub fn new() -> DomExceptionId {
+        PIPELINE_NAMESPACE.with(|tls| {
+            let mut namespace = tls.get().expect("No namespace set for this thread!");
+            let next_exception_id = namespace.next_dom_exception_id();
+            tls.set(Some(namespace));
+            next_exception_id
         })
     }
 }

--- a/components/shared/constellation/message_port.rs
+++ b/components/shared/constellation/message_port.rs
@@ -13,7 +13,7 @@ use std::cell::RefCell;
 use std::collections::{HashMap, VecDeque};
 use std::path::PathBuf;
 
-use base::id::{BlobId, DomPointId, MessagePortId};
+use base::id::{BlobId, DomExceptionId, DomPointId, MessagePortId};
 use log::warn;
 use malloc_size_of_derive::MallocSizeOf;
 use net_traits::filemanager_thread::RelativePos;
@@ -177,6 +177,8 @@ pub struct StructuredSerializedData {
     pub blobs: Option<HashMap<BlobId, BlobImpl>>,
     /// Serialized point objects.
     pub points: Option<HashMap<DomPointId, DomPoint>>,
+    /// Serialized exception objects.
+    pub exceptions: Option<HashMap<DomExceptionId, DomException>>,
     /// Transferred objects.
     pub ports: Option<HashMap<MessagePortId, MessagePortImpl>>,
 }
@@ -205,6 +207,8 @@ pub enum Serializable {
     DomPoint,
     /// The `DOMPointReadOnly` interface.
     DomPointReadOnly,
+    /// The `DOMException` interface.
+    DomException,
 }
 
 impl Serializable {
@@ -215,6 +219,9 @@ impl Serializable {
                 StructuredSerializedData::clone_all_of_type::<DomPoint>
             },
             Serializable::DomPoint => StructuredSerializedData::clone_all_of_type::<DomPoint>,
+            Serializable::DomException => {
+                StructuredSerializedData::clone_all_of_type::<DomException>
+            },
         }
     }
 }
@@ -294,6 +301,7 @@ pub struct PortMessageTask {
 
 /// Messages for communication between the constellation and a global managing ports.
 #[derive(Debug, Deserialize, Serialize)]
+#[allow(clippy::large_enum_variant)]
 pub enum MessagePortMsg {
     /// Complete the transfer for a batch of ports.
     CompleteTransfer(HashMap<MessagePortId, VecDeque<PortMessageTask>>),
@@ -520,6 +528,33 @@ impl BroadcastClone for DomPoint {
         data: &mut StructuredSerializedData,
     ) -> &mut Option<std::collections::HashMap<Self::Id, Self>> {
         &mut data.points
+    }
+
+    fn clone_for_broadcast(&self) -> Option<Self> {
+        Some(self.clone())
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
+/// A serializable version of the DOMException interface.
+pub struct DomException {
+    pub message: String,
+    pub name: String,
+}
+
+impl BroadcastClone for DomException {
+    type Id = DomExceptionId;
+
+    fn source(
+        data: &StructuredSerializedData,
+    ) -> &Option<std::collections::HashMap<Self::Id, Self>> {
+        &data.exceptions
+    }
+
+    fn destination(
+        data: &mut StructuredSerializedData,
+    ) -> &mut Option<std::collections::HashMap<Self::Id, Self>> {
+        &mut data.exceptions
     }
 
     fn clone_for_broadcast(&self) -> Option<Self> {

--- a/tests/wpt/meta/html/infrastructure/safe-passing-of-structured-data/structuredclone_0.html.ini
+++ b/tests/wpt/meta/html/infrastructure/safe-passing-of-structured-data/structuredclone_0.html.ini
@@ -4,9 +4,3 @@
 
   [ImageData expandos are not cloned]
     expected: FAIL
-
-  [DOMException objects can be cloned]
-    expected: FAIL
-
-  [DOMException objects created by the UA can be cloned]
-    expected: FAIL

--- a/tests/wpt/meta/streams/transferable/reason.html.ini
+++ b/tests/wpt/meta/streams/transferable/reason.html.ini
@@ -1,3 +1,0 @@
-[reason.html]
-  [DOMException errors should be preserved]
-    expected: FAIL


### PR DESCRIPTION
Follow the implementation of making DOMPoint and DOMPointReadOnly serializable in PR #35989

Testing: Passed a test previously expected to fail.
Fixes: #36463 