### PR TITLE
Streams: skip parts of test suites involving unimplemented apis

### DIFF
--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -230,28 +230,12 @@ skip: true
   skip: true
   [piping]
     skip: false
-  [readable-streams]
-    skip: false
   [readable-byte-streams]
+    skip: false
+  [readable-streams]
     skip: false
   [transferable]
     skip: false
-    [service-worker.https.html]
-      skip: true
-    [shared-worker.html]
-      skip: true
-    [transform-stream-members.any.shadowrealm-in-dedicatedworker.html]
-      skip: true
-    [transform-stream-members.any.shadowrealm-in-shadowrealm.html]
-      skip: true
-    [transform-stream-members.any.shadowrealm-in-sharedworker.html]
-      skip: true
-    [transform-stream-members.any.shadowrealm-in-window.html]
-      skip: true
-    [transform-stream-members.https.any.shadowrealm-in-audioworklet.html]
-      skip: true
-    [transform-stream-members.https.any.shadowrealm-in-serviceworker.html]
-      skip: true
   [writable-streams]
     skip: false
 [subresource-integrity]

--- a/tests/wpt/meta/streams/piping/abort.any.js.ini
+++ b/tests/wpt/meta/streams/piping/abort.any.js.ini
@@ -1,29 +1,29 @@
 [abort.https.any.shadowrealm-in-serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [abort.any.shadowrealm-in-window.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [abort.any.html]
   expected: ERROR
 
 [abort.any.shadowrealm-in-dedicatedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [abort.any.sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [abort.any.shadowrealm-in-sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [abort.any.serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [abort.any.worker.html]
   expected: ERROR
 
 [abort.https.any.shadowrealm-in-audioworklet.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/23807
 
 [abort.any.shadowrealm-in-shadowrealm.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563

--- a/tests/wpt/meta/streams/piping/close-propagation-backward.any.js.ini
+++ b/tests/wpt/meta/streams/piping/close-propagation-backward.any.js.ini
@@ -1,27 +1,23 @@
 [close-propagation-backward.https.any.shadowrealm-in-audioworklet.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/23807
 
 [close-propagation-backward.any.serviceworker.html]
-  expected: ERROR
-
-[close-propagation-backward.any.html]
+  disabled: https://github.com/servo/servo/issues/36538
 
 [close-propagation-backward.any.sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [close-propagation-backward.any.shadowrealm-in-shadowrealm.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [close-propagation-backward.any.shadowrealm-in-sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [close-propagation-backward.https.any.shadowrealm-in-serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [close-propagation-backward.any.shadowrealm-in-window.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [close-propagation-backward.any.shadowrealm-in-dedicatedworker.html]
-  expected: ERROR
-
-[close-propagation-backward.any.worker.html]
+  disabled: https://github.com/servo/servo/issues/36563

--- a/tests/wpt/meta/streams/piping/close-propagation-forward.any.js.ini
+++ b/tests/wpt/meta/streams/piping/close-propagation-forward.any.js.ini
@@ -1,27 +1,24 @@
 [close-propagation-forward.any.shadowrealm-in-sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [close-propagation-forward.https.any.shadowrealm-in-audioworklet.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/23807
 
 [close-propagation-forward.any.shadowrealm-in-window.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [close-propagation-forward.https.any.shadowrealm-in-serviceworker.html]
-  expected: ERROR
-
-[close-propagation-forward.any.worker.html]
+  disabled: https://github.com/servo/servo/issues/36538
 
 [close-propagation-forward.any.serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [close-propagation-forward.any.shadowrealm-in-shadowrealm.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [close-propagation-forward.any.sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [close-propagation-forward.any.shadowrealm-in-dedicatedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
-[close-propagation-forward.any.html]

--- a/tests/wpt/meta/streams/piping/error-propagation-backward.any.js.ini
+++ b/tests/wpt/meta/streams/piping/error-propagation-backward.any.js.ini
@@ -1,27 +1,23 @@
 [error-propagation-backward.https.any.shadowrealm-in-audioworklet.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/23807
 
 [error-propagation-backward.any.shadowrealm-in-sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [error-propagation-backward.any.shadowrealm-in-window.html]
-  expected: ERROR
-
-[error-propagation-backward.any.worker.html]
-
-[error-propagation-backward.any.html]
+  disabled: https://github.com/servo/servo/issues/36563
 
 [error-propagation-backward.any.shadowrealm-in-shadowrealm.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [error-propagation-backward.any.shadowrealm-in-dedicatedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [error-propagation-backward.https.any.shadowrealm-in-serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [error-propagation-backward.any.sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [error-propagation-backward.any.serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538

--- a/tests/wpt/meta/streams/piping/error-propagation-forward.any.js.ini
+++ b/tests/wpt/meta/streams/piping/error-propagation-forward.any.js.ini
@@ -1,27 +1,23 @@
-[error-propagation-forward.any.html]
-
 [error-propagation-forward.any.serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [error-propagation-forward.https.any.shadowrealm-in-audioworklet.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/23807
 
 [error-propagation-forward.any.shadowrealm-in-sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [error-propagation-forward.any.shadowrealm-in-dedicatedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [error-propagation-forward.any.shadowrealm-in-shadowrealm.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [error-propagation-forward.any.sharedworker.html]
-  expected: ERROR
-
-[error-propagation-forward.any.worker.html]
+  disabled: https://github.com/servo/servo/issues/7458
 
 [error-propagation-forward.any.shadowrealm-in-window.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [error-propagation-forward.https.any.shadowrealm-in-serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538

--- a/tests/wpt/meta/streams/piping/flow-control.any.js.ini
+++ b/tests/wpt/meta/streams/piping/flow-control.any.js.ini
@@ -1,27 +1,23 @@
-[flow-control.any.html]
-
 [flow-control.any.serviceworker.html]
-  expected: ERROR
-
-[flow-control.any.worker.html]
+  disabled: https://github.com/servo/servo/issues/36538
 
 [flow-control.any.sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [flow-control.any.shadowrealm-in-shadowrealm.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [flow-control.any.shadowrealm-in-dedicatedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [flow-control.https.any.shadowrealm-in-serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [flow-control.any.shadowrealm-in-sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [flow-control.any.shadowrealm-in-window.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [flow-control.https.any.shadowrealm-in-audioworklet.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/23807

--- a/tests/wpt/meta/streams/piping/general-addition.any.js.ini
+++ b/tests/wpt/meta/streams/piping/general-addition.any.js.ini
@@ -1,27 +1,23 @@
 [general-addition.any.sharedworker.html]
-  expected: ERROR
-
-[general-addition.any.html]
+  disabled: https://github.com/servo/servo/issues/7458
 
 [general-addition.any.shadowrealm-in-shadowrealm.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [general-addition.any.shadowrealm-in-window.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [general-addition.any.serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [general-addition.https.any.shadowrealm-in-audioworklet.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/23807
 
 [general-addition.https.any.shadowrealm-in-serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [general-addition.any.shadowrealm-in-sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [general-addition.any.shadowrealm-in-dedicatedworker.html]
-  expected: ERROR
-
-[general-addition.any.worker.html]
+  disabled: https://github.com/servo/servo/issues/36563

--- a/tests/wpt/meta/streams/piping/general.any.js.ini
+++ b/tests/wpt/meta/streams/piping/general.any.js.ini
@@ -1,27 +1,23 @@
 [general.any.sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [general.any.shadowrealm-in-dedicatedworker.html]
-  expected: ERROR
-
-[general.any.worker.html]
+  disabled: https://github.com/servo/servo/issues/36563
 
 [general.any.serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [general.https.any.shadowrealm-in-audioworklet.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/23807
 
 [general.any.shadowrealm-in-window.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [general.https.any.shadowrealm-in-serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [general.any.shadowrealm-in-sharedworker.html]
-  expected: ERROR
-
-[general.any.html]
+  disabled: https://github.com/servo/servo/issues/7458
 
 [general.any.shadowrealm-in-shadowrealm.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563

--- a/tests/wpt/meta/streams/piping/multiple-propagation.any.js.ini
+++ b/tests/wpt/meta/streams/piping/multiple-propagation.any.js.ini
@@ -1,27 +1,23 @@
 [multiple-propagation.https.any.shadowrealm-in-serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [multiple-propagation.https.any.shadowrealm-in-audioworklet.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/23807
 
 [multiple-propagation.any.shadowrealm-in-dedicatedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [multiple-propagation.any.serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [multiple-propagation.any.shadowrealm-in-window.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [multiple-propagation.any.shadowrealm-in-shadowrealm.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [multiple-propagation.any.shadowrealm-in-sharedworker.html]
-  expected: ERROR
-
-[multiple-propagation.any.worker.html]
-
-[multiple-propagation.any.html]
+  disabled: https://github.com/servo/servo/issues/7458
 
 [multiple-propagation.any.sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458

--- a/tests/wpt/meta/streams/piping/pipe-through.any.js.ini
+++ b/tests/wpt/meta/streams/piping/pipe-through.any.js.ini
@@ -1,8 +1,8 @@
 [pipe-through.any.shadowrealm-in-shadowrealm.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [pipe-through.any.serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [pipe-through.any.worker.html]
   expected: ERROR
@@ -65,22 +65,22 @@
 
 
 [pipe-through.any.sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [pipe-through.any.shadowrealm-in-window.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [pipe-through.any.shadowrealm-in-dedicatedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [pipe-through.https.any.shadowrealm-in-serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [pipe-through.https.any.shadowrealm-in-audioworklet.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/23807
 
 [pipe-through.any.shadowrealm-in-sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [pipe-through.any.html]
   expected: ERROR

--- a/tests/wpt/meta/streams/piping/then-interception.any.js.ini
+++ b/tests/wpt/meta/streams/piping/then-interception.any.js.ini
@@ -1,11 +1,11 @@
 [then-interception.any.shadowrealm-in-dedicatedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [then-interception.any.shadowrealm-in-shadowrealm.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [then-interception.any.serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [then-interception.any.worker.html]
   expected: CRASH
@@ -14,16 +14,16 @@
   expected: CRASH
 
 [then-interception.https.any.shadowrealm-in-serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [then-interception.any.shadowrealm-in-window.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [then-interception.https.any.shadowrealm-in-audioworklet.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/23807
 
 [then-interception.any.sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [then-interception.any.shadowrealm-in-sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458

--- a/tests/wpt/meta/streams/piping/throwing-options.any.js.ini
+++ b/tests/wpt/meta/streams/piping/throwing-options.any.js.ini
@@ -1,23 +1,23 @@
 [throwing-options.https.any.shadowrealm-in-serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [throwing-options.https.any.shadowrealm-in-audioworklet.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/23807
 
 [throwing-options.any.serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [throwing-options.any.shadowrealm-in-dedicatedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [throwing-options.any.shadowrealm-in-sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [throwing-options.any.shadowrealm-in-shadowrealm.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [throwing-options.any.shadowrealm-in-window.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [throwing-options.any.html]
   expected: TIMEOUT
@@ -36,7 +36,6 @@
   [pipeThrough should stop after getting signal throws]
     expected: FAIL
 
-
 [throwing-options.any.worker.html]
   expected: TIMEOUT
   [pipeThrough should stop after getting preventAbort throws]
@@ -54,6 +53,5 @@
   [pipeThrough should stop after getting signal throws]
     expected: FAIL
 
-
 [throwing-options.any.sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458

--- a/tests/wpt/meta/streams/piping/transform-streams.any.js.ini
+++ b/tests/wpt/meta/streams/piping/transform-streams.any.js.ini
@@ -1,14 +1,14 @@
 [transform-streams.any.shadowrealm-in-dedicatedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [transform-streams.https.any.shadowrealm-in-serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [transform-streams.any.sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [transform-streams.any.shadowrealm-in-sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [transform-streams.any.worker.html]
   [Piping through an identity transform stream should close the destination when the source closes]
@@ -16,7 +16,7 @@
 
 
 [transform-streams.any.shadowrealm-in-shadowrealm.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [transform-streams.any.html]
   [Piping through an identity transform stream should close the destination when the source closes]
@@ -24,10 +24,10 @@
 
 
 [transform-streams.any.shadowrealm-in-window.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [transform-streams.any.serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [transform-streams.https.any.shadowrealm-in-audioworklet.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/23807

--- a/tests/wpt/meta/streams/readable-byte-streams/bad-buffers-and-views.any.js.ini
+++ b/tests/wpt/meta/streams/readable-byte-streams/bad-buffers-and-views.any.js.ini
@@ -1,23 +1,23 @@
 [bad-buffers-and-views.any.serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [bad-buffers-and-views.any.shadowrealm-in-window.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [bad-buffers-and-views.any.shadowrealm-in-dedicatedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [bad-buffers-and-views.any.shadowrealm-in-shadowrealm.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [bad-buffers-and-views.https.any.shadowrealm-in-audioworklet.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/23807
 
 [bad-buffers-and-views.https.any.shadowrealm-in-serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [bad-buffers-and-views.any.shadowrealm-in-sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [bad-buffers-and-views.any.sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458

--- a/tests/wpt/meta/streams/readable-byte-streams/construct-byob-request.any.js.ini
+++ b/tests/wpt/meta/streams/readable-byte-streams/construct-byob-request.any.js.ini
@@ -1,23 +1,23 @@
 [construct-byob-request.https.any.shadowrealm-in-serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [construct-byob-request.https.any.shadowrealm-in-audioworklet.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/23807
 
 [construct-byob-request.any.shadowrealm-in-sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [construct-byob-request.any.shadowrealm-in-window.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [construct-byob-request.any.shadowrealm-in-dedicatedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [construct-byob-request.any.shadowrealm-in-shadowrealm.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [construct-byob-request.any.serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [construct-byob-request.any.sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458

--- a/tests/wpt/meta/streams/readable-byte-streams/enqueue-with-detached-buffer.any.js.ini
+++ b/tests/wpt/meta/streams/readable-byte-streams/enqueue-with-detached-buffer.any.js.ini
@@ -1,23 +1,23 @@
 [enqueue-with-detached-buffer.any.shadowrealm-in-shadowrealm.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [enqueue-with-detached-buffer.https.any.shadowrealm-in-audioworklet.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/23807
 
 [enqueue-with-detached-buffer.any.sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [enqueue-with-detached-buffer.any.shadowrealm-in-window.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [enqueue-with-detached-buffer.any.shadowrealm-in-sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [enqueue-with-detached-buffer.any.serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [enqueue-with-detached-buffer.https.any.shadowrealm-in-serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [enqueue-with-detached-buffer.any.shadowrealm-in-dedicatedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563

--- a/tests/wpt/meta/streams/readable-byte-streams/general.any.js.ini
+++ b/tests/wpt/meta/streams/readable-byte-streams/general.any.js.ini
@@ -1,23 +1,23 @@
 [general.any.shadowrealm-in-shadowrealm.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [general.any.shadowrealm-in-sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [general.https.any.shadowrealm-in-serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [general.any.sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [general.any.shadowrealm-in-dedicatedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [general.https.any.shadowrealm-in-audioworklet.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/23807
 
 [general.any.serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [general.any.shadowrealm-in-window.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563

--- a/tests/wpt/meta/streams/readable-byte-streams/non-transferable-buffers.any.js.ini
+++ b/tests/wpt/meta/streams/readable-byte-streams/non-transferable-buffers.any.js.ini
@@ -1,23 +1,23 @@
 [non-transferable-buffers.any.shadowrealm-in-shadowrealm.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [non-transferable-buffers.https.any.shadowrealm-in-audioworklet.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/23807
 
 [non-transferable-buffers.any.shadowrealm-in-dedicatedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [non-transferable-buffers.any.serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [non-transferable-buffers.https.any.shadowrealm-in-serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [non-transferable-buffers.any.shadowrealm-in-sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [non-transferable-buffers.any.sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [non-transferable-buffers.any.shadowrealm-in-window.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563

--- a/tests/wpt/meta/streams/readable-byte-streams/patched-global.any.js.ini
+++ b/tests/wpt/meta/streams/readable-byte-streams/patched-global.any.js.ini
@@ -1,23 +1,23 @@
 [patched-global.any.shadowrealm-in-sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [patched-global.any.shadowrealm-in-dedicatedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [patched-global.any.sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [patched-global.any.shadowrealm-in-shadowrealm.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [patched-global.any.shadowrealm-in-window.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [patched-global.https.any.shadowrealm-in-serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [patched-global.any.serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [patched-global.https.any.shadowrealm-in-audioworklet.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/23807

--- a/tests/wpt/meta/streams/readable-byte-streams/read-min.any.js.ini
+++ b/tests/wpt/meta/streams/readable-byte-streams/read-min.any.js.ini
@@ -1,26 +1,26 @@
 [read-min.https.any.shadowrealm-in-audioworklet.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/23807
 
 [read-min.any.sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [read-min.any.shadowrealm-in-shadowrealm.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [read-min.any.shadowrealm-in-dedicatedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [read-min.any.serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [read-min.any.shadowrealm-in-window.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [read-min.https.any.shadowrealm-in-serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [read-min.any.shadowrealm-in-sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [read-min.any.html]
   [ReadableStream with byte source: tee() with read({ min }) from branch1 and read() from branch2]

--- a/tests/wpt/meta/streams/readable-byte-streams/respond-after-enqueue.any.js.ini
+++ b/tests/wpt/meta/streams/readable-byte-streams/respond-after-enqueue.any.js.ini
@@ -1,23 +1,23 @@
 [respond-after-enqueue.https.any.shadowrealm-in-audioworklet.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/23807
 
 [respond-after-enqueue.any.shadowrealm-in-shadowrealm.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [respond-after-enqueue.any.shadowrealm-in-sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [respond-after-enqueue.any.serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [respond-after-enqueue.any.sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [respond-after-enqueue.any.shadowrealm-in-dedicatedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [respond-after-enqueue.any.shadowrealm-in-window.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [respond-after-enqueue.https.any.shadowrealm-in-serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538

--- a/tests/wpt/meta/streams/readable-byte-streams/tee.any.js.ini
+++ b/tests/wpt/meta/streams/readable-byte-streams/tee.any.js.ini
@@ -1,8 +1,8 @@
 [tee.any.shadowrealm-in-sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [tee.any.shadowrealm-in-window.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [tee.any.worker.html]
   [ReadableStream teeing with byte source: rs.tee() returns an array of two ReadableStreams]
@@ -121,10 +121,10 @@
 
 
 [tee.any.sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [tee.any.shadowrealm-in-dedicatedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [tee.any.html]
   [ReadableStream teeing with byte source: rs.tee() returns an array of two ReadableStreams]
@@ -243,13 +243,13 @@
 
 
 [tee.any.serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [tee.https.any.shadowrealm-in-serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [tee.https.any.shadowrealm-in-audioworklet.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/23807
 
 [tee.any.shadowrealm-in-shadowrealm.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563

--- a/tests/wpt/meta/streams/readable-byte-streams/templated.any.js.ini
+++ b/tests/wpt/meta/streams/readable-byte-streams/templated.any.js.ini
@@ -1,26 +1,26 @@
 [templated.https.any.shadowrealm-in-audioworklet.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/23807
 
 [templated.any.shadowrealm-in-dedicatedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [templated.any.sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [templated.any.serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [templated.https.any.shadowrealm-in-serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [templated.any.shadowrealm-in-window.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [templated.any.shadowrealm-in-shadowrealm.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [templated.any.shadowrealm-in-sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [templated.any.worker.html]
   [ReadableStream with byte source (empty): instances have the correct methods and properties]

--- a/tests/wpt/meta/streams/readable-streams/async-iterator.any.js.ini
+++ b/tests/wpt/meta/streams/readable-streams/async-iterator.any.js.ini
@@ -1,8 +1,8 @@
 [async-iterator.any.serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [async-iterator.any.sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [async-iterator.any.html]
   [return() rejects if the stream has errored]
@@ -255,22 +255,22 @@
 
 
 [async-iterator.any.shadowrealm.html]
-  expected: TIMEOUT
+  disabled: https://github.com/servo/servo/issues/36563
 
 [async-iterator.any.shadowrealm-in-dedicatedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [async-iterator.any.shadowrealm-in-window.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [async-iterator.https.any.shadowrealm-in-serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [async-iterator.https.any.shadowrealm-in-audioworklet.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/23807
 
 [async-iterator.any.shadowrealm-in-shadowrealm.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [async-iterator.any.shadowrealm-in-sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458

--- a/tests/wpt/meta/streams/readable-streams/bad-strategies.any.js.ini
+++ b/tests/wpt/meta/streams/readable-streams/bad-strategies.any.js.ini
@@ -1,30 +1,26 @@
 [bad-strategies.any.sharedworker.html]
-  expected: ERROR
-
-[bad-strategies.any.worker.html]
-
-[bad-strategies.any.html]
+  disabled: https://github.com/servo/servo/issues/7458
 
 [bad-strategies.any.serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [bad-strategies.any.shadowrealm.html]
-  expected: TIMEOUT
+  disabled: https://github.com/servo/servo/issues/36563
 
 [bad-strategies.any.shadowrealm-in-sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [bad-strategies.https.any.shadowrealm-in-serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [bad-strategies.any.shadowrealm-in-window.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [bad-strategies.any.shadowrealm-in-shadowrealm.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [bad-strategies.https.any.shadowrealm-in-audioworklet.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/23807
 
 [bad-strategies.any.shadowrealm-in-dedicatedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563

--- a/tests/wpt/meta/streams/readable-streams/bad-underlying-sources.any.js.ini
+++ b/tests/wpt/meta/streams/readable-streams/bad-underlying-sources.any.js.ini
@@ -1,30 +1,26 @@
-[bad-underlying-sources.any.html]
-
 [bad-underlying-sources.any.sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [bad-underlying-sources.any.serviceworker.html]
-  expected: ERROR
-
-[bad-underlying-sources.any.worker.html]
+  disabled: https://github.com/servo/servo/issues/36538
 
 [bad-underlying-sources.any.shadowrealm.html]
-  expected: TIMEOUT
+  disabled: https://github.com/servo/servo/issues/36563
 
 [bad-underlying-sources.any.shadowrealm-in-shadowrealm.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [bad-underlying-sources.https.any.shadowrealm-in-serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [bad-underlying-sources.any.shadowrealm-in-dedicatedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [bad-underlying-sources.https.any.shadowrealm-in-audioworklet.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/23807
 
 [bad-underlying-sources.any.shadowrealm-in-window.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [bad-underlying-sources.any.shadowrealm-in-sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458

--- a/tests/wpt/meta/streams/readable-streams/cancel.any.js.ini
+++ b/tests/wpt/meta/streams/readable-streams/cancel.any.js.ini
@@ -1,30 +1,26 @@
 [cancel.any.serviceworker.html]
-  expected: ERROR
-
-[cancel.any.html]
-
-[cancel.any.worker.html]
+  disabled: https://github.com/servo/servo/issues/36538
 
 [cancel.any.sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [cancel.any.shadowrealm.html]
-  expected: TIMEOUT
+  disabled: https://github.com/servo/servo/issues/36563
 
 [cancel.any.shadowrealm-in-sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [cancel.any.shadowrealm-in-dedicatedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [cancel.any.shadowrealm-in-window.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [cancel.any.shadowrealm-in-shadowrealm.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [cancel.https.any.shadowrealm-in-serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [cancel.https.any.shadowrealm-in-audioworklet.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/23807

--- a/tests/wpt/meta/streams/readable-streams/constructor.any.js.ini
+++ b/tests/wpt/meta/streams/readable-streams/constructor.any.js.ini
@@ -1,30 +1,26 @@
 [constructor.any.sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [constructor.any.serviceworker.html]
-  expected: ERROR
-
-[constructor.any.worker.html]
-
-[constructor.any.html]
+  disabled: https://github.com/servo/servo/issues/36538
 
 [constructor.any.shadowrealm.html]
-  expected: TIMEOUT
+  disabled: https://github.com/servo/servo/issues/36563
 
 [constructor.any.shadowrealm-in-dedicatedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [constructor.https.any.shadowrealm-in-serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [constructor.any.shadowrealm-in-sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [constructor.any.shadowrealm-in-shadowrealm.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [constructor.https.any.shadowrealm-in-audioworklet.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/23807
 
 [constructor.any.shadowrealm-in-window.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563

--- a/tests/wpt/meta/streams/readable-streams/count-queuing-strategy-integration.any.js.ini
+++ b/tests/wpt/meta/streams/readable-streams/count-queuing-strategy-integration.any.js.ini
@@ -1,30 +1,26 @@
 [count-queuing-strategy-integration.any.serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [count-queuing-strategy-integration.any.sharedworker.html]
-  expected: ERROR
-
-[count-queuing-strategy-integration.any.worker.html]
-
-[count-queuing-strategy-integration.any.html]
+  disabled: https://github.com/servo/servo/issues/7458
 
 [count-queuing-strategy-integration.any.shadowrealm.html]
-  expected: TIMEOUT
+  disabled: https://github.com/servo/servo/issues/36563
 
 [count-queuing-strategy-integration.any.shadowrealm-in-dedicatedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [count-queuing-strategy-integration.https.any.shadowrealm-in-serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [count-queuing-strategy-integration.https.any.shadowrealm-in-audioworklet.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/23807
 
 [count-queuing-strategy-integration.any.shadowrealm-in-sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [count-queuing-strategy-integration.any.shadowrealm-in-shadowrealm.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [count-queuing-strategy-integration.any.shadowrealm-in-window.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563

--- a/tests/wpt/meta/streams/readable-streams/default-reader.any.js.ini
+++ b/tests/wpt/meta/streams/readable-streams/default-reader.any.js.ini
@@ -1,26 +1,26 @@
 [default-reader.any.sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [default-reader.any.serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [default-reader.any.shadowrealm.html]
-  expected: TIMEOUT
+  disabled: https://github.com/servo/servo/issues/36563
 
 [default-reader.https.any.shadowrealm-in-audioworklet.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/23807
 
 [default-reader.any.shadowrealm-in-shadowrealm.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [default-reader.any.shadowrealm-in-sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [default-reader.any.shadowrealm-in-window.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [default-reader.https.any.shadowrealm-in-serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [default-reader.any.shadowrealm-in-dedicatedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563

--- a/tests/wpt/meta/streams/readable-streams/floating-point-total-queue-size.any.js.ini
+++ b/tests/wpt/meta/streams/readable-streams/floating-point-total-queue-size.any.js.ini
@@ -1,30 +1,26 @@
-[floating-point-total-queue-size.any.html]
-
 [floating-point-total-queue-size.any.serviceworker.html]
-  expected: ERROR
-
-[floating-point-total-queue-size.any.worker.html]
+  disabled: https://github.com/servo/servo/issues/36538
 
 [floating-point-total-queue-size.any.sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [floating-point-total-queue-size.any.shadowrealm.html]
-  expected: TIMEOUT
+  disabled: https://github.com/servo/servo/issues/36563
 
 [floating-point-total-queue-size.any.shadowrealm-in-shadowrealm.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [floating-point-total-queue-size.https.any.shadowrealm-in-audioworklet.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/23807
 
 [floating-point-total-queue-size.any.shadowrealm-in-sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [floating-point-total-queue-size.https.any.shadowrealm-in-serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [floating-point-total-queue-size.any.shadowrealm-in-dedicatedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [floating-point-total-queue-size.any.shadowrealm-in-window.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563

--- a/tests/wpt/meta/streams/readable-streams/from.any.js.ini
+++ b/tests/wpt/meta/streams/readable-streams/from.any.js.ini
@@ -106,10 +106,10 @@
 
 
 [from.any.serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [from.any.sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [from.any.worker.html]
   [ReadableStream.from accepts an array of values]
@@ -219,22 +219,22 @@
 
 
 [from.any.shadowrealm.html]
-  expected: TIMEOUT
+  disabled: https://github.com/servo/servo/issues/36563
 
 [from.any.shadowrealm-in-shadowrealm.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [from.any.shadowrealm-in-sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [from.any.shadowrealm-in-window.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [from.https.any.shadowrealm-in-serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [from.https.any.shadowrealm-in-audioworklet.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/23807
 
 [from.any.shadowrealm-in-dedicatedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563

--- a/tests/wpt/meta/streams/readable-streams/garbage-collection.any.js.ini
+++ b/tests/wpt/meta/streams/readable-streams/garbage-collection.any.js.ini
@@ -1,30 +1,26 @@
 [garbage-collection.any.sharedworker.html]
-  expected: ERROR
-
-[garbage-collection.any.worker.html]
-
-[garbage-collection.any.html]
+  disabled: https://github.com/servo/servo/issues/7458
 
 [garbage-collection.any.serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [garbage-collection.any.shadowrealm.html]
-  expected: TIMEOUT
+  disabled: https://github.com/servo/servo/issues/36563
 
 [garbage-collection.any.shadowrealm-in-shadowrealm.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [garbage-collection.any.shadowrealm-in-sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [garbage-collection.any.shadowrealm-in-window.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [garbage-collection.https.any.shadowrealm-in-serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [garbage-collection.https.any.shadowrealm-in-audioworklet.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/23807
 
 [garbage-collection.any.shadowrealm-in-dedicatedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563

--- a/tests/wpt/meta/streams/readable-streams/general.any.js.ini
+++ b/tests/wpt/meta/streams/readable-streams/general.any.js.ini
@@ -1,26 +1,26 @@
 [general.any.sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [general.any.serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [general.any.shadowrealm.html]
-  expected: TIMEOUT
+  disabled: https://github.com/servo/servo/issues/36563
 
 [general.any.shadowrealm-in-dedicatedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [general.https.any.shadowrealm-in-serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [general.any.shadowrealm-in-sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [general.any.shadowrealm-in-shadowrealm.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [general.https.any.shadowrealm-in-audioworklet.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/23807
 
 [general.any.shadowrealm-in-window.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563

--- a/tests/wpt/meta/streams/readable-streams/owning-type-message-port.any.js.ini
+++ b/tests/wpt/meta/streams/readable-streams/owning-type-message-port.any.js.ini
@@ -1,8 +1,8 @@
 [owning-type-message-port.any.sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [owning-type-message-port.any.serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [owning-type-message-port.any.worker.html]
   [Transferred MessageChannel works as expected]
@@ -21,22 +21,22 @@
 
 
 [owning-type-message-port.any.shadowrealm.html]
-  expected: TIMEOUT
+  disabled: https://github.com/servo/servo/issues/36563
 
 [owning-type-message-port.https.any.shadowrealm-in-serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [owning-type-message-port.any.shadowrealm-in-dedicatedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [owning-type-message-port.any.shadowrealm-in-sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [owning-type-message-port.any.shadowrealm-in-window.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [owning-type-message-port.any.shadowrealm-in-shadowrealm.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [owning-type-message-port.https.any.shadowrealm-in-audioworklet.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/23807

--- a/tests/wpt/meta/streams/readable-streams/owning-type-video-frame.any.js.ini
+++ b/tests/wpt/meta/streams/readable-streams/owning-type-video-frame.any.js.ini
@@ -16,7 +16,7 @@
 
 
 [owning-type-video-frame.any.serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [owning-type-video-frame.any.worker.html]
   [ReadableStream of type owning should close serialized chunks]
@@ -36,7 +36,7 @@
 
 
 [owning-type-video-frame.any.sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [owning-type-video-frame.any.shadowrealm.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563

--- a/tests/wpt/meta/streams/readable-streams/owning-type.any.js.ini
+++ b/tests/wpt/meta/streams/readable-streams/owning-type.any.js.ini
@@ -1,5 +1,5 @@
 [owning-type.any.sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [owning-type.any.html]
   [ReadableStream can be constructed with owning type]
@@ -19,7 +19,7 @@
 
 
 [owning-type.any.serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [owning-type.any.worker.html]
   [ReadableStream can be constructed with owning type]
@@ -39,22 +39,22 @@
 
 
 [owning-type.any.shadowrealm.html]
-  expected: TIMEOUT
+  disabled: https://github.com/servo/servo/issues/36563
 
 [owning-type.https.any.shadowrealm-in-serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [owning-type.any.shadowrealm-in-sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [owning-type.any.shadowrealm-in-dedicatedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [owning-type.https.any.shadowrealm-in-audioworklet.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/23807
 
 [owning-type.any.shadowrealm-in-shadowrealm.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [owning-type.any.shadowrealm-in-window.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563

--- a/tests/wpt/meta/streams/readable-streams/patched-global.any.js.ini
+++ b/tests/wpt/meta/streams/readable-streams/patched-global.any.js.ini
@@ -1,8 +1,8 @@
 [patched-global.any.serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [patched-global.any.sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [patched-global.any.html]
   [ReadableStream async iterator should use the original values of getReader() and ReadableStreamDefaultReader methods]
@@ -15,22 +15,22 @@
 
 
 [patched-global.any.shadowrealm.html]
-  expected: TIMEOUT
+  disabled: https://github.com/servo/servo/issues/36563
 
 [patched-global.any.shadowrealm-in-window.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [patched-global.any.shadowrealm-in-sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [patched-global.https.any.shadowrealm-in-serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [patched-global.any.shadowrealm-in-dedicatedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [patched-global.any.shadowrealm-in-shadowrealm.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [patched-global.https.any.shadowrealm-in-audioworklet.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/23807

--- a/tests/wpt/meta/streams/readable-streams/reentrant-strategies.any.js.ini
+++ b/tests/wpt/meta/streams/readable-streams/reentrant-strategies.any.js.ini
@@ -1,30 +1,26 @@
 [reentrant-strategies.any.sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [reentrant-strategies.any.serviceworker.html]
-  expected: ERROR
-
-[reentrant-strategies.any.html]
-
-[reentrant-strategies.any.worker.html]
+  disabled: https://github.com/servo/servo/issues/36538
 
 [reentrant-strategies.any.shadowrealm.html]
-  expected: TIMEOUT
+  disabled: https://github.com/servo/servo/issues/36563
 
 [reentrant-strategies.https.any.shadowrealm-in-serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [reentrant-strategies.any.shadowrealm-in-dedicatedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [reentrant-strategies.https.any.shadowrealm-in-audioworklet.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/23807
 
 [reentrant-strategies.any.shadowrealm-in-shadowrealm.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [reentrant-strategies.any.shadowrealm-in-sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [reentrant-strategies.any.shadowrealm-in-window.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563

--- a/tests/wpt/meta/streams/readable-streams/tee.any.js.ini
+++ b/tests/wpt/meta/streams/readable-streams/tee.any.js.ini
@@ -1,26 +1,26 @@
 [tee.any.sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [tee.any.serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [tee.any.shadowrealm.html]
-  expected: TIMEOUT
+  disabled: https://github.com/servo/servo/issues/36563
 
 [tee.any.shadowrealm-in-sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [tee.any.shadowrealm-in-dedicatedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [tee.any.shadowrealm-in-shadowrealm.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [tee.any.shadowrealm-in-window.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [tee.https.any.shadowrealm-in-audioworklet.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/23807
 
 [tee.https.any.shadowrealm-in-serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538

--- a/tests/wpt/meta/streams/readable-streams/templated.any.js.ini
+++ b/tests/wpt/meta/streams/readable-streams/templated.any.js.ini
@@ -1,8 +1,8 @@
 [templated.any.sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [templated.any.serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [templated.any.html]
   [ReadableStream (empty): instances have the correct methods and properties]
@@ -13,22 +13,22 @@
     expected: FAIL
 
 [templated.any.shadowrealm.html]
-  expected: TIMEOUT
+  disabled: https://github.com/servo/servo/issues/36563
 
 [templated.any.shadowrealm-in-dedicatedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [templated.any.shadowrealm-in-shadowrealm.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [templated.any.shadowrealm-in-window.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [templated.https.any.shadowrealm-in-serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [templated.https.any.shadowrealm-in-audioworklet.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/23807
 
 [templated.any.shadowrealm-in-sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458

--- a/tests/wpt/meta/streams/transferable/service-worker.https.html.ini
+++ b/tests/wpt/meta/streams/transferable/service-worker.https.html.ini
@@ -1,4 +1,2 @@
 [service-worker.https.html]
-  expected: ERROR
-  [service-worker]
-    expected: NOTRUN
+  disabled: https://github.com/servo/servo/issues/36538

--- a/tests/wpt/meta/streams/transferable/shared-worker.html.ini
+++ b/tests/wpt/meta/streams/transferable/shared-worker.html.ini
@@ -1,6 +1,2 @@
 [shared-worker.html]
-  [worker.postMessage should be able to transfer a ReadableStream]
-    expected: FAIL
-
-  [postMessage in a worker should be able to transfer a ReadableStream]
-    expected: FAIL
+  disabled: https://github.com/servo/servo/issues/7458

--- a/tests/wpt/meta/streams/transferable/transform-stream-members.any.js.ini
+++ b/tests/wpt/meta/streams/transferable/transform-stream-members.any.js.ini
@@ -1,23 +1,23 @@
 [transform-stream-members.any.shadowrealm-in-shadowrealm.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [transform-stream-members.any.shadowrealm-in-sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [transform-stream-members.https.any.shadowrealm-in-audioworklet.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/23807
 
 [transform-stream-members.any.shadowrealm-in-window.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [transform-stream-members.any.html]
   expected: ERROR
 
 [transform-stream-members.https.any.shadowrealm-in-serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [transform-stream-members.any.worker.html]
   expected: ERROR
 
 [transform-stream-members.any.shadowrealm-in-dedicatedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563

--- a/tests/wpt/meta/streams/writable-streams/aborting.any.js.ini
+++ b/tests/wpt/meta/streams/writable-streams/aborting.any.js.ini
@@ -31,7 +31,7 @@
 
 
 [aborting.https.any.shadowrealm-in-serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [aborting.any.worker.html]
   [WritableStreamDefaultController.signal]
@@ -66,22 +66,22 @@
 
 
 [aborting.any.shadowrealm-in-dedicatedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [aborting.https.any.shadowrealm-in-audioworklet.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/23807
 
 [aborting.any.shadowrealm-in-sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [aborting.any.sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [aborting.any.serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [aborting.any.shadowrealm-in-window.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [aborting.any.shadowrealm-in-shadowrealm.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563

--- a/tests/wpt/meta/streams/writable-streams/bad-strategies.any.js.ini
+++ b/tests/wpt/meta/streams/writable-streams/bad-strategies.any.js.ini
@@ -1,25 +1,23 @@
 [bad-strategies.https.any.shadowrealm-in-audioworklet.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/23807
 
 [bad-strategies.any.shadowrealm-in-shadowrealm.html]
-  expected: ERROR
-
-[bad-strategies.any.worker.html]
+  disabled: https://github.com/servo/servo/issues/36563
 
 [bad-strategies.any.shadowrealm-in-window.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [bad-strategies.https.any.shadowrealm-in-serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [bad-strategies.any.sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [bad-strategies.any.shadowrealm-in-dedicatedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [bad-strategies.any.serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [bad-strategies.any.shadowrealm-in-sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458

--- a/tests/wpt/meta/streams/writable-streams/bad-underlying-sinks.any.js.ini
+++ b/tests/wpt/meta/streams/writable-streams/bad-underlying-sinks.any.js.ini
@@ -1,23 +1,23 @@
 [bad-underlying-sinks.any.sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [bad-underlying-sinks.https.any.shadowrealm-in-serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [bad-underlying-sinks.any.shadowrealm-in-shadowrealm.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [bad-underlying-sinks.any.shadowrealm-in-sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [bad-underlying-sinks.any.shadowrealm-in-window.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [bad-underlying-sinks.https.any.shadowrealm-in-audioworklet.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/23807
 
 [bad-underlying-sinks.any.shadowrealm-in-dedicatedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [bad-underlying-sinks.any.serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538

--- a/tests/wpt/meta/streams/writable-streams/byte-length-queuing-strategy.any.js.ini
+++ b/tests/wpt/meta/streams/writable-streams/byte-length-queuing-strategy.any.js.ini
@@ -1,25 +1,23 @@
 [byte-length-queuing-strategy.https.any.shadowrealm-in-serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [byte-length-queuing-strategy.any.shadowrealm-in-window.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [byte-length-queuing-strategy.any.shadowrealm-in-dedicatedworker.html]
-  expected: ERROR
-
-[byte-length-queuing-strategy.any.html]
+  disabled: https://github.com/servo/servo/issues/36563
 
 [byte-length-queuing-strategy.any.shadowrealm-in-shadowrealm.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [byte-length-queuing-strategy.any.shadowrealm-in-sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [byte-length-queuing-strategy.any.serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [byte-length-queuing-strategy.https.any.shadowrealm-in-audioworklet.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/23807
 
 [byte-length-queuing-strategy.any.sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458

--- a/tests/wpt/meta/streams/writable-streams/close.any.js.ini
+++ b/tests/wpt/meta/streams/writable-streams/close.any.js.ini
@@ -1,26 +1,26 @@
 [close.any.serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [close.https.any.shadowrealm-in-serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [close.any.sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [close.any.shadowrealm-in-sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [close.any.shadowrealm-in-window.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [close.https.any.shadowrealm-in-audioworklet.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/23807
 
 [close.any.shadowrealm-in-dedicatedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [close.any.shadowrealm-in-shadowrealm.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [close.any.worker.html]
   expected: CRASH

--- a/tests/wpt/meta/streams/writable-streams/constructor.any.js.ini
+++ b/tests/wpt/meta/streams/writable-streams/constructor.any.js.ini
@@ -1,23 +1,23 @@
 [constructor.any.shadowrealm-in-sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [constructor.https.any.shadowrealm-in-serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [constructor.any.shadowrealm-in-shadowrealm.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [constructor.any.serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [constructor.any.sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [constructor.https.any.shadowrealm-in-audioworklet.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/23807
 
 [constructor.any.shadowrealm-in-window.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [constructor.any.shadowrealm-in-dedicatedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563

--- a/tests/wpt/meta/streams/writable-streams/count-queuing-strategy.any.js.ini
+++ b/tests/wpt/meta/streams/writable-streams/count-queuing-strategy.any.js.ini
@@ -1,25 +1,23 @@
 [count-queuing-strategy.https.any.shadowrealm-in-audioworklet.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/23807
 
 [count-queuing-strategy.any.shadowrealm-in-sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [count-queuing-strategy.any.shadowrealm-in-window.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [count-queuing-strategy.https.any.shadowrealm-in-serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [count-queuing-strategy.any.sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [count-queuing-strategy.any.serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [count-queuing-strategy.any.shadowrealm-in-dedicatedworker.html]
-  expected: ERROR
-
-[count-queuing-strategy.any.worker.html]
+  disabled: https://github.com/servo/servo/issues/36563
 
 [count-queuing-strategy.any.shadowrealm-in-shadowrealm.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563

--- a/tests/wpt/meta/streams/writable-streams/error.any.js.ini
+++ b/tests/wpt/meta/streams/writable-streams/error.any.js.ini
@@ -1,23 +1,23 @@
 [error.any.shadowrealm-in-sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [error.https.any.shadowrealm-in-audioworklet.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/23807
 
 [error.any.shadowrealm-in-dedicatedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [error.any.serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [error.any.shadowrealm-in-shadowrealm.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [error.any.shadowrealm-in-window.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [error.https.any.shadowrealm-in-serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [error.any.sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458

--- a/tests/wpt/meta/streams/writable-streams/floating-point-total-queue-size.any.js.ini
+++ b/tests/wpt/meta/streams/writable-streams/floating-point-total-queue-size.any.js.ini
@@ -1,23 +1,23 @@
 [floating-point-total-queue-size.any.shadowrealm-in-shadowrealm.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [floating-point-total-queue-size.https.any.shadowrealm-in-serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [floating-point-total-queue-size.any.serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [floating-point-total-queue-size.any.shadowrealm-in-dedicatedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [floating-point-total-queue-size.any.sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [floating-point-total-queue-size.any.shadowrealm-in-window.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [floating-point-total-queue-size.https.any.shadowrealm-in-audioworklet.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/23807
 
 [floating-point-total-queue-size.any.shadowrealm-in-sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458

--- a/tests/wpt/meta/streams/writable-streams/garbage-collection.any.js.ini
+++ b/tests/wpt/meta/streams/writable-streams/garbage-collection.any.js.ini
@@ -1,23 +1,23 @@
 [garbage-collection.https.any.shadowrealm-in-audioworklet.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/23807
 
 [garbage-collection.any.sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [garbage-collection.any.shadowrealm-in-dedicatedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [garbage-collection.https.any.shadowrealm-in-serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [garbage-collection.any.serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [garbage-collection.any.shadowrealm-in-shadowrealm.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [garbage-collection.any.shadowrealm-in-window.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [garbage-collection.any.shadowrealm-in-sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458

--- a/tests/wpt/meta/streams/writable-streams/general.any.js.ini
+++ b/tests/wpt/meta/streams/writable-streams/general.any.js.ini
@@ -1,27 +1,24 @@
 [general.https.any.shadowrealm-in-serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [general.any.shadowrealm-in-dedicatedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [general.any.shadowrealm-in-shadowrealm.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [general.any.shadowrealm-in-window.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [general.any.serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [general.https.any.shadowrealm-in-audioworklet.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/23807
 
 [general.any.shadowrealm-in-sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [general.any.sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
-[general.any.html]
-
-[general.any.worker.html]

--- a/tests/wpt/meta/streams/writable-streams/properties.any.js.ini
+++ b/tests/wpt/meta/streams/writable-streams/properties.any.js.ini
@@ -1,23 +1,23 @@
 [properties.any.serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [properties.https.any.shadowrealm-in-serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [properties.any.sharedworker.html]
-  expected: ERROR
+ disabled: https://github.com/servo/servo/issues/7458
 
 [properties.any.shadowrealm-in-window.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [properties.https.any.shadowrealm-in-audioworklet.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/23807
 
 [properties.any.shadowrealm-in-shadowrealm.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [properties.any.shadowrealm-in-dedicatedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [properties.any.shadowrealm-in-sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458

--- a/tests/wpt/meta/streams/writable-streams/reentrant-strategy.any.js.ini
+++ b/tests/wpt/meta/streams/writable-streams/reentrant-strategy.any.js.ini
@@ -1,23 +1,23 @@
 [reentrant-strategy.any.serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [reentrant-strategy.any.shadowrealm-in-sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [reentrant-strategy.any.shadowrealm-in-window.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [reentrant-strategy.any.shadowrealm-in-dedicatedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [reentrant-strategy.any.shadowrealm-in-shadowrealm.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [reentrant-strategy.https.any.shadowrealm-in-audioworklet.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/23807
 
 [reentrant-strategy.https.any.shadowrealm-in-serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [reentrant-strategy.any.sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458

--- a/tests/wpt/meta/streams/writable-streams/start.any.js.ini
+++ b/tests/wpt/meta/streams/writable-streams/start.any.js.ini
@@ -1,23 +1,23 @@
 [start.https.any.shadowrealm-in-audioworklet.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/23807
 
 [start.any.serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [start.https.any.shadowrealm-in-serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [start.any.shadowrealm-in-shadowrealm.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [start.any.sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [start.any.shadowrealm-in-sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [start.any.shadowrealm-in-dedicatedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [start.any.shadowrealm-in-window.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563

--- a/tests/wpt/meta/streams/writable-streams/write.any.js.ini
+++ b/tests/wpt/meta/streams/writable-streams/write.any.js.ini
@@ -1,23 +1,23 @@
 [write.https.any.shadowrealm-in-serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [write.any.shadowrealm-in-window.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [write.any.shadowrealm-in-sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [write.https.any.shadowrealm-in-audioworklet.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/23807
 
 [write.any.serviceworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36538
 
 [write.any.shadowrealm-in-shadowrealm.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563
 
 [write.any.sharedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/7458
 
 [write.any.shadowrealm-in-dedicatedworker.html]
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/36563


### PR DESCRIPTION
This skips the parts of the test suite involving:

- ~~Async iteration(https://github.com/servo/servo/issues/36536)~~ I'll keep this one as is, since does reflect the status of the implementation. 
- Service worker(https://github.com/servo/servo/issues/36538)
- Shared worker(https://github.com/servo/servo/issues/7458)
- Audio worklet(https://github.com/servo/servo/issues/23807)
- ShadowRealm https://github.com/servo/servo/issues/36563

The main goal is to show a more representative test score on https://servo.org/wpt/, but it will also remove a source of intermittent test results like https://github.com/servo/servo/issues/36426