### PR TITLE
media element: support seekable attribute

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6600,7 +6600,7 @@ dependencies = [
 [[package]]
 name = "servo-media"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#c7eab1ae326b8b95b938741660553342f7cd94b7"
+source = "git+https://github.com/servo/media#eb96030cdd153ebcbbe3836dc6471303187740e9"
 dependencies = [
  "once_cell",
  "servo-media-audio",
@@ -6613,7 +6613,7 @@ dependencies = [
 [[package]]
 name = "servo-media-audio"
 version = "0.2.0"
-source = "git+https://github.com/servo/media#c7eab1ae326b8b95b938741660553342f7cd94b7"
+source = "git+https://github.com/servo/media#eb96030cdd153ebcbbe3836dc6471303187740e9"
 dependencies = [
  "byte-slice-cast",
  "euclid",
@@ -6634,7 +6634,7 @@ dependencies = [
 [[package]]
 name = "servo-media-derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#c7eab1ae326b8b95b938741660553342f7cd94b7"
+source = "git+https://github.com/servo/media#eb96030cdd153ebcbbe3836dc6471303187740e9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6644,7 +6644,7 @@ dependencies = [
 [[package]]
 name = "servo-media-dummy"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#c7eab1ae326b8b95b938741660553342f7cd94b7"
+source = "git+https://github.com/servo/media#eb96030cdd153ebcbbe3836dc6471303187740e9"
 dependencies = [
  "ipc-channel",
  "servo-media",
@@ -6658,7 +6658,7 @@ dependencies = [
 [[package]]
 name = "servo-media-gstreamer"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#c7eab1ae326b8b95b938741660553342f7cd94b7"
+source = "git+https://github.com/servo/media#eb96030cdd153ebcbbe3836dc6471303187740e9"
 dependencies = [
  "byte-slice-cast",
  "glib",
@@ -6691,7 +6691,7 @@ dependencies = [
 [[package]]
 name = "servo-media-gstreamer-render"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#c7eab1ae326b8b95b938741660553342f7cd94b7"
+source = "git+https://github.com/servo/media#eb96030cdd153ebcbbe3836dc6471303187740e9"
 dependencies = [
  "gstreamer",
  "gstreamer-video",
@@ -6701,7 +6701,7 @@ dependencies = [
 [[package]]
 name = "servo-media-gstreamer-render-android"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#c7eab1ae326b8b95b938741660553342f7cd94b7"
+source = "git+https://github.com/servo/media#eb96030cdd153ebcbbe3836dc6471303187740e9"
 dependencies = [
  "glib",
  "gstreamer",
@@ -6715,7 +6715,7 @@ dependencies = [
 [[package]]
 name = "servo-media-gstreamer-render-unix"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#c7eab1ae326b8b95b938741660553342f7cd94b7"
+source = "git+https://github.com/servo/media#eb96030cdd153ebcbbe3836dc6471303187740e9"
 dependencies = [
  "glib",
  "gstreamer",
@@ -6730,7 +6730,7 @@ dependencies = [
 [[package]]
 name = "servo-media-player"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#c7eab1ae326b8b95b938741660553342f7cd94b7"
+source = "git+https://github.com/servo/media#eb96030cdd153ebcbbe3836dc6471303187740e9"
 dependencies = [
  "ipc-channel",
  "serde",
@@ -6742,7 +6742,7 @@ dependencies = [
 [[package]]
 name = "servo-media-streams"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#c7eab1ae326b8b95b938741660553342f7cd94b7"
+source = "git+https://github.com/servo/media#eb96030cdd153ebcbbe3836dc6471303187740e9"
 dependencies = [
  "uuid",
 ]
@@ -6750,12 +6750,12 @@ dependencies = [
 [[package]]
 name = "servo-media-traits"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#c7eab1ae326b8b95b938741660553342f7cd94b7"
+source = "git+https://github.com/servo/media#eb96030cdd153ebcbbe3836dc6471303187740e9"
 
 [[package]]
 name = "servo-media-webrtc"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#c7eab1ae326b8b95b938741660553342f7cd94b7"
+source = "git+https://github.com/servo/media#eb96030cdd153ebcbbe3836dc6471303187740e9"
 dependencies = [
  "log",
  "servo-media-streams",

--- a/components/script_bindings/webidls/HTMLMediaElement.webidl
+++ b/components/script_bindings/webidls/HTMLMediaElement.webidl
@@ -45,7 +45,7 @@ interface HTMLMediaElement : HTMLElement {
   [Throws] attribute double defaultPlaybackRate;
   [Throws] attribute double playbackRate;
   readonly attribute TimeRanges played;
-  // readonly attribute TimeRanges seekable;
+  readonly attribute TimeRanges seekable;
   readonly attribute boolean ended;
   [CEReactions] attribute boolean autoplay;
   [CEReactions] attribute boolean loop;

--- a/tests/wpt/meta/html/dom/idlharness.https.html.ini
+++ b/tests/wpt/meta/html/dom/idlharness.https.html.ini
@@ -2322,9 +2322,6 @@
   [HTMLSelectElement interface: document.createElement("select") must inherit property "autocomplete" with the proper type]
     expected: FAIL
 
-  [HTMLMediaElement interface: attribute seekable]
-    expected: FAIL
-
   [HTMLTableSectionElement interface: attribute align]
     expected: FAIL
 
@@ -6487,16 +6484,10 @@
   [HTMLMediaElement interface: document.createElement("video") must inherit property "preservesPitch" with the proper type]
     expected: FAIL
 
-  [HTMLMediaElement interface: document.createElement("video") must inherit property "seekable" with the proper type]
-    expected: FAIL
-
   [HTMLMediaElement interface: document.createElement("audio") must inherit property "getStartDate()" with the proper type]
     expected: FAIL
 
   [HTMLMediaElement interface: document.createElement("audio") must inherit property "preservesPitch" with the proper type]
-    expected: FAIL
-
-  [HTMLMediaElement interface: document.createElement("audio") must inherit property "seekable" with the proper type]
     expected: FAIL
 
   [HTMLMediaElement interface: new Audio() must inherit property "getStartDate()" with the proper type]
@@ -6505,16 +6496,10 @@
   [HTMLMediaElement interface: new Audio() must inherit property "preservesPitch" with the proper type]
     expected: FAIL
 
-  [HTMLMediaElement interface: new Audio() must inherit property "seekable" with the proper type]
-    expected: FAIL
-
   [HTMLMediaElement interface: operation getStartDate()]
     expected: FAIL
 
   [HTMLMediaElement interface: attribute preservesPitch]
-    expected: FAIL
-
-  [HTMLMediaElement interface: attribute seekable]
     expected: FAIL
 
   [HTMLMapElement interface: attribute name]

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/seeking/seek-to-currentTime.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/seeking/seek-to-currentTime.html.ini
@@ -1,4 +1,0 @@
-[seek-to-currentTime.html]
-  [seek to currentTime]
-    expected: FAIL
-


### PR DESCRIPTION
support seekable attribute in `htmlmediaelement`, modify `seek` algorithm to use `seekable` attribute.

related [specs](https://html.spec.whatwg.org/multipage/media.html#dom-media-seekable)
Testing: Run WPT Test
Fixes: https://github.com/servo/servo/issues/22297

Will wait for https://github.com/servo/media/pull/435 before turning this to ready for review.
cc @jdm @xiaochengh 