### PR TITLE
compositor: Unify the cross process and in-process API

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -19,11 +19,10 @@ use bitflags::bitflags;
 use compositing_traits::display_list::{CompositorDisplayListInfo, HitTestInfo, ScrollTree};
 use compositing_traits::rendering_context::RenderingContext;
 use compositing_traits::{
-    CompositionPipeline, CompositorMsg, CompositorReceiver, CrossProcessCompositorMessage,
-    ImageUpdate, RendererWebView, SendableFrameTree,
+    CompositionPipeline, CompositorMsg, ImageUpdate, RendererWebView, SendableFrameTree,
 };
 use constellation_traits::{AnimationTickType, EmbedderToConstellationMessage, PaintMetricEvent};
-use crossbeam_channel::Sender;
+use crossbeam_channel::{Receiver, Sender};
 use dpi::PhysicalSize;
 use embedder_traits::{
     AnimationState, CompositorHitTestResult, Cursor, InputEvent, MouseButtonEvent, MouseMoveEvent,
@@ -90,7 +89,7 @@ pub struct ServoRenderer {
     shutdown_state: Rc<Cell<ShutdownState>>,
 
     /// The port on which we receive messages.
-    compositor_receiver: CompositorReceiver,
+    compositor_receiver: Receiver<CompositorMsg>,
 
     /// The channel on which messages can be sent to the constellation.
     pub(crate) constellation_sender: Sender<EmbedderToConstellationMessage>,
@@ -467,8 +466,8 @@ impl IOCompositor {
             .global
             .borrow_mut()
             .compositor_receiver
-            .try_recv_compositor_msg()
-            .is_some()
+            .try_recv()
+            .is_ok()
         {}
 
         // Tell the profiler, memory profiler, and scrolling timer to shut down.
@@ -630,33 +629,14 @@ impl IOCompositor {
                 webview.dispatch_input_event(InputEvent::MouseMove(MouseMoveEvent { point }));
             },
 
-            CompositorMsg::CrossProcess(cross_proces_message) => {
-                self.handle_cross_process_message(cross_proces_message);
-            },
-        }
-    }
-
-    /// Accept messages from content processes that need to be relayed to the WebRender
-    /// instance in the parent process.
-    #[cfg_attr(
-        feature = "tracing",
-        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
-    )]
-    fn handle_cross_process_message(&mut self, msg: CrossProcessCompositorMessage) {
-        match msg {
-            CrossProcessCompositorMessage::SendInitialTransaction(pipeline) => {
+            CompositorMsg::SendInitialTransaction(pipeline) => {
                 let mut txn = Transaction::new();
                 txn.set_display_list(WebRenderEpoch(0), (pipeline, Default::default()));
                 self.generate_frame(&mut txn, RenderReasons::SCENE);
                 self.global.borrow_mut().send_transaction(txn);
             },
 
-            CrossProcessCompositorMessage::SendScrollNode(
-                webview_id,
-                pipeline_id,
-                point,
-                external_scroll_id,
-            ) => {
+            CompositorMsg::SendScrollNode(webview_id, pipeline_id, point, external_scroll_id) => {
                 let Some(webview) = self.webviews.get_mut(webview_id) else {
                     return;
                 };
@@ -690,7 +670,7 @@ impl IOCompositor {
                 self.global.borrow_mut().send_transaction(txn);
             },
 
-            CrossProcessCompositorMessage::SendDisplayList {
+            CompositorMsg::SendDisplayList {
                 webview_id,
                 display_list_descriptor,
                 display_list_receiver,
@@ -779,7 +759,7 @@ impl IOCompositor {
                 self.global.borrow_mut().send_transaction(transaction);
             },
 
-            CrossProcessCompositorMessage::HitTest(pipeline, point, flags, sender) => {
+            CompositorMsg::HitTest(pipeline, point, flags, sender) => {
                 // When a display list is sent to WebRender, it starts scene building in a
                 // separate thread and then that display list is available for hit testing.
                 // Without flushing scene building, any hit test we do might be done against
@@ -805,11 +785,11 @@ impl IOCompositor {
                 let _ = sender.send(result);
             },
 
-            CrossProcessCompositorMessage::GenerateImageKey(sender) => {
+            CompositorMsg::GenerateImageKey(sender) => {
                 let _ = sender.send(self.global.borrow().webrender_api.generate_image_key());
             },
 
-            CrossProcessCompositorMessage::UpdateImages(updates) => {
+            CompositorMsg::UpdateImages(updates) => {
                 let mut txn = Transaction::new();
                 for update in updates {
                     match update {
@@ -825,26 +805,21 @@ impl IOCompositor {
                 self.global.borrow_mut().send_transaction(txn);
             },
 
-            CrossProcessCompositorMessage::AddFont(font_key, data, index) => {
+            CompositorMsg::AddFont(font_key, data, index) => {
                 self.add_font(font_key, index, data);
             },
 
-            CrossProcessCompositorMessage::AddSystemFont(font_key, native_handle) => {
+            CompositorMsg::AddSystemFont(font_key, native_handle) => {
                 let mut transaction = Transaction::new();
                 transaction.add_native_font(font_key, native_handle);
                 self.global.borrow_mut().send_transaction(transaction);
             },
 
-            CrossProcessCompositorMessage::AddFontInstance(
-                font_instance_key,
-                font_key,
-                size,
-                flags,
-            ) => {
+            CompositorMsg::AddFontInstance(font_instance_key, font_key, size, flags) => {
                 self.add_font_instance(font_instance_key, font_key, size, flags);
             },
 
-            CrossProcessCompositorMessage::RemoveFonts(keys, instance_keys) => {
+            CompositorMsg::RemoveFonts(keys, instance_keys) => {
                 let mut transaction = Transaction::new();
 
                 for instance in instance_keys.into_iter() {
@@ -857,13 +832,13 @@ impl IOCompositor {
                 self.global.borrow_mut().send_transaction(transaction);
             },
 
-            CrossProcessCompositorMessage::AddImage(key, desc, data) => {
+            CompositorMsg::AddImage(key, desc, data) => {
                 let mut txn = Transaction::new();
                 txn.add_image(key, desc, data.into(), None);
                 self.global.borrow_mut().send_transaction(txn);
             },
 
-            CrossProcessCompositorMessage::GenerateFontKeys(
+            CompositorMsg::GenerateFontKeys(
                 number_of_font_keys,
                 number_of_font_instance_keys,
                 result_sender,
@@ -881,7 +856,7 @@ impl IOCompositor {
                     .collect();
                 let _ = result_sender.send((font_keys, font_instance_keys));
             },
-            CrossProcessCompositorMessage::GetClientWindowRect(webview_id, response_sender) => {
+            CompositorMsg::GetClientWindowRect(webview_id, response_sender) => {
                 let client_window_rect = self
                     .webviews
                     .get(webview_id)
@@ -891,7 +866,7 @@ impl IOCompositor {
                     warn!("Sending response to get client window failed ({error:?}).");
                 }
             },
-            CrossProcessCompositorMessage::GetScreenSize(webview_id, response_sender) => {
+            CompositorMsg::GetScreenSize(webview_id, response_sender) => {
                 let screen_size = self
                     .webviews
                     .get(webview_id)
@@ -901,7 +876,7 @@ impl IOCompositor {
                     warn!("Sending response to get screen size failed ({error:?}).");
                 }
             },
-            CrossProcessCompositorMessage::GetAvailableScreenSize(webview_id, response_sender) => {
+            CompositorMsg::GetAvailableScreenSize(webview_id, response_sender) => {
                 let available_screen_size = self
                     .webviews
                     .get(webview_id)
@@ -935,16 +910,14 @@ impl IOCompositor {
                 }
                 let _ = sender.send(());
             },
-            CompositorMsg::CrossProcess(CrossProcessCompositorMessage::GenerateImageKey(
-                sender,
-            )) => {
+            CompositorMsg::GenerateImageKey(sender) => {
                 let _ = sender.send(self.global.borrow().webrender_api.generate_image_key());
             },
-            CompositorMsg::CrossProcess(CrossProcessCompositorMessage::GenerateFontKeys(
+            CompositorMsg::GenerateFontKeys(
                 number_of_font_keys,
                 number_of_font_instance_keys,
                 result_sender,
-            )) => {
+            ) => {
                 let font_keys = (0..number_of_font_keys)
                     .map(|_| self.global.borrow().webrender_api.generate_font_key())
                     .collect();
@@ -958,26 +931,17 @@ impl IOCompositor {
                     .collect();
                 let _ = result_sender.send((font_keys, font_instance_keys));
             },
-            CompositorMsg::CrossProcess(CrossProcessCompositorMessage::GetClientWindowRect(
-                _,
-                response_sender,
-            )) => {
+            CompositorMsg::GetClientWindowRect(_, response_sender) => {
                 if let Err(error) = response_sender.send(Default::default()) {
                     warn!("Sending response to get client window failed ({error:?}).");
                 }
             },
-            CompositorMsg::CrossProcess(CrossProcessCompositorMessage::GetScreenSize(
-                _,
-                response_sender,
-            )) => {
+            CompositorMsg::GetScreenSize(_, response_sender) => {
                 if let Err(error) = response_sender.send(Default::default()) {
                     warn!("Sending response to get client window failed ({error:?}).");
                 }
             },
-            CompositorMsg::CrossProcess(CrossProcessCompositorMessage::GetAvailableScreenSize(
-                _,
-                response_sender,
-            )) => {
+            CompositorMsg::GetAvailableScreenSize(_, response_sender) => {
                 if let Err(error) = response_sender.send(Default::default()) {
                     warn!("Sending response to get client window failed ({error:?}).");
                 }
@@ -1600,12 +1564,7 @@ impl IOCompositor {
         // Check for new messages coming from the other threads in the system.
         let mut compositor_messages = vec![];
         let mut found_recomposite_msg = false;
-        while let Some(msg) = self
-            .global
-            .borrow_mut()
-            .compositor_receiver
-            .try_recv_compositor_msg()
-        {
+        while let Ok(msg) = self.global.borrow_mut().compositor_receiver.try_recv() {
             match msg {
                 CompositorMsg::NewWebRenderFrameReady(..) if found_recomposite_msg => {
                     // Only take one of duplicate NewWebRendeFrameReady messages, but do subtract

--- a/components/compositing/lib.rs
+++ b/components/compositing/lib.rs
@@ -8,9 +8,9 @@ use std::cell::Cell;
 use std::rc::Rc;
 
 use compositing_traits::rendering_context::RenderingContext;
-use compositing_traits::{CompositorProxy, CompositorReceiver};
+use compositing_traits::{CompositorMsg, CompositorProxy};
 use constellation_traits::EmbedderToConstellationMessage;
-use crossbeam_channel::Sender;
+use crossbeam_channel::{Receiver, Sender};
 use embedder_traits::ShutdownState;
 use profile_traits::{mem, time};
 use webrender::RenderApi;
@@ -32,7 +32,7 @@ pub struct InitialCompositorState {
     /// A channel to the compositor.
     pub sender: CompositorProxy,
     /// A port on which messages inbound to the compositor can be received.
-    pub receiver: CompositorReceiver,
+    pub receiver: Receiver<CompositorMsg>,
     /// A channel to the constellation.
     pub constellation_chan: Sender<EmbedderToConstellationMessage>,
     /// A channel to the time profiler thread.

--- a/components/compositing/tracing.rs
+++ b/components/compositing/tracing.rs
@@ -42,7 +42,21 @@ mod from_constellation {
                 Self::LoadComplete(..) => target!("LoadComplete"),
                 Self::WebDriverMouseButtonEvent(..) => target!("WebDriverMouseButtonEvent"),
                 Self::WebDriverMouseMoveEvent(..) => target!("WebDriverMouseMoveEvent"),
-                Self::CrossProcess(_) => target!("CrossProcess"),
+                Self::SendInitialTransaction(..) => target!("SendInitialTransaction"),
+                Self::SendScrollNode(..) => target!("SendScrollNode"),
+                Self::SendDisplayList { .. } => target!("SendDisplayList"),
+                Self::HitTest(..) => target!("HitTest"),
+                Self::GenerateImageKey(..) => target!("GenerateImageKey"),
+                Self::AddImage(..) => target!("AddImage"),
+                Self::UpdateImages(..) => target!("UpdateImages"),
+                Self::GenerateFontKeys(..) => target!("GenerateFontKeys"),
+                Self::AddFont(..) => target!("AddFont"),
+                Self::AddSystemFont(..) => target!("AddSystemFont"),
+                Self::AddFontInstance(..) => target!("AddFontInstance"),
+                Self::RemoveFonts(..) => target!("RemoveFonts"),
+                Self::GetClientWindowRect(..) => target!("GetClientWindowRect"),
+                Self::GetScreenSize(..) => target!("GetScreenSize"),
+                Self::GetAvailableScreenSize(..) => target!("GetAvailableScreenSize"),
             }
         }
     }

--- a/components/script/dom/screen.rs
+++ b/components/script/dom/screen.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use compositing_traits::CrossProcessCompositorMessage;
+use compositing_traits::CompositorMsg;
 use dom_struct::dom_struct;
 use euclid::Size2D;
 use profile_traits::ipc;
@@ -41,7 +41,7 @@ impl Screen {
         self.window
             .compositor_api()
             .sender()
-            .send(CrossProcessCompositorMessage::GetScreenSize(
+            .send(CompositorMsg::GetScreenSize(
                 self.window.webview_id(),
                 sender,
             ))
@@ -57,7 +57,7 @@ impl Screen {
         self.window
             .compositor_api()
             .sender()
-            .send(CrossProcessCompositorMessage::GetAvailableScreenSize(
+            .send(CompositorMsg::GetAvailableScreenSize(
                 self.window.webview_id(),
                 sender,
             ))

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1884,10 +1884,7 @@ impl Window {
         let (sender, receiver) =
             ProfiledIpc::channel::<DeviceIndependentIntRect>(timer_profile_chan).unwrap();
         let _ = self.compositor_api.sender().send(
-            compositing_traits::CrossProcessCompositorMessage::GetClientWindowRect(
-                self.webview_id(),
-                sender,
-            ),
+            compositing_traits::CompositorMsg::GetClientWindowRect(self.webview_id(), sender),
         );
         let rect = receiver.recv().unwrap_or_default();
         (

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -48,8 +48,8 @@ pub use compositing_traits::rendering_context::{
     OffscreenRenderingContext, RenderingContext, SoftwareRenderingContext, WindowRenderingContext,
 };
 use compositing_traits::{
-    CompositorMsg, CompositorProxy, CompositorReceiver, CrossProcessCompositorApi,
-    WebrenderExternalImageHandlers, WebrenderExternalImageRegistry, WebrenderImageHandlerType,
+    CompositorMsg, CompositorProxy, CrossProcessCompositorApi, WebrenderExternalImageHandlers,
+    WebrenderExternalImageRegistry, WebrenderImageHandlerType,
 };
 #[cfg(all(
     not(target_os = "windows"),
@@ -992,7 +992,7 @@ fn create_embedder_channel(
 
 fn create_compositor_channel(
     event_loop_waker: Box<dyn EventLoopWaker>,
-) -> (CompositorProxy, CompositorReceiver) {
+) -> (CompositorProxy, Receiver<CompositorMsg>) {
     let (sender, receiver) = unbounded();
 
     let (compositor_ipc_sender, compositor_ipc_receiver) =
@@ -1009,13 +1009,11 @@ fn create_compositor_channel(
     ROUTER.add_typed_route(
         compositor_ipc_receiver,
         Box::new(move |message| {
-            compositor_proxy_clone.send(CompositorMsg::CrossProcess(
-                message.expect("Could not convert Compositor message"),
-            ));
+            compositor_proxy_clone.send(message.expect("Could not convert Compositor message"));
         }),
     );
 
-    (compositor_proxy, CompositorReceiver { receiver })
+    (compositor_proxy, receiver)
 }
 
 #[allow(clippy::too_many_arguments)]


### PR DESCRIPTION
Because there used to be two traits exposing messages to the compositor,
there were two kinds of messages that could be sent:

1. In-process messages from the `Constellation`
2. Cross-process messages from other parts of Servo

Now these two types of messages can be unified into one type.

This is a reland of #36443, which caused regressions due to the fact
that messages to the compositor were no longer triggering the event loop
waker. This version of the PR splits out just the bits that unify the
two APIs, leaving the cleanup of routes in the constellation for another
PR.

Testing: This is covered by existing WPT tests.

