### PR TITLE
Fix git failure on macos

### DIFF
--- a/ports/servoshell/build.rs
+++ b/ports/servoshell/build.rs
@@ -11,6 +11,9 @@ use std::process::Command;
 fn git_sha() -> Result<String, String> {
     let output = Command::new("git")
         .args(["rev-parse", "--short", "HEAD"])
+        // on macos mach sets DYLD_LIBRARY_PATH since it is needed for unit-tests, but it
+        // causes git to fail, so we remove it for the git invocation.
+        .env_remove("DYLD_LIBRARY_PATH")
         .output()
         .map_err(|e| e.to_string())?;
     if output.status.success() {


### PR DESCRIPTION
Fixes the following warning:
```

warning: servoshell@0.0.1: Could not generate git version information: "dyld[59398]: Symbol not found: _libintl_setlocale\n  Referenced from: <CB4FE7B2-A5DC-34F0-8247-A96F45D664E8> /opt/homebrew/Cellar/git/2.48.1/bin/git\n  Expected in:     <0DA2D46D-7A17-3860-809D-71FD05B785FA> /Library/Frameworks/GStreamer.framework/Versions/1.0/lib/libintl.8.dylib\n"
```

This was discussed in https://github.com/servo/servo/issues/36435#issuecomment-2794224073.

mach sets DYLD_LIBRARY_PATH, which is currently necessary for our unit tests, but causes git to fail in the build script. Simply unsetting the environment variable before invoking git works around this problem.

Testing: Tested manually on macos and verified the warning does not occur anymore.
