### PR TITLE
canvas: Add "EnforceRange" attribute to CanvasImageData interface

### DIFF
--- a/components/script_bindings/webidls/CanvasRenderingContext2D.webidl
+++ b/components/script_bindings/webidls/CanvasRenderingContext2D.webidl
@@ -165,16 +165,16 @@ interface mixin CanvasDrawImage {
 interface mixin CanvasImageData {
   // pixel manipulation
   [Throws]
-  ImageData createImageData(long sw, long sh);
+  ImageData createImageData([EnforceRange] long sw, [EnforceRange] long sh);
   [Throws]
   ImageData createImageData(ImageData imagedata);
   [Throws]
-  ImageData getImageData(long sx, long sy, long sw, long sh);
-  undefined putImageData(ImageData imagedata, long dx, long dy);
-  undefined putImageData(ImageData imagedata,
-                    long dx, long dy,
-                    long dirtyX, long dirtyY,
-                    long dirtyWidth, long dirtyHeight);
+  ImageData getImageData([EnforceRange] long sx, [EnforceRange] long sy,
+                         [EnforceRange] long sw, [EnforceRange] long sh);
+  undefined putImageData(ImageData imagedata, [EnforceRange] long dx, [EnforceRange] long dy);
+  undefined putImageData(ImageData imagedata, [EnforceRange] long dx, [EnforceRange] long dy,
+                         [EnforceRange] long dirtyX, [EnforceRange] long dirtyY,
+                         [EnforceRange] long dirtyWidth, [EnforceRange] long dirtyHeight);
 };
 
 enum CanvasLineCap { "butt", "round", "square" };

--- a/tests/wpt/meta/html/canvas/element/pixel-manipulation/2d.imageData.create2.nonfinite.html.ini
+++ b/tests/wpt/meta/html/canvas/element/pixel-manipulation/2d.imageData.create2.nonfinite.html.ini
@@ -1,4 +1,0 @@
-[2d.imageData.create2.nonfinite.html]
-  [createImageData() throws TypeError if arguments are not finite]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/element/pixel-manipulation/2d.imageData.get.large.crash.html.ini
+++ b/tests/wpt/meta/html/canvas/element/pixel-manipulation/2d.imageData.get.large.crash.html.ini
@@ -1,3 +1,0 @@
-[2d.imageData.get.large.crash.html]
-  [Test that canvas crash when image data cannot be allocated.]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/pixel-manipulation/2d.imageData.get.nonfinite.html.ini
+++ b/tests/wpt/meta/html/canvas/element/pixel-manipulation/2d.imageData.get.nonfinite.html.ini
@@ -1,4 +1,0 @@
-[2d.imageData.get.nonfinite.html]
-  [getImageData() throws TypeError if arguments are not finite]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/element/pixel-manipulation/2d.imageData.put.nonfinite.html.ini
+++ b/tests/wpt/meta/html/canvas/element/pixel-manipulation/2d.imageData.put.nonfinite.html.ini
@@ -1,4 +1,0 @@
-[2d.imageData.put.nonfinite.html]
-  [putImageData() throws TypeError if arguments are not finite]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/pixel-manipulation/2d.imageData.create2.nonfinite.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/pixel-manipulation/2d.imageData.create2.nonfinite.html.ini
@@ -1,4 +1,0 @@
-[2d.imageData.create2.nonfinite.html]
-  [createImageData() throws TypeError if arguments are not finite]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/pixel-manipulation/2d.imageData.create2.nonfinite.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/pixel-manipulation/2d.imageData.create2.nonfinite.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.imageData.create2.nonfinite.worker.html]
-  [createImageData() throws TypeError if arguments are not finite]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/pixel-manipulation/2d.imageData.get.large.crash.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/pixel-manipulation/2d.imageData.get.large.crash.html.ini
@@ -1,3 +1,0 @@
-[2d.imageData.get.large.crash.html]
-  [Test that canvas crash when image data cannot be allocated.]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/pixel-manipulation/2d.imageData.get.large.crash.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/pixel-manipulation/2d.imageData.get.large.crash.worker.js.ini
@@ -1,3 +1,0 @@
-[2d.imageData.get.large.crash.worker.html]
-  [Test that canvas crash when image data cannot be allocated.]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/pixel-manipulation/2d.imageData.get.nonfinite.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/pixel-manipulation/2d.imageData.get.nonfinite.html.ini
@@ -1,4 +1,0 @@
-[2d.imageData.get.nonfinite.html]
-  [getImageData() throws TypeError if arguments are not finite]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/pixel-manipulation/2d.imageData.get.nonfinite.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/pixel-manipulation/2d.imageData.get.nonfinite.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.imageData.get.nonfinite.worker.html]
-  [getImageData() throws TypeError if arguments are not finite]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/pixel-manipulation/2d.imageData.put.nonfinite.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/pixel-manipulation/2d.imageData.put.nonfinite.html.ini
@@ -1,4 +1,0 @@
-[2d.imageData.put.nonfinite.html]
-  [putImageData() throws TypeError if arguments are not finite]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/pixel-manipulation/2d.imageData.put.nonfinite.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/pixel-manipulation/2d.imageData.put.nonfinite.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.imageData.put.nonfinite.worker.html]
-  [putImageData() throws TypeError if arguments are not finite]
-    expected: FAIL
-


### PR DESCRIPTION
Add missing "EnforceRange" attribute to interface methods https://html.spec.whatwg.org/multipage/canvas.html#canvasimagedata

--
- [x] ./mach build -d does not report any errors
- [x] ./mach test-tidy does not report any errors
- [x] There are tests for these changes
tests/wpt/tests/html/canvas/element/pixel-manipulation/2d.imageData*
tests/wpt/tests/html/canvas/offscreen/pixel-manipulation/2d.imageData*
