### PR TITLE
compositing: Remove `compositing_traits::MouseWindowEvent`

### DIFF
--- a/components/compositing/windowing.rs
+++ b/components/compositing/windowing.rs
@@ -4,16 +4,8 @@
 
 //! Abstract windowing methods. The concrete implementations of these can be found in `platform/`.
 
-use embedder_traits::{EventLoopWaker, MouseButton};
+use embedder_traits::EventLoopWaker;
 use net::protocols::ProtocolRegistry;
-use webrender_api::units::DevicePoint;
-
-#[derive(Clone)]
-pub enum MouseWindowEvent {
-    Click(MouseButton, DevicePoint),
-    MouseDown(MouseButton, DevicePoint),
-    MouseUp(MouseButton, DevicePoint),
-}
 
 /// Various debug and profiling flags that WebRender supports.
 #[derive(Clone)]


### PR DESCRIPTION
This data structure is unused.

Testing: No tests as this just removes dead code.
Signed-off-by: Martin Robinson <mrobinson@igalia.com>

