### PR TITLE
net: Report memory usage for image cache.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4899,6 +4899,7 @@ dependencies = [
  "num-traits",
  "percent-encoding",
  "pixels",
+ "profile_traits",
  "rustls-pki-types",
  "serde",
  "servo_arc",

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2426,10 +2426,13 @@ impl ScriptThread {
         let documents = self.documents.borrow();
         let urls = itertools::join(documents.iter().map(|(_, d)| d.url().to_string()), ", ");
 
-        let mut reports = self.get_cx().get_reports(format!("url({})", urls));
+        let prefix = format!("url({urls})");
+        let mut reports = self.get_cx().get_reports(prefix.clone());
         for (_, document) in documents.iter() {
             document.window().layout().collect_reports(&mut reports);
         }
+
+        reports.push(self.image_cache.memory_report(&prefix));
 
         reports_chan.send(ProcessReports::new(reports));
     }

--- a/components/shared/net/Cargo.toml
+++ b/components/shared/net/Cargo.toml
@@ -32,6 +32,7 @@ mime = { workspace = true }
 num-traits = { workspace = true }
 percent-encoding = { workspace = true }
 pixels = { path = "../../pixels" }
+profile_traits = { path = "../profile" }
 rustls-pki-types = { workspace = true }
 serde = { workspace = true }
 servo_arc = { workspace = true }

--- a/components/shared/net/image_cache.rs
+++ b/components/shared/net/image_cache.rs
@@ -10,6 +10,7 @@ use ipc_channel::ipc::IpcSender;
 use log::debug;
 use malloc_size_of_derive::MallocSizeOf;
 use pixels::{Image, ImageMetadata};
+use profile_traits::mem::Report;
 use serde::{Deserialize, Serialize};
 use servo_url::{ImmutableOrigin, ServoUrl};
 
@@ -36,7 +37,7 @@ pub enum ImageOrMetadataAvailable {
 /// and image, and returned to the specified event loop when the
 /// image load completes. It is typically used to trigger a reflow
 /// and/or repaint.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
 pub struct ImageResponder {
     pipeline_id: PipelineId,
     pub id: PendingImageId,
@@ -73,11 +74,11 @@ impl ImageResponder {
 #[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
 pub enum ImageResponse {
     /// The requested image was loaded.
-    Loaded(#[ignore_malloc_size_of = "Arc"] Arc<Image>, ServoUrl),
+    Loaded(#[conditional_malloc_size_of] Arc<Image>, ServoUrl),
     /// The request image metadata was loaded.
     MetadataLoaded(ImageMetadata),
     /// The requested image failed to load, so a placeholder was loaded instead.
-    PlaceholderLoaded(#[ignore_malloc_size_of = "Arc"] Arc<Image>, ServoUrl),
+    PlaceholderLoaded(#[conditional_malloc_size_of] Arc<Image>, ServoUrl),
     /// Neither the requested image nor the placeholder could be loaded.
     None,
 }
@@ -114,6 +115,8 @@ pub trait ImageCache: Sync + Send {
     fn new(compositor_api: CrossProcessCompositorApi, rippy_data: Vec<u8>) -> Self
     where
         Self: Sized;
+
+    fn memory_report(&self, prefix: &str) -> Report;
 
     /// Definitively check whether there is a cached, fully loaded image available.
     fn get_image(

--- a/components/shared/net/request.rs
+++ b/components/shared/net/request.rs
@@ -130,7 +130,7 @@ pub enum Window {
 }
 
 /// [CORS settings attribute](https://html.spec.whatwg.org/multipage/#attr-crossorigin-anonymous)
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, MallocSizeOf, PartialEq, Serialize)]
 pub enum CorsSettings {
     Anonymous,
     UseCredentials,


### PR DESCRIPTION
These changes add a new report for image cache memory usage for each script thread.

Testing: Looked at the numbers after browsing various stock photo sites that show galleries of images.