### PR TITLE
net: Measure HSTS memory usage.

### DIFF
--- a/components/net/hsts.rs
+++ b/components/net/hsts.rs
@@ -11,13 +11,14 @@ use embedder_traits::resources::{self, Resource};
 use headers::{HeaderMapExt, StrictTransportSecurity};
 use http::HeaderMap;
 use log::{error, info};
+use malloc_size_of_derive::MallocSizeOf;
 use net_traits::IncludeSubdomains;
 use net_traits::pub_domains::reg_suffix;
 use serde::{Deserialize, Serialize};
 use servo_config::pref;
 use servo_url::{Host, ServoUrl};
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
 pub struct HstsEntry {
     pub host: String,
     pub include_subdomains: bool,
@@ -60,7 +61,7 @@ impl HstsEntry {
     }
 }
 
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, MallocSizeOf, Serialize)]
 pub struct HstsList {
     pub entries_map: HashMap<String, Vec<HstsEntry>>,
 }

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -21,7 +21,7 @@ use embedder_traits::EmbedderProxy;
 use hyper_serde::Serde;
 use ipc_channel::ipc::{self, IpcReceiver, IpcReceiverSet, IpcSender};
 use log::{debug, trace, warn};
-use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
+use malloc_size_of::MallocSizeOfOps;
 use net_traits::blob_url_store::parse_blob_url;
 use net_traits::filemanager_thread::FileTokenCheck;
 use net_traits::request::{Destination, RequestBuilder, RequestId};
@@ -32,10 +32,7 @@ use net_traits::{
     FetchChannels, FetchTaskTarget, ResourceFetchTiming, ResourceThreads, ResourceTimingType,
     WebSocketDomAction, WebSocketNetworkEvent,
 };
-use profile_traits::mem::{
-    ProcessReports, ProfilerChan as MemProfilerChan, Report, ReportKind, ReportsChan,
-};
-use profile_traits::path;
+use profile_traits::mem::{ProcessReports, ProfilerChan as MemProfilerChan, ReportsChan};
 use profile_traits::time::ProfilerChan;
 use rustls::RootCertStore;
 use serde::{Deserialize, Serialize};
@@ -257,7 +254,7 @@ impl ResourceChannelManager {
                 // If message is memory report, get the size_of of public and private http caches
                 if id == reporter_id {
                     if let Ok(msg) = data.to() {
-                        self.process_report(msg, &private_http_state, &public_http_state);
+                        self.process_report(msg, &public_http_state, &private_http_state);
                         continue;
                     }
                 } else {
@@ -284,22 +281,9 @@ impl ResourceChannelManager {
         private_http_state: &Arc<HttpState>,
     ) {
         let mut ops = MallocSizeOfOps::new(servo_allocator::usable_size, None, None);
-        let public_cache = public_http_state.http_cache.read().unwrap();
-        let private_cache = private_http_state.http_cache.read().unwrap();
-
-        let public_report = Report {
-            path: path!["memory-cache", "public"],
-            kind: ReportKind::ExplicitJemallocHeapSize,
-            size: public_cache.size_of(&mut ops),
-        };
-
-        let private_report = Report {
-            path: path!["memory-cache", "private"],
-            kind: ReportKind::ExplicitJemallocHeapSize,
-            size: private_cache.size_of(&mut ops),
-        };
-
-        msg.send(ProcessReports::new(vec![public_report, private_report]));
+        let mut reports = public_http_state.memory_reports("public", &mut ops);
+        reports.extend(private_http_state.memory_reports("private", &mut ops));
+        msg.send(ProcessReports::new(reports));
     }
 
     fn cancellation_listener(&self, request_id: RequestId) -> Option<Arc<CancellationListener>> {


### PR DESCRIPTION
Records the memory usage of the HSTS lists in the network thread.

Testing: Verified the presence of the new reports for servo.org.
Fixes: #35059
