### PR TITLE
Devtools: Support worker scripts in `Debugger > Source` panel

### DIFF
--- a/components/devtools/actors/watcher.rs
+++ b/components/devtools/actors/watcher.rs
@@ -57,7 +57,7 @@ impl SessionContext {
             supported_targets: HashMap::from([
                 ("frame", true),
                 ("process", false),
-                ("worker", false),
+                ("worker", true),
                 ("service_worker", false),
                 ("shared_worker", false),
             ]),

--- a/components/devtools/actors/watcher.rs
+++ b/components/devtools/actors/watcher.rs
@@ -227,7 +227,7 @@ impl Actor for WatcherActor {
                 // As per logs we either get targetType as "frame" or "worker"
                 let target_type = msg
                     .get("targetType")
-                    .and_then(|v| v.as_str())
+                    .and_then(Value::as_str)
                     .unwrap_or("frame"); // default to "frame"
 
                 if target_type == "frame" {
@@ -249,6 +249,9 @@ impl Actor for WatcherActor {
                         };
                         let _ = stream.write_json_packet(&worker_msg);
                     }
+                } else {
+                    warn!("Unexpected target_type: {}", target_type);
+                    return Ok(ActorMessageStatus::Ignored);
                 }
 
                 // Messages that contain a `type` field are used to send event callbacks, but they
@@ -296,7 +299,6 @@ impl Actor for WatcherActor {
                             let sources = thread_actor.source_manager.sources();
                             target.resources_available(sources.iter().collect(), "source".into());
 
-                            // handle worker scripts
                             for worker_name in &root.workers {
                                 let worker = registry.find::<WorkerActor>(worker_name);
                                 let thread = registry.find::<ThreadActor>(&worker.thread);

--- a/components/devtools/actors/watcher.rs
+++ b/components/devtools/actors/watcher.rs
@@ -221,7 +221,6 @@ impl Actor for WatcherActor {
         _id: StreamId,
     ) -> Result<ActorMessageStatus, ()> {
         let target = registry.find::<BrowsingContextActor>(&self.browsing_context_actor);
-        println!("target: {:?}", target.name());
         let root = registry.find::<RootActor>("root");
         Ok(match msg_type {
             "watchTargets" => {
@@ -235,7 +234,6 @@ impl Actor for WatcherActor {
                 target.frame_update(stream);
 
                 for worker_name in &root.workers {
-                    println!("worker for loop");
                     let worker = registry.find::<WorkerActor>(worker_name);
                     let worker_msg = WatchTargetsReply {
                         from: self.name(),
@@ -292,11 +290,11 @@ impl Actor for WatcherActor {
 
                             // worker case
                             for worker_name in &root.workers {
-                                println!("worker for loop 1");
                                 let worker = registry.find::<WorkerActor>(worker_name);
                                 let thread = registry.find::<ThreadActor>(&worker.thread);
                                 let sources = thread.sources();
-                                worker.resources_available(sources.iter().collect(), "source".into());
+                                worker
+                                    .resources_available(sources.iter().collect(), "source".into());
                             }
                         },
                         "console-message" | "error-message" => {},

--- a/components/devtools/actors/watcher.rs
+++ b/components/devtools/actors/watcher.rs
@@ -105,6 +105,7 @@ pub enum SessionContextType {
 }
 
 #[derive(Serialize)]
+#[serde(untagged)]
 enum TargetActorMsg {
     BrowsingContext(BrowsingContextActorMsg),
     Worker(WorkerMsg),

--- a/components/devtools/actors/worker.rs
+++ b/components/devtools/actors/worker.rs
@@ -49,8 +49,10 @@ impl WorkerActor {
             url: self.url.to_string(),
             traits: WorkerTraits {
                 is_parent_intercept_enabled: false,
+                supports_top_level_target_flag: false,
             },
             type_: self.type_ as u32,
+            target_type: "worker".to_string(),
         }
     }
 }
@@ -183,6 +185,7 @@ struct ConnectReply {
 #[serde(rename_all = "camelCase")]
 struct WorkerTraits {
     is_parent_intercept_enabled: bool,
+    supports_top_level_target_flag: bool,
 }
 
 #[derive(Serialize)]
@@ -196,4 +199,6 @@ pub(crate) struct WorkerMsg {
     traits: WorkerTraits,
     #[serde(rename = "type")]
     type_: u32,
+    #[serde(rename = "targetType")]
+    target_type: String,
 }

--- a/components/devtools/actors/worker.rs
+++ b/components/devtools/actors/worker.rs
@@ -14,12 +14,11 @@ use serde::Serialize;
 use serde_json::{Map, Value};
 use servo_url::ServoUrl;
 
+use super::browsing_context::ResourceAvailableReply;
 use crate::StreamId;
 use crate::actor::{Actor, ActorMessageStatus, ActorRegistry};
 use crate::protocol::JsonPacketStream;
 use crate::resource::ResourceAvailable;
-
-use super::browsing_context::ResourceAvailableReply;
 
 #[derive(Clone, Copy)]
 #[allow(dead_code)]

--- a/components/devtools/actors/worker.rs
+++ b/components/devtools/actors/worker.rs
@@ -14,11 +14,10 @@ use serde::Serialize;
 use serde_json::{Map, Value};
 use servo_url::ServoUrl;
 
-use super::browsing_context::ResourceAvailableReply;
 use crate::StreamId;
 use crate::actor::{Actor, ActorMessageStatus, ActorRegistry};
 use crate::protocol::JsonPacketStream;
-use crate::resource::ResourceAvailable;
+use crate::resource::{ResourceAvailable, ResourceAvailableReply};
 
 #[derive(Clone, Copy)]
 #[allow(dead_code)]

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -531,20 +531,20 @@ impl DevtoolsInstance {
             };
             worker_actor.resource_available(source, "source".into());
         } else {
-        let browsing_context_id = match self.pipelines.get(&pipeline_id) {
-            Some(id) => id,
-            None => return,
-        };
+            let browsing_context_id = match self.pipelines.get(&pipeline_id) {
+                Some(id) => id,
+                None => return,
+            };
 
-        let actor_name = match self.browsing_contexts.get(browsing_context_id) {
-            Some(name) => name,
-            None => return,
-        };
+            let actor_name = match self.browsing_contexts.get(browsing_context_id) {
+                Some(name) => name,
+                None => return,
+            };
 
-        let thread_actor_name = actors
-            .find::<BrowsingContextActor>(actor_name)
-            .thread
-            .clone();
+            let thread_actor_name = actors
+                .find::<BrowsingContextActor>(actor_name)
+                .thread
+                .clone();
 
         let thread_actor = actors.find_mut::<ThreadActor>(&thread_actor_name);
         thread_actor
@@ -557,10 +557,10 @@ impl DevtoolsInstance {
             is_black_boxed: false,
         };
 
-        // Notify browsing context about the new source
-        let browsing_context = actors.find::<BrowsingContextActor>(actor_name);
-        browsing_context.resource_available(source, "source".into());
-    }
+            // Notify browsing context about the new source
+            let browsing_context = actors.find::<BrowsingContextActor>(actor_name);
+            browsing_context.resource_available(source, "source".into());
+        }
     }
 }
 

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -253,9 +253,8 @@ impl DevtoolsInstance {
                 )) => self.handle_console_message(pipeline_id, worker_id, console_message),
                 DevtoolsControlMsg::FromScript(ScriptToDevtoolsControlMsg::ScriptSourceLoaded(
                     pipeline_id,
-                    worker_id,
                     source_info,
-                )) => self.handle_script_source_info(pipeline_id, worker_id, source_info),
+                )) => self.handle_script_source_info(pipeline_id, source_info),
                 DevtoolsControlMsg::FromScript(ScriptToDevtoolsControlMsg::ReportPageError(
                     pipeline_id,
                     page_error,
@@ -508,15 +507,10 @@ impl DevtoolsInstance {
         }
     }
 
-    fn handle_script_source_info(
-        &mut self,
-        pipeline_id: PipelineId,
-        worker_id: Option<WorkerId>,
-        source_info: SourceInfo,
-    ) {
+    fn handle_script_source_info(&mut self, pipeline_id: PipelineId, source_info: SourceInfo) {
         let mut actors = self.actors.lock().unwrap();
 
-        if let Some(worker_id) = worker_id {
+        if let Some(worker_id) = source_info.worker_id {
             let Some(worker_actor_name) = self.actor_workers.get(&worker_id) else {
                 return;
             };

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -517,9 +517,8 @@ impl DevtoolsInstance {
         let mut actors = self.actors.lock().unwrap();
 
         if let Some(worker_id) = worker_id {
-            let worker_actor_name = match self.actor_workers.get(&worker_id) {
-                Some(name) => name,
-                None => return,
+            let Some(worker_actor_name) = self.actor_workers.get(&worker_id) else {
+                return;
             };
 
             let thread_actor_name = actors.find::<WorkerActor>(worker_actor_name).thread.clone();
@@ -538,14 +537,11 @@ impl DevtoolsInstance {
             let worker_actor = actors.find::<WorkerActor>(worker_actor_name);
             worker_actor.resource_available(source, "source".into());
         } else {
-            let browsing_context_id = match self.pipelines.get(&pipeline_id) {
-                Some(id) => id,
-                None => return,
+            let Some(browsing_context_id) = self.pipelines.get(&pipeline_id) else {
+                return;
             };
-
-            let actor_name = match self.browsing_contexts.get(browsing_context_id) {
-                Some(name) => name,
-                None => return,
+            let Some(actor_name) = self.browsing_contexts.get(browsing_context_id) else {
+                return;
             };
 
             let thread_actor_name = actors

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -525,9 +525,11 @@ impl DevtoolsInstance {
             let thread_actor_name = actors.find::<WorkerActor>(worker_actor_name).thread.clone();
 
             let thread_actor = actors.find_mut::<ThreadActor>(&thread_actor_name);
-            thread_actor.add_source(source_info.url.clone());
+            thread_actor
+                .source_manager
+                .add_source(source_info.url.clone());
 
-            let source = Source {
+            let source = SourceData {
                 actor: thread_actor_name.clone(),
                 url: source_info.url.to_string(),
                 is_black_boxed: false,
@@ -551,16 +553,16 @@ impl DevtoolsInstance {
                 .thread
                 .clone();
 
-        let thread_actor = actors.find_mut::<ThreadActor>(&thread_actor_name);
-        thread_actor
-            .source_manager
-            .add_source(source_info.url.clone());
+            let thread_actor = actors.find_mut::<ThreadActor>(&thread_actor_name);
+            thread_actor
+                .source_manager
+                .add_source(source_info.url.clone());
 
-        let source = SourceData {
-            actor: thread_actor_name.clone(),
-            url: source_info.url.to_string(),
-            is_black_boxed: false,
-        };
+            let source = SourceData {
+                actor: thread_actor_name.clone(),
+                url: source_info.url.to_string(),
+                is_black_boxed: false,
+            };
 
             // Notify browsing context about the new source
             let browsing_context = actors.find::<BrowsingContextActor>(actor_name);

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -527,12 +527,13 @@ impl DevtoolsInstance {
             let thread_actor = actors.find_mut::<ThreadActor>(&thread_actor_name);
             thread_actor.add_source(source_info.url.clone());
 
-            let worker_actor = actors.find::<WorkerActor>(worker_actor_name);
             let source = Source {
                 actor: thread_actor_name.clone(),
                 url: source_info.url.to_string(),
                 is_black_boxed: false,
             };
+
+            let worker_actor = actors.find::<WorkerActor>(worker_actor_name);
             worker_actor.resource_available(source, "source".into());
         } else {
             let browsing_context_id = match self.pipelines.get(&pipeline_id) {

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -508,7 +508,12 @@ impl DevtoolsInstance {
         }
     }
 
-    fn handle_script_source_info(&mut self, pipeline_id: PipelineId, worker_id: Option<WorkerId>, source_info: SourceInfo) {
+    fn handle_script_source_info(
+        &mut self,
+        pipeline_id: PipelineId,
+        worker_id: Option<WorkerId>,
+        source_info: SourceInfo,
+    ) {
         let mut actors = self.actors.lock().unwrap();
 
         if let Some(worker_id) = worker_id {
@@ -522,7 +527,6 @@ impl DevtoolsInstance {
             let thread_actor = actors.find_mut::<ThreadActor>(&thread_actor_name);
             thread_actor.add_source(source_info.url.clone());
 
-            // Also notify the worker actor for compatibility
             let worker_actor = actors.find::<WorkerActor>(worker_actor_name);
             let source = Source {
                 actor: thread_actor_name.clone(),

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -1017,6 +1017,7 @@ impl HTMLScriptElement {
             };
             let _ = chan.send(ScriptToDevtoolsControlMsg::ScriptSourceLoaded(
                 pipeline_id,
+                None,
                 source_info,
             ));
         }

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -1008,16 +1008,15 @@ impl HTMLScriptElement {
             Ok(script) => script,
         };
 
-        // TODO: we need to handle this for worker
         if let Some(chan) = self.global().devtools_chan() {
             let pipeline_id = self.global().pipeline_id();
             let source_info = SourceInfo {
                 url: script.url.clone(),
                 external: script.external,
+                worker_id: None,
             };
             let _ = chan.send(ScriptToDevtoolsControlMsg::ScriptSourceLoaded(
                 pipeline_id,
-                None,
                 source_info,
             ));
         }

--- a/components/script/dom/worker.rs
+++ b/components/script/dom/worker.rs
@@ -217,10 +217,10 @@ impl WorkerMethods<crate::DomTypeHolder> for Worker {
                 let source_info = SourceInfo {
                     url: worker_url.clone(),
                     external: true, // Worker scripts are always external.
+                    worker_id: Some(worker_id),
                 };
                 let _ = chan.send(ScriptToDevtoolsControlMsg::ScriptSourceLoaded(
                     pipeline_id,
-                    Some(worker_id),
                     source_info,
                 ));
             }

--- a/components/script/dom/worker.rs
+++ b/components/script/dom/worker.rs
@@ -8,7 +8,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use constellation_traits::{StructuredSerializedData, WorkerScriptLoadOrigin};
 use crossbeam_channel::{Sender, unbounded};
-use devtools_traits::{DevtoolsPageInfo, ScriptToDevtoolsControlMsg, WorkerId};
+use devtools_traits::{DevtoolsPageInfo, ScriptToDevtoolsControlMsg, SourceInfo, WorkerId};
 use dom_struct::dom_struct;
 use ipc_channel::ipc;
 use js::jsapi::{Heap, JSObject};
@@ -212,6 +212,17 @@ impl WorkerMethods<crate::DomTypeHolder> for Worker {
                     (browsing_context, pipeline_id, Some(worker_id), webview_id),
                     devtools_sender.clone(),
                     page_info,
+                ));
+
+                // send source info to devtools
+                let source_info = SourceInfo {
+                    url: worker_url.clone(),
+                    external: true, // worker scripts are always external
+                };
+                let _ = chan.send(ScriptToDevtoolsControlMsg::ScriptSourceLoaded(
+                    pipeline_id,
+                    Some(worker_id),
+                    source_info,
                 ));
             }
         }

--- a/components/script/dom/worker.rs
+++ b/components/script/dom/worker.rs
@@ -214,10 +214,9 @@ impl WorkerMethods<crate::DomTypeHolder> for Worker {
                     page_info,
                 ));
 
-                // send source info to devtools
                 let source_info = SourceInfo {
                     url: worker_url.clone(),
-                    external: true, // worker scripts are always external
+                    external: true, // Worker scripts are always external.
                 };
                 let _ = chan.send(ScriptToDevtoolsControlMsg::ScriptSourceLoaded(
                     pipeline_id,

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -105,7 +105,7 @@ pub enum ScriptToDevtoolsControlMsg {
     TitleChanged(PipelineId, String),
 
     /// Get source information from script
-    ScriptSourceLoaded(PipelineId, Option<WorkerId>, SourceInfo),
+    ScriptSourceLoaded(PipelineId, SourceInfo),
 }
 
 /// Serialized JS return values
@@ -551,4 +551,5 @@ impl fmt::Display for ShadowRootMode {
 pub struct SourceInfo {
     pub url: ServoUrl,
     pub external: bool,
+    pub worker_id: Option<WorkerId>,
 }

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -105,7 +105,7 @@ pub enum ScriptToDevtoolsControlMsg {
     TitleChanged(PipelineId, String),
 
     /// Get source information from script
-    ScriptSourceLoaded(PipelineId, SourceInfo),
+    ScriptSourceLoaded(PipelineId, Option<WorkerId>, SourceInfo),
 }
 
 /// Serialized JS return values


### PR DESCRIPTION
This patch adds support for listing `worker scripts` in `debugger > source` panel

For example:
```
<!-- test.html -->
<!doctype html><meta charset=utf-8>
<script>
    setTimeout(() => {
        console.log("inline classic");
        new Worker("worker.js");
        
        const blob = new Blob([`console.log("blob worker");`], { type: "text/javascript" });
        const blobURL = URL.createObjectURL(blob);
        new Worker(blobURL);
    }, 2000);
</script>
```

```
// worker.js
console.log("external classic worker");
```

```
./mach run --devtools=6080 http://127.0.0.1:3000/test.html
```
![file1](https://github.com/user-attachments/assets/84dd94b9-95d8-4087-b4bb-ab936fca0023)


Another example:
```
./mach run --devtools=6080 https://charming.daz.cat/ 
```

![blob](https://github.com/user-attachments/assets/a1341ee4-3a1c-4cca-ac04-658675cdcf39)


- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes partially implement #36027
- [x]  These changes require tests, but they are blocked on https://github.com/servo/servo/issues/36325