### PR TITLE
uv: Use native-tls

### DIFF
--- a/uv.toml
+++ b/uv.toml
@@ -1,0 +1,1 @@
+native-tls = true


### PR DESCRIPTION
uv by default uses baked in webpki certificates.
Using the system certificates is preferable for multiple reasons:

- OS updates will automatically update the certificates (including revoking)
- Supports custom certificates installed on the system (corporate networks)

uv does not enable this option by default, because it has a performance overhead on macos.
In our scenarios, with long-running commands, the overhead is basically not measurable.
I've been using the option on my mac for around 1 month now, without noticing any degradation.

See also the previous discussion in https://github.com/servo/book/issues/53 for some background.

Testing: We use `uv` in all our tests
