### PR TITLE
fix writablestream assertion crash when getting chunk size following spec change

### DIFF
--- a/components/script/dom/writablestreamdefaultcontroller.rs
+++ b/components/script/dom/writablestreamdefaultcontroller.rs
@@ -851,13 +851,13 @@ impl WritableStreamDefaultController {
         chunk: SafeHandleValue,
         can_gc: CanGc,
     ) -> f64 {
-        // If controller.[[strategySizeAlgorithm]] is undefined,
+        // If controller.[[strategySizeAlgorithm]] is undefined, then:
         let Some(strategy_size) = self.strategy_size.borrow().clone() else {
-            // Assert: controller.[[stream]].[[state]] is "erroring" or "errored".
+            // Assert: controller.[[stream]].[[state]] is not "writable".
             let Some(stream) = self.stream.get() else {
                 unreachable!("Controller should have a stream");
             };
-            assert!(stream.is_erroring() || stream.is_errored());
+            assert!(!stream.is_writable());
 
             // Return 1.
             return 1.0;

--- a/tests/wpt/meta/streams/writable-streams/close.any.js.ini
+++ b/tests/wpt/meta/streams/writable-streams/close.any.js.ini
@@ -21,9 +21,3 @@
 
 [close.any.shadowrealm-in-shadowrealm.html]
   expected: ERROR
-
-[close.any.worker.html]
-  expected: CRASH
-
-[close.any.html]
-  expected: CRASH


### PR DESCRIPTION
One-line change to align with the new spec and avoid a crash.
fix #36565 