### PR TITLE
layout: Always floor the max-content size by the min-content size

### DIFF
--- a/components/layout_2020/flow/inline/mod.rs
+++ b/components/layout_2020/flow/inline/mod.rs
@@ -2287,14 +2287,8 @@ impl<'layout_data> ContentSizesComputation<'layout_data> {
         }
         self.forced_line_break();
 
-        // We might get a max-content size which is smaller than the min-content size,
-        // due to negative margins. So we need to adjust to avoid problems down the line.
-        // This is being discussed in <https://github.com/w3c/csswg-drafts/issues/12076>.
-        let mut sizes = self.paragraph;
-        sizes.max_content.max_assign(sizes.min_content);
-
         InlineContentSizesResult {
-            sizes,
+            sizes: self.paragraph,
             depends_on_block_constraints: self.depends_on_block_constraints,
         }
     }

--- a/components/layout_2020/layout_box_base.rs
+++ b/components/layout_2020/layout_box_base.rs
@@ -60,7 +60,8 @@ impl LayoutBoxBase {
             // TODO: Should we keep multiple caches for various block sizes?
         }
 
-        let result = layout_box.compute_inline_content_sizes(layout_context, constraint_space);
+        let result =
+            layout_box.compute_inline_content_sizes_with_fixup(layout_context, constraint_space);
         *cache = Some(Box::new((constraint_space.block_size, result)));
         result
     }

--- a/components/layout_2020/sizing.rs
+++ b/components/layout_2020/sizing.rs
@@ -279,4 +279,18 @@ pub(crate) trait ComputeInlineContentSizes {
         layout_context: &LayoutContext,
         constraint_space: &ConstraintSpace,
     ) -> InlineContentSizesResult;
+
+    /// Returns the same result as [`Self::compute_inline_content_sizes()`], but adjusted
+    /// to floor the max-content size by the min-content size.
+    /// This is being discussed in <https://github.com/w3c/csswg-drafts/issues/12076>.
+    fn compute_inline_content_sizes_with_fixup(
+        &self,
+        layout_context: &LayoutContext,
+        constraint_space: &ConstraintSpace,
+    ) -> InlineContentSizesResult {
+        let mut result = self.compute_inline_content_sizes(layout_context, constraint_space);
+        let sizes = &mut result.sizes;
+        sizes.max_content.max_assign(sizes.min_content);
+        result
+    }
 }

--- a/tests/wpt/meta/css/css-flexbox/intrinsic-size/row-wrap-002.tentative.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/intrinsic-size/row-wrap-002.tentative.html.ini
@@ -1,2 +1,0 @@
-[row-wrap-002.tentative.html]
-  expected: FAIL


### PR DESCRIPTION
This is a follow-up to #36518, which only addressed inline formatting contexts. However, flex formatting contexts had the same problem, so it seems safer to address it in general.

Testing: this makes a WPT test pass
Fixes: #36570