### PR TITLE
compositing: Rename `WebView` to `WebViewRenderer`

### DIFF
--- a/components/compositing/lib.rs
+++ b/components/compositing/lib.rs
@@ -23,8 +23,8 @@ mod tracing;
 
 mod compositor;
 mod touch;
-pub mod webview;
 pub mod webview_manager;
+pub mod webview_renderer;
 
 /// Data used to construct a compositor.
 pub struct InitialCompositorState {

--- a/components/compositing/webview_manager.rs
+++ b/components/compositing/webview_manager.rs
@@ -7,7 +7,7 @@ use std::collections::hash_map::{Entry, Values, ValuesMut};
 
 use base::id::WebViewId;
 
-use crate::webview::UnknownWebView;
+use crate::webview_renderer::UnknownWebView;
 
 #[derive(Debug)]
 pub struct WebViewManager<WebView> {
@@ -117,8 +117,8 @@ mod test {
         BrowsingContextId, BrowsingContextIndex, PipelineNamespace, PipelineNamespaceId, WebViewId,
     };
 
-    use crate::webview::UnknownWebView;
     use crate::webview_manager::WebViewManager;
+    use crate::webview_renderer::UnknownWebView;
 
     fn top_level_id(namespace_id: u32, index: u32) -> WebViewId {
         WebViewId(BrowsingContextId {

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 
 use base::id::WebViewId;
 use compositing::IOCompositor;
-use compositing_traits::RendererWebView;
+use compositing_traits::WebViewTrait;
 use constellation_traits::{EmbedderToConstellationMessage, TraversalDirection};
 use dpi::PhysicalSize;
 use embedder_traits::{
@@ -558,7 +558,7 @@ struct ServoRendererWebView {
     weak_handle: Weak<RefCell<WebViewInner>>,
 }
 
-impl RendererWebView for ServoRendererWebView {
+impl WebViewTrait for ServoRendererWebView {
     fn id(&self) -> WebViewId {
         self.id
     }

--- a/components/shared/compositing/lib.rs
+++ b/components/shared/compositing/lib.rs
@@ -541,7 +541,7 @@ impl From<SerializableImageData> for ImageData {
 /// A trait that exposes the embedding layer's `WebView` to the Servo renderer.
 /// This is to prevent a dependency cycle between the renderer and the embedding
 /// layer.
-pub trait RendererWebView {
+pub trait WebViewTrait {
     fn id(&self) -> WebViewId;
     fn screen_geometry(&self) -> Option<ScreenGeometry>;
     fn set_animating(&self, new_value: bool);


### PR DESCRIPTION
There is a `WebView` in libservo (new) and a `WebView` in compositing
(old). Nowadays, the "real" `WebView` is the one in the libservo. The
`WebView` in `compositing` is really about rendering the contents of a
`WebView` from libservo. In addition there is also a trait exposed by
the compositor called `RendererWebView` which is a way for the
compositor to talk to libservo without a circular dependency.

This changes does some renames to make things clearer and so that there
is One Less WebView™:

- `compositing::WebView` -> `compositing::WebViewRenderer` (this is the
  same kind of naming as `ServoRenderer`).
- `compositing::RendererWebView` -> `compositing::WebViewTrait`

Testing: This is just a couple renames so should be covered by existing tests.
