### PR TITLE
Report memory usage for image frames.

### DIFF
--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -688,6 +688,12 @@ impl<T> MallocSizeOf for ipc_channel::ipc::IpcSender<T> {
     }
 }
 
+impl MallocSizeOf for ipc_channel::ipc::IpcSharedMemory {
+    fn size_of(&self, _ops: &mut MallocSizeOfOps) -> usize {
+        self.len()
+    }
+}
+
 impl<T: MallocSizeOf> MallocSizeOf for accountable_refcell::RefCell<T> {
     fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
         self.borrow().size_of(ops)

--- a/components/pixels/lib.rs
+++ b/components/pixels/lib.rs
@@ -123,7 +123,6 @@ pub struct Image {
     pub width: u32,
     pub height: u32,
     pub format: PixelFormat,
-    #[ignore_malloc_size_of = "Defined in webrender_api"]
     pub id: Option<ImageKey>,
     pub cors_status: CorsStatus,
     pub frames: Vec<ImageFrame>,
@@ -132,7 +131,6 @@ pub struct Image {
 #[derive(Clone, Deserialize, MallocSizeOf, Serialize)]
 pub struct ImageFrame {
     pub delay: Option<Duration>,
-    #[ignore_malloc_size_of = "Defined in ipc-channel"]
     pub bytes: IpcSharedMemory,
     pub width: u32,
     pub height: u32,


### PR DESCRIPTION
These changes make the image-cache memory reporter report much larger values after loading image-heavy pages.

Testing: Manual testing on https://www.nist.gov/image-gallery
Fixes: #36559 
