### PR TITLE
layout: Store `Fragment` results in `LayoutBoxBase` and start using them for queries

### DIFF
--- a/components/layout_2020/flexbox/mod.rs
+++ b/components/layout_2020/flexbox/mod.rs
@@ -19,7 +19,7 @@ use crate::context::LayoutContext;
 use crate::dom::{LayoutBox, NodeExt};
 use crate::dom_traversal::{NodeAndStyleInfo, NonReplacedContents};
 use crate::formatting_contexts::IndependentFormattingContext;
-use crate::fragment_tree::BaseFragmentInfo;
+use crate::fragment_tree::{BaseFragmentInfo, Fragment};
 use crate::positioned::AbsolutelyPositionedBox;
 
 mod geom;
@@ -155,6 +155,18 @@ impl FlexLevelBox {
                 .context
                 .base
                 .invalidate_cached_fragment(),
+        }
+    }
+
+    pub(crate) fn fragments(&self) -> Vec<Fragment> {
+        match self {
+            FlexLevelBox::FlexItem(flex_item_box) => flex_item_box
+                .independent_formatting_context
+                .base
+                .fragments(),
+            FlexLevelBox::OutOfFlowAbsolutelyPositionedBox(positioned_box) => {
+                positioned_box.borrow().context.base.fragments()
+            },
         }
     }
 }

--- a/components/layout_2020/flow/inline/inline_box.rs
+++ b/components/layout_2020/flow/inline/inline_box.rs
@@ -73,6 +73,10 @@ impl InlineBoxes {
         self.inline_boxes.len()
     }
 
+    pub(super) fn iter(&self) -> impl Iterator<Item = &ArcRefCell<InlineBox>> {
+        self.inline_boxes.iter()
+    }
+
     pub(super) fn get(&self, identifier: &InlineBoxIdentifier) -> ArcRefCell<InlineBox> {
         self.inline_boxes[identifier.index_in_inline_boxes as usize].clone()
     }

--- a/components/layout_2020/flow/inline/mod.rs
+++ b/components/layout_2020/flow/inline/mod.rs
@@ -221,6 +221,22 @@ impl InlineItem {
             },
         }
     }
+
+    pub(crate) fn fragments(&self) -> Vec<Fragment> {
+        match self {
+            InlineItem::StartInlineBox(inline_box) => inline_box.borrow().base.fragments(),
+            InlineItem::EndInlineBox | InlineItem::TextRun(..) => {
+                unreachable!("Should never have these kind of fragments attached to a DOM node")
+            },
+            InlineItem::OutOfFlowAbsolutelyPositionedBox(positioned_box, ..) => {
+                positioned_box.borrow().context.base.fragments()
+            },
+            InlineItem::OutOfFlowFloatBox(float_box) => float_box.contents.base.fragments(),
+            InlineItem::Atomic(independent_formatting_context, ..) => {
+                independent_formatting_context.base.fragments()
+            },
+        }
+    }
 }
 
 /// Information about the current line under construction for a particular
@@ -1081,8 +1097,8 @@ impl InlineFormattingContextLayout<'_> {
         float_item: &mut FloatLineItem,
         line_inline_size_without_trailing_whitespace: Au,
     ) {
-        let logical_margin_rect_size = float_item
-            .fragment
+        let mut float_fragment = float_item.fragment.borrow_mut();
+        let logical_margin_rect_size = float_fragment
             .margin_rect()
             .size
             .to_logical(self.containing_block.style.writing_mode);
@@ -1106,7 +1122,7 @@ impl InlineFormattingContextLayout<'_> {
         if needs_placement_later {
             self.current_line.has_floats_waiting_to_be_placed = true;
         } else {
-            self.place_float_fragment(&mut float_item.fragment);
+            self.place_float_fragment(&mut float_fragment);
             float_item.needs_placement = false;
         }
 
@@ -1657,6 +1673,11 @@ impl InlineFormattingContext {
             Au::zero()
         };
 
+        // Clear any cached inline fragments from previous layouts.
+        for inline_box in self.inline_boxes.iter() {
+            inline_box.borrow().base.clear_fragments();
+        }
+
         let style = containing_block.style;
 
         // It's unfortunate that it isn't possible to get this during IFC text processing, but in
@@ -2055,6 +2076,10 @@ impl IndependentFormattingContext {
             size.inline,
             SegmentContentFlags::empty(),
         );
+
+        let fragment = ArcRefCell::new(fragment);
+        self.base.set_fragment(Fragment::Box(fragment.clone()));
+
         layout.push_line_item_to_unbreakable_segment(LineItem::Atomic(
             layout.current_inline_box_identifier(),
             AtomicLineItem {
@@ -2131,11 +2156,15 @@ impl IndependentFormattingContext {
 
 impl FloatBox {
     fn layout_into_line_items(&self, layout: &mut InlineFormattingContextLayout) {
-        let fragment = self.layout(
+        let fragment = ArcRefCell::new(self.layout(
             layout.layout_context,
             layout.positioning_context,
             layout.containing_block,
-        );
+        ));
+
+        self.contents
+            .base
+            .set_fragment(Fragment::Box(fragment.clone()));
         layout.push_line_item_to_unbreakable_segment(LineItem::Float(
             layout.current_inline_box_identifier(),
             FloatLineItem {
@@ -2150,7 +2179,7 @@ fn place_pending_floats(ifc: &mut InlineFormattingContextLayout, line_items: &mu
     for item in line_items.iter_mut() {
         if let LineItem::Float(_, float_line_item) = item {
             if float_line_item.needs_placement {
-                ifc.place_float_fragment(&mut float_line_item.fragment);
+                ifc.place_float_fragment(&mut float_line_item.fragment.borrow_mut());
             }
         }
     }

--- a/components/layout_2020/layout_box_base.rs
+++ b/components/layout_2020/layout_box_base.rs
@@ -29,6 +29,7 @@ pub(crate) struct LayoutBoxBase {
     pub cached_inline_content_size:
         AtomicRefCell<Option<Box<(SizeConstraint, InlineContentSizesResult)>>>,
     pub cached_layout_result: AtomicRefCell<Option<Box<CacheableLayoutResultAndInputs>>>,
+    pub fragments: AtomicRefCell<Vec<Fragment>>,
 }
 
 impl LayoutBoxBase {
@@ -38,6 +39,7 @@ impl LayoutBoxBase {
             style,
             cached_inline_content_size: AtomicRefCell::default(),
             cached_layout_result: AtomicRefCell::default(),
+            fragments: AtomicRefCell::default(),
         }
     }
 
@@ -68,6 +70,22 @@ impl LayoutBoxBase {
 
     pub(crate) fn invalidate_cached_fragment(&self) {
         let _ = self.cached_layout_result.borrow_mut().take();
+    }
+
+    pub(crate) fn fragments(&self) -> Vec<Fragment> {
+        self.fragments.borrow().clone()
+    }
+
+    pub(crate) fn add_fragment(&self, fragment: Fragment) {
+        self.fragments.borrow_mut().push(fragment);
+    }
+
+    pub(crate) fn set_fragment(&self, fragment: Fragment) {
+        *self.fragments.borrow_mut() = vec![fragment];
+    }
+
+    pub(crate) fn clear_fragments(&self) {
+        self.fragments.borrow_mut().clear();
     }
 }
 

--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -436,9 +436,8 @@ impl HoistedAbsolutelyPositionedBox {
                         containing_block_padding,
                     );
 
-                    hoisted_box.fragment.borrow_mut().fragment =
-                        Some(Fragment::Box(new_fragment.clone()));
-                    (Fragment::Box(new_fragment), new_hoisted_boxes)
+                    hoisted_box.fragment.borrow_mut().fragment = Some(new_fragment.clone());
+                    (new_fragment, new_hoisted_boxes)
                 })
                 .unzip_into_vecs(&mut new_fragments, &mut new_hoisted_boxes);
 
@@ -454,8 +453,8 @@ impl HoistedAbsolutelyPositionedBox {
                     containing_block_padding,
                 );
 
-                box_.fragment.borrow_mut().fragment = Some(Fragment::Box(new_fragment.clone()));
-                Fragment::Box(new_fragment)
+                box_.fragment.borrow_mut().fragment = Some(new_fragment.clone());
+                new_fragment
             }))
         }
     }
@@ -466,7 +465,7 @@ impl HoistedAbsolutelyPositionedBox {
         for_nearest_containing_block_for_all_descendants: &mut Vec<HoistedAbsolutelyPositionedBox>,
         containing_block: &DefiniteContainingBlock,
         containing_block_padding: PhysicalSides<Au>,
-    ) -> ArcRefCell<BoxFragment> {
+    ) -> Fragment {
         let cbis = containing_block.size.inline;
         let cbbs = containing_block.size.block;
         let containing_block_writing_mode = containing_block.style.writing_mode;
@@ -714,7 +713,9 @@ impl HoistedAbsolutelyPositionedBox {
         for_nearest_containing_block_for_all_descendants
             .extend(positioning_context.for_nearest_containing_block_for_all_descendants);
 
-        ArcRefCell::new(new_fragment)
+        let fragment = Fragment::Box(ArcRefCell::new(new_fragment));
+        context.base.set_fragment(fragment.clone());
+        fragment
     }
 }
 

--- a/components/layout_2020/table/construct.rs
+++ b/components/layout_2020/table/construct.rs
@@ -728,8 +728,7 @@ where
 
         let style = anonymous_info.style.clone();
         self.push_table_row(ArcRefCell::new(TableTrack {
-            base_fragment_info: (&anonymous_info).into(),
-            style,
+            base: LayoutBoxBase::new((&anonymous_info).into(), style),
             group_index: self.current_row_group_index,
             is_anonymous: true,
         }));
@@ -773,8 +772,7 @@ where
 
                     let next_row_index = self.builder.table.rows.len();
                     let row_group = ArcRefCell::new(TableTrackGroup {
-                        base_fragment_info: info.into(),
-                        style: info.style.clone(),
+                        base: LayoutBoxBase::new(info.into(), info.style.clone()),
                         group_type: internal.into(),
                         track_range: next_row_index..next_row_index,
                     });
@@ -816,8 +814,7 @@ where
                     row_builder.finish();
 
                     let row = ArcRefCell::new(TableTrack {
-                        base_fragment_info: info.into(),
-                        style: info.style.clone(),
+                        base: LayoutBoxBase::new(info.into(), info.style.clone()),
                         group_index: self.current_row_group_index,
                         is_anonymous: false,
                     });
@@ -862,8 +859,7 @@ where
                     }
 
                     let column_group = ArcRefCell::new(TableTrackGroup {
-                        base_fragment_info: info.into(),
-                        style: info.style.clone(),
+                        base: LayoutBoxBase::new(info.into(), info.style.clone()),
                         group_type: internal.into(),
                         track_range: first_column..self.builder.table.columns.len(),
                     });
@@ -1155,8 +1151,7 @@ fn add_column<'dom, Node: NodeExt<'dom>>(
     };
 
     let column = ArcRefCell::new(TableTrack {
-        base_fragment_info: column_info.into(),
-        style: column_info.style.clone(),
+        base: LayoutBoxBase::new(column_info.into(), column_info.style.clone()),
         group_index,
         is_anonymous,
     });

--- a/components/layout_2020/taffy/layout.rs
+++ b/components/layout_2020/taffy/layout.rs
@@ -550,7 +550,7 @@ impl TaffyContainer {
                         false
                     };
 
-                match &mut child.taffy_level_box {
+                let fragment = match &mut child.taffy_level_box {
                     TaffyItemBoxInner::InFlowBox(independent_box) => {
                         let mut fragment_info = independent_box.base_fragment_info();
                         fragment_info
@@ -594,7 +594,6 @@ impl TaffyContainer {
                         container_ctx
                             .positioning_context
                             .append(child_positioning_context);
-
                         fragment
                     },
                     TaffyItemBoxInner::OutOfFlowAbsolutelyPositionedBox(abs_pos_box) => {
@@ -628,7 +627,16 @@ impl TaffyContainer {
                         container_ctx.positioning_context.push(hoisted_box);
                         Fragment::AbsoluteOrFixedPositioned(hoisted_fragment)
                     },
+                };
+
+                if let TaffyItemBoxInner::InFlowBox(independent_formatting_context) =
+                    &child.taffy_level_box
+                {
+                    independent_formatting_context
+                        .base
+                        .set_fragment(fragment.clone());
                 }
+                fragment
             })
             .collect();
 

--- a/components/layout_2020/taffy/mod.rs
+++ b/components/layout_2020/taffy/mod.rs
@@ -131,6 +131,17 @@ impl TaffyItemBox {
             },
         }
     }
+
+    pub(crate) fn fragments(&self) -> Vec<Fragment> {
+        match self.taffy_level_box {
+            TaffyItemBoxInner::InFlowBox(ref independent_formatting_context) => {
+                independent_formatting_context.base.fragments()
+            },
+            TaffyItemBoxInner::OutOfFlowAbsolutelyPositionedBox(ref positioned_box) => {
+                positioned_box.borrow().context.base.fragments()
+            },
+        }
+    }
 }
 
 /// Details from Taffy grid layout that will be stored


### PR DESCRIPTION
Start storing a link to laid-out `Fragment`s in `LayoutBoxBase`, so that
these are accessible for queries and eventually for incremental layout.
Some box tree data structures lacked a `LayoutBoxBase`, such as table
tracks and table track groups[^1].

In addition, start using these `Fragment`s for queries instead of
walking the entire `Fragment` tree. Currently, this isn't possible for
most queries as `Fragment`s do not cache their absolute offsets (which
are often necessary). This change uses the new box tree `Fragment`s for
most resolved style queries.

[^1]: Note that only rows and row groups store `Fragment`s as columsn and
   colgroups do not produce any.

Testing: This is covered by existing tests.
Fixes: This is part of #36525.
