### PR TITLE
Implement CSSStyleSheet::replaceSync

### DIFF
--- a/components/script/dom/bindings/error.rs
+++ b/components/script/dom/bindings/error.rs
@@ -93,6 +93,7 @@ pub(crate) fn throw_dom_exception(
         Error::NotReadable => DOMErrorName::NotReadableError,
         Error::Data => DOMErrorName::DataError,
         Error::Operation => DOMErrorName::OperationError,
+        Error::NotAllowed => DOMErrorName::NotAllowedError,
         Error::Type(message) => unsafe {
             assert!(!JS_IsExceptionPending(*cx));
             throw_type_error(*cx, &message);

--- a/components/script/dom/domexception.rs
+++ b/components/script/dom/domexception.rs
@@ -53,6 +53,7 @@ pub(crate) enum DOMErrorName {
     NotReadableError,
     DataError,
     OperationError,
+    NotAllowedError,
 }
 
 impl DOMErrorName {
@@ -84,6 +85,7 @@ impl DOMErrorName {
             "NotReadableError" => Some(DOMErrorName::NotReadableError),
             "DataError" => Some(DOMErrorName::DataError),
             "OperationError" => Some(DOMErrorName::OperationError),
+            "NotAllowedError" => Some(DOMErrorName::NotAllowedError),
             _ => None,
         }
     }
@@ -134,6 +136,10 @@ impl DOMException {
             DOMErrorName::DataError => "Provided data is inadequate.",
             DOMErrorName::OperationError => {
                 "The operation failed for an operation-specific reason."
+            },
+            DOMErrorName::NotAllowedError => {
+                r#"The request is not allowed by the user agent or the platform in the current context,
+                possibly because the user denied permission."#
             },
         };
 

--- a/components/script_bindings/error.rs
+++ b/components/script_bindings/error.rs
@@ -59,6 +59,8 @@ pub enum Error {
     Data,
     /// OperationError DOMException
     Operation,
+    /// NotAllowedError DOMException
+    NotAllowed,
 
     /// TypeError JavaScript Error
     Type(String),

--- a/components/script_bindings/webidls/CSSStyleSheet.webidl
+++ b/components/script_bindings/webidls/CSSStyleSheet.webidl
@@ -11,6 +11,7 @@ interface CSSStyleSheet : StyleSheet {
   [Throws, SameObject] readonly attribute CSSRuleList cssRules;
   [Throws] unsigned long insertRule(DOMString rule, optional unsigned long index = 0);
   [Throws] undefined deleteRule(unsigned long index);
+  [Throws] undefined replaceSync(USVString text);
 };
 
 dictionary CSSStyleSheetInit {

--- a/tests/wpt/meta/css/css-mixins/at-function-parsing.html.ini
+++ b/tests/wpt/meta/css/css-mixins/at-function-parsing.html.ini
@@ -11,12 +11,6 @@
   [@function --foo( --x ) is valid]
     expected: FAIL
 
-  [@function --foo () is invalid]
-    expected: FAIL
-
-  [@function --foo (--x) is invalid]
-    expected: FAIL
-
   [@function --foo(--x auto) is valid]
     expected: FAIL
 
@@ -113,9 +107,6 @@
   [@function --foo(--x <angle>: 10px) is valid]
     expected: FAIL
 
-  [@function --foo(--x: 10px !important) is invalid]
-    expected: FAIL
-
   [@function --foo(--x <length>#) is valid]
     expected: FAIL
 
@@ -129,30 +120,6 @@
     expected: FAIL
 
   [@function --foo(--x <transform-function>+) is valid]
-    expected: FAIL
-
-  [@function --foo(--x <transform-list>#) is invalid]
-    expected: FAIL
-
-  [@function --foo(--x <transform-list>+) is invalid]
-    expected: FAIL
-
-  [@function --foo(--x *) is invalid]
-    expected: FAIL
-
-  [@function --foo(--x !) is invalid]
-    expected: FAIL
-
-  [@function --foo(--x 50px) is invalid]
-    expected: FAIL
-
-  [@function --foo(--x <length> | auto) is invalid]
-    expected: FAIL
-
-  [@function --foo(--x none | auto) is invalid]
-    expected: FAIL
-
-  [@function --foo(--x <dino>) is invalid]
     expected: FAIL
 
   [@function --foo(--x) returns type(*) is valid]
@@ -173,71 +140,5 @@
   [@function --foo(--x) returns type(foo | bar) is valid]
     expected: FAIL
 
-  [@function --foo(--x) ! is invalid]
-    expected: FAIL
-
-  [@function --foo(--x) length is invalid]
-    expected: FAIL
-
-  [@function --foo(--x) returns is invalid]
-    expected: FAIL
-
-  [@function --foo(--x) returns  is invalid]
-    expected: FAIL
-
-  [@function --foo(--x) returns * is invalid]
-    expected: FAIL
-
-  [@function --foo(--x) returns <transform-list># is invalid]
-    expected: FAIL
-
-  [@function --foo(--x) returns <transform-list>+ is invalid]
-    expected: FAIL
-
-  [@function --foo(--x) returns auto | none is invalid]
-    expected: FAIL
-
-  [@function --foo(--x): <length> is invalid]
-    expected: FAIL
-
-  [@function --foo(--x): length is invalid]
-    expected: FAIL
-
-  [@function --foo(--x) returneth <length> is invalid]
-    expected: FAIL
-
   [@function --foo(--x:1px, --y, --z:2px) is valid]
-    expected: FAIL
-
-  [@function --foo(!) is invalid]
-    expected: FAIL
-
-  [@function --foo(--x: !) is invalid]
-    expected: FAIL
-
-  [@function --foo(--x type(!)) is invalid]
-    expected: FAIL
-
-  [@function --foo(,) is invalid]
-    expected: FAIL
-
-  [@function --foo(,,,) is invalid]
-    expected: FAIL
-
-  [@function --foo(--x, ;) is invalid]
-    expected: FAIL
-
-  [@function --foo(;) is invalid]
-    expected: FAIL
-
-  [@function --foo(\]) is invalid]
-    expected: FAIL
-
-  [@function --foo(, --x\]) is invalid]
-    expected: FAIL
-
-  [@function --foo(--x) ! <length> is invalid]
-    expected: FAIL
-
-  [@function --foo(--x) returns <length>! is invalid]
     expected: FAIL

--- a/tests/wpt/meta/css/css-nesting/nested-declarations-cssom.html.ini
+++ b/tests/wpt/meta/css/css-nesting/nested-declarations-cssom.html.ini
@@ -1,33 +1,3 @@
 [nested-declarations-cssom.html]
-  [Trailing declarations]
-    expected: FAIL
-
-  [Mixed declarations]
-    expected: FAIL
-
-  [CSSNestedDeclarations.style]
-    expected: FAIL
-
-  [Nested group rule]
-    expected: FAIL
-
-  [Nested @scope rule]
-    expected: FAIL
-
-  [Inner rule starting with an ident]
-    expected: FAIL
-
-  [Inserting a CSSNestedDeclaration rule into style rule]
-    expected: FAIL
-
   [Inserting a CSSNestedDeclaration rule into nested group rule]
-    expected: FAIL
-
-  [Attempting to insert a CSSNestedDeclaration rule into top-level @media rule]
-    expected: FAIL
-
-  [Attempting to insert a CSSNestedDeclaration rule, empty block]
-    expected: FAIL
-
-  [Attempting to insert a CSSNestedDeclaration rule, all invalid declarations]
     expected: FAIL

--- a/tests/wpt/meta/css/cssom/CSSStyleSheet-constructable-baseURL.html.ini
+++ b/tests/wpt/meta/css/cssom/CSSStyleSheet-constructable-baseURL.html.ini
@@ -1,9 +1,3 @@
 [CSSStyleSheet-constructable-baseURL.html]
-  [Constructing sheet with custom base URL ueses that URL for CSS rules]
-    expected: FAIL
-
-  [Constructing sheet with relative URL adds to the constructor document's base URL]
-    expected: FAIL
-
   [Constructing sheet with invalid base URL throws a NotAllowedError]
     expected: FAIL

--- a/tests/wpt/meta/css/cssom/CSSStyleSheet-constructable-disabled-regular-sheet-insertion.html.ini
+++ b/tests/wpt/meta/css/cssom/CSSStyleSheet-constructable-disabled-regular-sheet-insertion.html.ini
@@ -1,4 +1,0 @@
-[CSSStyleSheet-constructable-disabled-regular-sheet-insertion.html]
-  [Shouldn't crash / assert when inserting a stylesheet after there are disabled constructable sheets]
-    expected: FAIL
-

--- a/tests/wpt/meta/css/cssom/CSSStyleSheet-constructable.html.ini
+++ b/tests/wpt/meta/css/cssom/CSSStyleSheet-constructable.html.ini
@@ -41,9 +41,6 @@
   [Adding non-constructed stylesheet to AdoptedStyleSheets is not allowed when the owner document of the stylesheet and the AdoptedStyleSheets are in different document trees]
     expected: FAIL
 
-  [CSSStyleSheet.replaceSync replaces stylesheet text synchronously]
-    expected: FAIL
-
   [CSSStyleSheet.replaceSync correctly updates the style of its adopters synchronously]
     expected: FAIL
 
@@ -62,9 +59,6 @@
   [CSSStyleSheet.replace ignores @import rule but still loads other rules]
     expected: FAIL
 
-  [CSSStyleSheet.replaceSync allows, but ignores, import rule inside]
-    expected: FAIL
-
   [CSSStyleSheet.replace does not reject on failed imports]
     expected: FAIL
 
@@ -72,10 +66,4 @@
     expected: FAIL
 
   [Adopting a shadow host's ancestor will empty adoptedStyleSheets if adopting to a different document]
-    expected: FAIL
-
-  [Modifying an adopted stylesheet on a disconnected shadow root should not crash.]
-    expected: FAIL
-
-  [Constructing a sheet with the default base URL uses the constructor document's base URL for CSS rules]
     expected: FAIL

--- a/tests/wpt/meta/css/cssom/adoptedstylesheets-modify-array-and-sheet.html.ini
+++ b/tests/wpt/meta/css/cssom/adoptedstylesheets-modify-array-and-sheet.html.ini
@@ -1,2 +1,9 @@
 [adoptedstylesheets-modify-array-and-sheet.html]
-  expected: ERROR
+  [Add the two sheets. Text should be red.]
+    expected: FAIL
+
+  [Flip the two sheet. Still red.]
+    expected: FAIL
+
+  [Modify the color declaration. Should now be green.]
+    expected: FAIL

--- a/tests/wpt/meta/css/cssom/idlharness.html.ini
+++ b/tests/wpt/meta/css/cssom/idlharness.html.ini
@@ -395,19 +395,10 @@
   [CSSStyleSheet interface: operation replace(USVString)]
     expected: FAIL
 
-  [CSSStyleSheet interface: operation replaceSync(USVString)]
-    expected: FAIL
-
   [CSSStyleSheet interface: sheet must inherit property "replace(USVString)" with the proper type]
     expected: FAIL
 
   [CSSStyleSheet interface: calling replace(USVString) on sheet with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [CSSStyleSheet interface: sheet must inherit property "replaceSync(USVString)" with the proper type]
-    expected: FAIL
-
-  [CSSStyleSheet interface: calling replaceSync(USVString) on sheet with too few arguments must throw TypeError]
     expected: FAIL
 
   [Document interface: attribute adoptedStyleSheets]


### PR DESCRIPTION
Implements the `replaceSync` method on CSSStyleSheet

Testing: Covered by wpt tests. Expectations are updated.

