### PR TITLE
Implement trusted types url setter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1230,7 +1230,7 @@ dependencies = [
 [[package]]
 name = "content-security-policy"
 version = "0.5.4"
-source = "git+https://github.com/servo/rust-content-security-policy/?branch=servo-csp#be68d50b793c31403d858ecdfc6eb245085e7e7c"
+source = "git+https://github.com/servo/rust-content-security-policy/?branch=servo-csp#827eea44ec0f3d91457d1c0467881cb4f9752520"
 dependencies = [
  "base64 0.22.1",
  "bitflags 2.9.0",

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -78,7 +78,7 @@ use crate::dom::bindings::codegen::Bindings::ShadowRootBinding::{
 use crate::dom::bindings::codegen::Bindings::WindowBinding::{
     ScrollBehavior, ScrollToOptions, WindowMethods,
 };
-use crate::dom::bindings::codegen::UnionTypes::NodeOrString;
+use crate::dom::bindings::codegen::UnionTypes::{NodeOrString, TrustedScriptURLOrUSVString};
 use crate::dom::bindings::conversions::DerivedFrom;
 use crate::dom::bindings::error::{Error, ErrorResult, Fallible};
 use crate::dom::bindings::inheritance::{Castable, ElementTypeId, HTMLElementTypeId, NodeTypeId};
@@ -149,6 +149,7 @@ use crate::dom::raredata::ElementRareData;
 use crate::dom::servoparser::ServoParser;
 use crate::dom::shadowroot::{IsUserAgentWidget, ShadowRoot};
 use crate::dom::text::Text;
+use crate::dom::types::TrustedTypePolicyFactory;
 use crate::dom::validation::Validatable;
 use crate::dom::validitystate::ValidationFlags;
 use crate::dom::virtualmethods::{VirtualMethods, vtable_for};
@@ -1926,6 +1927,53 @@ impl Element {
     ) {
         assert!(*local_name == local_name.to_ascii_lowercase());
         self.set_attribute(local_name, AttrValue::String(value.to_string()), can_gc);
+    }
+
+    pub(crate) fn get_trusted_type_url_attribute(
+        &self,
+        local_name: &LocalName,
+    ) -> TrustedScriptURLOrUSVString {
+        assert!(*local_name == local_name.to_ascii_lowercase());
+        let attr = match self.get_attribute(&ns!(), local_name) {
+            Some(attr) => attr,
+            None => return TrustedScriptURLOrUSVString::USVString(USVString::default()),
+        };
+        let value = &**attr.value();
+        // XXXManishearth this doesn't handle `javascript:` urls properly
+        self.owner_document()
+            .base_url()
+            .join(value)
+            .map(|parsed| TrustedScriptURLOrUSVString::USVString(USVString(parsed.into_string())))
+            .unwrap_or_else(|_| TrustedScriptURLOrUSVString::USVString(USVString(value.to_owned())))
+    }
+
+    pub(crate) fn set_trusted_type_url_attribute(
+        &self,
+        local_name: &LocalName,
+        value: TrustedScriptURLOrUSVString,
+        can_gc: CanGc,
+    ) -> Fallible<()> {
+        assert!(*local_name == local_name.to_ascii_lowercase());
+        let value = match value {
+            TrustedScriptURLOrUSVString::USVString(url) => {
+                let global = self.owner_global();
+                // TODO(36258): Reflectively get the name of the class
+                let sink = format!("{} {}", "HTMLScriptElement", &local_name);
+                let result = TrustedTypePolicyFactory::get_trusted_type_compliant_string(
+                    &global,
+                    url.to_string(),
+                    &sink,
+                    "'script'",
+                    can_gc,
+                );
+                result?
+            },
+            // This partially implements <https://w3c.github.io/trusted-types/dist/spec/#get-trusted-type-compliant-string-algorithm>
+            // Step 1: If input is an instance of expectedType, return stringified input and abort these steps.
+            TrustedScriptURLOrUSVString::TrustedScriptURL(script_url) => script_url.to_string(),
+        };
+        self.set_attribute(local_name, AttrValue::String(value), can_gc);
+        Ok(())
     }
 
     pub(crate) fn get_string_attribute(&self, local_name: &LocalName) -> DOMString {

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -1933,7 +1933,7 @@ impl Element {
         &self,
         local_name: &LocalName,
     ) -> TrustedScriptURLOrUSVString {
-        assert!(*local_name == local_name.to_ascii_lowercase());
+        assert_eq!(*local_name, local_name.to_ascii_lowercase());
         let attr = match self.get_attribute(&ns!(), local_name) {
             Some(attr) => attr,
             None => return TrustedScriptURLOrUSVString::USVString(USVString::default()),
@@ -1953,7 +1953,7 @@ impl Element {
         value: TrustedScriptURLOrUSVString,
         can_gc: CanGc,
     ) -> Fallible<()> {
-        assert!(*local_name == local_name.to_ascii_lowercase());
+        assert_eq!(*local_name, local_name.to_ascii_lowercase());
         let value = match value {
             TrustedScriptURLOrUSVString::USVString(url) => {
                 let global = self.owner_global();

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -3456,11 +3456,16 @@ impl GlobalScope {
                 ViolationResource::TrustedTypePolicy { sample } => {
                     (Some(sample), "trusted-types-policy".to_owned())
                 },
+                ViolationResource::TrustedTypeSink { sample } => {
+                    (Some(sample), "trusted-types-sink".to_owned())
+                },
             };
             let report = CSPViolationReportBuilder::default()
                 .resource(resource)
                 .sample(sample)
                 .effective_directive(violation.directive.name)
+                .original_policy(violation.policy.to_string())
+                .report_only(violation.policy.disposition == PolicyDisposition::Report)
                 .build(self);
             let task = CSPViolationReportTask::new(self, report);
             self.task_manager()

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -44,6 +44,8 @@ use crate::dom::bindings::codegen::Bindings::DocumentBinding::DocumentMethods;
 use crate::dom::bindings::codegen::Bindings::HTMLScriptElementBinding::HTMLScriptElementMethods;
 use crate::dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
 use crate::dom::bindings::codegen::GenericBindings::HTMLElementBinding::HTMLElement_Binding::HTMLElementMethods;
+use crate::dom::bindings::codegen::UnionTypes::TrustedScriptURLOrUSVString;
+use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::DomGlobal;
@@ -1342,10 +1344,10 @@ impl VirtualMethods for HTMLScriptElement {
 
 impl HTMLScriptElementMethods<crate::DomTypeHolder> for HTMLScriptElement {
     // https://html.spec.whatwg.org/multipage/#dom-script-src
-    make_url_getter!(Src, "src");
+    make_trusted_type_url_getter!(Src, "src");
 
     // https://html.spec.whatwg.org/multipage/#dom-script-src
-    make_url_setter!(SetSrc, "src");
+    make_trusted_type_url_setter!(SetSrc, "src");
 
     // https://html.spec.whatwg.org/multipage/#dom-script-type
     make_getter!(Type, "type");

--- a/components/script/dom/macros.rs
+++ b/components/script/dom/macros.rs
@@ -122,6 +122,32 @@ macro_rules! make_url_setter(
 );
 
 #[macro_export]
+macro_rules! make_trusted_type_url_getter(
+    ( $attr:ident, $htmlname:tt ) => (
+        fn $attr(&self) -> TrustedScriptURLOrUSVString {
+            use $crate::dom::bindings::inheritance::Castable;
+            use $crate::dom::element::Element;
+            let element = self.upcast::<Element>();
+            element.get_trusted_type_url_attribute(&html5ever::local_name!($htmlname))
+        }
+    );
+);
+
+#[macro_export]
+macro_rules! make_trusted_type_url_setter(
+    ( $attr:ident, $htmlname:tt ) => (
+        fn $attr(&self, value: TrustedScriptURLOrUSVString, can_gc: CanGc) -> Fallible<()> {
+            use $crate::dom::bindings::inheritance::Castable;
+            use $crate::dom::element::Element;
+            use $crate::script_runtime::CanGc;
+            let element = self.upcast::<Element>();
+            element.set_trusted_type_url_attribute(&html5ever::local_name!($htmlname),
+                                         value, can_gc)
+        }
+    );
+);
+
+#[macro_export]
 macro_rules! make_form_action_getter(
     ( $attr:ident, $htmlname:tt ) => (
         fn $attr(&self) -> DOMString {

--- a/components/script/dom/trustedscripturl.rs
+++ b/components/script/dom/trustedscripturl.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::fmt;
+
 use dom_struct::dom_struct;
 
 use crate::dom::bindings::codegen::Bindings::TrustedScriptURLBinding::TrustedScriptURLMethods;
@@ -29,6 +31,13 @@ impl TrustedScriptURL {
     #[cfg_attr(crown, allow(crown::unrooted_must_root))]
     pub(crate) fn new(data: String, global: &GlobalScope, can_gc: CanGc) -> DomRoot<Self> {
         reflect_dom_object(Box::new(Self::new_inherited(data)), global, can_gc)
+    }
+}
+
+impl fmt::Display for TrustedScriptURL {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(&self.data)
     }
 }
 

--- a/components/script/dom/trustedtypepolicy.rs
+++ b/components/script/dom/trustedtypepolicy.rs
@@ -59,6 +59,13 @@ impl TrustedTypePolicy {
         reflect_dom_object(Box::new(Self::new_inherited(name, options)), global, can_gc)
     }
 
+    // TODO(36258): Remove when we refactor get_trusted_type_policy_value to take an enum
+    // value to handle which callback to call. The callback should not be exposed outside
+    // of the policy object, but is currently used in TrustedPolicyFactory::process_value_with_default_policy
+    pub(crate) fn create_script_url(&self) -> Option<Rc<CreateScriptURLCallback>> {
+        self.create_script_url.clone()
+    }
+
     /// This does not take all arguments as specified. That's because the return type of the
     /// trusted type function and object are not the same. 2 of the 3 string callbacks return
     /// a DOMString, while the other one returns an USVString. Additionally, all three callbacks

--- a/components/script/security_manager.rs
+++ b/components/script/security_manager.rs
@@ -62,6 +62,8 @@ pub(crate) struct CSPViolationReportBuilder {
     pub source_file: String,
     /// <https://www.w3.org/TR/CSP3/#violation-effective-directive>
     pub effective_directive: String,
+    /// <https://www.w3.org/TR/CSP3/#violation-policy>
+    pub original_policy: String,
 }
 
 impl CSPViolationReportBuilder {
@@ -106,6 +108,12 @@ impl CSPViolationReportBuilder {
         self
     }
 
+    /// <https://www.w3.org/TR/CSP3/#violation-policy>
+    pub fn original_policy(mut self, original_policy: String) -> CSPViolationReportBuilder {
+        self.original_policy = original_policy;
+        self
+    }
+
     /// <https://w3c.github.io/webappsec-csp/#strip-url-for-use-in-reports>
     fn strip_url_for_reports(&self, mut url: ServoUrl) -> String {
         let scheme = url.scheme();
@@ -141,7 +149,7 @@ impl CSPViolationReportBuilder {
             sample: self.sample,
             blocked_url: self.resource,
             source_file: self.source_file,
-            original_policy: "".to_owned(),
+            original_policy: self.original_policy,
             line_number: self.line_number,
             column_number: self.column_number,
             status_code: global.status_code().unwrap_or(0),

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -416,7 +416,7 @@ DOMInterfaces = {
 },
 
 'HTMLScriptElement': {
-    'canGc': ['SetAsync', 'SetCrossOrigin', 'SetText']
+    'canGc': ['SetAsync', 'SetCrossOrigin', 'SetSrc', 'SetText']
 },
 
 'HTMLSelectElement': {

--- a/components/script_bindings/webidls/HTMLScriptElement.webidl
+++ b/components/script_bindings/webidls/HTMLScriptElement.webidl
@@ -7,8 +7,8 @@
 interface HTMLScriptElement : HTMLElement {
   [HTMLConstructor] constructor();
 
-  [CEReactions]
-           attribute USVString src;
+  [CEReactions, SetterThrows]
+           attribute (TrustedScriptURL or USVString) src;
   [CEReactions]
            attribute DOMString type;
   [CEReactions]

--- a/tests/wpt/meta/content-security-policy/generic/generic-0_1-img-src.html.ini
+++ b/tests/wpt/meta/content-security-policy/generic/generic-0_1-img-src.html.ini
@@ -1,3 +1,0 @@
-[generic-0_1-img-src.html]
-  [Should fire violation events for every failed violation]
-    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/generic/generic-0_1-script-src.html.ini
+++ b/tests/wpt/meta/content-security-policy/generic/generic-0_1-script-src.html.ini
@@ -1,3 +1,0 @@
-[generic-0_1-script-src.html]
-  [Should fire violation events for every failed violation]
-    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/generic/generic-0_10_1.sub.html.ini
+++ b/tests/wpt/meta/content-security-policy/generic/generic-0_10_1.sub.html.ini
@@ -1,3 +1,0 @@
-[generic-0_10_1.sub.html]
-  [Should fire violation events for every failed violation]
-    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/generic/generic-0_2_2.sub.html.ini
+++ b/tests/wpt/meta/content-security-policy/generic/generic-0_2_2.sub.html.ini
@@ -1,3 +1,0 @@
-[generic-0_2_2.sub.html]
-  [Should fire violation events for every failed violation]
-    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/generic/generic-0_2_3.html.ini
+++ b/tests/wpt/meta/content-security-policy/generic/generic-0_2_3.html.ini
@@ -1,3 +1,0 @@
-[generic-0_2_3.html]
-  [Should fire violation events for every failed violation]
-    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/script-src/script-src-1_10.html.ini
+++ b/tests/wpt/meta/content-security-policy/script-src/script-src-1_10.html.ini
@@ -1,3 +1,0 @@
-[script-src-1_10.html]
-  [Test that securitypolicyviolation event is fired]
-    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/script-src/script-src-strict_dynamic_double_policy_different_nonce.html.ini
+++ b/tests/wpt/meta/content-security-policy/script-src/script-src-strict_dynamic_double_policy_different_nonce.html.ini
@@ -1,3 +1,0 @@
-[script-src-strict_dynamic_double_policy_different_nonce.html]
-  [Unnonced script injected via `appendChild` is not allowed with `strict-dynamic` + a nonce-only double policy.]
-    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/style-src/style-blocked.html.ini
+++ b/tests/wpt/meta/content-security-policy/style-src/style-blocked.html.ini
@@ -1,6 +1,3 @@
 [style-blocked.html]
-  [Violated directive is script-src-elem.]
-    expected: FAIL
-
   [document.styleSheets should contain an item for the blocked CSS.]
     expected: FAIL

--- a/tests/wpt/meta/trusted-types/HTMLScriptElement-internal-slot.html.ini
+++ b/tests/wpt/meta/trusted-types/HTMLScriptElement-internal-slot.html.ini
@@ -1,6 +1,3 @@
 [HTMLScriptElement-internal-slot.html]
   [Test TT application when manipulating <script> elements during loading.]
     expected: FAIL
-
-  [Setting .src to a plain string should throw an exception and not modify the script state, on an unconnected script element.]
-    expected: FAIL

--- a/tests/wpt/meta/trusted-types/TrustedTypePolicyFactory-createPolicy-cspTests-none.html.ini
+++ b/tests/wpt/meta/trusted-types/TrustedTypePolicyFactory-createPolicy-cspTests-none.html.ini
@@ -1,6 +1,0 @@
-[TrustedTypePolicyFactory-createPolicy-cspTests-none.html]
-  [Cannot create policy with name 'SomeName' - policy creation throws]
-    expected: FAIL
-
-  [Cannot create policy with name 'default' - policy creation throws]
-    expected: FAIL

--- a/tests/wpt/meta/trusted-types/TrustedTypePolicyFactory-createPolicy-cspTests.html.ini
+++ b/tests/wpt/meta/trusted-types/TrustedTypePolicyFactory-createPolicy-cspTests.html.ini
@@ -1,6 +1,0 @@
-[TrustedTypePolicyFactory-createPolicy-cspTests.html]
-  [Non-allowed name policy creation throws.]
-    expected: FAIL
-
-  [Duplicate name policy creation throws.]
-    expected: FAIL

--- a/tests/wpt/meta/trusted-types/block-string-assignment-to-Element-setAttribute.html.ini
+++ b/tests/wpt/meta/trusted-types/block-string-assignment-to-Element-setAttribute.html.ini
@@ -11,9 +11,6 @@
   [`Script.prototype.setAttribute.SrC = string` throws.]
     expected: FAIL
 
-  [script.src accepts string and null after default policy was created.]
-    expected: FAIL
-
   [script.src's mutationobservers receive the default policy's value.]
     expected: FAIL
 

--- a/tests/wpt/meta/trusted-types/block-string-assignment-to-HTMLElement-generic.html.ini
+++ b/tests/wpt/meta/trusted-types/block-string-assignment-to-HTMLElement-generic.html.ini
@@ -8,9 +8,6 @@
   [iframe.srcdoc accepts only TrustedHTML]
     expected: FAIL
 
-  [script.src accepts string and null after default policy was created]
-    expected: FAIL
-
   [div.innerHTML accepts string and null after default policy was created]
     expected: FAIL
 

--- a/tests/wpt/meta/trusted-types/block-string-assignment-to-text-and-url-sinks.html.ini
+++ b/tests/wpt/meta/trusted-types/block-string-assignment-to-text-and-url-sinks.html.ini
@@ -16,6 +16,3 @@
 
   [Setting HTMLScriptElement.text to a plain string]
     expected: FAIL
-
-  [Setting HTMLScriptElement.src to a plain string]
-    expected: FAIL

--- a/tests/wpt/meta/trusted-types/default-policy.html.ini
+++ b/tests/wpt/meta/trusted-types/default-policy.html.ini
@@ -12,21 +12,6 @@
   [script.text no default policy]
     expected: FAIL
 
-  [script.src default]
-    expected: FAIL
-
-  [script.src null]
-    expected: FAIL
-
-  [script.src throw]
-    expected: FAIL
-
-  [script.src undefined]
-    expected: FAIL
-
-  [script.src typeerror]
-    expected: FAIL
-
   [div.innerHTML default]
     expected: FAIL
 

--- a/tests/wpt/meta/trusted-types/empty-default-policy.html.ini
+++ b/tests/wpt/meta/trusted-types/empty-default-policy.html.ini
@@ -3,9 +3,6 @@
   [Count SecurityPolicyViolation events.]
     expected: TIMEOUT
 
-  [script.src default]
-    expected: FAIL
-
   [div.innerHTML default]
     expected: FAIL
 


### PR DESCRIPTION
We now check the sink of script.src for trusted types. This is the first attribute that we check, other sinks will be implemented in follow-up changes.

The algorithms currently hardcode various parts. That's because I need to refactor a couple of algorithms already present in TrustedTypePolicy. They use callbacks at the moment, which made sense for their initial use. However, for these new algorithms they don't work. Therefore, I will align them with the specification by taking in an enum. However, since that's a bigger refactoring, I left that out of this PR (which is already quite big).

The other trusted types support (createScript and createHTML) will also be implemented separately.

Part of #36258
