### PR TITLE
layout: Structure reflow code to make it more modular

### DIFF
--- a/components/layout/traversal.rs
+++ b/components/layout/traversal.rs
@@ -12,19 +12,15 @@ use crate::context::LayoutContext;
 use crate::dom::DOMLayoutData;
 
 pub struct RecalcStyle<'a> {
-    context: LayoutContext<'a>,
+    context: &'a LayoutContext<'a>,
 }
 
 impl<'a> RecalcStyle<'a> {
-    pub fn new(context: LayoutContext<'a>) -> Self {
+    pub fn new(context: &'a LayoutContext<'a>) -> Self {
         RecalcStyle { context }
     }
 
     pub fn context(&self) -> &LayoutContext<'a> {
-        &self.context
-    }
-
-    pub fn destroy(self) -> LayoutContext<'a> {
         self.context
     }
 }


### PR DESCRIPTION
This reworks the structure of reflow in `layout_thread_2020` in order to
make it more modular. The goal here is to allow possibly adding a new
fragment tree traversal and to, in general, make the code a bit more
organized.

Testing: This should not change any behavior so is covered by existing WPT tests.
