### PR TITLE
Set correct policy-container for worker construction

### DIFF
--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -479,6 +479,7 @@ impl DedicatedWorkerGlobalScope {
                     Ok((metadata, bytes)) => (metadata, bytes),
                 };
                 scope.set_url(metadata.final_url);
+                scope.set_csp_list(GlobalScope::parse_csp_list_from_metadata(&metadata.headers));
                 global_scope.set_https_state(metadata.https_state);
                 let source = String::from_utf8_lossy(&bytes);
 

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -9,7 +9,7 @@ use base::cross_process_instant::CrossProcessInstant;
 use base::id::PipelineId;
 use base64::Engine as _;
 use base64::engine::general_purpose;
-use content_security_policy::{self as csp, CspList};
+use content_security_policy as csp;
 use dom_struct::dom_struct;
 use embedder_traits::resources::{self, Resource};
 use encoding_rs::Encoding;
@@ -59,6 +59,7 @@ use crate::dom::document::{Document, DocumentSource, HasBrowsingContext, IsHTMLD
 use crate::dom::documentfragment::DocumentFragment;
 use crate::dom::documenttype::DocumentType;
 use crate::dom::element::{CustomElementCreationMode, Element, ElementCreator};
+use crate::dom::globalscope::GlobalScope;
 use crate::dom::htmlformelement::{FormControlElementHelpers, HTMLFormElement};
 use crate::dom::htmlimageelement::HTMLImageElement;
 use crate::dom::htmlinputelement::HTMLInputElement;
@@ -850,29 +851,9 @@ impl FetchResponseListener for ParserContext {
             .map(Serde::into_inner)
             .map(Into::into);
 
-        // https://www.w3.org/TR/CSP/#initialize-document-csp
-        // TODO: Implement step 1 (local scheme special case)
-        let csp_list = metadata.as_ref().and_then(|m| {
-            let h = m.headers.as_ref()?;
-            let mut csp = h.get_all("content-security-policy").iter();
-            // This silently ignores the CSP if it contains invalid Unicode.
-            // We should probably report an error somewhere.
-            let c = csp.next().and_then(|c| c.to_str().ok())?;
-            let mut csp_list = CspList::parse(
-                c,
-                csp::PolicySource::Header,
-                csp::PolicyDisposition::Enforce,
-            );
-            for c in csp {
-                let c = c.to_str().ok()?;
-                csp_list.append(CspList::parse(
-                    c,
-                    csp::PolicySource::Header,
-                    csp::PolicyDisposition::Enforce,
-                ));
-            }
-            Some(csp_list)
-        });
+        let csp_list = metadata
+            .as_ref()
+            .and_then(|m| GlobalScope::parse_csp_list_from_metadata(&m.headers));
 
         let parser = match ScriptThread::page_headers_available(&self.id, metadata, CanGc::note()) {
             Some(parser) => parser,

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -12,6 +12,7 @@ use std::time::Duration;
 use base::cross_process_instant::CrossProcessInstant;
 use base::id::{PipelineId, PipelineNamespace};
 use constellation_traits::WorkerGlobalScopeInit;
+use content_security_policy::CspList;
 use crossbeam_channel::Receiver;
 use devtools_traits::{DevtoolScriptControlMsg, WorkerId};
 use dom_struct::dom_struct;
@@ -246,6 +247,10 @@ impl WorkerGlobalScope {
         self.policy_container.borrow()
     }
 
+    pub(crate) fn set_csp_list(&self, csp_list: Option<CspList>) {
+        self.policy_container.borrow_mut().set_csp_list(csp_list);
+    }
+
     /// Get a mutable reference to the [`TimerScheduler`] for this [`ServiceWorkerGlobalScope`].
     pub(crate) fn timer_scheduler(&self) -> RefMut<TimerScheduler> {
         self.timer_scheduler.borrow_mut()
@@ -300,6 +305,7 @@ impl WorkerGlobalScopeMethods<crate::DomTypeHolder> for WorkerGlobalScope {
             .use_url_credentials(true)
             .origin(global_scope.origin().immutable().clone())
             .insecure_requests_policy(self.insecure_requests_policy())
+            .policy_container(global_scope.policy_container())
             .has_trustworthy_ancestor_origin(
                 global_scope.has_trustworthy_ancestor_or_current_origin(),
             )

--- a/tests/wpt/meta/content-security-policy/connect-src/worker-connect-src-blocked.sub.html.ini
+++ b/tests/wpt/meta/content-security-policy/connect-src/worker-connect-src-blocked.sub.html.ini
@@ -1,3 +1,0 @@
-[worker-connect-src-blocked.sub.html]
-  [Expecting logs: ["xhr blocked","TEST COMPLETE"\]]
-    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/inside-worker/dedicatedworker-connect-src.html.ini
+++ b/tests/wpt/meta/content-security-policy/inside-worker/dedicatedworker-connect-src.html.ini
@@ -1,14 +1,5 @@
 [dedicatedworker-connect-src.html]
-  [Cross-origin 'fetch()' in http: with connect-src 'self']
-    expected: FAIL
-
-  [Cross-origin XHR in http: with connect-src 'self']
-    expected: FAIL
-
   [Same-origin => cross-origin 'fetch()' in http: with connect-src 'self']
-    expected: FAIL
-
-  [WebSocket in http: with connect-src 'self']
     expected: FAIL
 
   [Reports match in http: with connect-src 'self']

--- a/tests/wpt/meta/content-security-policy/inside-worker/dedicatedworker-script-src.html.ini
+++ b/tests/wpt/meta/content-security-policy/inside-worker/dedicatedworker-script-src.html.ini
@@ -1,15 +1,16 @@
 [dedicatedworker-script-src.html]
+  expected: TIMEOUT
   [Cross-origin `importScripts()` blocked in http: with script-src 'self']
-    expected: FAIL
+    expected: TIMEOUT
 
   [`eval()` blocked in http: with script-src 'self']
-    expected: FAIL
+    expected: NOTRUN
 
   [`setTimeout([string\])` blocked in http: with script-src 'self']
-    expected: FAIL
+    expected: NOTRUN
 
   [Reports are sent for http: with script-src 'self']
-    expected: FAIL
+    expected: NOTRUN
 
   [Cross-origin `importScripts()` blocked in blob: with script-src 'self']
     expected: FAIL
@@ -22,3 +23,6 @@
 
   [Reports are sent for blob: with script-src 'self']
     expected: FAIL
+
+  [dedicatedworker-script-src]
+    expected: TIMEOUT

--- a/tests/wpt/meta/content-security-policy/script-src/worker-eval-blocked.sub.html.ini
+++ b/tests/wpt/meta/content-security-policy/script-src/worker-eval-blocked.sub.html.ini
@@ -1,3 +1,0 @@
-[worker-eval-blocked.sub.html]
-  [Expecting logs: ["eval blocked"\]]
-    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/script-src/worker-function-function-blocked.sub.html.ini
+++ b/tests/wpt/meta/content-security-policy/script-src/worker-function-function-blocked.sub.html.ini
@@ -1,3 +1,0 @@
-[worker-function-function-blocked.sub.html]
-  [Expecting logs: ["Function() function blocked"\]]
-    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/script-src/worker-importscripts.sub.html.ini
+++ b/tests/wpt/meta/content-security-policy/script-src/worker-importscripts.sub.html.ini
@@ -1,6 +1,3 @@
 [worker-importscripts.sub.html]
-  [Dedicated worker delivers its own CSP]
-    expected: FAIL
-
   [Shared worker delivers its own CSP]
     expected: FAIL

--- a/tests/wpt/meta/content-security-policy/script-src/worker-set-timeout.sub.html.ini
+++ b/tests/wpt/meta/content-security-policy/script-src/worker-set-timeout.sub.html.ini
@@ -1,6 +1,3 @@
 [worker-set-timeout.sub.html]
-  [Dedicated worker delivers its own CSP]
-    expected: FAIL
-
   [Shared worker delivers its own CSP]
     expected: FAIL

--- a/tests/wpt/meta/content-security-policy/securitypolicyviolation/inside-dedicated-worker.html.ini
+++ b/tests/wpt/meta/content-security-policy/securitypolicyviolation/inside-dedicated-worker.html.ini
@@ -1,7 +1,4 @@
 [inside-dedicated-worker.html]
   expected: TIMEOUT
-  [SecurityPolicyViolation event fired on global.]
-    expected: FAIL
-
   [SecurityPolicyViolation event fired on global with the correct blockedURI.]
     expected: TIMEOUT

--- a/tests/wpt/meta/content-security-policy/wasm-unsafe-eval/default-src-blocks-wasm.any.js.ini
+++ b/tests/wpt/meta/content-security-policy/wasm-unsafe-eval/default-src-blocks-wasm.any.js.ini
@@ -1,7 +1,4 @@
 [default-src-blocks-wasm.any.worker.html]
-  [default-src-blocks-wasm]
-    expected: FAIL
-
 
 [default-src-blocks-wasm.any.html]
 

--- a/tests/wpt/meta/content-security-policy/wasm-unsafe-eval/script-src-blocks-wasm.any.js.ini
+++ b/tests/wpt/meta/content-security-policy/wasm-unsafe-eval/script-src-blocks-wasm.any.js.ini
@@ -2,9 +2,6 @@
   expected: ERROR
 
 [script-src-blocks-wasm.any.worker.html]
-  [script-src-blocks-wasm]
-    expected: FAIL
-
 
 [script-src-blocks-wasm.any.html]
 

--- a/tests/wpt/meta/content-security-policy/wasm-unsafe-eval/script-src-spv-asynch.any.js.ini
+++ b/tests/wpt/meta/content-security-policy/wasm-unsafe-eval/script-src-spv-asynch.any.js.ini
@@ -7,9 +7,8 @@
 
 
 [script-src-spv-asynch.any.worker.html]
-  expected: TIMEOUT
   [Securitypolicyviolation event looks like it should]
-    expected: TIMEOUT
+    expected: FAIL
 
 
 [script-src-spv-asynch.any.serviceworker.html]

--- a/tests/wpt/meta/fetch/api/policies/csp-blocked-worker.html.ini
+++ b/tests/wpt/meta/fetch/api/policies/csp-blocked-worker.html.ini
@@ -1,3 +1,0 @@
-[csp-blocked-worker.html]
-  [Fetch is blocked by CSP, got a TypeError]
-    expected: FAIL

--- a/tests/wpt/meta/trusted-types/should-sink-type-mismatch-violation-be-blocked-by-csp-002-worker.html.ini
+++ b/tests/wpt/meta/trusted-types/should-sink-type-mismatch-violation-be-blocked-by-csp-002-worker.html.ini
@@ -1,4 +1,6 @@
 [should-sink-type-mismatch-violation-be-blocked-by-csp-002-worker.html]
-  expected: TIMEOUT
   [Checking reported violations for setTimeout(';;;;;') from DedicatedWorker]
-    expected: TIMEOUT
+    expected: FAIL
+
+  [Location of required-trusted-types-for violations.]
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/should-trusted-type-policy-creation-be-blocked-by-csp-004-worker.html.ini
+++ b/tests/wpt/meta/trusted-types/should-trusted-type-policy-creation-be-blocked-by-csp-004-worker.html.ini
@@ -1,10 +1,6 @@
 [should-trusted-type-policy-creation-be-blocked-by-csp-004-worker.html]
-  expected: TIMEOUT
-  [No violation/exception for allowed policy names (tt-policy-name-1 tt-policy-name-2 tt-policy-name-3).]
-    expected: TIMEOUT
+  [Exception and violations for CSP with multiple enforce and report-only policies.]
+    expected: FAIL
 
-  [Violation and exception for duplicate policy names (tt-policy-name-1 tt-policy-name-2 tt-policy-name-3).]
-    expected: NOTRUN
-
-  [Violation and exception for forbidden policy name (tt-policy-name-1 tt-policy-name-2 tt-policy-name-3).]
-    expected: NOTRUN
+  [Location of trusted-types violations.]
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/trusted-types-reporting-check-report-DedicatedWorker-sink-mismatch.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-reporting-check-report-DedicatedWorker-sink-mismatch.html.ini
@@ -1,7 +1,4 @@
 [trusted-types-reporting-check-report-DedicatedWorker-sink-mismatch.html]
-  [Passing a plain string to eval throws.]
-    expected: FAIL
-
   [Test report-uri works with require-trusted-types-for violation.]
     expected: FAIL
 

--- a/tests/wpt/meta/trusted-types/trusted-types-reporting-for-DedicatedWorker-DedicatedWorker-constructor.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-reporting-for-DedicatedWorker-DedicatedWorker-constructor.html.ini
@@ -1,7 +1,3 @@
 [trusted-types-reporting-for-DedicatedWorker-DedicatedWorker-constructor.html]
-  expected: TIMEOUT
-  [No violation reported for Worker constructor with TrustedScriptURL.]
-    expected: TIMEOUT
-
   [Violation report for Worker constructor with plain string.]
-    expected: NOTRUN
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/trusted-types-reporting-for-DedicatedWorker-ServiceWorkerContainer-register.https.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-reporting-for-DedicatedWorker-ServiceWorkerContainer-register.https.html.ini
@@ -1,7 +1,6 @@
 [trusted-types-reporting-for-DedicatedWorker-ServiceWorkerContainer-register.https.html]
-  expected: TIMEOUT
   [No violation reported for ServiceWorkerContainer register with TrustedScriptURL.]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Violation report for ServiceWorkerContainer register with plain string.]
-    expected: NOTRUN
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/trusted-types-reporting-for-DedicatedWorker-eval.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-reporting-for-DedicatedWorker-eval.html.ini
@@ -1,7 +1,6 @@
 [trusted-types-reporting-for-DedicatedWorker-eval.html]
-  expected: TIMEOUT
   [No violation reported for eval with TrustedScript.]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Violation report for eval with plain string.]
-    expected: NOTRUN
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/trusted-types-reporting-for-DedicatedWorker-function-constructor.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-reporting-for-DedicatedWorker-function-constructor.html.ini
@@ -1,37 +1,12 @@
 [trusted-types-reporting-for-DedicatedWorker-function-constructor.html]
-  expected: TIMEOUT
-  [No violation reported for Function with TrustedScript.]
-    expected: TIMEOUT
-
-  [No violation reported for Function with multiple TrustedScript args.]
-    expected: NOTRUN
-
   [Violation report for Function with plain string.]
-    expected: NOTRUN
-
-  [No violation reported for AsyncFunction with TrustedScript.]
-    expected: NOTRUN
-
-  [No violation reported for AsyncFunction with multiple TrustedScript args.]
-    expected: NOTRUN
+    expected: FAIL
 
   [Violation report for AsyncFunction with plain string.]
-    expected: NOTRUN
-
-  [No violation reported for GeneratorFunction with TrustedScript.]
-    expected: NOTRUN
-
-  [No violation reported for GeneratorFunction with multiple TrustedScript args.]
-    expected: NOTRUN
+    expected: FAIL
 
   [Violation report for GeneratorFunction with plain string.]
-    expected: NOTRUN
-
-  [No violation reported for AsyncGeneratorFunction with TrustedScript.]
-    expected: NOTRUN
-
-  [No violation reported for AsyncGeneratorFunction with multiple TrustedScript args.]
-    expected: NOTRUN
+    expected: FAIL
 
   [Violation report for AsyncGeneratorFunction with plain string.]
-    expected: NOTRUN
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/trusted-types-reporting-for-DedicatedWorker-importScripts.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-reporting-for-DedicatedWorker-importScripts.html.ini
@@ -1,7 +1,3 @@
 [trusted-types-reporting-for-DedicatedWorker-importScripts.html]
-  expected: TIMEOUT
-  [No violation reported for importScripts with TrustedScriptURL.]
-    expected: TIMEOUT
-
   [Violation report for importScripts with plain string.]
-    expected: NOTRUN
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/trusted-types-reporting-for-DedicatedWorker-setTimeout-setInterval.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-reporting-for-DedicatedWorker-setTimeout-setInterval.html.ini
@@ -1,13 +1,6 @@
 [trusted-types-reporting-for-DedicatedWorker-setTimeout-setInterval.html]
-  expected: TIMEOUT
-  [No violation reported for setTimeout with TrustedScript.]
-    expected: TIMEOUT
-
-  [No violation reported for setInterval with TrustedScript.]
-    expected: NOTRUN
-
   [Violation report for setTimeout with plain string.]
-    expected: NOTRUN
+    expected: FAIL
 
   [Violation report for setInterval with plain string.]
-    expected: NOTRUN
+    expected: FAIL


### PR DESCRIPTION
This makes sure that when workers are created, their global scope has the correct policy-container set
so that we can do CSP-checks.