### PR TITLE
htmlvideoelement: Include security settings in poster image request

### DIFF
--- a/components/script/dom/htmlvideoelement.rs
+++ b/components/script/dom/htmlvideoelement.rs
@@ -233,8 +233,10 @@ impl HTMLVideoElement {
         .credentials_mode(CredentialsMode::Include)
         .use_url_credentials(true)
         .origin(document.origin().immutable().clone())
-        .pipeline_id(Some(document.global().pipeline_id()));
-
+        .pipeline_id(Some(document.global().pipeline_id()))
+        .insecure_requests_policy(document.insecure_requests_policy())
+        .has_trustworthy_ancestor_origin(document.has_trustworthy_ancestor_origin())
+        .policy_container(document.policy_container().to_owned());
         // Step 5.
         // This delay must be independent from the ones created by HTMLMediaElement during
         // its media load algorithm, otherwise a code like

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -14171,6 +14171,13 @@
       {}
      ]
     ],
+    "video_poster_csp.sub.html": [
+     "cc5dfd54c1e39904d5c919f6bd6840d65dcc0fa8",
+     [
+      null,
+      {}
+     ]
+    ],
     "weakref.html": [
      "4deccbe1e26a3f921eea85a4395394a55cc88be4",
      [

--- a/tests/wpt/mozilla/meta/__dir__.ini
+++ b/tests/wpt/mozilla/meta/__dir__.ini
@@ -1,3 +1,4 @@
 prefs: [
   "dom_urlpattern_enabled:true",
+  "media_testing_enabled:true",
 ]

--- a/tests/wpt/mozilla/meta/mozilla/video_poster_frame.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/video_poster_frame.html.ini
@@ -1,2 +1,0 @@
-[video_poster_frame.html]
-  expected: TIMEOUT

--- a/tests/wpt/mozilla/tests/mozilla/video_poster_csp.sub.html
+++ b/tests/wpt/mozilla/tests/mozilla/video_poster_csp.sub.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<meta http-equiv="content-security-policy" content="img-src 'self'">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<video></video>
+<img></img>
+<script>
+  // This test sets up a cross-origin image URL for the video poster
+  // and verifies that the poster image is not shown.
+  // It also uses a separate image load to control when to end the test,
+  // since Servo doesn't fire any event handler if a poster image has an
+  // error (https://github.com/whatwg/html/issues/8445).
+  async_test(t => {
+      const pathparts = location.pathname.split('/');
+      const testfile = pathparts[pathparts.length - 1];
+      const url = location.href.replace(location.hostname, "{{hosts[alt][]}}").replace(testfile, "poster.png");
+      let img = document.querySelector("img");
+      img.src = url;
+      img.onload = t.unreached_func();
+      img.onerror = t.step_timeout(() => t.done(), 500);
+      let video = document.querySelector("video");
+      video.onpostershown = t.unreached_func();
+      video.poster = url;
+  });
+</script>


### PR DESCRIPTION
This PR addresses [#36593](https://github.com/servo/servo/issues/36593), where the poster image request for `<video>` elements lacked several settings introduced in `RequestBuilder`. These settings — `insecure_requests_policy`, `has_trustworthy_ancestor_origin`, and `policy_container` — are now forwarded from the document, aligning poster requests with other fetches using the correct policy container and trust assessment.

This ensures that poster images are requested under the same security assumptions as other media or resource loads.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #36593

<!-- Either: -->
- [X] There are tests for these changes 