### PR TITLE
Fix missing settings in script module requests

### DIFF
--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -1760,7 +1760,10 @@ fn fetch_single_module_script(
         .integrity_metadata(options.integrity_metadata.clone())
         .credentials_mode(options.credentials_mode)
         .referrer_policy(options.referrer_policy)
-        .mode(mode);
+        .mode(mode)
+        .insecure_requests_policy(global.insecure_requests_policy())
+        .has_trustworthy_ancestor_origin(global.has_trustworthy_ancestor_origin())
+        .policy_container(global.policy_container().to_owned());
 
     let context = Arc::new(Mutex::new(ModuleContext {
         owner,

--- a/tests/wpt/meta/html/semantics/scripting-1/the-script-element/module/dynamic-import/code-cache-nonce.html.ini
+++ b/tests/wpt/meta/html/semantics/scripting-1/the-script-element/module/dynamic-import/code-cache-nonce.html.ini
@@ -1,0 +1,9 @@
+[code-cache-nonce.html]
+  [First dynamic import should use nonce=abc]
+    expected: FAIL
+
+  [Second dynamic import should use nonce=def]
+    expected: FAIL
+
+  [Third dynamic import should use nonce=ghi]
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/scripting-1/the-script-element/module/dynamic-import/propagate-nonce-external-classic.html.ini
+++ b/tests/wpt/meta/html/semantics/scripting-1/the-script-element/module/dynamic-import/propagate-nonce-external-classic.html.ini
@@ -1,0 +1,3 @@
+[propagate-nonce-external-classic.html]
+  [Dynamically imported module should eval when imported from script w/ a valid nonce.]
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/scripting-1/the-script-element/module/dynamic-import/propagate-nonce-inline-classic.html.ini
+++ b/tests/wpt/meta/html/semantics/scripting-1/the-script-element/module/dynamic-import/propagate-nonce-inline-classic.html.ini
@@ -1,0 +1,3 @@
+[propagate-nonce-inline-classic.html]
+  [Dynamically imported module should eval when imported from script w/ a valid nonce.]
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/scripting-1/the-script-element/module/dynamic-import/string-compilation-nonce-classic.html.ini
+++ b/tests/wpt/meta/html/semantics/scripting-1/the-script-element/module/dynamic-import/string-compilation-nonce-classic.html.ini
@@ -1,6 +1,18 @@
 [string-compilation-nonce-classic.html]
   [reflected inline event handlers must not inherit the nonce from the triggering script, thus fail]
-    expected: FAIL
+    expected: PASS
 
   [inline event handlers triggered via UA code must not inherit the nonce from the triggering script, thus fail]
+    expected: PASS
+
+  [setTimeout must inherit the nonce from the triggering script, thus execute]
+    expected: FAIL
+ 
+  [direct eval must inherit the nonce from the triggering script, thus execute]
+    expected: FAIL
+ 
+  [indirect eval must inherit the nonce from the triggering script, thus execute]
+    expected: FAIL
+ 
+  [the Function constructor must inherit the nonce from the triggering script, thus execute]
     expected: FAIL

--- a/tests/wpt/meta/html/semantics/scripting-1/the-script-element/module/dynamic-import/string-compilation-nonce-module.html.ini
+++ b/tests/wpt/meta/html/semantics/scripting-1/the-script-element/module/dynamic-import/string-compilation-nonce-module.html.ini
@@ -1,9 +1,9 @@
 [string-compilation-nonce-module.html]
   [reflected inline event handlers must not inherit the nonce from the triggering script, thus fail]
-    expected: FAIL
+    expected: PASS
 
   [inline event handlers triggered via UA code must not inherit the nonce from the triggering script, thus fail]
-    expected: FAIL
+    expected: PASS
 
   [direct eval must inherit the nonce from the triggering script, thus execute]
     expected: FAIL
@@ -12,4 +12,7 @@
     expected: FAIL
 
   [the Function constructor must inherit the nonce from the triggering script, thus execute]
+    expected: FAIL
+
+  [setTimeout must inherit the nonce from the triggering script, thus execute]
     expected: FAIL

--- a/tests/wpt/meta/html/semantics/scripting-1/the-script-element/module/dynamic-import/v8-code-cache.html.ini
+++ b/tests/wpt/meta/html/semantics/scripting-1/the-script-element/module/dynamic-import/v8-code-cache.html.ini
@@ -1,0 +1,30 @@
+[v8-code-cache.html]
+  [text/javascript: Run #1]
+    expected: FAIL
+
+  [text/javascript: Run #2]
+    expected: FAIL
+
+  [text/javascript: Run #3]
+    expected: FAIL
+
+  [text/javascript: Run #4]
+    expected: FAIL
+
+  [text/javascript: Run #5]
+    expected: FAIL
+
+  [module: Run #1]
+    expected: FAIL
+
+  [module: Run #2]
+    expected: FAIL
+
+  [module: Run #3]
+    expected: FAIL
+
+  [module: Run #4]
+    expected: FAIL
+
+  [module: Run #5]
+    expected: FAIL


### PR DESCRIPTION
This PR resolves [#36592](https://github.com/servo/servo/issues/36592) by updating the `RequestBuilder` used in `script_module.rs` to include:
- `insecure_requests_policy`
- `has_trustworthy_ancestor_origin`
- `policy_container`

These fields are critical for enforcing proper fetch behavior under modern web security models, and were previously omitted from module script requests.

This change ensures that scripts loaded via `<script type="module">` or dynamic `import()` correctly reflect the calling document’s security environment.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #36592

<!-- Either: -->
- [X] There are tests for these changes 