### PR TITLE
fix crash occurs when the focus element is adopted

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -1180,7 +1180,9 @@ impl Document {
             let node = elem.upcast::<Node>();
             elem.set_focus_state(false);
             // FIXME: pass appropriate relatedTarget
-            self.fire_focus_event(FocusEventType::Blur, node, None, can_gc);
+            if node.is_connected() {
+                self.fire_focus_event(FocusEventType::Blur, node, None, can_gc);
+            }
 
             // Notify the embedder to hide the input method.
             if elem.input_method_type().is_some() {

--- a/tests/wpt/meta/dom/nodes/insertion-removing-steps/blur-event.window.js.ini
+++ b/tests/wpt/meta/dom/nodes/insertion-removing-steps/blur-event.window.js.ini
@@ -1,2 +1,0 @@
-[blur-event.window.html]
-  expected: CRASH

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -25,13 +25,6 @@
       {}
      ]
     ],
-    "focus-element-crash.html": [
-     "9200f1d64201b4bc697895b0430305beca492ce5",
-     [
-      null,
-      {}
-     ]
-    ],
     "global-enumerate-crash.html": [
      "a77e79b1465bf7555340dd5e9bf94a4c8caa85f2",
      [

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -25,6 +25,13 @@
       {}
      ]
     ],
+    "focus-element-crash.html": [
+     "9200f1d64201b4bc697895b0430305beca492ce5",
+     [
+      null,
+      {}
+     ]
+    ],
     "global-enumerate-crash.html": [
      "a77e79b1465bf7555340dd5e9bf94a4c8caa85f2",
      [

--- a/tests/wpt/mozilla/tests/mozilla/focus-element-crash.html
+++ b/tests/wpt/mozilla/tests/mozilla/focus-element-crash.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<meta charset="utf-8">
+<meta name="assert" content="focus element adopted or remounted shouldn't crash.">
+
+<body>
+
+<!--https://github.com/servo/servo/issues/36729 test case-->
+<audio onloadstart="select.focus()" src=""></audio>
+<iframe id="iframe"></iframe>
+<table id="table">
+    <td>
+        <select id="select" onblur=";"></select>
+    </td>
+</table>
+<script>
+    window.addEventListener("load", _ => iframe.appendChild(table));
+</script>
+
+<!--https://github.com/servo/servo/issues/36607 test case-->
+<input id="username" type="text" placeholder="username">
+<input id="password" type="text" placeholder="password">
+</body>
+<script>
+    let search = document.getElementById("search");
+    let username = document.getElementById("username");
+    username.focus();
+    window.onload = () => document.adoptNode(username);
+    username.addEventListener("blur", function (e) {
+        document.body.append(`event:${e.type} fire.`)
+    });
+</script>
+</html>

--- a/tests/wpt/tests/focus/focus-element-crash.html
+++ b/tests/wpt/tests/focus/focus-element-crash.html
@@ -5,7 +5,7 @@
 
 <body>
 
-<!--https://github.com/servo/servo/issues/36729 test case-->
+<!--focus element remounted test case-->
 <audio onloadstart="select.focus()" src=""></audio>
 <iframe id="iframe"></iframe>
 <table id="table">
@@ -17,7 +17,7 @@
     window.addEventListener("load", _ => iframe.appendChild(table));
 </script>
 
-<!--https://github.com/servo/servo/issues/36607 test case-->
+<!--focus element adopted test case-->
 <input id="username" type="text" placeholder="username">
 <input id="password" type="text" placeholder="password">
 </body>


### PR DESCRIPTION
fix crash occurs when the focus element is adopted.

Testing: wpt dom/nodes/insertion-removing-steps/blur-event.window.html not crash

Fixes:  #36607 #32972 
