### PR TITLE
Integrate fetch into WebSocket implementation

### DIFF
--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -15,7 +15,7 @@ use embedder_traits::resources::{self, Resource};
 use headers::{AccessControlExposeHeaders, ContentType, HeaderMapExt};
 use http::header::{self, HeaderMap, HeaderName, RANGE};
 use http::{HeaderValue, Method, StatusCode};
-use ipc_channel::ipc;
+use ipc_channel::ipc::{self, IpcReceiver, IpcSender};
 use log::{debug, trace, warn};
 use mime::{self, Mime};
 use net_traits::fetch::headers::extract_mime_type_as_mime;
@@ -30,7 +30,8 @@ use net_traits::request::{
 use net_traits::response::{Response, ResponseBody, ResponseType};
 use net_traits::{
     FetchTaskTarget, NetworkError, ReferrerPolicy, ResourceAttribute, ResourceFetchTiming,
-    ResourceTimeValue, ResourceTimingType, set_default_accept_language,
+    ResourceTimeValue, ResourceTimingType, WebSocketDomAction, WebSocketNetworkEvent,
+    set_default_accept_language,
 };
 use rustls_pki_types::CertificateDer;
 use serde::{Deserialize, Serialize};
@@ -39,6 +40,7 @@ use servo_url::{Host, ImmutableOrigin, ServoUrl};
 use tokio::sync::mpsc::{UnboundedReceiver as TokioReceiver, UnboundedSender as TokioSender};
 
 use super::fetch_params::FetchParams;
+use crate::connector::CACertificates;
 use crate::fetch::cors_cache::CorsCache;
 use crate::fetch::headers::determine_nosniff;
 use crate::filemanager_thread::FileManager;
@@ -62,6 +64,20 @@ pub enum Data {
     Cancelled,
 }
 
+pub struct WebSocketChannel {
+    pub sender: IpcSender<WebSocketNetworkEvent>,
+    pub receiver: Option<IpcReceiver<WebSocketDomAction>>,
+}
+
+impl WebSocketChannel {
+    pub fn new(
+        sender: IpcSender<WebSocketNetworkEvent>,
+        receiver: Option<IpcReceiver<WebSocketDomAction>>,
+    ) -> Self {
+        Self { sender, receiver }
+    }
+}
+
 pub struct FetchContext {
     pub state: Arc<HttpState>,
     pub user_agent: String,
@@ -72,6 +88,9 @@ pub struct FetchContext {
     pub cancellation_listener: Arc<CancellationListener>,
     pub timing: ServoArc<Mutex<ResourceFetchTiming>>,
     pub protocols: Arc<ProtocolRegistry>,
+    pub websocket_chan: Option<Arc<Mutex<WebSocketChannel>>>,
+    pub ca_certificates: CACertificates,
+    pub ignore_certificate_errors: bool,
 }
 
 #[derive(Default)]
@@ -178,8 +197,16 @@ pub(crate) fn convert_request_to_csp_request(request: &Request) -> Option<csp::R
         Origin::Client => return None,
         Origin::Origin(origin) => origin,
     };
+
+    // We need to retroactively upgrade the ws URL if the rewritten http URL was upgraded to a secure scheme.
+    // https://github.com/w3c/webappsec-csp/issues/532
+    let mut original_url = request.original_url();
+    if original_url.scheme() == "ws" && request.url().scheme() == "https" {
+        original_url.as_mut_url().set_scheme("wss").unwrap();
+    }
+
     let csp_request = csp::Request {
-        url: request.url().into_url(),
+        url: original_url.into_url(),
         origin: origin.clone().into_url_origin(),
         redirect_count: request.redirect_count,
         destination: request.destination,
@@ -238,6 +265,21 @@ fn should_response_be_blocked_by_csp(
             .actual_response()
             .url()
             .cloned()
+            // NOTE(pylbrecht): for WebSocket connections, the URL scheme is converted to http(s)
+            // to integrate with fetch(). We need to convert it back to ws(s) to get valid CSP
+            // checks.
+            // https://github.com/w3c/webappsec-csp/issues/532
+            .map(|mut url| {
+                match csp_request.url.scheme() {
+                    "ws" | "wss" => {
+                        url.as_mut_url()
+                            .set_scheme(csp_request.url.scheme())
+                            .expect("failed to set URL scheme");
+                    },
+                    _ => {},
+                };
+                url
+            })
             .expect("response must have a url")
             .into_url(),
         redirect_count: csp_request.redirect_count,

--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -346,7 +346,7 @@ pub async fn main_fetch(
     // TODO: handle request abort.
 
     // Step 4. Upgrade request to a potentially trustworthy URL, if appropriate.
-    if should_upgrade_request_to_potentially_trustworty(request, context) ||
+    if should_upgrade_request_to_potentially_trustworthy(request, context) ||
         should_upgrade_mixed_content_request(request, &context.protocols)
     {
         trace!(
@@ -1157,7 +1157,7 @@ pub fn is_form_submission_request(request: &Request) -> bool {
 }
 
 /// <https://w3c.github.io/webappsec-upgrade-insecure-requests/#upgrade-request>
-fn should_upgrade_request_to_potentially_trustworty(
+fn should_upgrade_request_to_potentially_trustworthy(
     request: &mut Request,
     context: &FetchContext,
 ) -> bool {

--- a/components/net/tests/fetch.rs
+++ b/components/net/tests/fetch.rs
@@ -28,6 +28,7 @@ use hyper::body::{Bytes, Incoming};
 use hyper::{Request as HyperRequest, Response as HyperResponse};
 use mime::{self, Mime};
 use net::async_runtime::spawn_blocking_task;
+use net::connector::CACertificates;
 use net::fetch::cors_cache::CorsCache;
 use net::fetch::methods::{self, FetchContext};
 use net::filemanager_thread::FileManager;
@@ -763,6 +764,9 @@ fn test_fetch_with_hsts() {
             ResourceTimingType::Navigation,
         ))),
         protocols: Arc::new(ProtocolRegistry::default()),
+        websocket_chan: None,
+        ca_certificates: CACertificates::Default,
+        ignore_certificate_errors: false,
     };
 
     // The server certificate is self-signed, so we need to add an override
@@ -824,6 +828,9 @@ fn test_load_adds_host_to_hsts_list_when_url_is_https() {
             ResourceTimingType::Navigation,
         ))),
         protocols: Arc::new(ProtocolRegistry::default()),
+        websocket_chan: None,
+        ca_certificates: CACertificates::Default,
+        ignore_certificate_errors: false,
     };
 
     // The server certificate is self-signed, so we need to add an override
@@ -891,6 +898,9 @@ fn test_fetch_self_signed() {
             ResourceTimingType::Navigation,
         ))),
         protocols: Arc::new(ProtocolRegistry::default()),
+        websocket_chan: None,
+        ca_certificates: CACertificates::Default,
+        ignore_certificate_errors: false,
     };
 
     let request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url.clone(), Referrer::NoReferrer)
@@ -1460,6 +1470,9 @@ fn test_fetch_request_intercepted() {
             ResourceTimingType::Navigation,
         ))),
         protocols: Arc::new(ProtocolRegistry::default()),
+        websocket_chan: None,
+        ca_certificates: CACertificates::Default,
+        ignore_certificate_errors: false,
     };
 
     let url = ServoUrl::parse("http://www.example.org").unwrap();

--- a/components/net/tests/main.rs
+++ b/components/net/tests/main.rs
@@ -39,7 +39,7 @@ use hyper::service::service_fn;
 use hyper::{Request as HyperRequest, Response as HyperResponse};
 use hyper_util::rt::tokio::TokioIo;
 use net::async_runtime::{init_async_runtime, spawn_blocking_task, spawn_task};
-use net::connector::{create_http_client, create_tls_config};
+use net::connector::{CACertificates, create_http_client, create_tls_config};
 use net::fetch::cors_cache::CorsCache;
 use net::fetch::methods::{self, FetchContext};
 use net::filemanager_thread::FileManager;
@@ -184,6 +184,9 @@ fn new_fetch_context(
             ResourceTimingType::Navigation,
         ))),
         protocols: Arc::new(ProtocolRegistry::with_internal_protocols()),
+        websocket_chan: None,
+        ca_certificates: CACertificates::Default,
+        ignore_certificate_errors: false,
     }
 }
 impl FetchTaskTarget for FetchResponseCollector {

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -372,6 +372,21 @@ impl FetchTaskTarget for IpcSender<FetchResponseMsg> {
     }
 }
 
+impl FetchTaskTarget for IpcSender<WebSocketNetworkEvent> {
+    fn process_request_body(&mut self, _: &Request) {}
+    fn process_request_eof(&mut self, _: &Request) {}
+    fn process_response(&mut self, _: &Request, response: &Response) {
+        if response.is_network_error() {
+            let _ = self.send(WebSocketNetworkEvent::Fail);
+        }
+    }
+    fn process_response_chunk(&mut self, _: &Request, _: Vec<u8>) {}
+    fn process_response_eof(&mut self, _: &Request, _: &Response) {}
+    fn process_csp_violations(&mut self, _: &Request, violations: Vec<csp::Violation>) {
+        let _ = self.send(WebSocketNetworkEvent::ReportCSPViolations(violations));
+    }
+}
+
 /// A fetch task that discards all data it's sent,
 /// useful when speculatively prefetching data that we don't need right
 /// now, but might need in the future.

--- a/components/shared/net/request.rs
+++ b/components/shared/net/request.rs
@@ -78,7 +78,10 @@ pub enum RequestMode {
     SameOrigin,
     NoCors,
     CorsMode,
-    WebSocket { protocols: Vec<String> },
+    WebSocket {
+        protocols: Vec<String>,
+        original_url: ServoUrl,
+    },
 }
 
 /// Request [credentials mode](https://fetch.spec.whatwg.org/#concept-request-credentials-mode)
@@ -701,6 +704,16 @@ impl Request {
     /// <https://fetch.spec.whatwg.org/#concept-request-url>
     pub fn url(&self) -> ServoUrl {
         self.url_list.first().unwrap().clone()
+    }
+
+    pub fn original_url(&self) -> ServoUrl {
+        match self.mode {
+            RequestMode::WebSocket {
+                protocols: _,
+                ref original_url,
+            } => original_url.clone(),
+            _ => self.url(),
+        }
     }
 
     /// <https://fetch.spec.whatwg.org/#concept-request-current-url>

--- a/tests/wpt/meta/content-security-policy/inside-worker/dedicatedworker-report-only.html.ini
+++ b/tests/wpt/meta/content-security-policy/inside-worker/dedicatedworker-report-only.html.ini
@@ -1,7 +1,3 @@
 [dedicatedworker-report-only.html]
-  expected: TIMEOUT
-  [WebSocket.]
-    expected: TIMEOUT
-
   [connect-src-self-report-only]
-    expected: NOTRUN
+    expected: FAIL

--- a/tests/wpt/meta/mixed-content/gen/top.http-rp/opt-in/websocket.https.html.ini
+++ b/tests/wpt/meta/mixed-content/gen/top.http-rp/opt-in/websocket.https.html.ini
@@ -1,6 +1,0 @@
-[websocket.https.html]
-  [Mixed-Content: Expects blocked for websocket to cross-ws origin and no-redirect redirection from https context.]
-    expected: FAIL
-
-  [Mixed-Content: Expects blocked for websocket to same-ws origin and no-redirect redirection from https context.]
-    expected: FAIL

--- a/tests/wpt/meta/mixed-content/gen/top.meta/opt-in/websocket.https.html.ini
+++ b/tests/wpt/meta/mixed-content/gen/top.meta/opt-in/websocket.https.html.ini
@@ -1,6 +1,0 @@
-[websocket.https.html]
-  [Mixed-Content: Expects blocked for websocket to cross-ws origin and no-redirect redirection from https context.]
-    expected: FAIL
-
-  [Mixed-Content: Expects blocked for websocket to same-ws origin and no-redirect redirection from https context.]
-    expected: FAIL

--- a/tests/wpt/meta/mixed-content/gen/top.meta/unset/websocket.https.html.ini
+++ b/tests/wpt/meta/mixed-content/gen/top.meta/unset/websocket.https.html.ini
@@ -1,6 +1,0 @@
-[websocket.https.html]
-  [Mixed-Content: Expects blocked for websocket to cross-ws origin and no-redirect redirection from https context.]
-    expected: FAIL
-
-  [Mixed-Content: Expects blocked for websocket to same-ws origin and no-redirect redirection from https context.]
-    expected: FAIL

--- a/tests/wpt/meta/mixed-content/gen/worker-classic-data.http-rp/opt-in/websocket.https.html.ini
+++ b/tests/wpt/meta/mixed-content/gen/worker-classic-data.http-rp/opt-in/websocket.https.html.ini
@@ -1,6 +1,0 @@
-[websocket.https.html]
-  [Mixed-Content: Expects blocked for websocket to cross-ws origin and no-redirect redirection from https context.]
-    expected: FAIL
-
-  [Mixed-Content: Expects blocked for websocket to same-ws origin and no-redirect redirection from https context.]
-    expected: FAIL

--- a/tests/wpt/meta/mixed-content/gen/worker-classic-data.meta/opt-in/websocket.https.html.ini
+++ b/tests/wpt/meta/mixed-content/gen/worker-classic-data.meta/opt-in/websocket.https.html.ini
@@ -1,6 +1,0 @@
-[websocket.https.html]
-  [Mixed-Content: Expects blocked for websocket to cross-ws origin and no-redirect redirection from https context.]
-    expected: FAIL
-
-  [Mixed-Content: Expects blocked for websocket to same-ws origin and no-redirect redirection from https context.]
-    expected: FAIL

--- a/tests/wpt/meta/mixed-content/gen/worker-classic-data.meta/unset/websocket.https.html.ini
+++ b/tests/wpt/meta/mixed-content/gen/worker-classic-data.meta/unset/websocket.https.html.ini
@@ -1,6 +1,0 @@
-[websocket.https.html]
-  [Mixed-Content: Expects blocked for websocket to cross-ws origin and no-redirect redirection from https context.]
-    expected: FAIL
-
-  [Mixed-Content: Expects blocked for websocket to same-ws origin and no-redirect redirection from https context.]
-    expected: FAIL

--- a/tests/wpt/meta/mixed-content/gen/worker-classic.http-rp/opt-in/websocket.https.html.ini
+++ b/tests/wpt/meta/mixed-content/gen/worker-classic.http-rp/opt-in/websocket.https.html.ini
@@ -1,6 +1,0 @@
-[websocket.https.html]
-  [Mixed-Content: Expects blocked for websocket to cross-ws origin and no-redirect redirection from https context.]
-    expected: FAIL
-
-  [Mixed-Content: Expects blocked for websocket to same-ws origin and no-redirect redirection from https context.]
-    expected: FAIL

--- a/tests/wpt/meta/mixed-content/gen/worker-classic.http-rp/unset/websocket.https.html.ini
+++ b/tests/wpt/meta/mixed-content/gen/worker-classic.http-rp/unset/websocket.https.html.ini
@@ -1,6 +1,0 @@
-[websocket.https.html]
-  [Mixed-Content: Expects blocked for websocket to cross-ws origin and no-redirect redirection from https context.]
-    expected: FAIL
-
-  [Mixed-Content: Expects blocked for websocket to same-ws origin and no-redirect redirection from https context.]
-    expected: FAIL

--- a/tests/wpt/meta/upgrade-insecure-requests/gen/iframe-blank-inherit.meta/upgrade/websocket.https.html.ini
+++ b/tests/wpt/meta/upgrade-insecure-requests/gen/iframe-blank-inherit.meta/upgrade/websocket.https.html.ini
@@ -1,6 +1,0 @@
-[websocket.https.html]
-  [Upgrade-Insecure-Requests: Expects allowed for websocket to cross-ws-downgrade origin and no-redirect redirection from https context.]
-    expected: FAIL
-
-  [Upgrade-Insecure-Requests: Expects allowed for websocket to same-ws-downgrade origin and no-redirect redirection from https context.]
-    expected: FAIL

--- a/tests/wpt/meta/upgrade-insecure-requests/gen/srcdoc-inherit.meta/upgrade/websocket.https.html.ini
+++ b/tests/wpt/meta/upgrade-insecure-requests/gen/srcdoc-inherit.meta/upgrade/websocket.https.html.ini
@@ -1,6 +1,0 @@
-[websocket.https.html]
-  [Upgrade-Insecure-Requests: Expects allowed for websocket to cross-ws-downgrade origin and no-redirect redirection from https context.]
-    expected: FAIL
-
-  [Upgrade-Insecure-Requests: Expects allowed for websocket to same-ws-downgrade origin and no-redirect redirection from https context.]
-    expected: FAIL

--- a/tests/wpt/meta/upgrade-insecure-requests/gen/top.http-rp/upgrade/websocket.https.html.ini
+++ b/tests/wpt/meta/upgrade-insecure-requests/gen/top.http-rp/upgrade/websocket.https.html.ini
@@ -1,6 +1,0 @@
-[websocket.https.html]
-  [Upgrade-Insecure-Requests: Expects allowed for websocket to cross-ws-downgrade origin and no-redirect redirection from https context.]
-    expected: FAIL
-
-  [Upgrade-Insecure-Requests: Expects allowed for websocket to same-ws-downgrade origin and no-redirect redirection from https context.]
-    expected: FAIL

--- a/tests/wpt/meta/upgrade-insecure-requests/gen/top.meta/upgrade/websocket.https.html.ini
+++ b/tests/wpt/meta/upgrade-insecure-requests/gen/top.meta/upgrade/websocket.https.html.ini
@@ -1,6 +1,0 @@
-[websocket.https.html]
-  [Upgrade-Insecure-Requests: Expects allowed for websocket to cross-ws-downgrade origin and no-redirect redirection from https context.]
-    expected: FAIL
-
-  [Upgrade-Insecure-Requests: Expects allowed for websocket to same-ws-downgrade origin and no-redirect redirection from https context.]
-    expected: FAIL

--- a/tests/wpt/meta/upgrade-insecure-requests/gen/worker-classic-data.meta/upgrade/websocket.https.html.ini
+++ b/tests/wpt/meta/upgrade-insecure-requests/gen/worker-classic-data.meta/upgrade/websocket.https.html.ini
@@ -1,6 +1,0 @@
-[websocket.https.html]
-  [Upgrade-Insecure-Requests: Expects allowed for websocket to cross-ws-downgrade origin and no-redirect redirection from https context.]
-    expected: FAIL
-
-  [Upgrade-Insecure-Requests: Expects allowed for websocket to same-ws-downgrade origin and no-redirect redirection from https context.]
-    expected: FAIL


### PR DESCRIPTION
# Description

For the initial WebSocket handshake, we need to create a proper handshake request and `fetch()` it. Creating this handshake request begins in `WebSocketMethods::Constructor()`, which sends the partially prepared `RequestBuilder` over to `components/net/resource_thread.rs`. There we handle the incoming `CoreResourceMsg::Fetch` message and finish creating the handshake request in `components/net/websocket_loader.rs::create_handshake_request()`. Finally we fetch the request by calling `components/net/fetch/methods.rs::fetch()`.

`fetch()` eventually calls `http_network_fetch()`. This is where the "actual fetching" of the request takes place on a network level, which means we need to handle WebSocket handshake requests differently than non-WebSocket requests. I mostly moved the existing code, which uses `tungstenite`, with some type massaging (thanks again, @jdm, for helping me out here!). This included converting from tungstenite types to Servo's net types (request/response).

# The tricky bits

In order to fetch the handshake request via `components/net/fetch/methods.rs::fetch()`, we need to convert the request URL's scheme from ws(s) to http(s). Then, we need to "undo" this conversion again when doing CSP checks (i.e. http(s) back to ws(s)). To avoid having this "undoing" logic in a bunch of places we introduced `Request::original_url()`, holding the URL before the scheme conversion took place. Unfortunately this only gets as so far. There are still some places, where we need to explicitly check and/or convert the URL scheme (e.g. retroactively upgrading to a secure scheme).

# Related

* https://websockets.spec.whatwg.org/#concept-websocket-establish
* https://fetch.spec.whatwg.org/#http-network-fetch
* https://github.com/w3c/webappsec-csp/issues/532

---

Fixes: #35028
