### PR TITLE
Use swap_remove when unrooting DOM objects.

### DIFF
--- a/components/script_bindings/root.rs
+++ b/components/script_bindings/root.rs
@@ -412,7 +412,7 @@ impl RootCollection {
             .rposition(|r| std::ptr::addr_eq(*r as *const (), object as *const ()))
         {
             Some(idx) => {
-                roots.remove(idx);
+                roots.swap_remove(idx);
             },
             None => panic!("Can't remove a root that was never rooted!"),
         }


### PR DESCRIPTION
Profiling from #36609 showed this is an easy win. Ordering of our root list does not matter, so swap_remove is a constant time operation compared to a linear time one that caused memmove to appear in profiles with lots of unrooting.

Testing: Existing WPT tests will cover this change.
Fixes: Part of #36609.