### PR TITLE
Rework `ScriptThread::handle_input_event` for behaviour and performance

### DIFF
--- a/components/shared/embedder/input_events.rs
+++ b/components/shared/embedder/input_events.rs
@@ -51,7 +51,7 @@ pub struct MouseButtonEvent {
     pub point: DevicePoint,
 }
 
-#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 pub enum MouseButton {
     Left,
     Middle,


### PR DESCRIPTION
Rework `ScriptThread::handle_input_event` for correct behaviour and better performance
1. Only trigger click event with primary button, according to spec
2. Avoid unnecessary clone of `ConstellationInputEvent`

This is a follow up of #36413 

Testing: Manually tested. Right mouse won't trigger click event now.
Fixes: #35666 
cc @jdm @xiaochengh 
