### PR TITLE
Fix: Slot Assignment mode according to the spec

### DIFF
--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -1462,7 +1462,7 @@ impl TreeSink for Sink {
             clonable,
             serializable,
             delegatesfocus,
-            SlotAssignmentMode::Manual,
+            SlotAssignmentMode::Named,
             CanGc::note(),
         ) {
             Ok(shadow_root) => {

--- a/tests/wpt/meta/shadow-dom/declarative/declarative-shadow-dom-basic.html.ini
+++ b/tests/wpt/meta/shadow-dom/declarative/declarative-shadow-dom-basic.html.ini
@@ -1,6 +1,0 @@
-[declarative-shadow-dom-basic.html]
-  [Declarative Shadow DOM: Basic test]
-    expected: FAIL
-
-  [Declarative Shadow DOM: Fragment parser basic test]
-    expected: FAIL

--- a/tests/wpt/meta/shadow-dom/declarative/declarative-shadow-dom-repeats.html.ini
+++ b/tests/wpt/meta/shadow-dom/declarative/declarative-shadow-dom-repeats.html.ini
@@ -1,3 +1,0 @@
-[declarative-shadow-dom-repeats.html]
-  [Calling attachShadow() on declarative shadow root must match all parameters]
-    expected: FAIL

--- a/tests/wpt/meta/shadow-dom/declarative/declarative-shadow-dom-write-to-iframe.html.ini
+++ b/tests/wpt/meta/shadow-dom/declarative/declarative-shadow-dom-write-to-iframe.html.ini
@@ -1,3 +1,0 @@
-[declarative-shadow-dom-write-to-iframe.html]
-  [`document.write` on inner iframe handles declarative shadow DOM]
-    expected: FAIL


### PR DESCRIPTION
When parsing a Declarative Shadow DOM, the slot assignment isn't being triggered as mentioned in the [spec](https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inhead:~:text=Attach%20a%20shadow%20root%20with%20declarative%20shadow%20host%20element%2C%20mode%2C%20clonable%2C%20serializable%2C%20delegatesFocus%2C%20%22named%22%2C%20and%20registry.). 

When creating a shadow root declaratively, SlotAssignment mode was set to "manual" instead of "named".

Tests: The followings should get fully passed with this change, so `.ini`s are removed.
 - `declarative-shadow-dom-basic.html` 
 - `declarative-shadow-dom-write-to-iframe.html`
 - `declarative-shadow-dom-repeats.html`

Fixes: #36100 
