### PR TITLE
layout_image: Include missing request settings in layout-initiated image loads

### DIFF
--- a/components/script/layout_image.rs
+++ b/components/script/layout_image.rs
@@ -119,7 +119,10 @@ pub(crate) fn fetch_image_for_layout(
     )
     .origin(document.origin().immutable().clone())
     .destination(Destination::Image)
-    .pipeline_id(Some(document.global().pipeline_id()));
+    .pipeline_id(Some(document.global().pipeline_id()))
+    .insecure_requests_policy(document.insecure_requests_policy())
+    .has_trustworthy_ancestor_origin(document.has_trustworthy_ancestor_origin())
+    .policy_container(document.policy_container().to_owned());
 
     // Layout image loads do not delay the document load event.
     document.fetch_background(request, context);

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -12755,6 +12755,13 @@
       {}
      ]
     ],
+    "background_image_csp.sub.html": [
+     "c326f54de52c6a36cbaf4871c947c5b785cac83d",
+     [
+      null,
+      {}
+     ]
+    ],
     "binding_keyword.html": [
      "818d2aa29471026c1b4215dfcd1b9939a052b1ea",
      [

--- a/tests/wpt/mozilla/tests/mozilla/background_image_csp.sub.html
+++ b/tests/wpt/mozilla/tests/mozilla/background_image_csp.sub.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<meta http-equiv="content-security-policy" content="img-src 'self'">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  #target {
+    width: 100px;
+    height: 100px;
+    background-size: cover;
+  }
+</style>
+<div id="target"></div>
+<img id="control">
+<script>
+  // This test sets up a cross-origin background-image on a div and checks that it's blocked by CSP.
+  // It also uses a regular <img> to control when the test should end.
+  async_test(t => {
+      const pathparts = location.pathname.split('/');
+      const testfile = pathparts[pathparts.length - 1];
+      const url = location.href.replace(location.hostname, "{{hosts[alt][]}}").replace(testfile, "poster.png");
+
+      const target = document.getElementById("target");
+      target.style.backgroundImage = `url('${url}')`;
+
+      // control image load
+      const control = document.getElementById("control");
+      control.src = url;
+      control.onload = t.unreached_func("Control image should not load (CSP should block it)");
+      control.onerror = t.step_timeout(() => {
+          // No way to assert background-image load failure directly, just ensure no crash / test timeout
+          t.done();
+      }, 500);
+  });
+</script>


### PR DESCRIPTION
This PR updates the `fetch_image_for_layout` function to include missing security-related request settings:

- `insecure_requests_policy`
- `has_trustworthy_ancestor_origin`
- `policy_container`

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #36591

<!-- Either: -->
- [X] There are tests for these changes