### PR TITLE
script_thread: HTML parser doesn't set relevant option

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -1108,6 +1108,12 @@ impl Document {
         self.scripting_enabled
     }
 
+    /// Return whether scripting is enabled or not
+    /// <https://html.spec.whatwg.org/multipage/#concept-n-noscript>
+    pub(crate) fn scripting_enabled(&self) -> bool {
+        self.has_browsing_context()
+    }
+
     /// Return the element that currently has focus.
     // https://w3c.github.io/uievents/#events-focusevent-doc-focus
     pub(crate) fn get_focused_element(&self) -> Option<DomRoot<Element>> {


### PR DESCRIPTION
This patch ensures that the Servo HTML parser uses the appropriate `TreeBuilderOpts` settings
as specified by the HTML specification.

Changes:
- **iframe_srcdoc:** Detect if the parsed document's URL scheme is `about:srcdoc`, and set the parser’s iframe_srcdoc option accordingly.
- **quirks_mode:** Use the associated Document's quirks mode to set the parser’s quirks mode flag, improving fragment parsing behavior.
- **scripting_enabled:** Add a `scripting_enabled` method to Document, based on whether it has a browsing context, and set this flag for the parser.

These updates align Servo's parsing behavior more closely with the specification:
https://html.spec.whatwg.org/multipage/parsing.html#the-initial-insertion-mode

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #35478

<!-- Either: -->
- [ ] There are tests for these changes
