### PR TITLE
Reduce indexing boilerplate for serializable/transferrable objects.

### DIFF
--- a/components/compositing/webview_manager.rs
+++ b/components/compositing/webview_manager.rs
@@ -111,11 +111,7 @@ impl<WebView> WebViewManager<WebView> {
 
 #[cfg(test)]
 mod test {
-    use std::num::NonZeroU32;
-
-    use base::id::{
-        BrowsingContextId, BrowsingContextIndex, PipelineNamespace, PipelineNamespaceId, WebViewId,
-    };
+    use base::id::{BrowsingContextId, Index, PipelineNamespace, PipelineNamespaceId, WebViewId};
 
     use crate::webview::UnknownWebView;
     use crate::webview_manager::WebViewManager;
@@ -123,7 +119,7 @@ mod test {
     fn top_level_id(namespace_id: u32, index: u32) -> WebViewId {
         WebViewId(BrowsingContextId {
             namespace_id: PipelineNamespaceId(namespace_id),
-            index: BrowsingContextIndex(NonZeroU32::new(index).unwrap()),
+            index: Index::new(index).unwrap(),
         })
     }
 

--- a/components/constellation/webview_manager.rs
+++ b/components/constellation/webview_manager.rs
@@ -81,18 +81,14 @@ impl<WebView> WebViewManager<WebView> {
 
 #[cfg(test)]
 mod test {
-    use std::num::NonZeroU32;
-
-    use base::id::{
-        BrowsingContextId, BrowsingContextIndex, PipelineNamespace, PipelineNamespaceId, WebViewId,
-    };
+    use base::id::{BrowsingContextId, Index, PipelineNamespace, PipelineNamespaceId, WebViewId};
 
     use crate::webview_manager::WebViewManager;
 
     fn id(namespace_id: u32, index: u32) -> WebViewId {
         WebViewId(BrowsingContextId {
             namespace_id: PipelineNamespaceId(namespace_id),
-            index: BrowsingContextIndex(NonZeroU32::new(index).expect("Incorrect test case")),
+            index: Index::new(index).expect("Incorrect test case"),
         })
     }
 

--- a/components/script/dom/bindings/serializable.rs
+++ b/components/script/dom/bindings/serializable.rs
@@ -8,7 +8,7 @@
 use std::collections::HashMap;
 use std::num::NonZeroU32;
 
-use base::id::PipelineNamespaceId;
+use base::id::{Index, NamespaceIndex, PipelineNamespaceId};
 
 use crate::dom::bindings::reflector::DomObject;
 use crate::dom::bindings::root::DomRoot;
@@ -35,11 +35,26 @@ impl StorageKey {
     }
 }
 
+impl<T> From<StorageKey> for NamespaceIndex<T> {
+    fn from(key: StorageKey) -> NamespaceIndex<T> {
+        NamespaceIndex {
+            namespace_id: PipelineNamespaceId(key.name_space),
+            index: Index::new(key.index).expect("Index must not be zero"),
+        }
+    }
+}
+
 pub(crate) trait IntoStorageKey
 where
     Self: Sized,
 {
     fn into_storage_key(self) -> StorageKey;
+}
+
+impl<T> IntoStorageKey for NamespaceIndex<T> {
+    fn into_storage_key(self) -> StorageKey {
+        StorageKey::new(self.namespace_id, self.index.0)
+    }
 }
 
 /// Interface for serializable platform objects.

--- a/components/script/dom/bindings/transferable.rs
+++ b/components/script/dom/bindings/transferable.rs
@@ -6,9 +6,10 @@
 //! (<https://html.spec.whatwg.org/multipage/#transferable-objects>).
 
 use std::collections::HashMap;
+use std::marker::PhantomData;
 use std::num::NonZeroU32;
 
-use base::id::PipelineNamespaceId;
+use base::id::{Index, NamespaceIndex, PipelineNamespaceId};
 
 use crate::dom::bindings::reflector::DomObject;
 use crate::dom::bindings::root::DomRoot;
@@ -22,8 +23,23 @@ where
     fn from(namespace_id: PipelineNamespaceId, index: NonZeroU32) -> Self;
 }
 
+impl<T> IdFromComponents for NamespaceIndex<T> {
+    fn from(namespace_id: PipelineNamespaceId, index: NonZeroU32) -> NamespaceIndex<T> {
+        NamespaceIndex {
+            namespace_id,
+            index: Index(index, PhantomData),
+        }
+    }
+}
+
 pub(crate) trait ExtractComponents {
     fn components(&self) -> (PipelineNamespaceId, NonZeroU32);
+}
+
+impl<T> ExtractComponents for NamespaceIndex<T> {
+    fn components(&self) -> (PipelineNamespaceId, NonZeroU32) {
+        (self.namespace_id, self.index.0)
+    }
 }
 
 pub(crate) trait Transferable: DomObject

--- a/components/script/dom/blob.rs
+++ b/components/script/dom/blob.rs
@@ -3,11 +3,10 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::collections::HashMap;
-use std::num::NonZeroU32;
 use std::ptr;
 use std::rc::Rc;
 
-use base::id::{BlobId, BlobIndex, PipelineNamespaceId};
+use base::id::BlobId;
 use constellation_traits::BlobImpl;
 use dom_struct::dom_struct;
 use encoding_rs::UTF_8;
@@ -25,7 +24,7 @@ use crate::dom::bindings::codegen::UnionTypes::ArrayBufferOrArrayBufferViewOrBlo
 use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::reflector::{DomGlobal, Reflector, reflect_dom_object_with_proto};
 use crate::dom::bindings::root::DomRoot;
-use crate::dom::bindings::serializable::{IntoStorageKey, Serializable, StorageKey};
+use crate::dom::bindings::serializable::{Serializable, StorageKey};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::bindings::structuredclone::{StructuredData, StructuredDataReader};
 use crate::dom::globalscope::GlobalScope;
@@ -133,26 +132,6 @@ impl Serializable for Blob {
         data: &mut StructuredDataReader,
     ) -> &mut Option<HashMap<StorageKey, DomRoot<Self>>> {
         &mut data.blobs
-    }
-}
-
-impl From<StorageKey> for BlobId {
-    fn from(storage_key: StorageKey) -> BlobId {
-        let namespace_id = PipelineNamespaceId(storage_key.name_space);
-        let index =
-            BlobIndex(NonZeroU32::new(storage_key.index).expect("Deserialized blob index is zero"));
-
-        BlobId {
-            namespace_id,
-            index,
-        }
-    }
-}
-
-impl IntoStorageKey for BlobId {
-    fn into_storage_key(self) -> StorageKey {
-        let BlobIndex(index) = self.index;
-        StorageKey::new(self.namespace_id, index)
     }
 }
 

--- a/components/script/dom/blob.rs
+++ b/components/script/dom/blob.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use std::ptr;
 use std::rc::Rc;
 
-use base::id::BlobId;
+use base::id::{BlobId, BlobIndex};
 use constellation_traits::BlobImpl;
 use dom_struct::dom_struct;
 use encoding_rs::UTF_8;
@@ -93,7 +93,7 @@ impl Blob {
 }
 
 impl Serializable for Blob {
-    type Id = BlobId;
+    type Index = BlobIndex;
     type Data = BlobImpl;
 
     /// <https://w3c.github.io/FileAPI/#ref-for-serialization-steps>
@@ -119,9 +119,7 @@ impl Serializable for Blob {
         Ok(deserialized_blob)
     }
 
-    fn serialized_storage(
-        reader: StructuredData<'_>,
-    ) -> &mut Option<HashMap<Self::Id, Self::Data>> {
+    fn serialized_storage(reader: StructuredData<'_>) -> &mut Option<HashMap<BlobId, Self::Data>> {
         match reader {
             StructuredData::Reader(r) => &mut r.blob_impls,
             StructuredData::Writer(w) => &mut w.blobs,

--- a/components/script/dom/domexception.rs
+++ b/components/script/dom/domexception.rs
@@ -3,9 +3,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::collections::HashMap;
-use std::num::NonZeroU32;
 
-use base::id::{DomExceptionId, DomExceptionIndex, PipelineNamespaceId};
+use base::id::DomExceptionId;
 use constellation_traits::DomException;
 use dom_struct::dom_struct;
 use js::rust::HandleObject;
@@ -18,7 +17,7 @@ use crate::dom::bindings::reflector::{
     Reflector, reflect_dom_object, reflect_dom_object_with_proto,
 };
 use crate::dom::bindings::root::DomRoot;
-use crate::dom::bindings::serializable::{IntoStorageKey, Serializable, StorageKey};
+use crate::dom::bindings::serializable::{Serializable, StorageKey};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::bindings::structuredclone::{StructuredData, StructuredDataReader};
 use crate::dom::globalscope::GlobalScope;
@@ -264,26 +263,5 @@ impl Serializable for DOMException {
         reader: &mut StructuredDataReader,
     ) -> &mut Option<HashMap<StorageKey, DomRoot<Self>>> {
         &mut reader.dom_exceptions
-    }
-}
-
-impl From<StorageKey> for DomExceptionId {
-    fn from(storage_key: StorageKey) -> DomExceptionId {
-        let namespace_id = PipelineNamespaceId(storage_key.name_space);
-        let index = DomExceptionIndex(
-            NonZeroU32::new(storage_key.index).expect("Deserialized exception index is zero"),
-        );
-
-        DomExceptionId {
-            namespace_id,
-            index,
-        }
-    }
-}
-
-impl IntoStorageKey for DomExceptionId {
-    fn into_storage_key(self) -> StorageKey {
-        let DomExceptionIndex(index) = self.index;
-        StorageKey::new(self.namespace_id, index)
     }
 }

--- a/components/script/dom/domexception.rs
+++ b/components/script/dom/domexception.rs
@@ -4,7 +4,7 @@
 
 use std::collections::HashMap;
 
-use base::id::DomExceptionId;
+use base::id::{DomExceptionId, DomExceptionIndex};
 use constellation_traits::DomException;
 use dom_struct::dom_struct;
 use js::rust::HandleObject;
@@ -223,11 +223,11 @@ impl DOMExceptionMethods<crate::DomTypeHolder> for DOMException {
 }
 
 impl Serializable for DOMException {
-    type Id = DomExceptionId;
+    type Index = DomExceptionIndex;
     type Data = DomException;
 
     // https://webidl.spec.whatwg.org/#idl-DOMException
-    fn serialize(&self) -> Result<(Self::Id, Self::Data), ()> {
+    fn serialize(&self) -> Result<(DomExceptionId, Self::Data), ()> {
         let serialized = DomException {
             message: self.message.to_string(),
             name: self.name.to_string(),
@@ -252,7 +252,9 @@ impl Serializable for DOMException {
         ))
     }
 
-    fn serialized_storage(data: StructuredData<'_>) -> &mut Option<HashMap<Self::Id, Self::Data>> {
+    fn serialized_storage(
+        data: StructuredData<'_>,
+    ) -> &mut Option<HashMap<DomExceptionId, Self::Data>> {
         match data {
             StructuredData::Reader(reader) => &mut reader.exceptions,
             StructuredData::Writer(writer) => &mut writer.exceptions,

--- a/components/script/dom/dompoint.rs
+++ b/components/script/dom/dompoint.rs
@@ -4,7 +4,7 @@
 
 use std::collections::HashMap;
 
-use base::id::DomPointId;
+use base::id::{DomPointId, DomPointIndex};
 use constellation_traits::DomPoint;
 use dom_struct::dom_struct;
 use js::rust::HandleObject;
@@ -132,10 +132,10 @@ impl DOMPointMethods<crate::DomTypeHolder> for DOMPoint {
 }
 
 impl Serializable for DOMPoint {
-    type Id = DomPointId;
+    type Index = DomPointIndex;
     type Data = DomPoint;
 
-    fn serialize(&self) -> Result<(Self::Id, Self::Data), ()> {
+    fn serialize(&self) -> Result<(DomPointId, Self::Data), ()> {
         let serialized = DomPoint {
             x: self.X(),
             y: self.Y(),
@@ -163,7 +163,9 @@ impl Serializable for DOMPoint {
         ))
     }
 
-    fn serialized_storage(data: StructuredData<'_>) -> &mut Option<HashMap<Self::Id, Self::Data>> {
+    fn serialized_storage(
+        data: StructuredData<'_>,
+    ) -> &mut Option<HashMap<DomPointId, Self::Data>> {
         match data {
             StructuredData::Reader(reader) => &mut reader.points,
             StructuredData::Writer(writer) => &mut writer.points,

--- a/components/script/dom/dompointreadonly.rs
+++ b/components/script/dom/dompointreadonly.rs
@@ -5,7 +5,7 @@
 use std::cell::Cell;
 use std::collections::HashMap;
 
-use base::id::DomPointId;
+use base::id::{DomPointId, DomPointIndex};
 use constellation_traits::DomPoint;
 use dom_struct::dom_struct;
 use js::rust::HandleObject;
@@ -141,10 +141,10 @@ impl DOMPointWriteMethods for DOMPointReadOnly {
 }
 
 impl Serializable for DOMPointReadOnly {
-    type Id = DomPointId;
+    type Index = DomPointIndex;
     type Data = DomPoint;
 
-    fn serialize(&self) -> Result<(Self::Id, Self::Data), ()> {
+    fn serialize(&self) -> Result<(DomPointId, Self::Data), ()> {
         let serialized = DomPoint {
             x: self.x.get(),
             y: self.y.get(),
@@ -172,7 +172,9 @@ impl Serializable for DOMPointReadOnly {
         ))
     }
 
-    fn serialized_storage(data: StructuredData<'_>) -> &mut Option<HashMap<Self::Id, Self::Data>> {
+    fn serialized_storage(
+        data: StructuredData<'_>,
+    ) -> &mut Option<HashMap<DomPointId, Self::Data>> {
         match data {
             StructuredData::Reader(r) => &mut r.points,
             StructuredData::Writer(w) => &mut w.points,

--- a/components/script/dom/dompointreadonly.rs
+++ b/components/script/dom/dompointreadonly.rs
@@ -4,9 +4,8 @@
 
 use std::cell::Cell;
 use std::collections::HashMap;
-use std::num::NonZeroU32;
 
-use base::id::{DomPointId, DomPointIndex, PipelineNamespaceId};
+use base::id::DomPointId;
 use constellation_traits::DomPoint;
 use dom_struct::dom_struct;
 use js::rust::HandleObject;
@@ -16,7 +15,7 @@ use crate::dom::bindings::codegen::Bindings::DOMPointReadOnlyBinding::DOMPointRe
 use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 use crate::dom::bindings::root::DomRoot;
-use crate::dom::bindings::serializable::{IntoStorageKey, Serializable, StorageKey};
+use crate::dom::bindings::serializable::{Serializable, StorageKey};
 use crate::dom::bindings::structuredclone::{StructuredData, StructuredDataReader};
 use crate::dom::globalscope::GlobalScope;
 use crate::script_runtime::CanGc;
@@ -184,26 +183,5 @@ impl Serializable for DOMPointReadOnly {
         reader: &mut StructuredDataReader,
     ) -> &mut Option<HashMap<StorageKey, DomRoot<Self>>> {
         &mut reader.points_read_only
-    }
-}
-
-impl From<StorageKey> for DomPointId {
-    fn from(storage_key: StorageKey) -> DomPointId {
-        let namespace_id = PipelineNamespaceId(storage_key.name_space);
-        let index = DomPointIndex(
-            NonZeroU32::new(storage_key.index).expect("Deserialized point index is zero"),
-        );
-
-        DomPointId {
-            namespace_id,
-            index,
-        }
-    }
-}
-
-impl IntoStorageKey for DomPointId {
-    fn into_storage_key(self) -> StorageKey {
-        let DomPointIndex(index) = self.index;
-        StorageKey::new(self.namespace_id, index)
     }
 }

--- a/components/script/dom/messageport.rs
+++ b/components/script/dom/messageport.rs
@@ -4,11 +4,10 @@
 
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
-use std::num::NonZeroU32;
 use std::ptr;
 use std::rc::Rc;
 
-use base::id::{MessagePortId, MessagePortIndex, PipelineNamespaceId};
+use base::id::MessagePortId;
 use constellation_traits::{MessagePortImpl, PortMessageTask};
 use dom_struct::dom_struct;
 use js::jsapi::{Heap, JS_NewObject, JSObject};
@@ -26,7 +25,7 @@ use crate::dom::bindings::reflector::{DomGlobal, reflect_dom_object};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::structuredclone::{self, StructuredData, StructuredDataReader};
 use crate::dom::bindings::trace::RootedTraceableBox;
-use crate::dom::bindings::transferable::{ExtractComponents, IdFromComponents, Transferable};
+use crate::dom::bindings::transferable::Transferable;
 use crate::dom::bindings::utils::set_dictionary_property;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
@@ -279,21 +278,6 @@ impl Transferable for MessagePort {
 
     fn deserialized_storage(reader: &mut StructuredDataReader) -> &mut Option<Vec<DomRoot<Self>>> {
         &mut reader.message_ports
-    }
-}
-
-impl IdFromComponents for MessagePortId {
-    fn from(namespace_id: PipelineNamespaceId, index: NonZeroU32) -> MessagePortId {
-        MessagePortId {
-            namespace_id,
-            index: MessagePortIndex(index),
-        }
-    }
-}
-
-impl ExtractComponents for MessagePortId {
-    fn components(&self) -> (PipelineNamespaceId, NonZeroU32) {
-        (self.namespace_id, self.index.0)
     }
 }
 

--- a/components/script/dom/messageport.rs
+++ b/components/script/dom/messageport.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use std::ptr;
 use std::rc::Rc;
 
-use base::id::MessagePortId;
+use base::id::{MessagePortId, MessagePortIndex};
 use constellation_traits::{MessagePortImpl, PortMessageTask};
 use dom_struct::dom_struct;
 use js::jsapi::{Heap, JS_NewObject, JSObject};
@@ -239,7 +239,7 @@ impl MessagePort {
 }
 
 impl Transferable for MessagePort {
-    type Id = MessagePortId;
+    type Index = MessagePortIndex;
     type Data = MessagePortImpl;
 
     /// <https://html.spec.whatwg.org/multipage/#message-ports:transfer-steps>
@@ -269,7 +269,9 @@ impl Transferable for MessagePort {
         Ok(transferred_port)
     }
 
-    fn serialized_storage(data: StructuredData<'_>) -> &mut Option<HashMap<Self::Id, Self::Data>> {
+    fn serialized_storage(
+        data: StructuredData<'_>,
+    ) -> &mut Option<HashMap<MessagePortId, Self::Data>> {
         match data {
             StructuredData::Reader(r) => &mut r.port_impls,
             StructuredData::Writer(w) => &mut w.ports,

--- a/components/script/dom/readablestream.rs
+++ b/components/script/dom/readablestream.rs
@@ -8,6 +8,8 @@ use std::ptr::{self};
 use std::rc::Rc;
 use std::collections::HashMap;
 
+use base::id::{MessagePortId, MessagePortIndex};
+use constellation_traits::MessagePortImpl;
 use dom_struct::dom_struct;
 use js::conversions::ToJSValConvertible;
 use js::jsapi::{Heap, JSObject};
@@ -56,8 +58,6 @@ use crate::js::conversions::FromJSValConvertible;
 use crate::realms::{enter_realm, InRealm};
 use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
 use crate::dom::promisenativehandler::{Callback, PromiseNativeHandler};
-use base::id::MessagePortId;
-use constellation_traits::MessagePortImpl;
 use crate::dom::bindings::transferable::Transferable;
 use crate::dom::bindings::structuredclone::{StructuredData, StructuredDataReader};
 
@@ -2190,7 +2190,7 @@ pub(crate) fn get_read_promise_bytes(
 
 /// <https://streams.spec.whatwg.org/#rs-transfer>
 impl Transferable for ReadableStream {
-    type Id = MessagePortId;
+    type Index = MessagePortIndex;
     type Data = MessagePortImpl;
 
     /// <https://streams.spec.whatwg.org/#ref-for-readablestream%E2%91%A1%E2%91%A0>
@@ -2258,7 +2258,9 @@ impl Transferable for ReadableStream {
     }
 
     /// Note: we are relying on the port transfer, so the data returned here are related to the port.
-    fn serialized_storage(data: StructuredData<'_>) -> &mut Option<HashMap<Self::Id, Self::Data>> {
+    fn serialized_storage(
+        data: StructuredData<'_>,
+    ) -> &mut Option<HashMap<MessagePortId, Self::Data>> {
         match data {
             StructuredData::Reader(r) => &mut r.port_impls,
             StructuredData::Writer(w) => &mut w.ports,

--- a/components/script/dom/writablestream.rs
+++ b/components/script/dom/writablestream.rs
@@ -8,7 +8,7 @@ use std::mem;
 use std::ptr::{self};
 use std::rc::Rc;
 
-use base::id::MessagePortId;
+use base::id::{MessagePortId, MessagePortIndex};
 use constellation_traits::MessagePortImpl;
 use dom_struct::dom_struct;
 use js::jsapi::{Heap, JSObject};
@@ -1114,7 +1114,7 @@ impl CrossRealmTransformWritable {
 
 /// <https://streams.spec.whatwg.org/#ws-transfer>
 impl Transferable for WritableStream {
-    type Id = MessagePortId;
+    type Index = MessagePortIndex;
     type Data = MessagePortImpl;
 
     /// <https://streams.spec.whatwg.org/#ref-for-writablestream%E2%91%A0%E2%91%A4>
@@ -1182,7 +1182,9 @@ impl Transferable for WritableStream {
     }
 
     /// Note: we are relying on the port transfer, so the data returned here are related to the port.
-    fn serialized_storage(data: StructuredData<'_>) -> &mut Option<HashMap<Self::Id, Self::Data>> {
+    fn serialized_storage(
+        data: StructuredData<'_>,
+    ) -> &mut Option<HashMap<MessagePortId, Self::Data>> {
         match data {
             StructuredData::Reader(r) => &mut r.port_impls,
             StructuredData::Writer(w) => &mut w.ports,


### PR DESCRIPTION
Rather than creating unique types for each pipeline-namespaced index type (eg. MessagePortId, DomExceptionId, etc.), we can create a generic common type that uses a marker to prevent type confusion. This change allows us to reduce the boilerplate code required when implementing serializable/transferable interfaces, since the structured clone implementation can rely on the common type.

Testing: Existing WPT tests for serialization and transferring provide coverage.
