### PR TITLE
Remove unnecessary map_err.

### DIFF
--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -3352,7 +3352,7 @@ impl GlobalScope {
 
         let data = structuredclone::write(cx, value, Some(guard))?;
 
-        structuredclone::read(self, data, retval).map_err(|_| Error::DataClone(None))?;
+        structuredclone::read(self, data, retval)?;
 
         Ok(())
     }


### PR DESCRIPTION
#36361 changed the return type of structuredclone::read, so this code is just stomping on an error value that is potentially more useful since #36308 was merged.

Testing: Existing WPT test coverage.