### PR TITLE
Streams: remove unnecessary special handling of dataclone error

### DIFF
--- a/components/script/dom/readablestream.rs
+++ b/components/script/dom/readablestream.rs
@@ -2088,19 +2088,8 @@ impl CrossRealmTransformReadable {
 
         // Otherwise, if type is "error",
         if type_string == "error" {
-            if value.is_undefined() {
-                // Note: for DataClone errors, we send UndefinedValue across,
-                // because somehow sending the error results in another error.
-                // The error is then created here.
-                rooted!(in(*cx) let mut rooted_error = UndefinedValue());
-                Error::DataClone(None).to_jsval(cx, global, rooted_error.handle_mut(), can_gc);
-
-                // Perform ! ReadableStreamDefaultControllerError(controller, value).
-                self.controller.error(rooted_error.handle(), can_gc);
-            } else {
-                // Perform ! ReadableStreamDefaultControllerError(controller, value).
-                self.controller.error(value.handle(), can_gc);
-            }
+            // Perform ! ReadableStreamDefaultControllerError(controller, value).
+            self.controller.error(value.handle(), can_gc);
 
             // Disentangle port.
             global.disentangle_port(port);


### PR DESCRIPTION
This removes a now unnecessary handling of dataclone error when port posts a message handling error to support stream transfers. 

Fix https://github.com/servo/servo/issues/36479