### PR TITLE
DevTools: `worker_id` should be `id` & thread for workers should be `thread`

### DIFF
--- a/components/devtools/actors/worker.rs
+++ b/components/devtools/actors/worker.rs
@@ -43,7 +43,7 @@ impl WorkerActor {
             actor: self.name.clone(),
             console_actor: self.console.clone(),
             thread_actor: self.thread.clone(),
-            worker_id: self.worker_id.0.to_string(),
+            id: self.worker_id.0.to_string(),
             url: self.url.to_string(),
             traits: WorkerTraits {
                 is_parent_intercept_enabled: false,
@@ -157,7 +157,7 @@ pub(crate) struct WorkerMsg {
     actor: String,
     console_actor: String,
     thread_actor: String,
-    worker_id: String,
+    id: String,
     url: String,
     traits: WorkerTraits,
     #[serde(rename = "type")]

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -334,7 +334,7 @@ impl DevtoolsInstance {
             assert!(self.pipelines.contains_key(&pipeline_id));
             assert!(self.browsing_contexts.contains_key(&browsing_context_id));
 
-            let thread = ThreadActor::new(actors.new_name("context"));
+            let thread = ThreadActor::new(actors.new_name("thread"));
             let thread_name = thread.name();
             actors.register(Box::new(thread));
 


### PR DESCRIPTION
This is part of https://github.com/servo/servo/pull/36562, where I discovered that we are sending thread as `context` and `id` for worker is called `worked_id`. In this PR, I have renamed the `worker_id` to `id` and thread is sent as `thread` and not context. These chages were tested in #36562 

Some logs for context(this logs are from firefox instance)

`worker_id` should be `id`
```
{"_from": "server1.conn0.watcher35", "message": {"from": "server1.conn0.watcher35", "target": {"actor": "server1.conn0.watcher34.process7//workerTarget21/workerTarget5", "consoleActor": "server1.conn0.watcher34.process7//workerTarget21/console2", "id": "f454ea34-c76a-4b6e-a079-43ee3128881e", "name": "", "objectsManagerActor": "server1.conn0.watcher34.process7//workerTarget21/objects-manager4", "relatedDocumentInnerWindowId": 15032385539, "targetType": "worker", "threadActor": "server1.conn0.watcher34.process7//workerTarget21/thread1", "tracerActor": "server1.conn0.watcher34.process7//workerTarget21/tracer3", "traits": {"supportsTopLevelTargetFlag": false}, "type": 0, "url": "http://localhost:8000/Documents/codespace/servo/worker.js"}, "type": "target-available-form"}}
```

Thread should be `thread` and not `context`
```
{"_from": "server1.conn0.watcher35", "message": {"from": "server1.conn0.watcher35", "target": {"actor": "server1.conn0.watcher34.process7//workerTarget21/workerTarget5", "consoleActor": "server1.conn0.watcher34.process7//workerTarget21/console2", "id": "f454ea34-c76a-4b6e-a079-43ee3128881e", "name": "", "objectsManagerActor": "server1.conn0.watcher34.process7//workerTarget21/objects-manager4", "relatedDocumentInnerWindowId": 15032385539, "targetType": "worker", "threadActor": "server1.conn0.watcher34.process7//workerTarget21/thread1", "tracerActor": "server1.conn0.watcher34.process7//workerTarget21/tracer3", "traits": {"supportsTopLevelTargetFlag": false}, "type": 0, "url": "http://localhost:8000/Documents/codespace/servo/worker.js"}, "type": "target-available-form"}}
```


- [x] ./mach build -d does not report any errors
- [x] ./mach test-tidy does not report any errors
- [x]  These changes partially implement https://github.com/servo/servo/issues/36027
