### PR TITLE
Streams: fix writable transfer sink abort steps

### DIFF
--- a/components/script/dom/writablestreamdefaultcontroller.rs
+++ b/components/script/dom/writablestreamdefaultcontroller.rs
@@ -555,7 +555,7 @@ impl WritableStreamDefaultController {
                     promise.reject_error(error, can_gc);
                 } else {
                     // Otherwise, return a promise resolved with undefined.
-                    promise.reject_native(&(), can_gc);
+                    promise.resolve_native(&(), can_gc);
                 }
                 promise
             },

--- a/tests/wpt/meta/streams/transferable/writable-stream.html.ini
+++ b/tests/wpt/meta/streams/transferable/writable-stream.html.ini
@@ -1,4 +1,3 @@
 [writable-stream.html]
-  expected: ERROR
   [window.postMessage should be able to transfer a {readable, writable} pair]
     expected: FAIL


### PR DESCRIPTION
Fixes an error where a promise was rejected where it should have been resolved. 

Follow-up to https://github.com/servo/servo/pull/36588/files#r2049437506; the initial diagnosis was wrong. 