### PR TITLE
dependabot: group objc2 crates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,9 @@ updates:
     servo-media-related:
       patterns:
         - "servo-media*"
+     objc2-related:
+      patterns:
+        - "objc2*"
   ignore:
   # Ignore all stylo crates as their upgrades are coordinated via companion PRs.
   - dependency-name: selectors


### PR DESCRIPTION
or else their PRs will fail in tidy:
https://github.com/servo/servo/pull/36637
https://github.com/servo/servo/pull/36635

Testing: It's bot config so no testing is possible.
