### PR TITLE
Fixup dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,7 +31,7 @@ updates:
     servo-media-related:
       patterns:
         - "servo-media*"
-     objc2-related:
+    objc2-related:
       patterns:
         - "objc2*"
   ignore:


### PR DESCRIPTION
fixups https://github.com/servo/servo/pull/36641, as yaml was not valid (one ` ` to many).

Testing: No testing for bot config.