### PR TITLE
chore: remove unnecessary `webrender_document` in script

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -973,7 +973,6 @@ where
             event_loop,
             load_data,
             prev_throttled: throttled,
-            webrender_document: self.webrender_document,
             webgl_chan: self
                 .webgl_threads
                 .as_ref()

--- a/components/constellation/pipeline.rs
+++ b/components/constellation/pipeline.rs
@@ -47,7 +47,6 @@ use serde::{Deserialize, Serialize};
 use servo_config::opts::{self, Opts};
 use servo_config::prefs::{self, Preferences};
 use servo_url::ServoUrl;
-use webrender_api::DocumentId;
 
 use crate::event_loop::EventLoop;
 use crate::process_manager::Process;
@@ -184,9 +183,6 @@ pub struct InitialPipelineState {
     /// compositor threads after spawning a pipeline.
     pub prev_throttled: bool,
 
-    /// The ID of the document processed by this script thread.
-    pub webrender_document: DocumentId,
-
     /// A channel to the WebGL thread.
     pub webgl_chan: Option<WebGLPipeline>,
 
@@ -288,7 +284,6 @@ impl Pipeline {
                     opts: (*opts::get()).clone(),
                     prefs: Box::new(prefs::get().clone()),
                     pipeline_namespace_id: state.pipeline_namespace_id,
-                    webrender_document: state.webrender_document,
                     cross_process_compositor_api: state
                         .compositor_proxy
                         .cross_process_compositor_api
@@ -503,7 +498,6 @@ pub struct UnprivilegedPipelineContent {
     prefs: Box<Preferences>,
     pipeline_namespace_id: PipelineNamespaceId,
     cross_process_compositor_api: CrossProcessCompositorApi,
-    webrender_document: DocumentId,
     webgl_chan: Option<WebGLPipeline>,
     webxr_registry: Option<webxr_api::Registry>,
     player_context: WindowGLContext,
@@ -551,7 +545,6 @@ impl UnprivilegedPipelineContent {
                 content_process_shutdown_sender: content_process_shutdown_chan,
                 webgl_chan: self.webgl_chan,
                 webxr_registry: self.webxr_registry,
-                webrender_document: self.webrender_document,
                 compositor_api: self.cross_process_compositor_api.clone(),
                 player_context: self.player_context.clone(),
                 inherited_secure_context: self.load_data.inherited_secure_context,

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -83,8 +83,8 @@ use style::stylesheets::UrlExtraData;
 use style_traits::CSSPixel;
 use stylo_atoms::Atom;
 use url::Position;
+use webrender_api::ExternalScrollId;
 use webrender_api::units::{DevicePixel, LayoutPixel};
-use webrender_api::{DocumentId, ExternalScrollId};
 
 use super::bindings::codegen::Bindings::MessagePortBinding::StructuredSerializeOptions;
 use super::bindings::trace::HashMapTracedValues;
@@ -353,10 +353,6 @@ pub(crate) struct Window {
     test_worklet: MutNullableDom<Worklet>,
     /// <https://drafts.css-houdini.org/css-paint-api-1/#paint-worklet>
     paint_worklet: MutNullableDom<Worklet>,
-    /// The Webrender Document id associated with this window.
-    #[ignore_malloc_size_of = "defined in webrender_api"]
-    #[no_trace]
-    webrender_document: DocumentId,
 
     /// Flag to identify whether mutation observers are present(true)/absent(false)
     exists_mut_observer: Cell<bool>,
@@ -2775,10 +2771,6 @@ impl Window {
             .unwrap();
     }
 
-    pub(crate) fn webrender_document(&self) -> DocumentId {
-        self.webrender_document
-    }
-
     #[cfg(feature = "webxr")]
     pub(crate) fn in_immersive_xr_session(&self) -> bool {
         self.navigator
@@ -2821,7 +2813,6 @@ impl Window {
         webgl_chan: Option<WebGLChan>,
         #[cfg(feature = "webxr")] webxr_registry: Option<webxr_api::Registry>,
         microtask_queue: Rc<MicrotaskQueue>,
-        webrender_document: DocumentId,
         compositor_api: CrossProcessCompositorApi,
         relayout_event: bool,
         unminify_js: bool,
@@ -2906,7 +2897,6 @@ impl Window {
             local_script_source,
             test_worklet: Default::default(),
             paint_worklet: Default::default(),
-            webrender_document,
             exists_mut_observer: Cell::new(false),
             compositor_api,
             has_sent_idle_message: Cell::new(false),

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -98,7 +98,6 @@ use timers::{TimerEventRequest, TimerScheduler};
 use url::Position;
 #[cfg(feature = "webgpu")]
 use webgpu_traits::{WebGPUDevice, WebGPUMsg};
-use webrender_api::DocumentId;
 use webrender_api::units::DevicePixel;
 
 use crate::document_collection::DocumentCollection;
@@ -283,10 +282,6 @@ pub struct ScriptThread {
 
     /// <https://html.spec.whatwg.org/multipage/#custom-element-reactions-stack>
     custom_element_reaction_stack: CustomElementReactionStack,
-
-    /// The Webrender Document ID associated with this thread.
-    #[no_trace]
-    webrender_document: DocumentId,
 
     /// Cross-process access to the compositor's API.
     #[no_trace]
@@ -938,7 +933,6 @@ impl ScriptThread {
             worklet_thread_pool: Default::default(),
             docs_with_no_blocking_loads: Default::default(),
             custom_element_reaction_stack: CustomElementReactionStack::new(),
-            webrender_document: state.webrender_document,
             compositor_api: state.compositor_api,
             profile_script_events: opts.debug.profile_script_events,
             print_pwm: opts.print_pwm,
@@ -3136,7 +3130,6 @@ impl ScriptThread {
             #[cfg(feature = "webxr")]
             self.webxr_registry.clone(),
             self.microtask_queue.clone(),
-            self.webrender_document,
             self.compositor_api.clone(),
             self.relayout_event,
             self.unminify_js,

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -47,8 +47,8 @@ use style_traits::{CSSPixel, SpeculativePainter};
 use stylo_atoms::Atom;
 #[cfg(feature = "webgpu")]
 use webgpu_traits::WebGPUMsg;
+use webrender_api::ImageKey;
 use webrender_api::units::DevicePixel;
-use webrender_api::{DocumentId, ImageKey};
 
 /// The initial data required to create a new layout attached to an existing script thread.
 #[derive(Debug, Deserialize, Serialize)]
@@ -318,8 +318,6 @@ pub struct InitialScriptState {
     pub webgl_chan: Option<WebGLPipeline>,
     /// The XR device registry
     pub webxr_registry: Option<webxr_api::Registry>,
-    /// The Webrender document ID associated with this thread.
-    pub webrender_document: DocumentId,
     /// Access to the compositor across a process boundary.
     pub compositor_api: CrossProcessCompositorApi,
     /// Application window's GL Context for Media player


### PR DESCRIPTION
remove `webrender_document` in script and constellation's pipeline

Testing: `webrender_document` in script crate is not being referenced anywhere in the Servo, should be safe to remove.
Fixes: https://github.com/servo/servo/issues/36647