### PR TITLE
Initial support for marking custom protocol secure

### DIFF
--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -357,7 +357,9 @@ pub async fn main_fetch(
             // request's current URL's origin is same origin with request's origin, and request's
             // response tainting is "basic"
             if (same_origin && request.response_tainting == ResponseTainting::Basic) ||
-                // request's current URL's scheme is "data" or is a fetchable custom protocol
+                // request's current URL's scheme is "data"
+                current_scheme == "data" ||
+                // or is a fetchable custom protocol
                 context.protocols.is_fetchable(current_scheme) ||
                 // request's mode is "navigate" or "websocket"
                 matches!(

--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -949,7 +949,7 @@ pub fn should_request_be_blocked_as_mixed_content(
     }
 
     // 1.2. request’s URL is a potentially trustworthy URL.
-    if is_url_potentially_trustworthy(&protocol_registry, &request.url()) {
+    if is_url_potentially_trustworthy(protocol_registry, &request.url()) {
         return false;
     }
 

--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -359,7 +359,9 @@ pub async fn main_fetch(
             if (same_origin && request.response_tainting == ResponseTainting::Basic) ||
                 // request's current URL's scheme is "data"
                 current_scheme == "data" ||
-                // or is a fetchable custom protocol
+                // Note: Although it is not part of the specification we make an 
+                // exception here for custom protocols that are explicitly marked 
+                // as active for fetch.
                 context.protocols.is_fetchable(current_scheme) ||
                 // request's mode is "navigate" or "websocket"
                 matches!(

--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -359,9 +359,8 @@ pub async fn main_fetch(
             if (same_origin && request.response_tainting == ResponseTainting::Basic) ||
                 // request's current URL's scheme is "data"
                 current_scheme == "data" ||
-                // Note: Although it is not part of the specification we make an 
-                // exception here for custom protocols that are explicitly marked 
-                // as active for fetch.
+                // Note: Although it is not part of the specification, we make an exception here
+                // for custom protocols that are explicitly marked as active for fetch.
                 context.protocols.is_fetchable(current_scheme) ||
                 // request's mode is "navigate" or "websocket"
                 matches!(

--- a/components/net/protocols/mod.rs
+++ b/components/net/protocols/mod.rs
@@ -49,9 +49,11 @@ pub trait ProtocolHandler: Send + Sync {
         false
     }
 
-    /// Specify if this custom protocol is considered secure context
+    /// Specify if this custom protocol can be used in a [secure context]
     ///
     /// Note: this only works for bypassing mixed content checks right now
+    ///
+    /// [secure context]: https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts
     fn is_secure(&self) -> bool {
         false
     }

--- a/components/net/protocols/mod.rs
+++ b/components/net/protocols/mod.rs
@@ -112,6 +112,11 @@ impl ProtocolRegistry {
             .get(scheme)
             .is_some_and(|handler| handler.is_secure())
     }
+
+    /// Test if the URL is potentially trustworthy or the custom protocol is registered as secure
+    pub fn is_url_potentially_trustworthy(&self, url: &ServoUrl) -> bool {
+        url.is_potentially_trustworthy() || self.is_secure(url.scheme())
+    }
 }
 
 pub fn range_not_satisfiable_error(response: &mut Response) {
@@ -140,21 +145,4 @@ pub fn get_range_request_bounds(range: Option<Range>, len: u64) -> RangeRequestB
 
 pub fn partial_content(response: &mut Response) {
     response.status = StatusCode::PARTIAL_CONTENT.into();
-}
-
-pub trait ProtocolUrlExt {
-    /// Checks if the URL is potentially trustworthy with the registered custom protocols
-    fn is_potentially_trustworthy_with_custom_protocols(
-        &self,
-        protocol_registry: &ProtocolRegistry,
-    ) -> bool;
-}
-
-impl ProtocolUrlExt for ServoUrl {
-    fn is_potentially_trustworthy_with_custom_protocols(
-        &self,
-        protocol_registry: &ProtocolRegistry,
-    ) -> bool {
-        self.is_potentially_trustworthy() || protocol_registry.is_secure(self.scheme())
-    }
 }

--- a/components/net/protocols/mod.rs
+++ b/components/net/protocols/mod.rs
@@ -114,11 +114,14 @@ impl ProtocolRegistry {
             .get(scheme)
             .is_some_and(|handler| handler.is_secure())
     }
+}
 
-    /// Test if the URL is potentially trustworthy or the custom protocol is registered as secure
-    pub fn is_url_potentially_trustworthy(&self, url: &ServoUrl) -> bool {
-        url.is_potentially_trustworthy() || self.is_secure(url.scheme())
-    }
+/// Test if the URL is potentially trustworthy or the custom protocol is registered as secure
+pub fn is_url_potentially_trustworthy(
+    protocol_registry: &ProtocolRegistry,
+    url: &ServoUrl,
+) -> bool {
+    url.is_potentially_trustworthy() || protocol_registry.is_secure(url.scheme())
 }
 
 pub fn range_not_satisfiable_error(response: &mut Response) {

--- a/ports/servoshell/desktop/protocols/urlinfo.rs
+++ b/ports/servoshell/desktop/protocols/urlinfo.rs
@@ -46,4 +46,8 @@ impl ProtocolHandler for UrlInfoProtocolHander {
     fn is_fetchable(&self) -> bool {
         true
     }
+
+    fn is_secure(&self) -> bool {
+        true
+    }
 }


### PR DESCRIPTION
Add initial support for marking custom protocol as secure, this makes it possible to `fetch` a custom protocol inside secure contexts (e.g. http://localhost)

Some additional contexts:

- [#embedding > Custom protocol secure context](https://servo.zulipchat.com/#narrow/channel/437943-embedding/topic/Custom.20protocol.20secure.20context)
- https://github.com/versotile-org/tauri-runtime-verso/issues/6#issuecomment-2820776128

Testing: use `fetch('urlinfo://abc').then(async (response) => console.log(await response.text())).catch(console.log)` in servoshell with in a secure context (e.g. https://servo.org), and see the response should not be an error
