### PR TITLE
Update missing steps in Webdriver - ElementClick

### DIFF
--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -1251,6 +1251,10 @@ pub(crate) fn handle_element_click(
         .send(
             // Step 3
             find_node_by_unique_id(documents, pipeline, element_id).and_then(|node| {
+                if !node.is::<Element>() {
+                    return Err(ErrorStatus::NoSuchElement);
+                }
+
                 // Step 4
                 if let Some(input_element) = node.downcast::<HTMLInputElement>() {
                     if input_element.input_type() == InputType::File {

--- a/tests/wpt/meta/webdriver/tests/classic/element_click/click.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/element_click/click.py.ini
@@ -1,0 +1,21 @@
+[click.py]
+  [test_no_browsing_context]
+    expected: FAIL
+
+  [test_no_such_element_with_shadow_root]
+    expected: FAIL
+
+  [test_no_such_element_from_other_window_handle[closed\]]
+    expected: FAIL
+
+  [test_no_such_element_from_other_frame[open\]]
+    expected: FAIL
+
+  [test_no_such_element_from_other_frame[closed\]]
+    expected: FAIL
+
+  [test_stale_element_reference[top_context\]]
+    expected: FAIL
+
+  [test_stale_element_reference[child_context\]]
+    expected: FAIL


### PR DESCRIPTION
Fix panic in WebDriver handle element click.
- Handle `receiver.recv()` instead of calling `unwrap()` directly.
- A bit refactor.

Testing: `tests/wpt/tests/webdriver/tests/classic/element_click/click.py`
Fixes: https://github.com/servo/servo/issues/36658

cc: @xiaochengh 