### PR TITLE
compositor: Tick animations for an entire WebView at once

### DIFF
--- a/components/constellation/event_loop.rs
+++ b/components/constellation/event_loop.rs
@@ -6,17 +6,36 @@
 //! view of a script thread. When an `EventLoop` is dropped, an `ExitScriptThread`
 //! message is sent to the script thread, asking it to shut down.
 
+use std::hash::Hash;
 use std::marker::PhantomData;
 use std::rc::Rc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use ipc_channel::Error;
 use ipc_channel::ipc::IpcSender;
 use script_traits::ScriptThreadMessage;
 
+static CURRENT_EVENT_LOOP_ID: AtomicUsize = AtomicUsize::new(0);
+
 /// <https://html.spec.whatwg.org/multipage/#event-loop>
 pub struct EventLoop {
     script_chan: IpcSender<ScriptThreadMessage>,
     dont_send_or_sync: PhantomData<Rc<()>>,
+    id: usize,
+}
+
+impl PartialEq for EventLoop {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+    }
+}
+
+impl Eq for EventLoop {}
+
+impl Hash for EventLoop {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.id.hash(state);
+    }
 }
 
 impl Drop for EventLoop {
@@ -28,9 +47,11 @@ impl Drop for EventLoop {
 impl EventLoop {
     /// Create a new event loop from the channel to its script thread.
     pub fn new(script_chan: IpcSender<ScriptThreadMessage>) -> Rc<EventLoop> {
+        let id = CURRENT_EVENT_LOOP_ID.fetch_add(1, Ordering::Relaxed);
         Rc::new(EventLoop {
             script_chan,
             dont_send_or_sync: PhantomData,
+            id,
         })
     }
 

--- a/components/script/messaging.rs
+++ b/components/script/messaging.rs
@@ -73,7 +73,7 @@ impl MixedMessage {
                 ScriptThreadMessage::RemoveHistoryStates(id, ..) => Some(*id),
                 ScriptThreadMessage::FocusIFrame(id, ..) => Some(*id),
                 ScriptThreadMessage::WebDriverScriptCommand(id, ..) => Some(*id),
-                ScriptThreadMessage::TickAllAnimations(id, ..) => Some(*id),
+                ScriptThreadMessage::TickAllAnimations(..) => None,
                 ScriptThreadMessage::WebFontLoaded(id, ..) => Some(*id),
                 ScriptThreadMessage::DispatchIFrameLoadEvent {
                     target: _,

--- a/components/shared/constellation/lib.rs
+++ b/components/shared/constellation/lib.rs
@@ -18,7 +18,6 @@ use std::time::Duration;
 use base::Epoch;
 use base::cross_process_instant::CrossProcessInstant;
 use base::id::{MessagePortId, PipelineId, WebViewId};
-use bitflags::bitflags;
 use embedder_traits::{
     CompositorHitTestResult, Cursor, InputEvent, MediaSessionActionType, Theme, ViewportDetails,
     WebDriverCommandMsg,
@@ -57,8 +56,9 @@ pub enum EmbedderToConstellationMessage {
     ChangeViewportDetails(WebViewId, ViewportDetails, WindowSizeType),
     /// Inform the constellation of a theme change.
     ThemeChange(Theme),
-    /// Requests that the constellation instruct layout to begin a new tick of the animation.
-    TickAnimation(PipelineId, AnimationTickType),
+    /// Requests that the constellation instruct script/layout to try to layout again and tick
+    /// animations.
+    TickAnimation(Vec<WebViewId>),
     /// Dispatch a webdriver command
     WebDriverCommand(WebDriverCommandMsg),
     /// Reload a top-level browsing context.
@@ -128,17 +128,6 @@ pub enum WindowSizeType {
     Initial,
     /// Window resize.
     Resize,
-}
-
-bitflags! {
-    #[derive(Debug, Default, Deserialize, Serialize)]
-    /// Specifies if rAF should be triggered and/or CSS Animations and Transitions.
-    pub struct AnimationTickType: u8 {
-        /// Trigger a call to requestAnimationFrame.
-        const REQUEST_ANIMATION_FRAME = 0b001;
-        /// Trigger restyles for CSS Animations and Transitions.
-        const CSS_ANIMATIONS_AND_TRANSITIONS = 0b010;
-    }
 }
 
 /// The scroll state of a stacking context.

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -20,7 +20,7 @@ use bluetooth_traits::BluetoothRequest;
 use canvas_traits::webgl::WebGLPipeline;
 use compositing_traits::CrossProcessCompositorApi;
 use constellation_traits::{
-    AnimationTickType, LoadData, NavigationHistoryBehavior, ScriptToConstellationChan, ScrollState,
+    LoadData, NavigationHistoryBehavior, ScriptToConstellationChan, ScrollState,
     StructuredSerializedData, WindowSizeType,
 };
 use crossbeam_channel::{RecvTimeoutError, Sender};
@@ -195,7 +195,7 @@ pub enum ScriptThreadMessage {
     /// Passes a webdriver command to the script thread for execution
     WebDriverScriptCommand(PipelineId, WebDriverScriptCommand),
     /// Notifies script thread that all animations are done
-    TickAllAnimations(PipelineId, AnimationTickType),
+    TickAllAnimations(Vec<WebViewId>),
     /// Notifies the script thread that a new Web font has been loaded, and thus the page should be
     /// reflowed.
     WebFontLoaded(PipelineId, bool /* success */),


### PR DESCRIPTION
Previously, when processing animations, the compositor would sent a tick
message to each pipeline. This is an issue because now the
`ScriptThread` always processes rendering updates for all `Document`s in
order to ensure properly ordering. This change makes it so that tick
messages are sent for an entire WebView. This means that each
`ScriptThread` will always receive a single tick for every time that
animations are processed, no matter how many frames are animating. This
is the first step toward a refresh driver.

In addition, we discard the idea of ticking animation only for
animations and or only for request animation frame callbacks. The
`ScriptThread` can no longer make this distinction due to the
specification and the compositor shouldn't either.

This should not really change observable behavior, but should make Servo
more efficient when more than a single frame in a `ScriptThread` is
animting at once.

Testing: This is covered by existing WPT tests as it mainly just improve
animation efficiency in a particular case.
