### PR TITLE
layout: Implement node geometry queries against `BoxTree`'s `Fragment`

### DIFF
--- a/components/layout/dom.rs
+++ b/components/layout/dom.rs
@@ -57,7 +57,7 @@ impl InnerDOMLayoutData {
 pub(super) enum LayoutBox {
     DisplayContents,
     BlockLevel(ArcRefCell<BlockLevelBox>),
-    InlineLevel(ArcRefCell<InlineItem>),
+    InlineLevel(Vec<ArcRefCell<InlineItem>>),
     FlexLevel(ArcRefCell<FlexLevelBox>),
     TableLevelBox(TableLevelBox),
     TaffyItemBox(ArcRefCell<TaffyItemBox>),
@@ -70,8 +70,10 @@ impl LayoutBox {
             LayoutBox::BlockLevel(block_level_box) => {
                 block_level_box.borrow().invalidate_cached_fragment()
             },
-            LayoutBox::InlineLevel(inline_item) => {
-                inline_item.borrow().invalidate_cached_fragment()
+            LayoutBox::InlineLevel(inline_items) => {
+                for inline_item in inline_items.iter() {
+                    inline_item.borrow().invalidate_cached_fragment()
+                }
             },
             LayoutBox::FlexLevel(flex_level_box) => {
                 flex_level_box.borrow().invalidate_cached_fragment()
@@ -87,7 +89,10 @@ impl LayoutBox {
         match self {
             LayoutBox::DisplayContents => vec![],
             LayoutBox::BlockLevel(block_level_box) => block_level_box.borrow().fragments(),
-            LayoutBox::InlineLevel(inline_item) => inline_item.borrow().fragments(),
+            LayoutBox::InlineLevel(inline_items) => inline_items
+                .iter()
+                .flat_map(|inline_item| inline_item.borrow().fragments())
+                .collect(),
             LayoutBox::FlexLevel(flex_level_box) => flex_level_box.borrow().fragments(),
             LayoutBox::TaffyItemBox(taffy_item_box) => taffy_item_box.borrow().fragments(),
             LayoutBox::TableLevelBox(table_box) => table_box.fragments(),

--- a/components/layout/flow/inline/inline_box.rs
+++ b/components/layout/flow/inline/inline_box.rs
@@ -23,8 +23,12 @@ pub(crate) struct InlineBox {
     pub base: LayoutBoxBase,
     /// The identifier of this inline box in the containing [`super::InlineFormattingContext`].
     pub(super) identifier: InlineBoxIdentifier,
-    pub is_first_fragment: bool,
-    pub is_last_fragment: bool,
+    /// Whether or not this is the first instance of an [`InlineBox`] before a possible
+    /// block-in-inline split. When no split occurs, this is always true.
+    pub is_first_split: bool,
+    /// Whether or not this is the last instance of an [`InlineBox`] before a possible
+    /// block-in-inline split. When no split occurs, this is always true.
+    pub is_last_split: bool,
     /// The index of the default font in the [`super::InlineFormattingContext`]'s font metrics store.
     /// This is initialized during IFC shaping.
     pub default_font_index: Option<usize>,
@@ -36,8 +40,8 @@ impl InlineBox {
             base: LayoutBoxBase::new(info.into(), info.style.clone()),
             // This will be assigned later, when the box is actually added to the IFC.
             identifier: InlineBoxIdentifier::default(),
-            is_first_fragment: true,
-            is_last_fragment: false,
+            is_first_split: true,
+            is_last_split: false,
             default_font_index: None,
         }
     }
@@ -45,8 +49,8 @@ impl InlineBox {
     pub(crate) fn split_around_block(&self) -> Self {
         Self {
             base: LayoutBoxBase::new(self.base.base_fragment_info, self.base.style.clone()),
-            is_first_fragment: false,
-            is_last_fragment: false,
+            is_first_split: false,
+            is_last_split: false,
             ..*self
         }
     }

--- a/components/layout/flow/inline/mod.rs
+++ b/components/layout/flow/inline/mod.rs
@@ -744,7 +744,7 @@ impl InlineFormattingContextLayout<'_> {
             self.containing_block,
             self.layout_context,
             self.current_inline_container_state(),
-            inline_box.is_last_fragment,
+            inline_box.is_last_split,
             inline_box
                 .default_font_index
                 .map(|index| &self.ifc.font_metrics[index].metrics),
@@ -773,7 +773,7 @@ impl InlineFormattingContextLayout<'_> {
             );
         }
 
-        if inline_box.is_first_fragment {
+        if inline_box.is_first_split {
             self.current_line_segment.inline_size += inline_box_state.pbm.padding.inline_start +
                 inline_box_state.pbm.border.inline_start +
                 inline_box_state.pbm.margin.inline_start.auto_is(Au::zero);
@@ -2349,10 +2349,10 @@ impl<'layout_data> ContentSizesComputation<'layout_data> {
                     .auto_is(Au::zero);
 
                 let pbm = margin + padding + border;
-                if inline_box.is_first_fragment {
+                if inline_box.is_first_split {
                     self.add_inline_size(pbm.inline_start);
                 }
-                if inline_box.is_last_fragment {
+                if inline_box.is_last_split {
                     self.ending_inline_pbm_stack.push(pbm.inline_end);
                 } else {
                     self.ending_inline_pbm_stack.push(Au::zero());

--- a/components/layout/flow/root.rs
+++ b/components/layout/flow/root.rs
@@ -195,16 +195,17 @@ impl BoxTree {
                         },
                         _ => return None,
                     },
-                    LayoutBox::InlineLevel(inline_level_box) => match &*inline_level_box.borrow() {
-                        InlineItem::OutOfFlowAbsolutelyPositionedBox(_, text_offset_index)
-                            if box_style.position.is_absolutely_positioned() =>
-                        {
-                            UpdatePoint::AbsolutelyPositionedInlineLevelBox(
-                                inline_level_box.clone(),
-                                *text_offset_index,
-                            )
-                        },
-                        _ => return None,
+                    LayoutBox::InlineLevel(inline_level_items) => {
+                        let inline_level_box = inline_level_items.first()?;
+                        let InlineItem::OutOfFlowAbsolutelyPositionedBox(_, text_offset_index) =
+                            &*inline_level_box.borrow()
+                        else {
+                            return None;
+                        };
+                        UpdatePoint::AbsolutelyPositionedInlineLevelBox(
+                            inline_level_box.clone(),
+                            *text_offset_index,
+                        )
                     },
                     LayoutBox::FlexLevel(flex_level_box) => match &*flex_level_box.borrow() {
                         FlexLevelBox::OutOfFlowAbsolutelyPositionedBox(_)

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -81,8 +81,8 @@ use webrender_api::{ExternalScrollId, HitTestFlags};
 use crate::context::LayoutContext;
 use crate::display_list::{DisplayList, WebRenderImageInfo};
 use crate::query::{
-    get_the_text_steps, process_content_box_request, process_content_boxes_request,
-    process_node_geometry_request, process_node_scroll_area_request, process_offset_parent_query,
+    get_the_text_steps, process_client_rect_request, process_content_box_request,
+    process_content_boxes_request, process_node_scroll_area_request, process_offset_parent_query,
     process_resolved_font_style_query, process_resolved_style_request, process_text_index_request,
 };
 use crate::traversal::RecalcStyle;
@@ -235,24 +235,27 @@ impl Layout for LayoutThread {
         feature = "tracing",
         tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
-    fn query_content_box(&self, node: OpaqueNode) -> Option<UntypedRect<Au>> {
-        process_content_box_request(node, self.fragment_tree.borrow().clone())
+    fn query_content_box(&self, node: TrustedNodeAddress) -> Option<UntypedRect<Au>> {
+        let node = unsafe { ServoLayoutNode::new(&node) };
+        process_content_box_request(node)
     }
 
     #[cfg_attr(
         feature = "tracing",
         tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
-    fn query_content_boxes(&self, node: OpaqueNode) -> Vec<UntypedRect<Au>> {
-        process_content_boxes_request(node, self.fragment_tree.borrow().clone())
+    fn query_content_boxes(&self, node: TrustedNodeAddress) -> Vec<UntypedRect<Au>> {
+        let node = unsafe { ServoLayoutNode::new(&node) };
+        process_content_boxes_request(node)
     }
 
     #[cfg_attr(
         feature = "tracing",
         tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
-    fn query_client_rect(&self, node: OpaqueNode) -> UntypedRect<i32> {
-        process_node_geometry_request(node, self.fragment_tree.borrow().clone())
+    fn query_client_rect(&self, node: TrustedNodeAddress) -> UntypedRect<i32> {
+        let node = unsafe { ServoLayoutNode::new(&node) };
+        process_client_rect_request(node)
     }
 
     #[cfg_attr(

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2250,7 +2250,9 @@ impl Window {
 
     // Query content box without considering any reflow
     pub(crate) fn content_box_query_unchecked(&self, node: &Node) -> Option<UntypedRect<Au>> {
-        self.layout.borrow().query_content_box(node.to_opaque())
+        self.layout
+            .borrow()
+            .query_content_box(node.to_trusted_node_address())
     }
 
     pub(crate) fn content_box_query(&self, node: &Node, can_gc: CanGc) -> Option<UntypedRect<Au>> {
@@ -2264,14 +2266,18 @@ impl Window {
         if !self.layout_reflow(QueryMsg::ContentBoxes, can_gc) {
             return vec![];
         }
-        self.layout.borrow().query_content_boxes(node.to_opaque())
+        self.layout
+            .borrow()
+            .query_content_boxes(node.to_trusted_node_address())
     }
 
     pub(crate) fn client_rect_query(&self, node: &Node, can_gc: CanGc) -> UntypedRect<i32> {
         if !self.layout_reflow(QueryMsg::ClientRectQuery, can_gc) {
             return Rect::zero();
         }
-        self.layout.borrow().query_client_rect(node.to_opaque())
+        self.layout
+            .borrow()
+            .query_client_rect(node.to_trusted_node_address())
     }
 
     /// Find the scroll area of the given node, if it is not None. If the node

--- a/components/shared/script_layout/lib.rs
+++ b/components/shared/script_layout/lib.rs
@@ -240,9 +240,9 @@ pub trait Layout {
     /// Set the scroll states of this layout after a compositor scroll.
     fn set_scroll_offsets(&mut self, scroll_states: &[ScrollState]);
 
-    fn query_content_box(&self, node: OpaqueNode) -> Option<Rect<Au>>;
-    fn query_content_boxes(&self, node: OpaqueNode) -> Vec<Rect<Au>>;
-    fn query_client_rect(&self, node: OpaqueNode) -> Rect<i32>;
+    fn query_content_box(&self, node: TrustedNodeAddress) -> Option<Rect<Au>>;
+    fn query_content_boxes(&self, node: TrustedNodeAddress) -> Vec<Rect<Au>>;
+    fn query_client_rect(&self, node: TrustedNodeAddress) -> Rect<i32>;
     fn query_element_inner_outer_text(&self, node: TrustedNodeAddress) -> String;
     fn query_nodes_from_point(
         &self,

--- a/tests/wpt/meta/css/cssom-view/getBoundingClientRect-shy.html.ini
+++ b/tests/wpt/meta/css/cssom-view/getBoundingClientRect-shy.html.ini
@@ -29,8 +29,5 @@
   [Rendered soft-hyphen should have a width.]
     expected: FAIL
 
-  [Collapsed soft-hyphen in a span should be 0 width.]
-    expected: FAIL
-
   [Rendered soft-hyphen in a span should have a width.]
     expected: FAIL


### PR DESCRIPTION
This is a followup to #36629, continuing to implement script-based
layout queries  using the `Fragment`s attached to the `BoxTree`. In this
change, geometry queris (apart from parent offset) are calculated using
`Fragment`s hanging of the `BoxTree`.

In order to make this work, all `Fragment`s for inlines split by blocks,
need to be accessible in the `BoxTree`. This required some changes to
the way that box tree items were stored in DOM `BoxSlot`s. Now every
inline level item can have more than a single `BoxTree` item. These are
carefully collected by the `InlineFormattingContextBuilder` -- currently
a bit fragile, but with more documentation.

Testing: There are tests for these changes.
