### PR TITLE
DevTools: Move `Source` related code to dedicated `source.rs` file

### DIFF
--- a/components/devtools/actors/source.rs
+++ b/components/devtools/actors/source.rs
@@ -10,7 +10,7 @@ use servo_url::ServoUrl;
 
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct SourceData {
+pub(crate) struct SourceData {
     pub actor: String,
     /// URL of the script, or URL of the page for inline scripts.
     pub url: String,
@@ -18,12 +18,12 @@ pub struct SourceData {
 }
 
 #[derive(Serialize)]
-pub struct SourcesReply {
+pub(crate) struct SourcesReply {
     pub from: String,
     pub sources: Vec<SourceData>,
 }
 
-pub struct Source {
+pub(crate) struct Source {
     actor_name: String,
     source_urls: RefCell<BTreeSet<SourceData>>,
 }

--- a/components/devtools/actors/source.rs
+++ b/components/devtools/actors/source.rs
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::cell::{Ref, RefCell};
+use std::collections::BTreeSet;
+
+use serde::Serialize;
+use servo_url::ServoUrl;
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SourceData {
+    pub actor: String,
+    /// URL of the script, or URL of the page for inline scripts.
+    pub url: String,
+    pub is_black_boxed: bool,
+}
+
+#[derive(Serialize)]
+pub struct SourcesReply {
+    pub from: String,
+    pub sources: Vec<SourceData>,
+}
+
+pub struct Source {
+    actor_name: String,
+    source_urls: RefCell<BTreeSet<SourceData>>,
+}
+
+impl Source {
+    pub fn new(actor_name: String) -> Self {
+        Self {
+            actor_name,
+            source_urls: RefCell::new(BTreeSet::default()),
+        }
+    }
+
+    pub fn add_source(&self, url: ServoUrl) {
+        self.source_urls.borrow_mut().insert(SourceData {
+            actor: self.actor_name.clone(),
+            url: url.to_string(),
+            is_black_boxed: false,
+        });
+    }
+
+    pub fn sources(&self) -> Ref<BTreeSet<SourceData>> {
+        self.source_urls.borrow()
+    }
+}

--- a/components/devtools/actors/watcher.rs
+++ b/components/devtools/actors/watcher.rs
@@ -264,7 +264,7 @@ impl Actor for WatcherActor {
                         },
                         "source" => {
                             let thread_actor = registry.find::<ThreadActor>(&target.thread);
-                            let sources = thread_actor.sources();
+                            let sources = thread_actor.source_manager.sources();
                             target.resources_available(sources.iter().collect(), "source".into());
                         },
                         "console-message" | "error-message" => {},

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -19,7 +19,7 @@ use std::net::{Shutdown, TcpListener, TcpStream};
 use std::sync::{Arc, Mutex};
 use std::thread;
 
-use actors::thread::Source;
+use actors::source::SourceData;
 use base::id::{BrowsingContextId, PipelineId, WebViewId};
 use crossbeam_channel::{Receiver, Sender, unbounded};
 use devtools_traits::{
@@ -65,6 +65,7 @@ mod actors {
     pub mod process;
     pub mod reflow;
     pub mod root;
+    pub mod source;
     pub mod stylesheets;
     pub mod tab;
     pub mod thread;
@@ -523,9 +524,11 @@ impl DevtoolsInstance {
             .clone();
 
         let thread_actor = actors.find_mut::<ThreadActor>(&thread_actor_name);
-        thread_actor.add_source(source_info.url.clone());
+        thread_actor
+            .source_manager
+            .add_source(source_info.url.clone());
 
-        let source = Source {
+        let source = SourceData {
             actor: thread_actor_name.clone(),
             url: source_info.url.to_string(),
             is_black_boxed: false,


### PR DESCRIPTION
Currently Source related code exists in watcher.rs and thread.rs. This change moves source-related code to a dedicated source.rs file. This is in preparation for adding support for showing source code in the Debugger > Source panel.

- [x] Testing: These changes should not affect current functionality as it only moves the existing code
- [x] Fixes: part of https://github.com/servo/servo/issues/36027
