### PR TITLE
Disable serviceworkers for webgpu CTS tests

### DIFF
--- a/tests/wpt/webgpu/meta/__dir__.ini
+++ b/tests/wpt/webgpu/meta/__dir__.ini
@@ -1,0 +1,4 @@
+prefs: [
+  "dom_serviceworker_enabled:false",
+  "dom_webgpu_enabled:true",
+]

--- a/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/resize_observer.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/resize_observer.https.html.ini
@@ -1,6 +1,2 @@
 [resize_observer.https.html]
-  expected:
-    if os == "win": TIMEOUT
-    if os == "linux" and debug: TIMEOUT
-    if os == "linux" and not debug: PASS
-    if os == "mac": TIMEOUT
+  expected: TIMEOUT


### PR DESCRIPTION
https://github.com/servo/servo/pull/36335 enabled all experimental features for all wpt tests, but `dom_serviceworker_enabled` makes all CTS tests fail, because servo reports working service worker impl, but CTS pre-setup of worker fails due too incomplete impl. The solution is that we disable service workers in CTS `__dir__.ini` (thus avoiding any CTS worker code) until impl is stable enough.

Testing: This makes tests works again
Fixes: #36657