### PR TITLE
Implement scroll event

### DIFF
--- a/components/compositing/webview_renderer.rs
+++ b/components/compositing/webview_renderer.rs
@@ -16,8 +16,8 @@ use compositing_traits::{SendableFrameTree, WebViewTrait};
 use constellation_traits::{EmbedderToConstellationMessage, WindowSizeType};
 use embedder_traits::{
     AnimationState, CompositorHitTestResult, InputEvent, MouseButton, MouseButtonAction,
-    MouseButtonEvent, MouseMoveEvent, ShutdownState, TouchEvent, TouchEventResult, TouchEventType,
-    TouchId, ViewportDetails,
+    MouseButtonEvent, MouseMoveEvent, ScrollEvent as EmbedderScrollEvent, ShutdownState,
+    TouchEvent, TouchEventResult, TouchEventType, TouchId, ViewportDetails,
 };
 use euclid::{Box2D, Point2D, Scale, Size2D, Vector2D};
 use fnv::FnvHashSet;
@@ -53,9 +53,9 @@ enum ScrollZoomEvent {
     Scroll(ScrollEvent),
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Debug)]
 pub(crate) struct ScrollResult {
-    pub pipeline_id: PipelineId,
+    pub hit_test_result: CompositorHitTestResult,
     pub external_scroll_id: ExternalScrollId,
     pub offset: LayoutVector2D,
 }
@@ -872,8 +872,14 @@ impl WebViewRenderer {
                 combined_event.scroll_location,
             )
         });
-        if let Some(scroll_result) = scroll_result {
-            self.send_scroll_positions_to_layout_for_pipeline(scroll_result.pipeline_id);
+        if let Some(scroll_result) = scroll_result.clone() {
+            self.send_scroll_positions_to_layout_for_pipeline(
+                scroll_result.hit_test_result.pipeline_id,
+            );
+            self.dispatch_scroll_event(
+                scroll_result.external_scroll_id,
+                scroll_result.hit_test_result,
+            );
         }
 
         let pinch_zoom_result = match self
@@ -888,8 +894,8 @@ impl WebViewRenderer {
 
     /// Perform a hit test at the given [`DevicePoint`] and apply the [`ScrollLocation`]
     /// scrolling to the applicable scroll node under that point. If a scroll was
-    /// performed, returns the [`PipelineId`] of the node scrolled, the id, and the final
-    /// scroll delta.
+    /// performed, returns the hit test result contains [`PipelineId`] of the node
+    /// scrolled, the id, and the final scroll delta.
     fn scroll_node_at_device_point(
         &mut self,
         cursor: DevicePoint,
@@ -924,22 +930,19 @@ impl WebViewRenderer {
         // This is needed to propagate the scroll events from a pipeline representing an iframe to
         // its ancestor pipelines.
         let mut previous_pipeline_id = None;
-        for CompositorHitTestResult {
-            pipeline_id,
-            scroll_tree_node,
-            ..
-        } in hit_test_results.iter()
-        {
-            let pipeline_details = self.pipelines.get_mut(pipeline_id)?;
-            if previous_pipeline_id.replace(pipeline_id) != Some(pipeline_id) {
+        for hit_test_result in hit_test_results.iter() {
+            let pipeline_details = self.pipelines.get_mut(&hit_test_result.pipeline_id)?;
+            if previous_pipeline_id.replace(&hit_test_result.pipeline_id) !=
+                Some(&hit_test_result.pipeline_id)
+            {
                 let scroll_result = pipeline_details.scroll_tree.scroll_node_or_ancestor(
-                    scroll_tree_node,
+                    &hit_test_result.scroll_tree_node,
                     scroll_location,
                     ScrollType::InputEvents,
                 );
                 if let Some((external_scroll_id, offset)) = scroll_result {
                     return Some(ScrollResult {
-                        pipeline_id: *pipeline_id,
+                        hit_test_result: hit_test_result.clone(),
                         external_scroll_id,
                         offset,
                     });
@@ -947,6 +950,22 @@ impl WebViewRenderer {
             }
         }
         None
+    }
+
+    fn dispatch_scroll_event(
+        &self,
+        external_id: ExternalScrollId,
+        hit_test_result: CompositorHitTestResult,
+    ) {
+        let event = InputEvent::Scroll(EmbedderScrollEvent { external_id });
+        let msg = EmbedderToConstellationMessage::ForwardInputEvent(
+            self.id,
+            event,
+            Some(hit_test_result),
+        );
+        if let Err(e) = self.global.borrow().constellation_sender.send(msg) {
+            warn!("Sending scroll event to constellation failed ({:?}).", e);
+        }
     }
 
     pub(crate) fn pinch_zoom_level(&self) -> Scale<f32, DevicePixel, DevicePixel> {

--- a/components/constellation/tracing.rs
+++ b/components/constellation/tracing.rs
@@ -99,6 +99,7 @@ mod from_compositor {
                 InputEvent::MouseMove(..) => target_variant!("MouseMove"),
                 InputEvent::Touch(..) => target_variant!("Touch"),
                 InputEvent::Wheel(..) => target_variant!("Wheel"),
+                InputEvent::Scroll(..) => target_variant!("Scroll"),
             }
         }
     }

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1167,6 +1167,9 @@ impl ScriptThread {
                 InputEvent::EditingAction(editing_action_event) => {
                     document.handle_editing_action(editing_action_event, can_gc);
                 },
+                InputEvent::Scroll(scroll_event) => {
+                    document.handle_scroll_event(scroll_event, can_gc);
+                },
             }
         }
         ScriptThread::set_user_interacting(false);

--- a/components/shared/embedder/input_events.rs
+++ b/components/shared/embedder/input_events.rs
@@ -6,6 +6,7 @@ use keyboard_types::{CompositionEvent, KeyboardEvent};
 use log::error;
 use malloc_size_of_derive::MallocSizeOf;
 use serde::{Deserialize, Serialize};
+use webrender_api::ExternalScrollId;
 use webrender_api::units::DevicePoint;
 
 use crate::WebDriverMessageId;
@@ -21,6 +22,7 @@ pub enum InputEvent {
     MouseMove(MouseMoveEvent),
     Touch(TouchEvent),
     Wheel(WheelEvent),
+    Scroll(ScrollEvent),
 }
 
 /// An editing action that should be performed on a `WebView`.
@@ -42,6 +44,7 @@ impl InputEvent {
             InputEvent::MouseMove(event) => Some(event.point),
             InputEvent::Touch(event) => Some(event.point),
             InputEvent::Wheel(event) => Some(event.point),
+            InputEvent::Scroll(..) => None,
         }
     }
 
@@ -55,6 +58,7 @@ impl InputEvent {
             InputEvent::MouseMove(event) => event.webdriver_id,
             InputEvent::Touch(..) => None,
             InputEvent::Wheel(event) => event.webdriver_id,
+            InputEvent::Scroll(..) => None,
         }
     }
 
@@ -74,6 +78,7 @@ impl InputEvent {
             InputEvent::Wheel(ref mut event) => {
                 event.webdriver_id = webdriver_id;
             },
+            InputEvent::Scroll(..) => {},
         };
 
         self
@@ -288,6 +293,11 @@ impl WheelEvent {
             webdriver_id: None,
         }
     }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+pub struct ScrollEvent {
+    pub external_id: ExternalScrollId,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]


### PR DESCRIPTION
Reimplementation of https://github.com/servo/servo/pull/35105.

test: `tests/wpt/tests/pointerevents/{pointerevent_hit_test_scroll, pointerevent_hit_test_scroll_visible_decendant}.html` (after https://github.com/servo/servo/pull/37461)