### PR TITLE
async clipboard: implement `readText`

### DIFF
--- a/components/script/dom/clipboard.rs
+++ b/components/script/dom/clipboard.rs
@@ -3,24 +3,74 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::rc::Rc;
+use std::str::FromStr;
 
 use constellation_traits::BlobImpl;
+use data_url::mime::Mime;
 use dom_struct::dom_struct;
 use embedder_traits::EmbedderMsg;
+use ipc_channel::ipc;
+use js::rust::HandleValue as SafeHandleValue;
 
 use crate::dom::bindings::codegen::Bindings::ClipboardBinding::{
     ClipboardMethods, PresentationStyle,
 };
+use crate::dom::bindings::error::Error;
 use crate::dom::bindings::refcounted::TrustedPromise;
 use crate::dom::bindings::reflector::{DomGlobal, reflect_dom_object};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::blob::Blob;
+use crate::dom::clipboarditem::Representation;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
+use crate::dom::promisenativehandler::{Callback, PromiseNativeHandler};
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
+use crate::realms::{InRealm, enter_realm};
+use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
+
+/// The fulfillment handler for the reacting to representationDataPromise part of
+/// <https://w3c.github.io/clipboard-apis/#dom-clipboard-readtext>.
+#[derive(Clone, JSTraceable, MallocSizeOf)]
+struct RepresentationDataPromiseFulfillmentHandler {
+    #[ignore_malloc_size_of = "Rc are hard"]
+    promise: Rc<Promise>,
+}
+
+impl Callback for RepresentationDataPromiseFulfillmentHandler {
+    /// The fulfillment case of Step 3.4.1.1.4.3 of
+    /// <https://w3c.github.io/clipboard-apis/#dom-clipboard-readtext>.
+    fn callback(&self, cx: SafeJSContext, v: SafeHandleValue, _realm: InRealm, can_gc: CanGc) {
+        // If v is a DOMString, then follow the below steps:
+        // Resolve p with v.
+        // Return p.
+        self.promise.resolve(cx, v, can_gc);
+
+        // If v is a Blob, then follow the below steps:
+        // Let string be the result of UTF-8 decoding v’s underlying byte sequence.
+        // Resolve p with string.
+        // Return p.
+    }
+}
+
+/// The rejection handler for the reacting to representationDataPromise part of
+/// <https://w3c.github.io/clipboard-apis/#dom-clipboard-readtext>.
+#[derive(Clone, JSTraceable, MallocSizeOf)]
+struct RepresentationDataPromiseRejectionHandler {
+    #[ignore_malloc_size_of = "Rc are hard"]
+    promise: Rc<Promise>,
+}
+
+impl Callback for RepresentationDataPromiseRejectionHandler {
+    /// The rejection case of Step 3.4.1.1.4.3 of
+    /// <https://w3c.github.io/clipboard-apis/#dom-clipboard-readtext>.
+    fn callback(&self, _cx: SafeJSContext, _v: SafeHandleValue, _realm: InRealm, can_gc: CanGc) {
+        // Reject p with "NotFoundError" DOMException in realm.
+        // Return p.
+        self.promise.reject_error(Error::NotFound, can_gc);
+    }
+}
 
 #[dom_struct]
 pub(crate) struct Clipboard {
@@ -40,6 +90,89 @@ impl Clipboard {
 }
 
 impl ClipboardMethods<crate::DomTypeHolder> for Clipboard {
+    /// <https://w3c.github.io/clipboard-apis/#dom-clipboard-readtext>
+    fn ReadText(&self, can_gc: CanGc) -> Rc<Promise> {
+        // Step 1 Let realm be this's relevant realm.
+        // Step 2 Let p be a new promise in realm.
+        let p = Promise::new(&self.global(), can_gc);
+
+        // Step 3 Run the following steps in parallel:
+
+        // Step 3.1 Let r be the result of running check clipboard read permission.
+        // Step 3.2 If r is false, then:
+        // Step 3.2.1 Queue a global task on the permission task source, given realm’s global object,
+        // to reject p with "NotAllowedError" DOMException in realm.
+        // Step 3.2.2 Abort these steps.
+
+        // Step 3.3 Let data be a copy of the system clipboard data.
+        let global = self.global();
+        let window = global.as_window();
+        let (sender, receiver) = ipc::channel().unwrap();
+        window.send_to_embedder(EmbedderMsg::GetClipboardText(window.webview_id(), sender));
+
+        let data = receiver
+            .recv()
+            .map(Result::unwrap_or_default)
+            .unwrap_or_default();
+
+        let trusted_promise = TrustedPromise::new(p.clone());
+
+        // Step 3.4 Queue a global task on the clipboard task source,
+        // given realm’s global object, to perform the below steps:
+        self.global()
+            .task_manager()
+            .clipboard_task_source()
+            .queue(task!(read_text: move || {
+                let promise = trusted_promise.root();
+                let global = promise.global();
+
+                // Step 3.4.1 For each systemClipboardItem in data:
+                // Step 3.4.1.1 For each systemClipboardRepresentation in systemClipboardItem:
+                // TODO: Arboard provide the first item that has a String representation
+
+                // Step 3.4.1.1.1 Let mimeType be the result of running the
+                // well-known mime type from os specific format algorithm given systemClipboardRepresentation’s name.
+                // Note: This is done by arboard, so we just convert the format to a MIME
+                let mime_type = Mime::from_str("text/plain").unwrap();
+
+                // Step 3.4.1.1.2 If mimeType is null, continue this loop.
+
+                // Step 3.4.1.1.3 Let representation be a new representation.
+                let representation = Representation {
+                    mime_type,
+                    is_custom: false,
+                    data: Promise::new_resolved(&global, GlobalScope::get_cx(), DOMString::from(data), CanGc::note()),
+                };
+
+                // Step 3.4.1.1.4 If representation’s MIME type essence is "text/plain", then:
+
+                // Step 3.4.1.1.4.1 Set representation’s MIME type to mimeType.
+
+                // Step 3.4.1.1.4.2 Let representationDataPromise be the representation’s data.
+                // Step 3.4.1.1.4.3 React to representationDataPromise:
+                let fulfillment_handler = Box::new(RepresentationDataPromiseFulfillmentHandler {
+                    promise: promise.clone(),
+                });
+                let rejection_handler = Box::new(RepresentationDataPromiseRejectionHandler {
+                    promise: promise.clone(),
+                });
+                let handler = PromiseNativeHandler::new(
+                    &global,
+                    Some(fulfillment_handler),
+                    Some(rejection_handler),
+                    CanGc::note(),
+                );
+                let realm = enter_realm(&*global);
+                let comp = InRealm::Entered(&realm);
+                representation.data.append_native_handler(&handler, comp, CanGc::note());
+
+                // Step 3.4.2 Reject p with "NotFoundError" DOMException in realm.
+                // Step 3.4.3 Return p.
+            }));
+
+        p
+    }
+
     /// <https://w3c.github.io/clipboard-apis/#dom-clipboard-writetext>
     fn WriteText(&self, data: DOMString, can_gc: CanGc) -> Rc<Promise> {
         // Step 1 Let realm be this's relevant realm.

--- a/components/script/dom/clipboard.rs
+++ b/components/script/dom/clipboard.rs
@@ -9,7 +9,6 @@ use constellation_traits::BlobImpl;
 use data_url::mime::Mime;
 use dom_struct::dom_struct;
 use embedder_traits::EmbedderMsg;
-use ipc_channel::ipc;
 use js::rust::HandleValue as SafeHandleValue;
 
 use crate::dom::bindings::codegen::Bindings::ClipboardBinding::{
@@ -28,6 +27,7 @@ use crate::dom::promise::Promise;
 use crate::dom::promisenativehandler::{Callback, PromiseNativeHandler};
 use crate::dom::window::Window;
 use crate::realms::{InRealm, enter_realm};
+use crate::routed_promise::{RoutedPromiseListener, route_promise};
 use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
 
 /// The fulfillment handler for the reacting to representationDataPromise part of
@@ -47,6 +47,7 @@ impl Callback for RepresentationDataPromiseFulfillmentHandler {
         // Return p.
         self.promise.resolve(cx, v, can_gc);
 
+        // NOTE: Since we ask text from arboard, v can't be a Blob
         // If v is a Blob, then follow the below steps:
         // Let string be the result of UTF-8 decoding v’s underlying byte sequence.
         // Resolve p with string.
@@ -93,82 +94,25 @@ impl ClipboardMethods<crate::DomTypeHolder> for Clipboard {
     /// <https://w3c.github.io/clipboard-apis/#dom-clipboard-readtext>
     fn ReadText(&self, can_gc: CanGc) -> Rc<Promise> {
         // Step 1 Let realm be this's relevant realm.
+        let global = self.global();
+
         // Step 2 Let p be a new promise in realm.
-        let p = Promise::new(&self.global(), can_gc);
+        let p = Promise::new(&global, can_gc);
 
         // Step 3 Run the following steps in parallel:
 
-        // Step 3.1 Let r be the result of running check clipboard read permission.
+        // TODO Step 3.1 Let r be the result of running check clipboard read permission.
         // Step 3.2 If r is false, then:
         // Step 3.2.1 Queue a global task on the permission task source, given realm’s global object,
         // to reject p with "NotAllowedError" DOMException in realm.
         // Step 3.2.2 Abort these steps.
 
         // Step 3.3 Let data be a copy of the system clipboard data.
-        let global = self.global();
         let window = global.as_window();
-        let (sender, receiver) = ipc::channel().unwrap();
+        let sender = route_promise(&p, self);
         window.send_to_embedder(EmbedderMsg::GetClipboardText(window.webview_id(), sender));
 
-        let data = receiver
-            .recv()
-            .map(Result::unwrap_or_default)
-            .unwrap_or_default();
-
-        let trusted_promise = TrustedPromise::new(p.clone());
-
-        // Step 3.4 Queue a global task on the clipboard task source,
-        // given realm’s global object, to perform the below steps:
-        self.global()
-            .task_manager()
-            .clipboard_task_source()
-            .queue(task!(read_text: move || {
-                let promise = trusted_promise.root();
-                let global = promise.global();
-
-                // Step 3.4.1 For each systemClipboardItem in data:
-                // Step 3.4.1.1 For each systemClipboardRepresentation in systemClipboardItem:
-                // TODO: Arboard provide the first item that has a String representation
-
-                // Step 3.4.1.1.1 Let mimeType be the result of running the
-                // well-known mime type from os specific format algorithm given systemClipboardRepresentation’s name.
-                // Note: This is done by arboard, so we just convert the format to a MIME
-                let mime_type = Mime::from_str("text/plain").unwrap();
-
-                // Step 3.4.1.1.2 If mimeType is null, continue this loop.
-
-                // Step 3.4.1.1.3 Let representation be a new representation.
-                let representation = Representation {
-                    mime_type,
-                    is_custom: false,
-                    data: Promise::new_resolved(&global, GlobalScope::get_cx(), DOMString::from(data), CanGc::note()),
-                };
-
-                // Step 3.4.1.1.4 If representation’s MIME type essence is "text/plain", then:
-
-                // Step 3.4.1.1.4.1 Set representation’s MIME type to mimeType.
-
-                // Step 3.4.1.1.4.2 Let representationDataPromise be the representation’s data.
-                // Step 3.4.1.1.4.3 React to representationDataPromise:
-                let fulfillment_handler = Box::new(RepresentationDataPromiseFulfillmentHandler {
-                    promise: promise.clone(),
-                });
-                let rejection_handler = Box::new(RepresentationDataPromiseRejectionHandler {
-                    promise: promise.clone(),
-                });
-                let handler = PromiseNativeHandler::new(
-                    &global,
-                    Some(fulfillment_handler),
-                    Some(rejection_handler),
-                    CanGc::note(),
-                );
-                let realm = enter_realm(&*global);
-                let comp = InRealm::Entered(&realm);
-                representation.data.append_native_handler(&handler, comp, CanGc::note());
-
-                // Step 3.4.2 Reject p with "NotFoundError" DOMException in realm.
-                // Step 3.4.3 Return p.
-            }));
+        // NOTE: Step 3.4 is done inside handle_response
 
         p
     }
@@ -225,6 +169,71 @@ impl ClipboardMethods<crate::DomTypeHolder> for Clipboard {
 
         // Step 3.4 Return p.
         p
+    }
+}
+
+impl RoutedPromiseListener<Result<String, String>> for Clipboard {
+    fn handle_response(
+        &self,
+        response: Result<String, String>,
+        promise: &Rc<Promise>,
+        _can_gc: CanGc,
+    ) {
+        let trusted_promise = TrustedPromise::new(promise.clone());
+        let text = response.unwrap_or_default();
+
+        // Step 3.4 Queue a global task on the clipboard task source,
+        // given realm’s global object, to perform the below steps:
+        self.global()
+            .task_manager()
+            .clipboard_task_source()
+            .queue(task!(read_text: move || {
+                let promise = trusted_promise.root();
+                let global = promise.global();
+
+                // Step 3.4.1 For each systemClipboardItem in data:
+                // Step 3.4.1.1 For each systemClipboardRepresentation in systemClipboardItem:
+                // TODO: Arboard provide the first item that has a String representation
+
+                // Step 3.4.1.1.1 Let mimeType be the result of running the
+                // well-known mime type from os specific format algorithm given systemClipboardRepresentation’s name.
+                // Note: This is done by arboard, so we just convert the format to a MIME
+                let mime_type = Mime::from_str("text/plain").unwrap();
+
+                // Step 3.4.1.1.2 If mimeType is null, continue this loop.
+
+                // Step 3.4.1.1.3 Let representation be a new representation.
+                let representation = Representation {
+                    mime_type,
+                    is_custom: false,
+                    data: Promise::new_resolved(&global, GlobalScope::get_cx(), DOMString::from(text), CanGc::note()),
+                };
+
+                // Step 3.4.1.1.4 If representation’s MIME type essence is "text/plain", then:
+
+                // Step 3.4.1.1.4.1 Set representation’s MIME type to mimeType.
+
+                // Step 3.4.1.1.4.2 Let representationDataPromise be the representation’s data.
+                // Step 3.4.1.1.4.3 React to representationDataPromise:
+                let fulfillment_handler = Box::new(RepresentationDataPromiseFulfillmentHandler {
+                    promise: promise.clone(),
+                });
+                let rejection_handler = Box::new(RepresentationDataPromiseRejectionHandler {
+                    promise: promise.clone(),
+                });
+                let handler = PromiseNativeHandler::new(
+                    &global,
+                    Some(fulfillment_handler),
+                    Some(rejection_handler),
+                    CanGc::note(),
+                );
+                let realm = enter_realm(&*global);
+                let comp = InRealm::Entered(&realm);
+                representation.data.append_native_handler(&handler, comp, CanGc::note());
+
+                // Step 3.4.2 Reject p with "NotFoundError" DOMException in realm.
+                // Step 3.4.3 Return p.
+            }));
     }
 }
 

--- a/components/script/dom/clipboard.rs
+++ b/components/script/dom/clipboard.rs
@@ -211,6 +211,7 @@ impl RoutedPromiseListener<Result<String, String>> for Clipboard {
         // Step 3.4.1.1.4 If representation’s MIME type essence is "text/plain", then:
 
         // Step 3.4.1.1.4.1 Set representation’s MIME type to mimeType.
+        // Note: Done when creating a new representation
 
         // Step 3.4.1.1.4.2 Let representationDataPromise be the representation’s data.
         // Step 3.4.1.1.4.3 React to representationDataPromise:

--- a/components/script/dom/clipboarditem.rs
+++ b/components/script/dom/clipboarditem.rs
@@ -29,13 +29,13 @@ const CUSTOM_FORMAT_PREFIX: &str = "web ";
 
 /// <https://w3c.github.io/clipboard-apis/#representation>
 #[derive(JSTraceable, MallocSizeOf)]
-struct Representation {
+pub(super) struct Representation {
     #[no_trace]
     #[ignore_malloc_size_of = "Extern type"]
-    mime_type: Mime,
-    is_custom: bool,
+    pub mime_type: Mime,
+    pub is_custom: bool,
     #[ignore_malloc_size_of = "Rc is hard"]
-    data: Rc<Promise>,
+    pub data: Rc<Promise>,
 }
 
 #[dom_struct]

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -88,7 +88,7 @@ DOMInterfaces = {
 },
 
 'Clipboard': {
-    'canGc': ['WriteText']
+    'canGc': ['ReadText', 'WriteText']
 },
 
 'ClipboardItem': {

--- a/components/script_bindings/webidls/Clipboard.webidl
+++ b/components/script_bindings/webidls/Clipboard.webidl
@@ -9,7 +9,7 @@ typedef sequence<ClipboardItem> ClipboardItems;
 [SecureContext, Exposed=Window, Pref="dom_async_clipboard_enabled"]
 interface Clipboard : EventTarget {
   // Promise<ClipboardItems> read();
-  // Promise<DOMString> readText();
+  Promise<DOMString> readText();
   // Promise<undefined> write(ClipboardItems data);
   Promise<undefined> writeText(DOMString data);
 };

--- a/tests/wpt/meta/clipboard-apis/idlharness.https.window.js.ini
+++ b/tests/wpt/meta/clipboard-apis/idlharness.https.window.js.ini
@@ -8,9 +8,6 @@
   [Clipboard interface: operation read(optional ClipboardUnsanitizedFormats)]
     expected: FAIL
 
-  [Clipboard interface: operation readText()]
-    expected: FAIL
-
   [Clipboard interface: operation write(ClipboardItems)]
     expected: FAIL
 
@@ -18,9 +15,6 @@
     expected: FAIL
 
   [Clipboard interface: calling read(optional ClipboardUnsanitizedFormats) on navigator.clipboard with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [Clipboard interface: navigator.clipboard must inherit property "readText()" with the proper type]
     expected: FAIL
 
   [Clipboard interface: navigator.clipboard must inherit property "write(ClipboardItems)" with the proper type]


### PR DESCRIPTION
part of #36084
Testing: Only idl harness tests will pass for now
