### PR TITLE
Fix taplo test target directories

### DIFF
--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -58,7 +58,7 @@ TOML_GLOBS = [
     "*.toml",
     ".cargo/*.toml",
     "components/*/*.toml",
-    "components/shared/*.toml",
+    "components/shared/*/*.toml",
     "ports/*/*.toml",
     "support/*/*.toml",
 ]


### PR DESCRIPTION
The command `./mach test-tidy` did not check the TOML files in the subdirectories of components/shared/, since the argument for taglo command was written as `components/shared/*.toml`.

This patch fixes it to include those TOML files in test-tidy.

Testing: It only involves python script for test-tidy. No test is needed.
Fixes: #36659
