### PR TITLE
Support `isSecureContext` for custom protocols

### DIFF
--- a/components/constellation/pipeline.rs
+++ b/components/constellation/pipeline.rs
@@ -33,8 +33,8 @@ use ipc_channel::router::ROUTER;
 use log::{debug, error, warn};
 use media::WindowGLContext;
 use net::image_cache::ImageCacheImpl;
-use net_traits::ResourceThreads;
 use net_traits::image_cache::ImageCache;
+use net_traits::{Protocols, ResourceThreads};
 use profile::system_reporter;
 use profile_traits::mem::{ProfilerMsg, Reporter};
 use profile_traits::{mem as profile_mem, time};
@@ -197,6 +197,9 @@ pub struct InitialPipelineState {
 
     /// User content manager
     pub user_content_manager: UserContentManager,
+
+    /// Registered custom protocols
+    pub protocols: Protocols,
 }
 
 pub struct NewPipeline {
@@ -294,6 +297,7 @@ impl Pipeline {
                     rippy_data: state.rippy_data,
                     user_content_manager: state.user_content_manager,
                     lifeline_sender: None,
+                    protocols: state.protocols,
                 };
 
                 // Spawn the child process.
@@ -503,6 +507,7 @@ pub struct UnprivilegedPipelineContent {
     player_context: WindowGLContext,
     rippy_data: Vec<u8>,
     user_content_manager: UserContentManager,
+    protocols: Protocols,
     lifeline_sender: Option<IpcSender<()>>,
 }
 
@@ -549,6 +554,7 @@ impl UnprivilegedPipelineContent {
                 player_context: self.player_context.clone(),
                 inherited_secure_context: self.load_data.inherited_secure_context,
                 user_content_manager: self.user_content_manager,
+                protocols: self.protocols.clone(),
             },
             layout_factory,
             Arc::new(self.system_font_service.to_proxy()),

--- a/components/net/protocols/mod.rs
+++ b/components/net/protocols/mod.rs
@@ -110,6 +110,10 @@ impl ProtocolRegistry {
         self.handlers.get(scheme).map(|e| e.as_ref())
     }
 
+    pub fn iter(&self) -> std::collections::hash_map::Iter<'_, String, Box<dyn ProtocolHandler>> {
+        self.handlers.iter()
+    }
+
     pub fn merge(&mut self, mut other: ProtocolRegistry) {
         for (scheme, handler) in other.handlers.drain() {
             if FORBIDDEN_SCHEMES.contains(&scheme.as_str()) {

--- a/components/script/dom/dissimilaroriginwindow.rs
+++ b/components/script/dom/dissimilaroriginwindow.rs
@@ -68,6 +68,7 @@ impl DissimilarOriginWindow {
                 global_to_clone_from.wgpu_id_hub(),
                 Some(global_to_clone_from.is_secure_context()),
                 false,
+                global_to_clone_from.registered_protocols().clone(),
             ),
             window_proxy: Dom::from_ref(window_proxy),
             location: Default::default(),

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -52,11 +52,11 @@ use js::rust::{
 };
 use malloc_size_of::MallocSizeOf;
 use media::WindowGLContext;
-use net_traits::ResourceThreads;
 use net_traits::image_cache::{
     ImageCache, ImageResponder, ImageResponse, PendingImageId, PendingImageResponse,
 };
 use net_traits::storage_thread::StorageType;
+use net_traits::{Protocols, ResourceThreads};
 use num_traits::ToPrimitive;
 use profile_traits::ipc as ProfiledIpc;
 use profile_traits::mem::ProfilerChan as MemProfilerChan;
@@ -2834,6 +2834,7 @@ impl Window {
         player_context: WindowGLContext,
         #[cfg(feature = "webgpu")] gpu_id_hub: Arc<IdentityHub>,
         inherited_secure_context: Option<bool>,
+        protocols: Arc<Protocols>,
     ) -> DomRoot<Self> {
         let error_reporter = CSSErrorReporter {
             pipelineid: pipeline_id,
@@ -2861,6 +2862,7 @@ impl Window {
                 gpu_id_hub,
                 inherited_secure_context,
                 unminify_js,
+                protocols,
             ),
             script_chan,
             layout: RefCell::new(layout),

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -83,6 +83,7 @@ pub(crate) fn prepare_workerscope_init(
         origin: global.origin().immutable().clone(),
         creation_url: global.creation_url().clone(),
         inherited_secure_context: Some(global.is_secure_context()),
+        protocols: global.registered_protocols().clone(),
     };
 
     init
@@ -155,6 +156,7 @@ impl WorkerGlobalScope {
             Some(..) => Some(devtools_receiver),
             None => None,
         };
+        let protocols = init.protocols;
 
         Self {
             globalscope: GlobalScope::new_inherited(
@@ -171,6 +173,7 @@ impl WorkerGlobalScope {
                 gpu_id_hub,
                 init.inherited_secure_context,
                 false,
+                protocols,
             ),
             worker_id: init.worker_id,
             worker_name,

--- a/components/script/dom/workletglobalscope.rs
+++ b/components/script/dom/workletglobalscope.rs
@@ -12,8 +12,8 @@ use dom_struct::dom_struct;
 use ipc_channel::ipc::IpcSender;
 use js::jsval::UndefinedValue;
 use js::rust::Runtime;
-use net_traits::ResourceThreads;
 use net_traits::image_cache::ImageCache;
+use net_traits::{Protocols, ResourceThreads};
 use profile_traits::{mem, time};
 use script_bindings::realms::InRealm;
 use script_traits::Painter;
@@ -108,6 +108,7 @@ impl WorkletGlobalScope {
                 init.gpu_id_hub.clone(),
                 init.inherited_secure_context,
                 false,
+                init.protocols.clone(),
             ),
             base_url,
             to_script_thread_sender: init.to_script_thread_sender.clone(),
@@ -197,6 +198,8 @@ pub(crate) struct WorkletGlobalScopeInit {
     pub(crate) gpu_id_hub: Arc<IdentityHub>,
     /// Is considered secure
     pub(crate) inherited_secure_context: Option<bool>,
+    /// Registered custom protocols
+    pub(crate) protocols: Arc<Protocols>,
 }
 
 /// <https://drafts.css-houdini.org/worklets/#worklet-global-scope-type>

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -75,7 +75,7 @@ use net_traits::request::{Referrer, RequestId};
 use net_traits::response::ResponseInit;
 use net_traits::storage_thread::StorageType;
 use net_traits::{
-    FetchMetadata, FetchResponseListener, FetchResponseMsg, Metadata, NetworkError,
+    FetchMetadata, FetchResponseListener, FetchResponseMsg, Metadata, NetworkError, Protocols,
     ResourceFetchTiming, ResourceThreads, ResourceTimingType,
 };
 use percent_encoding::percent_decode;
@@ -335,6 +335,10 @@ pub struct ScriptThread {
     // In future, this shall be mouse_down_point for primary button
     #[no_trace]
     relative_mouse_down_point: Cell<Point2D<f32, DevicePixel>>,
+
+    /// Registered custom protocols
+    #[no_trace]
+    protocols: Arc<Protocols>,
 }
 
 struct BHMExitSignal {
@@ -744,6 +748,7 @@ impl ScriptThread {
                         #[cfg(feature = "webgpu")]
                         gpu_id_hub: script_thread.gpu_id_hub.clone(),
                         inherited_secure_context: script_thread.inherited_secure_context,
+                        protocols: script_thread.protocols.clone(),
                     };
                     Rc::new(WorkletThreadPool::spawn(init))
                 })
@@ -949,6 +954,7 @@ impl ScriptThread {
             inherited_secure_context: state.inherited_secure_context,
             layout_factory,
             relative_mouse_down_point: Cell::new(Point2D::zero()),
+            protocols: Arc::new(state.protocols),
         }
     }
 
@@ -3125,6 +3131,7 @@ impl ScriptThread {
             #[cfg(feature = "webgpu")]
             self.gpu_id_hub.clone(),
             incomplete.load_data.inherited_secure_context,
+            self.protocols.clone(),
         );
 
         let _realm = enter_realm(&*window);

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -1032,6 +1032,8 @@ fn create_constellation(
     let bluetooth_thread: IpcSender<BluetoothRequest> =
         BluetoothThreadFactory::new(embedder_proxy.clone());
 
+    let protocols = Arc::new(protocols);
+
     let (public_resource_threads, private_resource_threads) = new_resource_threads(
         devtools_sender.clone(),
         time_profiler_chan.clone(),
@@ -1040,7 +1042,7 @@ fn create_constellation(
         config_dir,
         opts.certificate_path.clone(),
         opts.ignore_certificate_errors,
-        Arc::new(protocols),
+        protocols.clone(),
     );
 
     let system_font_service = Arc::new(
@@ -1075,6 +1077,7 @@ fn create_constellation(
         #[cfg(feature = "webgpu")]
         wgpu_image_map,
         user_content_manager,
+        protocols,
     };
 
     let layout_factory = Arc::new(LayoutFactoryImpl());

--- a/components/shared/constellation/from_script_message.rs
+++ b/components/shared/constellation/from_script_message.rs
@@ -6,6 +6,7 @@
 
 use std::collections::{HashMap, VecDeque};
 use std::fmt;
+use std::sync::Arc;
 
 use base::Epoch;
 use base::id::{
@@ -23,7 +24,7 @@ use ipc_channel::Error as IpcError;
 use ipc_channel::ipc::{IpcReceiver, IpcSender};
 use net_traits::request::{InsecureRequestsPolicy, Referrer, RequestBody};
 use net_traits::storage_thread::StorageType;
-use net_traits::{CoreResourceMsg, ReferrerPolicy, ResourceThreads};
+use net_traits::{CoreResourceMsg, Protocols, ReferrerPolicy, ResourceThreads};
 use profile_traits::mem::MemoryReportResult;
 use profile_traits::{mem, time as profile_time};
 use serde::{Deserialize, Serialize};
@@ -433,6 +434,8 @@ pub struct WorkerGlobalScopeInit {
     pub creation_url: Option<ServoUrl>,
     /// True if secure context
     pub inherited_secure_context: Option<bool>,
+    /// Registered custom protocols
+    pub protocols: Arc<Protocols>,
 }
 
 /// Common entities representing a network load origin

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -1013,3 +1013,29 @@ pub fn set_default_accept_language(headers: &mut HeaderMap) {
 
 pub static PRIVILEGED_SECRET: LazyLock<u32> =
     LazyLock::new(|| servo_rand::ServoRng::default().next_u32());
+
+/// Registered custom protocols
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Protocols(HashMap<String, Protocol>);
+
+impl Protocols {
+    /// Construct from a HashMap of string and protocols
+    pub fn new(protocols: HashMap<String, Protocol>) -> Self {
+        Self(protocols)
+    }
+
+    /// Test if the URL is potentially trustworthy or the custom protocol is registered as secure
+    pub fn is_url_potentially_trustworthy(&self, url: &ServoUrl) -> bool {
+        url.is_potentially_trustworthy() ||
+            self.0
+                .get(url.scheme())
+                .is_some_and(|protocol| protocol.is_secure)
+    }
+}
+
+/// A custom protocol
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Protocol {
+    /// If this custom protocol is considered secure context
+    pub is_secure: bool,
+}

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -35,9 +35,9 @@ use ipc_channel::ipc::{IpcReceiver, IpcSender};
 use keyboard_types::Modifiers;
 use malloc_size_of_derive::MallocSizeOf;
 use media::WindowGLContext;
-use net_traits::ResourceThreads;
 use net_traits::image_cache::ImageCache;
 use net_traits::storage_thread::StorageType;
+use net_traits::{Protocols, ResourceThreads};
 use pixels::PixelFormat;
 use profile_traits::mem;
 use serde::{Deserialize, Serialize};
@@ -324,6 +324,8 @@ pub struct InitialScriptState {
     pub player_context: WindowGLContext,
     /// User content manager
     pub user_content_manager: UserContentManager,
+    /// Registered custom protocols
+    pub protocols: Protocols,
 }
 
 /// Errors from executing a paint worklet


### PR DESCRIPTION
Follow up of #36656

Testing: Goto `urlinfo:123` in servoshell and run `console.log(window.isSecureContext)` in the console (or through user scripts), it should log `true`, and then goto `servo:newtab`, run the same script, it should be `false`
