### PR TITLE
Determine if ResizeTo is allowed

### DIFF
--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1389,7 +1389,17 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
     // https://drafts.csswg.org/cssom-view/#dom-window-resizeto
     fn ResizeTo(&self, width: i32, height: i32) {
         // Step 1
-        //TODO determine if this operation is allowed
+        let window_proxy = match self.window_proxy.get() {
+            Some(proxy) => proxy,
+            None => return,
+        };
+
+        // If target is not an auxiliary browsing context that was created by a script
+        // (as opposed to by an action of the user), then return.
+        if !window_proxy.is_auxiliary() {
+            return;
+        }
+
         let dpr = self.device_pixel_ratio();
         let size = Size2D::new(width, height).to_f32() * dpr;
         self.send_to_embedder(EmbedderMsg::ResizeTo(self.webview_id(), size.to_i32()));

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -43,6 +43,13 @@
       null,
       {}
      ]
+    ],
+    "window_resizeTo_not_permitted-crash.html": [
+     "7b6a67ff81436a91048bdb627f303f7fab2762f7",
+     [
+      null,
+      {}
+     ]
     ]
    }
   },
@@ -14321,7 +14328,7 @@
      ]
     ],
     "window_resizeTo.html": [
-     "87d60498e80bcd01b5790feb3f9e104410cb6e1b",
+     "3f6c5a610d52b64bf4457d478b929e95d79e9ab8",
      [
       null,
       {}

--- a/tests/wpt/mozilla/tests/mozilla/window_resizeTo.html
+++ b/tests/wpt/mozilla/tests/mozilla/window_resizeTo.html
@@ -1,16 +1,21 @@
 <!doctype html>
 <meta charset="utf-8">
-<title>Verify that the resize event is fired when the window is resized (particularly in headless mode)</title>
+<title>Verify that the resize event is fired when the window is resized (in popup)</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
     async_test(function (t) {
-        window.onresize = t.step_func(function () {
-            assert_equals(window.innerWidth, 200);
-            assert_equals(window.innerHeight, 200);
-            t.done();
-        });
+        var popup = window.open("about:blank", "_blank", "width=100,height=100");
+        assert_not_equals(popup, null, "Popup must be successfully opened");
 
-        window.resizeTo(200, 200);
-    }, "onresize");
+        popup.onload = function () {
+            popup.onresize = t.step_func(function () {
+                assert_approx_equals(popup.innerWidth, 200, 10, "Popup width should be ~200");
+                assert_approx_equals(popup.innerHeight, 200, 10, "Popup height should be ~200");
+                t.done();
+            });
+
+            popup.resizeTo(200, 200);
+        };
+    }, "Popup onresize event fires after resizeTo");
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/window_resizeTo_not_permitted-crash.html
+++ b/tests/wpt/mozilla/tests/mozilla/window_resizeTo_not_permitted-crash.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Test that calling resizeTo() on normal window does not crash</title>
+<script>
+    window.resizeTo(-1, -1);
+</script>


### PR DESCRIPTION
Spec says to check If target is not an auxiliary browsing context before performing ResizeTo.


Fixes: #36701
