### PR TITLE
Use snapshot size instead of canvas size when converting canvas to blob

### DIFF
--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -9,6 +9,15 @@
       {}
      ]
     ],
+    "canvas": {
+     "toblob-then-change-size-crash.html": [
+      "355474b4832dde985a73baad925702bbb0cbc73f",
+      [
+       null,
+       {}
+      ]
+     ]
+    },
     "datatransferitem-crash.html": [
      "d11355ab38c1e99e0ba3e10d7dfed18bf26af60b",
      [

--- a/tests/wpt/mozilla/tests/mozilla/canvas/toblob-then-change-size-crash.html
+++ b/tests/wpt/mozilla/tests/mozilla/canvas/toblob-then-change-size-crash.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<!-- https://github.com/servo/servo/issues/36702 -->
+<canvas id="canvas"></canvas>
+<script>
+  canvas.toBlob(() => {});
+  canvas.width = 0;
+</script>
+


### PR DESCRIPTION
The blob data is encoded asynchronously, therefore the canvas size may have changed since it's data was saved to a snapshot. Using the canvas size confuses the encoder, because the provided data does not match the expected size anymore.

Testing: This change includes a new web platform test
Fixes https://github.com/servo/servo/issues/36702
