### PR TITLE
layout: Add `WebFontDocumentContext` for CSS fonts

### DIFF
--- a/components/fonts/font_context.rs
+++ b/components/fonts/font_context.rs
@@ -15,7 +15,11 @@ use fonts_traits::StylesheetWebFontLoadFinishedCallback;
 use log::{debug, trace};
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 use malloc_size_of_derive::MallocSizeOf;
-use net_traits::request::{Destination, Referrer, RequestBuilder};
+use net_traits::policy_container::PolicyContainer;
+use net_traits::request::{
+    CredentialsMode, Destination, InsecureRequestsPolicy, Referrer, RequestBuilder, RequestMode,
+    ServiceWorkersMode,
+};
 use net_traits::{CoreResourceThread, FetchResponseMsg, ResourceThreads, fetch_async};
 use parking_lot::{Mutex, RwLock};
 use servo_arc::Arc as ServoArc;
@@ -81,6 +85,14 @@ pub struct FontContext {
     font_data: RwLock<HashMap<FontIdentifier, FontData>>,
 
     have_removed_web_fonts: AtomicBool,
+}
+
+#[derive(Clone)]
+pub struct WebFontDocumentContext {
+    pub policy_container: PolicyContainer,
+    pub document_url: ServoUrl,
+    pub has_trustworthy_ancestor_origin: bool,
+    pub insecure_requests_policy: InsecureRequestsPolicy,
 }
 
 impl MallocSizeOf for FontContext {
@@ -387,6 +399,7 @@ pub(crate) struct WebFontDownloadState {
     local_fonts: HashMap<Atom, Option<FontTemplateRef>>,
     font_context: Arc<FontContext>,
     initiator: WebFontLoadInitiator,
+    document_context: WebFontDocumentContext,
 }
 
 impl WebFontDownloadState {
@@ -397,6 +410,7 @@ impl WebFontDownloadState {
         initiator: WebFontLoadInitiator,
         sources: Vec<Source>,
         local_fonts: HashMap<Atom, Option<FontTemplateRef>>,
+        document_context: WebFontDocumentContext,
     ) -> WebFontDownloadState {
         match initiator {
             WebFontLoadInitiator::Stylesheet(ref stylesheet, _) => {
@@ -421,6 +435,7 @@ impl WebFontDownloadState {
             local_fonts,
             font_context,
             initiator,
+            document_context,
         }
     }
 
@@ -487,6 +502,7 @@ pub trait FontContextWebFontMethods {
         guard: &SharedRwLockReadGuard,
         device: &Device,
         finished_callback: StylesheetWebFontLoadFinishedCallback,
+        document_context: &WebFontDocumentContext,
     ) -> usize;
     fn load_web_font_for_script(
         &self,
@@ -494,6 +510,7 @@ pub trait FontContextWebFontMethods {
         source_list: SourceList,
         descriptors: CSSFontFaceDescriptors,
         finished_callback: ScriptWebFontLoadFinishedCallback,
+        document_context: &WebFontDocumentContext,
     );
     fn add_template_to_font_context(
         &self,
@@ -513,6 +530,7 @@ impl FontContextWebFontMethods for Arc<FontContext> {
         guard: &SharedRwLockReadGuard,
         device: &Device,
         finished_callback: StylesheetWebFontLoadFinishedCallback,
+        document_context: &WebFontDocumentContext,
     ) -> usize {
         let mut number_loading = 0;
         for rule in stylesheet.effective_rules(device, guard) {
@@ -535,6 +553,7 @@ impl FontContextWebFontMethods for Arc<FontContext> {
                 font_face.sources(),
                 css_font_face_descriptors,
                 completion_handler,
+                document_context,
             );
         }
 
@@ -643,9 +662,16 @@ impl FontContextWebFontMethods for Arc<FontContext> {
         sources: SourceList,
         descriptors: CSSFontFaceDescriptors,
         finished_callback: ScriptWebFontLoadFinishedCallback,
+        document_context: &WebFontDocumentContext,
     ) {
         let completion_handler = WebFontLoadInitiator::Script(finished_callback);
-        self.start_loading_one_web_font(webview_id, &sources, descriptors, completion_handler);
+        self.start_loading_one_web_font(
+            webview_id,
+            &sources,
+            descriptors,
+            completion_handler,
+            document_context,
+        );
     }
 
     fn add_template_to_font_context(
@@ -667,6 +693,7 @@ impl FontContext {
         source_list: &SourceList,
         css_font_face_descriptors: CSSFontFaceDescriptors,
         completion_handler: WebFontLoadInitiator,
+        document_context: &WebFontDocumentContext,
     ) {
         let sources: Vec<Source> = source_list
             .0
@@ -708,6 +735,7 @@ impl FontContext {
             completion_handler,
             sources,
             local_fonts,
+            document_context.clone(),
         ));
     }
 
@@ -792,10 +820,20 @@ impl RemoteWebFontDownloader {
             None => return,
         };
 
-        // FIXME: This shouldn't use NoReferrer, but the current documents url
-        let request =
-            RequestBuilder::new(state.webview_id, url.clone().into(), Referrer::NoReferrer)
-                .destination(Destination::Font);
+        let document_context = &state.document_context;
+
+        let request = RequestBuilder::new(
+            state.webview_id,
+            url.clone().into(),
+            Referrer::ReferrerUrl(document_context.document_url.clone()),
+        )
+        .destination(Destination::Font)
+        .mode(RequestMode::CorsMode)
+        .credentials_mode(CredentialsMode::CredentialsSameOrigin)
+        .service_workers_mode(ServiceWorkersMode::All)
+        .policy_container(document_context.policy_container.clone())
+        .insecure_requests_policy(document_context.insecure_requests_policy)
+        .has_trustworthy_ancestor_origin(document_context.has_trustworthy_ancestor_origin);
 
         let core_resource_thread_clone = state.core_resource_thread.clone();
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -818,6 +818,10 @@ impl ScriptThread {
         with_script_thread(|script_thread| script_thread.node_ids.borrow().contains(node_id))
     }
 
+    pub(crate) fn find_global(&self, pipeline_id: PipelineId) -> Option<DomRoot<GlobalScope>> {
+        self.documents.borrow().find_global(pipeline_id)
+    }
+
     /// Creates a new script thread.
     pub(crate) fn new(
         state: InitialScriptState,


### PR DESCRIPTION
Add WebFontDocumentContext for CSS Fonts 4 font fetching

-Introduces WebFontDocumentContext in fonts/font_context.rs with policy container,
document URL, trustworthy ancestor origin, and insecure requests policy
-Updates FontContextWebFontMethods::add_all_web_fonts_from_stylesheet, load_web_font_for_script,
and FontContext::start_loading_one_web_font to use it. 
-Adds it to WebFontDownloadState and sets RequestBuilder fields per CSS Fonts 4 spec.

Testing: 
Fixes: https://github.com/servo/servo/issues/36590
