### PR TITLE
Propagate parent policy container to local iframes

### DIFF
--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -279,6 +279,7 @@ impl HTMLIFrameElement {
                 Some(document.insecure_requests_policy()),
                 document.has_trustworthy_ancestor_or_current_origin(),
             );
+            load_data.policy_container = Some(window.as_global_scope().policy_container());
             let element = self.upcast::<Element>();
             load_data.srcdoc = String::from(element.get_string_attribute(&local_name!("srcdoc")));
             self.navigate_or_reload_child_browsing_context(
@@ -361,7 +362,7 @@ impl HTMLIFrameElement {
             None
         };
 
-        let load_data = LoadData::new(
+        let mut load_data = LoadData::new(
             LoadOrigin::Script(document.origin().immutable().clone()),
             url,
             creator_pipeline_id,
@@ -377,6 +378,10 @@ impl HTMLIFrameElement {
         // see https://html.spec.whatwg.org/multipage/#the-iframe-element:about:blank-3
         let is_about_blank =
             pipeline_id.is_some() && pipeline_id == self.about_blank_pipeline_id.get();
+
+        if is_about_blank {
+            load_data.policy_container = Some(window.as_global_scope().policy_container());
+        }
 
         let history_handling = if is_about_blank {
             NavigationHistoryBehavior::Replace
@@ -407,7 +412,7 @@ impl HTMLIFrameElement {
         let document = self.owner_document();
         let window = self.owner_window();
         let pipeline_id = Some(window.pipeline_id());
-        let load_data = LoadData::new(
+        let mut load_data = LoadData::new(
             LoadOrigin::Script(document.origin().immutable().clone()),
             url,
             pipeline_id,
@@ -417,6 +422,7 @@ impl HTMLIFrameElement {
             Some(document.insecure_requests_policy()),
             document.has_trustworthy_ancestor_or_current_origin(),
         );
+        load_data.policy_container = Some(window.as_global_scope().policy_container());
         let browsing_context_id = BrowsingContextId::new();
         let webview_id = window.window_proxy().webview_id();
         self.pipeline_id.set(None);

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3674,10 +3674,12 @@ impl ScriptThread {
             None => vec![],
         };
 
+        let policy_container = incomplete.load_data.policy_container.clone();
         self.incomplete_loads.borrow_mut().push(incomplete);
 
         let dummy_request_id = RequestId::default();
         context.process_response(dummy_request_id, Ok(FetchMetadata::Unfiltered(meta)));
+        context.append_parent_to_csp_list(policy_container.as_ref());
         context.process_response_chunk(dummy_request_id, chunk);
         context.process_response_eof(
             dummy_request_id,
@@ -3697,12 +3699,14 @@ impl ScriptThread {
         let srcdoc = std::mem::take(&mut incomplete.load_data.srcdoc);
         let chunk = srcdoc.into_bytes();
 
+        let policy_container = incomplete.load_data.policy_container.clone();
         self.incomplete_loads.borrow_mut().push(incomplete);
 
         let mut context = ParserContext::new(id, url);
         let dummy_request_id = RequestId::default();
 
         context.process_response(dummy_request_id, Ok(FetchMetadata::Unfiltered(meta)));
+        context.append_parent_to_csp_list(policy_container.as_ref());
         context.process_response_chunk(dummy_request_id, chunk);
         context.process_response_eof(
             dummy_request_id,

--- a/components/shared/constellation/from_script_message.rs
+++ b/components/shared/constellation/from_script_message.rs
@@ -22,6 +22,7 @@ use euclid::default::Size2D as UntypedSize2D;
 use http::{HeaderMap, Method};
 use ipc_channel::Error as IpcError;
 use ipc_channel::ipc::{IpcReceiver, IpcSender};
+use net_traits::policy_container::PolicyContainer;
 use net_traits::request::{InsecureRequestsPolicy, Referrer, RequestBody};
 use net_traits::storage_thread::StorageType;
 use net_traits::{CoreResourceMsg, ReferrerPolicy, ResourceThreads};
@@ -97,6 +98,8 @@ pub struct LoadData {
     pub referrer: Referrer,
     /// The referrer policy.
     pub referrer_policy: ReferrerPolicy,
+    /// The policy container.
+    pub policy_container: Option<PolicyContainer>,
 
     /// The source to use instead of a network response for a srcdoc document.
     pub srcdoc: String,
@@ -143,6 +146,7 @@ impl LoadData {
             js_eval_result: None,
             referrer,
             referrer_policy,
+            policy_container: None,
             srcdoc: "".to_string(),
             inherited_secure_context,
             crash: None,

--- a/tests/wpt/meta/content-security-policy/inheritance/document-write-iframe.html.ini
+++ b/tests/wpt/meta/content-security-policy/inheritance/document-write-iframe.html.ini
@@ -1,3 +1,0 @@
-[document-write-iframe.html]
-  [document.open() keeps inherited CSPs on empty iframe.]
-    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/inheritance/iframe-all-local-schemes.sub.html.ini
+++ b/tests/wpt/meta/content-security-policy/inheritance/iframe-all-local-schemes.sub.html.ini
@@ -1,29 +1,5 @@
 [iframe-all-local-schemes.sub.html]
-  [<iframe>'s about:blank inherits policy.]
-    expected: FAIL
-
-  [window about:blank inherits policy.]
-    expected: FAIL
-
-  [<iframe srcdoc>'s inherits policy.]
-    expected: FAIL
-
-  [<iframe src='blob:...'>'s inherits policy.]
-    expected: FAIL
-
-  [window url='blob:...' inherits policy.]
-    expected: FAIL
-
   [<iframe src='data:...'>'s inherits policy.]
-    expected: FAIL
-
-  [<iframe src='javascript:...'>'s inherits policy (static <img> is blocked)]
-    expected: FAIL
-
-  [window url='javascript:...'>'s inherits policy (static <img> is blocked)]
-    expected: FAIL
-
-  [<iframe src='javascript:...'>'s inherits policy (dynamically inserted <img> is blocked)]
     expected: FAIL
 
   [<iframe sandbox src='blob:...'>'s inherits policy. (opaque origin sandbox)]

--- a/tests/wpt/meta/content-security-policy/inheritance/iframe-srcdoc-inheritance.html.ini
+++ b/tests/wpt/meta/content-security-policy/inheritance/iframe-srcdoc-inheritance.html.ini
@@ -1,7 +1,4 @@
 [iframe-srcdoc-inheritance.html]
   expected: TIMEOUT
-  [First image should be blocked]
-    expected: FAIL
-
   [Second image should be blocked]
     expected: NOTRUN

--- a/tests/wpt/meta/content-security-policy/inheritance/location-reload.html.ini
+++ b/tests/wpt/meta/content-security-policy/inheritance/location-reload.html.ini
@@ -1,9 +1,4 @@
 [location-reload.html]
-  [location.reload() of empty iframe.]
-    expected: FAIL
-
-  [location.reload() of blob URL iframe.]
-    expected: FAIL
-
+  expected: TIMEOUT
   [location.reload() of srcdoc iframe.]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/content-security-policy/navigation/to-javascript-parent-initiated-parent-csp.html.ini
+++ b/tests/wpt/meta/content-security-policy/navigation/to-javascript-parent-initiated-parent-csp.html.ini
@@ -1,10 +1,10 @@
 [to-javascript-parent-initiated-parent-csp.html]
   expected: TIMEOUT
   [Should not have executed the javascript url for\n      iframe.contentWindow.location.href]
-    expected: FAIL
+    expected: TIMEOUT
 
   [Should not have executed the javascript url for\n      otherTab.location.href]
-    expected: TIMEOUT
+    expected: NOTRUN
 
   [Should not have executed the javascript url for\n      area[target=iframe\].href]
     expected: NOTRUN
@@ -16,4 +16,7 @@
     expected: NOTRUN
 
   [Should not have executed the javascript url for\n      a[target=iframe\].href]
+    expected: NOTRUN
+
+  [Should not have executed the javascript url for\n      iframe.src]
     expected: NOTRUN

--- a/tests/wpt/meta/content-security-policy/script-src/srcdoc-doesnt-bypass-script-src.sub.html.ini
+++ b/tests/wpt/meta/content-security-policy/script-src/srcdoc-doesnt-bypass-script-src.sub.html.ini
@@ -1,3 +1,0 @@
-[srcdoc-doesnt-bypass-script-src.sub.html]
-  [Expecting logs: ["violated-directive=script-src-elem"\]]
-    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/unsafe-eval/eval-blocked-in-about-blank-iframe.html.ini
+++ b/tests/wpt/meta/content-security-policy/unsafe-eval/eval-blocked-in-about-blank-iframe.html.ini
@@ -1,3 +1,0 @@
-[eval-blocked-in-about-blank-iframe.html]
-  [eval-blocked-in-about-blank-iframe]
-    expected: FAIL


### PR DESCRIPTION
This follows the rules as defined in
https://w3c.github.io/webappsec-csp/#security-inherit-csp
where local iframes (about:blank and about:srcdoc) should
initially start with the CSP rules of the parent. After
that, all new CSP headers should only be set on the
policy container of the iframe.

Part of #36437

Signed-off-by: Tim van der Lippe <tvanderlippe@gmail.com>