### PR TITLE
Let (Offscreen)RenderingContext implement CanvasContext

### DIFF
--- a/components/script/canvas_context.rs
+++ b/components/script/canvas_context.rs
@@ -5,6 +5,7 @@
 //! Common interfaces for Canvas Contexts
 
 use euclid::default::Size2D;
+use script_bindings::root::Dom;
 use script_layout_interface::{HTMLCanvasData, HTMLCanvasDataSource};
 use snapshot::Snapshot;
 
@@ -12,6 +13,10 @@ use crate::dom::bindings::codegen::UnionTypes::HTMLCanvasElementOrOffscreenCanva
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::htmlcanvaselement::HTMLCanvasElement;
 use crate::dom::node::{Node, NodeDamage};
+use crate::dom::types::{
+    CanvasRenderingContext2D, GPUCanvasContext, OffscreenCanvas, OffscreenCanvasRenderingContext2D,
+    WebGL2RenderingContext, WebGLRenderingContext,
+};
 
 pub(crate) trait LayoutCanvasRenderingContextHelpers {
     fn canvas_data_source(self) -> HTMLCanvasDataSource;
@@ -82,6 +87,183 @@ impl CanvasHelpers for HTMLCanvasElementOrOffscreenCanvas {
         match self {
             HTMLCanvasElementOrOffscreenCanvas::HTMLCanvasElement(canvas) => Some(canvas),
             HTMLCanvasElementOrOffscreenCanvas::OffscreenCanvas(canvas) => canvas.placeholder(),
+        }
+    }
+}
+
+/// Non rooted variant of [`crate::dom::bindings::codegen::Bindings::HTMLCanvasElementBinding::RenderingContext`]
+#[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
+#[derive(Clone, JSTraceable, MallocSizeOf)]
+pub(crate) enum RenderingContext {
+    Placeholder(Dom<OffscreenCanvas>),
+    Context2d(Dom<CanvasRenderingContext2D>),
+    WebGL(Dom<WebGLRenderingContext>),
+    WebGL2(Dom<WebGL2RenderingContext>),
+    #[cfg(feature = "webgpu")]
+    WebGPU(Dom<GPUCanvasContext>),
+}
+
+impl CanvasContext for RenderingContext {
+    type ID = ();
+
+    fn context_id(&self) -> Self::ID {}
+
+    fn canvas(&self) -> HTMLCanvasElementOrOffscreenCanvas {
+        match self {
+            RenderingContext::Placeholder(context) => (*context.context().unwrap()).canvas(),
+            RenderingContext::Context2d(context) => context.canvas(),
+            RenderingContext::WebGL(context) => context.canvas(),
+            RenderingContext::WebGL2(context) => context.canvas(),
+            #[cfg(feature = "webgpu")]
+            RenderingContext::WebGPU(context) => context.canvas(),
+        }
+    }
+
+    fn resize(&self) {
+        match self {
+            RenderingContext::Placeholder(context) => (*context.context().unwrap()).resize(),
+            RenderingContext::Context2d(context) => context.resize(),
+            RenderingContext::WebGL(context) => context.resize(),
+            RenderingContext::WebGL2(context) => context.resize(),
+            #[cfg(feature = "webgpu")]
+            RenderingContext::WebGPU(context) => context.resize(),
+        }
+    }
+
+    fn get_image_data(&self) -> Option<Snapshot> {
+        match self {
+            RenderingContext::Placeholder(context) => {
+                (*context.context().unwrap()).get_image_data()
+            },
+            RenderingContext::Context2d(context) => context.get_image_data(),
+            RenderingContext::WebGL(context) => context.get_image_data(),
+            RenderingContext::WebGL2(context) => context.get_image_data(),
+            #[cfg(feature = "webgpu")]
+            RenderingContext::WebGPU(context) => context.get_image_data(),
+        }
+    }
+
+    fn origin_is_clean(&self) -> bool {
+        match self {
+            RenderingContext::Placeholder(context) => {
+                (*context.context().unwrap()).origin_is_clean()
+            },
+            RenderingContext::Context2d(context) => context.origin_is_clean(),
+            RenderingContext::WebGL(context) => context.origin_is_clean(),
+            RenderingContext::WebGL2(context) => context.origin_is_clean(),
+            #[cfg(feature = "webgpu")]
+            RenderingContext::WebGPU(context) => context.origin_is_clean(),
+        }
+    }
+
+    fn size(&self) -> Size2D<u64> {
+        match self {
+            RenderingContext::Placeholder(context) => (*context.context().unwrap()).size(),
+            RenderingContext::Context2d(context) => context.size(),
+            RenderingContext::WebGL(context) => context.size(),
+            RenderingContext::WebGL2(context) => context.size(),
+            #[cfg(feature = "webgpu")]
+            RenderingContext::WebGPU(context) => context.size(),
+        }
+    }
+
+    fn mark_as_dirty(&self) {
+        match self {
+            RenderingContext::Placeholder(context) => (*context.context().unwrap()).mark_as_dirty(),
+            RenderingContext::Context2d(context) => context.mark_as_dirty(),
+            RenderingContext::WebGL(context) => context.mark_as_dirty(),
+            RenderingContext::WebGL2(context) => context.mark_as_dirty(),
+            #[cfg(feature = "webgpu")]
+            RenderingContext::WebGPU(context) => context.mark_as_dirty(),
+        }
+    }
+
+    fn update_rendering(&self) {
+        match self {
+            RenderingContext::Placeholder(context) => {
+                (*context.context().unwrap()).update_rendering()
+            },
+            RenderingContext::Context2d(context) => context.update_rendering(),
+            RenderingContext::WebGL(context) => context.update_rendering(),
+            RenderingContext::WebGL2(context) => context.update_rendering(),
+            #[cfg(feature = "webgpu")]
+            RenderingContext::WebGPU(context) => context.update_rendering(),
+        }
+    }
+
+    fn onscreen(&self) -> bool {
+        match self {
+            RenderingContext::Placeholder(context) => (*context.context().unwrap()).onscreen(),
+            RenderingContext::Context2d(context) => context.onscreen(),
+            RenderingContext::WebGL(context) => context.onscreen(),
+            RenderingContext::WebGL2(context) => context.onscreen(),
+            #[cfg(feature = "webgpu")]
+            RenderingContext::WebGPU(context) => context.onscreen(),
+        }
+    }
+}
+
+/// Non rooted variant of [`crate::dom::bindings::codegen::Bindings::OffscreenCanvasBinding::OffscreenRenderingContext`]
+#[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
+#[derive(Clone, JSTraceable, MallocSizeOf)]
+pub(crate) enum OffscreenRenderingContext {
+    Context2d(Dom<OffscreenCanvasRenderingContext2D>),
+    //WebGL(Dom<WebGLRenderingContext>),
+    //WebGL2(Dom<WebGL2RenderingContext>),
+    //#[cfg(feature = "webgpu")]
+    //WebGPU(Dom<GPUCanvasContext>),
+}
+
+impl CanvasContext for OffscreenRenderingContext {
+    type ID = ();
+
+    fn context_id(&self) -> Self::ID {}
+
+    fn canvas(&self) -> HTMLCanvasElementOrOffscreenCanvas {
+        match self {
+            OffscreenRenderingContext::Context2d(context) => context.canvas(),
+        }
+    }
+
+    fn resize(&self) {
+        match self {
+            OffscreenRenderingContext::Context2d(context) => context.resize(),
+        }
+    }
+
+    fn get_image_data(&self) -> Option<Snapshot> {
+        match self {
+            OffscreenRenderingContext::Context2d(context) => context.get_image_data(),
+        }
+    }
+
+    fn origin_is_clean(&self) -> bool {
+        match self {
+            OffscreenRenderingContext::Context2d(context) => context.origin_is_clean(),
+        }
+    }
+
+    fn size(&self) -> Size2D<u64> {
+        match self {
+            OffscreenRenderingContext::Context2d(context) => context.size(),
+        }
+    }
+
+    fn mark_as_dirty(&self) {
+        match self {
+            OffscreenRenderingContext::Context2d(context) => context.mark_as_dirty(),
+        }
+    }
+
+    fn update_rendering(&self) {
+        match self {
+            OffscreenRenderingContext::Context2d(context) => context.update_rendering(),
+        }
+    }
+
+    fn onscreen(&self) -> bool {
+        match self {
+            OffscreenRenderingContext::Context2d(context) => context.onscreen(),
         }
     }
 }

--- a/components/script/canvas_state.rs
+++ b/components/script/canvas_state.rs
@@ -36,6 +36,7 @@ use style_traits::{CssWriter, ParsingMode};
 use url::Url;
 use webrender_api::ImageKey;
 
+use crate::canvas_context::{OffscreenRenderingContext, RenderingContext};
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::CanvasRenderingContext2DBinding::{
     CanvasDirection, CanvasFillRule, CanvasImageSource, CanvasLineCap, CanvasLineJoin,
@@ -52,10 +53,10 @@ use crate::dom::canvaspattern::CanvasPattern;
 use crate::dom::dommatrix::DOMMatrix;
 use crate::dom::element::{Element, cors_setting_for_element};
 use crate::dom::globalscope::GlobalScope;
-use crate::dom::htmlcanvaselement::{CanvasContext, HTMLCanvasElement};
+use crate::dom::htmlcanvaselement::HTMLCanvasElement;
 use crate::dom::imagedata::ImageData;
 use crate::dom::node::{Node, NodeTraits};
-use crate::dom::offscreencanvas::{OffscreenCanvas, OffscreenCanvasContext};
+use crate::dom::offscreencanvas::OffscreenCanvas;
 use crate::dom::paintworkletglobalscope::PaintWorkletGlobalScope;
 use crate::dom::textmetrics::TextMetrics;
 use crate::script_runtime::CanGc;
@@ -522,7 +523,7 @@ impl CanvasState {
 
         if let Some(context) = canvas.context() {
             match *context {
-                OffscreenCanvasContext::OffscreenContext2d(ref context) => {
+                OffscreenRenderingContext::Context2d(ref context) => {
                     context.send_canvas_2d_msg(Canvas2dMsg::DrawImageInOther(
                         self.get_canvas_id(),
                         image_size,
@@ -577,7 +578,7 @@ impl CanvasState {
 
         if let Some(context) = canvas.context() {
             match *context {
-                CanvasContext::Context2d(ref context) => {
+                RenderingContext::Context2d(ref context) => {
                     context.send_canvas_2d_msg(Canvas2dMsg::DrawImageInOther(
                         self.get_canvas_id(),
                         image_size,
@@ -586,12 +587,12 @@ impl CanvasState {
                         smoothing_enabled,
                     ));
                 },
-                CanvasContext::Placeholder(ref context) => {
+                RenderingContext::Placeholder(ref context) => {
                     let Some(context) = context.context() else {
                         return Err(Error::InvalidState);
                     };
                     match *context {
-                        OffscreenCanvasContext::OffscreenContext2d(ref context) => context
+                        OffscreenRenderingContext::Context2d(ref context) => context
                             .send_canvas_2d_msg(Canvas2dMsg::DrawImageInOther(
                                 self.get_canvas_id(),
                                 image_size,

--- a/components/script/dom/offscreencanvasrenderingcontext2d.rs
+++ b/components/script/dom/offscreencanvasrenderingcontext2d.rs
@@ -3,11 +3,10 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use crate::dom::bindings::codegen::GenericBindings::CanvasRenderingContext2DBinding::CanvasRenderingContext2D_Binding::CanvasRenderingContext2DMethods;
-use crate::canvas_context::CanvasContext as _;
+use crate::canvas_context::CanvasContext;
 use crate::dom::bindings::codegen::UnionTypes::HTMLCanvasElementOrOffscreenCanvas;
 use canvas_traits::canvas::Canvas2dMsg;
 use dom_struct::dom_struct;
-use euclid::default::Size2D;
 use snapshot::Snapshot;
 
 use crate::dom::bindings::codegen::Bindings::CanvasRenderingContext2DBinding::{
@@ -64,20 +63,32 @@ impl OffscreenCanvasRenderingContext2D {
         reflect_dom_object(boxed, global, can_gc)
     }
 
-    pub(crate) fn set_canvas_bitmap_dimensions(&self, size: Size2D<u64>) {
-        self.context.set_canvas_bitmap_dimensions(size.cast());
-    }
-
     pub(crate) fn send_canvas_2d_msg(&self, msg: Canvas2dMsg) {
         self.context.send_canvas_2d_msg(msg)
     }
+}
 
-    pub(crate) fn origin_is_clean(&self) -> bool {
-        self.context.origin_is_clean()
+impl CanvasContext for OffscreenCanvasRenderingContext2D {
+    type ID = <CanvasRenderingContext2D as CanvasContext>::ID;
+
+    fn context_id(&self) -> Self::ID {
+        self.context.context_id()
     }
 
-    pub(crate) fn get_image_data(&self) -> Option<Snapshot> {
+    fn canvas(&self) -> HTMLCanvasElementOrOffscreenCanvas {
+        self.context.canvas()
+    }
+
+    fn resize(&self) {
+        self.context.resize()
+    }
+
+    fn get_image_data(&self) -> Option<Snapshot> {
         self.context.get_image_data()
+    }
+
+    fn origin_is_clean(&self) -> bool {
+        self.context.origin_is_clean()
     }
 }
 


### PR DESCRIPTION
this allows us to simplify canvas element/offscreen impl to only call CanvasContext implementations (no more match statements).

This will help with impl more offscreen canvas contextl.

Testing: WPT and rustc
