### PR TITLE
constellation: Move log inside relevant conditional.

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -3744,8 +3744,8 @@ where
     fn handle_load_complete_msg(&mut self, webview_id: WebViewId, pipeline_id: PipelineId) {
         let mut webdriver_reset = false;
         if let Some((expected_pipeline_id, ref reply_chan)) = self.webdriver.load_channel {
-            debug!("Sending load for {:?} to WebDriver", expected_pipeline_id);
             if expected_pipeline_id == pipeline_id {
+                debug!("Sending load for {:?} to WebDriver", expected_pipeline_id);
                 let _ = reply_chan.send(WebDriverLoadStatus::Complete);
                 webdriver_reset = true;
             }


### PR DESCRIPTION
This message is logged when we don't actually act on it and is confusing as a result. By moving it inside the conditional, we only log the message when we actually notify webdriver that the load is complete.

Testing: Manual testing.