### PR TITLE
Use utf16 as backing storage for `TextInput`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7320,6 +7320,7 @@ dependencies = [
  "bincode",
  "bitflags 2.9.4",
  "bluetooth_traits",
+ "byteorder",
  "canvas_traits",
  "cbc",
  "chrono",
@@ -7410,6 +7411,7 @@ dependencies = [
  "url",
  "urlpattern",
  "utf-8",
+ "utf16string",
  "uuid",
  "webdriver",
  "webgpu_traits",
@@ -7454,6 +7456,7 @@ dependencies = [
  "stylo_atoms",
  "tendril",
  "tracing",
+ "utf16string",
  "webxr-api",
  "xml5ever",
 ]
@@ -7466,6 +7469,7 @@ dependencies = [
  "keyboard-types",
  "script",
  "servo_url",
+ "utf16string",
 ]
 
 [[package]]
@@ -9362,6 +9366,11 @@ name = "utf16_iter"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
+name = "utf16string"
+version = "0.1.0"
+source = "git+https://github.com/simonwuelker/utf16string#e92dc5f3fce2d7cad04285276631b89e68f587d1"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7947,6 +7947,7 @@ dependencies = [
  "unicode-script",
  "url",
  "urlpattern",
+ "utf16string",
  "uuid",
  "webrender",
  "webrender_api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,6 +168,7 @@ unicode-script = "0.5"
 unicode-segmentation = "1.12.0"
 url = "2.5"
 urlpattern = "0.3"
+utf16string = { git = "https://github.com/simonwuelker/utf16string" }
 uuid = { version = "1.18.1", features = ["v4", "v5"] }
 vello = { git = "https://github.com/linebender/vello", rev = "5e3e12559781891b204553161aee761900c7e92d" }
 vello_cpu = { git = "https://github.com/linebender/vello", rev = "5e3e12559781891b204553161aee761900c7e92d" }

--- a/components/malloc_size_of/Cargo.toml
+++ b/components/malloc_size_of/Cargo.toml
@@ -42,3 +42,4 @@ uuid = { workspace = true }
 webrender = { workspace = true }
 webrender_api = { workspace = true }
 wr_malloc_size_of = { workspace = true }
+utf16string = { workspace = true }

--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -149,6 +149,12 @@ macro_rules! malloc_size_of_is_0(
     );
 );
 
+impl MallocSizeOf for utf16string::Utf16String {
+    fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
+        unsafe { ops.malloc_size_of(self.as_ptr()) }
+    }
+}
+
 impl MallocSizeOf for keyboard_types::Key {
     fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
         match &self {

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -136,6 +136,7 @@ url = { workspace = true }
 urlpattern = { workspace = true }
 utf-8 = "0.7"
 uuid = { workspace = true, features = ["serde"] }
+byteorder = { workspace = true }
 webdriver = { workspace = true }
 webgpu_traits = { workspace = true }
 webrender_api = { workspace = true }
@@ -143,6 +144,7 @@ webxr-api = { workspace = true, features = ["ipc"], optional = true }
 wgpu-core = { workspace = true }
 wgpu-types = { workspace = true }
 xml5ever = { workspace = true }
+utf16string = { workspace = true }
 
 [target.'cfg(not(target_os = "ios"))'.dependencies]
 mozangle = { workspace = true }

--- a/components/script/clipboard_provider.rs
+++ b/components/script/clipboard_provider.rs
@@ -30,9 +30,9 @@ impl ClipboardProvider for EmbedderClipboardProvider {
             .unwrap();
         rx.recv().unwrap()
     }
-    fn set_text(&mut self, s: String) {
+    fn set_text(&mut self, value: String) {
         self.embedder_sender
-            .send(EmbedderMsg::SetClipboardText(self.webview_id, s))
+            .send(EmbedderMsg::SetClipboardText(self.webview_id, value))
             .unwrap();
     }
 }

--- a/components/script/dom/html/htmltextareaelement.rs
+++ b/components/script/dom/html/htmltextareaelement.rs
@@ -11,6 +11,7 @@ use html5ever::{LocalName, Prefix, local_name, ns};
 use js::rust::HandleObject;
 use style::attr::AttrValue;
 use stylo_dom::ElementState;
+use utf16string::Utf16String;
 
 use crate::clipboard_provider::EmbedderClipboardProvider;
 use crate::dom::attr::Attr;
@@ -44,7 +45,6 @@ use crate::dom::virtualmethods::VirtualMethods;
 use crate::script_runtime::CanGc;
 use crate::textinput::{
     ClipboardEventReaction, Direction, KeyReaction, Lines, SelectionDirection, TextInput,
-    UTF8Bytes, UTF16CodeUnits,
 };
 
 #[dom_struct]
@@ -75,10 +75,11 @@ impl<'dom> LayoutDom<'dom, HTMLTextAreaElement> {
                 .textinput
                 .borrow_for_layout()
                 .get_content()
+                .into()
         }
     }
 
-    fn textinput_sorted_selection_offsets_range(self) -> Range<UTF8Bytes> {
+    fn textinput_sorted_selection_offsets_range(self) -> Range<usize> {
         unsafe {
             self.unsafe_get()
                 .textinput
@@ -108,9 +109,7 @@ impl LayoutHTMLTextAreaElementHelpers for LayoutDom<'_, HTMLTextAreaElement> {
         if !self.upcast::<Element>().focus_state() {
             return None;
         }
-        Some(UTF8Bytes::unwrap_range(
-            self.textinput_sorted_selection_offsets_range(),
-        ))
+        Some(self.textinput_sorted_selection_offsets_range())
     }
 
     fn get_cols(self) -> u32 {
@@ -156,7 +155,7 @@ impl HTMLTextAreaElement {
             placeholder: DomRefCell::new(DOMString::new()),
             textinput: DomRefCell::new(TextInput::new(
                 Lines::Multiple,
-                DOMString::new(),
+                Default::default(),
                 EmbedderClipboardProvider {
                     embedder_sender,
                     webview_id: document.webview_id(),
@@ -323,7 +322,7 @@ impl HTMLTextAreaElementMethods<crate::DomTypeHolder> for HTMLTextAreaElement {
 
     // https://html.spec.whatwg.org/multipage/#dom-textarea-value
     fn Value(&self) -> DOMString {
-        self.textinput.borrow().get_content()
+        self.textinput.borrow().get_content().to_string().into()
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-textarea-value
@@ -335,7 +334,7 @@ impl HTMLTextAreaElementMethods<crate::DomTypeHolder> for HTMLTextAreaElement {
             let old_value = textinput.get_content();
 
             // Step 2
-            textinput.set_content(value);
+            textinput.set_content(Utf16String::from(value));
 
             // Step 3
             self.value_dirty.set(true);
@@ -353,8 +352,7 @@ impl HTMLTextAreaElementMethods<crate::DomTypeHolder> for HTMLTextAreaElement {
 
     // https://html.spec.whatwg.org/multipage/#dom-textarea-textlength
     fn TextLength(&self) -> u32 {
-        let UTF16CodeUnits(num_units) = self.textinput.borrow().utf16_len();
-        num_units as u32
+        self.textinput.borrow().utf16_len() as u32
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-lfe-labels
@@ -402,8 +400,12 @@ impl HTMLTextAreaElementMethods<crate::DomTypeHolder> for HTMLTextAreaElement {
 
     // https://html.spec.whatwg.org/multipage/#dom-textarea/input-setrangetext
     fn SetRangeText(&self, replacement: DOMString) -> ErrorResult {
-        self.selection()
-            .set_dom_range_text(replacement, None, None, Default::default())
+        self.selection().set_dom_range_text(
+            Utf16String::from(replacement),
+            None,
+            None,
+            Default::default(),
+        )
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-textarea/input-setrangetext
@@ -414,8 +416,12 @@ impl HTMLTextAreaElementMethods<crate::DomTypeHolder> for HTMLTextAreaElement {
         end: u32,
         selection_mode: SelectionMode,
     ) -> ErrorResult {
-        self.selection()
-            .set_dom_range_text(replacement, Some(start), Some(end), selection_mode)
+        self.selection().set_dom_range_text(
+            Utf16String::from(replacement),
+            Some(start),
+            Some(end),
+            selection_mode,
+        )
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-cva-willvalidate
@@ -454,13 +460,13 @@ impl HTMLTextAreaElement {
     /// Used by WebDriver to clear the textarea element.
     pub(crate) fn clear(&self) {
         self.value_dirty.set(false);
-        self.textinput.borrow_mut().set_content(DOMString::from(""));
+        self.textinput.borrow_mut().set_content(Default::default());
     }
 
     pub(crate) fn reset(&self) {
         // https://html.spec.whatwg.org/multipage/#the-textarea-element:concept-form-reset-control
         let mut textinput = self.textinput.borrow_mut();
-        textinput.set_content(self.DefaultValue());
+        textinput.set_content(self.DefaultValue().str().into());
         self.value_dirty.set(false);
     }
 
@@ -508,7 +514,7 @@ impl VirtualMethods for HTMLTextAreaElement {
                     if value < 0 {
                         textinput.set_max_length(None);
                     } else {
-                        textinput.set_max_length(Some(UTF16CodeUnits(value as usize)))
+                        textinput.set_max_length(Some(value as usize))
                     }
                 },
                 _ => panic!("Expected an AttrValue::Int"),
@@ -520,7 +526,7 @@ impl VirtualMethods for HTMLTextAreaElement {
                     if value < 0 {
                         textinput.set_min_length(None);
                     } else {
-                        textinput.set_min_length(Some(UTF16CodeUnits(value as usize)))
+                        textinput.set_min_length(Some(value as usize))
                     }
                 },
                 _ => panic!("Expected an AttrValue::Int"),
@@ -776,7 +782,7 @@ impl Validatable for HTMLTextAreaElement {
         let mut failed_flags = ValidationFlags::empty();
 
         let textinput = self.textinput.borrow();
-        let UTF16CodeUnits(value_len) = textinput.utf16_len();
+        let value_len = textinput.utf16_len();
         let last_edit_by_user = !textinput.was_last_change_by_set_content();
         let value_dirty = self.value_dirty.get();
 

--- a/components/script/test.rs
+++ b/components/script/test.rs
@@ -72,7 +72,6 @@ pub mod timeranges {
 pub mod textinput {
     pub use crate::clipboard_provider::ClipboardProvider;
     pub use crate::textinput::{
-        Direction, Lines, Selection, SelectionDirection, TextInput, TextPoint, UTF8Bytes,
-        UTF16CodeUnits,
+        Direction, Lines, Selection, SelectionDirection, TextInput, TextPoint, UTF16CodeUnits,
     };
 }

--- a/components/script/textinput.rs
+++ b/components/script/textinput.rs
@@ -123,7 +123,6 @@ pub(crate) struct SelectionState {
 #[derive(JSTraceable, MallocSizeOf)]
 pub struct TextInput<T: ClipboardProvider> {
     /// Current text input content, split across lines without trailing '\n'
-    #[ignore_malloc_size_of = "FIXME"]
     #[no_trace]
     lines: Vec<Utf16String>,
 

--- a/components/script/textinput.rs
+++ b/components/script/textinput.rs
@@ -12,6 +12,7 @@ use std::ops::{Add, AddAssign, Range};
 use bitflags::bitflags;
 use keyboard_types::{Key, KeyState, Modifiers, NamedKey, ShortcutMatcher};
 use unicode_segmentation::UnicodeSegmentation;
+use utf16string::{Utf16Str, Utf16String, utf16};
 
 use crate::clipboard_provider::ClipboardProvider;
 use crate::dom::bindings::codegen::Bindings::EventBinding::Event_Binding::EventMethods;
@@ -34,54 +35,6 @@ pub enum SelectionDirection {
     Forward,
     Backward,
     None,
-}
-
-#[derive(Clone, Copy, Debug, Eq, JSTraceable, MallocSizeOf, Ord, PartialEq, PartialOrd)]
-pub struct UTF8Bytes(pub usize);
-
-impl UTF8Bytes {
-    pub fn zero() -> UTF8Bytes {
-        UTF8Bytes(0)
-    }
-
-    pub fn one() -> UTF8Bytes {
-        UTF8Bytes(1)
-    }
-
-    pub(crate) fn unwrap_range(byte_range: Range<UTF8Bytes>) -> Range<usize> {
-        byte_range.start.0..byte_range.end.0
-    }
-
-    pub(crate) fn saturating_sub(self, other: UTF8Bytes) -> UTF8Bytes {
-        if self > other {
-            UTF8Bytes(self.0 - other.0)
-        } else {
-            UTF8Bytes::zero()
-        }
-    }
-}
-
-impl Add for UTF8Bytes {
-    type Output = UTF8Bytes;
-
-    fn add(self, other: UTF8Bytes) -> UTF8Bytes {
-        UTF8Bytes(self.0 + other.0)
-    }
-}
-
-impl AddAssign for UTF8Bytes {
-    fn add_assign(&mut self, other: UTF8Bytes) {
-        *self = UTF8Bytes(self.0 + other.0)
-    }
-}
-
-trait StrExt {
-    fn len_utf8(&self) -> UTF8Bytes;
-}
-impl StrExt for str {
-    fn len_utf8(&self) -> UTF8Bytes {
-        UTF8Bytes(self.len())
-    }
 }
 
 #[derive(Clone, Copy, Debug, JSTraceable, MallocSizeOf, PartialEq, PartialOrd)]
@@ -139,22 +92,22 @@ impl From<SelectionDirection> for DOMString {
     }
 }
 
-#[derive(Clone, Copy, Debug, JSTraceable, MallocSizeOf, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Default, JSTraceable, MallocSizeOf, PartialEq, PartialOrd)]
 pub struct TextPoint {
     /// 0-based line number
     pub line: usize,
-    /// 0-based column number in bytes
-    pub index: UTF8Bytes,
+    /// 0-based column number in code units
+    pub index: usize,
 }
 
 impl TextPoint {
     /// Returns a TextPoint constrained to be a valid location within lines
-    fn constrain_to(&self, lines: &[DOMString]) -> TextPoint {
+    fn constrain_to(&self, lines: &[Utf16String]) -> TextPoint {
         let line = min(self.line, lines.len() - 1);
 
         TextPoint {
             line,
-            index: min(self.index, lines[line].len_utf8()),
+            index: min(self.index, lines[line].number_of_code_units()),
         }
     }
 }
@@ -170,7 +123,9 @@ pub(crate) struct SelectionState {
 #[derive(JSTraceable, MallocSizeOf)]
 pub struct TextInput<T: ClipboardProvider> {
     /// Current text input content, split across lines without trailing '\n'
-    lines: Vec<DOMString>,
+    #[ignore_malloc_size_of = "FIXME"]
+    #[no_trace]
+    lines: Vec<Utf16String>,
 
     /// Current cursor input point
     edit_point: TextPoint,
@@ -189,8 +144,12 @@ pub struct TextInput<T: ClipboardProvider> {
     /// The maximum number of UTF-16 code units this text input is allowed to hold.
     ///
     /// <https://html.spec.whatwg.org/multipage/#attr-fe-maxlength>
-    max_length: Option<UTF16CodeUnits>,
-    min_length: Option<UTF16CodeUnits>,
+    max_length: Option<usize>,
+
+    /// The maximum number of UTF-16 code units this text input is allowed to hold.
+    ///
+    /// <https://html.spec.whatwg.org/multipage/#attr-fe-minlength>
+    min_length: Option<usize>,
 
     /// Was last change made by set_content?
     was_last_change_by_set_content: bool,
@@ -210,15 +169,6 @@ bitflags! {
     pub struct ClipboardEventReaction: u8 {
         const QueueInputEvent = 1 << 0;
         const FireClipboardChangedEvent = 1 << 1;
-    }
-}
-
-impl Default for TextPoint {
-    fn default() -> TextPoint {
-        TextPoint {
-            line: 0,
-            index: UTF8Bytes::zero(),
-        }
     }
 }
 
@@ -246,37 +196,31 @@ pub(crate) const CMD_OR_CONTROL: Modifiers = Modifiers::CONTROL;
 ///
 /// If the string has fewer than n characters, returns the length of the whole string.
 /// If n is 0, returns 0
-fn len_of_first_n_chars(text: &str, n: usize) -> UTF8Bytes {
+fn len_of_first_n_chars(text: &Utf16Str, n: usize) -> usize {
     match text.char_indices().take(n).last() {
-        Some((index, ch)) => UTF8Bytes(index + ch.len_utf8()),
-        None => UTF8Bytes::zero(),
+        Some((index, ch)) => index + ch.map(|c| c.len_utf16()).unwrap_or(1),
+        None => 0,
     }
 }
 
 /// The length in bytes of the first n code units in a string when encoded in UTF-16.
 ///
 /// If the string is fewer than n code units, returns the length of the whole string.
-fn len_of_first_n_code_units(text: &str, n: UTF16CodeUnits) -> UTF8Bytes {
-    let mut utf8_len = UTF8Bytes::zero();
-    let mut utf16_len = UTF16CodeUnits::zero();
-    for c in text.chars() {
-        utf16_len += UTF16CodeUnits(c.len_utf16());
-        if utf16_len > n {
-            break;
-        }
-        utf8_len += UTF8Bytes(c.len_utf8());
-    }
-    utf8_len
+fn len_of_first_n_code_units(text: &Utf16Str, n: usize) -> usize {
+    text.char_indices()
+        .nth(n)
+        .map(|(position, _)| position)
+        .unwrap_or(text.number_of_code_units())
 }
 
 impl<T: ClipboardProvider> TextInput<T> {
     /// Instantiate a new text input control
     pub fn new(
         lines: Lines,
-        initial: DOMString,
+        initial: Utf16String,
         clipboard_provider: T,
-        max_length: Option<UTF16CodeUnits>,
-        min_length: Option<UTF16CodeUnits>,
+        max_length: Option<usize>,
+        min_length: Option<usize>,
         selection_direction: SelectionDirection,
     ) -> TextInput<T> {
         let mut i = TextInput {
@@ -312,11 +256,11 @@ impl<T: ClipboardProvider> TextInput<T> {
         self.selection_direction
     }
 
-    pub(crate) fn set_max_length(&mut self, length: Option<UTF16CodeUnits>) {
+    pub(crate) fn set_max_length(&mut self, length: Option<usize>) {
         self.max_length = length;
     }
 
-    pub(crate) fn set_min_length(&mut self, length: Option<UTF16CodeUnits>) {
+    pub(crate) fn set_min_length(&mut self, length: Option<usize>) {
         self.min_length = length;
     }
 
@@ -325,9 +269,9 @@ impl<T: ClipboardProvider> TextInput<T> {
         self.was_last_change_by_set_content
     }
 
-    /// Remove a character at the current editing point
+    /// Remove a character at the current editing point.
     ///
-    /// Returns true if any character was deleted
+    /// Returns true if any character was deleted.
     pub fn delete_char(&mut self, dir: Direction) -> bool {
         if self.selection_origin.is_none() || self.selection_origin == Some(self.edit_point) {
             self.adjust_horizontal_by_one(dir, Selection::Selected);
@@ -335,23 +279,22 @@ impl<T: ClipboardProvider> TextInput<T> {
         if self.selection_start() == self.selection_end() {
             false
         } else {
-            self.replace_selection(DOMString::new());
+            self.replace_selection(Default::default());
             true
         }
     }
 
     /// Insert a character at the current editing point
     pub fn insert_char(&mut self, ch: char) {
-        self.insert_string(ch.to_string());
+        self.insert_string(Utf16String::from(ch));
     }
 
-    /// Insert a string at the current editing point or replace the selection if
-    /// one exists.
-    pub fn insert_string<S: Into<String>>(&mut self, s: S) {
+    /// Insert a string at the current editing point
+    pub fn insert_string(&mut self, to_insert: Utf16String) {
         if self.selection_origin.is_none() {
             self.selection_origin = Some(self.edit_point);
         }
-        self.replace_selection(DOMString::from(s.into()));
+        self.replace_selection(to_insert);
     }
 
     /// The start of the selection (or the edit point, if there is no selection). Always less than
@@ -365,8 +308,8 @@ impl<T: ClipboardProvider> TextInput<T> {
         }
     }
 
-    /// The byte offset of the selection_start()
-    pub fn selection_start_offset(&self) -> UTF8Bytes {
+    /// The code unit offset of the selection_start()
+    pub fn selection_start_offset(&self) -> usize {
         self.text_point_to_offset(&self.selection_start())
     }
 
@@ -379,8 +322,8 @@ impl<T: ClipboardProvider> TextInput<T> {
         }
     }
 
-    /// The byte offset of the selection_end()
-    pub fn selection_end_offset(&self) -> UTF8Bytes {
+    /// The code unit offset of the selection_end()
+    pub fn selection_end_offset(&self) -> usize {
         self.text_point_to_offset(&self.selection_end())
     }
 
@@ -399,7 +342,7 @@ impl<T: ClipboardProvider> TextInput<T> {
     /// Return the selection range as byte offsets from the start of the content.
     ///
     /// If there is no selection, returns an empty range at the edit point.
-    pub(crate) fn sorted_selection_offsets_range(&self) -> Range<UTF8Bytes> {
+    pub(crate) fn sorted_selection_offsets_range(&self) -> Range<usize> {
         self.selection_start_offset()..self.selection_end_offset()
     }
 
@@ -420,7 +363,7 @@ impl<T: ClipboardProvider> TextInput<T> {
         );
         if let Some(begin) = self.selection_origin {
             debug_assert!(begin.line < self.lines.len());
-            debug_assert!(begin.index <= self.lines[begin.line].len_utf8());
+            debug_assert!(begin.index <= self.lines[begin.line].number_of_code_units());
 
             match self.selection_direction {
                 SelectionDirection::None | SelectionDirection::Forward => {
@@ -432,11 +375,14 @@ impl<T: ClipboardProvider> TextInput<T> {
         }
 
         debug_assert!(self.edit_point.line < self.lines.len());
-        debug_assert!(self.edit_point.index <= self.lines[self.edit_point.line].len_utf8());
+        debug_assert!(
+            self.edit_point.index <= self.lines[self.edit_point.line].number_of_code_units()
+        );
     }
 
-    pub(crate) fn get_selection_text(&self) -> Option<String> {
-        let text = self.fold_selection_slices(String::new(), |s, slice| s.push_str(slice));
+    pub(crate) fn get_selection_text(&self) -> Option<Utf16String> {
+        let text =
+            self.fold_selection_slices(Utf16String::new(), |s, slice| s.push_utf16_str(slice));
         if text.is_empty() {
             return None;
         }
@@ -444,38 +390,39 @@ impl<T: ClipboardProvider> TextInput<T> {
     }
 
     /// The length of the selected text in UTF-16 code units.
-    fn selection_utf16_len(&self) -> UTF16CodeUnits {
-        self.fold_selection_slices(UTF16CodeUnits::zero(), |len, slice| {
-            *len += UTF16CodeUnits(slice.chars().map(char::len_utf16).sum::<usize>())
-        })
+    fn selection_utf16_len(&self) -> usize {
+        self.fold_selection_slices(0, |len, slice| *len += slice.number_of_code_units())
     }
 
     /// Run the callback on a series of slices that, concatenated, make up the selected text.
     ///
     /// The accumulator `acc` can be mutated by the callback, and will be returned at the end.
-    fn fold_selection_slices<B, F: FnMut(&mut B, &str)>(&self, mut acc: B, mut f: F) -> B {
+    fn fold_selection_slices<B, F: FnMut(&mut B, &Utf16Str)>(&self, mut acc: B, mut f: F) -> B {
         if self.has_selection() {
             let (start, end) = self.sorted_selection_bounds();
-            let UTF8Bytes(start_offset) = start.index;
-            let UTF8Bytes(end_offset) = end.index;
+            let start_byte_offset = start.index;
+            let end_byte_offset = end.index;
 
             if start.line == end.line {
-                f(&mut acc, &self.lines[start.line][start_offset..end_offset])
+                f(
+                    &mut acc,
+                    &self.lines[start.line][start_byte_offset..end_byte_offset],
+                )
             } else {
-                f(&mut acc, &self.lines[start.line][start_offset..]);
+                f(&mut acc, &self.lines[start.line][start_byte_offset..]);
                 for line in &self.lines[start.line + 1..end.line] {
-                    f(&mut acc, "\n");
+                    f(&mut acc, utf16!("\n"));
                     f(&mut acc, line);
                 }
-                f(&mut acc, "\n");
-                f(&mut acc, &self.lines[end.line][..end_offset])
+                f(&mut acc, utf16!("\n"));
+                f(&mut acc, &self.lines[end.line][..end_byte_offset])
             }
         }
 
         acc
     }
 
-    pub fn replace_selection(&mut self, insert: DOMString) {
+    pub fn replace_selection(&mut self, insert: Utf16String) {
         if !self.has_selection() {
             return;
         }
@@ -485,41 +432,39 @@ impl<T: ClipboardProvider> TextInput<T> {
                 self.utf16_len().saturating_sub(self.selection_utf16_len());
             max_length.saturating_sub(len_after_selection_replaced)
         } else {
-            UTF16CodeUnits(usize::MAX)
+            usize::MAX
         };
 
-        let UTF8Bytes(last_char_index) =
-            len_of_first_n_code_units(&insert, allowed_to_insert_count);
-        let to_insert = &insert[..last_char_index];
+        let last_char_byte_index = len_of_first_n_code_units(&insert, allowed_to_insert_count);
+        let to_insert = &insert[..last_char_byte_index];
 
         let (start, end) = self.sorted_selection_bounds();
-        let UTF8Bytes(start_offset) = start.index;
-        let UTF8Bytes(end_offset) = end.index;
+        let start_byte_offset = start.index;
+        let end_byte_offset = end.index;
 
         let new_lines = {
-            let prefix = &self.lines[start.line][..start_offset];
-            let suffix = &self.lines[end.line][end_offset..];
+            let prefix = &self.lines[start.line][..start_byte_offset];
+            let suffix = &self.lines[end.line][end_byte_offset..];
             let lines_prefix = &self.lines[..start.line];
             let lines_suffix = &self.lines[end.line + 1..];
 
             let mut insert_lines = if self.multiline {
-                to_insert.split('\n').map(DOMString::from).collect()
+                to_insert.split('\n').map(Utf16String::from).collect()
             } else {
-                vec![DOMString::from(to_insert)]
+                vec![Utf16String::from(to_insert)]
             };
 
-            // FIXME(ajeffrey): efficient append for DOMStrings
-            let mut new_line = prefix.to_owned();
+            let mut new_line: Utf16String = prefix.to_owned();
 
-            new_line.push_str(&insert_lines[0]);
-            insert_lines[0] = DOMString::from(new_line);
+            new_line.push_utf16_str(&insert_lines[0]);
+            insert_lines[0] = new_line;
 
             let last_insert_lines_index = insert_lines.len() - 1;
-            self.edit_point.index = insert_lines[last_insert_lines_index].len_utf8();
+            self.edit_point.index = insert_lines[last_insert_lines_index].number_of_code_units();
             self.edit_point.line = start.line + last_insert_lines_index;
 
             // FIXME(ajeffrey): efficient append for DOMStrings
-            insert_lines[last_insert_lines_index].push_str(suffix);
+            insert_lines[last_insert_lines_index].push_utf16_str(suffix);
 
             let mut new_lines = vec![];
             new_lines.extend_from_slice(lines_prefix);
@@ -534,9 +479,9 @@ impl<T: ClipboardProvider> TextInput<T> {
         self.assert_ok_selection();
     }
 
-    /// Return the length in bytes of the current line under the editing point.
-    pub fn current_line_length(&self) -> UTF8Bytes {
-        self.lines[self.edit_point.line].len_utf8()
+    /// Return the length in code units of the current line under the editing point.
+    pub fn current_line_length(&self) -> usize {
+        self.lines[self.edit_point.line].number_of_code_units()
     }
 
     /// Adjust the editing point position by a given number of lines. The resulting column is
@@ -560,15 +505,12 @@ impl<T: ClipboardProvider> TextInput<T> {
 
         if target_line < 0 {
             self.edit_point.line = 0;
-            self.edit_point.index = UTF8Bytes::zero();
+            self.edit_point.index = 0;
             if self.selection_origin.is_some() &&
                 (self.selection_direction == SelectionDirection::None ||
                     self.selection_direction == SelectionDirection::Forward)
             {
-                self.selection_origin = Some(TextPoint {
-                    line: 0,
-                    index: UTF8Bytes::zero(),
-                });
+                self.selection_origin = Some(TextPoint { line: 0, index: 0 });
             }
             return;
         } else if target_line as usize >= self.lines.len() {
@@ -582,8 +524,7 @@ impl<T: ClipboardProvider> TextInput<T> {
             return;
         }
 
-        let UTF8Bytes(edit_index) = self.edit_point.index;
-        let col = self.lines[self.edit_point.line][..edit_index]
+        let col = self.lines[self.edit_point.line][..self.edit_point.index]
             .chars()
             .count();
         self.edit_point.line = target_line as usize;
@@ -607,14 +548,14 @@ impl<T: ClipboardProvider> TextInput<T> {
     /// adjusted vertically and the process repeats with the remaining adjustment requested.
     pub fn adjust_horizontal(
         &mut self,
-        adjust: UTF8Bytes,
+        adjust_by_bytes: usize,
         direction: Direction,
         select: Selection,
     ) {
         if self.adjust_selection_for_horizontal_change(direction, select) {
             return;
         }
-        self.perform_horizontal_adjustment(adjust, direction, select);
+        self.perform_horizontal_adjustment(adjust_by_bytes, direction, select);
     }
 
     /// Adjust the editing point position by exactly one grapheme cluster. If the edit point
@@ -624,19 +565,25 @@ impl<T: ClipboardProvider> TextInput<T> {
         if self.adjust_selection_for_horizontal_change(direction, select) {
             return;
         }
-        let adjust = {
-            let current_line = &self.lines[self.edit_point.line];
-            let UTF8Bytes(current_offset) = self.edit_point.index;
-            let next_ch = match direction {
-                Direction::Forward => current_line[current_offset..].graphemes(true).next(),
-                Direction::Backward => current_line[..current_offset].graphemes(true).next_back(),
+        let adjust_by_bytes = {
+            // FIXME: It would be really nice to not have to convert to utf8 here, but the
+            // unicode_segmentation crate understandably only concerns itself with utf8.
+            let current_line = &self.lines[self.edit_point.line].to_utf8();
+
+            let next_grapheme = match direction {
+                Direction::Forward => current_line[self.edit_point.index..].graphemes(true).next(),
+                Direction::Backward => current_line[..self.edit_point.index]
+                    .graphemes(true)
+                    .next_back(),
             };
-            match next_ch {
-                Some(c) => UTF8Bytes(c.len()),
-                None => UTF8Bytes::one(), // Going to the next line is a "one byte" offset
+            match next_grapheme {
+                Some(grapheme) => grapheme
+                    .chars()
+                    .fold(0, |accumulator, c| accumulator + c.len_utf16()),
+                None => 1, // Going to the next line is a "one byte" offset
             }
         };
-        self.perform_horizontal_adjustment(adjust, direction, select);
+        self.perform_horizontal_adjustment(adjust_by_bytes, direction, select);
     }
 
     /// Return whether to cancel the caret move
@@ -678,14 +625,14 @@ impl<T: ClipboardProvider> TextInput<T> {
 
     fn perform_horizontal_adjustment(
         &mut self,
-        adjust: UTF8Bytes,
+        adjust_by_bytes: usize,
         direction: Direction,
         select: Selection,
     ) {
         match direction {
             Direction::Backward => {
-                let remaining = self.edit_point.index;
-                if adjust > remaining && self.edit_point.line > 0 {
+                let remaining_bytes = self.edit_point.index;
+                if adjust_by_bytes > remaining_bytes && self.edit_point.line > 0 {
                     // Preserve the current selection origin because `adjust_vertical`
                     // modifies `selection_origin`. Since we are moving backward instead of
                     // highlighting vertically, we need to restore it after adjusting the line.
@@ -696,30 +643,32 @@ impl<T: ClipboardProvider> TextInput<T> {
                     self.selection_origin = selection_origin_temp;
                     // one shift is consumed by the change of line, hence the -1
                     self.adjust_horizontal(
-                        adjust.saturating_sub(remaining + UTF8Bytes::one()),
+                        adjust_by_bytes.saturating_sub(remaining_bytes + 1),
                         direction,
                         select,
                     );
                 } else {
-                    self.edit_point.index = remaining.saturating_sub(adjust);
+                    self.edit_point.index = remaining_bytes.saturating_sub(adjust_by_bytes);
                 }
             },
             Direction::Forward => {
                 let remaining = self
                     .current_line_length()
                     .saturating_sub(self.edit_point.index);
-                if adjust > remaining && self.lines.len() > self.edit_point.line + 1 {
+                if adjust_by_bytes > remaining && self.lines.len() > self.edit_point.line + 1 {
                     self.adjust_vertical(1, select);
-                    self.edit_point.index = UTF8Bytes::zero();
+                    self.edit_point.index = 0;
                     // one shift is consumed by the change of line, hence the -1
                     self.adjust_horizontal(
-                        adjust.saturating_sub(remaining + UTF8Bytes::one()),
+                        adjust_by_bytes.saturating_sub(remaining + 1),
                         direction,
                         select,
                     );
                 } else {
-                    self.edit_point.index =
-                        min(self.current_line_length(), self.edit_point.index + adjust);
+                    self.edit_point.index = min(
+                        self.current_line_length(),
+                        self.edit_point.index + adjust_by_bytes,
+                    );
                 }
             },
         };
@@ -739,13 +688,10 @@ impl<T: ClipboardProvider> TextInput<T> {
 
     /// Select all text in the input control.
     pub fn select_all(&mut self) {
-        self.selection_origin = Some(TextPoint {
-            line: 0,
-            index: UTF8Bytes::zero(),
-        });
+        self.selection_origin = Some(TextPoint { line: 0, index: 0 });
         let last_line = self.lines.len() - 1;
         self.edit_point.line = last_line;
-        self.edit_point.index = self.lines[last_line].len_utf8();
+        self.edit_point.index = self.lines[last_line].number_of_code_units();
         self.selection_direction = SelectionDirection::Forward;
         self.assert_ok_selection();
     }
@@ -766,20 +712,22 @@ impl<T: ClipboardProvider> TextInput<T> {
         if self.adjust_selection_for_horizontal_change(direction, select) {
             return;
         }
-        let shift_increment: UTF8Bytes = {
+
+        // FIXME: It would be really nice to not have to convert to utf8 here, but the
+        // unicode_segmentation crate understandably only concerns itself with utf8.
+        let shift_increment = {
             let current_index = self.edit_point.index;
             let current_line = self.edit_point.line;
-            let mut newline_adjustment = UTF8Bytes::zero();
-            let mut shift_temp = UTF8Bytes::zero();
+            let mut newline_adjustment = 0;
+            let mut shift_temp: usize = 0;
             match direction {
                 Direction::Backward => {
-                    let input: &str;
-                    if current_index == UTF8Bytes::zero() && current_line > 0 {
-                        input = &self.lines[current_line - 1];
-                        newline_adjustment = UTF8Bytes::one();
+                    let input: String;
+                    if current_index == 0 && current_line > 0 {
+                        input = self.lines[current_line - 1].to_utf8();
+                        newline_adjustment = 1;
                     } else {
-                        let UTF8Bytes(remaining) = current_index;
-                        input = &self.lines[current_line][..remaining];
+                        input = self.lines[current_line][..current_index].to_utf8();
                     }
 
                     let mut iter = input.split_word_bounds().rev();
@@ -787,7 +735,7 @@ impl<T: ClipboardProvider> TextInput<T> {
                         match iter.next() {
                             None => break,
                             Some(x) => {
-                                shift_temp += UTF8Bytes(x.len());
+                                shift_temp += x.chars().map(|c| c.len_utf16()).sum::<usize>();
                                 if x.chars().any(|x| x.is_alphabetic() || x.is_numeric()) {
                                     break;
                                 }
@@ -796,15 +744,13 @@ impl<T: ClipboardProvider> TextInput<T> {
                     }
                 },
                 Direction::Forward => {
-                    let input: &str;
+                    let input: String;
                     let remaining = self.current_line_length().saturating_sub(current_index);
-                    if remaining == UTF8Bytes::zero() && self.lines.len() > self.edit_point.line + 1
-                    {
-                        input = &self.lines[current_line + 1];
-                        newline_adjustment = UTF8Bytes::one();
+                    if remaining == 0 && self.lines.len() > self.edit_point.line + 1 {
+                        input = self.lines[current_line + 1].to_utf8();
+                        newline_adjustment = 1;
                     } else {
-                        let UTF8Bytes(current_offset) = current_index;
-                        input = &self.lines[current_line][current_offset..];
+                        input = self.lines[current_line][current_index..].to_utf8();
                     }
 
                     let mut iter = input.split_word_bounds();
@@ -812,7 +758,7 @@ impl<T: ClipboardProvider> TextInput<T> {
                         match iter.next() {
                             None => break,
                             Some(x) => {
-                                shift_temp += UTF8Bytes(x.len());
+                                shift_temp += x.len();
                                 if x.chars().any(|x| x.is_alphabetic() || x.is_numeric()) {
                                     break;
                                 }
@@ -832,15 +778,14 @@ impl<T: ClipboardProvider> TextInput<T> {
         if self.adjust_selection_for_horizontal_change(direction, select) {
             return;
         }
-        let shift: usize = {
+        let shift_by_bytes: usize = {
             let current_line = &self.lines[self.edit_point.line];
-            let UTF8Bytes(current_offset) = self.edit_point.index;
             match direction {
-                Direction::Backward => current_line[..current_offset].len(),
-                Direction::Forward => current_line[current_offset..].len(),
+                Direction::Backward => current_line[..self.edit_point.index].number_of_code_units(),
+                Direction::Forward => current_line[self.edit_point.index..].number_of_code_units(),
             }
         };
-        self.perform_horizontal_adjustment(UTF8Bytes(shift), direction, select);
+        self.perform_horizontal_adjustment(shift_by_bytes, direction, select);
     }
 
     pub(crate) fn adjust_horizontal_to_limit(&mut self, direction: Direction, select: Selection) {
@@ -850,11 +795,11 @@ impl<T: ClipboardProvider> TextInput<T> {
         match direction {
             Direction::Backward => {
                 self.edit_point.line = 0;
-                self.edit_point.index = UTF8Bytes::zero();
+                self.edit_point.index = 0;
             },
             Direction::Forward => {
                 self.edit_point.line = &self.lines.len() - 1;
-                self.edit_point.index = (self.lines[&self.lines.len() - 1]).len_utf8();
+                self.edit_point.index = (self.lines[&self.lines.len() - 1]).number_of_code_units();
             },
         }
     }
@@ -911,7 +856,7 @@ impl<T: ClipboardProvider> TextInput<T> {
             })
             .shortcut(CMD_OR_CONTROL, 'X', || {
                 if let Some(text) = self.get_selection_text() {
-                    self.clipboard_provider.set_text(text);
+                    self.clipboard_provider.set_text(text.to_utf8());
                     self.delete_char(Direction::Backward);
                 }
                 KeyReaction::DispatchInput
@@ -919,13 +864,13 @@ impl<T: ClipboardProvider> TextInput<T> {
             .shortcut(CMD_OR_CONTROL, 'C', || {
                 // TODO(stevennovaryo): we should not provide text to clipboard for type=password
                 if let Some(text) = self.get_selection_text() {
-                    self.clipboard_provider.set_text(text);
+                    self.clipboard_provider.set_text(text.to_utf8());
                 }
                 KeyReaction::DispatchInput
             })
             .shortcut(CMD_OR_CONTROL, 'V', || {
                 if let Ok(text_content) = self.clipboard_provider.get_text() {
-                    self.insert_string(text_content);
+                    self.insert_string(Utf16String::from(text_content));
                 }
                 KeyReaction::DispatchInput
             })
@@ -1011,7 +956,7 @@ impl<T: ClipboardProvider> TextInput<T> {
                 Modifiers::empty(),
                 Key::Named(NamedKey::Home),
                 || {
-                    self.edit_point.index = UTF8Bytes::zero();
+                    self.edit_point.index = 0;
                     KeyReaction::RedrawSelection
                 },
             )
@@ -1030,7 +975,7 @@ impl<T: ClipboardProvider> TextInput<T> {
             })
             .otherwise(|| {
                 if let Key::Character(ref c) = key {
-                    self.insert_string(c.as_str());
+                    self.insert_string(c.into());
                     return KeyReaction::DispatchInput;
                 }
                 if matches!(key, Key::Named(NamedKey::Process)) {
@@ -1042,16 +987,16 @@ impl<T: ClipboardProvider> TextInput<T> {
     }
 
     pub(crate) fn handle_compositionend(&mut self, event: &CompositionEvent) -> KeyReaction {
-        self.insert_string(event.data());
+        self.insert_string(Utf16String::from(event.data()));
         KeyReaction::DispatchInput
     }
 
     pub(crate) fn handle_compositionupdate(&mut self, event: &CompositionEvent) -> KeyReaction {
-        let start = self.selection_start_offset().0;
-        self.insert_string(event.data());
+        let start = self.selection_start_offset();
+        self.insert_string(event.data().into());
         self.set_selection_range(
-            start as u32,
-            (start + event.data().len_utf8().0) as u32,
+            start,
+            start + event.data().len(),
             SelectionDirection::Forward,
         );
         KeyReaction::DispatchInput
@@ -1062,25 +1007,25 @@ impl<T: ClipboardProvider> TextInput<T> {
         self.lines.len() <= 1 && self.lines.first().is_none_or(|line| line.is_empty())
     }
 
-    /// The length of the content in bytes.
-    pub(crate) fn len_utf8(&self) -> UTF8Bytes {
+    /// The length of the content in code units.
+    pub(crate) fn len(&self) -> usize {
         self.lines
             .iter()
-            .fold(UTF8Bytes::zero(), |m, l| {
-                m + l.len_utf8() + UTF8Bytes::one() // + 1 for the '\n'
+            .fold(0, |m, l| {
+                m + l.number_of_code_units() + 1 // + 1 for the '\n'
             })
-            .saturating_sub(UTF8Bytes::one())
+            .saturating_sub(1)
     }
 
     /// The total number of code units required to encode the content in utf16.
-    pub(crate) fn utf16_len(&self) -> UTF16CodeUnits {
+    pub(crate) fn utf16_len(&self) -> usize {
         self.lines
             .iter()
-            .fold(UTF16CodeUnits::zero(), |m, l| {
-                m + UTF16CodeUnits(l.chars().map(char::len_utf16).sum::<usize>() + 1)
+            .fold(0, |acc, l| {
+                acc + l.number_of_code_units() + 1
                 // + 1 for the '\n'
             })
-            .saturating_sub(UTF16CodeUnits::one())
+            .saturating_sub(1)
     }
 
     /// The length of the content in Unicode code points.
@@ -1091,32 +1036,32 @@ impl<T: ClipboardProvider> TextInput<T> {
     }
 
     /// Get the current contents of the text input. Multiple lines are joined by \n.
-    pub fn get_content(&self) -> DOMString {
-        let mut content = "".to_owned();
+    pub fn get_content(&self) -> Utf16String {
+        let mut content = Utf16String::default();
         for (i, line) in self.lines.iter().enumerate() {
-            content.push_str(line);
+            content.push_utf16_str(line);
             if i < self.lines.len() - 1 {
                 content.push('\n');
             }
         }
-        DOMString::from(content)
+        content
     }
 
     /// Get a reference to the contents of a single-line text input. Panics if self is a multiline input.
-    pub(crate) fn single_line_content(&self) -> &DOMString {
+    pub(crate) fn single_line_content(&self) -> &Utf16String {
         assert!(!self.multiline);
         &self.lines[0]
     }
 
     /// Set the current contents of the text input. If this is control supports multiple lines,
     /// any \n encountered will be stripped and force a new logical line.
-    pub fn set_content(&mut self, content: DOMString) {
+    pub fn set_content(&mut self, content: Utf16String) {
         self.lines = if self.multiline {
             // https://html.spec.whatwg.org/multipage/#textarea-line-break-normalisation-transformation
             content
-                .replace("\r\n", "\n")
+                .replace(utf16!("\r\n"), utf16!("\n"))
                 .split(['\n', '\r'])
-                .map(DOMString::from)
+                .map(Utf16String::from)
                 .collect()
         } else {
             vec![content]
@@ -1131,50 +1076,47 @@ impl<T: ClipboardProvider> TextInput<T> {
         self.assert_ok_selection();
     }
 
-    /// Convert a TextPoint into a byte offset from the start of the content.
-    fn text_point_to_offset(&self, text_point: &TextPoint) -> UTF8Bytes {
-        self.lines
-            .iter()
-            .enumerate()
-            .fold(UTF8Bytes::zero(), |acc, (i, val)| {
-                if i < text_point.line {
-                    acc + val.len_utf8() + UTF8Bytes::one() // +1 for the \n
-                } else {
-                    acc
-                }
-            }) +
-            text_point.index
+    /// Convert a TextPoint into a code unit offset from the start of the content.
+    fn text_point_to_offset(&self, text_point: &TextPoint) -> usize {
+        self.lines.iter().enumerate().fold(0, |acc, (i, val)| {
+            if i < text_point.line {
+                acc + val.number_of_code_units() + 1 // +1 for the \n
+            } else {
+                acc
+            }
+        }) + text_point.index
     }
 
-    /// Convert a byte offset from the start of the content into a TextPoint.
-    fn offset_to_text_point(&self, abs_point: UTF8Bytes) -> TextPoint {
-        let mut index = abs_point;
+    /// Convert a code unit offset from the start of the content into a [TextPoint].
+    fn offset_to_text_point(&self, code_unit_offset: usize) -> TextPoint {
+        let mut index = code_unit_offset;
         let mut line = 0;
         let last_line_idx = self.lines.len() - 1;
-        self.lines
-            .iter()
-            .enumerate()
-            .fold(UTF8Bytes::zero(), |acc, (i, val)| {
-                if i != last_line_idx {
-                    let line_end = val.len_utf8();
-                    let new_acc = acc + line_end + UTF8Bytes::one();
-                    if abs_point >= new_acc && index > line_end {
-                        index = index.saturating_sub(line_end + UTF8Bytes::one());
-                        line += 1;
-                    }
-                    new_acc
-                } else {
-                    acc
+        self.lines.iter().enumerate().fold(0, |acc, (i, val)| {
+            if i != last_line_idx {
+                let line_end = val.number_of_code_units();
+                let new_acc = acc + line_end + 1;
+                if code_unit_offset >= new_acc && index > line_end {
+                    index = index.saturating_sub(line_end + 1);
+                    line += 1;
                 }
-            });
+                new_acc
+            } else {
+                acc
+            }
+        });
 
         TextPoint { line, index }
     }
 
-    pub fn set_selection_range(&mut self, start: u32, end: u32, direction: SelectionDirection) {
-        let mut start = UTF8Bytes(start as usize);
-        let mut end = UTF8Bytes(end as usize);
-        let text_end = self.get_content().len_utf8();
+    /// Set the selection given start and end indices, in utf16 code units.
+    pub fn set_selection_range(
+        &mut self,
+        mut start: usize,
+        mut end: usize,
+        direction: SelectionDirection,
+    ) {
+        let text_end = self.get_content().number_of_code_units();
 
         if end > text_end {
             end = text_end;
@@ -1200,11 +1142,15 @@ impl<T: ClipboardProvider> TextInput<T> {
 
     /// Set the edit point index position based off of a given grapheme cluster offset
     pub fn set_edit_point_index(&mut self, index: usize) {
-        let byte_offset = self.lines[self.edit_point.line]
+        // FIXME: It would be really nice to not have to convert to utf8 here, but the
+        // unicode_segmentation crate understandably only concerns itself with utf8.
+        let code_unit_offset = self.lines[self.edit_point.line]
+            .to_utf8()
             .graphemes(true)
             .take(index)
-            .fold(UTF8Bytes::zero(), |acc, x| acc + x.len_utf8());
-        self.edit_point.index = byte_offset;
+            .map(|grapheme| grapheme.chars().map(|c| c.len_utf16()).sum::<usize>())
+            .sum();
+        self.edit_point.index = code_unit_offset;
     }
 
     /// This implements step 3 onward from:
@@ -1238,7 +1184,7 @@ impl<T: ClipboardProvider> TextInput<T> {
 
                 // Step 3.1 Copy the selected contents, if any, to the clipboard
                 if let Some(text) = selection {
-                    self.clipboard_provider.set_text(text);
+                    self.clipboard_provider.set_text(text.to_utf8());
                 }
 
                 // Step 3.2 Fire a clipboard event named clipboardchange
@@ -1255,7 +1201,7 @@ impl<T: ClipboardProvider> TextInput<T> {
                 };
 
                 // Step 3.1.1 Copy the selected contents, if any, to the clipboard
-                self.clipboard_provider.set_text(text);
+                self.clipboard_provider.set_text(text.to_utf8());
 
                 // Step 3.1.2 Remove the contents of the selection from the document and collapse the selection.
                 self.delete_char(Direction::Backward);
@@ -1297,7 +1243,7 @@ impl<T: ClipboardProvider> TextInput<T> {
                     return ClipboardEventReaction::empty();
                 }
 
-                self.insert_string(text_content);
+                self.insert_string(text_content.into());
 
                 // Step 3.1.2: Queue tasks to fire any events that should fire due to the
                 // modification, see § 5.3 Integration with other scripts and events for details.

--- a/components/script_bindings/Cargo.toml
+++ b/components/script_bindings/Cargo.toml
@@ -43,6 +43,7 @@ stylo = { workspace = true }
 stylo_atoms = { workspace = true }
 tendril = { version = "0.4.1", features = ["encoding_rs"] }
 tracing = { workspace = true, optional = true }
+utf16string = { workspace = true }
 webxr-api = { workspace = true, optional = true }
 xml5ever = { workspace = true }
 

--- a/components/script_bindings/str.rs
+++ b/components/script_bindings/str.rs
@@ -19,6 +19,7 @@ use js::rust::{HandleObject, HandleValue};
 use num_traits::Zero;
 use regex::Regex;
 use stylo_atoms::Atom;
+use utf16string::Utf16String;
 
 use crate::error::Error;
 use crate::script_runtime::JSContext as SafeJSContext;
@@ -479,5 +480,17 @@ impl Extend<char> for DOMString {
         I: IntoIterator<Item = char>,
     {
         self.0.extend(iterable)
+    }
+}
+
+impl From<Utf16String> for DOMString {
+    fn from(value: Utf16String) -> Self {
+        Self::from(value.to_string())
+    }
+}
+
+impl From<DOMString> for Utf16String {
+    fn from(value: DOMString) -> Self {
+        Self::from(value.str())
     }
 }

--- a/tests/unit/script/Cargo.toml
+++ b/tests/unit/script/Cargo.toml
@@ -14,5 +14,6 @@ path = "lib.rs"
 [dependencies]
 euclid = { workspace = true }
 keyboard-types = { workspace = true }
-script = {path = "../../../components/script"}
-servo_url = {path = "../../../components/url"}
+script = { path = "../../../components/script" }
+servo_url = { path = "../../../components/url" }
+utf16string = { workspace = true }

--- a/tests/unit/script/textinput.rs
+++ b/tests/unit/script/textinput.rs
@@ -8,11 +8,10 @@
 // except according to those terms.
 
 use keyboard_types::{Key, Modifiers, NamedKey};
-use script::test::DOMString;
 use script::test::textinput::{
     ClipboardProvider, Direction, Lines, Selection, SelectionDirection, TextInput, TextPoint,
-    UTF8Bytes, UTF16CodeUnits,
 };
+use utf16string::{Utf16String, utf16};
 
 pub struct DummyClipboardContext {
     content: String,
@@ -38,7 +37,7 @@ impl ClipboardProvider for DummyClipboardContext {
 fn text_input(lines: Lines, s: &str) -> TextInput<DummyClipboardContext> {
     TextInput::new(
         lines,
-        DOMString::from(s),
+        Utf16String::from(s),
         DummyClipboardContext::new(""),
         None,
         None,
@@ -50,30 +49,30 @@ fn text_input(lines: Lines, s: &str) -> TextInput<DummyClipboardContext> {
 fn test_set_content_ignores_max_length() {
     let mut textinput = TextInput::new(
         Lines::Single,
-        DOMString::from(""),
+        Default::default(),
         DummyClipboardContext::new(""),
-        Some(UTF16CodeUnits::one()),
+        Some(1),
         None,
         SelectionDirection::None,
     );
 
-    textinput.set_content(DOMString::from("mozilla rocks"));
-    assert_eq!(textinput.get_content(), DOMString::from("mozilla rocks"));
+    textinput.set_content(Utf16String::from("mozilla rocks"));
+    assert_eq!(&textinput.get_content(), utf16!("mozilla rocks"));
 }
 
 #[test]
 fn test_textinput_when_inserting_multiple_lines_over_a_selection_respects_max_length() {
     let mut textinput = TextInput::new(
         Lines::Multiple,
-        DOMString::from("hello\nworld"),
+        Utf16String::from("hello\nworld"),
         DummyClipboardContext::new(""),
-        Some(UTF16CodeUnits(17)),
+        Some(17),
         None,
         SelectionDirection::None,
     );
 
     textinput.adjust_horizontal(UTF8Bytes::one(), Direction::Forward, Selection::NotSelected);
-    textinput.adjust_horizontal(UTF8Bytes(3), Direction::Forward, Selection::Selected);
+    textinput.adjust_horizontal(3, Direction::Forward, Selection::Selected);
     textinput.adjust_vertical(1, Selection::Selected);
 
     // Selection is now "hello\n
@@ -81,26 +80,26 @@ fn test_textinput_when_inserting_multiple_lines_over_a_selection_respects_max_le
     //                   world"
     //                   ----
 
-    textinput.insert_string("cruel\nterrible\nbad".to_string());
+    textinput.insert_string(utf16!("cruel\nterrible\nbad").to_owned());
 
-    assert_eq!(textinput.get_content(), "hcruel\nterrible\nd");
+    assert_eq!(&textinput.get_content(), utf16!("hcruel\nterrible\nd"));
 }
 
 #[test]
 fn test_textinput_when_inserting_multiple_lines_still_respects_max_length() {
     let mut textinput = TextInput::new(
         Lines::Multiple,
-        DOMString::from("hello\nworld"),
+        Utf16String::from("hello\nworld"),
         DummyClipboardContext::new(""),
-        Some(UTF16CodeUnits(17)),
+        Some(17),
         None,
         SelectionDirection::None,
     );
 
     textinput.adjust_vertical(1, Selection::NotSelected);
-    textinput.insert_string("cruel\nterrible".to_string());
+    textinput.insert_string(utf16!("cruel\nterrible").to_owned());
 
-    assert_eq!(textinput.get_content(), "hello\ncruel\nworld");
+    assert_eq!(&textinput.get_content(), utf16!("hello\ncruel\nworld"));
 }
 
 #[test]
@@ -108,16 +107,16 @@ fn test_textinput_when_content_is_already_longer_than_max_length_and_theres_no_s
  {
     let mut textinput = TextInput::new(
         Lines::Single,
-        DOMString::from("abc"),
+        Utf16String::from("abc"),
         DummyClipboardContext::new(""),
-        Some(UTF16CodeUnits::one()),
+        Some(1),
         None,
         SelectionDirection::None,
     );
 
     textinput.insert_char('a');
 
-    assert_eq!(textinput.get_content(), "abc");
+    assert_eq!(&textinput.get_content(), utf16!("abc"));
 }
 
 #[test]
@@ -125,16 +124,16 @@ fn test_multi_line_textinput_with_maxlength_doesnt_allow_appending_characters_wh
  {
     let mut textinput = TextInput::new(
         Lines::Multiple,
-        DOMString::from("abc\nd"),
+        Utf16String::from("abc\nd"),
         DummyClipboardContext::new(""),
-        Some(UTF16CodeUnits(5)),
+        Some(5),
         None,
         SelectionDirection::None,
     );
 
     textinput.insert_char('a');
 
-    assert_eq!(textinput.get_content(), "abc\nd");
+    assert_eq!(&textinput.get_content(), utf16!("abc\nd"));
 }
 
 #[test]
@@ -142,99 +141,99 @@ fn test_single_line_textinput_with_max_length_doesnt_allow_appending_characters_
  {
     let mut textinput = TextInput::new(
         Lines::Single,
-        DOMString::from("abcde"),
+        Utf16String::from("abcde"),
         DummyClipboardContext::new(""),
-        Some(UTF16CodeUnits(5)),
+        Some(5),
         None,
         SelectionDirection::None,
     );
 
     textinput.adjust_horizontal(UTF8Bytes::one(), Direction::Forward, Selection::NotSelected);
-    textinput.adjust_horizontal(UTF8Bytes(3), Direction::Forward, Selection::Selected);
+    textinput.adjust_horizontal(3, Direction::Forward, Selection::Selected);
 
     // Selection is now "abcde"
     //                    ---
 
-    textinput.replace_selection(DOMString::from("too long"));
+    textinput.replace_selection(Utf16String::from("too long"));
 
-    assert_eq!(textinput.get_content(), "atooe");
+    assert_eq!(&textinput.get_content(), utf16!("atooe"));
 }
 
 #[test]
 fn test_single_line_textinput_with_max_length_allows_deletion_when_replacing_a_selection() {
     let mut textinput = TextInput::new(
         Lines::Single,
-        DOMString::from("abcde"),
+        Utf16String::from("abcde"),
         DummyClipboardContext::new(""),
-        Some(UTF16CodeUnits(1)),
+        Some(1),
         None,
         SelectionDirection::None,
     );
 
     textinput.adjust_horizontal(UTF8Bytes::one(), Direction::Forward, Selection::NotSelected);
-    textinput.adjust_horizontal(UTF8Bytes(2), Direction::Forward, Selection::Selected);
+    textinput.adjust_horizontal(2, Direction::Forward, Selection::Selected);
 
     // Selection is now "abcde"
     //                    --
 
-    textinput.replace_selection(DOMString::from("only deletion should be applied"));
+    textinput.replace_selection(Utf16String::from("only deletion should be applied"));
 
-    assert_eq!(textinput.get_content(), "ade");
+    assert_eq!(&textinput.get_content(), utf16!("ade"));
 }
 
 #[test]
 fn test_single_line_textinput_with_max_length_multibyte() {
     let mut textinput = TextInput::new(
         Lines::Single,
-        DOMString::from(""),
+        Default::default(),
         DummyClipboardContext::new(""),
-        Some(UTF16CodeUnits(2)),
+        Some(2),
         None,
         SelectionDirection::None,
     );
 
     textinput.insert_char('á');
-    assert_eq!(textinput.get_content(), "á");
+    assert_eq!(&textinput.get_content(), utf16!("á"));
     textinput.insert_char('é');
-    assert_eq!(textinput.get_content(), "áé");
+    assert_eq!(&textinput.get_content(), utf16!("áé"));
     textinput.insert_char('i');
-    assert_eq!(textinput.get_content(), "áé");
+    assert_eq!(&textinput.get_content(), utf16!("áé"));
 }
 
 #[test]
 fn test_single_line_textinput_with_max_length_multi_code_unit() {
     let mut textinput = TextInput::new(
         Lines::Single,
-        DOMString::from(""),
+        Default::default(),
         DummyClipboardContext::new(""),
-        Some(UTF16CodeUnits(3)),
+        Some(3),
         None,
         SelectionDirection::None,
     );
 
     textinput.insert_char('\u{10437}');
-    assert_eq!(textinput.get_content(), "\u{10437}");
+    assert_eq!(&textinput.get_content(), utf16!("\u{10437}"));
     textinput.insert_char('\u{10437}');
-    assert_eq!(textinput.get_content(), "\u{10437}");
+    assert_eq!(&textinput.get_content(), utf16!("\u{10437}"));
     textinput.insert_char('x');
-    assert_eq!(textinput.get_content(), "\u{10437}x");
+    assert_eq!(&textinput.get_content(), utf16!("\u{10437}x"));
     textinput.insert_char('x');
-    assert_eq!(textinput.get_content(), "\u{10437}x");
+    assert_eq!(&textinput.get_content(), utf16!("\u{10437}x"));
 }
 
 #[test]
 fn test_single_line_textinput_with_max_length_inside_char() {
     let mut textinput = TextInput::new(
         Lines::Single,
-        DOMString::from("\u{10437}"),
+        utf16!("\u{10437}").to_owned(),
         DummyClipboardContext::new(""),
-        Some(UTF16CodeUnits::one()),
+        Some(1),
         None,
         SelectionDirection::None,
     );
 
     textinput.insert_char('x');
-    assert_eq!(textinput.get_content(), "\u{10437}");
+    assert_eq!(&textinput.get_content(), utf16!("\u{10437}"));
 }
 
 #[test]
@@ -242,54 +241,54 @@ fn test_single_line_textinput_with_max_length_doesnt_allow_appending_characters_
  {
     let mut textinput = TextInput::new(
         Lines::Single,
-        DOMString::from("a"),
+        utf16!("a").to_owned(),
         DummyClipboardContext::new(""),
-        Some(UTF16CodeUnits::one()),
+        Some(1),
         None,
         SelectionDirection::None,
     );
 
     textinput.insert_char('b');
-    assert_eq!(textinput.get_content(), "a");
+    assert_eq!(&textinput.get_content(), utf16!("a"));
 }
 
 #[test]
 fn test_textinput_delete_char() {
     let mut textinput = text_input(Lines::Single, "abcdefg");
-    textinput.adjust_horizontal(UTF8Bytes(2), Direction::Forward, Selection::NotSelected);
+    textinput.adjust_horizontal(2, Direction::Forward, Selection::NotSelected);
     textinput.delete_char(Direction::Backward);
-    assert_eq!(textinput.get_content(), "acdefg");
+    assert_eq!(&textinput.get_content(), utf16!("acdefg"));
 
     textinput.delete_char(Direction::Forward);
-    assert_eq!(textinput.get_content(), "adefg");
+    assert_eq!(&textinput.get_content(), utf16!("adefg"));
 
-    textinput.adjust_horizontal(UTF8Bytes(2), Direction::Forward, Selection::Selected);
+    textinput.adjust_horizontal(2, Direction::Forward, Selection::Selected);
     textinput.delete_char(Direction::Forward);
-    assert_eq!(textinput.get_content(), "afg");
+    assert_eq!(&textinput.get_content(), utf16!("afg"));
 
     let mut textinput = text_input(Lines::Single, "a🌠b");
     // Same as "Right" key
     textinput.adjust_horizontal_by_one(Direction::Forward, Selection::NotSelected);
     textinput.delete_char(Direction::Forward);
     // Not splitting surrogate pairs.
-    assert_eq!(textinput.get_content(), "ab");
+    assert_eq!(&textinput.get_content(), utf16!("ab"));
 
     let mut textinput = text_input(Lines::Single, "abcdefg");
     textinput.set_selection_range(2, 2, SelectionDirection::None);
     textinput.delete_char(Direction::Backward);
-    assert_eq!(textinput.get_content(), "acdefg");
+    assert_eq!(&textinput.get_content(), utf16!("acdefg"));
 }
 
 #[test]
 fn test_textinput_insert_char() {
     let mut textinput = text_input(Lines::Single, "abcdefg");
-    textinput.adjust_horizontal(UTF8Bytes(2), Direction::Forward, Selection::NotSelected);
+    textinput.adjust_horizontal(2, Direction::Forward, Selection::NotSelected);
     textinput.insert_char('a');
-    assert_eq!(textinput.get_content(), "abacdefg");
+    assert_eq!(&textinput.get_content(), utf16!("abacdefg"));
 
-    textinput.adjust_horizontal(UTF8Bytes(2), Direction::Forward, Selection::Selected);
+    textinput.adjust_horizontal(2, Direction::Forward, Selection::Selected);
     textinput.insert_char('b');
-    assert_eq!(textinput.get_content(), "ababefg");
+    assert_eq!(&textinput.get_content(), utf16!("ababefg"));
 
     let mut textinput = text_input(Lines::Single, "a🌠c");
     // Same as "Right" key
@@ -297,34 +296,34 @@ fn test_textinput_insert_char() {
     textinput.adjust_horizontal_by_one(Direction::Forward, Selection::NotSelected);
     textinput.insert_char('b');
     // Not splitting surrogate pairs.
-    assert_eq!(textinput.get_content(), "a🌠bc");
+    assert_eq!(&textinput.get_content(), utf16!("a🌠bc"));
 }
 
 #[test]
 fn test_textinput_get_sorted_selection() {
     let mut textinput = text_input(Lines::Single, "abcdefg");
-    textinput.adjust_horizontal(UTF8Bytes(2), Direction::Forward, Selection::NotSelected);
-    textinput.adjust_horizontal(UTF8Bytes(2), Direction::Forward, Selection::Selected);
+    textinput.adjust_horizontal(2, Direction::Forward, Selection::NotSelected);
+    textinput.adjust_horizontal(2, Direction::Forward, Selection::Selected);
     let (start, end) = textinput.sorted_selection_bounds();
-    assert_eq!(start.index, UTF8Bytes(2));
-    assert_eq!(end.index, UTF8Bytes(4));
+    assert_eq!(start.index, 2);
+    assert_eq!(end.index, 4);
 
     textinput.clear_selection();
 
-    textinput.adjust_horizontal(UTF8Bytes(2), Direction::Backward, Selection::Selected);
+    textinput.adjust_horizontal(2, Direction::Backward, Selection::Selected);
     let (start, end) = textinput.sorted_selection_bounds();
-    assert_eq!(start.index, UTF8Bytes(2));
-    assert_eq!(end.index, UTF8Bytes(4));
+    assert_eq!(start.index, 2);
+    assert_eq!(end.index, 4);
 }
 
 #[test]
 fn test_textinput_replace_selection() {
     let mut textinput = text_input(Lines::Single, "abcdefg");
-    textinput.adjust_horizontal(UTF8Bytes(2), Direction::Forward, Selection::NotSelected);
-    textinput.adjust_horizontal(UTF8Bytes(2), Direction::Forward, Selection::Selected);
+    textinput.adjust_horizontal(2, Direction::Forward, Selection::NotSelected);
+    textinput.adjust_horizontal(2, Direction::Forward, Selection::Selected);
 
-    textinput.replace_selection(DOMString::from("xyz"));
-    assert_eq!(textinput.get_content(), "abxyzefg");
+    textinput.replace_selection(Utf16String::from("xyz"));
+    assert_eq!(&textinput.get_content(), utf16!("abxyzefg"));
 }
 
 #[test]
@@ -332,17 +331,17 @@ fn test_textinput_replace_selection_multibyte_char() {
     let mut textinput = text_input(Lines::Single, "é");
     textinput.adjust_horizontal_by_one(Direction::Forward, Selection::Selected);
 
-    textinput.replace_selection(DOMString::from("e"));
-    assert_eq!(textinput.get_content(), "e");
+    textinput.replace_selection(Utf16String::from("e"));
+    assert_eq!(&textinput.get_content(), utf16!("e"));
 }
 
 #[test]
 fn test_textinput_current_line_length() {
     let mut textinput = text_input(Lines::Multiple, "abc\nde\nf");
-    assert_eq!(textinput.current_line_length(), UTF8Bytes(3));
+    assert_eq!(textinput.current_line_length(), 3);
 
     textinput.adjust_vertical(1, Selection::NotSelected);
-    assert_eq!(textinput.current_line_length(), UTF8Bytes(2));
+    assert_eq!(textinput.current_line_length(), 2);
 
     textinput.adjust_vertical(1, Selection::NotSelected);
     assert_eq!(textinput.current_line_length(), UTF8Bytes::one());
@@ -351,22 +350,22 @@ fn test_textinput_current_line_length() {
 #[test]
 fn test_textinput_adjust_vertical() {
     let mut textinput = text_input(Lines::Multiple, "abc\nde\nf");
-    textinput.adjust_horizontal(UTF8Bytes(3), Direction::Forward, Selection::NotSelected);
+    textinput.adjust_horizontal(3, Direction::Forward, Selection::NotSelected);
     textinput.adjust_vertical(1, Selection::NotSelected);
     assert_eq!(textinput.edit_point().line, 1);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes(2));
+    assert_eq!(textinput.edit_point().index, 2);
 
     textinput.adjust_vertical(-1, Selection::NotSelected);
     assert_eq!(textinput.edit_point().line, 0);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes(2));
+    assert_eq!(textinput.edit_point().index, 2);
 
     textinput.adjust_vertical(2, Selection::NotSelected);
     assert_eq!(textinput.edit_point().line, 2);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes(1));
+    assert_eq!(textinput.edit_point().index, 1);
 
     textinput.adjust_vertical(-1, Selection::Selected);
     assert_eq!(textinput.edit_point().line, 1);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes(1));
+    assert_eq!(textinput.edit_point().index, 1);
 }
 
 #[test]
@@ -375,25 +374,25 @@ fn test_textinput_adjust_vertical_multibyte() {
 
     textinput.adjust_horizontal_by_one(Direction::Forward, Selection::NotSelected);
     assert_eq!(textinput.edit_point().line, 0);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes(2));
+    assert_eq!(textinput.edit_point().index, 2);
 
     textinput.adjust_vertical(1, Selection::NotSelected);
     assert_eq!(textinput.edit_point().line, 1);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes(1));
+    assert_eq!(textinput.edit_point().index, 1);
 }
 
 #[test]
 fn test_textinput_adjust_horizontal() {
     let mut textinput = text_input(Lines::Multiple, "abc\nde\nf");
-    textinput.adjust_horizontal(UTF8Bytes(4), Direction::Forward, Selection::NotSelected);
+    textinput.adjust_horizontal(4, Direction::Forward, Selection::NotSelected);
     assert_eq!(textinput.edit_point().line, 1);
     assert_eq!(textinput.edit_point().index, UTF8Bytes::zero());
 
     textinput.adjust_horizontal(UTF8Bytes::one(), Direction::Forward, Selection::NotSelected);
     assert_eq!(textinput.edit_point().line, 1);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes(1));
+    assert_eq!(textinput.edit_point().index, 1);
 
-    textinput.adjust_horizontal(UTF8Bytes(2), Direction::Forward, Selection::NotSelected);
+    textinput.adjust_horizontal(2, Direction::Forward, Selection::NotSelected);
     assert_eq!(textinput.edit_point().line, 2);
     assert_eq!(textinput.edit_point().index, UTF8Bytes::zero());
 
@@ -403,7 +402,7 @@ fn test_textinput_adjust_horizontal() {
         Selection::NotSelected,
     );
     assert_eq!(textinput.edit_point().line, 1);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes(2));
+    assert_eq!(textinput.edit_point().index, 2);
 }
 
 #[test]
@@ -413,10 +412,10 @@ fn test_textinput_adjust_horizontal_by_word() {
     textinput.adjust_horizontal_by_word(Direction::Forward, Selection::NotSelected);
     textinput.adjust_horizontal_by_word(Direction::Forward, Selection::NotSelected);
     assert_eq!(textinput.edit_point().line, 0);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes(7));
+    assert_eq!(textinput.edit_point().index, 7);
     textinput.adjust_horizontal_by_word(Direction::Backward, Selection::NotSelected);
     assert_eq!(textinput.edit_point().line, 0);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes(4));
+    assert_eq!(textinput.edit_point().index, 4);
     textinput.adjust_horizontal_by_word(Direction::Backward, Selection::NotSelected);
     assert_eq!(textinput.edit_point().line, 0);
     assert_eq!(textinput.edit_point().index, UTF8Bytes::zero());
@@ -426,7 +425,7 @@ fn test_textinput_adjust_horizontal_by_word() {
     textinput_2.adjust_horizontal_by_word(Direction::Forward, Selection::NotSelected);
     textinput_2.adjust_horizontal_by_word(Direction::Forward, Selection::NotSelected);
     assert_eq!(textinput_2.edit_point().line, 1);
-    assert_eq!(textinput_2.edit_point().index, UTF8Bytes(3));
+    assert_eq!(textinput_2.edit_point().index, 3);
     textinput_2.adjust_horizontal_by_word(Direction::Backward, Selection::NotSelected);
     assert_eq!(textinput_2.edit_point().line, 1);
     assert_eq!(textinput_2.edit_point().index, UTF8Bytes::zero());
@@ -438,19 +437,19 @@ fn test_textinput_adjust_horizontal_by_word() {
     let mut textinput_3 = text_input(Lines::Single, "áéc d🌠bc");
     textinput_3.adjust_horizontal_by_word(Direction::Forward, Selection::NotSelected);
     assert_eq!(textinput_3.edit_point().line, 0);
-    assert_eq!(textinput_3.edit_point().index, UTF8Bytes(5));
+    assert_eq!(textinput_3.edit_point().index, 5);
     textinput_3.adjust_horizontal_by_word(Direction::Forward, Selection::NotSelected);
     assert_eq!(textinput_3.edit_point().line, 0);
-    assert_eq!(textinput_3.edit_point().index, UTF8Bytes(7));
+    assert_eq!(textinput_3.edit_point().index, 7);
     textinput_3.adjust_horizontal_by_word(Direction::Forward, Selection::NotSelected);
     assert_eq!(textinput_3.edit_point().line, 0);
-    assert_eq!(textinput_3.edit_point().index, UTF8Bytes(13));
+    assert_eq!(textinput_3.edit_point().index, 13);
     textinput_3.adjust_horizontal_by_word(Direction::Backward, Selection::NotSelected);
     assert_eq!(textinput_3.edit_point().line, 0);
-    assert_eq!(textinput_3.edit_point().index, UTF8Bytes(11));
+    assert_eq!(textinput_3.edit_point().index, 11);
     textinput_3.adjust_horizontal_by_word(Direction::Backward, Selection::NotSelected);
     assert_eq!(textinput_3.edit_point().line, 0);
-    assert_eq!(textinput_3.edit_point().index, UTF8Bytes(6));
+    assert_eq!(textinput_3.edit_point().index, 6);
 }
 
 #[test]
@@ -459,16 +458,16 @@ fn test_textinput_adjust_horizontal_to_line_end() {
     let mut textinput = text_input(Lines::Single, "abc def");
     textinput.adjust_horizontal_to_line_end(Direction::Forward, Selection::NotSelected);
     assert_eq!(textinput.edit_point().line, 0);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes(7));
+    assert_eq!(textinput.edit_point().index, 7);
 
     // Test new line case of movement to end based on UAX#29 rules
     let mut textinput_2 = text_input(Lines::Multiple, "abc\ndef");
     textinput_2.adjust_horizontal_to_line_end(Direction::Forward, Selection::NotSelected);
     assert_eq!(textinput_2.edit_point().line, 0);
-    assert_eq!(textinput_2.edit_point().index, UTF8Bytes(3));
+    assert_eq!(textinput_2.edit_point().index, 3);
     textinput_2.adjust_horizontal_to_line_end(Direction::Forward, Selection::NotSelected);
     assert_eq!(textinput_2.edit_point().line, 0);
-    assert_eq!(textinput_2.edit_point().index, UTF8Bytes(3));
+    assert_eq!(textinput_2.edit_point().index, 3);
     textinput_2.adjust_horizontal_to_line_end(Direction::Backward, Selection::NotSelected);
     assert_eq!(textinput_2.edit_point().line, 0);
     assert_eq!(textinput_2.edit_point().index, UTF8Bytes::zero());
@@ -477,7 +476,7 @@ fn test_textinput_adjust_horizontal_to_line_end() {
     let mut textinput_3 = text_input(Lines::Single, "áéc d🌠bc");
     textinput_3.adjust_horizontal_to_line_end(Direction::Forward, Selection::NotSelected);
     assert_eq!(textinput_3.edit_point().line, 0);
-    assert_eq!(textinput_3.edit_point().index, UTF8Bytes(13));
+    assert_eq!(textinput_3.edit_point().index, 13);
     textinput_3.adjust_horizontal_to_line_end(Direction::Backward, Selection::NotSelected);
     assert_eq!(textinput_3.edit_point().line, 0);
     assert_eq!(textinput_3.edit_point().index, UTF8Bytes::zero());
@@ -489,7 +488,7 @@ fn test_navigation_keyboard_shortcuts() {
 
     // Test that CMD + Right moves to the end of the current line.
     textinput.handle_keydown_aux(Key::Named(NamedKey::ArrowRight), Modifiers::META, true);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes(11));
+    assert_eq!(textinput.edit_point().index, 11);
     // Test that CMD + Right moves to the beginning of the current line.
     textinput.handle_keydown_aux(Key::Named(NamedKey::ArrowLeft), Modifiers::META, true);
     assert_eq!(textinput.edit_point().index, UTF8Bytes::zero());
@@ -499,7 +498,7 @@ fn test_navigation_keyboard_shortcuts() {
         Modifiers::CONTROL | Modifiers::ALT,
         true,
     );
-    assert_eq!(textinput.edit_point().index, UTF8Bytes(11));
+    assert_eq!(textinput.edit_point().index, 11);
     // Test that CTRL + ALT + A moves to the beginning of the current line also.
     textinput.handle_keydown_aux(
         Key::Character("a".to_owned()),
@@ -510,17 +509,17 @@ fn test_navigation_keyboard_shortcuts() {
 
     // Test that ALT + Right moves to the end of the word.
     textinput.handle_keydown_aux(Key::Named(NamedKey::ArrowRight), Modifiers::ALT, true);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes(5));
+    assert_eq!(textinput.edit_point().index, 5);
     // Test that CTRL + ALT + F moves to the end of the word also.
     textinput.handle_keydown_aux(
         Key::Character("f".to_owned()),
         Modifiers::CONTROL | Modifiers::ALT,
         true,
     );
-    assert_eq!(textinput.edit_point().index, UTF8Bytes(11));
+    assert_eq!(textinput.edit_point().index, 11);
     // Test that ALT + Left moves to the end of the word.
     textinput.handle_keydown_aux(Key::Named(NamedKey::ArrowLeft), Modifiers::ALT, true);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes(6));
+    assert_eq!(textinput.edit_point().index, 6);
     // Test that CTRL + ALT + B moves to the end of the word also.
     textinput.handle_keydown_aux(
         Key::Character("b".to_owned()),
@@ -533,22 +532,14 @@ fn test_navigation_keyboard_shortcuts() {
 #[test]
 fn test_textinput_handle_return() {
     let mut single_line_textinput = text_input(Lines::Single, "abcdef");
-    single_line_textinput.adjust_horizontal(
-        UTF8Bytes(3),
-        Direction::Forward,
-        Selection::NotSelected,
-    );
+    single_line_textinput.adjust_horizontal(3, Direction::Forward, Selection::NotSelected);
     single_line_textinput.handle_return();
-    assert_eq!(single_line_textinput.get_content(), "abcdef");
+    assert_eq!(&single_line_textinput.get_content(), utf16!("abcdef"));
 
     let mut multi_line_textinput = text_input(Lines::Multiple, "abcdef");
-    multi_line_textinput.adjust_horizontal(
-        UTF8Bytes(3),
-        Direction::Forward,
-        Selection::NotSelected,
-    );
+    multi_line_textinput.adjust_horizontal(3, Direction::Forward, Selection::NotSelected);
     multi_line_textinput.handle_return();
-    assert_eq!(multi_line_textinput.get_content(), "abc\ndef");
+    assert_eq!(&multi_line_textinput.get_content(), utf16!("abc\ndef"));
 }
 
 #[test]
@@ -559,36 +550,36 @@ fn test_textinput_select_all() {
 
     textinput.select_all();
     assert_eq!(textinput.edit_point().line, 2);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes(1));
+    assert_eq!(textinput.edit_point().index, 1);
 }
 
 #[test]
 fn test_textinput_get_content() {
     let single_line_textinput = text_input(Lines::Single, "abcdefg");
-    assert_eq!(single_line_textinput.get_content(), "abcdefg");
+    assert_eq!(&single_line_textinput.get_content(), utf16!("abcdefg"));
 
     let multi_line_textinput = text_input(Lines::Multiple, "abc\nde\nf");
-    assert_eq!(multi_line_textinput.get_content(), "abc\nde\nf");
+    assert_eq!(&multi_line_textinput.get_content(), utf16!("abc\nde\nf"));
 }
 
 #[test]
 fn test_textinput_set_content() {
     let mut textinput = text_input(Lines::Multiple, "abc\nde\nf");
-    assert_eq!(textinput.get_content(), "abc\nde\nf");
+    assert_eq!(&textinput.get_content(), utf16!("abc\nde\nf"));
 
-    textinput.set_content(DOMString::from("abc\nf"));
-    assert_eq!(textinput.get_content(), "abc\nf");
+    textinput.set_content(Utf16String::from("abc\nf"));
+    assert_eq!(&textinput.get_content(), utf16!("abc\nf"));
 
     assert_eq!(textinput.edit_point().line, 0);
     assert_eq!(textinput.edit_point().index, UTF8Bytes::zero());
 
-    textinput.adjust_horizontal(UTF8Bytes(3), Direction::Forward, Selection::Selected);
+    textinput.adjust_horizontal(3, Direction::Forward, Selection::Selected);
     assert_eq!(textinput.edit_point().line, 0);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes(3));
-    textinput.set_content(DOMString::from("de"));
-    assert_eq!(textinput.get_content(), "de");
+    assert_eq!(textinput.edit_point().index, 3);
+    textinput.set_content(Utf16String::from("de"));
+    assert_eq!(&textinput.get_content(), utf16!("de"));
     assert_eq!(textinput.edit_point().line, 0);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes(2));
+    assert_eq!(textinput.edit_point().index, 2);
 }
 
 #[test]
@@ -600,16 +591,16 @@ fn test_clipboard_paste() {
 
     let mut textinput = TextInput::new(
         Lines::Single,
-        DOMString::from("defg"),
+        Utf16String::from("defg"),
         DummyClipboardContext::new("abc"),
         None,
         None,
         SelectionDirection::None,
     );
-    assert_eq!(textinput.get_content(), "defg");
+    assert_eq!(&textinput.get_content(), utf16!("defg"));
     assert_eq!(textinput.edit_point().index, UTF8Bytes::zero());
     textinput.handle_keydown_aux(Key::Character("v".to_owned()), MODIFIERS, false);
-    assert_eq!(textinput.get_content(), "abcdefg");
+    assert_eq!(&textinput.get_content(), utf16!("abcdefg"));
 }
 
 #[test]
@@ -617,18 +608,18 @@ fn test_textinput_cursor_position_correct_after_clearing_selection() {
     let mut textinput = text_input(Lines::Single, "abcdef");
 
     // Single line - Forward
-    textinput.adjust_horizontal(UTF8Bytes(3), Direction::Forward, Selection::Selected);
+    textinput.adjust_horizontal(3, Direction::Forward, Selection::Selected);
     textinput.adjust_horizontal(UTF8Bytes::one(), Direction::Forward, Selection::NotSelected);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes(3));
+    assert_eq!(textinput.edit_point().index, 3);
 
-    textinput.adjust_horizontal(UTF8Bytes(3), Direction::Backward, Selection::NotSelected);
-    textinput.adjust_horizontal(UTF8Bytes(3), Direction::Forward, Selection::Selected);
+    textinput.adjust_horizontal(3, Direction::Backward, Selection::NotSelected);
+    textinput.adjust_horizontal(3, Direction::Forward, Selection::Selected);
     textinput.adjust_horizontal_by_one(Direction::Forward, Selection::NotSelected);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes(3));
+    assert_eq!(textinput.edit_point().index, 3);
 
     // Single line - Backward
-    textinput.adjust_horizontal(UTF8Bytes(3), Direction::Backward, Selection::NotSelected);
-    textinput.adjust_horizontal(UTF8Bytes(3), Direction::Forward, Selection::Selected);
+    textinput.adjust_horizontal(3, Direction::Backward, Selection::NotSelected);
+    textinput.adjust_horizontal(3, Direction::Forward, Selection::Selected);
     textinput.adjust_horizontal(
         UTF8Bytes::one(),
         Direction::Backward,
@@ -636,28 +627,28 @@ fn test_textinput_cursor_position_correct_after_clearing_selection() {
     );
     assert_eq!(textinput.edit_point().index, UTF8Bytes::zero());
 
-    textinput.adjust_horizontal(UTF8Bytes(3), Direction::Backward, Selection::NotSelected);
-    textinput.adjust_horizontal(UTF8Bytes(3), Direction::Forward, Selection::Selected);
+    textinput.adjust_horizontal(3, Direction::Backward, Selection::NotSelected);
+    textinput.adjust_horizontal(3, Direction::Forward, Selection::Selected);
     textinput.adjust_horizontal_by_one(Direction::Backward, Selection::NotSelected);
     assert_eq!(textinput.edit_point().index, UTF8Bytes::zero());
 
     let mut textinput = text_input(Lines::Multiple, "abc\nde\nf");
 
     // Multiline - Forward
-    textinput.adjust_horizontal(UTF8Bytes(4), Direction::Forward, Selection::Selected);
+    textinput.adjust_horizontal(4, Direction::Forward, Selection::Selected);
     textinput.adjust_horizontal(UTF8Bytes::one(), Direction::Forward, Selection::NotSelected);
     assert_eq!(textinput.edit_point().index, UTF8Bytes::zero());
     assert_eq!(textinput.edit_point().line, 1);
 
-    textinput.adjust_horizontal(UTF8Bytes(4), Direction::Backward, Selection::NotSelected);
-    textinput.adjust_horizontal(UTF8Bytes(4), Direction::Forward, Selection::Selected);
+    textinput.adjust_horizontal(4, Direction::Backward, Selection::NotSelected);
+    textinput.adjust_horizontal(4, Direction::Forward, Selection::Selected);
     textinput.adjust_horizontal_by_one(Direction::Forward, Selection::NotSelected);
     assert_eq!(textinput.edit_point().index, UTF8Bytes::zero());
     assert_eq!(textinput.edit_point().line, 1);
 
     // Multiline - Backward
-    textinput.adjust_horizontal(UTF8Bytes(4), Direction::Backward, Selection::NotSelected);
-    textinput.adjust_horizontal(UTF8Bytes(4), Direction::Forward, Selection::Selected);
+    textinput.adjust_horizontal(4, Direction::Backward, Selection::NotSelected);
+    textinput.adjust_horizontal(4, Direction::Forward, Selection::Selected);
     textinput.adjust_horizontal(
         UTF8Bytes::one(),
         Direction::Backward,
@@ -666,8 +657,8 @@ fn test_textinput_cursor_position_correct_after_clearing_selection() {
     assert_eq!(textinput.edit_point().index, UTF8Bytes::zero());
     assert_eq!(textinput.edit_point().line, 0);
 
-    textinput.adjust_horizontal(UTF8Bytes(4), Direction::Backward, Selection::NotSelected);
-    textinput.adjust_horizontal(UTF8Bytes(4), Direction::Forward, Selection::Selected);
+    textinput.adjust_horizontal(4, Direction::Backward, Selection::NotSelected);
+    textinput.adjust_horizontal(4, Direction::Forward, Selection::Selected);
     textinput.adjust_horizontal_by_one(Direction::Backward, Selection::NotSelected);
     assert_eq!(textinput.edit_point().index, UTF8Bytes::zero());
     assert_eq!(textinput.edit_point().line, 0);
@@ -678,16 +669,16 @@ fn test_textinput_set_selection_with_direction() {
     let mut textinput = text_input(Lines::Single, "abcdef");
     textinput.set_selection_range(2, 6, SelectionDirection::Forward);
     assert_eq!(textinput.edit_point().line, 0);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes(6));
+    assert_eq!(textinput.edit_point().index, 6);
     assert_eq!(textinput.selection_direction(), SelectionDirection::Forward);
 
     assert!(textinput.selection_origin().is_some());
     assert_eq!(textinput.selection_origin().unwrap().line, 0);
-    assert_eq!(textinput.selection_origin().unwrap().index, UTF8Bytes(2));
+    assert_eq!(textinput.selection_origin().unwrap().index, 2);
 
     textinput.set_selection_range(2, 6, SelectionDirection::Backward);
     assert_eq!(textinput.edit_point().line, 0);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes(2));
+    assert_eq!(textinput.edit_point().index, 2);
     assert_eq!(
         textinput.selection_direction(),
         SelectionDirection::Backward
@@ -695,7 +686,7 @@ fn test_textinput_set_selection_with_direction() {
 
     assert!(textinput.selection_origin().is_some());
     assert_eq!(textinput.selection_origin().unwrap().line, 0);
-    assert_eq!(textinput.selection_origin().unwrap().index, UTF8Bytes(6));
+    assert_eq!(textinput.selection_origin().unwrap().index, 6);
 
     textinput = text_input(Lines::Multiple, "\n\n");
     textinput.set_selection_range(0, 1, SelectionDirection::Forward);
@@ -729,9 +720,9 @@ fn test_textinput_unicode_handling() {
     let mut textinput = text_input(Lines::Single, "éèùµ$£");
     assert_eq!(textinput.edit_point().index, UTF8Bytes::zero());
     textinput.set_edit_point_index(1);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes(2));
+    assert_eq!(textinput.edit_point().index, 2);
     textinput.set_edit_point_index(4);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes(8));
+    assert_eq!(textinput.edit_point().index, 8);
 }
 
 #[test]
@@ -762,53 +753,23 @@ fn test_selection_bounds() {
 
     textinput.set_selection_range(2, 5, SelectionDirection::Forward);
     assert_eq!(
-        TextPoint {
-            line: 0,
-            index: UTF8Bytes(2)
-        },
+        TextPoint { line: 0, index: 2 },
         textinput.selection_origin_or_edit_point()
     );
-    assert_eq!(
-        TextPoint {
-            line: 0,
-            index: UTF8Bytes(2)
-        },
-        textinput.selection_start()
-    );
-    assert_eq!(
-        TextPoint {
-            line: 0,
-            index: UTF8Bytes(5)
-        },
-        textinput.selection_end()
-    );
-    assert_eq!(UTF8Bytes(2), textinput.selection_start_offset());
-    assert_eq!(UTF8Bytes(5), textinput.selection_end_offset());
+    assert_eq!(TextPoint { line: 0, index: 2 }, textinput.selection_start());
+    assert_eq!(TextPoint { line: 0, index: 5 }, textinput.selection_end());
+    assert_eq!(2, textinput.selection_start_offset());
+    assert_eq!(5, textinput.selection_end_offset());
 
     textinput.set_selection_range(3, 6, SelectionDirection::Backward);
     assert_eq!(
-        TextPoint {
-            line: 0,
-            index: UTF8Bytes(6)
-        },
+        TextPoint { line: 0, index: 6 },
         textinput.selection_origin_or_edit_point()
     );
-    assert_eq!(
-        TextPoint {
-            line: 0,
-            index: UTF8Bytes(3)
-        },
-        textinput.selection_start()
-    );
-    assert_eq!(
-        TextPoint {
-            line: 0,
-            index: UTF8Bytes(6)
-        },
-        textinput.selection_end()
-    );
-    assert_eq!(UTF8Bytes(3), textinput.selection_start_offset());
-    assert_eq!(UTF8Bytes(6), textinput.selection_end_offset());
+    assert_eq!(TextPoint { line: 0, index: 3 }, textinput.selection_start());
+    assert_eq!(TextPoint { line: 0, index: 6 }, textinput.selection_end());
+    assert_eq!(3, textinput.selection_start_offset());
+    assert_eq!(6, textinput.selection_end_offset());
 
     textinput = text_input(Lines::Multiple, "\n\n");
     textinput.set_selection_range(0, 1, SelectionDirection::Forward);
@@ -841,20 +802,8 @@ fn test_select_all() {
     textinput.set_selection_range(2, 3, SelectionDirection::Backward);
     textinput.select_all();
     assert_eq!(textinput.selection_direction(), SelectionDirection::Forward);
-    assert_eq!(
-        TextPoint {
-            line: 0,
-            index: UTF8Bytes::zero()
-        },
-        textinput.selection_start()
-    );
-    assert_eq!(
-        TextPoint {
-            line: 0,
-            index: UTF8Bytes(3)
-        },
-        textinput.selection_end()
-    );
+    assert_eq!(TextPoint { line: 0, index: 3 }, textinput.selection_start());
+    assert_eq!(TextPoint { line: 0, index: 3 }, textinput.selection_end());
 }
 
 #[test]
@@ -862,5 +811,5 @@ fn test_backspace_in_textarea_at_beginning_of_line() {
     let mut textinput = text_input(Lines::Multiple, "first line\n");
     textinput.handle_keydown_aux(Key::Named(NamedKey::ArrowDown), Modifiers::empty(), false);
     textinput.handle_keydown_aux(Key::Named(NamedKey::Backspace), Modifiers::empty(), false);
-    assert_eq!(textinput.get_content(), DOMString::from("first line"));
+    assert_eq!(&textinput.get_content(), utf16!("first line"));
 }


### PR DESCRIPTION
Servo currently uses UTF8 to store values within text inputs. The spec however requires (potentially ill-formed) UTF16 and this causes a lot of problems related to selection code, because it needs to slice text based on code unit offset.
These bugs manifest as crashes, see https://github.com/servo/servo/issues/36719, https://github.com/servo/servo/issues/20028 and https://github.com/servo/servo/issues/39184.

This change makes `TextInput` store UTF16 data, which allows us to implement the required behaviour correctly. To achieve this, I've had to implement a custom crate for utf16 strings. Existing solutions that I've found are insufficient, as their API is usually far inferior and smaller compared to that of `std::string::String` and they can't represent lone surrogates, which we must support.

Fixes https://github.com/servo/servo/issues/36719.
Fixes https://github.com/servo/servo/issues/20028.
Fixes https://github.com/servo/servo/issues/39184.
This change includes a unit test to prevent regressions.

