### PR TITLE
layout: Let individual transform properties establish a stacking context

### DIFF
--- a/components/layout/style_ext.rs
+++ b/components/layout/style_ext.rs
@@ -712,15 +712,19 @@ impl ComputedValuesExt for ComputedValues {
         // From <https://www.w3.org/TR/css-transforms-1/#transform-rendering>
         // > For elements whose layout is governed by the CSS box model, any value other than
         // > `none` for the `transform` property results in the creation of a stacking context.
+        //
+        // From <https://www.w3.org/TR/css-transforms-2/#individual-transforms>
+        // > all other values […] create a stacking context and containing block for all
+        // > descendants, per usual for transforms.
+        //
+        // From <https://www.w3.org/TR/css-transforms-2/#perspective-property>
+        // > any value other than none establishes a stacking context.
+        //
         // From <https://www.w3.org/TR/css-transforms-2/#transform-style-property>
         // > A computed value of `preserve-3d` for `transform-style` on a transformable element
         // > establishes both a stacking context and a containing block for all descendants.
-        // From <https://www.w3.org/TR/css-transforms-2/#perspective-property>
-        // > any value other than none establishes a stacking context.
-        // TODO: handle individual transform properties (`translate`, `scale` and `rotate`).
-        // <https://www.w3.org/TR/css-transforms-2/#individual-transforms>
         if self.is_transformable(fragment_flags) &&
-            (!self.get_box().transform.0.is_empty() ||
+            (self.has_transform_or_perspective_style() ||
                 self.get_box().transform_style == ComputedTransformStyle::Preserve3d ||
                 will_change_bits
                     .intersects(WillChangeBits::TRANSFORM | WillChangeBits::PERSPECTIVE))

--- a/tests/wpt/tests/css/css-transforms/individual-transform/stacking-context-002.html
+++ b/tests/wpt/tests/css/css-transforms/individual-transform/stacking-context-002.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<title>CSS Test: Individual transform properties create stacking context</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://www.w3.org/TR/css-transforms-2/#individual-transforms">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="
+  Setting `rotate` to a value different than `none` establishes a stacking context.
+">
+
+<style>
+.transform {
+  width: 100px;
+  height: 100px;
+  background: red;
+  rotate: 0deg;
+}
+.child {
+  width: 100px;
+  height: 100px;
+  background: green;
+  position: relative;
+  z-index: -1;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div class="transform">
+  <div class="child"></div>
+</div>

--- a/tests/wpt/tests/css/css-transforms/individual-transform/stacking-context-003.html
+++ b/tests/wpt/tests/css/css-transforms/individual-transform/stacking-context-003.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<title>CSS Test: Individual transform properties create stacking context</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://www.w3.org/TR/css-transforms-2/#individual-transforms">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="
+  Setting `scale` to a value different than `none` establishes a stacking context.
+">
+
+<style>
+.transform {
+  width: 100px;
+  height: 100px;
+  background: red;
+  scale: 1;
+}
+.child {
+  width: 100px;
+  height: 100px;
+  background: green;
+  position: relative;
+  z-index: -1;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div class="transform">
+  <div class="child"></div>
+</div>

--- a/tests/wpt/tests/css/css-transforms/individual-transform/stacking-context-004.html
+++ b/tests/wpt/tests/css/css-transforms/individual-transform/stacking-context-004.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<title>CSS Test: Individual transform properties create stacking context</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://www.w3.org/TR/css-transforms-2/#individual-transforms">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="
+  Setting `translate` to a value different than `none` establishes a stacking context.
+">
+
+<style>
+.transform {
+  width: 100px;
+  height: 100px;
+  background: red;
+  translate: 0px;
+}
+.child {
+  width: 100px;
+  height: 100px;
+  background: green;
+  position: relative;
+  z-index: -1;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div class="transform">
+  <div class="child"></div>
+</div>


### PR DESCRIPTION
Non-initial values for the `scale`, `rotate` and `translate` properties should establish a stacking context, just like `transform`.

Testing: adding new WPT tests.
