### PR TITLE
build(deps): bump Stylo from `0eaeea3` to `03ffc85`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1074,7 +1074,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2031,7 +2031,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2557,7 +2557,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3999,7 +3999,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi 0.5.0",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6137,7 +6137,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6466,7 +6466,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.27.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-15#0eaeea3dfd4aa0415529700353075ad1e1e47e5b"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#03ffc85c45f53a3b11994f7c14adce7b90aa9c34"
 dependencies = [
  "bitflags 2.9.0",
  "cssparser",
@@ -6760,8 +6760,8 @@ dependencies = [
 
 [[package]]
 name = "servo_arc"
-version = "0.4.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-15#0eaeea3dfd4aa0415529700353075ad1e1e47e5b"
+version = "0.4.1"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#03ffc85c45f53a3b11994f7c14adce7b90aa9c34"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -7221,7 +7221,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.2.1"
-source = "git+https://github.com/servo/stylo?branch=2025-03-15#0eaeea3dfd4aa0415529700353075ad1e1e47e5b"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#03ffc85c45f53a3b11994f7c14adce7b90aa9c34"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -7240,7 +7240,6 @@ dependencies = [
  "lazy_static",
  "log",
  "malloc_size_of_derive",
- "markup5ever",
  "matches",
  "mime",
  "new_debug_unreachable",
@@ -7274,12 +7273,13 @@ dependencies = [
  "url",
  "void",
  "walkdir",
+ "web_atoms",
 ]
 
 [[package]]
 name = "stylo_atoms"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-15#0eaeea3dfd4aa0415529700353075ad1e1e47e5b"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#03ffc85c45f53a3b11994f7c14adce7b90aa9c34"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -7288,12 +7288,12 @@ dependencies = [
 [[package]]
 name = "stylo_config"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-15#0eaeea3dfd4aa0415529700353075ad1e1e47e5b"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#03ffc85c45f53a3b11994f7c14adce7b90aa9c34"
 
 [[package]]
 name = "stylo_derive"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-15#0eaeea3dfd4aa0415529700353075ad1e1e47e5b"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#03ffc85c45f53a3b11994f7c14adce7b90aa9c34"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -7305,7 +7305,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-15#0eaeea3dfd4aa0415529700353075ad1e1e47e5b"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#03ffc85c45f53a3b11994f7c14adce7b90aa9c34"
 dependencies = [
  "bitflags 2.9.0",
  "stylo_malloc_size_of",
@@ -7314,7 +7314,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-15#0eaeea3dfd4aa0415529700353075ad1e1e47e5b"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#03ffc85c45f53a3b11994f7c14adce7b90aa9c34"
 dependencies = [
  "app_units",
  "cssparser",
@@ -7331,12 +7331,12 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-15#0eaeea3dfd4aa0415529700353075ad1e1e47e5b"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#03ffc85c45f53a3b11994f7c14adce7b90aa9c34"
 
 [[package]]
 name = "stylo_traits"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-15#0eaeea3dfd4aa0415529700353075ad1e1e47e5b"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#03ffc85c45f53a3b11994f7c14adce7b90aa9c34"
 dependencies = [
  "app_units",
  "bitflags 2.9.0",
@@ -7500,7 +7500,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7719,7 +7719,7 @@ dependencies = [
 [[package]]
 name = "to_shmem"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-15#0eaeea3dfd4aa0415529700353075ad1e1e47e5b"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#03ffc85c45f53a3b11994f7c14adce7b90aa9c34"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -7732,7 +7732,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-15#0eaeea3dfd4aa0415529700353075ad1e1e47e5b"
+source = "git+https://github.com/servo/stylo?branch=2025-03-15#03ffc85c45f53a3b11994f7c14adce7b90aa9c34"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -8785,7 +8785,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]


### PR DESCRIPTION
https://github.com/servo/stylo/compare/0eaeea3dfd4aa0415529700353075ad1e1e47e5b...03ffc85c45f53a3b11994f7c14adce7b90aa9c34

- https://github.com/servo/stylo/pull/173
  Use web_atoms crate
- https://github.com/servo/stylo/pull/174
  servo_arc: make track_alloc_size feature a default feature

Testing: unneeded, no behavior change
