### PR TITLE
htmlinputelement: Fire `beforeinput` event before updating input state

### DIFF
--- a/components/script/dom/event.rs
+++ b/components/script/dom/event.rs
@@ -738,7 +738,7 @@ impl Event {
     }
 
     /// <https://dom.spec.whatwg.org/#set-the-canceled-flag>
-    fn set_the_cancelled_flag(&self) {
+    pub(crate) fn set_the_cancelled_flag(&self) {
         if self.cancelable.get() && !self.in_passive_listener.get() {
             self.canceled.set(EventDefault::Prevented)
         }

--- a/components/script/dom/inputevent.rs
+++ b/components/script/dom/inputevent.rs
@@ -24,7 +24,7 @@ pub(crate) struct InputEvent {
 
 impl InputEvent {
     #[allow(clippy::too_many_arguments)]
-    fn new(
+    pub fn new(
         window: &Window,
         proto: Option<HandleObject>,
         type_: DOMString,


### PR DESCRIPTION
This PR implements the [`beforeinput`](https://w3c.github.io/uievents/#event-type-beforeinput) event on `<input>` elements, firing it before `input` state updates when handling keyboard events.

### Behavior

- The `beforeinput` event is:
  - **Bubbling**
  - **Cancelable**
  - **Composed**
  - Fired **before** any DOM mutation occurs
- `preventDefault()` is not handled yet (TODO noted)

### Testing

Tested using:
```html
<input onbeforeinput="console.log('before')" oninput="console.log('input')">
```

You should see:
```
before
input
```

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors  
- [X] `./mach test-tidy` does not report any errors  
- [X] These changes fix #36396

<!-- Either: -->
- [X] There are tests for these changes