### PR TITLE
net: Perform CSP checks on fetch responses.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1232,7 +1232,7 @@ dependencies = [
 [[package]]
 name = "content-security-policy"
 version = "0.5.4"
-source = "git+https://github.com/servo/rust-content-security-policy/?branch=servo-csp#81f95254fbfe98dd6e130260fd872cf950de9fcd"
+source = "git+https://github.com/servo/rust-content-security-policy/?branch=servo-csp#bd35ef27b7b87c8e7cd05af6e13a2c4b7630165e"
 dependencies = [
  "base64 0.22.1",
  "bitflags 2.9.0",

--- a/tests/wpt/meta/content-security-policy/connect-src/connect-src-syncxmlhttprequest-redirect-to-blocked.sub.html.ini
+++ b/tests/wpt/meta/content-security-policy/connect-src/connect-src-syncxmlhttprequest-redirect-to-blocked.sub.html.ini
@@ -1,3 +1,0 @@
-[connect-src-syncxmlhttprequest-redirect-to-blocked.sub.html]
-  [Expecting logs: ["PASS Sync XMLHttpRequest.send() did not follow the disallowed redirect.","TEST COMPLETE","violated-directive=connect-src"\]]
-    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/connect-src/connect-src-xmlhttprequest-redirect-to-blocked.sub.html.ini
+++ b/tests/wpt/meta/content-security-policy/connect-src/connect-src-xmlhttprequest-redirect-to-blocked.sub.html.ini
@@ -1,3 +1,0 @@
-[connect-src-xmlhttprequest-redirect-to-blocked.sub.html]
-  [Expecting logs: ["PASS XMLHttpRequest.send() did not follow the disallowed redirect.","TEST COMPLETE","violated-directive=connect-src"\]]
-    expected: FAIL


### PR DESCRIPTION
This adds missing CSP checks that apply to redirections.

Testing: Existing WPT coverage.
Part of #4577 
