### PR TITLE
Remove lock around tokio-rt handle

### DIFF
--- a/components/net/async_runtime.rs
+++ b/components/net/async_runtime.rs
@@ -2,31 +2,27 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 use std::cmp::Ord;
+use std::sync::LazyLock;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{LazyLock, Mutex};
 use std::thread;
 
 use tokio::runtime::{Builder, Runtime};
 
-pub static HANDLE: LazyLock<Mutex<Option<Runtime>>> = LazyLock::new(|| {
-    Mutex::new(Some(
-        Builder::new_multi_thread()
-            .thread_name_fn(|| {
-                static ATOMIC_ID: AtomicUsize = AtomicUsize::new(0);
-                let id = ATOMIC_ID.fetch_add(1, Ordering::Relaxed);
-                format!("tokio-runtime-{}", id)
-            })
-            .worker_threads(
-                thread::available_parallelism()
-                    .map(|i| i.get())
-                    .unwrap_or(servo_config::pref!(threadpools_fallback_worker_num) as usize)
-                    .min(
-                        servo_config::pref!(threadpools_async_runtime_workers_max).max(1) as usize,
-                    ),
-            )
-            .enable_io()
-            .enable_time()
-            .build()
-            .unwrap(),
-    ))
+pub static HANDLE: LazyLock<Runtime> = LazyLock::new(|| {
+    Builder::new_multi_thread()
+        .thread_name_fn(|| {
+            static ATOMIC_ID: AtomicUsize = AtomicUsize::new(0);
+            let id = ATOMIC_ID.fetch_add(1, Ordering::Relaxed);
+            format!("tokio-runtime-{}", id)
+        })
+        .worker_threads(
+            thread::available_parallelism()
+                .map(|i| i.get())
+                .unwrap_or(servo_config::pref!(threadpools_fallback_worker_num) as usize)
+                .min(servo_config::pref!(threadpools_async_runtime_workers_max).max(1) as usize),
+        )
+        .enable_io()
+        .enable_time()
+        .build()
+        .expect("Unable to build tokio-runtime runtime")
 });

--- a/components/net/connector.rs
+++ b/components/net/connector.rs
@@ -165,7 +165,7 @@ where
     F: Future<Output = ()> + 'static + std::marker::Send,
 {
     fn execute(&self, fut: F) {
-        HANDLE.lock().unwrap().as_ref().unwrap().spawn(fut);
+        HANDLE.spawn(fut);
     }
 }
 

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -493,7 +493,7 @@ impl BodySink {
         match self {
             BodySink::Chunked(sender) => {
                 let sender = sender.clone();
-                HANDLE.lock().unwrap().as_mut().unwrap().spawn(async move {
+                HANDLE.spawn(async move {
                     let _ = sender.send(Ok(Frame::data(bytes.into()))).await;
                 });
             },
@@ -2016,7 +2016,7 @@ async fn http_network_fetch(
     let url1 = request.url();
     let url2 = url1.clone();
 
-    HANDLE.lock().unwrap().as_ref().unwrap().spawn(
+    HANDLE.spawn(
         res.into_body()
             .map_err(|e| {
                 warn!("Error streaming response body: {:?}", e);

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -771,7 +771,7 @@ impl CoreResourceManager {
             _ => (FileTokenCheck::NotRequired, None),
         };
 
-        HANDLE.lock().unwrap().as_ref().unwrap().spawn(async move {
+        HANDLE.spawn(async move {
             // XXXManishearth: Check origin against pipeline id (also ensure that the mode is allowed)
             // todo load context / mimesniff in fetch
             // todo referrer policy?

--- a/components/net/websocket_loader.rs
+++ b/components/net/websocket_loader.rs
@@ -418,24 +418,21 @@ fn connect(
     tls_config.alpn_protocols = vec!["http/1.1".to_string().into()];
 
     let resource_event_sender2 = resource_event_sender.clone();
-    match HANDLE.lock().unwrap().as_mut() {
-        Some(handle) => handle.spawn(
-            start_websocket(
-                http_state,
-                req_url.clone(),
-                resource_event_sender,
-                protocols,
-                client,
-                tls_config,
-                dom_action_receiver,
-            )
-            .map_err(move |e| {
-                warn!("Failed to establish a WebSocket connection: {:?}", e);
-                let _ = resource_event_sender2.send(WebSocketNetworkEvent::Fail);
-            }),
-        ),
-        None => return Err("No runtime available".to_string()),
-    };
+    HANDLE.spawn(
+        start_websocket(
+            http_state,
+            req_url.clone(),
+            resource_event_sender,
+            protocols,
+            client,
+            tls_config,
+            dom_action_receiver,
+        )
+        .map_err(move |e| {
+            warn!("Failed to establish a WebSocket connection: {:?}", e);
+            let _ = resource_event_sender2.send(WebSocketNetworkEvent::Fail);
+        }),
+    );
     Ok(())
 }
 


### PR DESCRIPTION
It seems sub-optimal to to sequentialise execution by grabbing a lock, each time we want to spawn a task onto the tokio runtime. We don't need the lock either, so it makes sense to just remove it, which also simplifies a bunch of the using code.

Testing: Covered by existing tests

