### PR TITLE
Don't explicitly restyle when updating `<details>` shadow tree

### DIFF
--- a/components/script/dom/htmldetailselement.rs
+++ b/components/script/dom/htmldetailselement.rs
@@ -178,8 +178,6 @@ impl HTMLDetailsElement {
             }
         }
         shadow_tree.descendants.Assign(slottable_children);
-
-        self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
     }
 
     fn update_shadow_tree_styles(&self, can_gc: CanGc) {
@@ -214,8 +212,6 @@ impl HTMLDetailsElement {
             .implicit_summary
             .upcast::<Element>()
             .set_string_attribute(&local_name!("style"), implicit_summary_style.into(), can_gc);
-
-        self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
     }
 }
 


### PR DESCRIPTION
I'm not sure why I added these calls in the first place, but they don't seem to be necessary and seem to be the cause of crashes.

This PR also adds some spec comments that I added while investigating the crash.


Testing: Covered by existing WPT tests
Fixes https://github.com/servo/servo/issues/36757
Fixes https://github.com/servo/servo/issues/36273

[try run](https://github.com/simonwuelker/servo/actions/runs/14753023662/job/41415889180)