### PR TITLE
Remove macro impl_rare_data

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -327,7 +327,22 @@ impl Element {
         )
     }
 
-    impl_rare_data!(ElementRareData);
+    fn rare_data(&self) -> Ref<Option<Box<ElementRareData>>> {
+        self.rare_data.borrow()
+    }
+
+    #[allow(dead_code)]
+    fn rare_data_mut(&self) -> RefMut<Option<Box<ElementRareData>>> {
+        self.rare_data.borrow_mut()
+    }
+
+    fn ensure_rare_data(&self) -> RefMut<Box<ElementRareData>> {
+        let mut rare_data = self.rare_data.borrow_mut();
+        if rare_data.is_none() {
+            *rare_data = Some(Default::default());
+        }
+        RefMut::map(rare_data, |rare_data| rare_data.as_mut().unwrap())
+    }
 
     pub(crate) fn restyle(&self, damage: NodeDamage) {
         let doc = self.node.owner_doc();

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -331,7 +331,6 @@ impl Element {
         self.rare_data.borrow()
     }
 
-    #[allow(dead_code)]
     fn rare_data_mut(&self) -> RefMut<Option<Box<ElementRareData>>> {
         self.rare_data.borrow_mut()
     }

--- a/components/script/dom/macros.rs
+++ b/components/script/dom/macros.rs
@@ -719,26 +719,3 @@ macro_rules! handle_potential_webgl_error {
         handle_potential_webgl_error!($context, $call, ())
     };
 }
-
-macro_rules! impl_rare_data (
-    ($type:ty) => (
-        fn rare_data(&self) -> Ref<Option<Box<$type>>> {
-            self.rare_data.borrow()
-        }
-
-        #[allow(dead_code)]
-        fn rare_data_mut(&self) -> RefMut<Option<Box<$type>>> {
-            self.rare_data.borrow_mut()
-        }
-
-        fn ensure_rare_data(&self) -> RefMut<Box<$type>> {
-            let mut rare_data = self.rare_data.borrow_mut();
-            if rare_data.is_none() {
-                *rare_data = Some(Default::default());
-            }
-            RefMut::map(rare_data, |rare_data| {
-                rare_data.as_mut().unwrap()
-            })
-        }
-    );
-);

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -564,7 +564,22 @@ impl Iterator for QuerySelectorIterator {
 }
 
 impl Node {
-    impl_rare_data!(NodeRareData);
+    fn rare_data(&self) -> Ref<Option<Box<NodeRareData>>> {
+        self.rare_data.borrow()
+    }
+
+    #[allow(dead_code)]
+    fn rare_data_mut(&self) -> RefMut<Option<Box<NodeRareData>>> {
+        self.rare_data.borrow_mut()
+    }
+
+    fn ensure_rare_data(&self) -> RefMut<Box<NodeRareData>> {
+        let mut rare_data = self.rare_data.borrow_mut();
+        if rare_data.is_none() {
+            *rare_data = Some(Default::default());
+        }
+        RefMut::map(rare_data, |rare_data| rare_data.as_mut().unwrap())
+    }
 
     /// Returns true if this node is before `other` in the same connected DOM
     /// tree.

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -568,11 +568,6 @@ impl Node {
         self.rare_data.borrow()
     }
 
-    #[allow(dead_code)]
-    fn rare_data_mut(&self) -> RefMut<Option<Box<NodeRareData>>> {
-        self.rare_data.borrow_mut()
-    }
-
     fn ensure_rare_data(&self) -> RefMut<Box<NodeRareData>> {
         let mut rare_data = self.rare_data.borrow_mut();
         if rare_data.is_none() {


### PR DESCRIPTION
This macro does not hide any complex or unsafe implementation details, and, it's only used in two files (node.rs and element.rs). This patch removes the macro, and move the implementation in place.

Moreover, the Element::rare_data_mut function in element.rs is called by other functions, so the #[allow(dead_code)] annotation is removed. The Node::rare_data_mut function in node.rs is not called anywhere, so it is removed.

Testing: No test is needed for this cleaning up.
Fixes: #36767 