### PR TITLE
DevTools: Implement support for showing `source_content` in `Debugger > Source` panel

### DIFF
--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -20,7 +20,6 @@ use ipc_channel::ipc::{self, IpcSender};
 use serde::Serialize;
 use serde_json::{Map, Value};
 
-use super::source::SourceActor;
 use crate::actor::{Actor, ActorMessageStatus, ActorRegistry};
 use crate::actors::inspector::InspectorActor;
 use crate::actors::inspector::accessibility::AccessibilityActor;
@@ -240,8 +239,6 @@ impl BrowsingContextActor {
             browsing_context: name.clone(),
         };
 
-        let source = SourceActor::new(actors.new_name("source"), "".to_string(), "".to_string());
-
         let reflow = ReflowActor::new(actors.new_name("reflow"));
 
         let style_sheets = StyleSheetsActor::new(actors.new_name("stylesheets"));
@@ -281,7 +278,6 @@ impl BrowsingContextActor {
         actors.register(Box::new(css_properties));
         actors.register(Box::new(inspector));
         actors.register(Box::new(reflow));
-        actors.register(Box::new(source));
         actors.register(Box::new(style_sheets));
         actors.register(Box::new(tabdesc));
         actors.register(Box::new(thread));

--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -20,6 +20,7 @@ use ipc_channel::ipc::{self, IpcSender};
 use serde::Serialize;
 use serde_json::{Map, Value};
 
+use super::source::SourceActor;
 use crate::actor::{Actor, ActorMessageStatus, ActorRegistry};
 use crate::actors::inspector::InspectorActor;
 use crate::actors::inspector::accessibility::AccessibilityActor;
@@ -239,6 +240,8 @@ impl BrowsingContextActor {
             browsing_context: name.clone(),
         };
 
+        let source = SourceActor::new(actors.new_name("source"), "".to_string(), "".to_string());
+
         let reflow = ReflowActor::new(actors.new_name("reflow"));
 
         let style_sheets = StyleSheetsActor::new(actors.new_name("stylesheets"));
@@ -278,6 +281,7 @@ impl BrowsingContextActor {
         actors.register(Box::new(css_properties));
         actors.register(Box::new(inspector));
         actors.register(Box::new(reflow));
+        actors.register(Box::new(source));
         actors.register(Box::new(style_sheets));
         actors.register(Box::new(tabdesc));
         actors.register(Box::new(thread));

--- a/components/devtools/actors/source.rs
+++ b/components/devtools/actors/source.rs
@@ -30,8 +30,7 @@ pub(crate) struct SourcesReply {
     pub sources: Vec<SourceData>,
 }
 
-pub(crate) struct Source {
-    pub actor_name: String,
+pub(crate) struct SourceManager {
     pub source_urls: RefCell<BTreeSet<SourceData>>,
 }
 
@@ -57,17 +56,16 @@ struct BreakableLinesReply {
     lines: Vec<u32>,
 }
 
-impl Source {
-    pub fn new(actor_name: String) -> Self {
+impl SourceManager {
+    pub fn new() -> Self {
         Self {
-            actor_name,
             source_urls: RefCell::new(BTreeSet::default()),
         }
     }
 
-    pub fn add_source(&self, url: ServoUrl, source_content: String) {
+    pub fn add_source(&self, url: ServoUrl, source_content: String, actor_name: String) {
         self.source_urls.borrow_mut().insert(SourceData {
-            actor: self.actor_name.clone(),
+            actor: actor_name,
             url: url.to_string(),
             is_black_boxed: false,
             source_content,

--- a/components/devtools/actors/source.rs
+++ b/components/devtools/actors/source.rs
@@ -34,8 +34,7 @@ pub(crate) struct SourceManager {
     pub source_urls: RefCell<BTreeSet<SourceData>>,
 }
 
-#[derive(Clone, Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug)]
 pub struct SourceActor {
     pub name: String,
     pub content: String,
@@ -104,6 +103,7 @@ impl Actor for SourceActor {
         _id: StreamId,
     ) -> Result<ActorMessageStatus, ()> {
         Ok(match msg_type {
+            // Client has requested contents of the source.
             "source" => {
                 let reply = SourceContentReply {
                     from: self.name(),

--- a/components/devtools/actors/source.rs
+++ b/components/devtools/actors/source.rs
@@ -50,12 +50,6 @@ struct SourceContentReply {
     source: String,
 }
 
-#[derive(Serialize)]
-struct BreakableLinesReply {
-    from: String,
-    lines: Vec<u32>,
-}
-
 impl SourceManager {
     pub fn new() -> Self {
         Self {
@@ -115,14 +109,6 @@ impl Actor for SourceActor {
                     from: self.name(),
                     content_type: self.content_type.clone(),
                     source: self.content.clone(),
-                };
-                let _ = stream.write_json_packet(&reply);
-                ActorMessageStatus::Processed
-            },
-            "getBreakableLines" => {
-                let reply = BreakableLinesReply {
-                    from: self.name(),
-                    lines: [].to_vec(),
                 };
                 let _ = stream.write_json_packet(&reply);
                 ActorMessageStatus::Processed

--- a/components/devtools/actors/source.rs
+++ b/components/devtools/actors/source.rs
@@ -86,16 +86,8 @@ impl SourceActor {
         }
     }
 
-    pub fn new_source(actors: &mut ActorRegistry, url: &ServoUrl, content: String) -> String {
+    pub fn new_source(actors: &mut ActorRegistry, content: String, content_type: String) -> String {
         let source_actor_name = actors.new_name("source");
-
-        // this can do better, we should find a way to identify content_type
-        // maybe get it directly from script?
-        let content_type = match url.path().rsplit('.').next() {
-            Some("js") => "application/javascript",
-            _ => "text/plain",
-        }
-        .to_string();
 
         let source_actor = SourceActor::new(source_actor_name.clone(), content, content_type);
         actors.register(Box::new(source_actor));

--- a/components/devtools/actors/source.rs
+++ b/components/devtools/actors/source.rs
@@ -86,11 +86,7 @@ impl SourceActor {
         }
     }
 
-    pub fn new_source(
-        actors: &mut ActorRegistry,
-        url: &ServoUrl,
-        content: String,
-    ) -> (SourceActor, String) {
+    pub fn new_source(actors: &mut ActorRegistry, url: &ServoUrl, content: String) -> String {
         let source_actor_name = actors.new_name("source");
 
         // this can do better, we should find a way to identify content_type
@@ -102,8 +98,9 @@ impl SourceActor {
         .to_string();
 
         let source_actor = SourceActor::new(source_actor_name.clone(), content, content_type);
+        actors.register(Box::new(source_actor));
 
-        (source_actor, source_actor_name)
+        source_actor_name
     }
 }
 

--- a/components/devtools/actors/thread.rs
+++ b/components/devtools/actors/thread.rs
@@ -7,7 +7,7 @@ use std::net::TcpStream;
 use serde::Serialize;
 use serde_json::{Map, Value};
 
-use super::source::{SourceData, SourcesReply, SourceManager};
+use super::source::{SourceData, SourceManager, SourcesReply};
 use crate::actor::{Actor, ActorMessageStatus, ActorRegistry};
 use crate::protocol::JsonPacketStream;
 use crate::{EmptyReplyMsg, StreamId};

--- a/components/devtools/actors/thread.rs
+++ b/components/devtools/actors/thread.rs
@@ -7,7 +7,7 @@ use std::net::TcpStream;
 use serde::Serialize;
 use serde_json::{Map, Value};
 
-use super::source::{Source, SourcesReply};
+use super::source::{Source, SourceData, SourcesReply};
 use crate::actor::{Actor, ActorMessageStatus, ActorRegistry};
 use crate::protocol::JsonPacketStream;
 use crate::{EmptyReplyMsg, StreamId};
@@ -124,14 +124,16 @@ impl Actor for ThreadActor {
             // Client has attached to the thread and wants to load script sources.
             // <https://firefox-source-docs.mozilla.org/devtools/backend/protocol.html#loading-script-sources>
             "sources" => {
+                let sources = self.source_manager.source_urls.borrow();
+                let sources_vec: Vec<SourceData> = sources.iter().cloned().collect();
+
                 let msg = SourcesReply {
                     from: self.name(),
-                    sources: vec![], // TODO: Add sources for the debugger here
+                    sources: sources_vec,
                 };
                 let _ = stream.write_json_packet(&msg);
                 ActorMessageStatus::Processed
             },
-
             _ => ActorMessageStatus::Ignored,
         })
     }

--- a/components/devtools/actors/thread.rs
+++ b/components/devtools/actors/thread.rs
@@ -7,7 +7,7 @@ use std::net::TcpStream;
 use serde::Serialize;
 use serde_json::{Map, Value};
 
-use super::source::{Source, SourceData, SourcesReply};
+use super::source::{Source, SourceData, SourcesReply, SourceManager};
 use crate::actor::{Actor, ActorMessageStatus, ActorRegistry};
 use crate::protocol::JsonPacketStream;
 use crate::{EmptyReplyMsg, StreamId};
@@ -52,14 +52,14 @@ struct ThreadInterruptedReply {
 
 pub struct ThreadActor {
     pub name: String,
-    pub source_manager: Source,
+    pub source_manager: SourceManager,
 }
 
 impl ThreadActor {
     pub fn new(name: String) -> ThreadActor {
         ThreadActor {
             name: name.clone(),
-            source_manager: Source::new(name),
+            source_manager: SourceManager::new(),
         }
     }
 }

--- a/components/devtools/actors/thread.rs
+++ b/components/devtools/actors/thread.rs
@@ -7,7 +7,7 @@ use std::net::TcpStream;
 use serde::Serialize;
 use serde_json::{Map, Value};
 
-use super::source::{Source, SourceData, SourcesReply, SourceManager};
+use super::source::{SourceData, SourcesReply, SourceManager};
 use crate::actor::{Actor, ActorMessageStatus, ActorRegistry};
 use crate::protocol::JsonPacketStream;
 use crate::{EmptyReplyMsg, StreamId};

--- a/components/devtools/actors/thread.rs
+++ b/components/devtools/actors/thread.rs
@@ -124,12 +124,17 @@ impl Actor for ThreadActor {
             // Client has attached to the thread and wants to load script sources.
             // <https://firefox-source-docs.mozilla.org/devtools/backend/protocol.html#loading-script-sources>
             "sources" => {
-                let sources = self.source_manager.source_urls.borrow();
-                let sources_vec: Vec<SourceData> = sources.iter().cloned().collect();
+                let sources: Vec<SourceData> = self
+                    .source_manager
+                    .source_urls
+                    .borrow()
+                    .iter()
+                    .cloned()
+                    .collect();
 
                 let msg = SourcesReply {
                     from: self.name(),
-                    sources: sources_vec,
+                    sources,
                 };
                 let _ = stream.write_json_packet(&msg);
                 ActorMessageStatus::Processed

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -518,8 +518,11 @@ impl DevtoolsInstance {
     fn handle_script_source_info(&mut self, pipeline_id: PipelineId, source_info: SourceInfo) {
         let mut actors = self.actors.lock().unwrap();
 
-        let source_actor_name =
-            SourceActor::new_source(&mut actors, &source_info.url, source_info.content.clone());
+        let source_actor_name = SourceActor::new_source(
+            &mut actors,
+            source_info.content.clone(),
+            source_info.content_type.unwrap(),
+        );
 
         if let Some(worker_id) = source_info.worker_id {
             let Some(worker_actor_name) = self.actor_workers.get(&worker_id) else {

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -529,9 +529,13 @@ impl DevtoolsInstance {
 
             let thread_actor_name = actors.find::<WorkerActor>(worker_actor_name).thread.clone();
             let thread_actor = actors.find_mut::<ThreadActor>(&thread_actor_name);
+<<<<<<< HEAD
             thread_actor
                 .source_manager
                 .add_source(source_info.url.clone(), source_info.content.clone());
+=======
+            thread_actor.source_manager.add_source(source_info.url.clone(), source_info.content.clone(), source_actor_name.clone());
+>>>>>>> 6eddb58a96d (pass correct actor name to SourceData)
 
             let source = SourceData {
                 actor: source_actor_name.clone(),
@@ -559,12 +563,16 @@ impl DevtoolsInstance {
             };
 
             let thread_actor = actors.find_mut::<ThreadActor>(&thread_actor_name);
+<<<<<<< HEAD
             thread_actor
                 .source_manager
                 .add_source(source_info.url.clone(), source_info.content.clone());
+=======
+            thread_actor.source_manager.add_source(source_info.url.clone(),  source_info.content.clone(), source_actor_name.clone());
+>>>>>>> 6eddb58a96d (pass correct actor name to SourceData)
 
             let source = SourceData {
-                actor: source_actor_name.clone(),
+                actor: source_actor_name,
                 url: source_info.url.to_string(),
                 is_black_boxed: false,
                 source_content: source_info.content,

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -518,9 +518,8 @@ impl DevtoolsInstance {
     fn handle_script_source_info(&mut self, pipeline_id: PipelineId, source_info: SourceInfo) {
         let mut actors = self.actors.lock().unwrap();
 
-        let (source_actor, source_actor_name) =
+        let source_actor_name =
             SourceActor::new_source(&mut actors, &source_info.url, source_info.content.clone());
-        actors.register(Box::new(source_actor));
 
         if let Some(worker_id) = source_info.worker_id {
             let Some(worker_actor_name) = self.actor_workers.get(&worker_id) else {
@@ -546,7 +545,7 @@ impl DevtoolsInstance {
 >>>>>>> 2fbcdac63d6 (fmt)
 
             let source = SourceData {
-                actor: source_actor_name.clone(),
+                actor: source_actor_name,
                 url: source_info.url.to_string(),
                 is_black_boxed: false,
                 source_content: source_info.content,

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -534,7 +534,7 @@ impl DevtoolsInstance {
                 .add_source(source_info.url.clone(), source_info.content.clone());
 
             let source = SourceData {
-                actor: thread_actor_name.clone(),
+                actor: source_actor_name.clone(),
                 url: source_info.url.to_string(),
                 is_black_boxed: false,
                 source_content: source_info.content,
@@ -564,7 +564,7 @@ impl DevtoolsInstance {
                 .add_source(source_info.url.clone(), source_info.content.clone());
 
             let source = SourceData {
-                actor: thread_actor_name.clone(),
+                actor: source_actor_name.clone(),
                 url: source_info.url.to_string(),
                 is_black_boxed: false,
                 source_content: source_info.content,

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -530,12 +530,20 @@ impl DevtoolsInstance {
             let thread_actor_name = actors.find::<WorkerActor>(worker_actor_name).thread.clone();
             let thread_actor = actors.find_mut::<ThreadActor>(&thread_actor_name);
 <<<<<<< HEAD
+<<<<<<< HEAD
             thread_actor
                 .source_manager
                 .add_source(source_info.url.clone(), source_info.content.clone());
 =======
             thread_actor.source_manager.add_source(source_info.url.clone(), source_info.content.clone(), source_actor_name.clone());
 >>>>>>> 6eddb58a96d (pass correct actor name to SourceData)
+=======
+            thread_actor.source_manager.add_source(
+                source_info.url.clone(),
+                source_info.content.clone(),
+                source_actor_name.clone(),
+            );
+>>>>>>> 2fbcdac63d6 (fmt)
 
             let source = SourceData {
                 actor: source_actor_name.clone(),
@@ -564,12 +572,20 @@ impl DevtoolsInstance {
 
             let thread_actor = actors.find_mut::<ThreadActor>(&thread_actor_name);
 <<<<<<< HEAD
+<<<<<<< HEAD
             thread_actor
                 .source_manager
                 .add_source(source_info.url.clone(), source_info.content.clone());
 =======
             thread_actor.source_manager.add_source(source_info.url.clone(),  source_info.content.clone(), source_actor_name.clone());
 >>>>>>> 6eddb58a96d (pass correct actor name to SourceData)
+=======
+            thread_actor.source_manager.add_source(
+                source_info.url.clone(),
+                source_info.content.clone(),
+                source_actor_name.clone(),
+            );
+>>>>>>> 2fbcdac63d6 (fmt)
 
             let source = SourceData {
                 actor: source_actor_name,

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -531,21 +531,12 @@ impl DevtoolsInstance {
 
             let thread_actor_name = actors.find::<WorkerActor>(worker_actor_name).thread.clone();
             let thread_actor = actors.find_mut::<ThreadActor>(&thread_actor_name);
-<<<<<<< HEAD
-<<<<<<< HEAD
-            thread_actor
-                .source_manager
-                .add_source(source_info.url.clone(), source_info.content.clone());
-=======
-            thread_actor.source_manager.add_source(source_info.url.clone(), source_info.content.clone(), source_actor_name.clone());
->>>>>>> 6eddb58a96d (pass correct actor name to SourceData)
-=======
+
             thread_actor.source_manager.add_source(
                 source_info.url.clone(),
                 source_info.content.clone(),
                 source_actor_name.clone(),
             );
->>>>>>> 2fbcdac63d6 (fmt)
 
             let source = SourceData {
                 actor: source_actor_name,
@@ -573,21 +564,12 @@ impl DevtoolsInstance {
             };
 
             let thread_actor = actors.find_mut::<ThreadActor>(&thread_actor_name);
-<<<<<<< HEAD
-<<<<<<< HEAD
-            thread_actor
-                .source_manager
-                .add_source(source_info.url.clone(), source_info.content.clone());
-=======
-            thread_actor.source_manager.add_source(source_info.url.clone(),  source_info.content.clone(), source_actor_name.clone());
->>>>>>> 6eddb58a96d (pass correct actor name to SourceData)
-=======
+
             thread_actor.source_manager.add_source(
                 source_info.url.clone(),
                 source_info.content.clone(),
                 source_actor_name.clone(),
             );
->>>>>>> 2fbcdac63d6 (fmt)
 
             let source = SourceData {
                 actor: source_actor_name,

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -19,7 +19,6 @@ use std::net::{Shutdown, TcpListener, TcpStream};
 use std::sync::{Arc, Mutex};
 use std::thread;
 
-use actors::source::SourceData;
 use base::id::{BrowsingContextId, PipelineId, WebViewId};
 use crossbeam_channel::{Receiver, Sender, unbounded};
 use devtools_traits::{
@@ -44,6 +43,7 @@ use crate::actors::performance::PerformanceActor;
 use crate::actors::preference::PreferenceActor;
 use crate::actors::process::ProcessActor;
 use crate::actors::root::RootActor;
+use crate::actors::source::{SourceActor, SourceData};
 use crate::actors::thread::ThreadActor;
 use crate::actors::worker::{WorkerActor, WorkerType};
 use crate::id::IdMap;
@@ -518,22 +518,26 @@ impl DevtoolsInstance {
     fn handle_script_source_info(&mut self, pipeline_id: PipelineId, source_info: SourceInfo) {
         let mut actors = self.actors.lock().unwrap();
 
+        let (source_actor, source_actor_name) =
+            SourceActor::new_source(&mut actors, &source_info.url, source_info.content.clone());
+        actors.register(Box::new(source_actor));
+
         if let Some(worker_id) = source_info.worker_id {
             let Some(worker_actor_name) = self.actor_workers.get(&worker_id) else {
                 return;
             };
 
             let thread_actor_name = actors.find::<WorkerActor>(worker_actor_name).thread.clone();
-
             let thread_actor = actors.find_mut::<ThreadActor>(&thread_actor_name);
             thread_actor
                 .source_manager
-                .add_source(source_info.url.clone());
+                .add_source(source_info.url.clone(), source_info.content.clone());
 
             let source = SourceData {
                 actor: thread_actor_name.clone(),
                 url: source_info.url.to_string(),
                 is_black_boxed: false,
+                source_content: source_info.content,
             };
 
             let worker_actor = actors.find::<WorkerActor>(worker_actor_name);
@@ -549,20 +553,21 @@ impl DevtoolsInstance {
                 return;
             };
 
-            let thread_actor_name = actors
-                .find::<BrowsingContextActor>(actor_name)
-                .thread
-                .clone();
+            let thread_actor_name = {
+                let browsing_context = actors.find::<BrowsingContextActor>(actor_name);
+                browsing_context.thread.clone()
+            };
 
             let thread_actor = actors.find_mut::<ThreadActor>(&thread_actor_name);
             thread_actor
                 .source_manager
-                .add_source(source_info.url.clone());
+                .add_source(source_info.url.clone(), source_info.content.clone());
 
             let source = SourceData {
                 actor: thread_actor_name.clone(),
                 url: source_info.url.to_string(),
                 is_black_boxed: false,
+                source_content: source_info.content,
             };
 
             // Notify browsing context about the new source

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -489,6 +489,7 @@ impl DedicatedWorkerGlobalScope {
                         external: true, // Worker scripts are always external.
                         worker_id: Some(global.upcast::<WorkerGlobalScope>().get_worker_id()),
                         content: source.to_string(),
+                        content_type: metadata.content_type.map(|c_type| c_type.0.to_string()),
                     };
                     let _ = chan.send(ScriptToDevtoolsControlMsg::ScriptSourceLoaded(
                         pipeline_id,

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -1012,8 +1012,6 @@ impl HTMLScriptElement {
             return;
         }
 
-        // TODO: Step 3. Unblock rendering on el.
-
         let mut script = match result {
             // Step 4. If el's result is null, then fire an event named error at el, and return.
             Err(e) => {
@@ -1033,11 +1031,15 @@ impl HTMLScriptElement {
                 SourceCode::Compiled(compiled) => compiled.original_text.to_string(),
             };
 
+            // Fix this, would be nice if we could use SCRIPT_JS_MIMES
+            let content_type = Some("application/javascript".to_string());
+
             let source_info = SourceInfo {
                 url: script.url.clone(),
                 external: script.external,
                 worker_id: None,
                 content,
+                content_type,
             };
             let _ = chan.send(ScriptToDevtoolsControlMsg::ScriptSourceLoaded(
                 pipeline_id,

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -1027,10 +1027,17 @@ impl HTMLScriptElement {
 
         if let Some(chan) = self.global().devtools_chan() {
             let pipeline_id = self.global().pipeline_id();
+
+            let content = match &script.code {
+                SourceCode::Text(text) => text.to_string(),
+                SourceCode::Compiled(compiled) => compiled.original_text.to_string(),
+            };
+
             let source_info = SourceInfo {
                 url: script.url.clone(),
                 external: script.external,
                 worker_id: None,
+                content,
             };
             let _ = chan.send(ScriptToDevtoolsControlMsg::ScriptSourceLoaded(
                 pipeline_id,

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -1012,6 +1012,7 @@ impl HTMLScriptElement {
             return;
         }
 
+        // TODO: Step 3. Unblock rendering on el.
         let mut script = match result {
             // Step 4. If el's result is null, then fire an event named error at el, and return.
             Err(e) => {
@@ -1026,13 +1027,14 @@ impl HTMLScriptElement {
         if let Some(chan) = self.global().devtools_chan() {
             let pipeline_id = self.global().pipeline_id();
 
+            // TODO: https://github.com/servo/servo/issues/36874
             let content = match &script.code {
                 SourceCode::Text(text) => text.to_string(),
                 SourceCode::Compiled(compiled) => compiled.original_text.to_string(),
             };
 
-            // Fix this, would be nice if we could use SCRIPT_JS_MIMES
-            let content_type = Some("application/javascript".to_string());
+            // https://html.spec.whatwg.org/multipage/#scriptingLanguages
+            let content_type = Some("text/javascript".to_string());
 
             let source_info = SourceInfo {
                 url: script.url.clone(),

--- a/components/script/dom/worker.rs
+++ b/components/script/dom/worker.rs
@@ -8,7 +8,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use constellation_traits::{StructuredSerializedData, WorkerScriptLoadOrigin};
 use crossbeam_channel::{Sender, unbounded};
-use devtools_traits::{DevtoolsPageInfo, ScriptToDevtoolsControlMsg, SourceInfo, WorkerId};
+use devtools_traits::{DevtoolsPageInfo, ScriptToDevtoolsControlMsg, WorkerId};
 use dom_struct::dom_struct;
 use ipc_channel::ipc;
 use js::jsapi::{Heap, JSObject};

--- a/components/script/dom/worker.rs
+++ b/components/script/dom/worker.rs
@@ -229,6 +229,7 @@ impl WorkerMethods<crate::DomTypeHolder> for Worker {
                     url: worker_url.clone(),
                     external: true, // Worker scripts are always external.
                     worker_id: Some(worker_id),
+                    content: "".to_string(),
                 };
                 let _ = chan.send(ScriptToDevtoolsControlMsg::ScriptSourceLoaded(
                     pipeline_id,

--- a/components/script/dom/worker.rs
+++ b/components/script/dom/worker.rs
@@ -224,17 +224,6 @@ impl WorkerMethods<crate::DomTypeHolder> for Worker {
                     devtools_sender.clone(),
                     page_info,
                 ));
-
-                let source_info = SourceInfo {
-                    url: worker_url.clone(),
-                    external: true, // Worker scripts are always external.
-                    worker_id: Some(worker_id),
-                    content: "".to_string(),
-                };
-                let _ = chan.send(ScriptToDevtoolsControlMsg::ScriptSourceLoaded(
-                    pipeline_id,
-                    source_info,
-                ));
             }
         }
 

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -564,4 +564,5 @@ pub struct SourceInfo {
     pub external: bool,
     pub worker_id: Option<WorkerId>,
     pub content: String,
+    pub content_type: Option<String>,
 }

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -563,4 +563,5 @@ pub struct SourceInfo {
     pub url: ServoUrl,
     pub external: bool,
     pub worker_id: Option<WorkerId>,
+    pub content: String,
 }

--- a/python/servo/devtools_tests.py
+++ b/python/servo/devtools_tests.py
@@ -60,6 +60,7 @@ class DevtoolsTests(unittest.IsolatedAsyncioTestCase):
                             f"{self.base_url}/classic.js",
                             f"{self.base_url}/test.html",
                             "https://servo.org/js/load-table.js",
+                            f"{self.base_url}/test.html",
                         ]
                     ),
                     tuple([f"{self.base_url}/worker.js"]),
@@ -91,6 +92,17 @@ class DevtoolsTests(unittest.IsolatedAsyncioTestCase):
     def test_sources_list_with_data_inline_module_script(self):
         self.run_servoshell(url="data:text/html,<script type=module>;</script>")
         self.assert_sources_list(1, set([tuple(["data:text/html,<script type=module>;</script>"])]))
+
+    def test_source_content_inline_script(self):
+        script_content = "console.log('Hello, world!');"
+        self.run_servoshell(url=f"data:text/html,<script>{script_content}</script>")
+        self.assert_source_content("data:text/html,<script>console.log('Hello, world!');</script>", script_content)
+
+    def test_source_content_external_script(self):
+        self.start_web_server(test_dir=os.path.join(DevtoolsTests.script_path, "devtools_tests/sources"))
+        self.run_servoshell(url=f'data:text/html,<script src="{self.base_url}/classic.js"></script>')
+        expected_content = 'console.log("external classic");\n'
+        self.assert_source_content(f"{self.base_url}/classic.js", expected_content)
 
     # Sets `base_url` and `web_server` and `web_server_thread`.
     def start_web_server(self, *, test_dir=None):
@@ -145,7 +157,7 @@ class DevtoolsTests(unittest.IsolatedAsyncioTestCase):
         if self.base_url is not None:
             self.base_url = None
 
-    def assert_sources_list(self, expected_targets: int, expected_urls_by_target: set[tuple[str]]):
+    def _setup_devtools_client(self, expected_targets=1):
         client = RDPClient()
         client.connect("127.0.0.1", 6080)
         root = RootActor(client)
@@ -179,6 +191,11 @@ class DevtoolsTests(unittest.IsolatedAsyncioTestCase):
         result: Optional[Exception] = done.result(1)
         if result:
             raise result
+
+        return client, watcher, targets
+
+    def assert_sources_list(self, expected_targets: int, expected_urls_by_target: set[tuple[str]]):
+        client, watcher, targets = self._setup_devtools_client(expected_targets)
         done = Future()
         # NOTE: breaks if two targets have the same list of source urls.
         # This should really be a multiset, but Python does not have multisets.
@@ -210,6 +227,45 @@ class DevtoolsTests(unittest.IsolatedAsyncioTestCase):
         if result:
             raise result
         self.assertEqual(actual_urls_by_target, expected_urls_by_target)
+        client.disconnect()
+
+    def assert_source_content(self, source_url: str, expected_content: str):
+        client, watcher, targets = self._setup_devtools_client()
+
+        done = Future()
+        source_actors = {}
+
+        def on_source_resource(data):
+            for [resource_type, sources] in data["array"]:
+                try:
+                    self.assertEqual(resource_type, "source")
+                    for source in sources:
+                        if source["url"] == source_url:
+                            source_actors[source_url] = source["actor"]
+                            done.set_result(None)
+                except Exception as e:
+                    done.set_result(e)
+
+        for target in targets:
+            client.add_event_listener(
+                target["actor"],
+                Events.Watcher.RESOURCES_AVAILABLE_ARRAY,
+                on_source_resource,
+            )
+        watcher.watch_resources([Resources.SOURCE])
+
+        result: Optional[Exception] = done.result(1)
+        if result:
+            raise result
+
+        #  we found at least one source with the url
+        self.assertIn(source_url, source_actors)
+        source_actor = source_actors[source_url]
+
+        response = client.send_receive({"to": source_actor, "type": "source"})
+
+        self.assertEqual(response["source"], expected_content)
+
         client.disconnect()
 
 

--- a/python/servo/devtools_tests.py
+++ b/python/servo/devtools_tests.py
@@ -258,7 +258,7 @@ class DevtoolsTests(unittest.IsolatedAsyncioTestCase):
         if result:
             raise result
 
-        #  we found at least one source with the url
+        # We found at least one source with the given url.
         self.assertIn(source_url, source_actors)
         source_actor = source_actors[source_url]
 


### PR DESCRIPTION
This patch adds support for showing source_content in `Debugger > Source` panel. This works by handling the clients `source` messages in the source actor. These source actors are already advertised as resource via the watcher, populating the source list. We also update the `sources` handler in thread actor for future work in thread debugging.

Note: while this PR also adds support for showing worker script source_content, worker has been broken (See https://github.com/servo/servo/issues/37012). I was able to confirm the `content_type` and `source_content` for worker script in logs.

![image](https://github.com/user-attachments/assets/bd53ea29-003a-4b5e-a3e8-6e280afa4671)

Fixes: part of https://github.com/servo/servo/issues/36027
