### PR TITLE
Send info about the `DocumentType` node to the devtools inspector 

### DIFF
--- a/components/devtools/actors/inspector/node.rs
+++ b/components/devtools/actors/inspector/node.rs
@@ -78,6 +78,18 @@ pub struct NodeActorMsg {
     shadow_root_mode: Option<String>,
     traits: HashMap<String, ()>,
     attrs: Vec<AttrMsg>,
+
+    /// The `DOCTYPE` name if this is a `DocumentType` node, `None` otherwise
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
+
+    /// The `DOCTYPE` public identifier if this is a `DocumentType` node, `None` otherwise
+    #[serde(skip_serializing_if = "Option::is_none")]
+    public_id: Option<String>,
+
+    /// The `DOCTYPE` system identifier if this is a `DocumentType` node, `None` otherwise
+    #[serde(skip_serializing_if = "Option::is_none")]
+    system_id: Option<String>,
 }
 
 pub struct NodeActor {
@@ -276,6 +288,9 @@ impl NodeInfoToProtocol for NodeInfo {
                     value: attr.value,
                 })
                 .collect(),
+            name: self.doctype_name,
+            public_id: self.doctype_public_identifier,
+            system_id: self.doctype_system_identifier,
         }
     }
 }

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -1272,6 +1272,21 @@ impl Node {
             is_shadow_host,
             shadow_root_mode,
             display,
+            doctype_name: self
+                .downcast::<DocumentType>()
+                .map(DocumentType::name)
+                .cloned()
+                .map(String::from),
+            doctype_public_identifier: self
+                .downcast::<DocumentType>()
+                .map(DocumentType::public_id)
+                .cloned()
+                .map(String::from),
+            doctype_system_identifier: self
+                .downcast::<DocumentType>()
+                .map(DocumentType::system_id)
+                .cloned()
+                .map(String::from),
         }
     }
 

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -144,6 +144,15 @@ pub struct NodeInfo {
     pub shadow_root_mode: Option<ShadowRootMode>,
     pub is_shadow_host: bool,
     pub display: Option<String>,
+
+    /// The `DOCTYPE` name if this is a `DocumentType` node, `None` otherwise
+    pub doctype_name: Option<String>,
+
+    /// The `DOCTYPE` public identifier if this is a `DocumentType` node , `None` otherwise
+    pub doctype_public_identifier: Option<String>,
+
+    /// The `DOCTYPE` system identifier if this is a `DocumentType` node, `None` otherwise
+    pub doctype_system_identifier: Option<String>,
 }
 
 pub struct StartedTimelineMarker {


### PR DESCRIPTION
This makes the DOCTYPE tag show up correctly in the inspector.

Before:
![image](https://github.com/user-attachments/assets/fd101337-95ce-45ee-8ac5-ae701109eb94)

After:
![image](https://github.com/user-attachments/assets/4e80f4c0-6ae4-4c53-88ca-614803caa032)


Testing: We don't have devtools tests