### PR TITLE
canvas: Move `CompositionOrBlending` and `ellipse()` from `RaqoteBackend` to `Backend`

### DIFF
--- a/components/canvas/backend.rs
+++ b/components/canvas/backend.rs
@@ -2,7 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use canvas_traits::canvas::{FillOrStrokeStyle, LineCapStyle, LineJoinStyle};
+use canvas_traits::canvas::{
+    CompositionOrBlending, FillOrStrokeStyle, LineCapStyle, LineJoinStyle,
+};
 use euclid::Angle;
 use euclid::default::{Point2D, Rect, Size2D, Transform2D, Vector2D};
 use lyon_geom::Arc;
@@ -16,7 +18,6 @@ pub(crate) trait Backend: Clone + Sized {
     type Color: Clone;
     type DrawOptions: DrawOptionsHelpers + Clone;
     type CompositionOp;
-    type CompositionOrBlending;
     type DrawTarget: GenericDrawTarget<Self>;
     type PathBuilder: GenericPathBuilder<Self>;
     type SourceSurface;
@@ -41,7 +42,7 @@ pub(crate) trait Backend: Clone + Sized {
     );
     fn set_global_composition(
         &mut self,
-        op: Self::CompositionOrBlending,
+        op: CompositionOrBlending,
         state: &mut CanvasPaintState<'_, Self>,
     );
     fn create_drawtarget(&self, size: Size2D<u64>) -> Self::DrawTarget;

--- a/components/canvas/canvas_data.rs
+++ b/components/canvas/canvas_data.rs
@@ -1183,7 +1183,7 @@ impl<'a, B: Backend> CanvasData<'a, B> {
         self.state.draw_options.set_alpha(alpha);
     }
 
-    pub(crate) fn set_global_composition(&mut self, op: B::CompositionOrBlending) {
+    pub(crate) fn set_global_composition(&mut self, op: CompositionOrBlending) {
         self.backend.set_global_composition(op, &mut self.state);
     }
 

--- a/components/canvas/raqote_backend.rs
+++ b/components/canvas/raqote_backend.rs
@@ -38,7 +38,6 @@ impl Backend for RaqoteBackend {
     type Color = raqote::SolidSource;
     type DrawOptions = raqote::DrawOptions;
     type CompositionOp = raqote::BlendMode;
-    type CompositionOrBlending = CompositionOrBlending;
     type DrawTarget = raqote::DrawTarget;
     type PathBuilder = PathBuilder;
     type SourceSurface = Vec<u8>; // TODO: See if we can avoid the alloc (probably?)
@@ -82,7 +81,7 @@ impl Backend for RaqoteBackend {
 
     fn set_global_composition(
         &mut self,
-        op: Self::CompositionOrBlending,
+        op: CompositionOrBlending,
         state: &mut CanvasPaintState<'_, Self>,
     ) {
         state.draw_options.blend_mode = op.to_raqote_style();


### PR DESCRIPTION
Small fixes of abstraction.

We do not need to generalize `CompositionOrBlending`, because it's from canvas_traits.
Ellipse impl that uses arc is not backend specific, so it serves as good trait default.

Reviewable per commit.


Testing: Only refactoring, but there are WPT tests
