### PR TITLE
libservo: Add a basic `WebView` API test

### DIFF
--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -141,3 +141,12 @@ libservo = { path = ".", features = ["tracing"] }
 rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs"] }
 tracing = { workspace = true }
 winit = "0.30.8"
+
+
+[[test]]
+name = "webview"
+harness = false
+
+[[test]]
+name = "servo"
+harness = false

--- a/components/servo/tests/servo.rs
+++ b/components/servo/tests/servo.rs
@@ -4,7 +4,7 @@
 
 //! Servo API unit tests.
 //!
-//! Since all Servo tests must rust serially on the same thread, it is important
+//! Since all Servo tests must run serially on the same thread, it is important
 //! that tests never panic. In order to ensure this, use `anyhow::ensure!` instead
 //! of `assert!` for test assertions. `ensure!` will produce a `Result::Err` in
 //! place of panicking.
@@ -12,21 +12,15 @@
 mod common;
 
 use anyhow::ensure;
-use common::*;
-use servo::WebViewBuilder;
+use common::{ServoTest, run_api_tests};
 
-#[test]
-fn test_simple_servo_is_not_animating_by_default() {
-    ServoTest::run(|servo_test| {
-        ensure!(!servo_test.servo().animating());
-        Ok(())
-    });
+fn test_simple_servo_is_not_animating_by_default(
+    servo_test: &ServoTest,
+) -> Result<(), anyhow::Error> {
+    ensure!(!servo_test.servo().animating());
+    Ok(())
 }
 
-#[test]
-fn test_simple_servo_construct_webview() {
-    ServoTest::run(|servo_test| {
-        WebViewBuilder::new(servo_test.servo()).build();
-        Ok(())
-    });
+fn main() {
+    run_api_tests!(test_simple_servo_is_not_animating_by_default);
 }

--- a/components/servo/tests/webview.rs
+++ b/components/servo/tests/webview.rs
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+//! WebView API unit tests.
+//!
+//! Since all Servo tests must run serially on the same thread, it is important
+//! that tests never panic. In order to ensure this, use `anyhow::ensure!` instead
+//! of `assert!` for test assertions. `ensure!` will produce a `Result::Err` in
+//! place of panicking.
+
+mod common;
+
+use std::cell::Cell;
+use std::rc::Rc;
+
+use anyhow::ensure;
+use common::{ServoTest, run_api_tests};
+use servo::{WebViewBuilder, WebViewDelegate};
+
+#[derive(Default)]
+struct WebViewDelegateImpl {
+    url_changed: Cell<bool>,
+}
+
+impl WebViewDelegate for WebViewDelegateImpl {
+    fn notify_url_changed(&self, _webview: servo::WebView, _url: url::Url) {
+        self.url_changed.set(true);
+    }
+}
+
+fn test_create_webview(servo_test: &ServoTest) -> Result<(), anyhow::Error> {
+    let delegate = Rc::new(WebViewDelegateImpl::default());
+    let webview = WebViewBuilder::new(servo_test.servo())
+        .delegate(delegate.clone())
+        .build();
+
+    servo_test.spin(move || Ok(!delegate.url_changed.get()))?;
+
+    let url = webview.url();
+    ensure!(url.is_some());
+    ensure!(url.unwrap().to_string() == "about:blank");
+
+    Ok(())
+}
+
+fn main() {
+    run_api_tests!(test_create_webview);
+}


### PR DESCRIPTION
This should allow us to start unit testing the `WebView` API.

Testing: This is a test.
