### PR TITLE
canvas: rename `snapshot(_data)` to `surface() -> SourceSurface`/`bytes() -> AsRef<[u8]>`

### DIFF
--- a/components/canvas/backend.rs
+++ b/components/canvas/backend.rs
@@ -21,6 +21,7 @@ pub(crate) trait Backend: Clone + Sized {
     type DrawTarget: GenericDrawTarget<Self>;
     type PathBuilder: GenericPathBuilder<Self>;
     type SourceSurface;
+    type Bytes<'a>: AsRef<[u8]>;
     type Path: PathHelpers<Self> + Clone;
     type GradientStop;
     type GradientStops;
@@ -98,7 +99,6 @@ pub(crate) trait GenericDrawTarget<B: Backend> {
     fn pop_clip(&mut self);
     fn push_clip(&mut self, path: &B::Path);
     fn set_transform(&mut self, matrix: &Transform2D<f32>);
-    fn snapshot(&self) -> B::SourceSurface;
     fn stroke(
         &mut self,
         path: &B::Path,
@@ -121,7 +121,8 @@ pub(crate) trait GenericDrawTarget<B: Backend> {
         stroke_options: &B::StrokeOptions,
         draw_options: &B::DrawOptions,
     );
-    fn snapshot_data(&self) -> &[u8];
+    fn surface(&self) -> B::SourceSurface;
+    fn bytes(&'_ self) -> B::Bytes<'_>;
 }
 
 /// A generic PathBuilder that abstracts the interface for azure's and raqote's PathBuilder.

--- a/components/canvas/canvas_data.rs
+++ b/components/canvas/canvas_data.rs
@@ -426,7 +426,7 @@ impl<'a, B: Backend> CanvasData<'a, B> {
             flags: ImageDescriptorFlags::empty(),
         };
         let data =
-            SerializableImageData::Raw(IpcSharedMemory::from_bytes(draw_target.snapshot_data()));
+            SerializableImageData::Raw(IpcSharedMemory::from_bytes(draw_target.bytes().as_ref()));
         compositor_api.update_images(vec![ImageUpdate::AddImage(image_key, descriptor, data)]);
         CanvasData {
             state: backend.new_paint_state(),
@@ -1209,7 +1209,7 @@ impl<'a, B: Backend> CanvasData<'a, B> {
             flags: ImageDescriptorFlags::empty(),
         };
         let data = SerializableImageData::Raw(IpcSharedMemory::from_bytes(
-            self.drawtarget.snapshot_data(),
+            self.drawtarget.bytes().as_ref(),
         ));
 
         self.compositor_api
@@ -1292,7 +1292,7 @@ impl<'a, B: Backend> CanvasData<'a, B> {
         let mut new_draw_target = self.create_draw_target_for_shadow(&shadow_src_rect);
         draw_shadow_source(&mut new_draw_target);
         self.drawtarget.draw_surface_with_shadow(
-            new_draw_target.snapshot(),
+            new_draw_target.surface(),
             &Point2D::new(shadow_src_rect.origin.x, shadow_src_rect.origin.y),
             &self.state.shadow_color,
             &Vector2D::new(
@@ -1323,11 +1323,11 @@ impl<'a, B: Backend> CanvasData<'a, B> {
             {
                 vec![]
             } else {
-                let bytes = self.drawtarget.snapshot_data();
-                pixels::rgba8_get_rect(bytes, canvas_size, read_rect).to_vec()
+                pixels::rgba8_get_rect(self.drawtarget.bytes().as_ref(), canvas_size, read_rect)
+                    .to_vec()
             }
         } else {
-            self.drawtarget.snapshot_data().to_vec()
+            self.drawtarget.bytes().as_ref().to_vec()
         };
 
         Snapshot::from_vec(

--- a/components/canvas/raqote_backend.rs
+++ b/components/canvas/raqote_backend.rs
@@ -41,6 +41,7 @@ impl Backend for RaqoteBackend {
     type DrawTarget = raqote::DrawTarget;
     type PathBuilder = PathBuilder;
     type SourceSurface = Vec<u8>; // TODO: See if we can avoid the alloc (probably?)
+    type Bytes<'a> = &'a [u8];
     type Path = raqote::Path;
     type GradientStop = raqote::GradientStop;
     type GradientStops = Vec<raqote::GradientStop>;
@@ -595,8 +596,8 @@ impl GenericDrawTarget<RaqoteBackend> for raqote::DrawTarget {
     fn set_transform(&mut self, matrix: &Transform2D<f32>) {
         self.set_transform(matrix);
     }
-    fn snapshot(&self) -> <RaqoteBackend as Backend>::SourceSurface {
-        self.snapshot_data().to_vec()
+    fn surface(&self) -> <RaqoteBackend as Backend>::SourceSurface {
+        self.bytes().to_vec()
     }
     fn stroke(
         &mut self,
@@ -655,7 +656,7 @@ impl GenericDrawTarget<RaqoteBackend> for raqote::DrawTarget {
         );
     }
     #[allow(unsafe_code)]
-    fn snapshot_data(&self) -> &[u8] {
+    fn bytes(&self) -> &[u8] {
         let v = self.get_data();
         unsafe { std::slice::from_raw_parts(v.as_ptr() as *const u8, std::mem::size_of_val(v)) }
     }


### PR DESCRIPTION
`surface()` returns `SourceSurface` which is/was meant as optimization when passing from canvas to canvas (in vello that would be wgpu texture; but raquote does not really have this) while bytes returns something that must impl AsRef<[u8]> (this is more generic then `&[u8]` as it allows us to have type with drop impl - wgpu's BufferView).

Testing: This is just refactoring (protected by rust), but there are WPT tests.