### PR TITLE
script: Move Window-only gamepad functionality out of GlobalScope

### DIFF
--- a/components/script/dom/gamepad.rs
+++ b/components/script/dom/gamepad.rs
@@ -13,7 +13,7 @@ use crate::dom::bindings::codegen::Bindings::GamepadBinding::{GamepadHand, Gamep
 use crate::dom::bindings::codegen::Bindings::GamepadButtonListBinding::GamepadButtonListMethods;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::num::Finite;
-use crate::dom::bindings::reflector::{DomGlobal, Reflector, reflect_dom_object_with_proto};
+use crate::dom::bindings::reflector::{DomGlobal, Reflector, reflect_dom_object};
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::event::Event;
@@ -23,6 +23,7 @@ use crate::dom::gamepadevent::{GamepadEvent, GamepadEventType};
 use crate::dom::gamepadhapticactuator::GamepadHapticActuator;
 use crate::dom::gamepadpose::GamepadPose;
 use crate::dom::globalscope::GlobalScope;
+use crate::dom::window::Window;
 use crate::script_runtime::{CanGc, JSContext};
 
 // This value is for determining when to consider a gamepad as having a user gesture
@@ -88,39 +89,14 @@ impl Gamepad {
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
-    pub(crate) fn new(
-        global: &GlobalScope,
-        gamepad_id: u32,
-        id: String,
-        mapping_type: String,
-        axis_bounds: (f64, f64),
-        button_bounds: (f64, f64),
-        supported_haptic_effects: GamepadSupportedHapticEffects,
-        xr: bool,
-        can_gc: CanGc,
-    ) -> DomRoot<Gamepad> {
-        Self::new_with_proto(
-            global,
-            gamepad_id,
-            id,
-            mapping_type,
-            axis_bounds,
-            button_bounds,
-            supported_haptic_effects,
-            xr,
-            can_gc,
-        )
-    }
-
     /// When we construct a new gamepad, we initialize the number of buttons and
     /// axes corresponding to the "standard" gamepad mapping.
     /// The spec says UAs *may* do this for fingerprint mitigation, and it also
     /// happens to simplify implementation
     /// <https://www.w3.org/TR/gamepad/#fingerprinting-mitigation>
     #[allow(clippy::too_many_arguments)]
-    fn new_with_proto(
-        global: &GlobalScope,
+    pub(crate) fn new(
+        window: &Window,
         gamepad_id: u32,
         id: String,
         mapping_type: String,
@@ -130,11 +106,11 @@ impl Gamepad {
         xr: bool,
         can_gc: CanGc,
     ) -> DomRoot<Gamepad> {
-        let button_list = GamepadButtonList::init_buttons(global, can_gc);
+        let button_list = GamepadButtonList::init_buttons(window, can_gc);
         let vibration_actuator =
-            GamepadHapticActuator::new(global, gamepad_id, supported_haptic_effects, can_gc);
+            GamepadHapticActuator::new(window, gamepad_id, supported_haptic_effects, can_gc);
         let index = if xr { -1 } else { 0 };
-        let gamepad = reflect_dom_object_with_proto(
+        let gamepad = reflect_dom_object(
             Box::new(Gamepad::new_inherited(
                 gamepad_id,
                 id,
@@ -149,8 +125,7 @@ impl Gamepad {
                 button_bounds,
                 &vibration_actuator,
             )),
-            global,
-            None,
+            window,
             can_gc,
         );
         gamepad.init_axes(can_gc);

--- a/components/script/dom/gamepadbutton.rs
+++ b/components/script/dom/gamepadbutton.rs
@@ -10,7 +10,7 @@ use crate::dom::bindings::codegen::Bindings::GamepadButtonBinding::GamepadButton
 use crate::dom::bindings::num::Finite;
 use crate::dom::bindings::reflector::{Reflector, reflect_dom_object};
 use crate::dom::bindings::root::DomRoot;
-use crate::dom::globalscope::GlobalScope;
+use crate::dom::window::Window;
 use crate::script_runtime::CanGc;
 
 #[dom_struct]
@@ -32,14 +32,14 @@ impl GamepadButton {
     }
 
     pub(crate) fn new(
-        global: &GlobalScope,
+        window: &Window,
         pressed: bool,
         touched: bool,
         can_gc: CanGc,
     ) -> DomRoot<GamepadButton> {
         reflect_dom_object(
             Box::new(GamepadButton::new_inherited(pressed, touched)),
-            global,
+            window,
             can_gc,
         )
     }

--- a/components/script/dom/gamepadbuttonlist.rs
+++ b/components/script/dom/gamepadbuttonlist.rs
@@ -8,7 +8,7 @@ use crate::dom::bindings::codegen::Bindings::GamepadButtonListBinding::GamepadBu
 use crate::dom::bindings::reflector::{Reflector, reflect_dom_object};
 use crate::dom::bindings::root::{Dom, DomRoot, DomSlice};
 use crate::dom::gamepadbutton::GamepadButton;
-use crate::dom::globalscope::GlobalScope;
+use crate::dom::window::Window;
 use crate::script_runtime::CanGc;
 
 // https://w3c.github.io/gamepad/#gamepadbutton-interface
@@ -28,13 +28,13 @@ impl GamepadButtonList {
     }
 
     pub(crate) fn new(
-        global: &GlobalScope,
+        window: &Window,
         list: &[&GamepadButton],
         can_gc: CanGc,
     ) -> DomRoot<GamepadButtonList> {
         reflect_dom_object(
             Box::new(GamepadButtonList::new_inherited(list)),
-            global,
+            window,
             can_gc,
         )
     }
@@ -62,27 +62,27 @@ impl GamepadButtonListMethods<crate::DomTypeHolder> for GamepadButtonList {
 impl GamepadButtonList {
     /// Initialize the number of buttons in the "standard" gamepad mapping.
     /// <https://www.w3.org/TR/gamepad/#dfn-initializing-buttons>
-    pub(crate) fn init_buttons(global: &GlobalScope, can_gc: CanGc) -> DomRoot<GamepadButtonList> {
+    pub(crate) fn init_buttons(window: &Window, can_gc: CanGc) -> DomRoot<GamepadButtonList> {
         let standard_buttons = &[
-            GamepadButton::new(global, false, false, can_gc), // Bottom button in right cluster
-            GamepadButton::new(global, false, false, can_gc), // Right button in right cluster
-            GamepadButton::new(global, false, false, can_gc), // Left button in right cluster
-            GamepadButton::new(global, false, false, can_gc), // Top button in right cluster
-            GamepadButton::new(global, false, false, can_gc), // Top left front button
-            GamepadButton::new(global, false, false, can_gc), // Top right front button
-            GamepadButton::new(global, false, false, can_gc), // Bottom left front button
-            GamepadButton::new(global, false, false, can_gc), // Bottom right front button
-            GamepadButton::new(global, false, false, can_gc), // Left button in center cluster
-            GamepadButton::new(global, false, false, can_gc), // Right button in center cluster
-            GamepadButton::new(global, false, false, can_gc), // Left stick pressed button
-            GamepadButton::new(global, false, false, can_gc), // Right stick pressed button
-            GamepadButton::new(global, false, false, can_gc), // Top button in left cluster
-            GamepadButton::new(global, false, false, can_gc), // Bottom button in left cluster
-            GamepadButton::new(global, false, false, can_gc), // Left button in left cluster
-            GamepadButton::new(global, false, false, can_gc), // Right button in left cluster
-            GamepadButton::new(global, false, false, can_gc), // Center button in center cluster
+            GamepadButton::new(window, false, false, can_gc), // Bottom button in right cluster
+            GamepadButton::new(window, false, false, can_gc), // Right button in right cluster
+            GamepadButton::new(window, false, false, can_gc), // Left button in right cluster
+            GamepadButton::new(window, false, false, can_gc), // Top button in right cluster
+            GamepadButton::new(window, false, false, can_gc), // Top left front button
+            GamepadButton::new(window, false, false, can_gc), // Top right front button
+            GamepadButton::new(window, false, false, can_gc), // Bottom left front button
+            GamepadButton::new(window, false, false, can_gc), // Bottom right front button
+            GamepadButton::new(window, false, false, can_gc), // Left button in center cluster
+            GamepadButton::new(window, false, false, can_gc), // Right button in center cluster
+            GamepadButton::new(window, false, false, can_gc), // Left stick pressed button
+            GamepadButton::new(window, false, false, can_gc), // Right stick pressed button
+            GamepadButton::new(window, false, false, can_gc), // Top button in left cluster
+            GamepadButton::new(window, false, false, can_gc), // Bottom button in left cluster
+            GamepadButton::new(window, false, false, can_gc), // Left button in left cluster
+            GamepadButton::new(window, false, false, can_gc), // Right button in left cluster
+            GamepadButton::new(window, false, false, can_gc), // Center button in center cluster
         ];
         rooted_vec!(let buttons <- standard_buttons.iter().map(DomRoot::as_traced));
-        Self::new(global, buttons.r(), can_gc)
+        Self::new(window, buttons.r(), can_gc)
     }
 }

--- a/components/script/dom/gamepadhapticactuator.rs
+++ b/components/script/dom/gamepadhapticactuator.rs
@@ -18,12 +18,12 @@ use crate::dom::bindings::codegen::Bindings::GamepadHapticActuatorBinding::{
 use crate::dom::bindings::codegen::Bindings::WindowBinding::Window_Binding::WindowMethods;
 use crate::dom::bindings::error::Error;
 use crate::dom::bindings::refcounted::{Trusted, TrustedPromise};
-use crate::dom::bindings::reflector::{DomGlobal, Reflector, reflect_dom_object_with_proto};
+use crate::dom::bindings::reflector::{DomGlobal, Reflector, reflect_dom_object};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::bindings::utils::to_frozen_array;
-use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
+use crate::dom::window::Window;
 use crate::realms::InRealm;
 use crate::script_runtime::{CanGc, JSContext};
 use crate::task_source::SendableTaskSource;
@@ -98,27 +98,17 @@ impl GamepadHapticActuator {
     }
 
     pub(crate) fn new(
-        global: &GlobalScope,
+        window: &Window,
         gamepad_index: u32,
         supported_haptic_effects: GamepadSupportedHapticEffects,
         can_gc: CanGc,
     ) -> DomRoot<GamepadHapticActuator> {
-        Self::new_with_proto(global, gamepad_index, supported_haptic_effects, can_gc)
-    }
-
-    fn new_with_proto(
-        global: &GlobalScope,
-        gamepad_index: u32,
-        supported_haptic_effects: GamepadSupportedHapticEffects,
-        can_gc: CanGc,
-    ) -> DomRoot<GamepadHapticActuator> {
-        reflect_dom_object_with_proto(
+        reflect_dom_object(
             Box::new(GamepadHapticActuator::new_inherited(
                 gamepad_index,
                 supported_haptic_effects,
             )),
-            global,
-            None,
+            window,
             can_gc,
         )
     }

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -27,9 +27,7 @@ use content_security_policy::{
 use crossbeam_channel::Sender;
 use devtools_traits::{PageError, ScriptToDevtoolsControlMsg};
 use dom_struct::dom_struct;
-use embedder_traits::{
-    EmbedderMsg, GamepadEvent, GamepadSupportedHapticEffects, GamepadUpdateType,
-};
+use embedder_traits::EmbedderMsg;
 use http::HeaderMap;
 use hyper_serde::Serde;
 use ipc_channel::ipc::{self, IpcSender};
@@ -81,9 +79,7 @@ use crate::dom::bindings::codegen::Bindings::FunctionBinding::Function;
 use crate::dom::bindings::codegen::Bindings::ImageBitmapBinding::{
     ImageBitmapOptions, ImageBitmapSource,
 };
-use crate::dom::bindings::codegen::Bindings::NavigatorBinding::NavigatorMethods;
 use crate::dom::bindings::codegen::Bindings::NotificationBinding::NotificationPermissionCallback;
-use crate::dom::bindings::codegen::Bindings::PerformanceBinding::Performance_Binding::PerformanceMethods;
 use crate::dom::bindings::codegen::Bindings::PermissionStatusBinding::{
     PermissionName, PermissionState,
 };
@@ -113,8 +109,6 @@ use crate::dom::event::{Event, EventBubbles, EventCancelable, EventStatus};
 use crate::dom::eventsource::EventSource;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::file::File;
-use crate::dom::gamepad::{Gamepad, contains_user_gesture};
-use crate::dom::gamepadevent::GamepadEventType;
 use crate::dom::htmlscriptelement::{ScriptId, SourceCode};
 use crate::dom::imagebitmap::ImageBitmap;
 use crate::dom::messageevent::MessageEvent;
@@ -3176,134 +3170,6 @@ impl GlobalScope {
         } else {
             warn!("Recived error for lost GPUDevice!")
         }
-    }
-
-    pub(crate) fn handle_gamepad_event(&self, gamepad_event: GamepadEvent) {
-        match gamepad_event {
-            GamepadEvent::Connected(index, name, bounds, supported_haptic_effects) => {
-                self.handle_gamepad_connect(
-                    index.0,
-                    name,
-                    bounds.axis_bounds,
-                    bounds.button_bounds,
-                    supported_haptic_effects,
-                );
-            },
-            GamepadEvent::Disconnected(index) => {
-                self.handle_gamepad_disconnect(index.0);
-            },
-            GamepadEvent::Updated(index, update_type) => {
-                self.receive_new_gamepad_button_or_axis(index.0, update_type);
-            },
-        };
-    }
-
-    /// <https://www.w3.org/TR/gamepad/#dfn-gamepadconnected>
-    fn handle_gamepad_connect(
-        &self,
-        // As the spec actually defines how to set the gamepad index, the GilRs index
-        // is currently unused, though in practice it will almost always be the same.
-        // More infra is currently needed to track gamepads across windows.
-        _index: usize,
-        name: String,
-        axis_bounds: (f64, f64),
-        button_bounds: (f64, f64),
-        supported_haptic_effects: GamepadSupportedHapticEffects,
-    ) {
-        // TODO: 2. If document is not null and is not allowed to use the "gamepad" permission,
-        //          then abort these steps.
-        let this = Trusted::new(self);
-        self.task_manager()
-            .gamepad_task_source()
-            .queue(task!(gamepad_connected: move || {
-                let global = this.root();
-
-                if let Some(window) = global.downcast::<Window>() {
-                    let navigator = window.Navigator();
-                    let selected_index = navigator.select_gamepad_index();
-                    let gamepad = Gamepad::new(
-                        &global,
-                        selected_index,
-                        name,
-                        "standard".into(),
-                        axis_bounds,
-                        button_bounds,
-                        supported_haptic_effects,
-                        false,
-                        CanGc::note(),
-                    );
-                    navigator.set_gamepad(selected_index as usize, &gamepad, CanGc::note());
-                }
-            }));
-    }
-
-    /// <https://www.w3.org/TR/gamepad/#dfn-gamepaddisconnected>
-    pub(crate) fn handle_gamepad_disconnect(&self, index: usize) {
-        let this = Trusted::new(self);
-        self.task_manager()
-            .gamepad_task_source()
-            .queue(task!(gamepad_disconnected: move || {
-                let global = this.root();
-                if let Some(window) = global.downcast::<Window>() {
-                    let navigator = window.Navigator();
-                    if let Some(gamepad) = navigator.get_gamepad(index) {
-                        if window.Document().is_fully_active() {
-                            gamepad.update_connected(false, gamepad.exposed(), CanGc::note());
-                            navigator.remove_gamepad(index);
-                        }
-                    }
-                }
-            }));
-    }
-
-    /// <https://www.w3.org/TR/gamepad/#receiving-inputs>
-    pub(crate) fn receive_new_gamepad_button_or_axis(
-        &self,
-        index: usize,
-        update_type: GamepadUpdateType,
-    ) {
-        let this = Trusted::new(self);
-
-        // <https://w3c.github.io/gamepad/#dfn-update-gamepad-state>
-        self.task_manager().gamepad_task_source().queue(
-                task!(update_gamepad_state: move || {
-                    let global = this.root();
-                    if let Some(window) = global.downcast::<Window>() {
-                        let navigator = window.Navigator();
-                        if let Some(gamepad) = navigator.get_gamepad(index) {
-                            let current_time = global.performance().Now();
-                            gamepad.update_timestamp(*current_time);
-                            match update_type {
-                                GamepadUpdateType::Axis(index, value) => {
-                                    gamepad.map_and_normalize_axes(index, value);
-                                },
-                                GamepadUpdateType::Button(index, value) => {
-                                    gamepad.map_and_normalize_buttons(index, value);
-                                }
-                            };
-                            if !navigator.has_gamepad_gesture() && contains_user_gesture(update_type) {
-                                navigator.set_has_gamepad_gesture(true);
-                                navigator.GetGamepads()
-                                    .iter()
-                                    .filter_map(|g| g.as_ref())
-                                    .for_each(|gamepad| {
-                                        gamepad.set_exposed(true);
-                                        gamepad.update_timestamp(*current_time);
-                                        let new_gamepad = Trusted::new(&**gamepad);
-                                        if window.Document().is_fully_active() {
-                                            global.task_manager().gamepad_task_source().queue(
-                                                task!(update_gamepad_connect: move || {
-                                                    let gamepad = new_gamepad.root();
-                                                    gamepad.notify_event(GamepadEventType::Connected, CanGc::note());
-                                                })
-                                            );
-                                        }
-                                });
-                            }
-                        }
-                    }
-                })
-            );
     }
 
     pub(crate) fn current_group_label(&self) -> Option<DOMString> {

--- a/components/script/dom/webxr/xrhittestsource.rs
+++ b/components/script/dom/webxr/xrhittestsource.rs
@@ -8,7 +8,7 @@ use webxr_api::HitTestId;
 use crate::dom::bindings::codegen::Bindings::XRHitTestSourceBinding::XRHitTestSourceMethods;
 use crate::dom::bindings::reflector::{Reflector, reflect_dom_object};
 use crate::dom::bindings::root::{Dom, DomRoot};
-use crate::dom::globalscope::GlobalScope;
+use crate::dom::window::Window;
 use crate::dom::xrsession::XRSession;
 use crate::script_runtime::CanGc;
 
@@ -31,14 +31,14 @@ impl XRHitTestSource {
     }
 
     pub(crate) fn new(
-        global: &GlobalScope,
+        window: &Window,
         id: HitTestId,
         session: &XRSession,
         can_gc: CanGc,
     ) -> DomRoot<XRHitTestSource> {
         reflect_dom_object(
             Box::new(XRHitTestSource::new_inherited(id, session)),
-            global,
+            window,
             can_gc,
         )
     }

--- a/components/script/dom/webxr/xrinputsource.rs
+++ b/components/script/dom/webxr/xrinputsource.rs
@@ -17,6 +17,7 @@ use crate::dom::bindings::reflector::{DomGlobal, Reflector, reflect_dom_object};
 use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
 use crate::dom::gamepad::Gamepad;
 use crate::dom::globalscope::GlobalScope;
+use crate::dom::window::Window;
 use crate::dom::xrhand::XRHand;
 use crate::dom::xrsession::XRSession;
 use crate::dom::xrspace::XRSpace;
@@ -40,14 +41,14 @@ pub(crate) struct XRInputSource {
 
 impl XRInputSource {
     pub(crate) fn new_inherited(
-        global: &GlobalScope,
+        window: &Window,
         session: &XRSession,
         info: InputSource,
         can_gc: CanGc,
     ) -> XRInputSource {
         // <https://www.w3.org/TR/webxr-gamepads-module-1/#gamepad-differences>
         let gamepad = Gamepad::new(
-            global,
+            window,
             0,
             "".into(),
             "xr-standard".into(),
@@ -74,18 +75,18 @@ impl XRInputSource {
 
     #[allow(unsafe_code)]
     pub(crate) fn new(
-        global: &GlobalScope,
+        window: &Window,
         session: &XRSession,
         info: InputSource,
         can_gc: CanGc,
     ) -> DomRoot<XRInputSource> {
         let source = reflect_dom_object(
-            Box::new(XRInputSource::new_inherited(global, session, info, can_gc)),
-            global,
+            Box::new(XRInputSource::new_inherited(window, session, info, can_gc)),
+            window,
             can_gc,
         );
 
-        let _ac = enter_realm(global);
+        let _ac = enter_realm(window);
         let cx = GlobalScope::get_cx();
         unsafe {
             rooted!(in(*cx) let mut profiles = UndefinedValue());

--- a/components/script/dom/webxr/xrinputsourcearray.rs
+++ b/components/script/dom/webxr/xrinputsourcearray.rs
@@ -11,7 +11,7 @@ use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::{DomGlobal, Reflector, reflect_dom_object};
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::event::Event;
-use crate::dom::globalscope::GlobalScope;
+use crate::dom::window::Window;
 use crate::dom::xrinputsource::XRInputSource;
 use crate::dom::xrinputsourceschangeevent::XRInputSourcesChangeEvent;
 use crate::dom::xrsession::XRSession;
@@ -31,10 +31,10 @@ impl XRInputSourceArray {
         }
     }
 
-    pub(crate) fn new(global: &GlobalScope, can_gc: CanGc) -> DomRoot<XRInputSourceArray> {
+    pub(crate) fn new(window: &Window, can_gc: CanGc) -> DomRoot<XRInputSourceArray> {
         reflect_dom_object(
             Box::new(XRInputSourceArray::new_inherited()),
-            global,
+            window,
             can_gc,
         )
     }
@@ -60,7 +60,7 @@ impl XRInputSourceArray {
                     .any(|i| i.id() == info.id),
                 "Should never add a duplicate input id!"
             );
-            let input = XRInputSource::new(&global, session, info.clone(), can_gc);
+            let input = XRInputSource::new(window, session, info.clone(), can_gc);
             self.input_sources.borrow_mut().push(Dom::from_ref(&input));
             added.push(input);
         }
@@ -121,7 +121,7 @@ impl XRInputSourceArray {
             &[]
         };
         self.input_sources.borrow_mut().retain(|i| i.id() != id);
-        let input = XRInputSource::new(&global, session, info, can_gc);
+        let input = XRInputSource::new(window, session, info, can_gc);
         self.input_sources.borrow_mut().push(Dom::from_ref(&input));
 
         let added = [input];

--- a/components/script/dom/webxr/xrrenderstate.rs
+++ b/components/script/dom/webxr/xrrenderstate.rs
@@ -14,7 +14,7 @@ use crate::dom::bindings::num::Finite;
 use crate::dom::bindings::reflector::{DomGlobal, Reflector, reflect_dom_object};
 use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
 use crate::dom::bindings::utils::to_frozen_array;
-use crate::dom::globalscope::GlobalScope;
+use crate::dom::window::Window;
 use crate::dom::xrlayer::XRLayer;
 use crate::dom::xrwebgllayer::XRWebGLLayer;
 use crate::script_runtime::{CanGc, JSContext};
@@ -49,7 +49,7 @@ impl XRRenderState {
     }
 
     pub(crate) fn new(
-        global: &GlobalScope,
+        window: &Window,
         depth_near: f64,
         depth_far: f64,
         inline_vertical_fov: Option<f64>,
@@ -65,14 +65,14 @@ impl XRRenderState {
                 layer,
                 layers,
             )),
-            global,
+            window,
             can_gc,
         )
     }
 
     pub(crate) fn clone_object(&self) -> DomRoot<Self> {
         XRRenderState::new(
-            &self.global(),
+            self.global().as_window(),
             self.depth_near.get(),
             self.depth_far.get(),
             self.inline_vertical_fov.get(),

--- a/components/script/dom/webxr/xrsession.rs
+++ b/components/script/dom/webxr/xrsession.rs
@@ -54,8 +54,8 @@ use crate::dom::bindings::root::{Dom, DomRoot, MutDom, MutNullableDom};
 use crate::dom::bindings::utils::to_frozen_array;
 use crate::dom::event::Event;
 use crate::dom::eventtarget::EventTarget;
-use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
+use crate::dom::window::Window;
 use crate::dom::xrboundedreferencespace::XRBoundedReferenceSpace;
 use crate::dom::xrframe::XRFrame;
 use crate::dom::xrhittestsource::XRHitTestSource;
@@ -152,7 +152,7 @@ impl XRSession {
     }
 
     pub(crate) fn new(
-        global: &GlobalScope,
+        window: &Window,
         session: Session,
         mode: XRSessionMode,
         frame_receiver: IpcReceiver<Frame>,
@@ -163,8 +163,8 @@ impl XRSession {
         } else {
             None
         };
-        let render_state = XRRenderState::new(global, 0.1, 1000.0, ivfov, None, Vec::new(), can_gc);
-        let input_sources = XRInputSourceArray::new(global, can_gc);
+        let render_state = XRRenderState::new(window, 0.1, 1000.0, ivfov, None, Vec::new(), can_gc);
+        let input_sources = XRInputSourceArray::new(window, can_gc);
         let ret = reflect_dom_object(
             Box::new(XRSession::new_inherited(
                 session,
@@ -172,7 +172,7 @@ impl XRSession {
                 &input_sources,
                 mode,
             )),
-            global,
+            window,
             can_gc,
         );
         ret.attach_event_handler();
@@ -587,7 +587,7 @@ impl XRSession {
             FrameUpdateEvent::HitTestSourceAdded(id) => {
                 if let Some(promise) = self.pending_hit_test_promises.borrow_mut().remove(&id) {
                     promise.resolve_native(
-                        &XRHitTestSource::new(&self.global(), id, self, can_gc),
+                        &XRHitTestSource::new(self.global().as_window(), id, self, can_gc),
                         can_gc,
                     );
                 } else {

--- a/components/script/dom/webxr/xrsystem.rs
+++ b/components/script/dom/webxr/xrsystem.rs
@@ -297,7 +297,13 @@ impl XRSystem {
                 return;
             },
         };
-        let session = XRSession::new(&self.global(), session, mode, frame_receiver, CanGc::note());
+        let session = XRSession::new(
+            self.global().as_window(),
+            session,
+            mode,
+            frame_receiver,
+            CanGc::note(),
+        );
         if mode == XRSessionMode::Inline {
             self.active_inline_sessions
                 .borrow_mut()

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1126,7 +1126,7 @@ impl ScriptThread {
                     document.dispatch_ime_event(ime_event, can_gc);
                 },
                 InputEvent::Gamepad(gamepad_event) => {
-                    window.as_global_scope().handle_gamepad_event(gamepad_event);
+                    window.handle_gamepad_event(gamepad_event);
                 },
                 InputEvent::EditingAction(editing_action_event) => {
                     document.handle_editing_action(editing_action_event, can_gc);


### PR DESCRIPTION
The only code that calls these methods is in the script thread, and the code is simpler when we can assume a Window global. Pulling this thread led to cleaning up a lot of constructors for Window-only WebXR code, too.

Testing: Existing WPT coverage.