### PR TITLE
script: Unconditionally send exit message during pipeline shutdown

### DIFF
--- a/components/servo/tests/webview.rs
+++ b/components/servo/tests/webview.rs
@@ -44,6 +44,18 @@ fn test_create_webview(servo_test: &ServoTest) -> Result<(), anyhow::Error> {
     Ok(())
 }
 
+fn test_create_webview_and_immediately_drop_webview_before_shutdown(
+    servo_test: &ServoTest,
+) -> Result<(), anyhow::Error> {
+    WebViewBuilder::new(servo_test.servo()).build();
+    Ok(())
+}
+
 fn main() {
-    run_api_tests!(test_create_webview);
+    run_api_tests!(
+        test_create_webview,
+        // This test needs to be last, as it tests creating and dropping
+        // a WebView right before shutdown.
+        test_create_webview_and_immediately_drop_webview_before_shutdown
+    );
 }


### PR DESCRIPTION
If a `WebView` is dropped immediately after creating it, the exit
pipeline message can arrive to the `ScriptThread` before the `Document`
is created for the pipeline. If this happens, we should still send a
message to the `Constellation` informing it that the pipeline is closed,
otherwise it will never know that this has happened properly.

Testing: This change includes a new unit test.
Fixes: #36807.
