### PR TITLE
Append to existing CSP list in Document::set_csp_list

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -4293,7 +4293,14 @@ impl Document {
     }
 
     pub(crate) fn set_csp_list(&self, csp_list: Option<CspList>) {
-        self.policy_container.borrow_mut().set_csp_list(csp_list);
+        if let Some(new_list) = csp_list {
+            let mut current = self.get_csp_list();
+            match current {
+                Some(ref mut existing) => existing.append(new_list),
+                None => current = Some(new_list),
+            }
+            self.policy_container.borrow_mut().set_csp_list(current);
+        }
     }
 
     pub(crate) fn get_csp_list(&self) -> Option<CspList> {

--- a/components/script/dom/htmlheadelement.rs
+++ b/components/script/dom/htmlheadelement.rs
@@ -2,19 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use content_security_policy::{CspList, PolicyDisposition, PolicySource};
 use dom_struct::dom_struct;
-use html5ever::{LocalName, Prefix, local_name, ns};
+use html5ever::{LocalName, Prefix};
 use js::rust::HandleObject;
 
-use crate::dom::bindings::codegen::Bindings::DocumentBinding::DocumentMethods;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::document::Document;
-use crate::dom::element::Element;
 use crate::dom::htmlelement::HTMLElement;
-use crate::dom::htmlmetaelement::HTMLMetaElement;
-use crate::dom::node::{BindContext, Node, NodeTraits, ShadowIncluding};
+use crate::dom::node::{BindContext, Node};
 use crate::dom::userscripts::load_script;
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::script_runtime::CanGc;
@@ -52,48 +48,6 @@ impl HTMLHeadElement {
 
         n.upcast::<Node>().set_weird_parser_insertion_mode();
         n
-    }
-
-    /// <https://html.spec.whatwg.org/multipage/#attr-meta-http-equiv-content-security-policy>
-    pub(crate) fn set_content_security_policy(&self) {
-        let doc = self.owner_document();
-
-        if doc.GetHead().as_deref() != Some(self) {
-            return;
-        }
-
-        let mut csp_list: Option<CspList> = None;
-        let node = self.upcast::<Node>();
-        let candidates = node
-            .traverse_preorder(ShadowIncluding::No)
-            .filter_map(DomRoot::downcast::<Element>)
-            .filter(|elem| elem.is::<HTMLMetaElement>())
-            .filter(|elem| {
-                elem.get_string_attribute(&local_name!("http-equiv"))
-                    .to_ascii_lowercase() ==
-                    *"content-security-policy"
-            })
-            .filter(|elem| {
-                elem.get_attribute(&ns!(), &local_name!("content"))
-                    .is_some()
-            });
-
-        for meta in candidates {
-            if let Some(ref content) = meta.get_attribute(&ns!(), &local_name!("content")) {
-                let content = content.value();
-                let content_val = content.trim();
-                if !content_val.is_empty() {
-                    let policies =
-                        CspList::parse(content_val, PolicySource::Meta, PolicyDisposition::Enforce);
-                    match csp_list {
-                        Some(ref mut csp_list) => csp_list.append(policies),
-                        None => csp_list = Some(policies),
-                    }
-                }
-            }
-        }
-
-        doc.set_csp_list(csp_list);
     }
 }
 

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -821,15 +821,7 @@ impl ParserContext {
         let Some(parser) = self.parser.as_ref().map(|p| p.root()) else {
             return;
         };
-        let new_csp_list = match parser.document.get_csp_list() {
-            None => parent_csp_list.clone(),
-            Some(original_csp_list) => {
-                let mut appended_csp_list = original_csp_list.clone();
-                appended_csp_list.append(parent_csp_list.clone());
-                appended_csp_list.to_owned()
-            },
-        };
-        parser.document.set_csp_list(Some(new_csp_list));
+        parser.document.set_csp_list(Some(parent_csp_list.clone()));
     }
 }
 

--- a/tests/wpt/tests/content-security-policy/meta/meta-append-header.html
+++ b/tests/wpt/tests/content-security-policy/meta/meta-append-header.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<meta http-equiv="Content-Security-Policy" content="img-src 'none'">
+<script nonce="abc" src="/resources/testharness.js"></script>
+<script nonce="abc" src="/resources/testharnessreport.js"></script>
+
+<body>
+  <script nonce="abc">
+    promise_test(t => {
+      return new Promise((resolve, reject) => {
+        const img = document.createElement("img");
+        img.src = "/content-security-policy/support/fail.png";
+
+        img.onload = () => reject("Image loaded unexpectedly");
+        img.onerror = (e) => resolve()
+
+        document.body.appendChild(img);
+      });
+    }, "dynamic img-src is blocked by meta CSP");
+
+    promise_test(t => {
+      return new Promise((resolve, reject) => {
+        const script = document.createElement("script");
+        script.src = "../resources/ran.js";
+
+        script.onload = () => reject("Script executed unexpectedly");
+        script.onerror = () => resolve();
+
+        document.body.appendChild(script);
+      });
+    }, "script without `abc` nonce is blocked by header CSP");
+  </script>
+</body>

--- a/tests/wpt/tests/content-security-policy/meta/meta-append-header.html.headers
+++ b/tests/wpt/tests/content-security-policy/meta/meta-append-header.html.headers
@@ -1,0 +1,1 @@
+Content-Security-Policy: script-src 'nonce-abc'

--- a/tests/wpt/tests/content-security-policy/meta/meta-multiple-csp.html
+++ b/tests/wpt/tests/content-security-policy/meta/meta-multiple-csp.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<meta http-equiv="Content-Security-Policy" content="script-src 'nonce-abc'">
+<meta http-equiv="Content-Security-Policy" content="img-src 'none'">
+<script nonce="abc" src="/resources/testharness.js"></script>
+<script nonce="abc" src="/resources/testharnessreport.js"></script>
+
+<body>
+  <script nonce="abc">
+    promise_test(t => {
+      return new Promise((resolve, reject) => {
+        const img = document.createElement("img");
+        img.src = "/content-security-policy/support/fail.png";
+
+        img.onload = () => reject("Image loaded unexpectedly");
+        img.onerror = (e) => resolve()
+
+        document.body.appendChild(img);
+      });
+    }, "dynamic img-src is blocked by meta CSP");
+
+    promise_test(t => {
+      return new Promise((resolve, reject) => {
+        const script = document.createElement("script");
+        script.src = "../resources/ran.js";
+
+        script.onload = () => reject("Script executed unexpectedly");
+        script.onerror = () => resolve();
+
+        document.body.appendChild(script);
+      });
+    }, "script without `abc` nonce is blocked by meta CSP");
+  </script>
+</body>


### PR DESCRIPTION
The `Document::set_csp_list` method now appends new policies to any
existing `CspList` rather than replacing it. This ensures that CSPs
from multiple sources (e.g., HTTP headers and `<meta>` tags) are
merged as expected, following the spec.

This change avoids silently discarding header-defined policies when
a `<meta http-equiv="Content-Security-Policy">` is present in the
document.

---
<!-- PR checklist -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #36822

- [X] There are tests for these changes (if applicable)