### PR TITLE
script: add `TaskSource` argument to `route_promise`

### DIFF
--- a/components/script/dom/servointernals.rs
+++ b/components/script/dom/servointernals.rs
@@ -43,7 +43,9 @@ impl ServoInternalsMethods<crate::DomTypeHolder> for ServoInternals {
     fn ReportMemory(&self, comp: InRealm, can_gc: CanGc) -> Rc<Promise> {
         let global = &self.global();
         let promise = Promise::new_in_current_realm(comp, can_gc);
-        let sender = route_promise(&promise, self);
+        let task_source = global.task_manager().dom_manipulation_task_source();
+        let sender = route_promise(&promise, self, task_source);
+
         let script_to_constellation_chan = global.script_to_constellation_chan();
         if script_to_constellation_chan
             .send(ScriptToConstellationMessage::ReportMemory(sender))

--- a/components/script/dom/webgpu/gpu.rs
+++ b/components/script/dom/webgpu/gpu.rs
@@ -56,7 +56,9 @@ impl GPUMethods<crate::DomTypeHolder> for GPU {
     ) -> Rc<Promise> {
         let global = &self.global();
         let promise = Promise::new_in_current_realm(comp, can_gc);
-        let sender = route_promise(&promise, self);
+        let task_source = global.task_manager().dom_manipulation_task_source();
+        let sender = route_promise(&promise, self, task_source);
+
         let power_preference = match options.powerPreference {
             Some(GPUPowerPreference::Low_power) => PowerPreference::LowPower,
             Some(GPUPowerPreference::High_performance) => PowerPreference::HighPerformance,

--- a/components/script/dom/webgpu/gpuadapter.rs
+++ b/components/script/dom/webgpu/gpuadapter.rs
@@ -117,7 +117,11 @@ impl GPUAdapterMethods<crate::DomTypeHolder> for GPUAdapter {
     ) -> Rc<Promise> {
         // Step 2
         let promise = Promise::new_in_current_realm(comp, can_gc);
-        let sender = route_promise(&promise, self);
+        let sender = route_promise(
+            &promise,
+            self,
+            self.global().task_manager().dom_manipulation_task_source(),
+        );
         let mut required_features = wgpu_types::Features::empty();
         for &ext in descriptor.requiredFeatures.iter() {
             if let Some(feature) = gpu_to_wgt_feature(ext) {

--- a/components/script/dom/webgpu/gpubuffer.rs
+++ b/components/script/dom/webgpu/gpubuffer.rs
@@ -271,7 +271,11 @@ impl GPUBufferMethods<crate::DomTypeHolder> for GPUBuffer {
             },
         };
 
-        let sender = route_promise(&promise, self);
+        let sender = route_promise(
+            &promise,
+            self,
+            self.global().task_manager().dom_manipulation_task_source(),
+        );
         if let Err(e) = self.channel.0.send(WebGPURequest::BufferMapAsync {
             sender,
             buffer_id: self.buffer.0,

--- a/components/script/dom/webgpu/gpudevice.rs
+++ b/components/script/dom/webgpu/gpudevice.rs
@@ -470,7 +470,11 @@ impl GPUDeviceMethods<crate::DomTypeHolder> for GPUDevice {
         can_gc: CanGc,
     ) -> Rc<Promise> {
         let promise = Promise::new_in_current_realm(comp, can_gc);
-        let sender = route_promise(&promise, self);
+        let sender = route_promise(
+            &promise,
+            self,
+            self.global().task_manager().dom_manipulation_task_source(),
+        );
         GPUComputePipeline::create(self, descriptor, Some(sender));
         promise
     }
@@ -518,7 +522,11 @@ impl GPUDeviceMethods<crate::DomTypeHolder> for GPUDevice {
     ) -> Fallible<Rc<Promise>> {
         let (implicit_ids, desc) = self.parse_render_pipeline(descriptor)?;
         let promise = Promise::new_in_current_realm(comp, can_gc);
-        let sender = route_promise(&promise, self);
+        let sender = route_promise(
+            &promise,
+            self,
+            self.global().task_manager().dom_manipulation_task_source(),
+        );
         GPURenderPipeline::create(self, implicit_ids, desc, Some(sender))?;
         Ok(promise)
     }
@@ -549,7 +557,11 @@ impl GPUDeviceMethods<crate::DomTypeHolder> for GPUDevice {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-poperrorscope>
     fn PopErrorScope(&self, comp: InRealm, can_gc: CanGc) -> Rc<Promise> {
         let promise = Promise::new_in_current_realm(comp, can_gc);
-        let sender = route_promise(&promise, self);
+        let sender = route_promise(
+            &promise,
+            self,
+            self.global().task_manager().dom_manipulation_task_source(),
+        );
         if self
             .channel
             .0

--- a/components/script/dom/webgpu/gpuqueue.rs
+++ b/components/script/dom/webgpu/gpuqueue.rs
@@ -200,7 +200,9 @@ impl GPUQueueMethods<crate::DomTypeHolder> for GPUQueue {
     fn OnSubmittedWorkDone(&self, can_gc: CanGc) -> Rc<Promise> {
         let global = self.global();
         let promise = Promise::new(&global, can_gc);
-        let sender = route_promise(&promise, self);
+        let task_source = global.task_manager().dom_manipulation_task_source();
+        let sender = route_promise(&promise, self, task_source);
+
         if let Err(e) = self
             .channel
             .0

--- a/components/script/dom/webgpu/gpushadermodule.rs
+++ b/components/script/dom/webgpu/gpushadermodule.rs
@@ -98,7 +98,7 @@ impl GPUShaderModule {
         let sender = route_promise(
             &promise,
             &*shader_module,
-            device
+            shader_module
                 .global()
                 .task_manager()
                 .dom_manipulation_task_source(),

--- a/components/script/dom/webgpu/gpushadermodule.rs
+++ b/components/script/dom/webgpu/gpushadermodule.rs
@@ -95,7 +95,14 @@ impl GPUShaderModule {
             promise.clone(),
             can_gc,
         );
-        let sender = route_promise(&promise, &*shader_module);
+        let sender = route_promise(
+            &promise,
+            &*shader_module,
+            device
+                .global()
+                .task_manager()
+                .dom_manipulation_task_source(),
+        );
         device
             .channel()
             .0


### PR DESCRIPTION
Added task_source argument to route_promise, enabling callers to pick the correct TaskSource.

Testing: No testing required, straightforward refactor
Fixes: #36825
