### PR TITLE
Create new image cache per document

### DIFF
--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -441,6 +441,8 @@ impl Layout for LayoutThread {
                 .map(|tree| tree.conditional_size_of(ops))
                 .unwrap_or_default(),
         });
+
+        reports.push(self.image_cache.memory_report(formatted_url, ops));
     }
 
     fn set_quirks_mode(&mut self, quirks_mode: QuirksMode) {

--- a/components/shared/net/image_cache.rs
+++ b/components/shared/net/image_cache.rs
@@ -141,4 +141,10 @@ pub trait ImageCache: Sync + Send {
 
     /// Inform the image cache about a response for a pending request.
     fn notify_pending_response(&self, id: PendingImageId, action: FetchResponseMsg);
+
+    /// Create new image cache based on this one, while reusing the existing thread_pool.
+    fn create_new_image_cache(
+        &self,
+        compositor_api: CrossProcessCompositorApi,
+    ) -> Arc<dyn ImageCache>;
 }

--- a/tests/wpt/meta/content-security-policy/generic/invalid-characters-in-policy.html.ini
+++ b/tests/wpt/meta/content-security-policy/generic/invalid-characters-in-policy.html.ini
@@ -1,18 +1,12 @@
 [invalid-characters-in-policy.html]
-  [Should not load image with 'none' CSP - meta tag]
-    expected: FAIL
-
-  [Should not load image with 'none' CSP - HTTP header]
-    expected: FAIL
-
-  [Non-ASCII character in directive value should not affect other directives. - meta tag]
-    expected: FAIL
-
   [Non-ASCII character in directive value should not affect other directives. - HTTP header]
     expected: FAIL
 
-  [Non-ASCII character in directive name should not affect other directives. - meta tag]
+  [Non-ASCII character in directive name should not affect other directives. - HTTP header]
     expected: FAIL
 
-  [Non-ASCII character in directive name should not affect other directives. - HTTP header]
+  [Non-ASCII character in directive value should drop the whole directive. - meta tag]
+    expected: FAIL
+
+  [Non-ASCII quote character in directive value should drop the whole directive. - meta tag]
     expected: FAIL

--- a/tests/wpt/meta/content-security-policy/generic/only-valid-whitespaces-are-allowed.html.ini
+++ b/tests/wpt/meta/content-security-policy/generic/only-valid-whitespaces-are-allowed.html.ini
@@ -6,50 +6,5 @@
   [U+000C FF    should be properly parsed inside directive value - HTTP header]
     expected: TIMEOUT
 
-  [Should not load image with 'none' CSP - meta tag]
-    expected: FAIL
-
-  [Should not load image with 'none' CSP - HTTP header]
-    expected: FAIL
-
-  [U+0009 TAB   should be properly parsed between directive name and value - meta tag]
-    expected: FAIL
-
-  [U+0009 TAB   should be properly parsed between directive name and value - HTTP header]
-    expected: FAIL
-
-  [U+000C FF    should be properly parsed between directive name and value - meta tag]
-    expected: FAIL
-
-  [U+000A LF    should be properly parsed between directive name and value - meta tag]
-    expected: FAIL
-
-  [U+000D CR    should be properly parsed between directive name and value - meta tag]
-    expected: FAIL
-
-  [U+0020 SPACE should be properly parsed between directive name and value - meta tag]
-    expected: FAIL
-
-  [U+0020 SPACE should be properly parsed between directive name and value - HTTP header]
-    expected: FAIL
-
-  [U+0009 TAB   should be properly parsed inside directive value - meta tag]
-    expected: FAIL
-
-  [U+0009 TAB   should be properly parsed inside directive value - HTTP header]
-    expected: FAIL
-
-  [U+000C FF    should be properly parsed inside directive value - meta tag]
-    expected: FAIL
-
-  [U+000A LF    should be properly parsed inside directive value - meta tag]
-    expected: FAIL
-
-  [U+000D CR    should be properly parsed inside directive value - meta tag]
-    expected: FAIL
-
-  [U+0020 SPACE should be properly parsed inside directive value - meta tag]
-    expected: FAIL
-
-  [U+0020 SPACE should be properly parsed inside directive value - HTTP header]
+  [U+00A0 NBSP  should not be parsed inside directive value - meta tag]
     expected: FAIL

--- a/tests/wpt/meta/content-security-policy/inheritance/history-iframe.sub.html.ini
+++ b/tests/wpt/meta/content-security-policy/inheritance/history-iframe.sub.html.ini
@@ -16,9 +16,3 @@
 
   [History navigation in iframe: data URL document is navigated back from history cross-origin.]
     expected: FAIL
-
-  [History navigation in iframe: srcdoc iframe is navigated back from history same-origin.]
-    expected: FAIL
-
-  [History navigation in iframe: srcdoc iframe is navigated back from history cross-origin.]
-    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/inheritance/iframe-all-local-schemes.sub.html.ini
+++ b/tests/wpt/meta/content-security-policy/inheritance/iframe-all-local-schemes.sub.html.ini
@@ -4,3 +4,15 @@
 
   [<iframe sandbox src='blob:...'>'s inherits policy. (opaque origin sandbox)]
     expected: FAIL
+
+  [window about:blank inherits policy.]
+    expected: FAIL
+
+  [<iframe src='blob:...'>'s inherits policy.]
+    expected: FAIL
+
+  [window url='blob:...' inherits policy.]
+    expected: FAIL
+
+  [window url='javascript:...'>'s inherits policy (static <img> is blocked)]
+    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/inheritance/iframe-srcdoc-inheritance.html.ini
+++ b/tests/wpt/meta/content-security-policy/inheritance/iframe-srcdoc-inheritance.html.ini
@@ -1,4 +1,0 @@
-[iframe-srcdoc-inheritance.html]
-  expected: TIMEOUT
-  [Second image should be blocked]
-    expected: NOTRUN

--- a/tests/wpt/meta/content-security-policy/inheritance/location-reload.html.ini
+++ b/tests/wpt/meta/content-security-policy/inheritance/location-reload.html.ini
@@ -2,3 +2,6 @@
   expected: TIMEOUT
   [location.reload() of srcdoc iframe.]
     expected: TIMEOUT
+
+  [location.reload() of blob URL iframe.]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-backgrounds/background-image-shared-stylesheet.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/background-image-shared-stylesheet.html.ini
@@ -1,2 +1,0 @@
-[background-image-shared-stylesheet.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/fetch/stale-while-revalidate/stale-image.html.ini
+++ b/tests/wpt/meta/fetch/stale-while-revalidate/stale-image.html.ini
@@ -1,4 +1,3 @@
 [stale-image.html]
-  expected: TIMEOUT
   [Cache returns stale resource]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/quirks/line-height-calculation.html.ini
+++ b/tests/wpt/meta/quirks/line-height-calculation.html.ini
@@ -7,3 +7,6 @@
 
   [The line height calculation quirk, <table><tr><td id=test><img src="{png}"> <img src="{png}"><tr><td id=ref>x<tr><td id=s_ref>x</table>]
     expected: FAIL
+
+  [The line height calculation quirk, #test img { padding:1px }<div id=test><img src="{png}"></div><img id=ref src="{png}" height=3><div id=s_ref>x</div>]
+    expected: FAIL

--- a/tests/wpt/meta/quirks/table-cell-width-calculation.html.ini
+++ b/tests/wpt/meta/quirks/table-cell-width-calculation.html.ini
@@ -1,18 +1,3 @@
 [table-cell-width-calculation.html]
-  [The table cell width calculation quirk, basic]
-    expected: FAIL
-
-  [The table cell width calculation quirk, inline-block]
-    expected: FAIL
-
-  [The table cell width calculation quirk, img in span]
-    expected: FAIL
-
-  [The table cell width calculation quirk, the don't-wrap rule is only for the purpose of calculating the width of the cell]
-    expected: FAIL
-
-  [The table cell width calculation quirk, display:table-cell on span]
-    expected: FAIL
-
-  [The table cell width calculation quirk, display:table-cell on span, wbr]
+  [The table cell width calculation quirk, the quirk shouldn't apply for <video poster>]
     expected: FAIL


### PR DESCRIPTION
Rather than sharing the full image cache in a script_thread, the image cache is now unique per document. This ensures that CSP factors no longer affect whether the image is retrieved from the cache incorrectly.

To do so, the thread_pool is shared across all caches, but the store is fresh. Except for the place_holder{image,url}, which are cloned. That's because the `rippy_data` is only available in the constellation and no longer accessible at the point that we need to create the document in the script_thread.

Contrary to the description in #36505, the script_thread still has an image_cache for this reason: so it has access to the store and thread_pool to clone it.

With these changes, the two CSP tests no longer flake. Confirmed with running the following commmand:

```
./mach test-wpt tests/wpt/tests/content-security-policy/generic/ --rerun=10
```

Fixes #36505