### PR TITLE
Remove unspecified early return in MessagePort::Close

### DIFF
--- a/components/script/dom/messageport.rs
+++ b/components/script/dom/messageport.rs
@@ -338,10 +338,6 @@ impl MessagePortMethods<crate::DomTypeHolder> for MessagePort {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-messageport-close>
     fn Close(&self, can_gc: CanGc) {
-        if self.detached.get() {
-            return;
-        }
-
         // Set this's [[Detached]] internal slot value to true.
         self.detached.set(true);
 


### PR DESCRIPTION
This change removes the early return in `MessagePort::Close` that occurred when the message port was detached. The [spec](https://html.spec.whatwg.org/multipage/web-messaging.html#dom-messageport-close) doesn't prescribe this behaviour for detached ports for this operation, so the early return was unnecessary.

Testing: Runs ./mach test-wpt /webmessaging/ and ./mach test-wpt /streams/
Fixes: #36765