### PR TITLE
net: Fix unit tests requiring default resources.

### DIFF
--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -75,6 +75,7 @@ webpki-roots = { workspace = true }
 webrender_api = { workspace = true }
 
 [dev-dependencies]
+embedder_traits = { workspace = true, features = ["baked-default-resources"] }
 flate2 = "1"
 futures = { version = "0.3", features = ["compat"] }
 hyper = { workspace = true, features = ["full"] }


### PR DESCRIPTION
When all unit tests are run, the existing feature flag use from net_traits was enough to ensure the default resources are baked into the test binary. When only the unit tests for the `net` crate are run, that feature flag was not enabled in the build so the tests that require the resources fail.

Testing: Ran `./mach test-unit -p net`
Fixes: #36837
