### PR TITLE
Update meta referrer parsing

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -6666,7 +6666,7 @@ pub(crate) fn determine_policy_for_token(token: &str) -> ReferrerPolicy {
         "same-origin" => ReferrerPolicy::SameOrigin,
         "strict-origin" => ReferrerPolicy::StrictOrigin,
         "default" | "strict-origin-when-cross-origin" => ReferrerPolicy::StrictOriginWhenCrossOrigin,
-        "origin-when-cross-origin" => ReferrerPolicy::OriginWhenCrossOrigin,
+        "origin-when-cross-origin" | "origin-when-crossorigin" => ReferrerPolicy::OriginWhenCrossOrigin,
         "always" | "unsafe-url" => ReferrerPolicy::UnsafeUrl,
         _ => ReferrerPolicy::EmptyString,
     }

--- a/components/script/dom/htmlmetaelement.rs
+++ b/components/script/dom/htmlmetaelement.rs
@@ -116,7 +116,7 @@ impl HTMLMetaElement {
                     };
                     last_atom.trim()
                 },
-                a => a.trim(),
+                val => val.trim(),
             };
             if !attr_val.is_empty() {
                 doc.set_referrer_policy(determine_policy_for_token(attr_val));

--- a/components/script/dom/htmlmetaelement.rs
+++ b/components/script/dom/htmlmetaelement.rs
@@ -5,7 +5,8 @@
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Prefix, local_name, ns};
 use js::rust::HandleObject;
-use style::{attr::AttrValue, str::HTML_SPACE_CHARACTERS};
+use style::attr::AttrValue;
+use style::str::HTML_SPACE_CHARACTERS;
 
 use crate::dom::attr::Attr;
 use crate::dom::bindings::codegen::Bindings::HTMLMetaElementBinding::HTMLMetaElementMethods;

--- a/components/script/dom/htmlmetaelement.rs
+++ b/components/script/dom/htmlmetaelement.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Prefix, local_name, ns};
 use js::rust::HandleObject;
-use style::str::HTML_SPACE_CHARACTERS;
+use style::{attr::AttrValue, str::HTML_SPACE_CHARACTERS};
 
 use crate::dom::attr::Attr;
 use crate::dom::bindings::codegen::Bindings::HTMLMetaElementBinding::HTMLMetaElementMethods;
@@ -108,7 +108,15 @@ impl HTMLMetaElement {
             .get_attribute(&ns!(), &local_name!("content"));
         if let Some(attr) = content {
             let attr = attr.value();
-            let attr_val = attr.trim();
+            let attr_val = match &*attr {
+                AttrValue::TokenList(_, list) => {
+                    let Some(last_atom) = list.last() else {
+                        return;
+                    };
+                    last_atom.trim()
+                },
+                a => a.trim(),
+            };
             if !attr_val.is_empty() {
                 doc.set_referrer_policy(determine_policy_for_token(attr_val));
             }


### PR DESCRIPTION
Updates the parsing algorithm for the referrer in the meta tag.

Fixes #36833.
