### PR TITLE
Avoid borrow panic when Path2D.addPath is called with self

### DIFF
--- a/components/script/dom/path2d.rs
+++ b/components/script/dom/path2d.rs
@@ -65,8 +65,14 @@ impl Path2DMethods<crate::DomTypeHolder> for Path2D {
     /// <https://html.spec.whatwg.org/multipage/#dom-path2d-addpath>
     fn AddPath(&self, other: &Path2D) {
         // Step 7. Add all the subpaths in c to a.
-        let mut dest = self.path.borrow_mut();
-        dest.extend(other.path.borrow().iter().copied());
+        if std::ptr::eq(&self.path, &other.path) {
+            // Note: this is not part of the spec, but it is a workaround to
+            // avoids borrow conflict when path is same as other.path
+            self.path.borrow_mut().extend_from_within(..);
+        } else {
+            let mut dest = self.path.borrow_mut();
+            dest.extend(other.path.borrow().iter().copied());
+        }
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-context-2d-closepath>

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -53,6 +53,13 @@
       {}
      ]
     ],
+    "path2D_addPath-crash.html": [
+     "f913e6baf8340886c58f99609755ae061bf64f12",
+     [
+      null,
+      {}
+     ]
+    ],
     "test-wait-crash.html": [
      "2419da6af0c278a17b9ff974d4418f9e386ef3e0",
      [

--- a/tests/wpt/mozilla/tests/mozilla/path2D_addPath-crash.html
+++ b/tests/wpt/mozilla/tests/mozilla/path2D_addPath-crash.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<script>
+let path2D = new Path2D();
+path2D.addPath(path2D);
+</script>


### PR DESCRIPTION
Fixes: #36842
