### PR TITLE
Don't slice a sliced blob

### DIFF
--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -737,7 +737,7 @@ impl RangeRequestBounds {
             RangeRequestBounds::Final(pos) => {
                 if let Some(len) = len {
                     if pos.start <= len as i64 {
-                        return Ok(pos.clone());
+                        return Ok(*pos);
                     }
                 }
                 Err("Tried to process RangeRequestBounds::Final without len")

--- a/components/script/dom/blob.rs
+++ b/components/script/dom/blob.rs
@@ -7,7 +7,7 @@ use std::ptr;
 use std::rc::Rc;
 
 use base::id::{BlobId, BlobIndex};
-use constellation_traits::BlobImpl;
+use constellation_traits::{BlobData, BlobImpl};
 use dom_struct::dom_struct;
 use encoding_rs::UTF_8;
 use js::jsapi::JSObject;
@@ -33,7 +33,7 @@ use crate::dom::readablestream::ReadableStream;
 use crate::realms::{AlreadyInRealm, InRealm};
 use crate::script_runtime::CanGc;
 
-// https://w3c.github.io/FileAPI/#blob
+/// <https://w3c.github.io/FileAPI/#dfn-Blob>
 #[dom_struct]
 pub(crate) struct Blob {
     reflector_: Reflector,
@@ -198,7 +198,7 @@ impl BlobMethods<crate::DomTypeHolder> for Blob {
         self.get_stream(can_gc)
     }
 
-    // https://w3c.github.io/FileAPI/#slice-method-algo
+    /// <https://w3c.github.io/FileAPI/#slice-method-algo>
     fn Slice(
         &self,
         start: Option<i64>,
@@ -206,11 +206,24 @@ impl BlobMethods<crate::DomTypeHolder> for Blob {
         content_type: Option<DOMString>,
         can_gc: CanGc,
     ) -> DomRoot<Blob> {
-        let type_string =
-            normalize_type_string(content_type.unwrap_or(DOMString::from("")).as_ref());
-        let rel_pos = RelativePos::from_opts(start, end);
-        let blob_impl = BlobImpl::new_sliced(rel_pos, self.blob_id, type_string);
-        Blob::new(&self.global(), blob_impl, can_gc)
+        let global = self.global();
+        let type_string = normalize_type_string(&content_type.unwrap_or_default());
+
+        // If our parent is already a sliced blob then we reference the data from the grandparent instead,
+        // to keep the blob ancestry chain short.
+        let (parent, range) = match *global.get_blob_data(&self.blob_id) {
+            BlobData::Sliced(grandparent, parent_range) => {
+                let range = RelativePos {
+                    start: parent_range.start + start.unwrap_or_default(),
+                    end: end.map(|end| end + parent_range.start).or(parent_range.end),
+                };
+                (grandparent, range)
+            },
+            _ => (self.blob_id, RelativePos::from_opts(start, end)),
+        };
+
+        let blob_impl = BlobImpl::new_sliced(range, parent, type_string);
+        Blob::new(&global, blob_impl, can_gc)
     }
 
     // https://w3c.github.io/FileAPI/#text-method-algo

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -1822,7 +1822,7 @@ impl GlobalScope {
     pub(crate) fn get_blob_bytes(&self, blob_id: &BlobId) -> Result<Vec<u8>, ()> {
         let parent = {
             match *self.get_blob_data(blob_id) {
-                BlobData::Sliced(parent, rel_pos) => Some((parent, rel_pos.clone())),
+                BlobData::Sliced(parent, rel_pos) => Some((parent, rel_pos)),
                 _ => None,
             }
         };
@@ -1883,7 +1883,7 @@ impl GlobalScope {
     fn get_blob_bytes_or_file_id(&self, blob_id: &BlobId) -> BlobResult {
         let parent = {
             match *self.get_blob_data(blob_id) {
-                BlobData::Sliced(parent, rel_pos) => Some((parent, rel_pos.clone())),
+                BlobData::Sliced(parent, rel_pos) => Some((parent, rel_pos)),
                 _ => None,
             }
         };
@@ -1931,7 +1931,7 @@ impl GlobalScope {
     pub(crate) fn get_blob_size(&self, blob_id: &BlobId) -> u64 {
         let parent = {
             match *self.get_blob_data(blob_id) {
-                BlobData::Sliced(parent, rel_pos) => Some((parent, rel_pos.clone())),
+                BlobData::Sliced(parent, rel_pos) => Some((parent, rel_pos)),
                 _ => None,
             }
         };
@@ -1965,7 +1965,7 @@ impl GlobalScope {
             blob_info.has_url = true;
 
             match blob_info.blob_impl.blob_data() {
-                BlobData::Sliced(parent, rel_pos) => Some((*parent, rel_pos.clone())),
+                BlobData::Sliced(parent, rel_pos) => Some((*parent, *rel_pos)),
                 _ => None,
             }
         };
@@ -2006,12 +2006,8 @@ impl GlobalScope {
         let origin = get_blob_origin(&self.get_url());
 
         let (tx, rx) = profile_ipc::channel(self.time_profiler_chan().clone()).unwrap();
-        let msg = FileManagerThreadMsg::AddSlicedURLEntry(
-            *parent_file_id,
-            rel_pos.clone(),
-            tx,
-            origin.clone(),
-        );
+        let msg =
+            FileManagerThreadMsg::AddSlicedURLEntry(*parent_file_id, *rel_pos, tx, origin.clone());
         self.send_to_file_manager(msg);
         match rx.recv().expect("File manager thread is down.") {
             Ok(new_id) => {

--- a/components/shared/constellation/structured_data/serializable.rs
+++ b/components/shared/constellation/structured_data/serializable.rs
@@ -221,9 +221,9 @@ impl BlobImpl {
     }
 
     /// Construct a BlobImpl from a slice of a parent.
-    pub fn new_sliced(rel_pos: RelativePos, parent: BlobId, type_string: String) -> BlobImpl {
+    pub fn new_sliced(range: RelativePos, parent: BlobId, type_string: String) -> BlobImpl {
         let blob_id = BlobId::new();
-        let blob_data = BlobData::Sliced(parent, rel_pos);
+        let blob_data = BlobData::Sliced(parent, range);
         BlobImpl {
             blob_id,
             type_string,

--- a/components/shared/net/filemanager_thread.rs
+++ b/components/shared/net/filemanager_thread.rs
@@ -39,7 +39,7 @@ pub enum FileTokenCheck {
 /// Relative slice positions of a sequence,
 /// whose semantic should be consistent with (start, end) parameters in
 /// <https://w3c.github.io/FileAPI/#dfn-slice>
-#[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, MallocSizeOf, Serialize)]
 pub struct RelativePos {
     /// Relative to first byte if non-negative,
     /// relative to one past last byte if negative,

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -60,6 +60,13 @@
       {}
      ]
     ],
+    "slice-blob-twice-crash.html": [
+     "94227dcc74d80dae19b39df025708ffc24ee78c5",
+     [
+      null,
+      {}
+     ]
+    ],
     "test-wait-crash.html": [
      "2419da6af0c278a17b9ff974d4418f9e386ef3e0",
      [

--- a/tests/wpt/mozilla/tests/mozilla/slice-blob-twice-crash.html
+++ b/tests/wpt/mozilla/tests/mozilla/slice-blob-twice-crash.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<script>
+  (new Blob()).slice().slice().size;
+</script>
+


### PR DESCRIPTION
When slicing a blob that is already sliced we should reference it's parent's data instead of creating a subview into the sliced blob. This keeps the blob ancestry chain small and reduces the number of blobs that we have to resolve.

Testing: Includes a new crashtest
Fixes: https://github.com/servo/servo/issues/36843

[try run](https://github.com/simonwuelker/servo/actions/runs/14844873660)