### PR TITLE
Remove service worker pref from experimental web features.

### DIFF
--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -574,7 +574,6 @@ pub(crate) fn parse_command_line_arguments(args: Vec<String>) -> ArgumentParsing
             "dom_offscreen_canvas_enabled",
             "dom_permissions_enabled",
             "dom_resize_observer_enabled",
-            "dom_serviceworker_enabled",
             "dom_svg_enabled",
             "dom_trusted_types_enabled",
             "dom_webgl2_enabled",

--- a/tests/wpt/meta/__dir__.ini
+++ b/tests/wpt/meta/__dir__.ini
@@ -1,4 +1,5 @@
 prefs: [
+  "dom_serviceworker_enabled:true",
   "dom_testutils_enabled:true",
   "dom_urlpattern_enabled:true",
 ]

--- a/tests/wpt/mozilla/meta/__dir__.ini
+++ b/tests/wpt/mozilla/meta/__dir__.ini
@@ -1,4 +1,5 @@
 prefs: [
+  "dom_serviceworker_enabled:true",
   "dom_urlpattern_enabled:true",
   "media_testing_enabled:true",
 ]


### PR DESCRIPTION
Most sites that feature detect Service Workers in Servo immediately break when this pref is enabled, since our implementation is very incomplete. This provides a poor user experience when recommending the `--enable-experimental-web-platform-features` flag.

Testing: Existing test coverage should be unchanged.