### PR TITLE
script_bindings: Check for null pointer before dereferencing proxy handler custom data

### DIFF
--- a/components/script_bindings/conversions.rs
+++ b/components/script_bindings/conversions.rs
@@ -245,6 +245,9 @@ pub unsafe fn get_dom_class(obj: *mut JSObject) -> Result<&'static DOMClass, ()>
     if is_dom_proxy(obj) {
         trace!("proxy dom object");
         let dom_class: *const DOMClass = GetProxyHandlerExtra(obj) as *const DOMClass;
+        if dom_class.is_null() {
+            return Err(());
+        }        
         return Ok(&*dom_class);
     }
     trace!("not a dom object");

--- a/components/script_bindings/conversions.rs
+++ b/components/script_bindings/conversions.rs
@@ -247,7 +247,7 @@ pub unsafe fn get_dom_class(obj: *mut JSObject) -> Result<&'static DOMClass, ()>
         let dom_class: *const DOMClass = GetProxyHandlerExtra(obj) as *const DOMClass;
         if dom_class.is_null() {
             return Err(());
-        }        
+        }
         return Ok(&*dom_class);
     }
     trace!("not a dom object");


### PR DESCRIPTION
While the vast majority of DOM proxy objects created have a non-null pointer in the handler's extra data field, there is one place we create a proxy object that has a null pointer: https://github.com/servo/servo/blob/8b05b7449d3ceaeb6ae834246012ac04a4f048c6/components/script/window_named_properties.rs#L76 . Before #36818, dereferencing this null pointer was undefined behaviour that was silently being ignored; now that Rust 1.86 adds debug pointer validity checks, we get a panic when trying to dereference it.

Testing: Tested about:memory with rustc 1.86.