### PR TITLE
Serialize attribute nodes as the empty string

### DIFF
--- a/components/script/dom/servoparser/html.rs
+++ b/components/script/dom/servoparser/html.rs
@@ -302,11 +302,10 @@ pub(crate) fn serialize_html_fragment<S: Serializer>(
                     serializer.write_processing_instruction(pi.target(), &data)?;
                 },
 
-                NodeTypeId::DocumentFragment(_) => {},
+                NodeTypeId::DocumentFragment(_) | NodeTypeId::Attr => {},
 
                 NodeTypeId::Document(_) => panic!("Can't serialize Document node itself"),
                 NodeTypeId::Element(_) => panic!("Element shouldn't appear here"),
-                NodeTypeId::Attr => panic!("Attr shouldn't appear here"),
             },
             SerializationCommand::SerializeShadowRoot(shadow_root) => {
                 // Shadow roots are serialized as template elements with a fixed set of

--- a/tests/wpt/tests/domparsing/XMLSerializer-serializeToString.html
+++ b/tests/wpt/tests/domparsing/XMLSerializer-serializeToString.html
@@ -256,6 +256,10 @@ test(function () {
   root.setAttributeNS(XMLNS_URI, 'xmlns:foo', '');
   assert_equals(serialize(root), '<root xmlns="" xmlns:foo=""/>');
 }, 'Check if a prefix bound to an empty namespace URI ("no namespace") serialize');
+
+test(function() {
+  assert_equals(serialize(document.createAttribute("foobar")), "")
+}, 'Attribute nodes are serialized as the empty string')
 </script>
  </body>
 </html>


### PR DESCRIPTION
The existing code asserts that attribute nodes are never serialized. This is wrong, because you can pass an attribute node to `XMLSerializer::serializeToString`. Instead, the spec mandates that these are serialized as empty strings (https://w3c.github.io/DOM-Parsing/#dfn-xml-serialization-algorithm).

Testing: Includes a new web platform test
Fixes: https://github.com/servo/servo/issues/36872
