### PR TITLE
layout: Use `ServoLayoutNode` directly instead of a generic `impl`

### DIFF
--- a/components/layout/dom_traversal.rs
+++ b/components/layout/dom_traversal.rs
@@ -8,11 +8,14 @@ use std::iter::FusedIterator;
 use fonts::ByteIndex;
 use html5ever::{LocalName, local_name};
 use range::Range;
-use script_layout_interface::wrapper_traits::{ThreadSafeLayoutElement, ThreadSafeLayoutNode};
+use script::layout_dom::ServoLayoutNode;
+use script_layout_interface::wrapper_traits::{
+    LayoutNode, ThreadSafeLayoutElement, ThreadSafeLayoutNode,
+};
 use script_layout_interface::{LayoutElementType, LayoutNodeType};
 use selectors::Element as SelectorsElement;
 use servo_arc::Arc as ServoArc;
-use style::dom::{TElement, TShadowRoot};
+use style::dom::{NodeInfo, TElement, TNode, TShadowRoot};
 use style::properties::ComputedValues;
 use style::selector_parser::PseudoElement;
 use style::values::generics::counters::{Content, ContentItem};
@@ -28,15 +31,15 @@ use crate::style_ext::{Display, DisplayGeneratingBox, DisplayInside, DisplayOuts
 /// A data structure used to pass and store related layout information together to
 /// avoid having to repeat the same arguments in argument lists.
 #[derive(Clone)]
-pub(crate) struct NodeAndStyleInfo<Node> {
-    pub node: Node,
+pub(crate) struct NodeAndStyleInfo<'dom> {
+    pub node: ServoLayoutNode<'dom>,
     pub pseudo_element_type: Option<PseudoElement>,
     pub style: ServoArc<ComputedValues>,
 }
 
-impl<'dom, Node: NodeExt<'dom>> NodeAndStyleInfo<Node> {
+impl<'dom> NodeAndStyleInfo<'dom> {
     fn new_with_pseudo(
-        node: Node,
+        node: ServoLayoutNode<'dom>,
         pseudo_element_type: PseudoElement,
         style: ServoArc<ComputedValues>,
     ) -> Self {
@@ -47,7 +50,7 @@ impl<'dom, Node: NodeExt<'dom>> NodeAndStyleInfo<Node> {
         }
     }
 
-    pub(crate) fn new(node: Node, style: ServoArc<ComputedValues>) -> Self {
+    pub(crate) fn new(node: ServoLayoutNode<'dom>, style: ServoArc<ComputedValues>) -> Self {
         Self {
             node,
             pseudo_element_type: None,
@@ -86,11 +89,8 @@ impl<'dom, Node: NodeExt<'dom>> NodeAndStyleInfo<Node> {
     }
 }
 
-impl<'dom, Node> From<&NodeAndStyleInfo<Node>> for BaseFragmentInfo
-where
-    Node: NodeExt<'dom>,
-{
-    fn from(info: &NodeAndStyleInfo<Node>) -> Self {
+impl<'dom> From<&NodeAndStyleInfo<'dom>> for BaseFragmentInfo {
+    fn from(info: &NodeAndStyleInfo<'dom>) -> Self {
         let node = info.node;
         let pseudo = info.pseudo_element_type;
         let threadsafe_node = node.to_threadsafe();
@@ -174,29 +174,24 @@ pub(super) enum PseudoElementContentItem {
     Replaced(ReplacedContents),
 }
 
-pub(super) trait TraversalHandler<'dom, Node>
-where
-    Node: 'dom,
-{
-    fn handle_text(&mut self, info: &NodeAndStyleInfo<Node>, text: Cow<'dom, str>);
+pub(super) trait TraversalHandler<'dom> {
+    fn handle_text(&mut self, info: &NodeAndStyleInfo<'dom>, text: Cow<'dom, str>);
 
     /// Or pseudo-element
     fn handle_element(
         &mut self,
-        info: &NodeAndStyleInfo<Node>,
+        info: &NodeAndStyleInfo<'dom>,
         display: DisplayGeneratingBox,
         contents: Contents,
         box_slot: BoxSlot<'dom>,
     );
 }
 
-fn traverse_children_of<'dom, Node>(
-    parent_element: Node,
+fn traverse_children_of<'dom>(
+    parent_element: ServoLayoutNode<'dom>,
     context: &LayoutContext,
-    handler: &mut impl TraversalHandler<'dom, Node>,
-) where
-    Node: NodeExt<'dom>,
-{
+    handler: &mut impl TraversalHandler<'dom>,
+) {
     traverse_eager_pseudo_element(PseudoElement::Before, parent_element, context, handler);
 
     let is_text_input_element = matches!(
@@ -240,13 +235,11 @@ fn traverse_children_of<'dom, Node>(
     traverse_eager_pseudo_element(PseudoElement::After, parent_element, context, handler);
 }
 
-fn traverse_element<'dom, Node>(
-    element: Node,
+fn traverse_element<'dom>(
+    element: ServoLayoutNode<'dom>,
     context: &LayoutContext,
-    handler: &mut impl TraversalHandler<'dom, Node>,
-) where
-    Node: NodeExt<'dom>,
-{
+    handler: &mut impl TraversalHandler<'dom>,
+) {
     // Clear any existing pseudo-element box slot, because markers are not handled like
     // `::before`` and `::after`. They are processed during box tree creation.
     element.unset_pseudo_element_box(PseudoElement::Marker);
@@ -286,14 +279,12 @@ fn traverse_element<'dom, Node>(
     }
 }
 
-fn traverse_eager_pseudo_element<'dom, Node>(
+fn traverse_eager_pseudo_element<'dom>(
     pseudo_element_type: PseudoElement,
-    node: Node,
+    node: ServoLayoutNode<'dom>,
     context: &LayoutContext,
-    handler: &mut impl TraversalHandler<'dom, Node>,
-) where
-    Node: NodeExt<'dom>,
-{
+    handler: &mut impl TraversalHandler<'dom>,
+) {
     assert!(pseudo_element_type.is_eager());
 
     // First clear any old contents from the node.
@@ -329,14 +320,12 @@ fn traverse_eager_pseudo_element<'dom, Node>(
     }
 }
 
-fn traverse_pseudo_element_contents<'dom, Node>(
-    info: &NodeAndStyleInfo<Node>,
+fn traverse_pseudo_element_contents<'dom>(
+    info: &NodeAndStyleInfo<'dom>,
     context: &LayoutContext,
-    handler: &mut impl TraversalHandler<'dom, Node>,
+    handler: &mut impl TraversalHandler<'dom>,
     items: Vec<PseudoElementContentItem>,
-) where
-    Node: NodeExt<'dom>,
-{
+) {
     let mut anonymous_info = None;
     for item in items {
         match item {
@@ -396,14 +385,12 @@ impl std::convert::TryFrom<Contents> for NonReplacedContents {
 }
 
 impl NonReplacedContents {
-    pub(crate) fn traverse<'dom, Node>(
+    pub(crate) fn traverse<'dom>(
         self,
         context: &LayoutContext,
-        info: &NodeAndStyleInfo<Node>,
-        handler: &mut impl TraversalHandler<'dom, Node>,
-    ) where
-        Node: NodeExt<'dom>,
-    {
+        info: &NodeAndStyleInfo<'dom>,
+        handler: &mut impl TraversalHandler<'dom>,
+    ) {
         match self {
             NonReplacedContents::OfElement | NonReplacedContents::OfTextControl => {
                 traverse_children_of(info.node, context, handler)
@@ -427,14 +414,11 @@ where
 }
 
 /// <https://www.w3.org/TR/CSS2/generate.html#propdef-content>
-fn generate_pseudo_element_content<'dom, Node>(
+fn generate_pseudo_element_content(
     pseudo_element_style: &ComputedValues,
-    element: Node,
+    element: ServoLayoutNode<'_>,
     context: &LayoutContext,
-) -> Vec<PseudoElementContentItem>
-where
-    Node: NodeExt<'dom>,
-{
+) -> Vec<PseudoElementContentItem> {
     match &pseudo_element_style.get_counters().content {
         Content::Items(items) => {
             let mut vec = vec![];
@@ -517,18 +501,14 @@ where
     }
 }
 
-pub enum ChildNodeIterator<Node> {
+pub enum ChildNodeIterator<'dom> {
     /// Iterating over the children of a node
-    Node(Option<Node>),
+    Node(Option<ServoLayoutNode<'dom>>),
     /// Iterating over the assigned nodes of a `HTMLSlotElement`
-    Slottables(<Vec<Node> as IntoIterator>::IntoIter),
+    Slottables(<Vec<ServoLayoutNode<'dom>> as IntoIterator>::IntoIter),
 }
 
-#[allow(clippy::unnecessary_to_owned)] // Clippy is wrong.
-pub(crate) fn iter_child_nodes<'dom, Node>(parent: Node) -> ChildNodeIterator<Node>
-where
-    Node: NodeExt<'dom>,
-{
+pub(crate) fn iter_child_nodes(parent: ServoLayoutNode<'_>) -> ChildNodeIterator<'_> {
     if let Some(element) = parent.as_element() {
         if let Some(shadow) = element.shadow_root() {
             return iter_child_nodes(shadow.as_node());
@@ -536,6 +516,7 @@ where
 
         let slotted_nodes = element.slotted_nodes();
         if !slotted_nodes.is_empty() {
+            #[allow(clippy::unnecessary_to_owned)] // Clippy is wrong.
             return ChildNodeIterator::Slottables(slotted_nodes.to_owned().into_iter());
         }
     }
@@ -544,11 +525,8 @@ where
     ChildNodeIterator::Node(first)
 }
 
-impl<'dom, Node> Iterator for ChildNodeIterator<Node>
-where
-    Node: NodeExt<'dom>,
-{
-    type Item = Node;
+impl<'dom> Iterator for ChildNodeIterator<'dom> {
+    type Item = ServoLayoutNode<'dom>;
 
     fn next(&mut self) -> Option<Self::Item> {
         match self {
@@ -562,4 +540,4 @@ where
     }
 }
 
-impl<'dom, Node> FusedIterator for ChildNodeIterator<Node> where Node: NodeExt<'dom> {}
+impl FusedIterator for ChildNodeIterator<'_> {}

--- a/components/layout/flexbox/mod.rs
+++ b/components/layout/flexbox/mod.rs
@@ -17,7 +17,7 @@ use crate::PropagatedBoxTreeData;
 use crate::cell::ArcRefCell;
 use crate::construct_modern::{ModernContainerBuilder, ModernItemKind};
 use crate::context::LayoutContext;
-use crate::dom::{LayoutBox, NodeExt};
+use crate::dom::LayoutBox;
 use crate::dom_traversal::{NodeAndStyleInfo, NonReplacedContents};
 use crate::formatting_contexts::IndependentFormattingContext;
 use crate::fragment_tree::{BaseFragmentInfo, Fragment};
@@ -98,9 +98,9 @@ pub(crate) struct FlexContainer {
 }
 
 impl FlexContainer {
-    pub fn construct<'dom>(
+    pub fn construct(
         context: &LayoutContext,
-        info: &NodeAndStyleInfo<impl NodeExt<'dom>>,
+        info: &NodeAndStyleInfo<'_>,
         contents: NonReplacedContents,
         propagated_data: PropagatedBoxTreeData,
     ) -> Self {

--- a/components/layout/flow/float.rs
+++ b/components/layout/flow/float.rs
@@ -22,7 +22,6 @@ use style::properties::ComputedValues;
 use style::values::computed::Clear as StyleClear;
 
 use crate::context::LayoutContext;
-use crate::dom::NodeExt;
 use crate::dom_traversal::{Contents, NodeAndStyleInfo};
 use crate::formatting_contexts::IndependentFormattingContext;
 use crate::fragment_tree::{BoxFragment, CollapsedMargin};
@@ -885,9 +884,9 @@ impl FloatBandLink {
 
 impl FloatBox {
     /// Creates a new float box.
-    pub fn construct<'dom>(
+    pub fn construct(
         context: &LayoutContext,
-        info: &NodeAndStyleInfo<impl NodeExt<'dom>>,
+        info: &NodeAndStyleInfo<'_>,
         display_inside: DisplayInside,
         contents: Contents,
         propagated_data: PropagatedBoxTreeData,

--- a/components/layout/flow/inline/construct.rs
+++ b/components/layout/flow/inline/construct.rs
@@ -17,7 +17,6 @@ use super::{InlineBox, InlineBoxIdentifier, InlineBoxes, InlineFormattingContext
 use crate::PropagatedBoxTreeData;
 use crate::cell::ArcRefCell;
 use crate::context::LayoutContext;
-use crate::dom::NodeExt;
 use crate::dom_traversal::NodeAndStyleInfo;
 use crate::flow::float::FloatBox;
 use crate::formatting_contexts::IndependentFormattingContext;
@@ -225,11 +224,7 @@ impl InlineFormattingContextBuilder {
         (identifier, block_in_inline_splits)
     }
 
-    pub(crate) fn push_text<'dom, Node: NodeExt<'dom>>(
-        &mut self,
-        text: Cow<'dom, str>,
-        info: &NodeAndStyleInfo<Node>,
-    ) {
+    pub(crate) fn push_text<'dom>(&mut self, text: Cow<'dom, str>, info: &NodeAndStyleInfo<'dom>) {
         let white_space_collapse = info.style.clone_white_space_collapse();
         let collapsed = WhitespaceCollapse::new(
             text.chars(),

--- a/components/layout/flow/inline/inline_box.rs
+++ b/components/layout/flow/inline/inline_box.rs
@@ -12,7 +12,6 @@ use super::{InlineContainerState, InlineContainerStateFlags, inline_container_ne
 use crate::ContainingBlock;
 use crate::cell::ArcRefCell;
 use crate::context::LayoutContext;
-use crate::dom::NodeExt;
 use crate::dom_traversal::NodeAndStyleInfo;
 use crate::fragment_tree::BaseFragmentInfo;
 use crate::layout_box_base::LayoutBoxBase;
@@ -35,7 +34,7 @@ pub(crate) struct InlineBox {
 }
 
 impl InlineBox {
-    pub(crate) fn new<'dom, Node: NodeExt<'dom>>(info: &NodeAndStyleInfo<Node>) -> Self {
+    pub(crate) fn new(info: &NodeAndStyleInfo) -> Self {
         Self {
             base: LayoutBoxBase::new(info.into(), info.style.clone()),
             // This will be assigned later, when the box is actually added to the IFC.

--- a/components/layout/formatting_contexts.rs
+++ b/components/layout/formatting_contexts.rs
@@ -4,12 +4,12 @@
 
 use app_units::Au;
 use malloc_size_of_derive::MallocSizeOf;
+use script::layout_dom::ServoLayoutElement;
 use servo_arc::Arc;
 use style::properties::ComputedValues;
 use style::selector_parser::PseudoElement;
 
 use crate::context::LayoutContext;
-use crate::dom::NodeExt;
 use crate::dom_traversal::{Contents, NodeAndStyleInfo};
 use crate::flexbox::FlexContainer;
 use crate::flow::BlockFormattingContext;
@@ -69,9 +69,9 @@ impl Baselines {
 }
 
 impl IndependentFormattingContext {
-    pub fn construct<'dom, Node: NodeExt<'dom>>(
+    pub fn construct(
         context: &LayoutContext,
-        node_and_style_info: &NodeAndStyleInfo<Node>,
+        node_and_style_info: &NodeAndStyleInfo,
         display_inside: DisplayInside,
         contents: Contents,
         propagated_data: PropagatedBoxTreeData,
@@ -111,11 +111,11 @@ impl IndependentFormattingContext {
                         let table_grid_style = context
                             .shared_context()
                             .stylist
-                            .style_for_anonymous::<Node::ConcreteElement>(
-                            &context.shared_context().guards,
-                            &PseudoElement::ServoTableGrid,
-                            &node_and_style_info.style,
-                        );
+                            .style_for_anonymous::<ServoLayoutElement>(
+                                &context.shared_context().guards,
+                                &PseudoElement::ServoTableGrid,
+                                &node_and_style_info.style,
+                            );
                         base_fragment_info.flags.insert(FragmentFlags::DO_NOT_PAINT);
                         IndependentNonReplacedContents::Table(Table::construct(
                             context,

--- a/components/layout/lists.rs
+++ b/components/layout/lists.rs
@@ -7,18 +7,14 @@ use style::properties::style_structs;
 use style::values::computed::Image;
 
 use crate::context::LayoutContext;
-use crate::dom::NodeExt;
 use crate::dom_traversal::{NodeAndStyleInfo, PseudoElementContentItem};
 use crate::replaced::ReplacedContents;
 
 /// <https://drafts.csswg.org/css-lists/#content-property>
-pub(crate) fn make_marker<'dom, Node>(
+pub(crate) fn make_marker<'dom>(
     context: &LayoutContext,
-    info: &NodeAndStyleInfo<Node>,
-) -> Option<(NodeAndStyleInfo<Node>, Vec<PseudoElementContentItem>)>
-where
-    Node: NodeExt<'dom>,
-{
+    info: &NodeAndStyleInfo<'dom>,
+) -> Option<(NodeAndStyleInfo<'dom>, Vec<PseudoElementContentItem>)> {
     let marker_info = info.pseudo(context, style::selector_parser::PseudoElement::Marker)?;
     let style = &marker_info.style;
     let list_style = style.get_list();

--- a/components/layout/positioned.rs
+++ b/components/layout/positioned.rs
@@ -16,7 +16,6 @@ use style::values::specified::align::AlignFlags;
 
 use crate::cell::ArcRefCell;
 use crate::context::LayoutContext;
-use crate::dom::NodeExt;
 use crate::dom_traversal::{Contents, NodeAndStyleInfo};
 use crate::formatting_contexts::{
     IndependentFormattingContext, IndependentFormattingContextContents,
@@ -57,9 +56,9 @@ impl AbsolutelyPositionedBox {
         Self { context }
     }
 
-    pub fn construct<'dom>(
+    pub fn construct(
         context: &LayoutContext,
-        node_info: &NodeAndStyleInfo<impl NodeExt<'dom>>,
+        node_info: &NodeAndStyleInfo,
         display_inside: DisplayInside,
         contents: Contents,
     ) -> Self {

--- a/components/layout/replaced.rs
+++ b/components/layout/replaced.rs
@@ -13,10 +13,12 @@ use euclid::{Scale, Size2D};
 use malloc_size_of_derive::MallocSizeOf;
 use net_traits::image_cache::{ImageOrMetadataAvailable, UsePlaceholder};
 use pixels::Image;
+use script::layout_dom::ServoLayoutNode;
 use script_layout_interface::IFrameSize;
 use servo_arc::Arc as ServoArc;
 use style::Zero;
 use style::computed_values::object_fit::T as ObjectFit;
+use style::dom::TNode;
 use style::logical_geometry::{Direction, WritingMode};
 use style::properties::ComputedValues;
 use style::servo::url::ComputedUrl;
@@ -120,7 +122,7 @@ pub(crate) enum ReplacedContentKind {
 }
 
 impl ReplacedContents {
-    pub fn for_element<'dom>(element: impl NodeExt<'dom>, context: &LayoutContext) -> Option<Self> {
+    pub fn for_element(element: ServoLayoutNode<'_>, context: &LayoutContext) -> Option<Self> {
         if let Some(ref data_attribute_string) = element.as_typeless_object_with_data_attribute() {
             if let Some(url) = try_to_parse_image_data_url(data_attribute_string) {
                 return Self::from_image_url(
@@ -184,8 +186,8 @@ impl ReplacedContents {
         })
     }
 
-    pub fn from_image_url<'dom>(
-        element: impl NodeExt<'dom>,
+    pub fn from_image_url(
+        element: ServoLayoutNode<'_>,
         context: &LayoutContext,
         image_url: &ComputedUrl,
     ) -> Option<Self> {
@@ -213,8 +215,8 @@ impl ReplacedContents {
         None
     }
 
-    pub fn from_image<'dom>(
-        element: impl NodeExt<'dom>,
+    pub fn from_image(
+        element: ServoLayoutNode<'_>,
         context: &LayoutContext,
         image: &ComputedImage,
     ) -> Option<Self> {

--- a/components/layout/taffy/mod.rs
+++ b/components/layout/taffy/mod.rs
@@ -15,7 +15,7 @@ use crate::PropagatedBoxTreeData;
 use crate::cell::ArcRefCell;
 use crate::construct_modern::{ModernContainerBuilder, ModernItemKind};
 use crate::context::LayoutContext;
-use crate::dom::{LayoutBox, NodeExt};
+use crate::dom::LayoutBox;
 use crate::dom_traversal::{NodeAndStyleInfo, NonReplacedContents};
 use crate::formatting_contexts::IndependentFormattingContext;
 use crate::fragment_tree::Fragment;
@@ -29,9 +29,9 @@ pub(crate) struct TaffyContainer {
 }
 
 impl TaffyContainer {
-    pub fn construct<'dom>(
+    pub fn construct(
         context: &LayoutContext,
-        info: &NodeAndStyleInfo<impl NodeExt<'dom>>,
+        info: &NodeAndStyleInfo,
         contents: NonReplacedContents,
         propagated_data: PropagatedBoxTreeData,
     ) -> Self {


### PR DESCRIPTION
This makes it so that layout is no longer generic on the node type,
depending directly on `script`'s `ServoLayoutNode`. In addition to
greatly simplifying layout, this is necessary because incremental layout
needs to be able to create pseudo-element styles without having a handle
on the original `impl LayoutNode`. We feel this is a reasonable
tradeoff.

Testing: No functional changes, so covered by existing WPT tests.
