### PR TITLE
Added a new workflow that benchmarks simple startup and loading of servo.org on HarmonyOS.

### DIFF
--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -36,6 +36,7 @@ env:
   RUST_BACKTRACE: 1
   SHELL: /bin/bash
   CARGO_INCREMENTAL: 0
+  BENCHER_PROJECT: ${{ vars.BENCHER_PROJECT || 'servo' }}
 
 jobs:
   build:
@@ -238,3 +239,10 @@ jobs:
           [[ $servo_pid =~ ^[0-9]+$ ]] || { echo "It looks like servo crashed!" ; exit 1; }
           # If the grep fails, then the trace output for the "page loaded" prompt is missing
           grep 'org\.servo\.servo-.* tracing_mark_write.*PageLoadEndedPrompt' test_output/servo.ftrace
+      - name: "Run benchmark"
+        run: hitrace-bench --bencher -b "org.servo.servo" -p "https://www.servo.org" -n 5
+      - name: Getting bencher
+        uses: bencherdev/bencher@main
+      - name: Uploading to bencher.dev
+        run: |
+          bencher run --adapter json --file bench.json --project '${{ env.BENCHER_PROJECT }}' --token '${{ secrets.BENCHER_API_TOKEN }}' --github-actions '${{ secrets.GITHUB_TOKEN }}'

--- a/ports/servoshell/egl/ohos.rs
+++ b/ports/servoshell/egl/ohos.rs
@@ -217,6 +217,8 @@ static SERVO_CHANNEL: OnceLock<Sender<ServoAction>> = OnceLock::new();
 #[unsafe(no_mangle)]
 extern "C" fn on_surface_created_cb(xcomponent: *mut OH_NativeXComponent, window: *mut c_void) {
     info!("on_surface_created_cb");
+    #[cfg(feature = "tracing-hitrace")]
+    let _ = hitrace::ScopedTrace::start_trace(&c"on_surface_created_cb");
 
     let xc_wrapper = XComponentWrapper(xcomponent);
     let window_wrapper = WindowWrapper(window);
@@ -812,6 +814,12 @@ impl HostTrait for HostCallbacks {
             #[cfg(feature = "tracing-hitrace")]
             let _scope = hitrace::ScopedTrace::start_trace(&c"PageLoadEndedPrompt");
             self.show_alert("Page finished loading!".to_string());
+        } else {
+            #[cfg(feature = "tracing-hitrace")]
+            let _ = hitrace::ScopedTrace::start_trace_str(&format!(
+                "load status changed {:?}",
+                load_status
+            ));
         }
     }
 


### PR DESCRIPTION
Added a new workflow that benchmarks simple startup and loading of servo.org on HarmonyOS.
Needs https://github.com/servo/ci-runners/pull/34 to be merged and applied to the runners.
