### PR TITLE
Fix double borrow panic in Node.childNodes

### DIFF
--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -3110,11 +3110,15 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
 
     /// <https://dom.spec.whatwg.org/#dom-node-childnodes>
     fn ChildNodes(&self, can_gc: CanGc) -> DomRoot<NodeList> {
-        self.ensure_rare_data().child_list.or_init(|| {
-            let doc = self.owner_doc();
-            let window = doc.window();
-            NodeList::new_child_list(window, self, can_gc)
-        })
+        if let Some(list) = self.ensure_rare_data().child_list.get() {
+            return list;
+        }
+
+        let doc = self.owner_doc();
+        let window = doc.window();
+        let list = NodeList::new_child_list(window, self, can_gc);
+        self.ensure_rare_data().child_list.set(Some(&list));
+        list
     }
 
     /// <https://dom.spec.whatwg.org/#dom-node-firstchild>


### PR DESCRIPTION
`ensure_rare_data` returns a RefMut that extends the borrow of Node.rare_data. This can lead to a panic in any method that triggers a GC while this borrow is outstanding, such as Node.childNodes.

Testing: Manual testing on the testcase from the issue. It is impossible to create a deterministic WPT crash test that is fast enough and can be counted upon to continue working in the future.
Fixes: #36868
