### PR TITLE
layout: Store shared styles for table backgrounds in `SharedBackgroundStyle`

### DIFF
--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -1020,7 +1020,7 @@ impl<'a> BuilderForBoxFragment<'a> {
             for extra_background in extra_backgrounds {
                 let positioning_area = extra_background.rect;
                 let painter = BackgroundPainter {
-                    style: &extra_background.style,
+                    style: &extra_background.style.borrow_mut().0,
                     painting_area_override: None,
                     positioning_area_override: Some(
                         positioning_area

--- a/components/layout/fragment_tree/box_fragment.rs
+++ b/components/layout/fragment_tree/box_fragment.rs
@@ -17,6 +17,7 @@ use style::properties::ComputedValues;
 use style::values::specified::box_::DisplayOutside;
 
 use super::{BaseFragment, BaseFragmentInfo, CollapsedBlockMargins, Fragment};
+use crate::ArcRefCell;
 use crate::display_list::ToWebRender;
 use crate::formatting_contexts::Baselines;
 use crate::geom::{
@@ -40,10 +41,14 @@ pub(crate) enum BackgroundMode {
     Normal,
 }
 
+#[derive(Debug, MallocSizeOf)]
+pub(crate) struct BackgroundStyle(#[conditional_malloc_size_of] pub ServoArc<ComputedValues>);
+
+pub(crate) type SharedBackgroundStyle = ArcRefCell<BackgroundStyle>;
+
 #[derive(MallocSizeOf)]
 pub(crate) struct ExtraBackground {
-    #[conditional_malloc_size_of]
-    pub style: ServoArc<ComputedValues>,
+    pub style: SharedBackgroundStyle,
     pub rect: PhysicalRect<Au>,
 }
 

--- a/components/layout/table/construct.rs
+++ b/components/layout/table/construct.rs
@@ -29,7 +29,7 @@ use crate::formatting_contexts::{
     IndependentFormattingContext, IndependentFormattingContextContents,
     IndependentNonReplacedContents,
 };
-use crate::fragment_tree::BaseFragmentInfo;
+use crate::fragment_tree::{BackgroundStyle, BaseFragmentInfo, SharedBackgroundStyle};
 use crate::layout_box_base::LayoutBoxBase;
 use crate::style_ext::{DisplayGeneratingBox, DisplayLayoutInternal};
 
@@ -722,9 +722,10 @@ impl<'style, 'dom> TableBuilderTraversal<'style, 'dom> {
 
         let style = anonymous_info.style.clone();
         self.push_table_row(ArcRefCell::new(TableTrack {
-            base: LayoutBoxBase::new((&anonymous_info).into(), style),
+            base: LayoutBoxBase::new((&anonymous_info).into(), style.clone()),
             group_index: self.current_row_group_index,
             is_anonymous: true,
+            shared_background_style: SharedBackgroundStyle::new(BackgroundStyle(style)),
         }));
     }
 
@@ -766,6 +767,9 @@ impl<'dom> TraversalHandler<'dom> for TableBuilderTraversal<'_, 'dom> {
                         base: LayoutBoxBase::new(info.into(), info.style.clone()),
                         group_type: internal.into(),
                         track_range: next_row_index..next_row_index,
+                        shared_background_style: SharedBackgroundStyle::new(BackgroundStyle(
+                            info.style.clone(),
+                        )),
                     });
                     self.builder.table.row_groups.push(row_group.clone());
 
@@ -808,6 +812,9 @@ impl<'dom> TraversalHandler<'dom> for TableBuilderTraversal<'_, 'dom> {
                         base: LayoutBoxBase::new(info.into(), info.style.clone()),
                         group_index: self.current_row_group_index,
                         is_anonymous: false,
+                        shared_background_style: SharedBackgroundStyle::new(BackgroundStyle(
+                            info.style.clone(),
+                        )),
                     });
                     self.push_table_row(row.clone());
                     box_slot.set(LayoutBox::TableLevelBox(TableLevelBox::Track(row)));
@@ -853,6 +860,9 @@ impl<'dom> TraversalHandler<'dom> for TableBuilderTraversal<'_, 'dom> {
                         base: LayoutBoxBase::new(info.into(), info.style.clone()),
                         group_type: internal.into(),
                         track_range: first_column..self.builder.table.columns.len(),
+                        shared_background_style: SharedBackgroundStyle::new(BackgroundStyle(
+                            info.style.clone(),
+                        )),
                     });
                     self.builder.table.column_groups.push(column_group.clone());
                     box_slot.set(LayoutBox::TableLevelBox(TableLevelBox::TrackGroup(
@@ -1135,6 +1145,9 @@ fn add_column(
         base: LayoutBoxBase::new(column_info.into(), column_info.style.clone()),
         group_index,
         is_anonymous,
+        shared_background_style: SharedBackgroundStyle::new(BackgroundStyle(
+            column_info.style.clone(),
+        )),
     });
     collection.extend(repeat(column.clone()).take(span as usize));
     column

--- a/components/layout/table/layout.rs
+++ b/components/layout/table/layout.rs
@@ -2063,7 +2063,7 @@ impl<'a> TableLayout<'a> {
             let column_group = column_group.borrow();
             let rect = make_relative_to_row_start(dimensions.get_column_group_rect(&column_group));
             fragment.add_extra_background(ExtraBackground {
-                style: column_group.base.style.clone(),
+                style: column_group.shared_background_style.clone(),
                 rect,
             })
         }
@@ -2072,7 +2072,7 @@ impl<'a> TableLayout<'a> {
             if !column.is_anonymous {
                 let rect = make_relative_to_row_start(dimensions.get_column_rect(column_index));
                 fragment.add_extra_background(ExtraBackground {
-                    style: column.base.style.clone(),
+                    style: column.shared_background_style.clone(),
                     rect,
                 })
             }
@@ -2085,7 +2085,7 @@ impl<'a> TableLayout<'a> {
             let rect =
                 make_relative_to_row_start(dimensions.get_row_group_rect(&row_group.borrow()));
             fragment.add_extra_background(ExtraBackground {
-                style: row_group.borrow().base.style.clone(),
+                style: row_group.borrow().shared_background_style.clone(),
                 rect,
             })
         }
@@ -2093,7 +2093,7 @@ impl<'a> TableLayout<'a> {
             let row = row.borrow();
             let rect = make_relative_to_row_start(row_fragment_layout.rect);
             fragment.add_extra_background(ExtraBackground {
-                style: row.base.style.clone(),
+                style: row.shared_background_style.clone(),
                 rect,
             })
         }

--- a/components/layout/table/mod.rs
+++ b/components/layout/table/mod.rs
@@ -85,7 +85,7 @@ use super::flow::BlockFormattingContext;
 use crate::cell::ArcRefCell;
 use crate::flow::BlockContainer;
 use crate::formatting_contexts::IndependentFormattingContext;
-use crate::fragment_tree::{BaseFragmentInfo, Fragment};
+use crate::fragment_tree::{BaseFragmentInfo, Fragment, SharedBackgroundStyle};
 use crate::geom::PhysicalVec;
 use crate::layout_box_base::LayoutBoxBase;
 use crate::style_ext::BorderStyleColor;
@@ -288,6 +288,11 @@ pub struct TableTrack {
     /// Whether or not this [`TableTrack`] was anonymous, for instance created due to
     /// a `span` attribute set on a parent `<colgroup>`.
     is_anonymous: bool,
+
+    /// A shared container for this track's style, used to share the style for the purposes
+    /// of drawing backgrounds in individual cells. This allows updating the style in a
+    /// single place and having it affect all cell `Fragment`s.
+    shared_background_style: SharedBackgroundStyle,
 }
 
 #[derive(Debug, MallocSizeOf, PartialEq)]
@@ -308,6 +313,11 @@ pub struct TableTrackGroup {
 
     /// The range of tracks in this [`TableTrackGroup`].
     track_range: Range<usize>,
+
+    /// A shared container for this track's style, used to share the style for the purposes
+    /// of drawing backgrounds in individual cells. This allows updating the style in a
+    /// single place and having it affect all cell `Fragment`s.
+    shared_background_style: SharedBackgroundStyle,
 }
 
 impl TableTrackGroup {


### PR DESCRIPTION
Table cells share background styles with their track and track group
boxes. When a track and track group style is repaired, this new data
structure will allow reparing the style of the cell `Fragment`s without
having to lay the table out again or walk through `Fragment`s and
individually repair their background styles.

Testing: This doesn't change behavior and is thus tested by existing
WPT tests.
