### PR TITLE
pixels: Actually write pixels in `MULTIPLY` `generic_transform_inplace` operations

### DIFF
--- a/components/pixels/lib.rs
+++ b/components/pixels/lib.rs
@@ -294,9 +294,10 @@ pub fn generic_transform_inplace<
         match MULTIPLY {
             1 => {
                 let a = rgba[3];
-                multiply_u8_color(rgba[0], a);
-                multiply_u8_color(rgba[1], a);
-                multiply_u8_color(rgba[2], a);
+
+                rgba[0] = multiply_u8_color(rgba[0], a);
+                rgba[1] = multiply_u8_color(rgba[1], a);
+                rgba[2] = multiply_u8_color(rgba[2], a);
             },
             2 => {
                 let a = rgba[3] as u32;

--- a/tests/wpt/webgl/meta/conformance/context/premultiplyalpha-test.html.ini
+++ b/tests/wpt/webgl/meta/conformance/context/premultiplyalpha-test.html.ini
@@ -1,8 +1,0 @@
-[premultiplyalpha-test.html]
-  bug: https://github.com/servo/servo/issues/21132
-
-  [WebGL test #62]
-    expected: FAIL
-
-  [WebGL test #69]
-    expected: FAIL


### PR DESCRIPTION
Multiply operations applied in `generic_transform_inplace` were
calculating the new pixel values, but not actually writing them.
This changes fixes that issue.

Testing: /webgl/tests/conformance/context/premultiplyalpha-test.html
Fixes: #35759
