### PR TITLE
layout: Share styles to inline box children via `SharedInlineStyles`

### DIFF
--- a/components/layout/construct_modern.rs
+++ b/components/layout/construct_modern.rs
@@ -142,7 +142,7 @@ impl<'a, 'dom> ModernContainerBuilder<'a, 'dom> {
             .filter_map(|job| match job {
                 ModernContainerJob::TextRuns(runs) => {
                     let mut inline_formatting_context_builder =
-                        InlineFormattingContextBuilder::new();
+                        InlineFormattingContextBuilder::new(self.info);
                     for flex_text_run in runs.into_iter() {
                         inline_formatting_context_builder
                             .push_text(flex_text_run.text, &flex_text_run.info);

--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -14,6 +14,7 @@ use euclid::{Point2D, SideOffsets2D, Size2D, UnknownUnit};
 use fonts::GlyphStore;
 use gradient::WebRenderGradient;
 use range::Range as ServoRange;
+use servo_arc::Arc as ServoArc;
 use servo_geometry::MaxRect;
 use style::Zero;
 use style::color::{AbsoluteColor, ColorSpace};
@@ -544,7 +545,13 @@ impl Fragment {
             },
             Fragment::Text(text) => {
                 let text = &*text.borrow();
-                match text.parent_style.get_inherited_box().visibility {
+                match text
+                    .inline_styles
+                    .style
+                    .borrow()
+                    .get_inherited_box()
+                    .visibility
+                {
                     Visibility::Visible => {
                         self.build_display_list_for_text_fragment(text, builder, containing_block)
                     },
@@ -604,22 +611,23 @@ impl Fragment {
             return;
         }
 
+        let parent_style = fragment.inline_styles.style.borrow();
         self.maybe_push_hit_test_for_style_and_tag(
             builder,
-            &fragment.parent_style,
+            &parent_style,
             fragment.base.tag,
             rect,
             Cursor::Text,
         );
 
-        let color = fragment.parent_style.clone_color();
+        let color = parent_style.clone_color();
         let font_metrics = &fragment.font_metrics;
         let dppx = builder.context.style_context.device_pixel_ratio().get();
-        let common = builder.common_properties(rect.to_webrender(), &fragment.parent_style);
+        let common = builder.common_properties(rect.to_webrender(), &parent_style);
 
         // Shadows. According to CSS-BACKGROUNDS, text shadows render in *reverse* order (front to
         // back).
-        let shadows = &fragment.parent_style.get_inherited_text().text_shadow;
+        let shadows = &parent_style.get_inherited_text().text_shadow;
         for shadow in shadows.0.iter().rev() {
             builder.wr().push_shadow(
                 &wr::SpaceAndClipInfo {
@@ -642,7 +650,7 @@ impl Fragment {
             let mut rect = rect;
             rect.origin.y += font_metrics.ascent - font_metrics.underline_offset;
             rect.size.height = Au::from_f32_px(font_metrics.underline_size.to_nearest_pixel(dppx));
-            self.build_display_list_for_text_decoration(fragment, builder, &rect, &color);
+            self.build_display_list_for_text_decoration(&parent_style, builder, &rect, &color);
         }
 
         if fragment
@@ -651,7 +659,7 @@ impl Fragment {
         {
             let mut rect = rect;
             rect.size.height = Au::from_f32_px(font_metrics.underline_size.to_nearest_pixel(dppx));
-            self.build_display_list_for_text_decoration(fragment, builder, &rect, &color);
+            self.build_display_list_for_text_decoration(&parent_style, builder, &rect, &color);
         }
 
         // TODO: This caret/text selection implementation currently does not account for vertical text
@@ -678,12 +686,13 @@ impl Fragment {
                     Point2D::new(end.x.to_f32_px(), containing_block.max_y().to_f32_px()),
                 );
                 if let Some(selection_color) = fragment
-                    .selected_style
+                    .inline_styles
+                    .selected
+                    .borrow()
                     .clone_background_color()
                     .as_absolute()
                 {
-                    let selection_common =
-                        builder.common_properties(selection_rect, &fragment.parent_style);
+                    let selection_common = builder.common_properties(selection_rect, &parent_style);
                     builder.wr().push_rect(
                         &selection_common,
                         selection_rect,
@@ -709,7 +718,7 @@ impl Fragment {
                     ),
                 );
                 let insertion_point_common =
-                    builder.common_properties(insertion_point_rect, &fragment.parent_style);
+                    builder.common_properties(insertion_point_rect, &parent_style);
                 // TODO: The color of the caret is currently hardcoded to the text color.
                 // We should be retrieving the caret color from the style properly.
                 builder
@@ -734,7 +743,7 @@ impl Fragment {
             let mut rect = rect;
             rect.origin.y += font_metrics.ascent - font_metrics.strikeout_offset;
             rect.size.height = Au::from_f32_px(font_metrics.strikeout_size.to_nearest_pixel(dppx));
-            self.build_display_list_for_text_decoration(fragment, builder, &rect, &color);
+            self.build_display_list_for_text_decoration(&parent_style, builder, &rect, &color);
         }
 
         if !shadows.0.is_empty() {
@@ -744,23 +753,22 @@ impl Fragment {
 
     fn build_display_list_for_text_decoration(
         &self,
-        fragment: &TextFragment,
+        parent_style: &ServoArc<ComputedValues>,
         builder: &mut DisplayListBuilder,
         rect: &PhysicalRect<Au>,
         color: &AbsoluteColor,
     ) {
         let rect = rect.to_webrender();
         let wavy_line_thickness = (0.33 * rect.size().height).ceil();
-        let text_decoration_color = fragment
-            .parent_style
+        let text_decoration_color = parent_style
             .clone_text_decoration_color()
             .resolve_to_absolute(color);
-        let text_decoration_style = fragment.parent_style.clone_text_decoration_style();
+        let text_decoration_style = parent_style.clone_text_decoration_style();
         if text_decoration_style == ComputedTextDecorationStyle::MozNone {
             return;
         }
         builder.display_list.wr.push_line(
-            &builder.common_properties(rect, &fragment.parent_style),
+            &builder.common_properties(rect, parent_style),
             &rect,
             wavy_line_thickness,
             wr::LineOrientation::Horizontal,
@@ -1026,7 +1034,7 @@ impl<'a> BuilderForBoxFragment<'a> {
             for extra_background in extra_backgrounds {
                 let positioning_area = extra_background.rect;
                 let painter = BackgroundPainter {
-                    style: &extra_background.style.borrow_mut().0,
+                    style: &extra_background.style.borrow_mut(),
                     painting_area_override: None,
                     positioning_area_override: Some(
                         positioning_area

--- a/components/layout/dom.rs
+++ b/components/layout/dom.rs
@@ -26,7 +26,7 @@ use crate::cell::ArcRefCell;
 use crate::context::LayoutContext;
 use crate::flexbox::FlexLevelBox;
 use crate::flow::BlockLevelBox;
-use crate::flow::inline::InlineItem;
+use crate::flow::inline::{InlineItem, SharedInlineStyles};
 use crate::fragment_tree::Fragment;
 use crate::geom::PhysicalSize;
 use crate::replaced::CanvasInfo;
@@ -59,7 +59,7 @@ impl InnerDOMLayoutData {
 /// A box that is stored in one of the `DOMLayoutData` slots.
 #[derive(MallocSizeOf)]
 pub(super) enum LayoutBox {
-    DisplayContents,
+    DisplayContents(SharedInlineStyles),
     BlockLevel(ArcRefCell<BlockLevelBox>),
     InlineLevel(Vec<ArcRefCell<InlineItem>>),
     FlexLevel(ArcRefCell<FlexLevelBox>),
@@ -70,7 +70,7 @@ pub(super) enum LayoutBox {
 impl LayoutBox {
     fn invalidate_cached_fragment(&self) {
         match self {
-            LayoutBox::DisplayContents => {},
+            LayoutBox::DisplayContents(..) => {},
             LayoutBox::BlockLevel(block_level_box) => {
                 block_level_box.borrow().invalidate_cached_fragment()
             },
@@ -91,7 +91,7 @@ impl LayoutBox {
 
     pub(crate) fn fragments(&self) -> Vec<Fragment> {
         match self {
-            LayoutBox::DisplayContents => vec![],
+            LayoutBox::DisplayContents(..) => vec![],
             LayoutBox::BlockLevel(block_level_box) => block_level_box.borrow().fragments(),
             LayoutBox::InlineLevel(inline_items) => inline_items
                 .iter()

--- a/components/layout/flexbox/mod.rs
+++ b/components/layout/flexbox/mod.rs
@@ -90,7 +90,6 @@ impl FlexContainerConfig {
 pub(crate) struct FlexContainer {
     children: Vec<ArcRefCell<FlexLevelBox>>,
 
-    #[conditional_malloc_size_of]
     style: ServoArc<ComputedValues>,
 
     /// The configuration of this [`FlexContainer`].

--- a/components/layout/flow/mod.rs
+++ b/components/layout/flow/mod.rs
@@ -249,7 +249,6 @@ pub(crate) struct CollapsibleWithParentStartMargin(bool);
 /// for a list that has `list-style-position: outside`.
 #[derive(Debug, MallocSizeOf)]
 pub(crate) struct OutsideMarker {
-    #[conditional_malloc_size_of]
     pub list_item_style: Arc<ComputedValues>,
     pub base: LayoutBoxBase,
     pub block_container: BlockContainer,

--- a/components/layout/flow/root.rs
+++ b/components/layout/flow/root.rs
@@ -174,7 +174,7 @@ impl BoxTree {
 
             let update_point =
                 match &*AtomicRef::filter_map(layout_data.self_box.borrow(), Option::as_ref)? {
-                    LayoutBox::DisplayContents => return None,
+                    LayoutBox::DisplayContents(..) => return None,
                     LayoutBox::BlockLevel(block_level_box) => match &*block_level_box.borrow() {
                         BlockLevelBox::OutOfFlowAbsolutelyPositionedBox(_)
                             if box_style.position.is_absolutely_positioned() =>

--- a/components/layout/fragment_tree/box_fragment.rs
+++ b/components/layout/fragment_tree/box_fragment.rs
@@ -17,7 +17,7 @@ use style::properties::ComputedValues;
 use style::values::specified::box_::DisplayOutside;
 
 use super::{BaseFragment, BaseFragmentInfo, CollapsedBlockMargins, Fragment, FragmentFlags};
-use crate::ArcRefCell;
+use crate::SharedStyle;
 use crate::display_list::ToWebRender;
 use crate::formatting_contexts::Baselines;
 use crate::geom::{
@@ -40,15 +40,9 @@ pub(crate) enum BackgroundMode {
     /// Draw the background normally, getting information from the Fragment style.
     Normal,
 }
-
-#[derive(Debug, MallocSizeOf)]
-pub(crate) struct BackgroundStyle(#[conditional_malloc_size_of] pub ServoArc<ComputedValues>);
-
-pub(crate) type SharedBackgroundStyle = ArcRefCell<BackgroundStyle>;
-
 #[derive(MallocSizeOf)]
 pub(crate) struct ExtraBackground {
-    pub style: SharedBackgroundStyle,
+    pub style: SharedStyle,
     pub rect: PhysicalRect<Au>,
 }
 
@@ -64,7 +58,6 @@ pub(crate) enum SpecificLayoutInfo {
 pub(crate) struct BoxFragment {
     pub base: BaseFragment,
 
-    #[conditional_malloc_size_of]
     pub style: ServoArc<ComputedValues>,
     pub children: Vec<Fragment>,
 

--- a/components/layout/fragment_tree/fragment.rs
+++ b/components/layout/fragment_tree/fragment.rs
@@ -22,6 +22,7 @@ use super::{
     Tag,
 };
 use crate::cell::ArcRefCell;
+use crate::flow::inline::SharedInlineStyles;
 use crate::geom::{LogicalSides, PhysicalPoint, PhysicalRect};
 use crate::style_ext::ComputedValuesExt;
 
@@ -64,8 +65,7 @@ pub(crate) struct CollapsedMargin {
 #[derive(MallocSizeOf)]
 pub(crate) struct TextFragment {
     pub base: BaseFragment,
-    #[conditional_malloc_size_of]
-    pub parent_style: ServoArc<ComputedValues>,
+    pub inline_styles: SharedInlineStyles,
     pub rect: PhysicalRect<Au>,
     pub font_metrics: FontMetrics,
     pub font_key: FontInstanceKey,
@@ -78,14 +78,11 @@ pub(crate) struct TextFragment {
     /// Extra space to add for each justification opportunity.
     pub justification_adjustment: Au,
     pub selection_range: Option<ServoRange<ByteIndex>>,
-    #[conditional_malloc_size_of]
-    pub selected_style: ServoArc<ComputedValues>,
 }
 
 #[derive(MallocSizeOf)]
 pub(crate) struct ImageFragment {
     pub base: BaseFragment,
-    #[conditional_malloc_size_of]
     pub style: ServoArc<ComputedValues>,
     pub rect: PhysicalRect<Au>,
     pub clip: PhysicalRect<Au>,
@@ -97,7 +94,6 @@ pub(crate) struct IFrameFragment {
     pub base: BaseFragment,
     pub pipeline_id: PipelineId,
     pub rect: PhysicalRect<Au>,
-    #[conditional_malloc_size_of]
     pub style: ServoArc<ComputedValues>,
 }
 

--- a/components/layout/fragment_tree/positioning_fragment.rs
+++ b/components/layout/fragment_tree/positioning_fragment.rs
@@ -25,7 +25,6 @@ pub(crate) struct PositioningFragment {
     pub scrollable_overflow: PhysicalRect<Au>,
 
     /// If this fragment was created with a style, the style of the fragment.
-    #[conditional_malloc_size_of]
     pub style: Option<ServoArc<ComputedValues>>,
 
     /// This [`PositioningFragment`]'s containing block rectangle in coordinates relative to

--- a/components/layout/layout_box_base.rs
+++ b/components/layout/layout_box_base.rs
@@ -27,7 +27,6 @@ use crate::{ConstraintSpace, ContainingBlockSize};
 #[derive(MallocSizeOf)]
 pub(crate) struct LayoutBoxBase {
     pub base_fragment_info: BaseFragmentInfo,
-    #[conditional_malloc_size_of]
     pub style: Arc<ComputedValues>,
     pub cached_inline_content_size:
         AtomicRefCell<Option<Box<(SizeConstraint, InlineContentSizesResult)>>>,

--- a/components/layout/lib.rs
+++ b/components/layout/lib.rs
@@ -38,12 +38,23 @@ pub use flow::BoxTree;
 pub use fragment_tree::FragmentTree;
 pub use layout_impl::LayoutFactoryImpl;
 use malloc_size_of_derive::MallocSizeOf;
+use servo_arc::Arc as ServoArc;
 use style::logical_geometry::WritingMode;
 use style::properties::ComputedValues;
 use style::values::computed::TextDecorationLine;
 
 use crate::geom::{LogicalVec2, SizeConstraint};
 use crate::style_ext::AspectRatio;
+
+/// At times, a style is "owned" by more than one layout object. For example, text
+/// fragments need a handle on their parent inline box's style. In order to make
+/// incremental layout easier to implement, another layer of shared ownership is added via
+/// [`SharedStyle`]. This allows updating the style in originating layout object and
+/// having all "depdendent" objects update automatically.
+///
+///  Note that this is not a cost-free data structure, so should only be
+/// used when necessary.
+pub(crate) type SharedStyle = ArcRefCell<ServoArc<ComputedValues>>;
 
 /// Represents the set of constraints that we use when computing the min-content
 /// and max-content inline sizes of an element.

--- a/components/layout/table/construct.rs
+++ b/components/layout/table/construct.rs
@@ -19,7 +19,6 @@ use super::{
     Table, TableCaption, TableLevelBox, TableSlot, TableSlotCell, TableSlotCoordinates,
     TableSlotOffset, TableTrack, TableTrackGroup, TableTrackGroupType,
 };
-use crate::PropagatedBoxTreeData;
 use crate::cell::ArcRefCell;
 use crate::context::LayoutContext;
 use crate::dom::{BoxSlot, LayoutBox};
@@ -29,9 +28,10 @@ use crate::formatting_contexts::{
     IndependentFormattingContext, IndependentFormattingContextContents,
     IndependentNonReplacedContents,
 };
-use crate::fragment_tree::{BackgroundStyle, BaseFragmentInfo, SharedBackgroundStyle};
+use crate::fragment_tree::BaseFragmentInfo;
 use crate::layout_box_base::LayoutBoxBase;
 use crate::style_ext::{DisplayGeneratingBox, DisplayLayoutInternal};
+use crate::{PropagatedBoxTreeData, SharedStyle};
 
 /// A reference to a slot and its coordinates in the table
 #[derive(Debug)]
@@ -725,7 +725,7 @@ impl<'style, 'dom> TableBuilderTraversal<'style, 'dom> {
             base: LayoutBoxBase::new((&anonymous_info).into(), style.clone()),
             group_index: self.current_row_group_index,
             is_anonymous: true,
-            shared_background_style: SharedBackgroundStyle::new(BackgroundStyle(style)),
+            shared_background_style: SharedStyle::new(style),
         }));
     }
 
@@ -767,9 +767,7 @@ impl<'dom> TraversalHandler<'dom> for TableBuilderTraversal<'_, 'dom> {
                         base: LayoutBoxBase::new(info.into(), info.style.clone()),
                         group_type: internal.into(),
                         track_range: next_row_index..next_row_index,
-                        shared_background_style: SharedBackgroundStyle::new(BackgroundStyle(
-                            info.style.clone(),
-                        )),
+                        shared_background_style: SharedStyle::new(info.style.clone()),
                     });
                     self.builder.table.row_groups.push(row_group.clone());
 
@@ -812,9 +810,7 @@ impl<'dom> TraversalHandler<'dom> for TableBuilderTraversal<'_, 'dom> {
                         base: LayoutBoxBase::new(info.into(), info.style.clone()),
                         group_index: self.current_row_group_index,
                         is_anonymous: false,
-                        shared_background_style: SharedBackgroundStyle::new(BackgroundStyle(
-                            info.style.clone(),
-                        )),
+                        shared_background_style: SharedStyle::new(info.style.clone()),
                     });
                     self.push_table_row(row.clone());
                     box_slot.set(LayoutBox::TableLevelBox(TableLevelBox::Track(row)));
@@ -860,9 +856,7 @@ impl<'dom> TraversalHandler<'dom> for TableBuilderTraversal<'_, 'dom> {
                         base: LayoutBoxBase::new(info.into(), info.style.clone()),
                         group_type: internal.into(),
                         track_range: first_column..self.builder.table.columns.len(),
-                        shared_background_style: SharedBackgroundStyle::new(BackgroundStyle(
-                            info.style.clone(),
-                        )),
+                        shared_background_style: SharedStyle::new(info.style.clone()),
                     });
                     self.builder.table.column_groups.push(column_group.clone());
                     box_slot.set(LayoutBox::TableLevelBox(TableLevelBox::TrackGroup(
@@ -1145,9 +1139,7 @@ fn add_column(
         base: LayoutBoxBase::new(column_info.into(), column_info.style.clone()),
         group_index,
         is_anonymous,
-        shared_background_style: SharedBackgroundStyle::new(BackgroundStyle(
-            column_info.style.clone(),
-        )),
+        shared_background_style: SharedStyle::new(column_info.style.clone()),
     });
     collection.extend(repeat(column.clone()).take(span as usize));
     column

--- a/components/layout/table/mod.rs
+++ b/components/layout/table/mod.rs
@@ -82,10 +82,11 @@ use style::properties::style_structs::Font;
 use style_traits::dom::OpaqueNode;
 
 use super::flow::BlockFormattingContext;
+use crate::SharedStyle;
 use crate::cell::ArcRefCell;
 use crate::flow::BlockContainer;
 use crate::formatting_contexts::IndependentFormattingContext;
-use crate::fragment_tree::{BaseFragmentInfo, Fragment, SharedBackgroundStyle};
+use crate::fragment_tree::{BaseFragmentInfo, Fragment};
 use crate::geom::PhysicalVec;
 use crate::layout_box_base::LayoutBoxBase;
 use crate::style_ext::BorderStyleColor;
@@ -98,12 +99,10 @@ pub struct Table {
     /// The style of this table. These are the properties that apply to the "wrapper" ie the element
     /// that contains both the grid and the captions. Not all properties are actually used on the
     /// wrapper though, such as background and borders, which apply to the grid.
-    #[conditional_malloc_size_of]
     style: Arc<ComputedValues>,
 
     /// The style of this table's grid. This is an anonymous style based on the table's style, but
     /// eliminating all the properties handled by the "wrapper."
-    #[conditional_malloc_size_of]
     grid_style: Arc<ComputedValues>,
 
     /// The [`BaseFragmentInfo`] for this table's grid. This is necessary so that when the
@@ -292,7 +291,7 @@ pub struct TableTrack {
     /// A shared container for this track's style, used to share the style for the purposes
     /// of drawing backgrounds in individual cells. This allows updating the style in a
     /// single place and having it affect all cell `Fragment`s.
-    shared_background_style: SharedBackgroundStyle,
+    shared_background_style: SharedStyle,
 }
 
 #[derive(Debug, MallocSizeOf, PartialEq)]
@@ -317,7 +316,7 @@ pub struct TableTrackGroup {
     /// A shared container for this track's style, used to share the style for the purposes
     /// of drawing backgrounds in individual cells. This allows updating the style in a
     /// single place and having it affect all cell `Fragment`s.
-    shared_background_style: SharedBackgroundStyle,
+    shared_background_style: SharedStyle,
 }
 
 impl TableTrackGroup {

--- a/components/layout/taffy/mod.rs
+++ b/components/layout/taffy/mod.rs
@@ -24,7 +24,6 @@ use crate::positioned::{AbsolutelyPositionedBox, PositioningContext};
 #[derive(Debug, MallocSizeOf)]
 pub(crate) struct TaffyContainer {
     children: Vec<ArcRefCell<TaffyItemBox>>,
-    #[conditional_malloc_size_of]
     style: Arc<ComputedValues>,
 }
 
@@ -76,7 +75,6 @@ pub(crate) struct TaffyItemBox {
     pub(crate) taffy_layout: taffy::Layout,
     pub(crate) child_fragments: Vec<Fragment>,
     pub(crate) positioning_context: PositioningContext,
-    #[conditional_malloc_size_of]
     pub(crate) style: Arc<ComputedValues>,
     pub(crate) taffy_level_box: TaffyItemBoxInner,
 }

--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -53,6 +53,7 @@ use std::ops::Range;
 use std::rc::Rc;
 use std::sync::Arc;
 
+use style::properties::ComputedValues;
 use style::values::generics::length::GenericLengthPercentageOrAuto;
 pub use stylo_malloc_size_of::MallocSizeOfOps;
 use uuid::Uuid;
@@ -747,6 +748,12 @@ impl MallocSizeOf for ipc_channel::ipc::IpcSharedMemory {
 impl<T: MallocSizeOf> MallocSizeOf for accountable_refcell::RefCell<T> {
     fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
         self.borrow().size_of(ops)
+    }
+}
+
+impl MallocSizeOf for servo_arc::Arc<ComputedValues> {
+    fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
+        self.conditional_size_of(ops)
     }
 }
 

--- a/tests/wpt/tests/css/css-display/display-contents-inline-002.html
+++ b/tests/wpt/tests/css/css-display/display-contents-inline-002.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Display: display:contents in inline layout should affect style of descendants</title>
+<link rel="author" title="Martin Robinson" href="mailto:mrobinson@igalia.com">
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
+<link rel="match" href="display-contents-pass-no-red-ref.html">
+<style>
+    #contents {
+        display: contents;
+        color: black;
+    }
+    .red { color: red; }
+</style>
+<p>You should see the word PASS and no red below.</p>
+<span>
+    P<span class="red"><div id="contents">AS</div></span>S
+</span>


### PR DESCRIPTION
`TextRun`s use their parent style to render. Previously, these styles
were cloned and stored directly in the box tree `TextRun` and resulting
`TextFragment`s. This presents a problem for incremental layout.
Wrapping the style in another layer of shared ownership and mutability
will allow updating all `TextFragment`s during repaint-only incremental
layout by simply updating the box tree styles of the original text
parents.

This adds a new set of borrows when accessing text styles, but also
makes it so that during box tree block construction
`InlineFormattingContext`s are created lazily and now
`InlineFormattingContextBuilder::finish` consumes the builder, making
the API make a bit more sense. This should also improve performance of
box tree block construction slightly.

Testing: This should not change observable behavior and thus is covered
by existing WPT tests.
