### PR TITLE
constellation: Ignore `zombie_process` warning

### DIFF
--- a/components/constellation/sandboxing.rs
+++ b/components/constellation/sandboxing.rs
@@ -159,6 +159,7 @@ pub fn spawn_multiprocess(content: UnprivilegedContent) -> Result<Process, Error
     let mut child_process = process::Command::new(path_to_self);
     setup_common(&mut child_process, token);
 
+    #[allow(clippy::zombie_processes)]
     let child = child_process
         .spawn()
         .expect("Failed to start unsandboxed child process!");


### PR DESCRIPTION
`rust-analyzer` shows a `zombie_process` warning, but only on macOS as far
as I can tell. This change ignores the warning here. We aren't currently
in a position where we can reliably `wait()` on spawned processes, which
needs to happen as part of a larger multiprocess / cleanup effort.

Testing: No testing as this just ignores an LSP warning.
