### PR TITLE
rework webdriver deserialization to avoid false-positive cycle error

### DIFF
--- a/tests/wpt/meta/webdriver/tests/classic/execute_async_script/collections.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/execute_async_script/collections.py.ini
@@ -1,7 +1,4 @@
 [collections.py]
-  [test_array_in_array]
-    expected: FAIL
-
   [test_file_list]
     expected: FAIL
 

--- a/tests/wpt/meta/webdriver/tests/classic/execute_script/collections.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/execute_script/collections.py.ini
@@ -4,6 +4,3 @@
 
   [test_html_all_collection]
     expected: FAIL
-
-  [test_array_in_array]
-    expected: FAIL


### PR DESCRIPTION
1. Avoid false-positive cycle error when deserilizing
 - Only detect cycle for Objects
  - Remove last element of seen when success
2. Cite spec

Testing: `./mach test-wpt --product servodriver -r tests\wpt\tests\webdriver\tests\classic\element_click\events.py`
Fixes: #36890 
cc @jdm @xiaochengh