### PR TITLE
Add Zed configuration files to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,9 @@ webrender-captures/
 Session.vim
 Sessionx.vim
 
+# Zed
+/.zed
+
 /unminified-js
 /unminified-css
 


### PR DESCRIPTION
The Zed editor (https://zed.dev/) leaves files in a `.zed` directory in
the top-level.

Testing: No tests necessary as this just updates `.gitignore`.
