### PR TITLE
webgl: Use `glow::Context::supported_extensions()` to implement `getSupportedExtensions()`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8557,6 +8557,7 @@ dependencies = [
  "glow",
  "half",
  "ipc-channel",
+ "itertools 0.14.0",
  "log",
  "pixels",
  "snapshot",

--- a/components/webgl/Cargo.toml
+++ b/components/webgl/Cargo.toml
@@ -26,6 +26,7 @@ fnv = { workspace = true }
 glow = { workspace = true }
 half = "2"
 ipc-channel = { workspace = true }
+itertools = { workspace = true }
 log = { workspace = true }
 pixels = { path = "../pixels" }
 snapshot = { workspace = true }


### PR DESCRIPTION
Not only does this simplify the code, it fixes a problem where we were
attempting to use an OpenGL 3.0 API on an incompatible GL context.

Testing: There are already tests for `getSupportedExtensions()` in the WebGL
suite, but effectively testing this requires drivers that do not support
a particular version of OpenGL, so it is a bit hard to actually test.
Fixes: #36852.
