### PR TITLE
ohos: Set custom log domain

### DIFF
--- a/ports/servoshell/egl/ohos.rs
+++ b/ports/servoshell/egl/ohos.rs
@@ -387,6 +387,7 @@ extern "C" fn on_dispatch_key_event(xc: *mut OH_NativeXComponent, _window: *mut 
 
 static LOGGER: LazyLock<hilog::Logger> = LazyLock::new(|| {
     let mut builder = hilog::Builder::new();
+    builder.set_domain(hilog::LogDomain::new(0xE0C3));
     let filters = [
         "fonts",
         "servo",
@@ -678,7 +679,7 @@ impl EventLoopWaker for WakeupCallback {
     }
 
     fn wake(&self) {
-        info!("wake called!");
+        log::trace!("wake called!");
         self.chan.send(ServoAction::WakeUp).unwrap_or_else(|e| {
             error!("Failed to send wake message with: {e}");
         });


### PR DESCRIPTION
This allows us to easily filter logs related to the servo app via our domain tag, e.g.
The domain value was chosen empirically and doesn't seem to collide as of now. From the OpenHarmony side there are no requirements on the value as long as it is between `0x0000` and `0xFFFF`. A value of zero (current status) doesn't allow filtering in hilog.

```
hdc shell hilog -D 0xE0C3
```



Testing: No functional changes

