### PR TITLE
layout: Impl internal private `line-height: -moz-block-height` for form control UA stylesheet.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6524,7 +6524,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.28.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#bc815af4b5ae01768eaef64d21cebe6d66be06ea"
+source = "git+https://github.com/stevennovaryo/stylo?branch=moz-block-height#621bbb1203a1e796561e17123e8e4bec9e8c5090"
 dependencies = [
  "bitflags 2.9.0",
  "cssparser",
@@ -6819,7 +6819,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.1"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#bc815af4b5ae01768eaef64d21cebe6d66be06ea"
+source = "git+https://github.com/stevennovaryo/stylo?branch=moz-block-height#621bbb1203a1e796561e17123e8e4bec9e8c5090"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -7280,7 +7280,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#bc815af4b5ae01768eaef64d21cebe6d66be06ea"
+source = "git+https://github.com/stevennovaryo/stylo?branch=moz-block-height#621bbb1203a1e796561e17123e8e4bec9e8c5090"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -7338,7 +7338,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#bc815af4b5ae01768eaef64d21cebe6d66be06ea"
+source = "git+https://github.com/stevennovaryo/stylo?branch=moz-block-height#621bbb1203a1e796561e17123e8e4bec9e8c5090"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -7347,12 +7347,12 @@ dependencies = [
 [[package]]
 name = "stylo_config"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#bc815af4b5ae01768eaef64d21cebe6d66be06ea"
+source = "git+https://github.com/stevennovaryo/stylo?branch=moz-block-height#621bbb1203a1e796561e17123e8e4bec9e8c5090"
 
 [[package]]
 name = "stylo_derive"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#bc815af4b5ae01768eaef64d21cebe6d66be06ea"
+source = "git+https://github.com/stevennovaryo/stylo?branch=moz-block-height#621bbb1203a1e796561e17123e8e4bec9e8c5090"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -7364,7 +7364,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#bc815af4b5ae01768eaef64d21cebe6d66be06ea"
+source = "git+https://github.com/stevennovaryo/stylo?branch=moz-block-height#621bbb1203a1e796561e17123e8e4bec9e8c5090"
 dependencies = [
  "bitflags 2.9.0",
  "stylo_malloc_size_of",
@@ -7373,7 +7373,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#bc815af4b5ae01768eaef64d21cebe6d66be06ea"
+source = "git+https://github.com/stevennovaryo/stylo?branch=moz-block-height#621bbb1203a1e796561e17123e8e4bec9e8c5090"
 dependencies = [
  "app_units",
  "cssparser",
@@ -7390,12 +7390,12 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#bc815af4b5ae01768eaef64d21cebe6d66be06ea"
+source = "git+https://github.com/stevennovaryo/stylo?branch=moz-block-height#621bbb1203a1e796561e17123e8e4bec9e8c5090"
 
 [[package]]
 name = "stylo_traits"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#bc815af4b5ae01768eaef64d21cebe6d66be06ea"
+source = "git+https://github.com/stevennovaryo/stylo?branch=moz-block-height#621bbb1203a1e796561e17123e8e4bec9e8c5090"
 dependencies = [
  "app_units",
  "bitflags 2.9.0",
@@ -7778,7 +7778,7 @@ dependencies = [
 [[package]]
 name = "to_shmem"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#bc815af4b5ae01768eaef64d21cebe6d66be06ea"
+source = "git+https://github.com/stevennovaryo/stylo?branch=moz-block-height#621bbb1203a1e796561e17123e8e4bec9e8c5090"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -7791,7 +7791,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#bc815af4b5ae01768eaef64d21cebe6d66be06ea"
+source = "git+https://github.com/stevennovaryo/stylo?branch=moz-block-height#621bbb1203a1e796561e17123e8e4bec9e8c5090"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,7 +118,7 @@ rustls-pemfile = "2.0"
 rustls-pki-types = "1.12"
 script_layout_interface = { path = "components/shared/script_layout" }
 script_traits = { path = "components/shared/script" }
-selectors = { git = "https://github.com/servo/stylo", branch = "2025-05-01" }
+selectors = { git = "https://github.com/stevennovaryo/stylo", branch = "moz-block-height" }
 serde = "1.0.219"
 serde_bytes = "0.11"
 serde_json = "1.0"
@@ -126,7 +126,7 @@ servo-media = { git = "https://github.com/servo/media" }
 servo-media-dummy = { git = "https://github.com/servo/media" }
 servo-media-gstreamer = { git = "https://github.com/servo/media" }
 servo-tracing = { path = "components/servo_tracing" }
-servo_arc = { git = "https://github.com/servo/stylo", branch = "2025-05-01" }
+servo_arc = { git = "https://github.com/stevennovaryo/stylo", branch = "moz-block-height" }
 smallbitvec = "2.6.0"
 smallvec = "1.15"
 snapshot = { path = "./components/shared/snapshot" }
@@ -135,12 +135,12 @@ string_cache = "0.8"
 string_cache_codegen = "0.5"
 strum = "0.26"
 strum_macros = "0.26"
-stylo = { git = "https://github.com/servo/stylo", branch = "2025-05-01" }
-stylo_atoms = { git = "https://github.com/servo/stylo", branch = "2025-05-01" }
-stylo_config = { git = "https://github.com/servo/stylo", branch = "2025-05-01" }
-stylo_dom = { git = "https://github.com/servo/stylo", branch = "2025-05-01" }
-stylo_malloc_size_of = { git = "https://github.com/servo/stylo", branch = "2025-05-01" }
-stylo_traits = { git = "https://github.com/servo/stylo", branch = "2025-05-01" }
+stylo = { git = "https://github.com/stevennovaryo/stylo", branch = "moz-block-height" }
+stylo_atoms = { git = "https://github.com/stevennovaryo/stylo", branch = "moz-block-height" }
+stylo_config = { git = "https://github.com/stevennovaryo/stylo", branch = "moz-block-height" }
+stylo_dom = { git = "https://github.com/stevennovaryo/stylo", branch = "moz-block-height" }
+stylo_malloc_size_of = { git = "https://github.com/stevennovaryo/stylo", branch = "moz-block-height" }
+stylo_traits = { git = "https://github.com/stevennovaryo/stylo", branch = "moz-block-height" }
 surfman = { git = "https://github.com/servo/surfman", rev = "f7688b4585f9e0b5d4bf8ee8e4a91e82349610b1", features = ["chains"] }
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"

--- a/components/layout/flow/inline/inline_box.rs
+++ b/components/layout/flow/inline/inline_box.rs
@@ -261,6 +261,7 @@ impl InlineBoxContainerState {
                 flags,
                 Some(parent_container),
                 parent_container.text_decoration_line,
+                containing_block,
                 font_metrics,
             ),
             identifier: inline_box.identifier,

--- a/components/layout/flow/inline/line.rs
+++ b/components/layout/flow/inline/line.rs
@@ -887,10 +887,9 @@ fn line_height(parent_style: &ComputedValues, font_metrics: &FontMetrics) -> Au 
     let font = parent_style.get_font();
     let font_size = font.font_size.computed_size();
     match font.line_height {
-        LineHeight::Normal => font_metrics.line_gap,
+        LineHeight::Normal | LineHeight::MozBlockHeight => font_metrics.line_gap,
         LineHeight::Number(number) => (font_size * number.0).into(),
         LineHeight::Length(length) => length.0.into(),
-        LineHeight::MozBlockHeight => font_metrics.line_gap,
     }
 }
 

--- a/components/layout/flow/inline/line.rs
+++ b/components/layout/flow/inline/line.rs
@@ -890,6 +890,7 @@ fn line_height(parent_style: &ComputedValues, font_metrics: &FontMetrics) -> Au 
         LineHeight::Normal => font_metrics.line_gap,
         LineHeight::Number(number) => (font_size * number.0).into(),
         LineHeight::Length(length) => length.0.into(),
+        LineHeight::MozBlockHeight => font_metrics.line_gap,
     }
 }
 

--- a/components/layout/flow/inline/mod.rs
+++ b/components/layout/flow/inline/mod.rs
@@ -2241,6 +2241,10 @@ fn place_pending_floats(ifc: &mut InlineFormattingContextLayout, line_items: &mu
     }
 }
 
+/// Resolve line height for a given parameters.
+/// Argument `parent_block_size` is used only to resolve `-moz-block-height`,
+/// giving None `parent_block_size` will cause `-moz-block-height` to resolve
+/// like `normal`.
 fn line_height(
     parent_style: &ComputedValues,
     font_metrics: &FontMetrics,
@@ -2254,8 +2258,8 @@ fn line_height(
         LineHeight::Number(number) => (font_size * number.0).into(),
         LineHeight::Length(length) => length.0.into(),
         LineHeight::MozBlockHeight => match parent_block_size {
-            Some(SizeConstraint::Definite(au)) => *au,
-            Some(SizeConstraint::MinMax(min_au, _)) => *min_au,
+            Some(SizeConstraint::Definite(definite)) => *definite,
+            Some(SizeConstraint::MinMax(min_size, _)) => *min_size,
             None => font_metrics.line_gap,
         },
     };

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -168,20 +168,6 @@ pub fn process_resolved_style_request(
     // properties we might need to walk the Fragment tree to figure those out. We always
     // fall back to returning the computed value.
 
-    // For line height, the resolved value is the computed value if it
-    // is "normal" and the used value otherwise.
-    if longhand_id == LonghandId::LineHeight {
-        let font = style.get_font();
-        let font_size = font.font_size.computed_size();
-        return match font.line_height {
-            // There could be a fragment, but it's only interesting for `min-width` and `min-height`,
-            // so just pass None.
-            LineHeight::Normal => computed_style(None),
-            LineHeight::Number(value) => (font_size * value.0).to_css_string(),
-            LineHeight::Length(value) => value.0.to_css_string(),
-        };
-    }
-
     // https://drafts.csswg.org/cssom/#dom-window-getcomputedstyle
     // The properties that we calculate below all resolve to the computed value
     // when the element is display:none or display:contents.
@@ -227,6 +213,21 @@ pub fn process_resolved_style_request(
             },
             _ => return computed_style(Some(fragment)),
         };
+
+        // For line height, the resolved value is the computed value if it
+        // is "normal" and the used value otherwise.
+        if longhand_id == LonghandId::LineHeight {
+            let font = style.get_font();
+            let font_size = font.font_size.computed_size();
+            return match font.line_height {
+                // There could be a fragment, but it's only interesting for `min-width` and `min-height`,
+                // so just pass None.
+                LineHeight::Normal => computed_style(None),
+                LineHeight::Number(value) => (font_size * value.0).to_css_string(),
+                LineHeight::Length(value) => value.0.to_css_string(),
+                LineHeight::MozBlockHeight => content_rect.size.height.to_css_string(),
+            };
+        }
 
         // https://drafts.csswg.org/css-grid/#resolved-track-list
         // > The grid-template-rows and grid-template-columns properties are

--- a/components/layout/stylesheets/servo.css
+++ b/components/layout/stylesheets/servo.css
@@ -87,6 +87,20 @@ input[type="file"] {
   border-style: none;
 }
 
+/*
+ * Here, We are directly aligning the content of single line form controls
+ * vertically, but ideally we should encapsulate this inside UA shadow DOM.
+ */
+input[type="text"],
+input[type="number"],
+input[type="email"],
+input[type="password"],
+input[type="url"],
+input[type="tel"],
+input[type="search"] {
+  line-height: -moz-block-height !important;
+}
+
 td[align="left"]    { text-align: left; }
 td[align="center"]  { text-align: center; }
 td[align="right"]   { text-align: right; }

--- a/tests/wpt/meta/html/rendering/non-replaced-elements/form-controls/input-line-height-computed.html.ini
+++ b/tests/wpt/meta/html/rendering/non-replaced-elements/form-controls/input-line-height-computed.html.ini
@@ -1,35 +1,17 @@
 [input-line-height-computed.html]
-  [getComputedStyle(<input type=text>).lineHeight should return a used value that is no smaller than 'normal' (but should not literally be 'normal')]
-    expected: FAIL
-
   [<input type=text>.computedStyleMap().get('line-height') should not be affected by the used value clamping]
-    expected: FAIL
-
-  [getComputedStyle(<input type=tel>).lineHeight should return a used value that is no smaller than 'normal' (but should not literally be 'normal')]
     expected: FAIL
 
   [<input type=tel>.computedStyleMap().get('line-height') should not be affected by the used value clamping]
     expected: FAIL
 
-  [getComputedStyle(<input type=search>).lineHeight should return a used value that is no smaller than 'normal' (but should not literally be 'normal')]
-    expected: FAIL
-
   [<input type=search>.computedStyleMap().get('line-height') should not be affected by the used value clamping]
-    expected: FAIL
-
-  [getComputedStyle(<input type=url>).lineHeight should return a used value that is no smaller than 'normal' (but should not literally be 'normal')]
     expected: FAIL
 
   [<input type=url>.computedStyleMap().get('line-height') should not be affected by the used value clamping]
     expected: FAIL
 
-  [getComputedStyle(<input type=email>).lineHeight should return a used value that is no smaller than 'normal' (but should not literally be 'normal')]
-    expected: FAIL
-
   [<input type=email>.computedStyleMap().get('line-height') should not be affected by the used value clamping]
-    expected: FAIL
-
-  [getComputedStyle(<input type=password>).lineHeight should return a used value that is no smaller than 'normal' (but should not literally be 'normal')]
     expected: FAIL
 
   [<input type=password>.computedStyleMap().get('line-height') should not be affected by the used value clamping]


### PR DESCRIPTION
Implement `-moz-block-height`, internal value for CSS `line-height` property that is only usable in UA stylesheet. 

Specifically, it will resolve the line height calculation to the containing block height, and in the calculation of the block height contribution, it will resolve like `line-height: normal`.

This property would then be able to be used to correct `<input>` element widget as specified by https://html.spec.whatwg.org/multipage/rendering.html#the-input-element-as-a-text-entry-widget, where the used value for it's line height should be greater or equal to `normal`. And, https://drafts.csswg.org/css-ui/#input-rules where by default, one line text control should have it's content be aligned center vertically. Though further encapsulation with UA shadow dom is still necessary.

Testing: Existing WPT Test
Fixes: #36307
