### PR TITLE
DevTools: Improve `resource_available` to handle multiple connections

### DIFF
--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -149,10 +149,6 @@ impl ResourceAvailable for BrowsingContextActor {
     fn actor_name(&self) -> String {
         self.name.clone()
     }
-
-    fn get_streams(&self) -> &RefCell<HashMap<StreamId, TcpStream>> {
-        &self.streams
-    }
 }
 
 impl Actor for BrowsingContextActor {

--- a/components/devtools/actors/console.rs
+++ b/components/devtools/actors/console.rs
@@ -252,6 +252,7 @@ impl ConsoleActor {
         page_error: PageError,
         id: UniqueId,
         registry: &ActorRegistry,
+        stream: &mut TcpStream,
     ) {
         self.cached_events
             .borrow_mut()
@@ -262,7 +263,11 @@ impl ConsoleActor {
             if let Root::BrowsingContext(bc) = &self.root {
                 registry
                     .find::<BrowsingContextActor>(bc)
-                    .resource_available(PageErrorWrapper { page_error }, "error-message".into())
+                    .resource_available(
+                        PageErrorWrapper { page_error },
+                        "error-message".into(),
+                        stream,
+                    )
             };
         }
     }
@@ -272,6 +277,7 @@ impl ConsoleActor {
         console_message: ConsoleMessage,
         id: UniqueId,
         registry: &ActorRegistry,
+        stream: &mut TcpStream,
     ) {
         let log_message: ConsoleLog = console_message.into();
         self.cached_events
@@ -283,7 +289,7 @@ impl ConsoleActor {
             if let Root::BrowsingContext(bc) = &self.root {
                 registry
                     .find::<BrowsingContextActor>(bc)
-                    .resource_available(log_message, "console-message".into())
+                    .resource_available(log_message, "console-message".into(), stream)
             };
         }
     }

--- a/components/devtools/actors/worker.rs
+++ b/components/devtools/actors/worker.rs
@@ -17,7 +17,7 @@ use servo_url::ServoUrl;
 use crate::StreamId;
 use crate::actor::{Actor, ActorMessageStatus, ActorRegistry};
 use crate::protocol::JsonPacketStream;
-use crate::resource::{ResourceAvailable, ResourceAvailableReply};
+use crate::resource::ResourceAvailable;
 
 #[derive(Clone, Copy)]
 #[allow(dead_code)]
@@ -59,10 +59,6 @@ impl WorkerActor {
 impl ResourceAvailable for WorkerActor {
     fn actor_name(&self) -> String {
         self.name.clone()
-    }
-
-    fn get_streams(&self) -> &RefCell<HashMap<StreamId, TcpStream>> {
-        &self.streams
     }
 }
 
@@ -129,28 +125,6 @@ impl Actor for WorkerActor {
             self.script_chan
                 .send(WantsLiveNotifications(TEST_PIPELINE_ID, false))
                 .unwrap();
-        }
-    }
-}
-
-impl WorkerActor {
-    pub(crate) fn resource_available<T: Serialize>(&self, resource: T, resource_type: String) {
-        self.resources_available(vec![resource], resource_type);
-    }
-
-    pub(crate) fn resources_available<T: Serialize>(
-        &self,
-        resources: Vec<T>,
-        resource_type: String,
-    ) {
-        let msg = ResourceAvailableReply::<T> {
-            from: self.name(),
-            type_: "resources-available-array".into(),
-            array: vec![(resource_type, resources)],
-        };
-
-        for stream in self.streams.borrow_mut().values_mut() {
-            let _ = stream.write_json_packet(&msg);
         }
     }
 }

--- a/components/devtools/resource.rs
+++ b/components/devtools/resource.rs
@@ -2,13 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::cell::RefCell;
-use std::collections::HashMap;
 use std::net::TcpStream;
 
 use serde::Serialize;
 
-use crate::StreamId;
 use crate::protocol::JsonPacketStream;
 
 #[derive(Serialize)]
@@ -22,21 +19,27 @@ pub(crate) struct ResourceAvailableReply<T: Serialize> {
 pub(crate) trait ResourceAvailable {
     fn actor_name(&self) -> String;
 
-    fn get_streams(&self) -> &RefCell<HashMap<StreamId, TcpStream>>;
-
-    fn resource_available<T: Serialize>(&self, resource: T, resource_type: String) {
-        self.resources_available(vec![resource], resource_type);
+    fn resource_available<T: Serialize>(
+        &self,
+        resource: T,
+        resource_type: String,
+        stream: &mut TcpStream,
+    ) {
+        self.resources_available(vec![resource], resource_type, stream);
     }
 
-    fn resources_available<T: Serialize>(&self, resources: Vec<T>, resource_type: String) {
+    fn resources_available<T: Serialize>(
+        &self,
+        resources: Vec<T>,
+        resource_type: String,
+        stream: &mut TcpStream,
+    ) {
         let msg = ResourceAvailableReply::<T> {
             from: self.actor_name(),
             type_: "resources-available-array".into(),
             array: vec![(resource_type, resources)],
         };
 
-        for stream in self.get_streams().borrow_mut().values_mut() {
-            let _ = stream.write_json_packet(&msg);
-        }
+        let _ = stream.write_json_packet(&msg);
     }
 }


### PR DESCRIPTION
This patch improves the `resource_available` trait to handle multiple connections. In this patch we also remove the redundant `resource_available` from worker actor 

Testing: Existing tests in DevTools already tests for this. We do not need to add new test
Fixes: part of #36027 
