### PR TITLE
net: Fix broken SSL certificate error override.

### DIFF
--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -4,10 +4,8 @@
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
-use std::{io, mem, str};
+use std::{mem, str};
 
-use base64::Engine as _;
-use base64::engine::general_purpose;
 use content_security_policy as csp;
 use crossbeam_channel::Sender;
 use devtools_traits::DevtoolsControlMsg;
@@ -15,23 +13,21 @@ use embedder_traits::resources::{self, Resource};
 use headers::{AccessControlExposeHeaders, ContentType, HeaderMapExt};
 use http::header::{self, HeaderMap, HeaderName, RANGE};
 use http::{HeaderValue, Method, StatusCode};
-use ipc_channel::ipc;
 use log::{debug, trace, warn};
 use mime::{self, Mime};
 use net_traits::filemanager_thread::{FileTokenCheck, RelativePos};
 use net_traits::http_status::HttpStatus;
 use net_traits::policy_container::{PolicyContainer, RequestPolicyContainer};
 use net_traits::request::{
-    BodyChunkRequest, BodyChunkResponse, CredentialsMode, Destination, Initiator,
-    InsecureRequestsPolicy, Origin, ParserMetadata, RedirectMode, Referrer, Request, RequestMode,
-    ResponseTainting, Window, is_cors_safelisted_method, is_cors_safelisted_request_header,
+    CredentialsMode, Destination, Initiator, InsecureRequestsPolicy, Origin, ParserMetadata,
+    RedirectMode, Referrer, Request, RequestMode, ResponseTainting, Window,
+    is_cors_safelisted_method, is_cors_safelisted_request_header,
 };
 use net_traits::response::{Response, ResponseBody, ResponseType};
 use net_traits::{
     FetchTaskTarget, NetworkError, ReferrerPolicy, ResourceAttribute, ResourceFetchTiming,
     ResourceTimeValue, ResourceTimingType, set_default_accept_language,
 };
-use rustls_pki_types::CertificateDer;
 use serde::{Deserialize, Serialize};
 use servo_arc::Arc as ServoArc;
 use servo_url::{Host, ImmutableOrigin, ServoUrl};
@@ -775,48 +771,6 @@ fn create_about_memory(url: ServoUrl, timing_type: ResourceTimingType) -> Respon
     response
 }
 
-/// Handle a request from the user interface to ignore validation errors for a certificate.
-fn handle_allowcert_request(request: &mut Request, context: &FetchContext) -> io::Result<()> {
-    let error = |string| Err(io::Error::new(io::ErrorKind::Other, string));
-
-    let body = match request.body.as_mut() {
-        Some(body) => body,
-        None => return error("No body found"),
-    };
-
-    let stream = body.take_stream();
-    let stream = stream.lock().unwrap();
-    let (body_chan, body_port) = ipc::channel().unwrap();
-    let _ = stream.send(BodyChunkRequest::Connect(body_chan));
-    let _ = stream.send(BodyChunkRequest::Chunk);
-    let body_bytes = match body_port.recv().ok() {
-        Some(BodyChunkResponse::Chunk(bytes)) => bytes,
-        _ => return error("Certificate not sent in a single chunk"),
-    };
-
-    let split_idx = match body_bytes.iter().position(|b| *b == b'&') {
-        Some(split_idx) => split_idx,
-        None => return error("Could not find ampersand in data"),
-    };
-    let (secret, cert_base64) = body_bytes.split_at(split_idx);
-
-    let secret = str::from_utf8(secret).ok().and_then(|s| s.parse().ok());
-    if secret != Some(*net_traits::PRIVILEGED_SECRET) {
-        return error("Invalid secret sent. Ignoring request");
-    }
-
-    let cert_bytes = match general_purpose::STANDARD_NO_PAD.decode(&cert_base64[1..]) {
-        Ok(bytes) => bytes,
-        Err(_) => return error("Could not decode certificate base64"),
-    };
-
-    context
-        .state
-        .override_manager
-        .add_override(&CertificateDer::from_slice(&cert_bytes).into_owned());
-    Ok(())
-}
-
 /// [Scheme fetch](https://fetch.spec.whatwg.org#scheme-fetch)
 async fn scheme_fetch(
     fetch_params: &mut FetchParams,
@@ -835,13 +789,6 @@ async fn scheme_fetch(
     match scheme {
         "about" if url.path() == "blank" => create_blank_reply(url, request.timing_type()),
         "about" if url.path() == "memory" => create_about_memory(url, request.timing_type()),
-
-        "chrome" if url.path() == "allowcert" => {
-            if let Err(error) = handle_allowcert_request(request, context) {
-                warn!("Could not handle allowcert request: {error}");
-            }
-            create_blank_reply(url, request.timing_type())
-        },
 
         "http" | "https" => {
             http_fetch(

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -444,6 +444,9 @@ impl ResourceChannelManager {
                 http_state.http_cache.write().unwrap().clear();
             },
             CoreResourceMsg::ToFileManager(msg) => self.resource_manager.filemanager.handle(msg),
+            CoreResourceMsg::OverrideCert(bytes) => {
+                http_state.override_manager.add_override_from_base64(&bytes)
+            },
             CoreResourceMsg::Exit(sender) => {
                 if let Some(ref config_dir) = self.config_dir {
                     match http_state.auth_cache.read() {

--- a/components/net/tests/fetch.rs
+++ b/components/net/tests/fetch.rs
@@ -739,7 +739,10 @@ fn test_fetch_with_hsts() {
     // The server certificate is self-signed, so we need to add an override
     // so that the connection works properly.
     for certificate in server.certificates.as_ref().unwrap().iter() {
-        context.state.override_manager.add_override(certificate);
+        context
+            .state
+            .override_manager
+            .add_override_from_certificate_bytes(certificate);
     }
 
     {
@@ -799,7 +802,10 @@ fn test_load_adds_host_to_hsts_list_when_url_is_https() {
     // The server certificate is self-signed, so we need to add an override
     // so that the connection works properly.
     for certificate in server.certificates.as_ref().unwrap().iter() {
-        context.state.override_manager.add_override(certificate);
+        context
+            .state
+            .override_manager
+            .add_override_from_certificate_bytes(certificate);
     }
 
     let request = RequestBuilder::new(None, url.clone(), Referrer::NoReferrer)
@@ -880,7 +886,10 @@ fn test_fetch_self_signed() {
     // The server certificate is self-signed, so we need to add an override
     // so that the connection works properly.
     for certificate in server.certificates.as_ref().unwrap().iter() {
-        context.state.override_manager.add_override(certificate);
+        context
+            .state
+            .override_manager
+            .add_override_from_certificate_bytes(certificate);
     }
 
     let request = RequestBuilder::new(None, url.clone(), Referrer::NoReferrer)

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -567,6 +567,8 @@ pub(crate) struct Document {
     active_keyboard_modifiers: Cell<Modifiers>,
     /// The node that is currently highlighted by the devtools
     highlighted_dom_node: MutNullableDom<Node>,
+    /// Whether this document is synthesized for engine-internal page content.
+    is_internal_content: Cell<bool>,
 }
 
 #[allow(non_snake_case)]
@@ -4225,7 +4227,16 @@ impl Document {
             intersection_observers: Default::default(),
             active_keyboard_modifiers: Cell::new(Modifiers::empty()),
             highlighted_dom_node: Default::default(),
+            is_internal_content: Default::default(),
         }
+    }
+
+    pub(crate) fn mark_internal_content(&self) {
+        self.is_internal_content.set(true);
+    }
+
+    pub(crate) fn is_internal_content(&self) -> bool {
+        self.is_internal_content.get()
     }
 
     /// Returns a policy value that should be used for fetches initiated by this document.

--- a/components/script/dom/servointernals.rs
+++ b/components/script/dom/servointernals.rs
@@ -7,16 +7,21 @@ use std::rc::Rc;
 use constellation_traits::ScriptToConstellationMessage;
 use dom_struct::dom_struct;
 use js::rust::HandleObject;
+use net_traits::{CoreResourceMsg, IpcSend};
 use profile_traits::mem::MemoryReportResult;
+use script_bindings::inheritance::Castable;
 use script_bindings::interfaces::ServoInternalsHelpers;
 use script_bindings::script_runtime::JSContext;
+use script_bindings::str::ByteString;
 
 use crate::dom::bindings::codegen::Bindings::ServoInternalsBinding::ServoInternalsMethods;
+use crate::dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
 use crate::dom::bindings::error::Error;
 use crate::dom::bindings::reflector::{DomGlobal, Reflector, reflect_dom_object};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
+use crate::dom::window::Window;
 use crate::realms::{AlreadyInRealm, InRealm};
 use crate::routed_promise::{RoutedPromiseListener, route_promise};
 use crate::script_runtime::CanGc;
@@ -55,6 +60,14 @@ impl ServoInternalsMethods<crate::DomTypeHolder> for ServoInternals {
         }
         promise
     }
+
+    /// <https://servo.org/internal-no-spec>
+    fn AllowCertOverride(&self, cert: ByteString) {
+        let _ = self
+            .global()
+            .resource_threads()
+            .send(CoreResourceMsg::OverrideCert(cert.to_vec()));
+    }
 }
 
 impl RoutedPromiseListener<MemoryReportResult> for ServoInternals {
@@ -71,7 +84,11 @@ impl ServoInternalsHelpers for ServoInternals {
             let in_realm_proof = AlreadyInRealm::assert_for_cx(cx);
             let global_scope = GlobalScope::from_context(*cx, InRealm::Already(&in_realm_proof));
             let url = global_scope.get_url();
-            url.scheme() == "about" && url.as_str() != "about:blank"
+            let is_safe_about_url = url.scheme() == "about" && url.as_str() != "about:blank";
+            let is_internal_document = global_scope
+                .downcast::<Window>()
+                .is_some_and(|window| window.Document().is_internal_content());
+            is_safe_about_url || is_internal_document
         }
     }
 }

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -929,8 +929,6 @@ impl FetchResponseListener for ParserContext {
                     let page = page.replace("${reason}", &reason);
                     let encoded_bytes = general_purpose::STANDARD_NO_PAD.encode(bytes);
                     let page = page.replace("${bytes}", encoded_bytes.as_str());
-                    let page =
-                        page.replace("${secret}", &net_traits::PRIVILEGED_SECRET.to_string());
                     parser.push_string_input_chunk(page);
                     parser.parse_sync(CanGc::note());
                 },
@@ -966,6 +964,10 @@ impl FetchResponseListener for ParserContext {
                 parser.push_string_input_chunk(page);
                 parser.parse_sync(CanGc::note());
             },
+        }
+
+        if self.is_synthesized_document {
+            parser.document.mark_internal_content();
         }
     }
 

--- a/components/script_bindings/webidls/ServoInternals.webidl
+++ b/components/script_bindings/webidls/ServoInternals.webidl
@@ -11,6 +11,7 @@
 Func="ServoInternals::is_servo_internal"]
 interface ServoInternals {
     Promise<object> reportMemory();
+    undefined allowCertOverride(ByteString cert);
 };
 
 partial interface Navigator {

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -6,7 +6,7 @@
 
 use std::collections::HashMap;
 use std::fmt::Display;
-use std::sync::{LazyLock, OnceLock};
+use std::sync::OnceLock;
 use std::thread;
 
 use base::cross_process_instant::CrossProcessInstant;
@@ -27,7 +27,6 @@ use mime::Mime;
 use request::RequestId;
 use rustls_pki_types::CertificateDer;
 use serde::{Deserialize, Serialize};
-use servo_rand::RngCore;
 use servo_url::{ImmutableOrigin, ServoUrl};
 
 use crate::filemanager_thread::FileManagerThreadMsg;
@@ -528,6 +527,8 @@ pub enum CoreResourceMsg {
     /// Break the load handler loop, send a reply when done cleaning up local resources
     /// and exit
     Exit(IpcSender<()>),
+    /// Override the given erroring SSL certificate
+    OverrideCert(Vec<u8>),
 }
 
 // FIXME: https://github.com/servo/servo/issues/34591
@@ -1010,6 +1011,3 @@ pub fn set_default_accept_language(headers: &mut HeaderMap) {
         HeaderValue::from_static("en-US,en;q=0.5"),
     );
 }
-
-pub static PRIVILEGED_SECRET: LazyLock<u32> =
-    LazyLock::new(|| servo_rand::ServoRng::default().next_u32());

--- a/resources/badcert.html
+++ b/resources/badcert.html
@@ -13,12 +13,8 @@
     let exitButton = document.getElementById('leave');
     if (bytes.length) {
         button.onclick = function() {
-            let xhr = new XMLHttpRequest();
-            xhr.open('POST', 'chrome:allowcert');
-            xhr.onloadend = function() {
-                location.reload(true);
-            };
-            xhr.send("${secret}&${bytes}");
+            navigator.servo.allowCertOverride(bytes);
+            location.reload(true);
         };
     } else {
         button.style.display = "none";


### PR DESCRIPTION
The current support for enabling certificate overrides is fragile—the certificate error page makes a request to the special `about:allowcert` URL, passing the certificate bytes in the request body. This has been broken unintentionally by multiple changes to the network stack (most recently https://github.com/servo/servo/pull/36157), and we can provide more robust APIs to support this now through the ServoInternals interface.

Since the certificate error page just transparently replaces any page content without redirecting to another URL, this change requires exposing the ServoInternals interface in documents that we know to be strictly synthesized internal content. This means that we now also expose ServoInternals in:
* image documents
* the crash details page
* network failure pages
* unknown content pages

Testing: Loaded `https://easyjet.co.uk` and pressed the Allow button.
Fixes: #34685
