### PR TITLE
CI: add `build-args`

### DIFF
--- a/.github/workflows/dispatch-workflow.yml
+++ b/.github/workflows/dispatch-workflow.yml
@@ -8,6 +8,9 @@ on:
       profile:
         required: true
         type: string
+      build-args:
+        required: true
+        type: string
       wpt-args:
         required: true
         type: string
@@ -35,6 +38,7 @@ jobs:
     secrets: inherit
     with:
       profile: ${{ inputs.profile }}
+      build-args: ${{ inputs.build-args }}
       unit-tests: ${{ inputs.unit-tests }}
       build-libservo: ${{ inputs.build-libservo }}
       bencher: ${{ inputs.bencher }}
@@ -46,6 +50,7 @@ jobs:
     secrets: inherit
     with:
       profile: ${{ inputs.profile }}
+      build-args: ${{ inputs.build-args }}
       wpt: ${{ inputs.wpt }}
       unit-tests: ${{ inputs.unit-tests }}
       build-libservo: ${{ inputs.build-libservo }}
@@ -59,6 +64,7 @@ jobs:
     secrets: inherit
     with:
       profile: ${{ inputs.profile }}
+      build-args: ${{ inputs.build-args }}
       wpt: ${{ inputs.wpt }}
       number-of-wpt-chunks: ${{ inputs.number-of-wpt-chunks }}
       unit-tests: ${{ inputs.unit-tests }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -6,6 +6,10 @@ on:
         required: false
         default: "release"
         type: string
+      build-args:
+        default: ""
+        required: false
+        type: string
       wpt-args:
         default: ""
         required: false
@@ -166,7 +170,7 @@ jobs:
 
       - name: Build (${{ inputs.profile }})
         run: |
-          ./mach build --use-crown --locked --${{ inputs.profile }}
+          ./mach build --use-crown --locked --${{ inputs.profile }} ${{ inputs.build-args }}
           cp -r target/cargo-timings target/cargo-timings-linux
       - name: Smoketest
         run: xvfb-run ./mach smoketest --${{ inputs.profile  }}

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -7,6 +7,10 @@ on:
         required: false
         default: "release"
         type: string
+      build-args:
+        default: ""
+        required: false
+        type: string
       wpt-args:
         default: ""
         required: false
@@ -146,7 +150,7 @@ jobs:
           brew install gnu-tar
       - name: Build (${{ inputs.profile }})
         run: |
-          ./mach build --use-crown --locked --${{ inputs.profile }}
+          ./mach build --use-crown --locked --${{ inputs.profile }}  ${{ inputs.build-args }}
           cp -r target/cargo-timings target/cargo-timings-macos
       - name: Smoketest
         uses: nick-fields/retry@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,6 +56,7 @@ jobs:
       unit-tests: ${{ matrix.unit_tests }}
       build-libservo: ${{ matrix.build_libservo }}
       wpt-args: ${{ matrix.wpt_args }}
+      build-args: ${{ matrix.build_args }}
       number-of-wpt-chunks: ${{ matrix.number_of_wpt_chunks }}
       bencher: ${{ matrix.bencher }}
 

--- a/.github/workflows/try-label.yml
+++ b/.github/workflows/try-label.yml
@@ -128,6 +128,7 @@ jobs:
       unit-tests: ${{ matrix.unit_tests }}
       build-libservo: ${{ matrix.build_libservo }}
       wpt-args: ${{ matrix.wpt_args }}
+      build-args: ${{ matrix.build_args }}
       number-of-wpt-chunks: ${{ matrix.number_of_wpt_chunks }}
       bencher: ${{ matrix.bencher }}
 

--- a/.github/workflows/try.yml
+++ b/.github/workflows/try.yml
@@ -10,6 +10,10 @@ on:
         default: "release"
         type: choice
         options: ["release", "debug", "production"]
+      build-args:
+        default: ""
+        required: false
+        type: string
       wpt-args:
         default: ""
         required: false
@@ -79,6 +83,7 @@ jobs:
               // WPT-related overrides only affect Linux currently, as tests don't run by default on other platforms.
               configuration.matrix[0].wpt = Boolean(${{ inputs.wpt }});
               configuration.matrix[0].wpt_args = "${{ inputs.wpt-args }}" || "";
+              configuration.matrix[0].build_args = "${{ inputs.build-args }}" || "";
 
               let unit_tests = Boolean(${{ inputs.unit-tests }});
               let profile = '${{ inputs.profile }}';
@@ -107,6 +112,7 @@ jobs:
       profile: ${{ matrix.profile }}
       unit-tests: ${{ matrix.unit_tests }}
       build-libservo: ${{ matrix.build_libservo }}
+      build-args: ${{ matrix.build_args }}
       wpt-args: ${{ matrix.wpt_args }}
       number-of-wpt-chunks: ${{ matrix.number_of_wpt_chunks }}
       bencher: ${{ matrix.bencher }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -7,6 +7,10 @@ on:
         required: false
         default: "release"
         type: string
+      build-args:
+        default: ""
+        required: false
+        type: string
       unit-tests:
         required: false
         default: false
@@ -161,7 +165,7 @@ jobs:
 
       - name: Build (${{ inputs.profile }})
         run: |
-          .\mach build --use-crown --locked --${{ inputs.profile }}
+          .\mach build --use-crown --locked --${{ inputs.profile }} ${{ inputs.build-args }}
           cp C:\a\servo\servo\target\cargo-timings C:\a\servo\servo\target\cargo-timings-windows -Recurse
       - name: Copy resources
         if: ${{ runner.environment != 'self-hosted' }}

--- a/python/servo/try_parser.py
+++ b/python/servo/try_parser.py
@@ -39,11 +39,12 @@ class JobConfig(object):
     unit_tests: bool = False
     build_libservo: bool = False
     bencher: bool = False
+    build_args: str = ""
     wpt_args: str = ""
     number_of_wpt_chunks: int = 20
     # These are the fields that must match in between two JobConfigs for them to be able to be
     # merged. If you modify any of the fields above, make sure to update this line as well.
-    merge_compatibility_fields: ClassVar[List[str]] = ['workflow', 'profile', 'wpt_args']
+    merge_compatibility_fields: ClassVar[List[str]] = ['workflow', 'profile', 'wpt_args', 'build_args']
 
     def merge(self, other: JobConfig) -> bool:
         """Try to merge another job with this job. Returns True if merging is successful
@@ -209,7 +210,8 @@ class TestParser(unittest.TestCase):
                                   'build_libservo': False,
                                   'workflow': 'linux',
                                   'wpt': False,
-                                  'wpt_args': ''
+                                  'wpt_args': '',
+                                  'build_args': ''
                               }]
                               })
 
@@ -225,7 +227,8 @@ class TestParser(unittest.TestCase):
                                   "unit_tests": True,
                                   'build_libservo': False,
                                   'bencher': True,
-                                  "wpt_args": ""
+                                  "wpt_args": "",
+                                  'build_args': ''
                               },
                               {
                                   "name": "MacOS (Unit Tests)",
@@ -236,7 +239,8 @@ class TestParser(unittest.TestCase):
                                   "unit_tests": True,
                                   'build_libservo': False,
                                   'bencher': False,
-                                  "wpt_args": ""
+                                  "wpt_args": "",
+                                  'build_args': ''
                               },
                               {
                                   "name": "Windows (Unit Tests)",
@@ -247,7 +251,8 @@ class TestParser(unittest.TestCase):
                                   "unit_tests": True,
                                   'build_libservo': False,
                                   'bencher': False,
-                                  "wpt_args": ""
+                                  "wpt_args": "",
+                                  'build_args': ''
                               },
                               {
                                   "name": "Android",
@@ -258,7 +263,8 @@ class TestParser(unittest.TestCase):
                                   "unit_tests": False,
                                   'build_libservo': False,
                                   'bencher': False,
-                                  "wpt_args": ""
+                                  "wpt_args": "",
+                                  'build_args': ''
                               },
                               {
                                   "name": "OpenHarmony",
@@ -269,7 +275,8 @@ class TestParser(unittest.TestCase):
                                   "unit_tests": False,
                                   'build_libservo': False,
                                   'bencher': False,
-                                  "wpt_args": ""
+                                  "wpt_args": "",
+                                  'build_args': ''
                               },
                               {
                                   "name": "Lint",
@@ -280,7 +287,9 @@ class TestParser(unittest.TestCase):
                                   "unit_tests": False,
                                   'build_libservo': False,
                                   'bencher': False,
-                                  "wpt_args": ""}
+                                  "wpt_args": "",
+                                  'build_args': ''
+                              }
                               ]})
 
     def test_job_merging(self):
@@ -295,7 +304,8 @@ class TestParser(unittest.TestCase):
                                   'build_libservo': False,
                                   'workflow': 'linux',
                                   'wpt': True,
-                                  'wpt_args': ''
+                                  'wpt_args': '',
+                                  'build_args': ''
                               }]
                               })
 
@@ -325,6 +335,11 @@ class TestParser(unittest.TestCase):
         a = JobConfig("Linux (Unit Tests)", Workflow.LINUX, unit_tests=True)
         b = JobConfig("Linux (Unit Tests)", Workflow.LINUX, unit_tests=True, wpt_args="/css")
         self.assertFalse(a.merge(b), "Should not merge jobs that run different WPT tests.")
+        self.assertEqual(a, JobConfig("Linux (Unit Tests)", Workflow.LINUX, unit_tests=True))
+
+        a = JobConfig("Linux (Unit Tests)", Workflow.LINUX, unit_tests=True)
+        b = JobConfig("Linux (Unit Tests)", Workflow.LINUX, unit_tests=True, build_args="--help")
+        self.assertFalse(a.merge(b), "Should not merge jobs with different build arguments.")
         self.assertEqual(a, JobConfig("Linux (Unit Tests)", Workflow.LINUX, unit_tests=True))
 
     def test_full(self):


### PR DESCRIPTION
Add `build-args` input in CI and try_parser job definition so we can pass own build args to `./mach build`

Testing: There are tests for try parser and I tested CI in my fork.
Fixes: partial fix #36823 
