### PR TITLE
Remove duplicate click event in `simulate_mouse_click`

### DIFF
--- a/components/compositing/webview_renderer.rs
+++ b/components/compositing/webview_renderer.rs
@@ -689,11 +689,6 @@ impl WebViewRenderer {
             action: MouseButtonAction::Up,
             point,
         }));
-        self.dispatch_input_event(InputEvent::MouseButton(MouseButtonEvent {
-            button,
-            action: MouseButtonAction::Click,
-            point,
-        }));
     }
 
     pub(crate) fn notify_scroll_event(


### PR DESCRIPTION
After `InputEvent::Touch` processed by Script, it sends `TouchEventProcessed` back to Constellation, which goes through hit-test etc. and loops back to Script again. However, `WebViewRenderer::simulate_mouse_click` should not send `MouseButtonAction::Click` due to #36413 

Testing: Manually tested by converting mouse to touch

cc @jdm @xiaochengh 