### PR TITLE
Update select shadow tree when contents of selected option change

### DIFF
--- a/components/script/dom/htmloptgroupelement.rs
+++ b/components/script/dom/htmloptgroupelement.rs
@@ -135,8 +135,8 @@ impl VirtualMethods for HTMLOptGroupElement {
     }
 
     fn bind_to_tree(&self, context: &BindContext, can_gc: CanGc) {
-        if let Some(s) = self.super_type() {
-            s.bind_to_tree(context, can_gc);
+        if let Some(super_type) = self.super_type() {
+            super_type.bind_to_tree(context, can_gc);
         }
 
         self.update_select_validity(can_gc);

--- a/components/script/dom/htmlselectelement.rs
+++ b/components/script/dom/htmlselectelement.rs
@@ -153,7 +153,7 @@ impl HTMLSelectElement {
         n
     }
 
-    // https://html.spec.whatwg.org/multipage/#concept-select-option-list
+    /// <https://html.spec.whatwg.org/multipage/#concept-select-option-list>
     pub(crate) fn list_of_options(
         &self,
     ) -> impl Iterator<Item = DomRoot<HTMLOptionElement>> + use<'_> {
@@ -353,8 +353,10 @@ impl HTMLSelectElement {
             .fire_bubbling_event(atom!("change"), can_gc);
     }
 
-    fn selected_option(&self) -> Option<DomRoot<HTMLOptionElement>> {
-        self.list_of_options().find(|opt_elem| opt_elem.Selected())
+    pub(crate) fn selected_option(&self) -> Option<DomRoot<HTMLOptionElement>> {
+        self.list_of_options()
+            .find(|opt_elem| opt_elem.Selected())
+            .or_else(|| self.list_of_options().next())
     }
 
     pub(crate) fn show_menu(&self, can_gc: CanGc) -> Option<usize> {
@@ -539,7 +541,8 @@ impl HTMLSelectElementMethods<crate::DomTypeHolder> for HTMLSelectElement {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-select-value>
     fn Value(&self) -> DOMString {
-        self.selected_option()
+        self.list_of_options()
+            .find(|opt_elem| opt_elem.Selected())
             .map(|opt_elem| opt_elem.Value())
             .unwrap_or_default()
     }

--- a/tests/wpt/meta/html/rendering/replaced-elements/the-select-element/select-1-block-size.html.ini
+++ b/tests/wpt/meta/html/rendering/replaced-elements/the-select-element/select-1-block-size.html.ini
@@ -1,2 +1,0 @@
-[select-1-block-size.html]
-  expected: FAIL

--- a/tests/wpt/meta/html/rendering/replaced-elements/the-select-element/select-multiple-re-add-option-via-document-fragment.html.ini
+++ b/tests/wpt/meta/html/rendering/replaced-elements/the-select-element/select-multiple-re-add-option-via-document-fragment.html.ini
@@ -1,2 +1,0 @@
-[select-multiple-re-add-option-via-document-fragment.html]
-  expected: FAIL


### PR DESCRIPTION
The label that is displayed inside a `<select>` element is that of the selected option, or it's text contents if the option does not have a label. Therefore, we need to update the `<select>` shadow tree when the contents of the selected option change.

Testing: Covered by existing web platform tests
Fixes https://github.com/servo/servo/issues/36926
Fixes https://github.com/servo/servo/issues/36925
