### PR TITLE
Implement is-element-nonceable

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -4313,9 +4313,7 @@ impl Document {
             },
             Some(csp_list) => {
                 let element = csp::Element {
-                    nonce: el
-                        .get_attribute(&ns!(), &local_name!("nonce"))
-                        .map(|attr| Cow::Owned(attr.value().to_string())),
+                    nonce: el.nonce_attribute_if_nonceable().map(Cow::Owned),
                 };
                 csp_list.should_elements_inline_type_behavior_be_blocked(&element, type_, source)
             },

--- a/tests/wpt/meta/content-security-policy/script-src/scriptnonce-basic-blocked.sub.html.ini
+++ b/tests/wpt/meta/content-security-policy/script-src/scriptnonce-basic-blocked.sub.html.ini
@@ -1,3 +1,0 @@
-[scriptnonce-basic-blocked.sub.html]
-  [Expecting alerts: ["PASS (closely-quoted nonce)","PASS (nonce w/whitespace)", "violated-directive=script-src-elem", "violated-directive=script-src-elem", "violated-directive=script-src-elem"\]]
-    expected: FAIL


### PR DESCRIPTION
Unfortunately while it now passes almost all cases in `tests/wpt/tests/content-security-policy/script-src/nonce-enforce-blocked.html`, the test in question doesn't pass yet as it requires all cases to be correct. Here, we still miss the "check for duplicate attributes during parsing". Since we don't have this information available yet from the parser, skip this for now.

Part of #36437
