### PR TITLE
codegen: use `FromJSValConvertible` trait for `Promise`

### DIFF
--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -3562,10 +3562,6 @@ impl GlobalScopeHelpers<crate::DomTypeHolder> for GlobalScope {
         GlobalScope::from_reflector(reflector, realm)
     }
 
-    unsafe fn from_object_maybe_wrapped(obj: *mut JSObject, cx: *mut JSContext) -> DomRoot<Self> {
-        GlobalScope::from_object_maybe_wrapped(obj, cx)
-    }
-
     fn origin(&self) -> &MutableOrigin {
         GlobalScope::origin(self)
     }

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -538,7 +538,7 @@ DOMInterfaces = {
 
 'Promise': {
     'spiderMonkeyInterface': True,
-    'additionalTraits': ["crate::interfaces::PromiseHelpers<Self>", "js::conversions::FromJSValConvertibleRc"]
+    'additionalTraits': ["js::conversions::FromJSValConvertibleRc"]
 },
 
 'Range': {

--- a/components/script_bindings/import.rs
+++ b/components/script_bindings/import.rs
@@ -11,12 +11,12 @@ pub(crate) mod base {
     };
     pub(crate) use js::error::throw_type_error;
     pub(crate) use js::jsapi::{
-        CurrentGlobalOrNull, HandleValue as RawHandleValue, HandleValueArray, Heap, IsCallable,
-        JS_NewObject, JSContext, JSObject,
+        HandleValue as RawHandleValue, HandleValueArray, Heap, IsCallable, JS_NewObject, JSContext,
+        JSObject,
     };
     pub(crate) use js::jsval::{JSVal, NullValue, ObjectOrNullValue, ObjectValue, UndefinedValue};
     pub(crate) use js::panic::maybe_resume_unwind;
-    pub(crate) use js::rust::wrappers::{Call, JS_WrapValue};
+    pub(crate) use js::rust::wrappers::Call;
     pub(crate) use js::rust::{HandleObject, HandleValue, MutableHandleObject, MutableHandleValue};
 
     pub(crate) use crate::callback::{

--- a/components/script_bindings/interfaces.rs
+++ b/components/script_bindings/interfaces.rs
@@ -3,10 +3,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::cell::RefCell;
-use std::rc::Rc;
 use std::thread::LocalKey;
 
-use js::conversions::ToJSValConvertible;
 use js::glue::JSPrincipalsCallbacks;
 use js::jsapi::{CallArgs, HandleObject as RawHandleObject, JSContext as RawJSContext, JSObject};
 use js::rust::{HandleObject, MutableHandleObject};
@@ -78,14 +76,6 @@ pub trait GlobalScopeHelpers<D: DomTypes> {
     unsafe fn from_object(obj: *mut JSObject) -> DomRoot<D::GlobalScope>;
     fn from_reflector(reflector: &impl DomObject, realm: InRealm) -> DomRoot<D::GlobalScope>;
 
-    /// # Safety
-    /// `obj` must point to a valid, non-null JSObject.
-    /// `cx` must point to a valid, non-null RawJSContext.
-    unsafe fn from_object_maybe_wrapped(
-        obj: *mut JSObject,
-        cx: *mut RawJSContext,
-    ) -> DomRoot<D::GlobalScope>;
-
     fn origin(&self) -> &MutableOrigin;
 
     fn incumbent() -> Option<DomRoot<D::GlobalScope>>;
@@ -99,15 +89,6 @@ pub trait GlobalScopeHelpers<D: DomTypes> {
 
 pub trait DocumentHelpers {
     fn ensure_safe_to_run_script_or_layout(&self);
-}
-
-/// Operations that must be invoked from the generated bindings.
-pub trait PromiseHelpers<D: crate::DomTypes> {
-    fn new_resolved(
-        global: &D::GlobalScope,
-        cx: JSContext,
-        value: impl ToJSValConvertible,
-    ) -> Rc<D::Promise>;
 }
 
 pub trait ServoInternalsHelpers {


### PR DESCRIPTION
Before it was only used when converting to a `Record`, using it all the times allow us to remove two methods.
Plus added a helper method in CodegenRust.py to avoid repeated code.

Testing: a successful build and existing tests should cover the changes.
Fixes: #36410
