### PR TITLE
layout: Obey intrinsic min/max block sizes on flex containers

### DIFF
--- a/components/layout/formatting_contexts.rs
+++ b/components/layout/formatting_contexts.rs
@@ -243,7 +243,7 @@ impl IndependentNonReplacedContents {
         containing_block_for_children: &ContainingBlock,
         containing_block: &ContainingBlock,
         depends_on_block_constraints: bool,
-        _lazy_block_size: &LazySize,
+        lazy_block_size: &LazySize,
     ) -> CacheableLayoutResult {
         match self {
             IndependentNonReplacedContents::Flow(bfc) => bfc.layout(
@@ -257,6 +257,7 @@ impl IndependentNonReplacedContents {
                 positioning_context,
                 containing_block_for_children,
                 depends_on_block_constraints,
+                lazy_block_size,
             ),
             IndependentNonReplacedContents::Grid(fc) => fc.layout(
                 layout_context,

--- a/tests/wpt/meta/css/css-flexbox/flex-container-max-content-002.tentative.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-container-max-content-002.tentative.html.ini
@@ -1,0 +1,12 @@
+[flex-container-max-content-002.tentative.html]
+  [.flex 2]
+    expected: FAIL
+
+  [.flex 3]
+    expected: FAIL
+
+  [.flex 5]
+    expected: FAIL
+
+  [.flex 6]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flex-container-min-content-002.tentative.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-container-min-content-002.tentative.html.ini
@@ -1,0 +1,21 @@
+[flex-container-min-content-002.tentative.html]
+  [.flex 2]
+    expected: FAIL
+
+  [.flex 3]
+    expected: FAIL
+
+  [.flex 5]
+    expected: FAIL
+
+  [.flex 6]
+    expected: FAIL
+
+  [.flex 13]
+    expected: FAIL
+
+  [.flex 14]
+    expected: FAIL
+
+  [.flex 15]
+    expected: FAIL

--- a/tests/wpt/tests/css/css-flexbox/flex-container-max-content-002.tentative.html
+++ b/tests/wpt/tests/css/css-flexbox/flex-container-max-content-002.tentative.html
@@ -1,0 +1,169 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Flex Container Max-Content Sizes</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#intrinsic-main-sizes"
+      title="9.9.1. Flex Container Intrinsic Main Sizes">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#intrinsic-cross-sizes"
+      title="9.9.2. Flex Container Intrinsic Cross Sizes">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/12123">
+
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+.flex {
+  display: inline-flex;
+  vertical-align: top;
+  border: 5px solid magenta;
+  width: max-content;
+  height: max-content;
+}
+.flex.min {
+  width: 0;
+  height: 0;
+  min-width: max-content;
+  min-height: max-content;
+}
+.flex.max {
+  width: 200px;
+  height: 200px;
+  max-width: max-content;
+  max-height: max-content;
+}
+.flex > div {
+  font: 25px/1 Ahem;
+  border: 5px solid cyan;
+}
+</style>
+
+<!-- Single-line row flex container -->
+<div class="flex" style="flex-flow: row nowrap"
+     data-expected-width="45" data-expected-height="45">
+  <div style="width: 25px; height: 25px">X</div>
+</div>
+<div class="flex min" style="flex-flow: row nowrap"
+     data-expected-width="45" data-expected-height="45">
+  <div style="width: 25px; height: 25px">X</div>
+</div>
+<div class="flex max" style="flex-flow: row nowrap"
+     data-expected-width="45" data-expected-height="45">
+  <div style="width: 25px; height: 25px">X</div>
+</div>
+
+<div class="flex" style="flex-flow: row nowrap"
+     data-expected-width="180" data-expected-height="45">
+  <div data-expected-width="85" data-expected-height="35">X X</div>
+  <div data-expected-width="85" data-expected-height="35">X X</div>
+</div>
+<div class="flex min" style="flex-flow: row nowrap"
+     data-expected-width="180" data-expected-height="45">
+  <div data-expected-width="85" data-expected-height="35">X X</div>
+  <div data-expected-width="85" data-expected-height="35">X X</div>
+</div>
+<div class="flex max" style="flex-flow: row nowrap"
+     data-expected-width="180" data-expected-height="45">
+  <div data-expected-width="85" data-expected-height="35">X X</div>
+  <div data-expected-width="85" data-expected-height="35">X X</div>
+</div>
+
+<hr>
+
+<!-- Single-line column flex container -->
+<div class="flex" style="flex-flow: column nowrap"
+     data-expected-width="45" data-expected-height="45">
+  <div style="width: 25px; height: 25px">X</div>
+</div>
+<div class="flex min" style="flex-flow: column nowrap"
+     data-expected-width="45" data-expected-height="45">
+  <div style="width: 25px; height: 25px">X</div>
+</div>
+<div class="flex max" style="flex-flow: column nowrap"
+     data-expected-width="45" data-expected-height="45">
+  <div style="width: 25px; height: 25px">X</div>
+</div>
+
+<div class="flex" style="flex-flow: column nowrap"
+     data-expected-width="95" data-expected-height="80">
+  <div data-expected-width="85" data-expected-height="35">X X</div>
+  <div data-expected-width="85" data-expected-height="35">X X</div>
+</div>
+<div class="flex min" style="flex-flow: column nowrap"
+     data-expected-width="95" data-expected-height="80">
+  <div data-expected-width="85" data-expected-height="35">X X</div>
+  <div data-expected-width="85" data-expected-height="35">X X</div>
+</div>
+<div class="flex max" style="flex-flow: column nowrap"
+     data-expected-width="95" data-expected-height="80">
+  <div data-expected-width="85" data-expected-height="35">X X</div>
+  <div data-expected-width="85" data-expected-height="35">X X</div>
+</div>
+
+<hr>
+
+<!-- Multi-line row flex container -->
+<div class="flex" style="flex-flow: row wrap"
+     data-expected-width="45" data-expected-height="45">
+  <div style="width: 25px; height: 25px">X</div>
+</div>
+<div class="flex min" style="flex-flow: row wrap"
+     data-expected-width="45" data-expected-height="45">
+  <div style="width: 25px; height: 25px">X</div>
+</div>
+<div class="flex max" style="flex-flow: row wrap"
+     data-expected-width="45" data-expected-height="45">
+  <div style="width: 25px; height: 25px">X</div>
+</div>
+
+<div class="flex" style="flex-flow: row wrap"
+     data-expected-width="180" data-expected-height="45">
+  <div data-expected-width="85" data-expected-height="35">X X</div>
+  <div data-expected-width="85" data-expected-height="35">X X</div>
+</div>
+<div class="flex min" style="flex-flow: row wrap"
+     data-expected-width="180" data-expected-height="45">
+  <div data-expected-width="85" data-expected-height="35">X X</div>
+  <div data-expected-width="85" data-expected-height="35">X X</div>
+</div>
+<div class="flex max" style="flex-flow: row wrap"
+     data-expected-width="180" data-expected-height="45">
+  <div data-expected-width="85" data-expected-height="35">X X</div>
+  <div data-expected-width="85" data-expected-height="35">X X</div>
+</div>
+
+<hr>
+
+<!-- Multi-line column flex container -->
+<div class="flex" style="flex-flow: column wrap"
+     data-expected-width="45" data-expected-height="45">
+  <div style="width: 25px; height: 25px">X</div>
+</div>
+<div class="flex min" style="flex-flow: column wrap"
+     data-expected-width="45" data-expected-height="45">
+  <div style="width: 25px; height: 25px">X</div>
+</div>
+<div class="flex max" style="flex-flow: column wrap"
+     data-expected-width="45" data-expected-height="45">
+  <div style="width: 25px; height: 25px">X</div>
+</div>
+
+<div class="flex" style="flex-flow: column wrap"
+     data-expected-width="95" data-expected-height="80">
+  <div data-expected-width="85" data-expected-height="35">X X</div>
+  <div data-expected-width="85" data-expected-height="35">X X</div>
+</div>
+<div class="flex min" style="flex-flow: column wrap"
+     data-expected-width="95" data-expected-height="80">
+  <div data-expected-width="85" data-expected-height="35">X X</div>
+  <div data-expected-width="85" data-expected-height="35">X X</div>
+</div>
+<div class="flex max" style="flex-flow: column wrap"
+     data-expected-width="95" data-expected-height="80">
+  <div data-expected-width="85" data-expected-height="35">X X</div>
+  <div data-expected-width="85" data-expected-height="35">X X</div>
+</div>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<script>
+checkLayout(".flex");
+</script>

--- a/tests/wpt/tests/css/css-flexbox/flex-container-min-content-002.tentative.html
+++ b/tests/wpt/tests/css/css-flexbox/flex-container-min-content-002.tentative.html
@@ -1,0 +1,169 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Flex Container Min-Content Sizes</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#intrinsic-main-sizes"
+      title="9.9.1. Flex Container Intrinsic Main Sizes">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#intrinsic-cross-sizes"
+      title="9.9.2. Flex Container Intrinsic Cross Sizes">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/12123">
+
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+.flex {
+  display: inline-flex;
+  vertical-align: top;
+  border: 5px solid magenta;
+  width: min-content;
+  height: min-content;
+}
+.flex.min {
+  width: 0;
+  height: 0;
+  min-width: min-content;
+  min-height: min-content;
+}
+.flex.max {
+  width: 200px;
+  height: 200px;
+  max-width: min-content;
+  max-height: min-content;
+}
+.flex > div {
+  font: 25px/1 Ahem;
+  border: 5px solid cyan;
+}
+</style>
+
+<!-- Single-line row flex container -->
+<div class="flex" style="flex-flow: row nowrap"
+     data-expected-width="45" data-expected-height="45">
+  <div style="width: 25px; height: 25px">X</div>
+</div>
+<div class="flex min" style="flex-flow: row nowrap"
+     data-expected-width="45" data-expected-height="45">
+  <div style="width: 25px; height: 25px">X</div>
+</div>
+<div class="flex max" style="flex-flow: row nowrap"
+     data-expected-width="45" data-expected-height="45">
+  <div style="width: 25px; height: 25px">X</div>
+</div>
+
+<div class="flex" style="flex-flow: row nowrap"
+     data-expected-width="80" data-expected-height="70">
+  <div data-expected-width="35" data-expected-height="60">X X</div>
+  <div data-expected-width="35" data-expected-height="60">X X</div>
+</div>
+<div class="flex min" style="flex-flow: row nowrap"
+     data-expected-width="80" data-expected-height="70">
+  <div data-expected-width="35" data-expected-height="60">X X</div>
+  <div data-expected-width="35" data-expected-height="60">X X</div>
+</div>
+<div class="flex max" style="flex-flow: row nowrap"
+     data-expected-width="80" data-expected-height="70">
+  <div data-expected-width="35" data-expected-height="60">X X</div>
+  <div data-expected-width="35" data-expected-height="60">X X</div>
+</div>
+
+<hr>
+
+<!-- Single-line column flex container -->
+<div class="flex" style="flex-flow: column nowrap"
+     data-expected-width="45" data-expected-height="45">
+  <div style="width: 25px; height: 25px">X</div>
+</div>
+<div class="flex min" style="flex-flow: column nowrap"
+     data-expected-width="45" data-expected-height="45">
+  <div style="width: 25px; height: 25px">X</div>
+</div>
+<div class="flex max" style="flex-flow: column nowrap"
+     data-expected-width="45" data-expected-height="45">
+  <div style="width: 25px; height: 25px">X</div>
+</div>
+
+<div class="flex" style="flex-flow: column nowrap"
+     data-expected-width="45" data-expected-height="130">
+  <div data-expected-width="35" data-expected-height="60">X X</div>
+  <div data-expected-width="35" data-expected-height="60">X X</div>
+</div>
+<div class="flex min" style="flex-flow: column nowrap"
+     data-expected-width="45" data-expected-height="130">
+  <div data-expected-width="35" data-expected-height="60">X X</div>
+  <div data-expected-width="35" data-expected-height="60">X X</div>
+</div>
+<div class="flex max" style="flex-flow: column nowrap"
+     data-expected-width="45" data-expected-height="130">
+  <div data-expected-width="35" data-expected-height="60">X X</div>
+  <div data-expected-width="35" data-expected-height="60">X X</div>
+</div>
+
+<hr>
+
+<!-- Multi-line row flex container -->
+<div class="flex" style="flex-flow: row wrap"
+     data-expected-width="45" data-expected-height="45">
+  <div style="width: 25px; height: 25px">X</div>
+</div>
+<div class="flex min" style="flex-flow: row wrap"
+     data-expected-width="45" data-expected-height="45">
+  <div style="width: 25px; height: 25px">X</div>
+</div>
+<div class="flex max" style="flex-flow: row wrap"
+     data-expected-width="45" data-expected-height="45">
+  <div style="width: 25px; height: 25px">X</div>
+</div>
+
+<div class="flex" style="flex-flow: row wrap"
+     data-expected-width="45" data-expected-height="130">
+  <div data-expected-width="35" data-expected-height="60">X X</div>
+  <div data-expected-width="35" data-expected-height="60">X X</div>
+</div>
+<div class="flex min" style="flex-flow: row wrap"
+     data-expected-width="45" data-expected-height="130">
+  <div data-expected-width="35" data-expected-height="60">X X</div>
+  <div data-expected-width="35" data-expected-height="60">X X</div>
+</div>
+<div class="flex max" style="flex-flow: row wrap"
+     data-expected-width="45" data-expected-height="130">
+  <div data-expected-width="35" data-expected-height="60">X X</div>
+  <div data-expected-width="35" data-expected-height="60">X X</div>
+</div>
+
+<hr>
+
+<!-- Multi-line column flex container -->
+<div class="flex" style="flex-flow: column wrap"
+     data-expected-width="45" data-expected-height="45">
+  <div style="width: 25px; height: 25px">X</div>
+</div>
+<div class="flex min" style="flex-flow: column wrap"
+     data-expected-width="45" data-expected-height="45">
+  <div style="width: 25px; height: 25px">X</div>
+</div>
+<div class="flex max" style="flex-flow: column wrap"
+     data-expected-width="45" data-expected-height="45">
+  <div style="width: 25px; height: 25px">X</div>
+</div>
+
+<div class="flex" style="flex-flow: column wrap"
+     data-expected-width="45" data-expected-height="130">
+  <div data-expected-width="35" data-expected-height="60">X X</div>
+  <div data-expected-width="35" data-expected-height="60">X X</div>
+</div>
+<div class="flex min" style="flex-flow: column wrap"
+     data-expected-width="45" data-expected-height="130">
+  <div data-expected-width="35" data-expected-height="60">X X</div>
+  <div data-expected-width="35" data-expected-height="60">X X</div>
+</div>
+<div class="flex max" style="flex-flow: column wrap"
+     data-expected-width="45" data-expected-height="130">
+  <div data-expected-width="35" data-expected-height="60">X X</div>
+  <div data-expected-width="35" data-expected-height="60">X X</div>
+</div>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<script>
+checkLayout(".flex");
+</script>


### PR DESCRIPTION
Intrinsic sizing keywords weren't working correctly on the min and max block sizes of a flex container, because we weren't setting the `CacheableLayoutResult::content_block_size` to the right value. This also ensures that `align-content` aligns within the final size of the container.

Note it's not very clear what to do for single-line containers, they are being discussed in https://github.com/w3c/csswg-drafts/issues/12123

Testing: Adding new WPT tests. There are still some failures, but most subtests would fail without this change.
Fixes: #36981
