### PR TITLE
compositor: Batch all pending scroll event updates into a single transaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1103,6 +1103,7 @@ dependencies = [
  "servo_allocator",
  "servo_config",
  "servo_geometry",
+ "smallvec",
  "stylo_traits",
  "surfman",
  "tracing",

--- a/components/compositing/Cargo.toml
+++ b/components/compositing/Cargo.toml
@@ -38,6 +38,7 @@ script_traits = { workspace = true }
 servo_allocator = { path = "../allocator" }
 servo_config = { path = "../config" }
 servo_geometry = { path = "../geometry" }
+smallvec = { workspace = true }
 stylo_traits = { workspace = true }
 tracing = { workspace = true, optional = true }
 webrender = { workspace = true }


### PR DESCRIPTION
When multiple WebViews are updating scroll events, instead of taking the
list of `WebView`s to avoid a double-borrow, batch scroll events into a
single transaction. This should make processing slightly more efficient
and avoids having to take the vector of WebViews.

Testing: No behavior change here and this aspect of WebView interaction
is untestable currently.
