### PR TITLE
Use servoshell custom logging domain for OHOS workflow

### DIFF
--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -223,10 +223,8 @@ jobs:
           hdc shell snapshot_display -f /data/local/tmp/servo.jpeg
           hdc file recv /data/local/tmp/servo.jpeg  test_output/servo_hos_screenshot.jpeg
           hdc file recv /data/local/tmp/ohtrace.txt  test_output/servo.ftrace
-          # To limit the logsize we only save logs from servo. 
-          # Todo:  investigate giving servo a custom domain tag, so we can also log appspawn etc, 
-          # since another common error might be the dynamic loader failing to relocate libservoshell.so
-          hdc shell hilog --exit --pid=${servo_pid} > test_output/servo.log
+          # To limit the logsize we only save logs from servo.
+          hdc shell hilog --exit -D 0xE0C3 > test_output/servo.log
       # todo: Also benchmark some other websites....
       - name: Upload artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Use the introduced logging domain on OHOS to get the log on the workflow. This improves the reliability of getting the logs if servoshell crashed.

Testing: This was tested on the CI Runner
