### PR TITLE
layout: Inform child layout about final block size

### DIFF
--- a/components/layout/formatting_contexts.rs
+++ b/components/layout/formatting_contexts.rs
@@ -15,6 +15,7 @@ use crate::dom_traversal::{Contents, NodeAndStyleInfo};
 use crate::flexbox::FlexContainer;
 use crate::flow::BlockFormattingContext;
 use crate::fragment_tree::{BaseFragmentInfo, FragmentFlags};
+use crate::geom::LazySize;
 use crate::layout_box_base::{
     CacheableLayoutResult, CacheableLayoutResultAndInputs, LayoutBoxBase,
 };
@@ -242,6 +243,7 @@ impl IndependentNonReplacedContents {
         containing_block_for_children: &ContainingBlock,
         containing_block: &ContainingBlock,
         depends_on_block_constraints: bool,
+        _lazy_block_size: &LazySize,
     ) -> CacheableLayoutResult {
         match self {
             IndependentNonReplacedContents::Flow(bfc) => bfc.layout(
@@ -281,6 +283,7 @@ impl IndependentNonReplacedContents {
             level = "trace",
         )
     )]
+    #[allow(clippy::too_many_arguments)]
     pub fn layout(
         &self,
         layout_context: &LayoutContext,
@@ -289,6 +292,7 @@ impl IndependentNonReplacedContents {
         containing_block: &ContainingBlock,
         base: &LayoutBoxBase,
         depends_on_block_constraints: bool,
+        lazy_block_size: &LazySize,
     ) -> CacheableLayoutResult {
         if let Some(cache) = base.cached_layout_result.borrow().as_ref() {
             let cache = &**cache;
@@ -317,6 +321,7 @@ impl IndependentNonReplacedContents {
             containing_block_for_children,
             containing_block,
             depends_on_block_constraints,
+            lazy_block_size,
         );
 
         *base.cached_layout_result.borrow_mut() = Some(Box::new(CacheableLayoutResultAndInputs {


### PR DESCRIPTION
Before this patch it wasn't possibly to simultaneously support intrinsic min/max sizes and content alignment in the block axis. For example, block containers only support the former, and flex containers only the latter.

The reason is that the final block size was decided by the parent formatting context *after* performing layout, while content alignment is performed *during* layout.

To address the problem, this introduces the struct `LazySize`, which contains the data to resolve the final size, except for the intrinsic size. Thus the parent formatting context can first create a `LazySize`, then pass it to the child layout so that (if necessary) it can compute the final size once the intrinsic one is known, and after layout the parent formatting context uses it to actually size the child.

This PR just provides the functionality that will be used by follow-ups, but at this point no layout is using the `LazySize` provided by the parent, so there shouldn't be any behavior change yet.

Testing: Unnecessary (no behavior change)
This is part of #36981 and #36982