### PR TITLE
The click event does not to be dispatched after the click event is iggered by the script

### DIFF
--- a/components/compositing/webview_renderer.rs
+++ b/components/compositing/webview_renderer.rs
@@ -689,11 +689,6 @@ impl WebViewRenderer {
             action: MouseButtonAction::Up,
             point,
         }));
-        self.dispatch_input_event(InputEvent::MouseButton(MouseButtonEvent {
-            button,
-            action: MouseButtonAction::Click,
-            point,
-        }));
     }
 
     pub(crate) fn notify_scroll_event(


### PR DESCRIPTION
In the OpenHarmony platform, the click event is triggered after the script is moved, and the click event does not need to be dispatched.