### PR TITLE
layout: Implement quote depth calculation for CSS `quotes`

### DIFF
--- a/components/layout/context.rs
+++ b/components/layout/context.rs
@@ -231,8 +231,8 @@ impl LayoutContext<'_> {
                                     // > for a raster image, it also specifies the image’s natural
                                     // > resolution, overriding any other source of data that might
                                     // > supply a natural resolution.
-                                    image_info.size = (image_info.size.to_f32()
-                                        / image.resolution.dppx())
+                                    image_info.size = (image_info.size.to_f32() /
+                                        image.resolution.dppx())
                                     .to_u32();
                                     ResolvedImage::Image(image_info)
                                 },

--- a/components/layout/context.rs
+++ b/components/layout/context.rs
@@ -49,6 +49,9 @@ pub struct LayoutContext<'a> {
 
     /// The DOM node that is highlighted by the devtools inspector, if any
     pub highlighted_dom_node: Option<OpaqueNode>,
+
+    /// The current quote depth to be used for the current layout pass.
+    pub quote_depth: Mutex<usize>,
 }
 
 pub enum ResolvedImage<'a> {
@@ -228,8 +231,8 @@ impl LayoutContext<'_> {
                                     // > for a raster image, it also specifies the image’s natural
                                     // > resolution, overriding any other source of data that might
                                     // > supply a natural resolution.
-                                    image_info.size = (image_info.size.to_f32() /
-                                        image.resolution.dppx())
+                                    image_info.size = (image_info.size.to_f32()
+                                        / image.resolution.dppx())
                                     .to_u32();
                                     ResolvedImage::Image(image_info)
                                 },
@@ -238,5 +241,28 @@ impl LayoutContext<'_> {
                     })
             },
         }
+    }
+
+    pub fn increment_quote_depth(&self) -> usize {
+        let mut depth = self.quote_depth.lock();
+        *depth += 1;
+        *depth
+    }
+
+    pub fn decrement_quote_depth(&self) -> usize {
+        let mut depth = self.quote_depth.lock();
+        if *depth > 0 {
+            *depth -= 1;
+        }
+        *depth
+    }
+
+    pub fn get_quote_depth(&self) -> usize {
+        *self.quote_depth.lock()
+    }
+
+    pub fn reset_quote_depth(&self) {
+        let mut depth = self.quote_depth.lock();
+        *depth = 0;
     }
 }

--- a/components/layout/dom_traversal.rs
+++ b/components/layout/dom_traversal.rs
@@ -104,10 +104,10 @@ impl<'dom> From<&NodeAndStyleInfo<'dom>> for BaseFragmentInfo {
         // some WPT tests. This needs more investigation.
         if matches!(
             pseudo,
-            Some(PseudoElement::ServoAnonymousBox)
-                | Some(PseudoElement::ServoAnonymousTable)
-                | Some(PseudoElement::ServoAnonymousTableCell)
-                | Some(PseudoElement::ServoAnonymousTableRow)
+            Some(PseudoElement::ServoAnonymousBox) |
+                Some(PseudoElement::ServoAnonymousTable) |
+                Some(PseudoElement::ServoAnonymousTableCell) |
+                Some(PseudoElement::ServoAnonymousTableRow)
         ) {
             return Self::anonymous();
         }
@@ -364,8 +364,8 @@ fn traverse_pseudo_element_contents<'dom>(
                 };
                 // `display` is not inherited, so we get the initial value
                 debug_assert!(
-                    Display::from(anonymous_info.style.get_box().display)
-                        == Display::GeneratingBox(display_inline)
+                    Display::from(anonymous_info.style.get_box().display) ==
+                        Display::GeneratingBox(display_inline)
                 );
                 handler.handle_element(
                     anonymous_info,

--- a/components/layout/dom_traversal.rs
+++ b/components/layout/dom_traversal.rs
@@ -486,9 +486,11 @@ fn generate_pseudo_element_content(
                             vec.push(PseudoElementContentItem::Replaced(replaced_content));
                         }
                     },
+                    // https://drafts.csswg.org/css-content/#valdef-content-open-quote
                     ContentItem::OpenQuote => {
                         let quote_depth = context.get_quote_depth();
                         let maybe_quote = match &pseudo_element_style.get_list().quotes {
+                            // https://drafts.csswg.org/css-content/#quotes-property
                             Quotes::Auto => {
                                 let lang = &pseudo_element_style.get_font()._x_lang;
                                 let quote_pair = quotes_for_lang(lang.0.as_ref(), quote_depth);
@@ -517,11 +519,13 @@ fn generate_pseudo_element_content(
                         }
                         context.increment_quote_depth();
                     },
+                    // https://drafts.csswg.org/css-content/#valdef-content-close-quote
                     ContentItem::CloseQuote => {
                         let quote_depth = context.get_quote_depth();
                         if quote_depth > 0 {
                             let updated_depth = context.decrement_quote_depth();
                             let maybe_quote = match &pseudo_element_style.get_list().quotes {
+                                // https://drafts.csswg.org/css-content/#quotes-property
                                 Quotes::Auto => {
                                     let lang = &pseudo_element_style.get_font()._x_lang;
                                     let quote_pair =
@@ -552,9 +556,11 @@ fn generate_pseudo_element_content(
                             }
                         }
                     },
+                    // https://drafts.csswg.org/css-content/#valdef-content-no-open-quote
                     ContentItem::NoOpenQuote => {
                         context.increment_quote_depth();
                     },
+                    // https://drafts.csswg.org/css-content/#valdef-content-no-close-quote
                     ContentItem::NoCloseQuote => {
                         context.decrement_quote_depth();
                     },

--- a/components/layout/dom_traversal.rs
+++ b/components/layout/dom_traversal.rs
@@ -495,7 +495,7 @@ fn generate_pseudo_element_content(
                                 let lang = &pseudo_element_style.get_font()._x_lang;
                                 let quote_pair = quotes_for_lang(lang.0.as_ref(), quote_depth);
                                 Some(get_quote_from_pair(
-                                    &item,
+                                    item,
                                     &quote_pair.opening,
                                     &quote_pair.closing,
                                 ))
@@ -507,7 +507,7 @@ fn generate_pseudo_element_content(
                                     let idx = std::cmp::min(quote_depth, quote_list.0.len() - 1);
                                     let quote_pair = &quote_list.0[idx];
                                     Some(get_quote_from_pair(
-                                        &item,
+                                        item,
                                         &*quote_pair.opening,
                                         &*quote_pair.closing,
                                     ))
@@ -531,7 +531,7 @@ fn generate_pseudo_element_content(
                                     let quote_pair =
                                         quotes_for_lang(lang.0.as_ref(), updated_depth);
                                     Some(get_quote_from_pair(
-                                        &item,
+                                        item,
                                         &quote_pair.opening,
                                         &quote_pair.closing,
                                     ))
@@ -544,7 +544,7 @@ fn generate_pseudo_element_content(
                                             std::cmp::min(updated_depth, quote_list.0.len() - 1);
                                         let quote_pair = &quote_list.0[idx];
                                         Some(get_quote_from_pair(
-                                            &item,
+                                            item,
                                             &*quote_pair.opening,
                                             &*quote_pair.closing,
                                         ))

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -647,7 +647,10 @@ impl LayoutThread {
             iframe_sizes: Mutex::default(),
             use_rayon: rayon_pool.is_some(),
             highlighted_dom_node: reflow_request.highlighted_dom_node,
+            quote_depth: Mutex::new(0),
         };
+
+        layout_context.reset_quote_depth();
 
         self.restyle_and_build_trees(
             &reflow_request,

--- a/tests/wpt/meta/css/css-content/content-quotes-depth.html.ini
+++ b/tests/wpt/meta/css/css-content/content-quotes-depth.html.ini
@@ -1,0 +1,2 @@
+[content-quotes-depth.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-content/quotes-001.html.ini
+++ b/tests/wpt/meta/css/css-content/quotes-001.html.ini
@@ -1,2 +1,0 @@
-[quotes-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-content/quotes-003.html.ini
+++ b/tests/wpt/meta/css/css-content/quotes-003.html.ini
@@ -1,2 +1,0 @@
-[quotes-003.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-content/quotes-004.html.ini
+++ b/tests/wpt/meta/css/css-content/quotes-004.html.ini
@@ -1,2 +1,0 @@
-[quotes-004.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-content/quotes-005.html.ini
+++ b/tests/wpt/meta/css/css-content/quotes-005.html.ini
@@ -1,2 +1,0 @@
-[quotes-005.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-content/quotes-006.html.ini
+++ b/tests/wpt/meta/css/css-content/quotes-006.html.ini
@@ -1,2 +1,0 @@
-[quotes-006.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-content/quotes-007.html.ini
+++ b/tests/wpt/meta/css/css-content/quotes-007.html.ini
@@ -1,2 +1,0 @@
-[quotes-007.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-content/quotes-008.html.ini
+++ b/tests/wpt/meta/css/css-content/quotes-008.html.ini
@@ -1,2 +1,0 @@
-[quotes-008.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-content/quotes-009.html.ini
+++ b/tests/wpt/meta/css/css-content/quotes-009.html.ini
@@ -1,2 +1,0 @@
-[quotes-009.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-content/quotes-011.html.ini
+++ b/tests/wpt/meta/css/css-content/quotes-011.html.ini
@@ -1,2 +1,0 @@
-[quotes-011.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-content/quotes-012.html.ini
+++ b/tests/wpt/meta/css/css-content/quotes-012.html.ini
@@ -1,2 +1,0 @@
-[quotes-012.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-content/quotes-013.html.ini
+++ b/tests/wpt/meta/css/css-content/quotes-013.html.ini
@@ -1,2 +1,0 @@
-[quotes-013.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-content/quotes-014.html.ini
+++ b/tests/wpt/meta/css/css-content/quotes-014.html.ini
@@ -1,2 +1,0 @@
-[quotes-014.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-content/quotes-015.html.ini
+++ b/tests/wpt/meta/css/css-content/quotes-015.html.ini
@@ -1,2 +1,0 @@
-[quotes-015.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-content/quotes-016.html.ini
+++ b/tests/wpt/meta/css/css-content/quotes-016.html.ini
@@ -1,0 +1,2 @@
+[quotes-016.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-content/quotes-017.html.ini
+++ b/tests/wpt/meta/css/css-content/quotes-017.html.ini
@@ -1,2 +1,0 @@
-[quotes-017.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-content/quotes-018.html.ini
+++ b/tests/wpt/meta/css/css-content/quotes-018.html.ini
@@ -1,2 +1,0 @@
-[quotes-018.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-content/quotes-019.html.ini
+++ b/tests/wpt/meta/css/css-content/quotes-019.html.ini
@@ -1,2 +1,0 @@
-[quotes-019.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-content/quotes-020.html.ini
+++ b/tests/wpt/meta/css/css-content/quotes-020.html.ini
@@ -1,2 +1,0 @@
-[quotes-020.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-content/quotes-022.html.ini
+++ b/tests/wpt/meta/css/css-content/quotes-022.html.ini
@@ -1,2 +1,0 @@
-[quotes-022.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-content/quotes-023.html.ini
+++ b/tests/wpt/meta/css/css-content/quotes-023.html.ini
@@ -1,2 +1,0 @@
-[quotes-023.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-content/quotes-024.html.ini
+++ b/tests/wpt/meta/css/css-content/quotes-024.html.ini
@@ -1,2 +1,0 @@
-[quotes-024.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-content/quotes-025.html.ini
+++ b/tests/wpt/meta/css/css-content/quotes-025.html.ini
@@ -1,2 +1,0 @@
-[quotes-025.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-content/quotes-026.html.ini
+++ b/tests/wpt/meta/css/css-content/quotes-026.html.ini
@@ -1,0 +1,2 @@
+[quotes-026.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-content/quotes-027.html.ini
+++ b/tests/wpt/meta/css/css-content/quotes-027.html.ini
@@ -1,2 +1,0 @@
-[quotes-027.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-content/quotes-028.html.ini
+++ b/tests/wpt/meta/css/css-content/quotes-028.html.ini
@@ -1,2 +1,0 @@
-[quotes-028.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-content/quotes-029.html.ini
+++ b/tests/wpt/meta/css/css-content/quotes-029.html.ini
@@ -1,2 +1,0 @@
-[quotes-029.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-content/quotes-033.html.ini
+++ b/tests/wpt/meta/css/css-content/quotes-033.html.ini
@@ -1,2 +1,0 @@
-[quotes-033.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-content/quotes-slot-scoping.html.ini
+++ b/tests/wpt/meta/css/css-content/quotes-slot-scoping.html.ini
@@ -1,2 +1,0 @@
-[quotes-slot-scoping.html]
-  expected: FAIL

--- a/tests/wpt/tests/css/css-content/content-quotes-depth-ref.html
+++ b/tests/wpt/tests/css/css-content/content-quotes-depth-ref.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Reference: quote-depth behavior</title>
+<body>
+  <div>&#x201c;Test1&#x201d;</div>
+  <div>&#x201c;Test2&#x201d;</div>
+  <div>&#x201c;Test3&#x2018;Test3 Inner&#x2019;&#x201d;</div>
+  <div>Test4</div>
+  <div>&#x201c;Test5</div>
+  <div>Test6&#x201d;</div>
+</body>

--- a/tests/wpt/tests/css/css-content/content-quotes-depth.html
+++ b/tests/wpt/tests/css/css-content/content-quotes-depth.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Content: quote-depth behavior</title>
+<link rel="author" href="mailto:saku@email.sakupi01.com" title="saku">
+<link rel="help" href="https://www.w3.org/TR/css-content-3/#quotes">
+<meta name="assert" content="content quotes are correctly applied respecting to the depth of the element.">
+<link rel="match" href="content-quotes-depth-ref.html">
+<style>
+  :root {
+    quotes: "\201c" "\201d" "\2018" "\2019";
+  }
+
+  /* quotes made only with before */
+  .test1::before {
+    content: open-quote "Test1" close-quote;
+  }
+
+  /* quotes made only with before and after pseudo-elements */
+  .test2::before {
+    content: open-quote;
+  }
+  
+  .test2::after {
+    content: close-quote;
+  }
+
+  /* Nested quotes */
+  .test3::before {
+    content: open-quote;
+  }
+  
+  .test3::after {
+    content: open-quote "Test3 Inner" close-quote close-quote;
+  }
+
+  /* close-quote will be ignored */
+  .test4::before {
+    content: close-quote;
+  }
+  
+  /* close-quote will be ignored */
+  .test5::before {
+    content: open-quote;
+  }
+  
+  .test5::after { 
+    content: no-close-quote;
+  }
+  
+  /* open-quote will be ignored */
+  .test6::before {
+    content: no-open-quote;
+  }
+  
+  .test6::after { 
+    content: close-quote;
+  }
+</style>
+<body>
+  <div class="test1"></div>
+  <div class="test2">Test2</div>
+  <div class="test3">Test3</div>
+  <div class="test4">Test4</div>
+  <div class="test5">Test5</div>
+  <div class="test6">Test6</div>
+</body>

--- a/tests/wpt/tests/css/css-content/content-quotes-depth.html
+++ b/tests/wpt/tests/css/css-content/content-quotes-depth.html
@@ -19,7 +19,7 @@
   .test2::before {
     content: open-quote;
   }
-  
+
   .test2::after {
     content: close-quote;
   }
@@ -28,7 +28,7 @@
   .test3::before {
     content: open-quote;
   }
-  
+
   .test3::after {
     content: open-quote "Test3 Inner" close-quote close-quote;
   }
@@ -37,22 +37,22 @@
   .test4::before {
     content: close-quote;
   }
-  
+
   /* close-quote will be ignored */
   .test5::before {
     content: open-quote;
   }
-  
-  .test5::after { 
+
+  .test5::after {
     content: no-close-quote;
   }
-  
+
   /* open-quote will be ignored */
   .test6::before {
     content: no-open-quote;
   }
-  
-  .test6::after { 
+
+  .test6::after {
     content: close-quote;
   }
 </style>


### PR DESCRIPTION
This PR is a supplement to the initial CSS quotes implementation (https://github.com/servo/servo/pull/34770) and implements CSS quotes depth calculation. It also addresses the other issue related to depth calculation. (https://github.com/servo/servo/issues/36686)

- implements CSS quotes depth calculation in layout context level
  - supports nested quotes
  - supports `::before` `::after` content-based quotes (`content: open-quote "Test1" close-quote;` in `::before` was only supported in initial, but now supports `::after` `content: open-quote;` & `::before` `content: close-quote;` way.)
  - ignore `close-quote` if the depth is 0
- implements `no-open-quote` and `no-close-quote` according to the spec

However, this PR has the problem that the calculation sometimes fails and sometimes succeeds. The fail/success timing depends on the layout, and I suspect that the problem is not the calculation logic itself.
I gess the underlying problem would be the parallelization of reflow step.
It'd be great if I could get your opinion on whether the potential problem should be solved in this PR or could be a pending for the future.

Testing: A new reftest is added. (`css/css-content/content-quotes-depth.html`) However, the test is currently marked as FAIL since it's flaky because of the reason previously mentioned. 
Fixes: https://github.com/servo/servo/issues/36686

---

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are for https://github.com/servo/servo/issues/34446, https://github.com/servo/servo/issues/36686 (GitHub issue number if applicable)

- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___