### PR TITLE
canvas: Move generic implementations into `GenericPathBuilder` trait

### DIFF
--- a/components/canvas/backend.rs
+++ b/components/canvas/backend.rs
@@ -134,7 +134,18 @@ pub(crate) trait GenericPathBuilder<B: Backend> {
         start_angle: f32,
         end_angle: f32,
         anticlockwise: bool,
-    );
+    ) {
+        <PathBuilder as GenericPathBuilder<RaqoteBackend>>::ellipse(
+            self,
+            origin,
+            radius,
+            radius,
+            0.,
+            start_angle,
+            end_angle,
+            anticlockwise,
+        );
+    }
     fn bezier_curve_to(
         &mut self,
         control_point1: &Point2D<f32>,
@@ -212,7 +223,23 @@ pub(crate) trait GenericPathBuilder<B: Backend> {
         large_arc: bool,
         sweep: bool,
         end_point: Point2D<f32>,
-    );
+    ) {
+        let Some(start) = self.get_current_point() else {
+            return;
+        };
+
+        let arc = lyon_geom::SvgArc {
+            from: start,
+            to: end_point,
+            radii: lyon_geom::vector(radius_x, radius_y),
+            x_rotation: lyon_geom::Angle::degrees(rotation_angle),
+            flags: lyon_geom::ArcFlags { large_arc, sweep },
+        };
+
+        arc.for_each_quadratic_bezier(&mut |q| {
+            self.quadratic_curve_to(&q.ctrl, &q.to);
+        });
+    }
     fn finish(&mut self) -> B::Path;
 }
 

--- a/components/canvas/backend.rs
+++ b/components/canvas/backend.rs
@@ -135,7 +135,7 @@ pub(crate) trait GenericPathBuilder<B: Backend> {
         end_angle: f32,
         anticlockwise: bool,
     ) {
-        <PathBuilder as GenericPathBuilder<RaqoteBackend>>::ellipse(
+        Self::ellipse(
             self,
             origin,
             radius,

--- a/components/canvas/raqote_backend.rs
+++ b/components/canvas/raqote_backend.rs
@@ -680,26 +680,6 @@ impl PathBuilder {
 }
 
 impl GenericPathBuilder<RaqoteBackend> for PathBuilder {
-    fn arc(
-        &mut self,
-        origin: Point2D<f32>,
-        radius: f32,
-        start_angle: f32,
-        end_angle: f32,
-        anticlockwise: bool,
-    ) {
-        <PathBuilder as GenericPathBuilder<RaqoteBackend>>::ellipse(
-            self,
-            origin,
-            radius,
-            radius,
-            0.,
-            start_angle,
-            end_angle,
-            anticlockwise,
-        );
-    }
-
     fn bezier_curve_to(
         &mut self,
         control_point1: &Point2D<f32>,
@@ -718,32 +698,6 @@ impl GenericPathBuilder<RaqoteBackend> for PathBuilder {
 
     fn close(&mut self) {
         self.0.as_mut().unwrap().close();
-    }
-
-    fn svg_arc(
-        &mut self,
-        radius_x: f32,
-        radius_y: f32,
-        rotation_angle: f32,
-        large_arc: bool,
-        sweep: bool,
-        end_point: Point2D<f32>,
-    ) {
-        let Some(start) = self.get_current_point() else {
-            return;
-        };
-
-        let arc = lyon_geom::SvgArc {
-            from: start,
-            to: end_point,
-            radii: lyon_geom::vector(radius_x, radius_y),
-            x_rotation: lyon_geom::Angle::degrees(rotation_angle),
-            flags: lyon_geom::ArcFlags { large_arc, sweep },
-        };
-
-        arc.for_each_quadratic_bezier(&mut |q| {
-            self.quadratic_curve_to(&q.ctrl, &q.to);
-        });
     }
 
     fn get_current_point(&mut self) -> Option<Point2D<f32>> {


### PR DESCRIPTION
There is no reason to require this impls, because we already have written them in generic way.

Testing: Just refactoring, but there are WPT tests
