### PR TITLE
HSTS list memory reduction and fixes

### DIFF
--- a/components/net/hsts.rs
+++ b/components/net/hsts.rs
@@ -176,26 +176,6 @@ impl HstsPreloadList {
 }
 
 impl HstsList {
-    /// Create an `HstsList` from the bytes of a JSON preload file.
-    pub fn from_preload(preload_content: &str) -> Option<HstsList> {
-        #[derive(Deserialize)]
-        struct HstsEntries {
-            entries: Vec<HstsEntry>,
-        }
-
-        let hsts_entries: Option<HstsEntries> = serde_json::from_str(preload_content).ok();
-
-        hsts_entries.map(|hsts_entries| {
-            let mut hsts_list: HstsList = HstsList::default();
-
-            for hsts_entry in hsts_entries.entries {
-                hsts_list.push(hsts_entry);
-            }
-
-            hsts_list
-        })
-    }
-
     pub fn is_host_secure(&self, host: &str) -> bool {
         debug!("HSTS: is {host} secure?");
         if PRELOAD_LIST_ENTRIES.is_host_secure(host) {

--- a/components/net/tests/hsts.rs
+++ b/components/net/tests/hsts.rs
@@ -11,24 +11,11 @@ use net_traits::IncludeSubdomains;
 use time::Duration;
 
 #[test]
-fn test_hsts_entry_is_not_expired_when_it_has_no_timestamp() {
+fn test_hsts_entry_is_not_expired_when_it_has_no_expires_at() {
     let entry = HstsEntry {
         host: "mozilla.org".to_owned(),
         include_subdomains: false,
-        max_age: Some(StdDuration::from_secs(20)),
-        timestamp: None,
-    };
-
-    assert!(!entry.is_expired());
-}
-
-#[test]
-fn test_hsts_entry_is_not_expired_when_it_has_no_max_age() {
-    let entry = HstsEntry {
-        host: "mozilla.org".to_owned(),
-        include_subdomains: false,
-        max_age: None,
-        timestamp: Some(CrossProcessInstant::now()),
+        expires_at: None,
     };
 
     assert!(!entry.is_expired());
@@ -39,8 +26,7 @@ fn test_hsts_entry_is_expired_when_it_has_reached_its_max_age() {
     let entry = HstsEntry {
         host: "mozilla.org".to_owned(),
         include_subdomains: false,
-        max_age: Some(StdDuration::from_secs(10)),
-        timestamp: Some(CrossProcessInstant::now() - Duration::seconds(20)),
+        expires_at: Some(CrossProcessInstant::now() - Duration::seconds(20)),
     };
 
     assert!(entry.is_expired());
@@ -378,8 +364,7 @@ fn test_hsts_list_with_expired_entry_is_not_is_host_secure() {
         vec![HstsEntry {
             host: "mozilla.org".to_owned(),
             include_subdomains: false,
-            max_age: Some(StdDuration::from_secs(20)),
-            timestamp: Some(CrossProcessInstant::now() - Duration::seconds(100)),
+            expires_at: Some(CrossProcessInstant::now() - Duration::seconds(100)),
         }],
     );
     let hsts_list = HstsList {


### PR DESCRIPTION
Combines the 2 time values in the HSTS entry with a single timestamp for expiration. (9MB savings per list)

The previous time representations were based on system boot time which meant that the `hsts_list.json` round trip across boots resulted in completely erroneous expiration times.

The preload list is now initialized separately from the public and private lists and shared by both, cutting memory use in half.

Overall takes memory use from 64MB for HSTS to 24MB.

Expired HSTS entries are now removed from the list when updating an entry and subdomains can be added to a list if the superdomain does not already include them.

Testing: New unit tests added
Related to #25929 but the next step would be to attempt to use https://github.com/BurntSushi/fst Which will be explored in a follow-up.
