### PR TITLE
htmlmediaelement:  Fix fetch request race on "seek-data" event

### DIFF
--- a/tests/wpt/meta/html/canvas/element/manual/imagebitmap/createImageBitmap-origin.sub.html.ini
+++ b/tests/wpt/meta/html/canvas/element/manual/imagebitmap/createImageBitmap-origin.sub.html.ini
@@ -1,5 +1,4 @@
 [createImageBitmap-origin.sub.html]
-  expected: TIMEOUT
   [redirected to cross-origin HTMLVideoElement: origin unclear 2dContext.drawImage]
     expected: FAIL
 


### PR DESCRIPTION
On execution media element load algorithm
https://html.spec.whatwg.org/multipage/media.html#media-element-load-algorithm
we can observe race condition between parallel running fetch requests:
 R1: (media element) initial request (see "resource_fetch_algorithm" function)
 R2: (gstreamer) duration "seek-data" request (see PlayerEvent::SeekData)
 R3: (gstreamer) continue on last interrupted time "seek-data" request

At time there are only one current fetch context for media element but
because resource fetch and cancellation are async operations need
to identify (by request id) and skip processing outdated fetch request
(fetch listener callbacks).

Async load in background sequence (stream content length = 2757913):
```
R1 (seek-offset=0):          [------------------------------X]
R2 (seek-offset=2757866):          [---------Y]
                               AS-****-+++-AE
R3 (seek-offset=98304):                         [----------------Z]
                                             BS-****-+++BE

R1 (seek-offset=0):          [------X]
R2 (seek-offset=2757866):                [--------Y] (discarded data)
                                     AS-****---------+++-AE

- A*/B* performed seeks (*** seek lock, +++ flush buffer queue + reset EOS)
  (on Gstreamer streaming thread)
- X/Y/Z "end-of-stream" events from fetch requests
  (on Servo script thread)
```

All incoming input data from different requests are mixed and
pushed to active media player, plus abnormal behaviour due to
intermixed X/Y/Z "end-of-stream" events.

To handle it properly we will unblock seek lock on "seek-data" event
(on script thread) as soon as possible (GStreamer will be able
to flush buffer queue and reset EOS state) and introduce buffered data source
to delay pushing input data/EOS event until media player will be actually ready.

Testing: Improvements to the following tests:
  - /html/canvas/element/manual/imagebitmap/createImageBitmap-origin.sub.html
  - /html/semantics/embedded-content/the-canvas-element/security.pattern.fillStyle.sub.html

Fixes: https://github.com/servo/servo/issues/31931
Fixes: https://github.com/servo/servo/issues/36989