### PR TITLE
layout: Correct damage propagation and style repair for repaint-only layout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1065,7 +1065,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2033,7 +2033,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2560,7 +2560,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4002,7 +4002,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi 0.5.0",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4255,7 +4255,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a793df0d7afeac54f95b471d3af7f0d4fb975699f972341a4b76988d49cdf0c"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -6177,7 +6177,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6509,7 +6509,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.28.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#bc815af4b5ae01768eaef64d21cebe6d66be06ea"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#fb74b958cc7bb93a9335766130d6711ad3e071ce"
 dependencies = [
  "bitflags 2.9.1",
  "cssparser",
@@ -6804,7 +6804,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.1"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#bc815af4b5ae01768eaef64d21cebe6d66be06ea"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#fb74b958cc7bb93a9335766130d6711ad3e071ce"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -7265,7 +7265,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#bc815af4b5ae01768eaef64d21cebe6d66be06ea"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#fb74b958cc7bb93a9335766130d6711ad3e071ce"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -7323,7 +7323,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#bc815af4b5ae01768eaef64d21cebe6d66be06ea"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#fb74b958cc7bb93a9335766130d6711ad3e071ce"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -7332,12 +7332,12 @@ dependencies = [
 [[package]]
 name = "stylo_config"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#bc815af4b5ae01768eaef64d21cebe6d66be06ea"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#fb74b958cc7bb93a9335766130d6711ad3e071ce"
 
 [[package]]
 name = "stylo_derive"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#bc815af4b5ae01768eaef64d21cebe6d66be06ea"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#fb74b958cc7bb93a9335766130d6711ad3e071ce"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -7349,7 +7349,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#bc815af4b5ae01768eaef64d21cebe6d66be06ea"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#fb74b958cc7bb93a9335766130d6711ad3e071ce"
 dependencies = [
  "bitflags 2.9.1",
  "stylo_malloc_size_of",
@@ -7358,7 +7358,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#bc815af4b5ae01768eaef64d21cebe6d66be06ea"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#fb74b958cc7bb93a9335766130d6711ad3e071ce"
 dependencies = [
  "app_units",
  "cssparser",
@@ -7375,12 +7375,12 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#bc815af4b5ae01768eaef64d21cebe6d66be06ea"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#fb74b958cc7bb93a9335766130d6711ad3e071ce"
 
 [[package]]
 name = "stylo_traits"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#bc815af4b5ae01768eaef64d21cebe6d66be06ea"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#fb74b958cc7bb93a9335766130d6711ad3e071ce"
 dependencies = [
  "app_units",
  "bitflags 2.9.1",
@@ -7544,7 +7544,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7763,7 +7763,7 @@ dependencies = [
 [[package]]
 name = "to_shmem"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#bc815af4b5ae01768eaef64d21cebe6d66be06ea"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#fb74b958cc7bb93a9335766130d6711ad3e071ce"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -7776,7 +7776,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#bc815af4b5ae01768eaef64d21cebe6d66be06ea"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#fb74b958cc7bb93a9335766130d6711ad3e071ce"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -8901,7 +8901,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/components/layout/dom.rs
+++ b/components/layout/dom.rs
@@ -126,15 +126,15 @@ impl LayoutBox {
                         .repair_style(context, node, new_style);
                 }
             },
-            LayoutBox::FlexLevel(flex_level_box) => {
-                flex_level_box.borrow_mut().repair_style(context, new_style)
-            },
+            LayoutBox::FlexLevel(flex_level_box) => flex_level_box
+                .borrow_mut()
+                .repair_style(context, node, new_style),
             LayoutBox::TableLevelBox(table_level_box) => {
-                table_level_box.repair_style(context, new_style)
+                table_level_box.repair_style(context, node, new_style)
             },
-            LayoutBox::TaffyItemBox(taffy_item_box) => {
-                taffy_item_box.borrow_mut().repair_style(context, new_style)
-            },
+            LayoutBox::TaffyItemBox(taffy_item_box) => taffy_item_box
+                .borrow_mut()
+                .repair_style(context, node, new_style),
         }
     }
 }

--- a/components/layout/flexbox/mod.rs
+++ b/components/layout/flexbox/mod.rs
@@ -4,6 +4,7 @@
 
 use geom::{FlexAxis, MainStartCrossStart};
 use malloc_size_of_derive::MallocSizeOf;
+use script::layout_dom::ServoLayoutNode;
 use servo_arc::Arc as ServoArc;
 use style::context::SharedStyleContext;
 use style::logical_geometry::WritingMode;
@@ -154,16 +155,17 @@ impl FlexLevelBox {
     pub(crate) fn repair_style(
         &mut self,
         context: &SharedStyleContext,
+        node: &ServoLayoutNode,
         new_style: &ServoArc<ComputedValues>,
     ) {
         match self {
             FlexLevelBox::FlexItem(flex_item_box) => flex_item_box
                 .independent_formatting_context
-                .repair_style(context, new_style),
+                .repair_style(context, node, new_style),
             FlexLevelBox::OutOfFlowAbsolutelyPositionedBox(positioned_box) => positioned_box
                 .borrow_mut()
                 .context
-                .repair_style(context, new_style),
+                .repair_style(context, node, new_style),
         }
     }
 

--- a/components/layout/flow/inline/construct.rs
+++ b/components/layout/flow/inline/construct.rs
@@ -31,7 +31,7 @@ pub(crate) struct InlineFormattingContextBuilder {
     /// inline box stack, and importantly, one for every `display: contents` element that we are
     /// currently processing. Normally `display: contents` elements don't affect the structure of
     /// the [`InlineFormattingContext`], but the styles they provide do style their children.
-    shared_inline_styles_stack: Vec<SharedInlineStyles>,
+    pub shared_inline_styles_stack: Vec<SharedInlineStyles>,
 
     /// The collection of text strings that make up this [`InlineFormattingContext`] under
     /// construction.

--- a/components/layout/formatting_contexts.rs
+++ b/components/layout/formatting_contexts.rs
@@ -4,7 +4,7 @@
 
 use app_units::Au;
 use malloc_size_of_derive::MallocSizeOf;
-use script::layout_dom::ServoLayoutElement;
+use script::layout_dom::{ServoLayoutElement, ServoLayoutNode};
 use servo_arc::Arc;
 use style::context::SharedStyleContext;
 use style::properties::ComputedValues;
@@ -223,12 +223,13 @@ impl IndependentFormattingContext {
     pub(crate) fn repair_style(
         &mut self,
         context: &SharedStyleContext,
+        node: &ServoLayoutNode,
         new_style: &Arc<ComputedValues>,
     ) {
         self.base.repair_style(new_style);
         match &mut self.contents {
             IndependentFormattingContextContents::NonReplaced(content) => {
-                content.repair_style(context, new_style);
+                content.repair_style(context, node, new_style);
             },
             IndependentFormattingContextContents::Replaced(..) => {},
         }
@@ -356,9 +357,16 @@ impl IndependentNonReplacedContents {
         matches!(self, Self::Table(_))
     }
 
-    fn repair_style(&mut self, context: &SharedStyleContext, new_style: &Arc<ComputedValues>) {
+    fn repair_style(
+        &mut self,
+        context: &SharedStyleContext,
+        node: &ServoLayoutNode,
+        new_style: &Arc<ComputedValues>,
+    ) {
         match self {
-            IndependentNonReplacedContents::Flow(..) => {},
+            IndependentNonReplacedContents::Flow(block_formatting_context) => {
+                block_formatting_context.repair_style(node, new_style);
+            },
             IndependentNonReplacedContents::Flex(flex_container) => {
                 flex_container.repair_style(new_style)
             },

--- a/components/layout/table/mod.rs
+++ b/components/layout/table/mod.rs
@@ -76,7 +76,7 @@ pub(crate) use construct::AnonymousTableContent;
 pub use construct::TableBuilder;
 use euclid::{Point2D, Size2D, UnknownUnit, Vector2D};
 use malloc_size_of_derive::MallocSizeOf;
-use script::layout_dom::ServoLayoutElement;
+use script::layout_dom::{ServoLayoutElement, ServoLayoutNode};
 use servo_arc::Arc;
 use style::context::SharedStyleContext;
 use style::properties::ComputedValues;
@@ -425,13 +425,14 @@ impl TableLevelBox {
     pub(crate) fn repair_style(
         &self,
         context: &SharedStyleContext<'_>,
+        node: &ServoLayoutNode,
         new_style: &Arc<ComputedValues>,
     ) {
         match self {
             TableLevelBox::Caption(caption) => caption
                 .borrow_mut()
                 .context
-                .repair_style(context, new_style),
+                .repair_style(context, node, new_style),
             TableLevelBox::Cell(cell) => cell.borrow_mut().repair_style(new_style),
             TableLevelBox::TrackGroup(track_group) => {
                 track_group.borrow_mut().repair_style(new_style);

--- a/components/layout/taffy/mod.rs
+++ b/components/layout/taffy/mod.rs
@@ -7,6 +7,7 @@ use std::fmt;
 
 use app_units::Au;
 use malloc_size_of_derive::MallocSizeOf;
+use script::layout_dom::ServoLayoutNode;
 use servo_arc::Arc;
 use style::context::SharedStyleContext;
 use style::properties::ComputedValues;
@@ -152,17 +153,18 @@ impl TaffyItemBox {
     pub(crate) fn repair_style(
         &mut self,
         context: &SharedStyleContext,
+        node: &ServoLayoutNode,
         new_style: &Arc<ComputedValues>,
     ) {
         self.style = new_style.clone();
         match &mut self.taffy_level_box {
             TaffyItemBoxInner::InFlowBox(independent_formatting_context) => {
-                independent_formatting_context.repair_style(context, new_style)
+                independent_formatting_context.repair_style(context, node, new_style)
             },
             TaffyItemBoxInner::OutOfFlowAbsolutelyPositionedBox(positioned_box) => positioned_box
                 .borrow_mut()
                 .context
-                .repair_style(context, new_style),
+                .repair_style(context, node, new_style),
         }
     }
 }

--- a/components/layout/traversal.rs
+++ b/components/layout/traversal.rs
@@ -112,15 +112,14 @@ pub(crate) fn compute_damage_and_repair_style_inner(
             .element_data
             .borrow_mut();
 
+        original_damage = std::mem::take(&mut element_data.damage);
         if let Some(ref style) = element_data.styles.primary {
             if style.get_box().display == Display::None {
                 return parent_restyle_damage;
             }
         }
 
-        original_damage = std::mem::take(&mut element_data.damage);
-        element_data.damage |= parent_restyle_damage;
-        element_data.damage
+        original_damage | parent_restyle_damage
     };
 
     let mut propagated_damage = damage;


### PR DESCRIPTION
When making last-minute changes to the repaint-only layout pass, damage
propagation was broken, meaning that full layout was always done. This
change fixes that, meaning that times in the `blaster.html` test case
now reflect those described in the original commit message from #36978.

In addition, some style repair is now fixed:
 - `InlineFormattingContext`s now keep a `SharedInlineStyles` for the root of the IFC
    which is updated during style repair.
 - `BlockFormattingContext`s now properly update their style.

These changes are verified by turning on repaint only layout for more properties
in Stylo via servo/stylo#183.

Testing: Manual performance testing via `blaster.html`.
