### PR TITLE
Remove some references to layout 2013 vs layout 2020

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,7 +11,6 @@
 /components/compositing @mrobinson
 
 # Reviewers for layout-related code
-/components/layout_2020 @mrobinson @Loirooriol @nicoburns
 /components/layout @mrobinson @Loirooriol @nicoburns
 
 # Reviewers for Minibrowser related code

--- a/components/config/opts.rs
+++ b/components/config/opts.rs
@@ -104,7 +104,7 @@ pub struct DebugOptions {
     /// Dumps the rule tree.
     pub dump_rule_tree: bool,
 
-    /// Print the flow tree (Layout 2013) or fragment tree (Layout 2020) after each layout.
+    /// Print the fragment tree after each layout.
     pub dump_flow_tree: bool,
 
     /// Print the stacking context tree after each layout.

--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -736,7 +736,7 @@ fn print_debug_options_usage(app: &str) {
     );
     print_option(
         "dump-flow-tree",
-        "Print the flow tree (Layout 2013) or fragment tree (Layout 2020) after each layout.",
+        "Print the fragment tree after each layout.",
     );
     print_option(
         "dump-rule-tree",

--- a/servobuild.example
+++ b/servobuild.example
@@ -36,9 +36,6 @@ webgl-backtrace = false
 # that triggered it.
 dom-backtrace = false
 
-# Default to the “2020” implementation of CSS layout instead of the “2013” one.
-layout-2020 = true
-
 # Pick a media stack based on the target. Other values are "gstreamer" and "dummy"
 media-stack = "auto"
 


### PR DESCRIPTION
We no longer have both layout systems.

Testing: not needed (no behavior change)