### PR TITLE
ServoShell: introduce refresh_tick to trigger process_animation

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -1264,6 +1264,10 @@ impl IOCompositor {
         self.set_needs_repaint(RepaintReason::Resize);
     }
 
+    pub fn handle_refresh_tick(&mut self) {
+        self.process_animations(true);
+    }
+
     /// If there are any animations running, dispatches appropriate messages to the constellation.
     fn process_animations(&mut self, force: bool) {
         // When running animations in order to dump a screenshot (not after a full composite), don't send
@@ -1411,9 +1415,6 @@ impl IOCompositor {
         // We've painted the default target, which means that from the embedder's perspective,
         // the scene no longer needs to be repainted.
         self.needs_repaint.set(RepaintReason::empty());
-
-        // Queue up any subsequent paints for animations.
-        self.process_animations(true);
 
         true
     }

--- a/ports/servoshell/desktop/app_state.rs
+++ b/ports/servoshell/desktop/app_state.rs
@@ -168,6 +168,7 @@ impl RunningAppState {
     /// painted or false otherwise. Something may not be painted if Servo is waiting
     /// for a stable image to paint.
     pub(crate) fn repaint_servo_if_necessary(&self) {
+        self.servo.set_refresh_tick();
         if !self.inner().need_repaint {
             return;
         }

--- a/ports/servoshell/egl/app_state.rs
+++ b/ports/servoshell/egl/app_state.rs
@@ -630,6 +630,7 @@ impl RunningAppState {
 
     pub fn notify_vsync(&self) {
         self.active_webview().notify_vsync();
+        self.servo.set_refresh_tick();
         self.perform_updates();
     }
 


### PR DESCRIPTION
As the first step of introducing platform-agnostic, unified interface that  have periodic signal to trigger display content refresh, a.k.a `RefreshDriver`, this PR introduce `refresh_tick` to avoid the present -> process_animation -> present loop. 


Testing: This is internal change, should not affect any test.
Fixes: The first step of introducing refresh driver: https://github.com/servo/servo/issues/3406

Next step should be figure out how to get this kind of periodic signal in desktop `winit`

cc @mrobinson @xiaochengh 