### PR TITLE
Fix `WebDriverSession::input_cancel_list` related logic

### DIFF
--- a/components/webdriver_server/actions.rs
+++ b/components/webdriver_server/actions.rs
@@ -33,6 +33,9 @@ pub(crate) enum InputSourceState {
 }
 
 // https://w3c.github.io/webdriver/#dfn-pointer-input-source
+// TODO: subtype is used for https://w3c.github.io/webdriver/#dfn-get-a-pointer-id
+// Need to add pointer-id to the following struct
+#[allow(dead_code)]
 pub(crate) struct PointerInputState {
     subtype: PointerType,
     pressed: HashSet<u64>,

--- a/components/webdriver_server/actions.rs
+++ b/components/webdriver_server/actions.rs
@@ -336,25 +336,6 @@ impl Handler {
         }
         pointer_input_state.pressed.remove(&action.button);
 
-        session.input_cancel_list.push(ActionSequence {
-            id: source_id.into(),
-            actions: ActionsType::Pointer {
-                parameters: PointerActionParameters {
-                    pointer_type: match pointer_input_state.subtype {
-                        PointerType::Mouse => PointerType::Mouse,
-                        PointerType::Pen => PointerType::Pen,
-                        PointerType::Touch => PointerType::Touch,
-                    },
-                },
-                actions: vec![PointerActionItem::Pointer(PointerAction::Down(
-                    PointerDownAction {
-                        button: action.button,
-                        ..Default::default()
-                    },
-                ))],
-            },
-        });
-
         let cmd_msg = WebDriverCommandMsg::MouseButtonAction(
             session.webview_id,
             MouseButtonAction::Up,

--- a/components/webdriver_server/actions.rs
+++ b/components/webdriver_server/actions.rs
@@ -426,7 +426,7 @@ impl Handler {
         tick_start: Instant,
     ) {
         let webview_id = self.session().unwrap().webview_id;
-        let chain = self.constellation_chan.clone();
+        let constellation_chan = self.constellation_chan.clone();
         let pointer_input_state = self.get_pointer_input_state_mut(source_id);
         loop {
             // Step 1
@@ -461,7 +461,7 @@ impl Handler {
                 // Step 7.2
                 let cmd_msg = WebDriverCommandMsg::MouseMoveAction(webview_id, x as f32, y as f32);
                 //TODO: Need Synchronization here before updating `pointer_input_state`
-                chain
+                constellation_chan
                     .send(EmbedderToConstellationMessage::WebDriverCommand(cmd_msg))
                     .unwrap();
                 // Step 7.3


### PR DESCRIPTION
- Remove incorrect addition to `input_cancel_list` in `dispatch_keyup_action`
- For `KeyDown` and `PointerDown`, delay the addition to `input_cancel_list` until "Dispatching action algorithm" is done to match the spec. Previously the addition is done before notifying constellation. Moreover, this makes sure that `pointerUp` is appended even if `dispatch_pointerdown_action` returns early, so that [Release Actions](https://w3c.github.io/webdriver/#release-actions) always have the correct order.
- Remove incorrect addition to `input_cancel_list` in `dispatch_pointerup_action`. This wrongly added "pointerdown" in [Release Actions](https://w3c.github.io/webdriver/#release-actions)
- Reduce code duplication
- Add TODO for PointerInputState::subtype and pointerID

Testing: `./mach test-wpt -r --log-raw "D:\servo test log\perform-actions.txt" tests\wpt\tests\webdriver\tests\classic\perform_actions --product servodriver` has no new failures so no regression. There are a lot more passing tests, but I think mostly are because there is no CI for webdriver.

cc @xiaochengh @jdm @PotatoCP @longvatrong111 