### PR TITLE
Remove layout-2013 profiling categories

### DIFF
--- a/components/profile/time.rs
+++ b/components/profile/time.rs
@@ -69,27 +69,6 @@ impl Formattable for Option<TimerMetadata> {
     }
 }
 
-impl Formattable for ProfilerCategory {
-    // some categories are subcategories of LayoutPerformCategory
-    // and should be printed to indicate this
-    fn format(&self, _output: &Option<OutputOptions>) -> String {
-        let padding = match *self {
-            ProfilerCategory::LayoutStyleRecalc |
-            ProfilerCategory::LayoutRestyleDamagePropagation |
-            ProfilerCategory::LayoutGeneratedContent |
-            ProfilerCategory::LayoutFloatPlacementSpeculation |
-            ProfilerCategory::LayoutMain |
-            ProfilerCategory::LayoutStoreOverflow |
-            ProfilerCategory::LayoutDispListBuild |
-            ProfilerCategory::LayoutParallelWarmup |
-            ProfilerCategory::LayoutTextShaping => "| + ",
-            _ => "",
-        };
-        let name: &'static str = self.into();
-        format!("{padding}{name}")
-    }
-}
-
 type ProfilerBuckets = BTreeMap<(ProfilerCategory, Option<TimerMetadata>), Vec<Duration>>;
 
 // back end of the profiler that handles data aggregation and performance metrics
@@ -276,7 +255,7 @@ impl Profiler {
                         writeln!(
                             file,
                             "{}\t{}\t{:15.4}\t{:15.4}\t{:15.4}\t{:15.4}\t{:15}",
-                            category.format(&self.output),
+                            category.variant_name(),
                             meta.format(&self.output),
                             mean.as_seconds_f64() * 1000.,
                             median.as_seconds_f64() * 1000.,
@@ -319,7 +298,7 @@ impl Profiler {
                         writeln!(
                             &mut lock,
                             "{:-35}{} {:15.4} {:15.4} {:15.4} {:15.4} {:15}",
-                            category.format(&self.output),
+                            category.variant_name(),
                             meta.format(&self.output),
                             mean.as_seconds_f64() * 1000.,
                             median.as_seconds_f64() * 1000.,

--- a/components/shared/profile/time.rs
+++ b/components/shared/profile/time.rs
@@ -8,7 +8,6 @@ use log::warn;
 use malloc_size_of_derive::MallocSizeOf;
 use serde::{Deserialize, Serialize};
 use servo_config::opts;
-use strum_macros::IntoStaticStr;
 use time::Duration;
 
 #[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
@@ -59,9 +58,7 @@ pub enum ProfilerMsg {
 
 /// Usage sites of variants marked “Rust tracing only” are not visible to rust-analyzer.
 #[repr(u32)]
-#[derive(
-    Clone, Copy, Debug, Deserialize, Eq, Hash, IntoStaticStr, Ord, PartialEq, PartialOrd, Serialize,
-)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum ProfilerCategory {
     /// The compositor is rasterising or presenting.
     ///
@@ -70,17 +67,6 @@ pub enum ProfilerCategory {
 
     /// The script thread is doing layout work.
     LayoutPerform = 0x10,
-
-    /// Events currently only used by Layout 2013.
-    LayoutStyleRecalc = 0x11,
-    LayoutTextShaping = 0x12,
-    LayoutRestyleDamagePropagation = 0x13,
-    LayoutGeneratedContent = 0x18,
-    LayoutFloatPlacementSpeculation = 0x1a,
-    LayoutMain = 0x1b,
-    LayoutStoreOverflow = 0x1c,
-    LayoutParallelWarmup = 0x1d,
-    LayoutDispListBuild = 0x1e,
 
     ImageSaving = 0x51,
     ScriptAttachLayout = 0x60,
@@ -139,15 +125,6 @@ impl ProfilerCategory {
         match self {
             ProfilerCategory::Compositing => "Compositing",
             ProfilerCategory::LayoutPerform => "LayoutPerform",
-            ProfilerCategory::LayoutStyleRecalc => "LayoutStyleRecalc",
-            ProfilerCategory::LayoutTextShaping => "LayoutTextShaping",
-            ProfilerCategory::LayoutRestyleDamagePropagation => "LayoutRestyleDamagePropagation",
-            ProfilerCategory::LayoutGeneratedContent => "LayoutGeneratedContent",
-            ProfilerCategory::LayoutFloatPlacementSpeculation => "LayoutFloatPlacementSpeculation",
-            ProfilerCategory::LayoutMain => "LayoutMain",
-            ProfilerCategory::LayoutStoreOverflow => "LayoutStoreOverflow",
-            ProfilerCategory::LayoutParallelWarmup => "LayoutParallelWarmup",
-            ProfilerCategory::LayoutDispListBuild => "LayoutDispListBuild",
             ProfilerCategory::ImageSaving => "ImageSaving",
             ProfilerCategory::ScriptAttachLayout => "ScriptAttachLayout",
             ProfilerCategory::ScriptConstellationMsg => "ScriptConstellationMsg",


### PR DESCRIPTION
This change also removes the ProfilingCategory::variant_name function, because strum_macros::IntoStaticStr is already being used and does the same thing.

Testing: This change compiles and that's good enough
