### PR TITLE
Remove `CoreResourceMsg::Synchronize`

### DIFF
--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -445,9 +445,6 @@ impl ResourceChannelManager {
                     history_states.remove(&history_state);
                 }
             },
-            CoreResourceMsg::Synchronize(sender) => {
-                let _ = sender.send(());
-            },
             CoreResourceMsg::ClearCache => {
                 http_state.http_cache.write().unwrap().clear();
             },

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -517,8 +517,6 @@ pub enum CoreResourceMsg {
     SetHistoryState(HistoryStateId, Vec<u8>),
     /// Removes history states for the given ids
     RemoveHistoryStates(Vec<HistoryStateId>),
-    /// Synchronization message solely for knowing the state of the ResourceChannelManager loop
-    Synchronize(IpcSender<()>),
     /// Clear the network cache.
     ClearCache,
     /// Send the service worker network mediator for an origin to CoreResourceThread


### PR DESCRIPTION
This message is unused.
