### PR TITLE
Allow OHOS bencher to get the model name for testbed.

### DIFF
--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -243,6 +243,9 @@ jobs:
         run: hitrace-bench --bencher -b "org.servo.servo" -p "https://www.servo.org" -n 5
       - name: Getting bencher
         uses: bencherdev/bencher@main
+      - name: Getting model name
+        run: |
+          echo "MODEL_NAME=$(hdc bugreport | head -n 20 | grep MarketName | awk '{for (i=2; i<NF; i++) printf $i " "; print $NF}' -)" >> $GITHUB_ENV
       - name: Uploading to bencher.dev
         run: |
-          bencher run --adapter json --file bench.json --project '${{ env.BENCHER_PROJECT }}' --token '${{ secrets.BENCHER_API_TOKEN }}' --github-actions '${{ secrets.GITHUB_TOKEN }}'
+          bencher run --adapter json --file bench.json --project '${{ env.BENCHER_PROJECT }}' --token '${{ secrets.BENCHER_API_TOKEN }}' --github-actions '${{ secrets.GITHUB_TOKEN }}' --testbed="$MODEL_NAME"


### PR DESCRIPTION
Allow OHOS bencher to get the model name for testbed.

Currently we rely on simple `hdc bugreport` and awk. `hdc bugreport` spits out a lot of information so it is kind of slow. But that should be ok.
Working run (with the usual caveats of removing the checks in the file) can be found here: https://github.com/Narfinger/servo/actions/runs/15069652902