### PR TITLE
Unsimplify `rust-toolchain.toml` by adding `clippy` and `rustfmt`

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -5,9 +5,12 @@
 channel = "1.85.0"
 
 components = [
+    "clippy",
     # For support/crown
     "llvm-tools",
     # For support/crown
+    "rustc-dev",
+    "rustfmt",
     "rustc-dev",
     # For rust-analyzer
     "rust-src",


### PR DESCRIPTION
This is a speculative fix for some intermittent clippy failures that we
are seeing on the CI such as:
https://github.com/servo/servo/actions/runs/15066235369/job/42351666174

These entries were removed in #35117, but it seems that they are necessary now.

Testing: This is a fix for the CI, so functioning CI is effectively the test.