### PR TITLE
fonts: Fix calculation of font underline thickness on macOS

### DIFF
--- a/components/fonts/platform/macos/font.rs
+++ b/components/fonts/platform/macos/font.rs
@@ -287,7 +287,7 @@ impl PlatformFontMethods for PlatformFont {
             .unwrap_or(average_advance);
 
         let metrics = FontMetrics {
-            underline_size: Au::from_f64_au(underline_thickness),
+            underline_size: Au::from_f64_px(underline_thickness),
             // TODO(Issue #201): underline metrics are not reliable. Have to pull out of font table
             // directly.
             //


### PR DESCRIPTION
There was a typo in how underline thickness (in pixels) was converted
to app units. It was interpreting the pixel value as an f64 app unit
value, which meant that the resulting thickness was 1/60 of the value
expected.

Testing: macOS does not currently run WPT tests, so it is difficult to test
this one. I have manually confirmed that underlines now show up and are the
expected thickness.
Fixes: #36945
