### PR TITLE
docs(security): avoid possible misconception in the security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,4 +1,4 @@
 # Security Policy
 
-Given that Servo does not yet have customers or products, we are comfortable accepting the security related vulnerabilities as a [new GitHub issue](https://github.com/servo/servo/security/advisories/new) for now.
+Given that Servo does not yet have customers or products, we are comfortable accepting the security related issues as [GitHub security reports](https://github.com/servo/servo/security/advisories/new) for now.
 


### PR DESCRIPTION
With ac24cd61395f6a9646efe1da13ba5674eea59e7e, the URL is changed from pointing to the normal Github issues to Github's private security reporting feature, but the text hasn't been updated to reflect this.


Testing: Static docs file without dynamic effects.
