### PR TITLE
Make `getAllTypes` unwrap IDL `record<K, V>` types

### DIFF
--- a/components/script_bindings/webidls/TestBinding.webidl
+++ b/components/script_bindings/webidls/TestBinding.webidl
@@ -621,3 +621,9 @@ namespace TestNS {
 };
 
 typedef Promise<undefined> PromiseUndefined;
+
+// https://github.com/servo/servo/issues/37038
+dictionary NotUsedAnyWhereElse {};
+dictionary RecordFieldWithUnionInside {
+    record<USVString, (USVString or NotUsedAnyWhereElse)> recordWithUnionField;
+};


### PR DESCRIPTION
IDL `record` types can themselves contain types that are not described anywhere else. An example is in https://github.com/servo/servo/issues/37038, where the `record` contains a definition of a union. These inner types must be returned from `getAllTypes`, otherwise we won't generate code for them.

This PR also adds a few type annotations. I can remove them if requested, but I think they're helpful.

Testing:  Includes a regression test
Fixes: https://github.com/servo/servo/issues/37038
