### PR TITLE
net: Measure memory usage of storage thread.

### DIFF
--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -94,14 +94,15 @@ pub fn new_resource_threads(
     let (public_core, private_core) = new_core_resource_thread(
         devtools_sender,
         time_profiler_chan,
-        mem_profiler_chan,
+        mem_profiler_chan.clone(),
         embedder_proxy,
         config_dir.clone(),
         ca_certificates,
         ignore_certificate_errors,
         protocols,
     );
-    let storage: IpcSender<StorageThreadMsg> = StorageThreadFactory::new(config_dir);
+    let storage: IpcSender<StorageThreadMsg> =
+        StorageThreadFactory::new(config_dir, mem_profiler_chan);
     (
         ResourceThreads::new(public_core, storage.clone()),
         ResourceThreads::new(private_core, storage),

--- a/components/shared/net/storage_thread.rs
+++ b/components/shared/net/storage_thread.rs
@@ -4,6 +4,7 @@
 
 use ipc_channel::ipc::IpcSender;
 use malloc_size_of_derive::MallocSizeOf;
+use profile_traits::mem::ReportsChan;
 use serde::{Deserialize, Serialize};
 use servo_url::ServoUrl;
 
@@ -45,4 +46,7 @@ pub enum StorageThreadMsg {
 
     /// send a reply when done cleaning up thread resources and then shut it down
     Exit(IpcSender<()>),
+
+    /// Measure memory used by this thread and send the report over the provided channel.
+    CollectMemoryReport(ReportsChan),
 }


### PR DESCRIPTION
Our persistent localstorage data can be meaningfully large after testing real world sites. This change ensures it shows up in about:memory.

Testing: Opened about:memory after launching the browser with a persistent config 
Fixes: Part of #11559
