### PR TITLE
Improved OHOS Benchmarking to use different websites

### DIFF
--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -169,11 +169,16 @@ jobs:
       - name: Build for aarch64 HarmonyOS
         run: |
           ./mach build --locked --target aarch64-unknown-linux-ohos --profile=${{ inputs.profile }} --flavor=harmonyos --no-default-features --features tracing,tracing-hitrace
+      - name: Upload supprt/hitrace-bencher/runs.json
+        uses: actions/upload-artifact@v4
+        with:
+          name: runs.json
+          path: support/hitrace-bencher/runs.json
       - uses: actions/upload-artifact@v4
         with:
           # Upload the **unsigned** artifact - We don't have the signing materials in pull request workflows
-          path: target/openharmony/aarch64-unknown-linux-ohos/${{ inputs.profile }}/entry/build/harmonyos/outputs/default/servoshell-default-unsigned.hap
           name: servoshell-hos-${{ inputs.profile }}.hap
+          path: target/openharmony/aarch64-unknown-linux-ohos/${{ inputs.profile }}/entry/build/harmonyos/outputs/default/servoshell-default-unsigned.hap
 
 
   test-harmonyos-aarch64:
@@ -239,8 +244,14 @@ jobs:
           [[ $servo_pid =~ ^[0-9]+$ ]] || { echo "It looks like servo crashed!" ; exit 1; }
           # If the grep fails, then the trace output for the "page loaded" prompt is missing
           grep 'org\.servo\.servo-.* tracing_mark_write.*PageLoadEndedPrompt' test_output/servo.ftrace
+      - name: Getting runs file
+        uses: actions/download-artifact@v4
+        with:
+          # Name of the artifact to download.
+          # If unspecified, all artifacts for the run are downloaded.
+          name: runs.json
       - name: "Run benchmark"
-        run: hitrace-bench --bencher -b "org.servo.servo" -p "https://www.servo.org" -n 5
+        run: hitrace-bench -r runs.json
       - name: Getting bencher
         uses: bencherdev/bencher@main
       - name: Getting model name

--- a/support/hitrace-bencher/runs.json
+++ b/support/hitrace-bencher/runs.json
@@ -1,0 +1,45 @@
+// This json file allows comments and is technically a hjson file.
+// Different {} correspond to completely different runs which can have
+// different filters and different arguments
+[
+    {
+        "args": {
+            "bencher": true, // output in bencher format
+            "url": "https://www.google.com", // the url to test
+            "tries": 5 // How many repeated tries we should have, we show the min,max,avg in the output
+            //"trace_buffer": 524288,   // trace_buffer size of hitrace
+            //"sleep": 10,  // how long should we wait for servo to load the page
+            //"bundle_name": "org.servo.servo", // the bundle name to start
+            //"commands": ["--ps=--tracing-filter", "info"] // arbitrary additional arguments
+        },
+        "filters": [
+            // Filters are currently given via the simple serialize of `filters::JsonValueFilter`.
+            // Filters have an arbitrary name that identifies them. This name will be used in bencher output
+            // where we format it with the E2E and the url.
+            // start_fn_partial matches a hitrace _start_ event where the given string is a substring of the function name.
+            // end_fn_partial matches a hitrace _start_ event where the given string is a substring of the function name.
+            // The filter will calculate the difference between these two start events.
+            // We currently do not support trace spans and only support exactly one match for start_fn_partial and end_fn_partial.
+            {
+                "name": "Load",
+                "start_fn_partial": "on_surface_created_cb",
+                "end_fn_partial": "PageLoadEndedPrompt"
+            }
+        ]
+    },
+    {
+        "args": {
+            "bencher": true,
+            "url": "https://www.servo.org",
+            "tries": 5
+        },
+        "filters": [
+            {
+                "name": "Load",
+                "start_fn_partial": "on_surface_created_cb",
+                "end_fn_partial": "PageLoadEndedPrompt"
+            }
+        ]
+    }
+]
+


### PR DESCRIPTION
Workflow changes includes to allow a given runs.json file to be read by hitrace-bench and perform the benchmarks.
It depends on the updated CI tools. Requires CI modification in https://github.com/servo/ci-runners/pull/36.

Testing: This change was tested on the CI. https://github.com/Narfinger/servo/actions/runs/15157760046/job/42616776563
A corresponding bencher output is here: https://bencher.dev/console/projects/servo-ci/reports/99a369f7-e6c3-4141-83f9-0ecddac484a5?back=L2NvbnNvbGUvcHJvamVjdHMvc2Vydm8tY2kvcmVwb3J0cz9wZXJfcGFnZT04JnBhZ2U9MQ%3D%3D
