### PR TITLE
Coalesce animated image frame data into a single shared memory region

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -1456,10 +1456,11 @@ impl IOCompositor {
                 format: PixelFormat::RGBA8,
                 frames: vec![ImageFrame {
                     delay: None,
-                    bytes: ipc::IpcSharedMemory::from_bytes(&image),
+                    byte_range: 0..image.len(),
                     width: image.width(),
                     height: image.height(),
                 }],
+                bytes: ipc::IpcSharedMemory::from_bytes(&image),
                 id: None,
                 cors_status: CorsStatus::Safe,
             }))

--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -66,10 +66,10 @@ fn set_webrender_image_key(compositor_api: &CrossProcessCompositorApi, image: &m
         return;
     }
     let mut bytes = Vec::new();
-    let frame_bytes = image.bytes();
+    let frame_bytes = image.first_frame().bytes;
     let is_opaque = match image.format {
         PixelFormat::BGRA8 => {
-            bytes.extend_from_slice(&frame_bytes);
+            bytes.extend_from_slice(frame_bytes);
             pixels::rgba8_premultiply_inplace(bytes.as_mut_slice())
         },
         PixelFormat::RGB8 => {

--- a/components/script/canvas_state.rs
+++ b/components/script/canvas_state.rs
@@ -17,7 +17,7 @@ use cssparser::color::clamp_unit_f32;
 use cssparser::{Parser, ParserInput};
 use euclid::default::{Point2D, Rect, Size2D, Transform2D};
 use euclid::vec2;
-use ipc_channel::ipc::{self, IpcSender};
+use ipc_channel::ipc::{self, IpcSender, IpcSharedMemory};
 use net_traits::image_cache::{ImageCache, ImageResponse};
 use net_traits::request::CorsSettings;
 use pixels::PixelFormat;
@@ -350,7 +350,7 @@ impl CanvasState {
             size.cast(),
             format,
             alpha_mode,
-            img.bytes(),
+            IpcSharedMemory::from_bytes(img.first_frame().bytes),
         ))
     }
 

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -619,7 +619,8 @@ impl WebGLRenderingContext {
 
                 let size = Size2D::new(img.width, img.height);
 
-                TexPixels::new(img.bytes(), size, img.format, false)
+                let data = IpcSharedMemory::from_bytes(img.first_frame().bytes);
+                TexPixels::new(data, size, img.format, false)
             },
             // TODO(emilio): Getting canvas data is implemented in CanvasRenderingContext2D,
             // but we need to refactor it moving it to `HTMLCanvasElement` and support

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -1709,7 +1709,8 @@ impl Handler {
             "Unexpected screenshot pixel format"
         );
 
-        let rgb = RgbaImage::from_raw(img.width, img.height, img.bytes().to_vec()).unwrap();
+        let rgb =
+            RgbaImage::from_raw(img.width, img.height, img.first_frame().bytes.to_vec()).unwrap();
         let mut png_data = Cursor::new(Vec::new());
         DynamicImage::ImageRgba8(rgb)
             .write_to(&mut png_data, ImageFormat::Png)


### PR DESCRIPTION
This makes servo use less file descriptors for animated images and avoids the crash described in
https://github.com/servo/servo/issues/36792.

Doing this also forces the end users to be more explicit about whether they want to deal with all image frames or just the first one. Previously, `Image::bytes` silently returned only the data for the first frame. With this change there's now a `frames` method which returns an iterator over all frames in the image.

Testing: No tests - this simply reduces the number of fds used. Servo doesn't currently display animated gifs anyways.
Fixes: https://github.com/servo/servo/issues/36792
