### PR TITLE
Draft: Bump mozjs-sys to 128.9-3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4653,7 +4653,7 @@ dependencies = [
 [[package]]
 name = "mozjs"
 version = "0.14.1"
-source = "git+https://github.com/servo/mozjs#728acdf3d4ce0604e9f75dd1d539dc6f291ccec7"
+source = "git+https://github.com/jschwe/mozjs?branch=jschwender%2Fhilog_domain#04b67af079f6c06ae68f7b96bd8faab5516fe84c"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -4664,8 +4664,8 @@ dependencies = [
 
 [[package]]
 name = "mozjs_sys"
-version = "0.128.9-2"
-source = "git+https://github.com/servo/mozjs#728acdf3d4ce0604e9f75dd1d539dc6f291ccec7"
+version = "0.128.9-3"
+source = "git+https://github.com/jschwe/mozjs?branch=jschwender%2Fhilog_domain#04b67af079f6c06ae68f7b96bd8faab5516fe84c"
 dependencies = [
  "bindgen 0.71.1",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ imsz = "0.2"
 indexmap = { version = "2.9.0", features = ["std"] }
 ipc-channel = "0.19"
 itertools = "0.14"
-js = { package = "mozjs", git = "https://github.com/servo/mozjs" }
+js = { package = "mozjs", git = "https://github.com/jschwe/mozjs", branch = "jschwender/hilog_domain" }
 keyboard-types = "0.7"
 libc = "0.2"
 log = "0.4"


### PR DESCRIPTION
Sets the hilog log domain for Spidermonkey C++ code.

Corresponding mozjs PR: https://github.com/servo/mozjs/pull/583

Testing: CI smoketests on ohos boards
