### PR TITLE
bump(deps): bump servo-media from eb96030 to 4931a4b

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6627,7 +6627,7 @@ dependencies = [
 [[package]]
 name = "servo-media"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#eb96030cdd153ebcbbe3836dc6471303187740e9"
+source = "git+https://github.com/servo/media#4931a4b380acd9c95b8787cbcfa812823864e2d0"
 dependencies = [
  "once_cell",
  "servo-media-audio",
@@ -6640,7 +6640,7 @@ dependencies = [
 [[package]]
 name = "servo-media-audio"
 version = "0.2.0"
-source = "git+https://github.com/servo/media#eb96030cdd153ebcbbe3836dc6471303187740e9"
+source = "git+https://github.com/servo/media#4931a4b380acd9c95b8787cbcfa812823864e2d0"
 dependencies = [
  "byte-slice-cast",
  "euclid",
@@ -6661,7 +6661,7 @@ dependencies = [
 [[package]]
 name = "servo-media-derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#eb96030cdd153ebcbbe3836dc6471303187740e9"
+source = "git+https://github.com/servo/media#4931a4b380acd9c95b8787cbcfa812823864e2d0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6671,7 +6671,7 @@ dependencies = [
 [[package]]
 name = "servo-media-dummy"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#eb96030cdd153ebcbbe3836dc6471303187740e9"
+source = "git+https://github.com/servo/media#4931a4b380acd9c95b8787cbcfa812823864e2d0"
 dependencies = [
  "ipc-channel",
  "servo-media",
@@ -6685,7 +6685,7 @@ dependencies = [
 [[package]]
 name = "servo-media-gstreamer"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#eb96030cdd153ebcbbe3836dc6471303187740e9"
+source = "git+https://github.com/servo/media#4931a4b380acd9c95b8787cbcfa812823864e2d0"
 dependencies = [
  "byte-slice-cast",
  "glib",
@@ -6718,7 +6718,7 @@ dependencies = [
 [[package]]
 name = "servo-media-gstreamer-render"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#eb96030cdd153ebcbbe3836dc6471303187740e9"
+source = "git+https://github.com/servo/media#4931a4b380acd9c95b8787cbcfa812823864e2d0"
 dependencies = [
  "gstreamer",
  "gstreamer-video",
@@ -6728,7 +6728,7 @@ dependencies = [
 [[package]]
 name = "servo-media-gstreamer-render-android"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#eb96030cdd153ebcbbe3836dc6471303187740e9"
+source = "git+https://github.com/servo/media#4931a4b380acd9c95b8787cbcfa812823864e2d0"
 dependencies = [
  "glib",
  "gstreamer",
@@ -6742,7 +6742,7 @@ dependencies = [
 [[package]]
 name = "servo-media-gstreamer-render-unix"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#eb96030cdd153ebcbbe3836dc6471303187740e9"
+source = "git+https://github.com/servo/media#4931a4b380acd9c95b8787cbcfa812823864e2d0"
 dependencies = [
  "glib",
  "gstreamer",
@@ -6757,7 +6757,7 @@ dependencies = [
 [[package]]
 name = "servo-media-player"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#eb96030cdd153ebcbbe3836dc6471303187740e9"
+source = "git+https://github.com/servo/media#4931a4b380acd9c95b8787cbcfa812823864e2d0"
 dependencies = [
  "ipc-channel",
  "serde",
@@ -6769,7 +6769,7 @@ dependencies = [
 [[package]]
 name = "servo-media-streams"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#eb96030cdd153ebcbbe3836dc6471303187740e9"
+source = "git+https://github.com/servo/media#4931a4b380acd9c95b8787cbcfa812823864e2d0"
 dependencies = [
  "uuid",
 ]
@@ -6777,12 +6777,12 @@ dependencies = [
 [[package]]
 name = "servo-media-traits"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#eb96030cdd153ebcbbe3836dc6471303187740e9"
+source = "git+https://github.com/servo/media#4931a4b380acd9c95b8787cbcfa812823864e2d0"
 
 [[package]]
 name = "servo-media-webrtc"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#eb96030cdd153ebcbbe3836dc6471303187740e9"
+source = "git+https://github.com/servo/media#4931a4b380acd9c95b8787cbcfa812823864e2d0"
 dependencies = [
  "log",
  "servo-media-streams",


### PR DESCRIPTION
Summary:
- Do validation of stream duration on seekable() method (https://github.com/servo/media/pull/437)

Testing: /html/semantics/embedded-content/*

Fixes: https://github.com/servo/servo/issues/36748
Fixes: https://github.com/servo/servo/issues/36809