### PR TITLE
layout: Move text decoration propagation to stacking context tree construction

### DIFF
--- a/components/layout/construct_modern.rs
+++ b/components/layout/construct_modern.rs
@@ -150,7 +150,6 @@ impl<'a, 'dom> ModernContainerBuilder<'a, 'dom> {
 
                     let inline_formatting_context = inline_formatting_context_builder.finish(
                         self.context,
-                        self.propagated_data,
                         true,  /* has_first_formatted_line */
                         false, /* is_single_line_text_box */
                         self.info.style.writing_mode.to_bidi_level(),

--- a/components/layout/flexbox/mod.rs
+++ b/components/layout/flexbox/mod.rs
@@ -105,8 +105,7 @@ impl FlexContainer {
         contents: NonReplacedContents,
         propagated_data: PropagatedBoxTreeData,
     ) -> Self {
-        let mut builder =
-            ModernContainerBuilder::new(context, info, propagated_data.union(&info.style));
+        let mut builder = ModernContainerBuilder::new(context, info, propagated_data);
         contents.traverse(context, info, &mut builder);
         let items = builder.finish();
 

--- a/components/layout/flow/float.rs
+++ b/components/layout/flow/float.rs
@@ -897,8 +897,7 @@ impl FloatBox {
                 info,
                 display_inside,
                 contents,
-                // Text decorations are not propagated to any out-of-flow descendants
-                propagated_data.without_text_decorations(),
+                propagated_data,
             ),
         }
     }

--- a/components/layout/flow/inline/construct.rs
+++ b/components/layout/flow/inline/construct.rs
@@ -16,7 +16,6 @@ use super::{
     InlineBox, InlineBoxIdentifier, InlineBoxes, InlineFormattingContext, InlineItem,
     SharedInlineStyles,
 };
-use crate::PropagatedBoxTreeData;
 use crate::cell::ArcRefCell;
 use crate::context::LayoutContext;
 use crate::dom_traversal::NodeAndStyleInfo;
@@ -344,7 +343,6 @@ impl InlineFormattingContextBuilder {
     pub(crate) fn split_around_block_and_finish(
         &mut self,
         layout_context: &LayoutContext,
-        propagated_data: PropagatedBoxTreeData,
         has_first_formatted_line: bool,
         default_bidi_level: Level,
     ) -> Option<InlineFormattingContext> {
@@ -386,7 +384,6 @@ impl InlineFormattingContextBuilder {
 
         inline_builder_from_before_split.finish(
             layout_context,
-            propagated_data,
             has_first_formatted_line,
             /* is_single_line_text_input = */ false,
             default_bidi_level,
@@ -397,7 +394,6 @@ impl InlineFormattingContextBuilder {
     pub(crate) fn finish(
         self,
         layout_context: &LayoutContext,
-        propagated_data: PropagatedBoxTreeData,
         has_first_formatted_line: bool,
         is_single_line_text_input: bool,
         default_bidi_level: Level,
@@ -410,7 +406,6 @@ impl InlineFormattingContextBuilder {
         Some(InlineFormattingContext::new_with_builder(
             self,
             layout_context,
-            propagated_data,
             has_first_formatted_line,
             is_single_line_text_input,
             default_bidi_level,

--- a/components/layout/flow/inline/inline_box.rs
+++ b/components/layout/flow/inline/inline_box.rs
@@ -256,13 +256,7 @@ impl InlineBoxContainerState {
         }
 
         Self {
-            base: InlineContainerState::new(
-                style,
-                flags,
-                Some(parent_container),
-                parent_container.text_decoration_line,
-                font_metrics,
-            ),
+            base: InlineContainerState::new(style, flags, Some(parent_container), font_metrics),
             identifier: inline_box.identifier,
             base_fragment_info: inline_box.base.base_fragment_info,
             pbm,

--- a/components/layout/flow/inline/line.rs
+++ b/components/layout/flow/inline/line.rs
@@ -15,7 +15,6 @@ use style::values::generics::box_::{GenericVerticalAlign, VerticalAlignKeyword};
 use style::values::generics::font::LineHeight;
 use style::values::specified::align::AlignFlags;
 use style::values::specified::box_::DisplayOutside;
-use style::values::specified::text::TextDecorationLine;
 use unicode_bidi::{BidiInfo, Level};
 use webrender_api::FontInstanceKey;
 
@@ -572,7 +571,6 @@ impl LineItemLayout<'_, '_> {
                 font_metrics: text_item.font_metrics,
                 font_key: text_item.font_key,
                 glyphs: text_item.text,
-                text_decoration_line: text_item.text_decoration_line,
                 justification_adjustment: self.justification_adjustment,
                 selection_range: text_item.selection_range,
             })),
@@ -765,7 +763,6 @@ pub(super) struct TextRunLineItem {
     pub text: Vec<std::sync::Arc<GlyphStore>>,
     pub font_metrics: FontMetrics,
     pub font_key: FontInstanceKey,
-    pub text_decoration_line: TextDecorationLine,
     /// The BiDi level of this [`TextRunLineItem`] to enable reordering.
     pub bidi_level: Level,
     pub selection_range: Option<Range<ByteIndex>>,

--- a/components/layout/flow/inline/mod.rs
+++ b/components/layout/flow/inline/mod.rs
@@ -103,7 +103,7 @@ use style::properties::style_structs::InheritedText;
 use style::values::generics::box_::VerticalAlignKeyword;
 use style::values::generics::font::LineHeight;
 use style::values::specified::box_::BaselineSource;
-use style::values::specified::text::{TextAlignKeyword, TextDecorationLine};
+use style::values::specified::text::TextAlignKeyword;
 use style::values::specified::{TextAlignLast, TextJustify};
 use text_run::{
     TextRun, XI_LINE_BREAKING_CLASS_GL, XI_LINE_BREAKING_CLASS_WJ, XI_LINE_BREAKING_CLASS_ZWJ,
@@ -134,7 +134,7 @@ use crate::geom::{LogicalRect, LogicalVec2, ToLogical};
 use crate::positioned::{AbsolutelyPositionedBox, PositioningContext};
 use crate::sizing::{ComputeInlineContentSizes, ContentSizes, InlineContentSizesResult};
 use crate::style_ext::{ComputedValuesExt, PaddingBorderMargin};
-use crate::{ConstraintSpace, ContainingBlock, PropagatedBoxTreeData, SharedStyle};
+use crate::{ConstraintSpace, ContainingBlock, SharedStyle};
 
 // From gfxFontConstants.h in Firefox.
 static FONT_SUBSCRIPT_OFFSET_RATIO: f32 = 0.20;
@@ -162,8 +162,6 @@ pub(crate) struct InlineFormattingContext {
     /// The [`SharedInlineStyles`] for the root of this [`InlineFormattingContext`] that are used to
     /// share styles with all [`TextRun`] children.
     pub(super) shared_inline_styles: SharedInlineStyles,
-
-    pub(super) text_decoration_line: TextDecorationLine,
 
     /// Whether this IFC contains the 1st formatted line of an element:
     /// <https://www.w3.org/TR/css-pseudo-4/#first-formatted-line>.
@@ -627,12 +625,6 @@ pub(super) struct InlineContainerState {
     /// Whether or not we have processed any content (an atomic element or text) for
     /// this inline box on the current line OR any previous line.
     has_content: RefCell<bool>,
-
-    /// Indicates whether this nesting level have text decorations in effect.
-    /// From <https://drafts.csswg.org/css-text-decor/#line-decoration>
-    // "When specified on or propagated to a block container that establishes
-    //  an IFC..."
-    text_decoration_line: TextDecorationLine,
 
     /// The block size contribution of this container's default font ie the size of the
     /// "strut." Whether this is integrated into the [`Self::nested_strut_block_sizes`]
@@ -1461,7 +1453,6 @@ impl InlineFormattingContextLayout<'_> {
                 inline_styles: text_run.inline_styles.clone(),
                 font_metrics,
                 font_key: ifc_font_info.key,
-                text_decoration_line: self.current_inline_container_state().text_decoration_line,
                 bidi_level,
                 selection_range,
             },
@@ -1655,7 +1646,6 @@ impl InlineFormattingContext {
     pub(super) fn new_with_builder(
         builder: InlineFormattingContextBuilder,
         layout_context: &LayoutContext,
-        propagated_data: PropagatedBoxTreeData,
         has_first_formatted_line: bool,
         is_single_line_text_input: bool,
         starting_bidi_level: Level,
@@ -1711,7 +1701,6 @@ impl InlineFormattingContext {
                 .last()
                 .expect("Should have at least one SharedInlineStyle for the root of an IFC")
                 .clone(),
-            text_decoration_line: propagated_data.text_decoration,
             has_first_formatted_line,
             contains_floats: builder.contains_floats,
             is_single_line_text_input,
@@ -1781,7 +1770,6 @@ impl InlineFormattingContext {
                 style.to_arc(),
                 inline_container_state_flags,
                 None, /* parent_container */
-                self.text_decoration_line,
                 default_font_metrics.as_ref(),
             ),
             inline_box_state_stack: Vec::new(),
@@ -1879,10 +1867,8 @@ impl InlineContainerState {
         style: Arc<ComputedValues>,
         flags: InlineContainerStateFlags,
         parent_container: Option<&InlineContainerState>,
-        parent_text_decoration_line: TextDecorationLine,
         font_metrics: Option<&FontMetrics>,
     ) -> Self {
-        let text_decoration_line = parent_text_decoration_line | style.clone_text_decoration_line();
         let font_metrics = font_metrics.cloned().unwrap_or_else(FontMetrics::empty);
         let line_height = line_height(
             &style,
@@ -1919,7 +1905,6 @@ impl InlineContainerState {
             style,
             flags,
             has_content: RefCell::new(false),
-            text_decoration_line,
             nested_strut_block_sizes: nested_block_sizes,
             strut_block_sizes,
             baseline_offset,

--- a/components/layout/flow/root.rs
+++ b/components/layout/flow/root.rs
@@ -314,7 +314,7 @@ fn construct_for_root_element(
     let contents = ReplacedContents::for_element(root_element, context)
         .map_or_else(|| NonReplacedContents::OfElement.into(), Contents::Replaced);
 
-    let propagated_data = PropagatedBoxTreeData::default().union(&info.style);
+    let propagated_data = PropagatedBoxTreeData::default();
     let root_box = if box_style.position.is_absolutely_positioned() {
         BlockLevelBox::OutOfFlowAbsolutelyPositionedBox(ArcRefCell::new(
             AbsolutelyPositionedBox::construct(context, &info, display_inside, contents),

--- a/components/layout/fragment_tree/fragment.rs
+++ b/components/layout/fragment_tree/fragment.rs
@@ -14,7 +14,6 @@ use range::Range as ServoRange;
 use servo_arc::Arc as ServoArc;
 use style::Zero;
 use style::properties::ComputedValues;
-use style::values::specified::text::TextDecorationLine;
 use webrender_api::{FontInstanceKey, ImageKey};
 
 use super::{
@@ -71,9 +70,6 @@ pub(crate) struct TextFragment {
     pub font_key: FontInstanceKey,
     #[conditional_malloc_size_of]
     pub glyphs: Vec<Arc<GlyphStore>>,
-
-    /// A flag that represents the _used_ value of the text-decoration property.
-    pub text_decoration_line: TextDecorationLine,
 
     /// Extra space to add for each justification opportunity.
     pub justification_adjustment: Au,

--- a/components/layout/lib.rs
+++ b/components/layout/lib.rs
@@ -41,7 +41,6 @@ use malloc_size_of_derive::MallocSizeOf;
 use servo_arc::Arc as ServoArc;
 use style::logical_geometry::WritingMode;
 use style::properties::ComputedValues;
-use style::values::computed::TextDecorationLine;
 
 use crate::geom::{LogicalVec2, SizeConstraint};
 use crate::style_ext::AspectRatio;
@@ -163,39 +162,20 @@ impl<'a> From<&'_ DefiniteContainingBlock<'a>> for ContainingBlock<'a> {
 /// propoagation, but only during `BoxTree` construction.
 #[derive(Clone, Copy, Debug)]
 struct PropagatedBoxTreeData {
-    text_decoration: TextDecorationLine,
     allow_percentage_column_in_tables: bool,
 }
 
 impl Default for PropagatedBoxTreeData {
     fn default() -> Self {
         Self {
-            text_decoration: Default::default(),
             allow_percentage_column_in_tables: true,
         }
     }
 }
 
 impl PropagatedBoxTreeData {
-    pub(crate) fn union(&self, style: &ComputedValues) -> Self {
-        Self {
-            // FIXME(#31736): This is only taking into account the line style and not the decoration
-            // color. This should collect information about both so that they can be rendered properly.
-            text_decoration: self.text_decoration | style.clone_text_decoration_line(),
-            allow_percentage_column_in_tables: self.allow_percentage_column_in_tables,
-        }
-    }
-
-    pub(crate) fn without_text_decorations(&self) -> Self {
-        Self {
-            text_decoration: TextDecorationLine::NONE,
-            allow_percentage_column_in_tables: self.allow_percentage_column_in_tables,
-        }
-    }
-
     fn disallowing_percentage_table_columns(&self) -> PropagatedBoxTreeData {
         Self {
-            text_decoration: self.text_decoration,
             allow_percentage_column_in_tables: false,
         }
     }

--- a/components/layout/table/construct.rs
+++ b/components/layout/table/construct.rs
@@ -81,12 +81,7 @@ impl Table {
         contents: NonReplacedContents,
         propagated_data: PropagatedBoxTreeData,
     ) -> Self {
-        let mut traversal = TableBuilderTraversal::new(
-            context,
-            info,
-            grid_style,
-            propagated_data.union(&info.style),
-        );
+        let mut traversal = TableBuilderTraversal::new(context, info, grid_style, propagated_data);
         contents.traverse(context, info, &mut traversal);
         traversal.finish()
     }
@@ -771,9 +766,6 @@ impl<'dom> TraversalHandler<'dom> for TableBuilderTraversal<'_, 'dom> {
                     });
                     self.builder.table.row_groups.push(row_group.clone());
 
-                    let previous_propagated_data = self.current_propagated_data;
-                    self.current_propagated_data = self.current_propagated_data.union(&info.style);
-
                     let new_row_group_index = self.builder.table.row_groups.len() - 1;
                     self.current_row_group_index = Some(new_row_group_index);
 
@@ -785,7 +777,6 @@ impl<'dom> TraversalHandler<'dom> for TableBuilderTraversal<'_, 'dom> {
                     self.finish_anonymous_row_if_needed();
 
                     self.current_row_group_index = None;
-                    self.current_propagated_data = previous_propagated_data;
                     self.builder.incoming_rowspans.clear();
 
                     box_slot.set(LayoutBox::TableLevelBox(TableLevelBox::TrackGroup(
@@ -936,7 +927,7 @@ impl<'style, 'builder, 'dom, 'a> TableRowBuilder<'style, 'builder, 'dom, 'a> {
             table_traversal,
             info,
             current_anonymous_cell_content: Vec::new(),
-            propagated_data: propagated_data.union(&info.style),
+            propagated_data,
         }
     }
 

--- a/components/layout/taffy/mod.rs
+++ b/components/layout/taffy/mod.rs
@@ -36,8 +36,7 @@ impl TaffyContainer {
         contents: NonReplacedContents,
         propagated_data: PropagatedBoxTreeData,
     ) -> Self {
-        let mut builder =
-            ModernContainerBuilder::new(context, info, propagated_data.union(&info.style));
+        let mut builder = ModernContainerBuilder::new(context, info, propagated_data);
         contents.traverse(context, info, &mut builder);
         let items = builder.finish();
 

--- a/tests/wpt/meta/css/CSS2/generated-content/content-070.xht.ini
+++ b/tests/wpt/meta/css/CSS2/generated-content/content-070.xht.ini
@@ -1,2 +1,0 @@
-[content-070.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/text/text-decoration-va-length-001.xht.ini
+++ b/tests/wpt/meta/css/CSS2/text/text-decoration-va-length-001.xht.ini
@@ -1,0 +1,2 @@
+[text-decoration-va-length-001.xht]
+  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/text/text-decoration-va-length-002.xht.ini
+++ b/tests/wpt/meta/css/CSS2/text/text-decoration-va-length-002.xht.ini
@@ -1,0 +1,2 @@
+[text-decoration-va-length-002.xht]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text-decor/text-decoration-decorating-box-001.html.ini
+++ b/tests/wpt/meta/css/css-text-decor/text-decoration-decorating-box-001.html.ini
@@ -1,0 +1,2 @@
+[text-decoration-decorating-box-001.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text-decor/text-decoration-dotted-002.html.ini
+++ b/tests/wpt/meta/css/css-text-decor/text-decoration-dotted-002.html.ini
@@ -1,2 +1,0 @@
-[text-decoration-dotted-002.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text-decor/text-decoration-propagation-display-contents.html.ini
+++ b/tests/wpt/meta/css/css-text-decor/text-decoration-propagation-display-contents.html.ini
@@ -1,2 +1,0 @@
-[text-decoration-propagation-display-contents.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text-decor/text-decoration-style-multiple.html.ini
+++ b/tests/wpt/meta/css/css-text-decor/text-decoration-style-multiple.html.ini
@@ -1,2 +1,0 @@
-[text-decoration-style-multiple.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text-decor/text-shadow/decorations-multiple-zorder.html.ini
+++ b/tests/wpt/meta/css/css-text-decor/text-shadow/decorations-multiple-zorder.html.ini
@@ -1,2 +1,0 @@
-[decorations-multiple-zorder.html]
-  expected: FAIL


### PR DESCRIPTION
Text decorations have a special kind of propagation. Instead of
propating these during box tree construction, move propagation to
stacking context tree construction. This will allow for using a very
easy type of incremental layout when text decorations change. For
instance, when a link changes color during hovering over it, we can skip
all of box and fragment tree construction.

In addition, propagation works a bit better now and color and style
properly move down from their originating `Fragment`s.

This introduces three new failures, because now we are drawing the
text-decoration with the correct color in more places, which exposes an
issue we have with text-decorations not being drawn in relation to the
baseline (taking into account `vertical-align`).

Testing: There are tests for these changes.
Fixes #31736.
