### PR TITLE
Wrap tests with #[cfg(test)]

### DIFF
--- a/components/config/pref_util.rs
+++ b/components/config/pref_util.rs
@@ -130,20 +130,25 @@ impl From<PrefValue> for [f64; 4] {
     }
 }
 
-#[test]
-fn test_pref_value_from_str() {
-    let value = PrefValue::from_booleanish_str("21");
-    assert_eq!(value, PrefValue::Int(21));
+#[cfg(test)]
+mod tests {
+    use super::PrefValue;
 
-    let value = PrefValue::from_booleanish_str("12.5");
-    assert_eq!(value, PrefValue::Float(12.5));
+    #[test]
+    fn test_pref_value_from_str() {
+        let value = PrefValue::from_booleanish_str("21");
+        assert_eq!(value, PrefValue::Int(21));
 
-    let value = PrefValue::from_booleanish_str("a string");
-    assert_eq!(value, PrefValue::Str("a string".into()));
+        let value = PrefValue::from_booleanish_str("12.5");
+        assert_eq!(value, PrefValue::Float(12.5));
 
-    let value = PrefValue::from_booleanish_str("false");
-    assert_eq!(value, PrefValue::Bool(false));
+        let value = PrefValue::from_booleanish_str("a string");
+        assert_eq!(value, PrefValue::Str("a string".into()));
 
-    let value = PrefValue::from_booleanish_str("true");
-    assert_eq!(value, PrefValue::Bool(true));
+        let value = PrefValue::from_booleanish_str("false");
+        assert_eq!(value, PrefValue::Bool(false));
+
+        let value = PrefValue::from_booleanish_str("true");
+        assert_eq!(value, PrefValue::Bool(true));
+    }
 }

--- a/components/devtools/id.rs
+++ b/components/devtools/id.rs
@@ -81,95 +81,98 @@ impl DevtoolsOuterWindowId {
     }
 }
 
-#[test]
-pub(crate) fn test_id_map() {
-    use std::thread;
+#[cfg(test)]
+mod tests {
+    #[test]
+    pub(crate) fn test_id_map() {
+        use std::thread;
 
-    use base::id::{PipelineNamespace, PipelineNamespaceId};
-    use crossbeam_channel::unbounded;
+        use base::id::{PipelineNamespace, PipelineNamespaceId};
+        use crossbeam_channel::unbounded;
 
-    macro_rules! test_sequential_id_assignment {
-        ($id_type:ident, $new_id_function:expr, $map_id_function:expr) => {
-            let (sender, receiver) = unbounded();
-            let sender1 = sender.clone();
-            let sender2 = sender.clone();
-            let sender3 = sender.clone();
-            let threads = [
-                thread::spawn(move || {
-                    PipelineNamespace::install(PipelineNamespaceId(1));
-                    sender1.send($new_id_function()).expect("Send failed");
-                    sender1.send($new_id_function()).expect("Send failed");
-                    sender1.send($new_id_function()).expect("Send failed");
-                }),
-                thread::spawn(move || {
-                    PipelineNamespace::install(PipelineNamespaceId(2));
-                    sender2.send($new_id_function()).expect("Send failed");
-                    sender2.send($new_id_function()).expect("Send failed");
-                    sender2.send($new_id_function()).expect("Send failed");
-                }),
-                thread::spawn(move || {
-                    PipelineNamespace::install(PipelineNamespaceId(3));
-                    sender3.send($new_id_function()).expect("Send failed");
-                    sender3.send($new_id_function()).expect("Send failed");
-                    sender3.send($new_id_function()).expect("Send failed");
-                }),
-            ];
-            for thread in threads {
-                thread.join().expect("Thread join failed");
-            }
-            let mut id_map = IdMap::default();
-            assert_eq!(
-                $map_id_function(&mut id_map, receiver.recv().expect("Recv failed")),
-                $id_type(1)
-            );
-            assert_eq!(
-                $map_id_function(&mut id_map, receiver.recv().expect("Recv failed")),
-                $id_type(2)
-            );
-            assert_eq!(
-                $map_id_function(&mut id_map, receiver.recv().expect("Recv failed")),
-                $id_type(3)
-            );
-            assert_eq!(
-                $map_id_function(&mut id_map, receiver.recv().expect("Recv failed")),
-                $id_type(4)
-            );
-            assert_eq!(
-                $map_id_function(&mut id_map, receiver.recv().expect("Recv failed")),
-                $id_type(5)
-            );
-            assert_eq!(
-                $map_id_function(&mut id_map, receiver.recv().expect("Recv failed")),
-                $id_type(6)
-            );
-            assert_eq!(
-                $map_id_function(&mut id_map, receiver.recv().expect("Recv failed")),
-                $id_type(7)
-            );
-            assert_eq!(
-                $map_id_function(&mut id_map, receiver.recv().expect("Recv failed")),
-                $id_type(8)
-            );
-            assert_eq!(
-                $map_id_function(&mut id_map, receiver.recv().expect("Recv failed")),
-                $id_type(9)
-            );
-        };
+        macro_rules! test_sequential_id_assignment {
+            ($id_type:ident, $new_id_function:expr, $map_id_function:expr) => {
+                let (sender, receiver) = unbounded();
+                let sender1 = sender.clone();
+                let sender2 = sender.clone();
+                let sender3 = sender.clone();
+                let threads = [
+                    thread::spawn(move || {
+                        PipelineNamespace::install(PipelineNamespaceId(1));
+                        sender1.send($new_id_function()).expect("Send failed");
+                        sender1.send($new_id_function()).expect("Send failed");
+                        sender1.send($new_id_function()).expect("Send failed");
+                    }),
+                    thread::spawn(move || {
+                        PipelineNamespace::install(PipelineNamespaceId(2));
+                        sender2.send($new_id_function()).expect("Send failed");
+                        sender2.send($new_id_function()).expect("Send failed");
+                        sender2.send($new_id_function()).expect("Send failed");
+                    }),
+                    thread::spawn(move || {
+                        PipelineNamespace::install(PipelineNamespaceId(3));
+                        sender3.send($new_id_function()).expect("Send failed");
+                        sender3.send($new_id_function()).expect("Send failed");
+                        sender3.send($new_id_function()).expect("Send failed");
+                    }),
+                ];
+                for thread in threads {
+                    thread.join().expect("Thread join failed");
+                }
+                let mut id_map = IdMap::default();
+                assert_eq!(
+                    $map_id_function(&mut id_map, receiver.recv().expect("Recv failed")),
+                    $id_type(1)
+                );
+                assert_eq!(
+                    $map_id_function(&mut id_map, receiver.recv().expect("Recv failed")),
+                    $id_type(2)
+                );
+                assert_eq!(
+                    $map_id_function(&mut id_map, receiver.recv().expect("Recv failed")),
+                    $id_type(3)
+                );
+                assert_eq!(
+                    $map_id_function(&mut id_map, receiver.recv().expect("Recv failed")),
+                    $id_type(4)
+                );
+                assert_eq!(
+                    $map_id_function(&mut id_map, receiver.recv().expect("Recv failed")),
+                    $id_type(5)
+                );
+                assert_eq!(
+                    $map_id_function(&mut id_map, receiver.recv().expect("Recv failed")),
+                    $id_type(6)
+                );
+                assert_eq!(
+                    $map_id_function(&mut id_map, receiver.recv().expect("Recv failed")),
+                    $id_type(7)
+                );
+                assert_eq!(
+                    $map_id_function(&mut id_map, receiver.recv().expect("Recv failed")),
+                    $id_type(8)
+                );
+                assert_eq!(
+                    $map_id_function(&mut id_map, receiver.recv().expect("Recv failed")),
+                    $id_type(9)
+                );
+            };
+        }
+
+        test_sequential_id_assignment!(
+            DevtoolsBrowserId,
+            || WebViewId::new(),
+            |id_map: &mut IdMap, id| id_map.browser_id(id)
+        );
+        test_sequential_id_assignment!(
+            DevtoolsBrowsingContextId,
+            || BrowsingContextId::new(),
+            |id_map: &mut IdMap, id| id_map.browsing_context_id(id)
+        );
+        test_sequential_id_assignment!(
+            DevtoolsOuterWindowId,
+            || PipelineId::new(),
+            |id_map: &mut IdMap, id| id_map.outer_window_id(id)
+        );
     }
-
-    test_sequential_id_assignment!(
-        DevtoolsBrowserId,
-        || WebViewId::new(),
-        |id_map: &mut IdMap, id| id_map.browser_id(id)
-    );
-    test_sequential_id_assignment!(
-        DevtoolsBrowsingContextId,
-        || BrowsingContextId::new(),
-        |id_map: &mut IdMap, id| id_map.browsing_context_id(id)
-    );
-    test_sequential_id_assignment!(
-        DevtoolsOuterWindowId,
-        || PipelineId::new(),
-        |id_map: &mut IdMap, id| id_map.outer_window_id(id)
-    );
 }

--- a/components/layout/flow/inline/line_breaker.rs
+++ b/components/layout/flow/inline/line_breaker.rs
@@ -54,67 +54,70 @@ impl LineBreaker {
     }
 }
 
-#[test]
-fn test_linebreaker_ranges() {
-    let linebreaker = LineBreaker::new("abc def");
-    assert_eq!(linebreaker.linebreaks, [4, 7]);
-    assert_eq!(
-        linebreaker.linebreaks_in_range_after_current_offset(0..5),
-        0..1
-    );
-    // The last linebreak should not be included for the text range we are interested in.
-    assert_eq!(
-        linebreaker.linebreaks_in_range_after_current_offset(0..7),
-        0..1
-    );
-
-    let linebreaker = LineBreaker::new("abc d def");
-    assert_eq!(linebreaker.linebreaks, [4, 6, 9]);
-    assert_eq!(
-        linebreaker.linebreaks_in_range_after_current_offset(0..5),
-        0..1
-    );
-    assert_eq!(
-        linebreaker.linebreaks_in_range_after_current_offset(0..7),
-        0..2
-    );
-    assert_eq!(
-        linebreaker.linebreaks_in_range_after_current_offset(0..9),
-        0..2
-    );
-
-    assert_eq!(
-        linebreaker.linebreaks_in_range_after_current_offset(4..9),
-        0..2
-    );
-
-    std::panic::catch_unwind(|| {
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_linebreaker_ranges() {
         let linebreaker = LineBreaker::new("abc def");
-        linebreaker.linebreaks_in_range_after_current_offset(5..2);
-    })
-    .expect_err("Reversed range should cause an assertion failure.");
-}
+        assert_eq!(linebreaker.linebreaks, [4, 7]);
+        assert_eq!(
+            linebreaker.linebreaks_in_range_after_current_offset(0..5),
+            0..1
+        );
+        // The last linebreak should not be included for the text range we are interested in.
+        assert_eq!(
+            linebreaker.linebreaks_in_range_after_current_offset(0..7),
+            0..1
+        );
 
-#[test]
-fn test_linebreaker_stateful_advance() {
-    let mut linebreaker = LineBreaker::new("abc d def");
-    assert_eq!(linebreaker.linebreaks, [4, 6, 9]);
-    assert!(linebreaker.advance_to_linebreaks_in_range(0..7) == &[4, 6]);
-    assert!(linebreaker.advance_to_linebreaks_in_range(8..9).is_empty());
+        let linebreaker = LineBreaker::new("abc d def");
+        assert_eq!(linebreaker.linebreaks, [4, 6, 9]);
+        assert_eq!(
+            linebreaker.linebreaks_in_range_after_current_offset(0..5),
+            0..1
+        );
+        assert_eq!(
+            linebreaker.linebreaks_in_range_after_current_offset(0..7),
+            0..2
+        );
+        assert_eq!(
+            linebreaker.linebreaks_in_range_after_current_offset(0..9),
+            0..2
+        );
 
-    // We've already advanced, so a range from the beginning shouldn't affect things.
-    assert!(linebreaker.advance_to_linebreaks_in_range(0..9).is_empty());
+        assert_eq!(
+            linebreaker.linebreaks_in_range_after_current_offset(4..9),
+            0..2
+        );
 
-    linebreaker.current_offset = 0;
+        std::panic::catch_unwind(|| {
+            let linebreaker = LineBreaker::new("abc def");
+            linebreaker.linebreaks_in_range_after_current_offset(5..2);
+        })
+        .expect_err("Reversed range should cause an assertion failure.");
+    }
 
-    // Sending a value out of range shoudn't break things.
-    assert!(linebreaker.advance_to_linebreaks_in_range(0..999) == &[4, 6]);
-
-    linebreaker.current_offset = 0;
-
-    std::panic::catch_unwind(|| {
+    #[test]
+    fn test_linebreaker_stateful_advance() {
         let mut linebreaker = LineBreaker::new("abc d def");
-        linebreaker.advance_to_linebreaks_in_range(2..0);
-    })
-    .expect_err("Reversed range should cause an assertion failure.");
+        assert_eq!(linebreaker.linebreaks, [4, 6, 9]);
+        assert!(linebreaker.advance_to_linebreaks_in_range(0..7) == &[4, 6]);
+        assert!(linebreaker.advance_to_linebreaks_in_range(8..9).is_empty());
+
+        // We've already advanced, so a range from the beginning shouldn't affect things.
+        assert!(linebreaker.advance_to_linebreaks_in_range(0..9).is_empty());
+
+        linebreaker.current_offset = 0;
+
+        // Sending a value out of range shoudn't break things.
+        assert!(linebreaker.advance_to_linebreaks_in_range(0..999) == &[4, 6]);
+
+        linebreaker.current_offset = 0;
+
+        std::panic::catch_unwind(|| {
+            let mut linebreaker = LineBreaker::new("abc d def");
+            linebreaker.advance_to_linebreaks_in_range(2..0);
+        })
+        .expect_err("Reversed range should cause an assertion failure.");
+    }
 }

--- a/components/metrics/lib.rs
+++ b/components/metrics/lib.rs
@@ -277,95 +277,98 @@ impl ProgressiveWebMetrics {
 }
 
 #[cfg(test)]
-fn test_metrics() -> ProgressiveWebMetrics {
-    let (sender, _) = ipc_channel::ipc::channel().unwrap();
-    let profiler_chan = ProfilerChan(sender);
-    let mut metrics = ProgressiveWebMetrics::new(
-        profiler_chan,
-        ServoUrl::parse("about:blank").unwrap(),
-        TimerMetadataFrameType::RootWindow,
-    );
+mod tests {
+    #[test]
+    fn test_metrics() -> ProgressiveWebMetrics {
+        let (sender, _) = ipc_channel::ipc::channel().unwrap();
+        let profiler_chan = ProfilerChan(sender);
+        let mut metrics = ProgressiveWebMetrics::new(
+            profiler_chan,
+            ServoUrl::parse("about:blank").unwrap(),
+            TimerMetadataFrameType::RootWindow,
+        );
 
-    assert!((&metrics).navigation_start().is_none());
-    assert!(metrics.get_tti().is_none());
-    assert!(metrics.first_contentful_paint().is_none());
-    assert!(metrics.first_paint().is_none());
+        assert!((&metrics).navigation_start().is_none());
+        assert!(metrics.get_tti().is_none());
+        assert!(metrics.first_contentful_paint().is_none());
+        assert!(metrics.first_paint().is_none());
 
-    metrics.set_navigation_start(CrossProcessInstant::now());
+        metrics.set_navigation_start(CrossProcessInstant::now());
 
-    metrics
-}
+        metrics
+    }
 
-#[test]
-fn test_set_dcl() {
-    let metrics = test_metrics();
-    metrics.maybe_set_tti(InteractiveFlag::DOMContentLoaded);
-    let dcl = metrics.dom_content_loaded();
-    assert!(dcl.is_some());
+    #[test]
+    fn test_set_dcl() {
+        let metrics = test_metrics();
+        metrics.maybe_set_tti(InteractiveFlag::DOMContentLoaded);
+        let dcl = metrics.dom_content_loaded();
+        assert!(dcl.is_some());
 
-    //try to overwrite
-    metrics.maybe_set_tti(InteractiveFlag::DOMContentLoaded);
-    assert_eq!(metrics.dom_content_loaded(), dcl);
-    assert_eq!(metrics.get_tti(), None);
-}
+        //try to overwrite
+        metrics.maybe_set_tti(InteractiveFlag::DOMContentLoaded);
+        assert_eq!(metrics.dom_content_loaded(), dcl);
+        assert_eq!(metrics.get_tti(), None);
+    }
 
-#[test]
-fn test_set_mta() {
-    let metrics = test_metrics();
-    let now = CrossProcessInstant::now();
-    metrics.maybe_set_tti(InteractiveFlag::TimeToInteractive(now));
-    let main_thread_available_time = metrics.main_thread_available();
-    assert!(main_thread_available_time.is_some());
-    assert_eq!(main_thread_available_time, Some(now));
+    #[test]
+    fn test_set_mta() {
+        let metrics = test_metrics();
+        let now = CrossProcessInstant::now();
+        metrics.maybe_set_tti(InteractiveFlag::TimeToInteractive(now));
+        let main_thread_available_time = metrics.main_thread_available();
+        assert!(main_thread_available_time.is_some());
+        assert_eq!(main_thread_available_time, Some(now));
 
-    //try to overwrite
-    metrics.maybe_set_tti(InteractiveFlag::TimeToInteractive(
-        CrossProcessInstant::now(),
-    ));
-    assert_eq!(metrics.main_thread_available(), main_thread_available_time);
-    assert_eq!(metrics.get_tti(), None);
-}
+        //try to overwrite
+        metrics.maybe_set_tti(InteractiveFlag::TimeToInteractive(
+            CrossProcessInstant::now(),
+        ));
+        assert_eq!(metrics.main_thread_available(), main_thread_available_time);
+        assert_eq!(metrics.get_tti(), None);
+    }
 
-#[test]
-fn test_set_tti_dcl() {
-    let metrics = test_metrics();
-    let now = CrossProcessInstant::now();
-    metrics.maybe_set_tti(InteractiveFlag::TimeToInteractive(now));
-    let main_thread_available_time = metrics.main_thread_available();
-    assert!(main_thread_available_time.is_some());
+    #[test]
+    fn test_set_tti_dcl() {
+        let metrics = test_metrics();
+        let now = CrossProcessInstant::now();
+        metrics.maybe_set_tti(InteractiveFlag::TimeToInteractive(now));
+        let main_thread_available_time = metrics.main_thread_available();
+        assert!(main_thread_available_time.is_some());
 
-    metrics.maybe_set_tti(InteractiveFlag::DOMContentLoaded);
-    let dom_content_loaded_time = metrics.dom_content_loaded();
-    assert!(dom_content_loaded_time.is_some());
+        metrics.maybe_set_tti(InteractiveFlag::DOMContentLoaded);
+        let dom_content_loaded_time = metrics.dom_content_loaded();
+        assert!(dom_content_loaded_time.is_some());
 
-    assert_eq!(metrics.get_tti(), dom_content_loaded_time);
-}
+        assert_eq!(metrics.get_tti(), dom_content_loaded_time);
+    }
 
-#[test]
-fn test_set_tti_mta() {
-    let metrics = test_metrics();
-    metrics.maybe_set_tti(InteractiveFlag::DOMContentLoaded);
-    let dcl = metrics.dom_content_loaded();
-    assert!(dcl.is_some());
+    #[test]
+    fn test_set_tti_mta() {
+        let metrics = test_metrics();
+        metrics.maybe_set_tti(InteractiveFlag::DOMContentLoaded);
+        let dcl = metrics.dom_content_loaded();
+        assert!(dcl.is_some());
 
-    let time = CrossProcessInstant::now();
-    metrics.maybe_set_tti(InteractiveFlag::TimeToInteractive(time));
-    let mta = metrics.main_thread_available();
-    assert!(mta.is_some());
+        let time = CrossProcessInstant::now();
+        metrics.maybe_set_tti(InteractiveFlag::TimeToInteractive(time));
+        let mta = metrics.main_thread_available();
+        assert!(mta.is_some());
 
-    assert_eq!(metrics.get_tti(), mta);
-}
+        assert_eq!(metrics.get_tti(), mta);
+    }
 
-#[test]
-fn test_first_paint_setter() {
-    let metrics = test_metrics();
-    metrics.set_first_paint(CrossProcessInstant::now(), false);
-    assert!(metrics.first_paint().is_some());
-}
+    #[test]
+    fn test_first_paint_setter() {
+        let metrics = test_metrics();
+        metrics.set_first_paint(CrossProcessInstant::now(), false);
+        assert!(metrics.first_paint().is_some());
+    }
 
-#[test]
-fn test_first_contentful_paint_setter() {
-    let metrics = test_metrics();
-    metrics.set_first_contentful_paint(CrossProcessInstant::now(), false);
-    assert!(metrics.first_contentful_paint().is_some());
+    #[test]
+    fn test_first_contentful_paint_setter() {
+        let metrics = test_metrics();
+        metrics.set_first_contentful_paint(CrossProcessInstant::now(), false);
+        assert!(metrics.first_contentful_paint().is_some());
+    }
 }

--- a/components/servo/webview_delegate.rs
+++ b/components/servo/webview_delegate.rs
@@ -590,199 +590,204 @@ pub trait WebViewDelegate {
 pub(crate) struct DefaultWebViewDelegate;
 impl WebViewDelegate for DefaultWebViewDelegate {}
 
-#[test]
-fn test_allow_deny_request() {
-    use ipc_channel::ipc;
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_allow_deny_request() {
+        use ipc_channel::ipc;
 
-    use crate::ServoErrorChannel;
+        use crate::ServoErrorChannel;
 
-    for default_response in [AllowOrDeny::Allow, AllowOrDeny::Deny] {
-        // Explicit allow yields allow and nothing else
+        for default_response in [AllowOrDeny::Allow, AllowOrDeny::Deny] {
+            // Explicit allow yields allow and nothing else
+            let errors = ServoErrorChannel::default();
+            let (sender, receiver) = ipc::channel().expect("Failed to create IPC channel");
+            let request = AllowOrDenyRequest::new(sender, default_response, errors.sender());
+            request.allow();
+            assert_eq!(receiver.try_recv().ok(), Some(AllowOrDeny::Allow));
+            assert_eq!(receiver.try_recv().ok(), None);
+            assert!(errors.try_recv().is_none());
+
+            // Explicit deny yields deny and nothing else
+            let errors = ServoErrorChannel::default();
+            let (sender, receiver) = ipc::channel().expect("Failed to create IPC channel");
+            let request = AllowOrDenyRequest::new(sender, default_response, errors.sender());
+            request.deny();
+            assert_eq!(receiver.try_recv().ok(), Some(AllowOrDeny::Deny));
+            assert_eq!(receiver.try_recv().ok(), None);
+            assert!(errors.try_recv().is_none());
+
+            // No response yields default response and nothing else
+            let errors = ServoErrorChannel::default();
+            let (sender, receiver) = ipc::channel().expect("Failed to create IPC channel");
+            let request = AllowOrDenyRequest::new(sender, default_response, errors.sender());
+            drop(request);
+            assert_eq!(receiver.try_recv().ok(), Some(default_response));
+            assert_eq!(receiver.try_recv().ok(), None);
+            assert!(errors.try_recv().is_none());
+
+            // Explicit allow when receiver disconnected yields error
+            let errors = ServoErrorChannel::default();
+            let (sender, receiver) = ipc::channel().expect("Failed to create IPC channel");
+            let request = AllowOrDenyRequest::new(sender, default_response, errors.sender());
+            drop(receiver);
+            request.allow();
+            assert!(errors.try_recv().is_some());
+
+            // Explicit deny when receiver disconnected yields error
+            let errors = ServoErrorChannel::default();
+            let (sender, receiver) = ipc::channel().expect("Failed to create IPC channel");
+            let request = AllowOrDenyRequest::new(sender, default_response, errors.sender());
+            drop(receiver);
+            request.deny();
+            assert!(errors.try_recv().is_some());
+
+            // No response when receiver disconnected yields no error
+            let errors = ServoErrorChannel::default();
+            let (sender, receiver) = ipc::channel().expect("Failed to create IPC channel");
+            let request = AllowOrDenyRequest::new(sender, default_response, errors.sender());
+            drop(receiver);
+            drop(request);
+            assert!(errors.try_recv().is_none());
+        }
+    }
+
+    #[test]
+    fn test_authentication_request() {
+        use ipc_channel::ipc;
+
+        use crate::ServoErrorChannel;
+
+        let url = Url::parse("https://example.com").expect("Guaranteed by argument");
+
+        // Explicit response yields that response and nothing else
         let errors = ServoErrorChannel::default();
         let (sender, receiver) = ipc::channel().expect("Failed to create IPC channel");
-        let request = AllowOrDenyRequest::new(sender, default_response, errors.sender());
-        request.allow();
-        assert_eq!(receiver.try_recv().ok(), Some(AllowOrDeny::Allow));
+        let request = AuthenticationRequest::new(url.clone(), false, sender, errors.sender());
+        request.authenticate("diffie".to_owned(), "hunter2".to_owned());
+        assert_eq!(
+            receiver.try_recv().ok(),
+            Some(Some(AuthenticationResponse {
+                username: "diffie".to_owned(),
+                password: "hunter2".to_owned(),
+            }))
+        );
         assert_eq!(receiver.try_recv().ok(), None);
         assert!(errors.try_recv().is_none());
 
-        // Explicit deny yields deny and nothing else
+        // No response yields None response and nothing else
         let errors = ServoErrorChannel::default();
         let (sender, receiver) = ipc::channel().expect("Failed to create IPC channel");
-        let request = AllowOrDenyRequest::new(sender, default_response, errors.sender());
-        request.deny();
-        assert_eq!(receiver.try_recv().ok(), Some(AllowOrDeny::Deny));
-        assert_eq!(receiver.try_recv().ok(), None);
-        assert!(errors.try_recv().is_none());
-
-        // No response yields default response and nothing else
-        let errors = ServoErrorChannel::default();
-        let (sender, receiver) = ipc::channel().expect("Failed to create IPC channel");
-        let request = AllowOrDenyRequest::new(sender, default_response, errors.sender());
+        let request = AuthenticationRequest::new(url.clone(), false, sender, errors.sender());
         drop(request);
-        assert_eq!(receiver.try_recv().ok(), Some(default_response));
+        assert_eq!(receiver.try_recv().ok(), Some(None));
         assert_eq!(receiver.try_recv().ok(), None);
         assert!(errors.try_recv().is_none());
 
-        // Explicit allow when receiver disconnected yields error
+        // Explicit response when receiver disconnected yields error
         let errors = ServoErrorChannel::default();
         let (sender, receiver) = ipc::channel().expect("Failed to create IPC channel");
-        let request = AllowOrDenyRequest::new(sender, default_response, errors.sender());
+        let request = AuthenticationRequest::new(url.clone(), false, sender, errors.sender());
         drop(receiver);
-        request.allow();
-        assert!(errors.try_recv().is_some());
-
-        // Explicit deny when receiver disconnected yields error
-        let errors = ServoErrorChannel::default();
-        let (sender, receiver) = ipc::channel().expect("Failed to create IPC channel");
-        let request = AllowOrDenyRequest::new(sender, default_response, errors.sender());
-        drop(receiver);
-        request.deny();
+        request.authenticate("diffie".to_owned(), "hunter2".to_owned());
         assert!(errors.try_recv().is_some());
 
         // No response when receiver disconnected yields no error
         let errors = ServoErrorChannel::default();
         let (sender, receiver) = ipc::channel().expect("Failed to create IPC channel");
-        let request = AllowOrDenyRequest::new(sender, default_response, errors.sender());
+        let request = AuthenticationRequest::new(url.clone(), false, sender, errors.sender());
         drop(receiver);
         drop(request);
         assert!(errors.try_recv().is_none());
     }
-}
 
-#[test]
-fn test_authentication_request() {
-    use ipc_channel::ipc;
+    #[test]
+    fn test_web_resource_load() {
+        use http::{HeaderMap, Method, StatusCode};
+        use ipc_channel::ipc;
 
-    use crate::ServoErrorChannel;
+        use crate::ServoErrorChannel;
 
-    let url = Url::parse("https://example.com").expect("Guaranteed by argument");
-
-    // Explicit response yields that response and nothing else
-    let errors = ServoErrorChannel::default();
-    let (sender, receiver) = ipc::channel().expect("Failed to create IPC channel");
-    let request = AuthenticationRequest::new(url.clone(), false, sender, errors.sender());
-    request.authenticate("diffie".to_owned(), "hunter2".to_owned());
-    assert_eq!(
-        receiver.try_recv().ok(),
-        Some(Some(AuthenticationResponse {
-            username: "diffie".to_owned(),
-            password: "hunter2".to_owned(),
-        }))
-    );
-    assert_eq!(receiver.try_recv().ok(), None);
-    assert!(errors.try_recv().is_none());
-
-    // No response yields None response and nothing else
-    let errors = ServoErrorChannel::default();
-    let (sender, receiver) = ipc::channel().expect("Failed to create IPC channel");
-    let request = AuthenticationRequest::new(url.clone(), false, sender, errors.sender());
-    drop(request);
-    assert_eq!(receiver.try_recv().ok(), Some(None));
-    assert_eq!(receiver.try_recv().ok(), None);
-    assert!(errors.try_recv().is_none());
-
-    // Explicit response when receiver disconnected yields error
-    let errors = ServoErrorChannel::default();
-    let (sender, receiver) = ipc::channel().expect("Failed to create IPC channel");
-    let request = AuthenticationRequest::new(url.clone(), false, sender, errors.sender());
-    drop(receiver);
-    request.authenticate("diffie".to_owned(), "hunter2".to_owned());
-    assert!(errors.try_recv().is_some());
-
-    // No response when receiver disconnected yields no error
-    let errors = ServoErrorChannel::default();
-    let (sender, receiver) = ipc::channel().expect("Failed to create IPC channel");
-    let request = AuthenticationRequest::new(url.clone(), false, sender, errors.sender());
-    drop(receiver);
-    drop(request);
-    assert!(errors.try_recv().is_none());
-}
-
-#[test]
-fn test_web_resource_load() {
-    use http::{HeaderMap, Method, StatusCode};
-    use ipc_channel::ipc;
-
-    use crate::ServoErrorChannel;
-
-    let web_resource_request = || WebResourceRequest {
-        method: Method::GET,
-        headers: HeaderMap::default(),
-        url: Url::parse("https://example.com").expect("Guaranteed by argument"),
-        is_for_main_frame: false,
-        is_redirect: false,
-    };
-    let web_resource_response = || {
-        WebResourceResponse::new(Url::parse("https://diffie.test").expect("Guaranteed by argument"))
+        let web_resource_request = || WebResourceRequest {
+            method: Method::GET,
+            headers: HeaderMap::default(),
+            url: Url::parse("https://example.com").expect("Guaranteed by argument"),
+            is_for_main_frame: false,
+            is_redirect: false,
+        };
+        let web_resource_response = || {
+            WebResourceResponse::new(
+                Url::parse("https://diffie.test").expect("Guaranteed by argument"),
+            )
             .status_code(StatusCode::IM_A_TEAPOT)
-    };
+        };
 
-    // Explicit intercept with explicit cancel yields Start and Cancel and nothing else
-    let errors = ServoErrorChannel::default();
-    let (sender, receiver) = ipc::channel().expect("Failed to create IPC channel");
-    let request = WebResourceLoad::new(web_resource_request(), sender, errors.sender());
-    request.intercept(web_resource_response()).cancel();
-    assert!(matches!(
-        receiver.try_recv(),
-        Ok(WebResourceResponseMsg::Start(_))
-    ));
-    assert!(matches!(
-        receiver.try_recv(),
-        Ok(WebResourceResponseMsg::CancelLoad)
-    ));
-    assert!(matches!(receiver.try_recv(), Err(_)));
-    assert!(errors.try_recv().is_none());
+        // Explicit intercept with explicit cancel yields Start and Cancel and nothing else
+        let errors = ServoErrorChannel::default();
+        let (sender, receiver) = ipc::channel().expect("Failed to create IPC channel");
+        let request = WebResourceLoad::new(web_resource_request(), sender, errors.sender());
+        request.intercept(web_resource_response()).cancel();
+        assert!(matches!(
+            receiver.try_recv(),
+            Ok(WebResourceResponseMsg::Start(_))
+        ));
+        assert!(matches!(
+            receiver.try_recv(),
+            Ok(WebResourceResponseMsg::CancelLoad)
+        ));
+        assert!(matches!(receiver.try_recv(), Err(_)));
+        assert!(errors.try_recv().is_none());
 
-    // Explicit intercept with no further action yields Start and FinishLoad and nothing else
-    let errors = ServoErrorChannel::default();
-    let (sender, receiver) = ipc::channel().expect("Failed to create IPC channel");
-    let request = WebResourceLoad::new(web_resource_request(), sender, errors.sender());
-    drop(request.intercept(web_resource_response()));
-    assert!(matches!(
-        receiver.try_recv(),
-        Ok(WebResourceResponseMsg::Start(_))
-    ));
-    assert!(matches!(
-        receiver.try_recv(),
-        Ok(WebResourceResponseMsg::FinishLoad)
-    ));
-    assert!(matches!(receiver.try_recv(), Err(_)));
-    assert!(errors.try_recv().is_none());
+        // Explicit intercept with no further action yields Start and FinishLoad and nothing else
+        let errors = ServoErrorChannel::default();
+        let (sender, receiver) = ipc::channel().expect("Failed to create IPC channel");
+        let request = WebResourceLoad::new(web_resource_request(), sender, errors.sender());
+        drop(request.intercept(web_resource_response()));
+        assert!(matches!(
+            receiver.try_recv(),
+            Ok(WebResourceResponseMsg::Start(_))
+        ));
+        assert!(matches!(
+            receiver.try_recv(),
+            Ok(WebResourceResponseMsg::FinishLoad)
+        ));
+        assert!(matches!(receiver.try_recv(), Err(_)));
+        assert!(errors.try_recv().is_none());
 
-    // No response yields DoNotIntercept and nothing else
-    let errors = ServoErrorChannel::default();
-    let (sender, receiver) = ipc::channel().expect("Failed to create IPC channel");
-    let request = WebResourceLoad::new(web_resource_request(), sender, errors.sender());
-    drop(request);
-    assert!(matches!(
-        receiver.try_recv(),
-        Ok(WebResourceResponseMsg::DoNotIntercept)
-    ));
-    assert!(matches!(receiver.try_recv(), Err(_)));
-    assert!(errors.try_recv().is_none());
+        // No response yields DoNotIntercept and nothing else
+        let errors = ServoErrorChannel::default();
+        let (sender, receiver) = ipc::channel().expect("Failed to create IPC channel");
+        let request = WebResourceLoad::new(web_resource_request(), sender, errors.sender());
+        drop(request);
+        assert!(matches!(
+            receiver.try_recv(),
+            Ok(WebResourceResponseMsg::DoNotIntercept)
+        ));
+        assert!(matches!(receiver.try_recv(), Err(_)));
+        assert!(errors.try_recv().is_none());
 
-    // Explicit intercept with explicit cancel when receiver disconnected yields error
-    let errors = ServoErrorChannel::default();
-    let (sender, receiver) = ipc::channel().expect("Failed to create IPC channel");
-    let request = WebResourceLoad::new(web_resource_request(), sender, errors.sender());
-    drop(receiver);
-    request.intercept(web_resource_response()).cancel();
-    assert!(errors.try_recv().is_some());
+        // Explicit intercept with explicit cancel when receiver disconnected yields error
+        let errors = ServoErrorChannel::default();
+        let (sender, receiver) = ipc::channel().expect("Failed to create IPC channel");
+        let request = WebResourceLoad::new(web_resource_request(), sender, errors.sender());
+        drop(receiver);
+        request.intercept(web_resource_response()).cancel();
+        assert!(errors.try_recv().is_some());
 
-    // Explicit intercept with no further action when receiver disconnected yields error
-    let errors = ServoErrorChannel::default();
-    let (sender, receiver) = ipc::channel().expect("Failed to create IPC channel");
-    let request = WebResourceLoad::new(web_resource_request(), sender, errors.sender());
-    drop(receiver);
-    drop(request.intercept(web_resource_response()));
-    assert!(errors.try_recv().is_some());
+        // Explicit intercept with no further action when receiver disconnected yields error
+        let errors = ServoErrorChannel::default();
+        let (sender, receiver) = ipc::channel().expect("Failed to create IPC channel");
+        let request = WebResourceLoad::new(web_resource_request(), sender, errors.sender());
+        drop(receiver);
+        drop(request.intercept(web_resource_response()));
+        assert!(errors.try_recv().is_some());
 
-    // No response when receiver disconnected yields no error
-    let errors = ServoErrorChannel::default();
-    let (sender, receiver) = ipc::channel().expect("Failed to create IPC channel");
-    let request = WebResourceLoad::new(web_resource_request(), sender, errors.sender());
-    drop(receiver);
-    drop(request);
-    assert!(errors.try_recv().is_none());
+        // No response when receiver disconnected yields no error
+        let errors = ServoErrorChannel::default();
+        let (sender, receiver) = ipc::channel().expect("Failed to create IPC channel");
+        let request = WebResourceLoad::new(web_resource_request(), sender, errors.sender());
+        drop(receiver);
+        drop(request);
+        assert!(errors.try_recv().is_none());
+    }
 }

--- a/components/shared/base/text.rs
+++ b/components/shared/base/text.rs
@@ -44,21 +44,26 @@ pub fn is_cjk(codepoint: char) -> bool {
     unicode_plane(codepoint) == 2 || unicode_plane(codepoint) == 3
 }
 
-#[test]
-fn test_is_cjk() {
-    // Test characters from different CJK blocks
-    assert_eq!(is_cjk('〇'), true);
-    assert_eq!(is_cjk('㐀'), true);
-    assert_eq!(is_cjk('あ'), true);
-    assert_eq!(is_cjk('ア'), true);
-    assert_eq!(is_cjk('㆒'), true);
-    assert_eq!(is_cjk('ㆣ'), true);
-    assert_eq!(is_cjk('龥'), true);
-    assert_eq!(is_cjk('𰾑'), true);
-    assert_eq!(is_cjk('𰻝'), true);
+#[cfg(test)]
+mod tests {
+    use super::is_cjk;
 
-    // Test characters from outside CJK blocks
-    assert_eq!(is_cjk('a'), false);
-    assert_eq!(is_cjk('🙂'), false);
-    assert_eq!(is_cjk('©'), false);
+    #[test]
+    fn test_is_cjk() {
+        // Test characters from different CJK blocks
+        assert_eq!(is_cjk('〇'), true);
+        assert_eq!(is_cjk('㐀'), true);
+        assert_eq!(is_cjk('あ'), true);
+        assert_eq!(is_cjk('ア'), true);
+        assert_eq!(is_cjk('㆒'), true);
+        assert_eq!(is_cjk('ㆣ'), true);
+        assert_eq!(is_cjk('龥'), true);
+        assert_eq!(is_cjk('𰾑'), true);
+        assert_eq!(is_cjk('𰻝'), true);
+
+        // Test characters from outside CJK blocks
+        assert_eq!(is_cjk('a'), false);
+        assert_eq!(is_cjk('🙂'), false);
+        assert_eq!(is_cjk('©'), false);
+    }
 }


### PR DESCRIPTION
Make in-line unittests compile conditionally by wrapping them with `#[cfg(test)]`. This should slightly reduce compile times.