### PR TITLE
Script/fire offline and online events

### DIFF
--- a/components/script/dom/dissimilaroriginwindow.rs
+++ b/components/script/dom/dissimilaroriginwindow.rs
@@ -68,6 +68,7 @@ impl DissimilarOriginWindow {
                 global_to_clone_from.wgpu_id_hub(),
                 Some(global_to_clone_from.is_secure_context()),
                 false,
+                global_to_clone_from.is_online().clone(),
             ),
             window_proxy: Dom::from_ref(window_proxy),
             location: Default::default(),

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -3453,7 +3453,7 @@ impl GlobalScope {
         unreachable!();
     }
 
-    pub(crate) fn is_online(&self) -> Arc<Mutex<bool> {
+    pub(crate) fn is_online(&self) -> Arc<Mutex<bool>> {
         Arc::clone(&self.is_online)
     }
 

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -3454,7 +3454,7 @@ impl GlobalScope {
     }
 
     pub(crate) fn is_online(&self) -> Arc<Mutex<bool>> {
-        Arc::clone(&self.is_online)
+        self.is_online.clone()
     }
 
     /// <https://www.w3.org/TR/CSP/#report-violation>

--- a/components/script/dom/navigator.rs
+++ b/components/script/dom/navigator.rs
@@ -224,8 +224,9 @@ impl NavigatorMethods<crate::DomTypeHolder> for Navigator {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-navigator-online>
     fn OnLine(&self) -> bool {
-        true
+        *self.global().is_online().lock().unwrap()
     }
+
 
     // https://html.spec.whatwg.org/multipage/#dom-navigator-plugins
     fn Plugins(&self) -> DomRoot<PluginArray> {

--- a/components/script/dom/navigator.rs
+++ b/components/script/dom/navigator.rs
@@ -227,7 +227,6 @@ impl NavigatorMethods<crate::DomTypeHolder> for Navigator {
         *self.global().is_online().lock().unwrap()
     }
 
-
     // https://html.spec.whatwg.org/multipage/#dom-navigator-plugins
     fn Plugins(&self) -> DomRoot<PluginArray> {
         self.plugins

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -398,6 +398,12 @@ pub(crate) struct Window {
 
     /// <https://dom.spec.whatwg.org/#window-current-event>
     current_event: DomRefCell<Option<Dom<Event>>>,
+    
+
+    /// Switch offline and online events
+    #[no_trace]
+    #[ignore_malloc_size_of = "Arc<Mutex<bool>> does not implement MallocSizeOf"]
+    is_online: Arc<Mutex<bool>>,
 }
 
 impl Window {
@@ -3033,6 +3039,7 @@ impl Window {
         player_context: WindowGLContext,
         #[cfg(feature = "webgpu")] gpu_id_hub: Arc<IdentityHub>,
         inherited_secure_context: Option<bool>,
+        is_online: Arc<Mutex<bool>>,
     ) -> DomRoot<Self> {
         let error_reporter = CSSErrorReporter {
             pipelineid: pipeline_id,
@@ -3060,6 +3067,8 @@ impl Window {
                 gpu_id_hub,
                 inherited_secure_context,
                 unminify_js,
+                is_online,
+            
             ),
             script_chan,
             layout: RefCell::new(layout),
@@ -3120,6 +3129,7 @@ impl Window {
             current_event: DomRefCell::new(None),
             theme: Cell::new(PrefersColorScheme::Light),
             trusted_types: Default::default(),
+            is_online: Arc::new(Mutex::new(true)),
         });
 
         unsafe {

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -398,7 +398,6 @@ pub(crate) struct Window {
 
     /// <https://dom.spec.whatwg.org/#window-current-event>
     current_event: DomRefCell<Option<Dom<Event>>>,
-    
 
     /// Switch offline and online events
     #[no_trace]
@@ -3068,7 +3067,6 @@ impl Window {
                 inherited_secure_context,
                 unminify_js,
                 is_online,
-            
             ),
             script_chan,
             layout: RefCell::new(layout),

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -5,8 +5,8 @@
 use std::cell::{RefCell, RefMut};
 use std::default::Default;
 use std::rc::Rc;
-use std::sync::{Arc, Mutex};
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use base::cross_process_instant::CrossProcessInstant;

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -5,7 +5,7 @@
 use std::cell::{RefCell, RefMut};
 use std::default::Default;
 use std::rc::Rc;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
@@ -174,6 +174,7 @@ impl WorkerGlobalScope {
                 gpu_id_hub,
                 init.inherited_secure_context,
                 false,
+                Arc::new(Mutex::new(true)),
             ),
             worker_id: init.worker_id,
             worker_name,

--- a/components/script/dom/workernavigator.rs
+++ b/components/script/dom/workernavigator.rs
@@ -19,6 +19,7 @@ use crate::dom::webgpu::gpu::GPU;
 use crate::dom::workerglobalscope::WorkerGlobalScope;
 use crate::script_runtime::{CanGc, JSContext};
 
+
 // https://html.spec.whatwg.org/multipage/#workernavigator
 #[dom_struct]
 pub(crate) struct WorkerNavigator {
@@ -107,7 +108,7 @@ impl WorkerNavigatorMethods<crate::DomTypeHolder> for WorkerNavigator {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-navigator-online>
     fn OnLine(&self) -> bool {
-        true
+       *self.global().is_online().lock().unwrap()
     }
 
     // https://w3c.github.io/permissions/#navigator-and-workernavigator-extension

--- a/components/script/dom/workernavigator.rs
+++ b/components/script/dom/workernavigator.rs
@@ -19,7 +19,6 @@ use crate::dom::webgpu::gpu::GPU;
 use crate::dom::workerglobalscope::WorkerGlobalScope;
 use crate::script_runtime::{CanGc, JSContext};
 
-
 // https://html.spec.whatwg.org/multipage/#workernavigator
 #[dom_struct]
 pub(crate) struct WorkerNavigator {
@@ -108,7 +107,7 @@ impl WorkerNavigatorMethods<crate::DomTypeHolder> for WorkerNavigator {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-navigator-online>
     fn OnLine(&self) -> bool {
-       *self.global().is_online().lock().unwrap()
+        *self.global().is_online().lock().unwrap()
     }
 
     // https://w3c.github.io/permissions/#navigator-and-workernavigator-extension

--- a/components/script/dom/workletglobalscope.rs
+++ b/components/script/dom/workletglobalscope.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use base::id::PipelineId;
 use constellation_traits::{ScriptToConstellationChan, ScriptToConstellationMessage};
@@ -110,6 +110,7 @@ impl WorkletGlobalScope {
                 init.gpu_id_hub.clone(),
                 init.inherited_secure_context,
                 false,
+                Arc::new(Mutex::new(true)),
             ),
             base_url,
             to_script_thread_sender: init.to_script_thread_sender.clone(),

--- a/components/script/messaging.rs
+++ b/components/script/messaging.rs
@@ -92,6 +92,7 @@ impl MixedMessage {
                 ScriptThreadMessage::SetWebGPUPort(..) => None,
                 ScriptThreadMessage::SetScrollStates(id, ..) => Some(*id),
                 ScriptThreadMessage::EvaluateJavaScript(id, _, _) => Some(*id),
+                ScriptThreadMessage::SetNetWorkState(..) => None,
             },
             MixedMessage::FromScript(inner_msg) => match inner_msg {
                 MainThreadScriptMsg::Common(CommonScriptMsg::Task(_, _, pipeline_id, _)) => {

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1911,20 +1911,19 @@ impl ScriptThread {
         }
     }
 
-    fn fire_network_events(&self, is_online: bool, can_gc: CanGc) {
-        for (_, document) in self.documents.borrow().iter() {
-            let window = document.window();
+fn fire_network_events(&self, is_online: bool, can_gc: CanGc) {
+    let event_name = if is_online {
+        Atom::from("online")
+    } else {
+        Atom::from("offline")
+    };
 
-            let event_name = if is_online {
-                Atom::from("online")
-            } else {
-                Atom::from("offline")
-            };
-
-            let event_target = window.upcast::<EventTarget>();
-            event_target.fire_event(event_name, can_gc);
-        }
+    for document in self.documents.borrow().values() {
+        let window = document.window();
+        let event_target = window.upcast::<EventTarget>();
+        event_target.fire_event(event_name.clone(), can_gc);
     }
+}
 
     fn handle_set_scroll_states(&self, pipeline_id: PipelineId, scroll_states: Vec<ScrollState>) {
         let Some(window) = self.documents.borrow().find_window(pipeline_id) else {

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1,5 +1,5 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
+
+/* License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 //! The script thread is the thread that owns the DOM in memory, runs JavaScript, and triggers
@@ -23,7 +23,7 @@ use std::default::Default;
 use std::option::Option;
 use std::rc::Rc;
 use std::result::Result;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
 use std::time::{Duration, Instant, SystemTime};
@@ -336,6 +336,10 @@ pub struct ScriptThread {
     /// The screen coordinates where the primary mouse button was pressed.
     #[no_trace]
     relative_mouse_down_point: Cell<Point2D<f32, DevicePixel>>,
+
+    /// Switch offline and online events
+    #[no_trace]
+    is_online: Arc<Mutex<bool>>,
 }
 
 struct BHMExitSignal {
@@ -957,6 +961,7 @@ impl ScriptThread {
             inherited_secure_context: state.inherited_secure_context,
             layout_factory,
             relative_mouse_down_point: Cell::new(Point2D::zero()),
+            is_online: Arc::new(Mutex::new(true)),
         }
     }
 
@@ -3224,6 +3229,7 @@ impl ScriptThread {
             #[cfg(feature = "webgpu")]
             self.gpu_id_hub.clone(),
             incomplete.load_data.inherited_secure_context,
+            self.is_online.clone(),
         );
 
         let _realm = enter_realm(&*window);

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -248,6 +248,8 @@ pub enum ScriptThreadMessage {
     /// Evaluate the given JavaScript and return a result via a corresponding message
     /// to the Constellation.
     EvaluateJavaScript(PipelineId, JavaScriptEvaluationId, String),
+    /// Parameter indicates if online (true) or offline (false)
+    SetNetWorkState(bool),
 }
 
 impl fmt::Debug for ScriptThreadMessage {


### PR DESCRIPTION
## Implement firing of online and offline events (Part 1 of 2)
This PR implements the internal infrastructure for online/offline network state detection. This is Part 1 of a two-part implementation - the external API for embedders will be added in Issue #36611.

### What This PR Does:
* Adds is_online: Arc<Mutex<bool>> shared state to ScriptThread and GlobalScope
* Wires the state through GlobalScope::new_inherited, Window::new, DedicatedWorkerGlobalScope::new, and WorkletGlobalScope::new
* Updates Navigator::OnLine and WorkerNavigator::OnLine to return real state instead of hardcoded true

### Event System
* Adds SetNetWorkOnlineState(bool) message handling in ScriptThread
* Fires online/offline events at all Window instances when network state changes
Note: Worker globals are not handled in this PR (mentioned in original issue)

### Shared State Architecture
All GlobalScope instances (Windows, Workers, Worklets) share the same Arc<Mutex<bool>> reference, ensuring consistent state across all browsing contexts.

What's Missing: (Issue #36611)
Currently, the is_online state is initialized to true and never changes because there's no external mechanism to trigger state updates. The complete feature requires:

- EmbedderToConstellationMessage variant for network state updates
- Constellation code to broadcast state changes to all pipelines
- Public Servo API for embedders to report network changes

Testing: Not yet covered - will be added once the external API is implemented in #36611.
Fixes: #36610
Related: #36611 (External embedder API)
cc @jdm