### PR TITLE
Let `input` JS event be dispatched by `keydown` instead of `keypress`

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -2374,6 +2374,9 @@ impl Document {
         let mut cancel_state = event.get_cancel_state();
 
         // https://w3c.github.io/uievents/#keys-cancelable-keys
+        // it MUST prevent the respective beforeinput and input
+        // (and keypress if supported) events from being generated
+        // TODO: keypress should be deprecated and superceded by beforeinput
         if keyboard_event.state == KeyState::Down &&
             is_character_value_key(&(keyboard_event.key)) &&
             !keyboard_event.is_composing &&

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -2879,6 +2879,17 @@ impl VirtualMethods for HTMLInputElement {
                         self.implicit_submission(can_gc);
                     },
                     DispatchInput => {
+                        if event.IsTrusted() {
+                            self.owner_global()
+                                .task_manager()
+                                .user_interaction_task_source()
+                                .queue_event(
+                                    self.upcast(),
+                                    atom!("input"),
+                                    EventBubbles::Bubbles,
+                                    EventCancelable::NotCancelable,
+                                );
+                        }
                         self.value_dirty.set(true);
                         self.update_placeholder_shown_state();
                         self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
@@ -2895,17 +2906,9 @@ impl VirtualMethods for HTMLInputElement {
             !event.DefaultPrevented() &&
             self.input_type().is_textual_or_password()
         {
-            if event.IsTrusted() {
-                self.owner_global()
-                    .task_manager()
-                    .user_interaction_task_source()
-                    .queue_event(
-                        self.upcast(),
-                        atom!("input"),
-                        EventBubbles::Bubbles,
-                        EventCancelable::NotCancelable,
-                    );
-            }
+            // keypress should be deprecated and replaced by beforeinput.
+            // keypress was supposed to fire "blur" and "focus" events
+            // but already done in `document.rs`
         } else if (event.type_() == atom!("compositionstart") ||
             event.type_() == atom!("compositionupdate") ||
             event.type_() == atom!("compositionend")) &&

--- a/components/script/dom/htmltextareaelement.rs
+++ b/components/script/dom/htmltextareaelement.rs
@@ -643,6 +643,17 @@ impl VirtualMethods for HTMLTextAreaElement {
                 match action {
                     KeyReaction::TriggerDefaultAction => (),
                     KeyReaction::DispatchInput => {
+                        if event.IsTrusted() {
+                            self.owner_global()
+                                .task_manager()
+                                .user_interaction_task_source()
+                                .queue_event(
+                                    self.upcast(),
+                                    atom!("input"),
+                                    EventBubbles::Bubbles,
+                                    EventCancelable::NotCancelable,
+                                );
+                        }
                         self.value_dirty.set(true);
                         self.update_placeholder_shown_state();
                         self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
@@ -656,17 +667,9 @@ impl VirtualMethods for HTMLTextAreaElement {
                 }
             }
         } else if event.type_() == atom!("keypress") && !event.DefaultPrevented() {
-            if event.IsTrusted() {
-                self.owner_global()
-                    .task_manager()
-                    .user_interaction_task_source()
-                    .queue_event(
-                        self.upcast(),
-                        atom!("input"),
-                        EventBubbles::Bubbles,
-                        EventCancelable::NotCancelable,
-                    );
-            }
+            // keypress should be deprecated and replaced by beforeinput.
+            // keypress was supposed to fire "blur" and "focus" events
+            // but already done in `document.rs`
         } else if event.type_() == atom!("compositionstart") ||
             event.type_() == atom!("compositionupdate") ||
             event.type_() == atom!("compositionend")


### PR DESCRIPTION
1. Let `input` JS event be dispatched by `keydown` instead of `keypress`, according to spec
2. Fire `input` event for Backspace and Delete. But do so only when something is actually deleted

Testing: Manually tested and compared with other browsers.
Fixes: #37051
cc @xiaochengh 