### PR TITLE
OHOS CI: Allow run.json to be overwritten in upload action.

### DIFF
--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -174,6 +174,7 @@ jobs:
         with:
           name: runs.json
           path: support/hitrace-bencher/runs.json
+          overwrite: true
       - uses: actions/upload-artifact@v4
         with:
           # Upload the **unsigned** artifact - We don't have the signing materials in pull request workflows


### PR DESCRIPTION
The CI does multiple build runs so we need to handle it being
overwritten.

Multiple different build of OHOS servoshell would fight for who is first to upload run.json and the other would error out.
Now we allow both to succeed by overwrite the run.json

Testing: Testrun: https://github.com/Narfinger/servo/actions/runs/15180797189/job/42689748807

Signed-off-by: Narfinger <Narfinger@users.noreply.github.com>
