### PR TITLE
Add retry for hit tests with expired epoch in result

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -283,8 +283,7 @@ impl PipelineDetails {
 
 pub enum HitTestError {
     EpochMismatch,
-    #[allow(dead_code)]
-    Other,
+    Others,
 }
 
 impl ServoRenderer {
@@ -296,14 +295,17 @@ impl ServoRenderer {
         &self,
         point: DevicePoint,
         details_for_pipeline: impl Fn(PipelineId) -> Option<&'a PipelineDetails>,
-    ) -> Result<Option<CompositorHitTestResult>, HitTestError> {
+    ) -> Result<CompositorHitTestResult, HitTestError> {
         match self.hit_test_at_point_with_flags_and_pipeline(
             point,
             HitTestFlags::empty(),
             None,
             details_for_pipeline,
         ) {
-            Ok(hit_test_results) => Ok(hit_test_results.first().cloned()),
+            Ok(hit_test_results) => hit_test_results
+                .first()
+                .cloned()
+                .ok_or(HitTestError::Others),
             Err(error) => Err(error),
         }
     }
@@ -639,7 +641,7 @@ impl IOCompositor {
                         .global
                         .borrow()
                         .hit_test_at_point(point, details_for_pipeline);
-                    if let Ok(Some(result)) = result {
+                    if let Ok(result) = result {
                         self.global.borrow_mut().update_cursor(point, &result);
                     }
                 }

--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -814,10 +814,13 @@ impl IOCompositor {
                 let Some(webview_renderer) = self.webview_renderers.get_mut(webview_id) else {
                     return warn!("Could not find WebView for incoming display list");
                 };
+                webview_renderer.epoch_not_synchronized.set(true);
 
                 let pipeline_id = display_list_info.pipeline_id;
                 let details = webview_renderer.ensure_pipeline_details(pipeline_id.into());
+
                 details.most_recent_display_list_epoch = Some(display_list_info.epoch);
+
                 details.hit_test_items = display_list_info.hit_test_info;
                 details.install_new_scroll_tree(display_list_info.scroll_tree);
 
@@ -1662,6 +1665,7 @@ impl IOCompositor {
             // Process all pending events
             self.webview_renderers.iter().for_each(|webview| {
                 webview.dispatch_pending_input_events();
+                webview.epoch_not_synchronized.set(false);
             });
         }
 

--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -814,13 +814,12 @@ impl IOCompositor {
                 let Some(webview_renderer) = self.webview_renderers.get_mut(webview_id) else {
                     return warn!("Could not find WebView for incoming display list");
                 };
+                // epoch is outdated until we receive "NewWebRenderFrameReady" message.
                 webview_renderer.epoch_not_synchronized.set(true);
 
                 let pipeline_id = display_list_info.pipeline_id;
                 let details = webview_renderer.ensure_pipeline_details(pipeline_id.into());
-
                 details.most_recent_display_list_epoch = Some(display_list_info.epoch);
-
                 details.hit_test_items = display_list_info.hit_test_info;
                 details.install_new_scroll_tree(display_list_info.scroll_tree);
 
@@ -1664,7 +1663,7 @@ impl IOCompositor {
         if found_recomposite_msg {
             // Process all pending events
             self.webview_renderers.iter().for_each(|webview| {
-                webview.dispatch_pending_input_events();
+                webview.dispatch_pending_point_input_events();
                 webview.epoch_not_synchronized.set(false);
             });
         }

--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -671,7 +671,7 @@ impl IOCompositor {
                 };
                 let dppx = webview_renderer.device_pixels_per_page_pixel();
                 let point = dppx.transform_point(Point2D::new(x, y));
-                webview_renderer.dispatch_input_event(
+                webview_renderer.dispatch_point_input_event(
                     InputEvent::MouseButton(MouseButtonEvent::new(action, button, point))
                         .with_webdriver_message_id(Some(message_id)),
                 );
@@ -684,7 +684,7 @@ impl IOCompositor {
                 };
                 let dppx = webview_renderer.device_pixels_per_page_pixel();
                 let point = dppx.transform_point(Point2D::new(x, y));
-                webview_renderer.dispatch_input_event(
+                webview_renderer.dispatch_point_input_event(
                     InputEvent::MouseMove(MouseMoveEvent::new(point))
                         .with_webdriver_message_id(Some(message_id)),
                 );
@@ -706,7 +706,7 @@ impl IOCompositor {
                 let scroll_delta =
                     dppx.transform_vector(Vector2D::new(delta_x as f32, delta_y as f32));
                 webview_renderer
-                    .dispatch_input_event(InputEvent::Wheel(WheelEvent { delta, point }));
+                    .dispatch_point_input_event(InputEvent::Wheel(WheelEvent { delta, point }));
                 webview_renderer.on_webdriver_wheel_action(scroll_delta, point);
             },
 
@@ -815,7 +815,7 @@ impl IOCompositor {
                     return warn!("Could not find WebView for incoming display list");
                 };
                 // epoch is outdated until we receive "NewWebRenderFrameReady" message.
-                webview_renderer.epoch_not_synchronized.set(true);
+                webview_renderer.webrender_frame_ready.set(false);
 
                 let pipeline_id = display_list_info.pipeline_id;
                 let details = webview_renderer.ensure_pipeline_details(pipeline_id.into());
@@ -1664,7 +1664,7 @@ impl IOCompositor {
             // Process all pending events
             self.webview_renderers.iter().for_each(|webview| {
                 webview.dispatch_pending_point_input_events();
-                webview.epoch_not_synchronized.set(false);
+                webview.webrender_frame_ready.set(true);
             });
         }
 

--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -814,7 +814,7 @@ impl IOCompositor {
                 let Some(webview_renderer) = self.webview_renderers.get_mut(webview_id) else {
                     return warn!("Could not find WebView for incoming display list");
                 };
-                // epoch is outdated until we receive "NewWebRenderFrameReady" message.
+                // WebRender is not ready until we receive "NewWebRenderFrameReady"
                 webview_renderer.webrender_frame_ready.set(false);
 
                 let pipeline_id = display_list_info.pipeline_id;

--- a/components/compositing/webview_renderer.rs
+++ b/components/compositing/webview_renderer.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::collections::hash_map::Keys;
 use std::collections::{HashMap, VecDeque};
 use std::rc::Rc;
@@ -100,6 +100,8 @@ pub(crate) struct WebViewRenderer {
     animating: bool,
     /// Pending input events queue. Priavte and only this thread pushes events to it.
     pending_input_events: RefCell<VecDeque<InputEvent>>,
+    /// Flag to indicate that the epoch has been not synchronized yet.
+    pub epoch_not_synchronized: Cell<bool>,
 }
 
 impl Drop for WebViewRenderer {
@@ -135,6 +137,7 @@ impl WebViewRenderer {
             hidpi_scale_factor: Scale::new(hidpi_scale_factor.0),
             animating: false,
             pending_input_events: Default::default(),
+            epoch_not_synchronized: Cell::default(),
         }
     }
 
@@ -319,7 +322,7 @@ impl WebViewRenderer {
             return;
         };
 
-        if self.pending_input_events.borrow().len() > 0 {
+        if self.epoch_not_synchronized.get() {
             self.pending_input_events.borrow_mut().push_back(event);
             return;
         }


### PR DESCRIPTION
Follow up to [hit_test failed occasionally when the touch event is sent](https://github.com/servo/servo/issues/35788#top) and https://github.com/servo/servo/issues/36676#issuecomment-2882917136, this PR adds a retry for hit tests with expired epoch in result.

Hit tests with outdated epoch mean it is too early to perform the hit test.

Solution: retry hit test for the event on the next webrender frame.
The retry should guarantee that:

- Keep the correct order of events
- Retry time is not too long

Test cases: `./mach test-wpt --product servodriver -r tests\wpt\tests\webdriver\tests\classic\element_click\events.py`

cc: @xiaochengh , @yezhizhen 
