### PR TITLE
ohos: servoshell: Use Flex{Column} to avoid Column bug

### DIFF
--- a/support/openharmony/entry/src/main/ets/pages/Index.ets
+++ b/support/openharmony/entry/src/main/ets/pages/Index.ets
@@ -76,7 +76,10 @@ struct Index {
   }
 
   build() {
-    Column() {
+    // We originally use `Column()` here, but for some reason the column
+    // extends beyond the edge of the screen. This does not happen with
+    // Flex.
+    Flex({ direction: FlexDirection.Column}) {
       Row() {
         Button('⇦').backgroundColor(Color.White)
           .fontColor(Color.Black)


### PR DESCRIPTION
The `Column()` height and thus also the XComponent height extends beyond the physical display for unknown reasons. This is a problem on websites that have a footer bar, since the footer is partially below the display end.
Using Flex with Column direction works as expected.

Testing: Manual inspection with DevEco Testing inspecting the height of the children elements in ArkUI
Fixes: Part of the servoshell surface extending beyond the physical screen on ohos

