### PR TITLE
Add another incremental layout that starts at stacking tree construction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6507,7 +6507,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.28.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#88b34ae4293ca7286584cee37bca1f58ab79a8cb"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#1707256dd825f14e98161a49fdd6749f8ca0d506"
 dependencies = [
  "bitflags 2.9.1",
  "cssparser",
@@ -6802,7 +6802,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.1"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#88b34ae4293ca7286584cee37bca1f58ab79a8cb"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#1707256dd825f14e98161a49fdd6749f8ca0d506"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -7247,7 +7247,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#88b34ae4293ca7286584cee37bca1f58ab79a8cb"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#1707256dd825f14e98161a49fdd6749f8ca0d506"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -7305,7 +7305,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#88b34ae4293ca7286584cee37bca1f58ab79a8cb"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#1707256dd825f14e98161a49fdd6749f8ca0d506"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -7314,12 +7314,12 @@ dependencies = [
 [[package]]
 name = "stylo_config"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#88b34ae4293ca7286584cee37bca1f58ab79a8cb"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#1707256dd825f14e98161a49fdd6749f8ca0d506"
 
 [[package]]
 name = "stylo_derive"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#88b34ae4293ca7286584cee37bca1f58ab79a8cb"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#1707256dd825f14e98161a49fdd6749f8ca0d506"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -7331,7 +7331,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#88b34ae4293ca7286584cee37bca1f58ab79a8cb"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#1707256dd825f14e98161a49fdd6749f8ca0d506"
 dependencies = [
  "bitflags 2.9.1",
  "stylo_malloc_size_of",
@@ -7340,7 +7340,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#88b34ae4293ca7286584cee37bca1f58ab79a8cb"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#1707256dd825f14e98161a49fdd6749f8ca0d506"
 dependencies = [
  "app_units",
  "cssparser",
@@ -7357,12 +7357,12 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#88b34ae4293ca7286584cee37bca1f58ab79a8cb"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#1707256dd825f14e98161a49fdd6749f8ca0d506"
 
 [[package]]
 name = "stylo_traits"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#88b34ae4293ca7286584cee37bca1f58ab79a8cb"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#1707256dd825f14e98161a49fdd6749f8ca0d506"
 dependencies = [
  "app_units",
  "bitflags 2.9.1",
@@ -7745,7 +7745,7 @@ dependencies = [
 [[package]]
 name = "to_shmem"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#88b34ae4293ca7286584cee37bca1f58ab79a8cb"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#1707256dd825f14e98161a49fdd6749f8ca0d506"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -7758,7 +7758,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#88b34ae4293ca7286584cee37bca1f58ab79a8cb"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#1707256dd825f14e98161a49fdd6749f8ca0d506"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/components/layout/traversal.rs
+++ b/components/layout/traversal.rs
@@ -131,7 +131,9 @@ pub(crate) fn compute_damage_and_repair_style_inner(
         }
     }
 
-    if propagated_damage == RestyleDamage::REPAINT && original_damage == RestyleDamage::REPAINT {
+    if !propagated_damage.contains(RestyleDamage::REBUILD_BOX) &&
+        !original_damage.contains(RestyleDamage::REBUILD_BOX)
+    {
         node.repair_style(context);
     }
 

--- a/tests/wpt/tests/css/CSS2/zindex/z-index-020.html
+++ b/tests/wpt/tests/css/CSS2/zindex/z-index-020.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<title>CSS Test: z-index - dynamic changes</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#z-index" />
+<link rel="match" href="../../reference/ref-filled-green-200px-square.html">
+<meta name="assert" content="Checks that z-index can be changed dynamically.">
+<style>
+div {
+  width: 200px;
+  height: 200px;
+  position: absolute;
+}
+#red {
+  background: red;
+}
+#target {
+  background: green;
+  z-index: -1;
+}
+#target.front {
+  z-index: 1;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div id="red"></div>
+<div id="target"></div>
+
+<script src="/common/reftest-wait.js"></script>
+<script src="/common/rendering-utils.js"></script>
+<script>
+waitForAtLeastOneFrame().then(() => {
+  document.getElementById("target").className = "front";
+  takeScreenshot();
+});
+</script>
+</html>


### PR DESCRIPTION
This allows to skip rebuilding the box tree when it's only necessary to rebuild the stacking context tree.
Bumps Stylo to https://github.com/servo/stylo/pull/187

Testing: Unneeded (no behavior change). Just improving performance. However, this adds a new test for dynamic changes of `z-index`, which we were breaking in an earlier iteration of this patch.