### PR TITLE
OHOS: Workaround for a bug in getopts and updating the crate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ fnv = "1.0"
 fonts_traits = { path = "components/shared/fonts" }
 freetype-sys = "0.20"
 fxhash = "0.2"
-getopts = "0.2.11"
+getopts = "0.2.21"
 gleam = "0.15"
 glib = "0.19"
 glow = "0.16"

--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -363,6 +363,13 @@ pub(crate) fn parse_command_line_arguments(args: Vec<String>) -> ArgumentParsing
         "FILTER",
     );
 
+    opts.optmulti(
+        "",
+        "dev-tools",
+        "Start the devtools on the supplied port",
+        "1234",
+    );
+
     opts.optflag(
         "",
         "enable-experimental-web-platform-features",
@@ -506,9 +513,9 @@ pub(crate) fn parse_command_line_arguments(args: Vec<String>) -> ArgumentParsing
                 })
             });
 
-    if opt_match.opt_present("devtools") {
+    if opt_match.opt_present("dev-tools") {
         let port = opt_match
-            .opt_str("devtools")
+            .opt_str("dev-tools")
             .map(|port| {
                 port.parse().unwrap_or_else(|err| {
                     args_fail(&format!("Error parsing option: --devtools ({})", err))


### PR DESCRIPTION
Currently getopts does not work with the devtools flag and just ignores
the argument to it. This was actually raised in
https://github.com/servo/servo/issues/28306. This workaround (by
renaming the flag to have a dash) fixes this for some reason.

The getopts issue is tracked here
https://github.com/rust-lang/getopts/issues/104.

Additionally, I updated the dependency as it was quite out of date.

Signed-off-by: Narfinger <Narfinger@users.noreply.github.com>

*Describe the changes that this pull request makes here. This will be the commit message.*

Testing: Flags for embedded applications do not have test cases and the CI did not hit this case.
Fixes: https://github.com/servo/servo/issues/28306 which was closed by the author for unknown reason. The bug was still there.
