### PR TITLE
Enable all remaining disabled intermittent tests

### DIFF
--- a/tests/wpt/meta/html/browsers/history/the-history-interface/001.html.ini
+++ b/tests/wpt/meta/html/browsers/history/the-history-interface/001.html.ini
@@ -1,6 +1,0 @@
-[001.html]
-  type: testharness
-  disabled: https://github.com/servo/servo/issues/12580
-  [history.length should update when setting location.hash]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/dom/reflection-embedded.html.ini
+++ b/tests/wpt/meta/html/dom/reflection-embedded.html.ini
@@ -1,3 +1,8802 @@
 [reflection-embedded.html]
-  type: testharness
-  disabled: https://github.com/servo/servo/issues/11100
+  [picture.accessKey: typeof IDL attribute]
+    expected: FAIL
+
+  [picture.accessKey: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [picture.accessKey: setAttribute() to ""]
+    expected: FAIL
+
+  [picture.accessKey: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [picture.accessKey: setAttribute() to undefined]
+    expected: FAIL
+
+  [picture.accessKey: setAttribute() to 7]
+    expected: FAIL
+
+  [picture.accessKey: setAttribute() to 1.5]
+    expected: FAIL
+
+  [picture.accessKey: setAttribute() to "5%"]
+    expected: FAIL
+
+  [picture.accessKey: setAttribute() to "+100"]
+    expected: FAIL
+
+  [picture.accessKey: setAttribute() to ".5"]
+    expected: FAIL
+
+  [picture.accessKey: setAttribute() to true]
+    expected: FAIL
+
+  [picture.accessKey: setAttribute() to false]
+    expected: FAIL
+
+  [picture.accessKey: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [picture.accessKey: setAttribute() to NaN]
+    expected: FAIL
+
+  [picture.accessKey: setAttribute() to Infinity]
+    expected: FAIL
+
+  [picture.accessKey: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [picture.accessKey: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [picture.accessKey: setAttribute() to null]
+    expected: FAIL
+
+  [picture.accessKey: setAttribute() to object "test-toString"]
+    expected: FAIL
+
+  [picture.accessKey: setAttribute() to object "test-valueOf"]
+    expected: FAIL
+
+  [picture.accessKey: IDL set to ""]
+    expected: FAIL
+
+  [picture.accessKey: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [picture.accessKey: IDL set to undefined]
+    expected: FAIL
+
+  [picture.accessKey: IDL set to 7]
+    expected: FAIL
+
+  [picture.accessKey: IDL set to 1.5]
+    expected: FAIL
+
+  [picture.accessKey: IDL set to "5%"]
+    expected: FAIL
+
+  [picture.accessKey: IDL set to "+100"]
+    expected: FAIL
+
+  [picture.accessKey: IDL set to ".5"]
+    expected: FAIL
+
+  [picture.accessKey: IDL set to true]
+    expected: FAIL
+
+  [picture.accessKey: IDL set to false]
+    expected: FAIL
+
+  [picture.accessKey: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [picture.accessKey: IDL set to NaN]
+    expected: FAIL
+
+  [picture.accessKey: IDL set to Infinity]
+    expected: FAIL
+
+  [picture.accessKey: IDL set to -Infinity]
+    expected: FAIL
+
+  [picture.accessKey: IDL set to "\\0"]
+    expected: FAIL
+
+  [picture.accessKey: IDL set to null]
+    expected: FAIL
+
+  [picture.accessKey: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [picture.accessKey: IDL set to object "test-valueOf"]
+    expected: FAIL
+
+  [picture.tabIndex: typeof IDL attribute]
+    expected: FAIL
+
+  [picture.tabIndex: setAttribute() to -36]
+    expected: FAIL
+
+  [picture.tabIndex: setAttribute() to -1]
+    expected: FAIL
+
+  [picture.tabIndex: setAttribute() to 0]
+    expected: FAIL
+
+  [picture.tabIndex: setAttribute() to 1]
+    expected: FAIL
+
+  [picture.tabIndex: setAttribute() to 2147483647]
+    expected: FAIL
+
+  [picture.tabIndex: setAttribute() to -2147483648]
+    expected: FAIL
+
+  [picture.tabIndex: setAttribute() to "-1"]
+    expected: FAIL
+
+  [picture.tabIndex: setAttribute() to "-0"]
+    expected: FAIL
+
+  [picture.tabIndex: setAttribute() to "0"]
+    expected: FAIL
+
+  [picture.tabIndex: setAttribute() to "1"]
+    expected: FAIL
+
+  [picture.tabIndex: setAttribute() to "\\t7"]
+    expected: FAIL
+
+  [picture.tabIndex: setAttribute() to "\\f7"]
+    expected: FAIL
+
+  [picture.tabIndex: setAttribute() to " 7"]
+    expected: FAIL
+
+  [picture.tabIndex: setAttribute() to "\\n7"]
+    expected: FAIL
+
+  [picture.tabIndex: setAttribute() to "\\r7"]
+    expected: FAIL
+
+  [picture.tabIndex: setAttribute() to "7\\v"]
+    expected: FAIL
+
+  [picture.tabIndex: setAttribute() to 1.5]
+    expected: FAIL
+
+  [picture.tabIndex: setAttribute() to "5%"]
+    expected: FAIL
+
+  [picture.tabIndex: setAttribute() to "+100"]
+    expected: FAIL
+
+  [picture.tabIndex: setAttribute() to object "2"]
+    expected: FAIL
+
+  [picture.tabIndex: setAttribute() to object "3"]
+    expected: FAIL
+
+  [picture.tabIndex: IDL set to -36]
+    expected: FAIL
+
+  [picture.tabIndex: IDL set to -1]
+    expected: FAIL
+
+  [picture.tabIndex: IDL set to 0]
+    expected: FAIL
+
+  [picture.tabIndex: IDL set to 1]
+    expected: FAIL
+
+  [picture.tabIndex: IDL set to 2147483647]
+    expected: FAIL
+
+  [picture.tabIndex: IDL set to -2147483648]
+    expected: FAIL
+
+  [img.accessKey: typeof IDL attribute]
+    expected: FAIL
+
+  [img.accessKey: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [img.accessKey: setAttribute() to ""]
+    expected: FAIL
+
+  [img.accessKey: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [img.accessKey: setAttribute() to undefined]
+    expected: FAIL
+
+  [img.accessKey: setAttribute() to 7]
+    expected: FAIL
+
+  [img.accessKey: setAttribute() to 1.5]
+    expected: FAIL
+
+  [img.accessKey: setAttribute() to "5%"]
+    expected: FAIL
+
+  [img.accessKey: setAttribute() to "+100"]
+    expected: FAIL
+
+  [img.accessKey: setAttribute() to ".5"]
+    expected: FAIL
+
+  [img.accessKey: setAttribute() to true]
+    expected: FAIL
+
+  [img.accessKey: setAttribute() to false]
+    expected: FAIL
+
+  [img.accessKey: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [img.accessKey: setAttribute() to NaN]
+    expected: FAIL
+
+  [img.accessKey: setAttribute() to Infinity]
+    expected: FAIL
+
+  [img.accessKey: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [img.accessKey: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [img.accessKey: setAttribute() to null]
+    expected: FAIL
+
+  [img.accessKey: setAttribute() to object "test-toString"]
+    expected: FAIL
+
+  [img.accessKey: setAttribute() to object "test-valueOf"]
+    expected: FAIL
+
+  [img.accessKey: IDL set to ""]
+    expected: FAIL
+
+  [img.accessKey: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [img.accessKey: IDL set to undefined]
+    expected: FAIL
+
+  [img.accessKey: IDL set to 7]
+    expected: FAIL
+
+  [img.accessKey: IDL set to 1.5]
+    expected: FAIL
+
+  [img.accessKey: IDL set to "5%"]
+    expected: FAIL
+
+  [img.accessKey: IDL set to "+100"]
+    expected: FAIL
+
+  [img.accessKey: IDL set to ".5"]
+    expected: FAIL
+
+  [img.accessKey: IDL set to true]
+    expected: FAIL
+
+  [img.accessKey: IDL set to false]
+    expected: FAIL
+
+  [img.accessKey: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [img.accessKey: IDL set to NaN]
+    expected: FAIL
+
+  [img.accessKey: IDL set to Infinity]
+    expected: FAIL
+
+  [img.accessKey: IDL set to -Infinity]
+    expected: FAIL
+
+  [img.accessKey: IDL set to "\\0"]
+    expected: FAIL
+
+  [img.accessKey: IDL set to null]
+    expected: FAIL
+
+  [img.accessKey: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [img.accessKey: IDL set to object "test-valueOf"]
+    expected: FAIL
+
+  [img.tabIndex: typeof IDL attribute]
+    expected: FAIL
+
+  [img.tabIndex: setAttribute() to -36]
+    expected: FAIL
+
+  [img.tabIndex: setAttribute() to -1]
+    expected: FAIL
+
+  [img.tabIndex: setAttribute() to 0]
+    expected: FAIL
+
+  [img.tabIndex: setAttribute() to 1]
+    expected: FAIL
+
+  [img.tabIndex: setAttribute() to 2147483647]
+    expected: FAIL
+
+  [img.tabIndex: setAttribute() to -2147483648]
+    expected: FAIL
+
+  [img.tabIndex: setAttribute() to "-1"]
+    expected: FAIL
+
+  [img.tabIndex: setAttribute() to "-0"]
+    expected: FAIL
+
+  [img.tabIndex: setAttribute() to "0"]
+    expected: FAIL
+
+  [img.tabIndex: setAttribute() to "1"]
+    expected: FAIL
+
+  [img.tabIndex: setAttribute() to "\\t7"]
+    expected: FAIL
+
+  [img.tabIndex: setAttribute() to "\\f7"]
+    expected: FAIL
+
+  [img.tabIndex: setAttribute() to " 7"]
+    expected: FAIL
+
+  [img.tabIndex: setAttribute() to "\\n7"]
+    expected: FAIL
+
+  [img.tabIndex: setAttribute() to "\\r7"]
+    expected: FAIL
+
+  [img.tabIndex: setAttribute() to "7\\v"]
+    expected: FAIL
+
+  [img.tabIndex: setAttribute() to 1.5]
+    expected: FAIL
+
+  [img.tabIndex: setAttribute() to "5%"]
+    expected: FAIL
+
+  [img.tabIndex: setAttribute() to "+100"]
+    expected: FAIL
+
+  [img.tabIndex: setAttribute() to object "2"]
+    expected: FAIL
+
+  [img.tabIndex: setAttribute() to object "3"]
+    expected: FAIL
+
+  [img.tabIndex: IDL set to -36]
+    expected: FAIL
+
+  [img.tabIndex: IDL set to -1]
+    expected: FAIL
+
+  [img.tabIndex: IDL set to 0]
+    expected: FAIL
+
+  [img.tabIndex: IDL set to 1]
+    expected: FAIL
+
+  [img.tabIndex: IDL set to 2147483647]
+    expected: FAIL
+
+  [img.tabIndex: IDL set to -2147483648]
+    expected: FAIL
+
+  [img.srcset: setAttribute() to ""]
+    expected: FAIL
+
+  [img.srcset: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [img.srcset: setAttribute() to undefined]
+    expected: FAIL
+
+  [img.srcset: setAttribute() to 7]
+    expected: FAIL
+
+  [img.srcset: setAttribute() to 1.5]
+    expected: FAIL
+
+  [img.srcset: setAttribute() to "5%"]
+    expected: FAIL
+
+  [img.srcset: setAttribute() to "+100"]
+    expected: FAIL
+
+  [img.srcset: setAttribute() to ".5"]
+    expected: FAIL
+
+  [img.srcset: setAttribute() to true]
+    expected: FAIL
+
+  [img.srcset: setAttribute() to false]
+    expected: FAIL
+
+  [img.srcset: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [img.srcset: setAttribute() to NaN]
+    expected: FAIL
+
+  [img.srcset: setAttribute() to Infinity]
+    expected: FAIL
+
+  [img.srcset: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [img.srcset: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [img.srcset: setAttribute() to null]
+    expected: FAIL
+
+  [img.srcset: setAttribute() to object "test-toString"]
+    expected: FAIL
+
+  [img.srcset: setAttribute() to object "test-valueOf"]
+    expected: FAIL
+
+  [img.srcset: IDL set to ""]
+    expected: FAIL
+
+  [img.srcset: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [img.srcset: IDL set to undefined]
+    expected: FAIL
+
+  [img.srcset: IDL set to 7]
+    expected: FAIL
+
+  [img.srcset: IDL set to 1.5]
+    expected: FAIL
+
+  [img.srcset: IDL set to "5%"]
+    expected: FAIL
+
+  [img.srcset: IDL set to "+100"]
+    expected: FAIL
+
+  [img.srcset: IDL set to ".5"]
+    expected: FAIL
+
+  [img.srcset: IDL set to true]
+    expected: FAIL
+
+  [img.srcset: IDL set to false]
+    expected: FAIL
+
+  [img.srcset: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [img.srcset: IDL set to NaN]
+    expected: FAIL
+
+  [img.srcset: IDL set to Infinity]
+    expected: FAIL
+
+  [img.srcset: IDL set to -Infinity]
+    expected: FAIL
+
+  [img.srcset: IDL set to "\\0"]
+    expected: FAIL
+
+  [img.srcset: IDL set to null]
+    expected: FAIL
+
+  [img.srcset: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [img.srcset: IDL set to object "test-valueOf"]
+    expected: FAIL
+
+  [img.referrerPolicy: IDL set to ""]
+    expected: FAIL
+
+  [img.referrerPolicy: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [img.referrerPolicy: IDL set to undefined]
+    expected: FAIL
+
+  [img.referrerPolicy: IDL set to 7]
+    expected: FAIL
+
+  [img.referrerPolicy: IDL set to 1.5]
+    expected: FAIL
+
+  [img.referrerPolicy: IDL set to "5%"]
+    expected: FAIL
+
+  [img.referrerPolicy: IDL set to "+100"]
+    expected: FAIL
+
+  [img.referrerPolicy: IDL set to ".5"]
+    expected: FAIL
+
+  [img.referrerPolicy: IDL set to true]
+    expected: FAIL
+
+  [img.referrerPolicy: IDL set to false]
+    expected: FAIL
+
+  [img.referrerPolicy: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [img.referrerPolicy: IDL set to NaN]
+    expected: FAIL
+
+  [img.referrerPolicy: IDL set to Infinity]
+    expected: FAIL
+
+  [img.referrerPolicy: IDL set to -Infinity]
+    expected: FAIL
+
+  [img.referrerPolicy: IDL set to "\\0"]
+    expected: FAIL
+
+  [img.referrerPolicy: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [img.referrerPolicy: IDL set to object "test-valueOf"]
+    expected: FAIL
+
+  [img.referrerPolicy: IDL set to "xno-referrer"]
+    expected: FAIL
+
+  [img.referrerPolicy: IDL set to "no-referrer\\0"]
+    expected: FAIL
+
+  [img.referrerPolicy: IDL set to "o-referrer"]
+    expected: FAIL
+
+  [img.referrerPolicy: IDL set to "NO-REFERRER"]
+    expected: FAIL
+
+  [img.referrerPolicy: IDL set to "xno-referrer-when-downgrade"]
+    expected: FAIL
+
+  [img.referrerPolicy: IDL set to "no-referrer-when-downgrade\\0"]
+    expected: FAIL
+
+  [img.referrerPolicy: IDL set to "o-referrer-when-downgrade"]
+    expected: FAIL
+
+  [img.referrerPolicy: IDL set to "NO-REFERRER-WHEN-DOWNGRADE"]
+    expected: FAIL
+
+  [img.referrerPolicy: IDL set to "xsame-origin"]
+    expected: FAIL
+
+  [img.referrerPolicy: IDL set to "same-origin\\0"]
+    expected: FAIL
+
+  [img.referrerPolicy: IDL set to "ame-origin"]
+    expected: FAIL
+
+  [img.referrerPolicy: IDL set to "SAME-ORIGIN"]
+    expected: FAIL
+
+  [img.referrerPolicy: IDL set to "ſame-origin"]
+    expected: FAIL
+
+  [img.referrerPolicy: IDL set to "xorigin"]
+    expected: FAIL
+
+  [img.referrerPolicy: IDL set to "origin\\0"]
+    expected: FAIL
+
+  [img.referrerPolicy: IDL set to "rigin"]
+    expected: FAIL
+
+  [img.referrerPolicy: IDL set to "ORIGIN"]
+    expected: FAIL
+
+  [img.referrerPolicy: IDL set to "xstrict-origin"]
+    expected: FAIL
+
+  [img.referrerPolicy: IDL set to "strict-origin\\0"]
+    expected: FAIL
+
+  [img.referrerPolicy: IDL set to "trict-origin"]
+    expected: FAIL
+
+  [img.referrerPolicy: IDL set to "STRICT-ORIGIN"]
+    expected: FAIL
+
+  [img.referrerPolicy: IDL set to "ſtrict-origin"]
+    expected: FAIL
+
+  [img.referrerPolicy: IDL set to "xorigin-when-cross-origin"]
+    expected: FAIL
+
+  [img.referrerPolicy: IDL set to "origin-when-cross-origin\\0"]
+    expected: FAIL
+
+  [img.referrerPolicy: IDL set to "rigin-when-cross-origin"]
+    expected: FAIL
+
+  [img.referrerPolicy: IDL set to "ORIGIN-WHEN-CROSS-ORIGIN"]
+    expected: FAIL
+
+  [img.referrerPolicy: IDL set to "origin-when-croſſ-origin"]
+    expected: FAIL
+
+  [img.referrerPolicy: IDL set to "xstrict-origin-when-cross-origin"]
+    expected: FAIL
+
+  [img.referrerPolicy: IDL set to "strict-origin-when-cross-origin\\0"]
+    expected: FAIL
+
+  [img.referrerPolicy: IDL set to "trict-origin-when-cross-origin"]
+    expected: FAIL
+
+  [img.referrerPolicy: IDL set to "STRICT-ORIGIN-WHEN-CROSS-ORIGIN"]
+    expected: FAIL
+
+  [img.referrerPolicy: IDL set to "ſtrict-origin-when-croſſ-origin"]
+    expected: FAIL
+
+  [img.referrerPolicy: IDL set to "xunsafe-url"]
+    expected: FAIL
+
+  [img.referrerPolicy: IDL set to "unsafe-url\\0"]
+    expected: FAIL
+
+  [img.referrerPolicy: IDL set to "nsafe-url"]
+    expected: FAIL
+
+  [img.referrerPolicy: IDL set to "UNSAFE-URL"]
+    expected: FAIL
+
+  [img.referrerPolicy: IDL set to "unſafe-url"]
+    expected: FAIL
+
+  [img.decoding: typeof IDL attribute]
+    expected: FAIL
+
+  [img.decoding: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [img.decoding: setAttribute() to ""]
+    expected: FAIL
+
+  [img.decoding: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [img.decoding: setAttribute() to undefined]
+    expected: FAIL
+
+  [img.decoding: setAttribute() to 7]
+    expected: FAIL
+
+  [img.decoding: setAttribute() to 1.5]
+    expected: FAIL
+
+  [img.decoding: setAttribute() to "5%"]
+    expected: FAIL
+
+  [img.decoding: setAttribute() to "+100"]
+    expected: FAIL
+
+  [img.decoding: setAttribute() to ".5"]
+    expected: FAIL
+
+  [img.decoding: setAttribute() to true]
+    expected: FAIL
+
+  [img.decoding: setAttribute() to false]
+    expected: FAIL
+
+  [img.decoding: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [img.decoding: setAttribute() to NaN]
+    expected: FAIL
+
+  [img.decoding: setAttribute() to Infinity]
+    expected: FAIL
+
+  [img.decoding: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [img.decoding: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [img.decoding: setAttribute() to null]
+    expected: FAIL
+
+  [img.decoding: setAttribute() to object "test-toString"]
+    expected: FAIL
+
+  [img.decoding: setAttribute() to object "test-valueOf"]
+    expected: FAIL
+
+  [img.decoding: setAttribute() to "async"]
+    expected: FAIL
+
+  [img.decoding: setAttribute() to "xasync"]
+    expected: FAIL
+
+  [img.decoding: setAttribute() to "async\\0"]
+    expected: FAIL
+
+  [img.decoding: setAttribute() to "ASYNC"]
+    expected: FAIL
+
+  [img.decoding: setAttribute() to "aſync"]
+    expected: FAIL
+
+  [img.decoding: setAttribute() to "sync"]
+    expected: FAIL
+
+  [img.decoding: setAttribute() to "xsync"]
+    expected: FAIL
+
+  [img.decoding: setAttribute() to "sync\\0"]
+    expected: FAIL
+
+  [img.decoding: setAttribute() to "ync"]
+    expected: FAIL
+
+  [img.decoding: setAttribute() to "SYNC"]
+    expected: FAIL
+
+  [img.decoding: setAttribute() to "ſync"]
+    expected: FAIL
+
+  [img.decoding: setAttribute() to "auto"]
+    expected: FAIL
+
+  [img.decoding: setAttribute() to "xauto"]
+    expected: FAIL
+
+  [img.decoding: setAttribute() to "auto\\0"]
+    expected: FAIL
+
+  [img.decoding: setAttribute() to "uto"]
+    expected: FAIL
+
+  [img.decoding: setAttribute() to "AUTO"]
+    expected: FAIL
+
+  [img.decoding: IDL set to ""]
+    expected: FAIL
+
+  [img.decoding: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [img.decoding: IDL set to undefined]
+    expected: FAIL
+
+  [img.decoding: IDL set to 7]
+    expected: FAIL
+
+  [img.decoding: IDL set to 1.5]
+    expected: FAIL
+
+  [img.decoding: IDL set to "5%"]
+    expected: FAIL
+
+  [img.decoding: IDL set to "+100"]
+    expected: FAIL
+
+  [img.decoding: IDL set to ".5"]
+    expected: FAIL
+
+  [img.decoding: IDL set to true]
+    expected: FAIL
+
+  [img.decoding: IDL set to false]
+    expected: FAIL
+
+  [img.decoding: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [img.decoding: IDL set to NaN]
+    expected: FAIL
+
+  [img.decoding: IDL set to Infinity]
+    expected: FAIL
+
+  [img.decoding: IDL set to -Infinity]
+    expected: FAIL
+
+  [img.decoding: IDL set to "\\0"]
+    expected: FAIL
+
+  [img.decoding: IDL set to null]
+    expected: FAIL
+
+  [img.decoding: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [img.decoding: IDL set to object "test-valueOf"]
+    expected: FAIL
+
+  [img.decoding: IDL set to "async"]
+    expected: FAIL
+
+  [img.decoding: IDL set to "xasync"]
+    expected: FAIL
+
+  [img.decoding: IDL set to "async\\0"]
+    expected: FAIL
+
+  [img.decoding: IDL set to "ASYNC"]
+    expected: FAIL
+
+  [img.decoding: IDL set to "aſync"]
+    expected: FAIL
+
+  [img.decoding: IDL set to "sync"]
+    expected: FAIL
+
+  [img.decoding: IDL set to "xsync"]
+    expected: FAIL
+
+  [img.decoding: IDL set to "sync\\0"]
+    expected: FAIL
+
+  [img.decoding: IDL set to "ync"]
+    expected: FAIL
+
+  [img.decoding: IDL set to "SYNC"]
+    expected: FAIL
+
+  [img.decoding: IDL set to "ſync"]
+    expected: FAIL
+
+  [img.decoding: IDL set to "auto"]
+    expected: FAIL
+
+  [img.decoding: IDL set to "xauto"]
+    expected: FAIL
+
+  [img.decoding: IDL set to "auto\\0"]
+    expected: FAIL
+
+  [img.decoding: IDL set to "uto"]
+    expected: FAIL
+
+  [img.decoding: IDL set to "AUTO"]
+    expected: FAIL
+
+  [img.lowsrc: typeof IDL attribute]
+    expected: FAIL
+
+  [img.lowsrc: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [img.lowsrc: setAttribute() to ""]
+    expected: FAIL
+
+  [img.lowsrc: setAttribute() to " foo "]
+    expected: FAIL
+
+  [img.lowsrc: setAttribute() to "http://site.example/"]
+    expected: FAIL
+
+  [img.lowsrc: setAttribute() to "//site.example/path???@#l"]
+    expected: FAIL
+
+  [img.lowsrc: setAttribute() to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f "]
+    expected: FAIL
+
+  [img.lowsrc: setAttribute() to undefined]
+    expected: FAIL
+
+  [img.lowsrc: setAttribute() to 7]
+    expected: FAIL
+
+  [img.lowsrc: setAttribute() to 1.5]
+    expected: FAIL
+
+  [img.lowsrc: setAttribute() to "5%"]
+    expected: FAIL
+
+  [img.lowsrc: setAttribute() to "+100"]
+    expected: FAIL
+
+  [img.lowsrc: setAttribute() to ".5"]
+    expected: FAIL
+
+  [img.lowsrc: setAttribute() to true]
+    expected: FAIL
+
+  [img.lowsrc: setAttribute() to false]
+    expected: FAIL
+
+  [img.lowsrc: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [img.lowsrc: setAttribute() to NaN]
+    expected: FAIL
+
+  [img.lowsrc: setAttribute() to Infinity]
+    expected: FAIL
+
+  [img.lowsrc: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [img.lowsrc: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [img.lowsrc: setAttribute() to null]
+    expected: FAIL
+
+  [img.lowsrc: setAttribute() to object "test-toString"]
+    expected: FAIL
+
+  [img.lowsrc: setAttribute() to object "test-valueOf"]
+    expected: FAIL
+
+  [img.lowsrc: IDL set to ""]
+    expected: FAIL
+
+  [img.lowsrc: IDL set to " foo "]
+    expected: FAIL
+
+  [img.lowsrc: IDL set to "http://site.example/"]
+    expected: FAIL
+
+  [img.lowsrc: IDL set to "//site.example/path???@#l"]
+    expected: FAIL
+
+  [img.lowsrc: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f "]
+    expected: FAIL
+
+  [img.lowsrc: IDL set to undefined]
+    expected: FAIL
+
+  [img.lowsrc: IDL set to 7]
+    expected: FAIL
+
+  [img.lowsrc: IDL set to 1.5]
+    expected: FAIL
+
+  [img.lowsrc: IDL set to "5%"]
+    expected: FAIL
+
+  [img.lowsrc: IDL set to "+100"]
+    expected: FAIL
+
+  [img.lowsrc: IDL set to ".5"]
+    expected: FAIL
+
+  [img.lowsrc: IDL set to true]
+    expected: FAIL
+
+  [img.lowsrc: IDL set to false]
+    expected: FAIL
+
+  [img.lowsrc: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [img.lowsrc: IDL set to NaN]
+    expected: FAIL
+
+  [img.lowsrc: IDL set to Infinity]
+    expected: FAIL
+
+  [img.lowsrc: IDL set to -Infinity]
+    expected: FAIL
+
+  [img.lowsrc: IDL set to "\\0"]
+    expected: FAIL
+
+  [img.lowsrc: IDL set to null]
+    expected: FAIL
+
+  [img.lowsrc: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [img.lowsrc: IDL set to object "test-valueOf"]
+    expected: FAIL
+
+  [img.longDesc: setAttribute() to ""]
+    expected: FAIL
+
+  [img.longDesc: setAttribute() to " foo "]
+    expected: FAIL
+
+  [img.longDesc: setAttribute() to "//site.example/path???@#l"]
+    expected: FAIL
+
+  [img.longDesc: setAttribute() to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f "]
+    expected: FAIL
+
+  [img.longDesc: setAttribute() to undefined]
+    expected: FAIL
+
+  [img.longDesc: setAttribute() to 7]
+    expected: FAIL
+
+  [img.longDesc: setAttribute() to 1.5]
+    expected: FAIL
+
+  [img.longDesc: setAttribute() to "5%"]
+    expected: FAIL
+
+  [img.longDesc: setAttribute() to "+100"]
+    expected: FAIL
+
+  [img.longDesc: setAttribute() to ".5"]
+    expected: FAIL
+
+  [img.longDesc: setAttribute() to true]
+    expected: FAIL
+
+  [img.longDesc: setAttribute() to false]
+    expected: FAIL
+
+  [img.longDesc: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [img.longDesc: setAttribute() to NaN]
+    expected: FAIL
+
+  [img.longDesc: setAttribute() to Infinity]
+    expected: FAIL
+
+  [img.longDesc: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [img.longDesc: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [img.longDesc: setAttribute() to null]
+    expected: FAIL
+
+  [img.longDesc: setAttribute() to object "test-toString"]
+    expected: FAIL
+
+  [img.longDesc: setAttribute() to object "test-valueOf"]
+    expected: FAIL
+
+  [img.longDesc: IDL set to ""]
+    expected: FAIL
+
+  [img.longDesc: IDL set to " foo "]
+    expected: FAIL
+
+  [img.longDesc: IDL set to "//site.example/path???@#l"]
+    expected: FAIL
+
+  [img.longDesc: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f "]
+    expected: FAIL
+
+  [img.longDesc: IDL set to undefined]
+    expected: FAIL
+
+  [img.longDesc: IDL set to 7]
+    expected: FAIL
+
+  [img.longDesc: IDL set to 1.5]
+    expected: FAIL
+
+  [img.longDesc: IDL set to "5%"]
+    expected: FAIL
+
+  [img.longDesc: IDL set to "+100"]
+    expected: FAIL
+
+  [img.longDesc: IDL set to ".5"]
+    expected: FAIL
+
+  [img.longDesc: IDL set to true]
+    expected: FAIL
+
+  [img.longDesc: IDL set to false]
+    expected: FAIL
+
+  [img.longDesc: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [img.longDesc: IDL set to NaN]
+    expected: FAIL
+
+  [img.longDesc: IDL set to Infinity]
+    expected: FAIL
+
+  [img.longDesc: IDL set to -Infinity]
+    expected: FAIL
+
+  [img.longDesc: IDL set to "\\0"]
+    expected: FAIL
+
+  [img.longDesc: IDL set to null]
+    expected: FAIL
+
+  [img.longDesc: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [img.longDesc: IDL set to object "test-valueOf"]
+    expected: FAIL
+
+  [iframe.accessKey: typeof IDL attribute]
+    expected: FAIL
+
+  [iframe.accessKey: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [iframe.accessKey: setAttribute() to ""]
+    expected: FAIL
+
+  [iframe.accessKey: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [iframe.accessKey: setAttribute() to undefined]
+    expected: FAIL
+
+  [iframe.accessKey: setAttribute() to 7]
+    expected: FAIL
+
+  [iframe.accessKey: setAttribute() to 1.5]
+    expected: FAIL
+
+  [iframe.accessKey: setAttribute() to "5%"]
+    expected: FAIL
+
+  [iframe.accessKey: setAttribute() to "+100"]
+    expected: FAIL
+
+  [iframe.accessKey: setAttribute() to ".5"]
+    expected: FAIL
+
+  [iframe.accessKey: setAttribute() to true]
+    expected: FAIL
+
+  [iframe.accessKey: setAttribute() to false]
+    expected: FAIL
+
+  [iframe.accessKey: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [iframe.accessKey: setAttribute() to NaN]
+    expected: FAIL
+
+  [iframe.accessKey: setAttribute() to Infinity]
+    expected: FAIL
+
+  [iframe.accessKey: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [iframe.accessKey: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [iframe.accessKey: setAttribute() to null]
+    expected: FAIL
+
+  [iframe.accessKey: setAttribute() to object "test-toString"]
+    expected: FAIL
+
+  [iframe.accessKey: setAttribute() to object "test-valueOf"]
+    expected: FAIL
+
+  [iframe.accessKey: IDL set to ""]
+    expected: FAIL
+
+  [iframe.accessKey: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [iframe.accessKey: IDL set to undefined]
+    expected: FAIL
+
+  [iframe.accessKey: IDL set to 7]
+    expected: FAIL
+
+  [iframe.accessKey: IDL set to 1.5]
+    expected: FAIL
+
+  [iframe.accessKey: IDL set to "5%"]
+    expected: FAIL
+
+  [iframe.accessKey: IDL set to "+100"]
+    expected: FAIL
+
+  [iframe.accessKey: IDL set to ".5"]
+    expected: FAIL
+
+  [iframe.accessKey: IDL set to true]
+    expected: FAIL
+
+  [iframe.accessKey: IDL set to false]
+    expected: FAIL
+
+  [iframe.accessKey: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [iframe.accessKey: IDL set to NaN]
+    expected: FAIL
+
+  [iframe.accessKey: IDL set to Infinity]
+    expected: FAIL
+
+  [iframe.accessKey: IDL set to -Infinity]
+    expected: FAIL
+
+  [iframe.accessKey: IDL set to "\\0"]
+    expected: FAIL
+
+  [iframe.accessKey: IDL set to null]
+    expected: FAIL
+
+  [iframe.accessKey: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [iframe.accessKey: IDL set to object "test-valueOf"]
+    expected: FAIL
+
+  [iframe.tabIndex: typeof IDL attribute]
+    expected: FAIL
+
+  [iframe.tabIndex: setAttribute() to -36]
+    expected: FAIL
+
+  [iframe.tabIndex: setAttribute() to -1]
+    expected: FAIL
+
+  [iframe.tabIndex: setAttribute() to 0]
+    expected: FAIL
+
+  [iframe.tabIndex: setAttribute() to 1]
+    expected: FAIL
+
+  [iframe.tabIndex: setAttribute() to 2147483647]
+    expected: FAIL
+
+  [iframe.tabIndex: setAttribute() to -2147483648]
+    expected: FAIL
+
+  [iframe.tabIndex: setAttribute() to "-1"]
+    expected: FAIL
+
+  [iframe.tabIndex: setAttribute() to "-0"]
+    expected: FAIL
+
+  [iframe.tabIndex: setAttribute() to "0"]
+    expected: FAIL
+
+  [iframe.tabIndex: setAttribute() to "1"]
+    expected: FAIL
+
+  [iframe.tabIndex: setAttribute() to "\\t7"]
+    expected: FAIL
+
+  [iframe.tabIndex: setAttribute() to "\\f7"]
+    expected: FAIL
+
+  [iframe.tabIndex: setAttribute() to " 7"]
+    expected: FAIL
+
+  [iframe.tabIndex: setAttribute() to "\\n7"]
+    expected: FAIL
+
+  [iframe.tabIndex: setAttribute() to "\\r7"]
+    expected: FAIL
+
+  [iframe.tabIndex: setAttribute() to "7\\v"]
+    expected: FAIL
+
+  [iframe.tabIndex: setAttribute() to 1.5]
+    expected: FAIL
+
+  [iframe.tabIndex: setAttribute() to "5%"]
+    expected: FAIL
+
+  [iframe.tabIndex: setAttribute() to "+100"]
+    expected: FAIL
+
+  [iframe.tabIndex: setAttribute() to object "2"]
+    expected: FAIL
+
+  [iframe.tabIndex: setAttribute() to object "3"]
+    expected: FAIL
+
+  [iframe.tabIndex: IDL set to -36]
+    expected: FAIL
+
+  [iframe.tabIndex: IDL set to -1]
+    expected: FAIL
+
+  [iframe.tabIndex: IDL set to 0]
+    expected: FAIL
+
+  [iframe.tabIndex: IDL set to 1]
+    expected: FAIL
+
+  [iframe.tabIndex: IDL set to 2147483647]
+    expected: FAIL
+
+  [iframe.tabIndex: IDL set to -2147483648]
+    expected: FAIL
+
+  [iframe.allowUserMedia: typeof IDL attribute]
+    expected: FAIL
+
+  [iframe.allowUserMedia: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [iframe.allowUserMedia: setAttribute() to ""]
+    expected: FAIL
+
+  [iframe.allowUserMedia: setAttribute() to " foo "]
+    expected: FAIL
+
+  [iframe.allowUserMedia: setAttribute() to undefined]
+    expected: FAIL
+
+  [iframe.allowUserMedia: setAttribute() to null]
+    expected: FAIL
+
+  [iframe.allowUserMedia: setAttribute() to 7]
+    expected: FAIL
+
+  [iframe.allowUserMedia: setAttribute() to 1.5]
+    expected: FAIL
+
+  [iframe.allowUserMedia: setAttribute() to "5%"]
+    expected: FAIL
+
+  [iframe.allowUserMedia: setAttribute() to "+100"]
+    expected: FAIL
+
+  [iframe.allowUserMedia: setAttribute() to ".5"]
+    expected: FAIL
+
+  [iframe.allowUserMedia: setAttribute() to true]
+    expected: FAIL
+
+  [iframe.allowUserMedia: setAttribute() to false]
+    expected: FAIL
+
+  [iframe.allowUserMedia: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [iframe.allowUserMedia: setAttribute() to NaN]
+    expected: FAIL
+
+  [iframe.allowUserMedia: setAttribute() to Infinity]
+    expected: FAIL
+
+  [iframe.allowUserMedia: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [iframe.allowUserMedia: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [iframe.allowUserMedia: setAttribute() to object "test-toString"]
+    expected: FAIL
+
+  [iframe.allowUserMedia: setAttribute() to object "test-valueOf"]
+    expected: FAIL
+
+  [iframe.allowUserMedia: setAttribute() to "allowUserMedia"]
+    expected: FAIL
+
+  [iframe.allowUserMedia: IDL set to ""]
+    expected: FAIL
+
+  [iframe.allowUserMedia: IDL set to " foo "]
+    expected: FAIL
+
+  [iframe.allowUserMedia: IDL set to undefined]
+    expected: FAIL
+
+  [iframe.allowUserMedia: IDL set to null]
+    expected: FAIL
+
+  [iframe.allowUserMedia: IDL set to 7]
+    expected: FAIL
+
+  [iframe.allowUserMedia: IDL set to 1.5]
+    expected: FAIL
+
+  [iframe.allowUserMedia: IDL set to "5%"]
+    expected: FAIL
+
+  [iframe.allowUserMedia: IDL set to "+100"]
+    expected: FAIL
+
+  [iframe.allowUserMedia: IDL set to ".5"]
+    expected: FAIL
+
+  [iframe.allowUserMedia: IDL set to false]
+    expected: FAIL
+
+  [iframe.allowUserMedia: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [iframe.allowUserMedia: IDL set to NaN]
+    expected: FAIL
+
+  [iframe.allowUserMedia: IDL set to Infinity]
+    expected: FAIL
+
+  [iframe.allowUserMedia: IDL set to -Infinity]
+    expected: FAIL
+
+  [iframe.allowUserMedia: IDL set to "\\0"]
+    expected: FAIL
+
+  [iframe.allowUserMedia: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [iframe.allowUserMedia: IDL set to object "test-valueOf"]
+    expected: FAIL
+
+  [iframe.delegateStickyUserActivation: typeof IDL attribute]
+    expected: FAIL
+
+  [iframe.delegateStickyUserActivation: setAttribute() to "vibration"]
+    expected: FAIL
+
+  [iframe.delegateStickyUserActivation: setAttribute() to "VIBRATION"]
+    expected: FAIL
+
+  [iframe.delegateStickyUserActivation: setAttribute() to "media"]
+    expected: FAIL
+
+  [iframe.delegateStickyUserActivation: setAttribute() to "MEDIA"]
+    expected: FAIL
+
+  [iframe.delegateStickyUserActivation: IDL set to ""]
+    expected: FAIL
+
+  [iframe.delegateStickyUserActivation: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [iframe.delegateStickyUserActivation: IDL set to undefined]
+    expected: FAIL
+
+  [iframe.delegateStickyUserActivation: IDL set to 7]
+    expected: FAIL
+
+  [iframe.delegateStickyUserActivation: IDL set to 1.5]
+    expected: FAIL
+
+  [iframe.delegateStickyUserActivation: IDL set to "5%"]
+    expected: FAIL
+
+  [iframe.delegateStickyUserActivation: IDL set to "+100"]
+    expected: FAIL
+
+  [iframe.delegateStickyUserActivation: IDL set to ".5"]
+    expected: FAIL
+
+  [iframe.delegateStickyUserActivation: IDL set to true]
+    expected: FAIL
+
+  [iframe.delegateStickyUserActivation: IDL set to false]
+    expected: FAIL
+
+  [iframe.delegateStickyUserActivation: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [iframe.delegateStickyUserActivation: IDL set to NaN]
+    expected: FAIL
+
+  [iframe.delegateStickyUserActivation: IDL set to Infinity]
+    expected: FAIL
+
+  [iframe.delegateStickyUserActivation: IDL set to -Infinity]
+    expected: FAIL
+
+  [iframe.delegateStickyUserActivation: IDL set to "\\0"]
+    expected: FAIL
+
+  [iframe.delegateStickyUserActivation: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [iframe.delegateStickyUserActivation: IDL set to object "test-valueOf"]
+    expected: FAIL
+
+  [iframe.delegateStickyUserActivation: IDL set to "vibration"]
+    expected: FAIL
+
+  [iframe.delegateStickyUserActivation: IDL set to "xvibration"]
+    expected: FAIL
+
+  [iframe.delegateStickyUserActivation: IDL set to "vibration\\0"]
+    expected: FAIL
+
+  [iframe.delegateStickyUserActivation: IDL set to "ibration"]
+    expected: FAIL
+
+  [iframe.delegateStickyUserActivation: IDL set to "VIBRATION"]
+    expected: FAIL
+
+  [iframe.delegateStickyUserActivation: IDL set to "media"]
+    expected: FAIL
+
+  [iframe.delegateStickyUserActivation: IDL set to "xmedia"]
+    expected: FAIL
+
+  [iframe.delegateStickyUserActivation: IDL set to "media\\0"]
+    expected: FAIL
+
+  [iframe.delegateStickyUserActivation: IDL set to "edia"]
+    expected: FAIL
+
+  [iframe.delegateStickyUserActivation: IDL set to "MEDIA"]
+    expected: FAIL
+
+  [iframe.align: typeof IDL attribute]
+    expected: FAIL
+
+  [iframe.align: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [iframe.align: setAttribute() to ""]
+    expected: FAIL
+
+  [iframe.align: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [iframe.align: setAttribute() to undefined]
+    expected: FAIL
+
+  [iframe.align: setAttribute() to 7]
+    expected: FAIL
+
+  [iframe.align: setAttribute() to 1.5]
+    expected: FAIL
+
+  [iframe.align: setAttribute() to "5%"]
+    expected: FAIL
+
+  [iframe.align: setAttribute() to "+100"]
+    expected: FAIL
+
+  [iframe.align: setAttribute() to ".5"]
+    expected: FAIL
+
+  [iframe.align: setAttribute() to true]
+    expected: FAIL
+
+  [iframe.align: setAttribute() to false]
+    expected: FAIL
+
+  [iframe.align: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [iframe.align: setAttribute() to NaN]
+    expected: FAIL
+
+  [iframe.align: setAttribute() to Infinity]
+    expected: FAIL
+
+  [iframe.align: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [iframe.align: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [iframe.align: setAttribute() to null]
+    expected: FAIL
+
+  [iframe.align: setAttribute() to object "test-toString"]
+    expected: FAIL
+
+  [iframe.align: setAttribute() to object "test-valueOf"]
+    expected: FAIL
+
+  [iframe.align: IDL set to ""]
+    expected: FAIL
+
+  [iframe.align: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [iframe.align: IDL set to undefined]
+    expected: FAIL
+
+  [iframe.align: IDL set to 7]
+    expected: FAIL
+
+  [iframe.align: IDL set to 1.5]
+    expected: FAIL
+
+  [iframe.align: IDL set to "5%"]
+    expected: FAIL
+
+  [iframe.align: IDL set to "+100"]
+    expected: FAIL
+
+  [iframe.align: IDL set to ".5"]
+    expected: FAIL
+
+  [iframe.align: IDL set to true]
+    expected: FAIL
+
+  [iframe.align: IDL set to false]
+    expected: FAIL
+
+  [iframe.align: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [iframe.align: IDL set to NaN]
+    expected: FAIL
+
+  [iframe.align: IDL set to Infinity]
+    expected: FAIL
+
+  [iframe.align: IDL set to -Infinity]
+    expected: FAIL
+
+  [iframe.align: IDL set to "\\0"]
+    expected: FAIL
+
+  [iframe.align: IDL set to null]
+    expected: FAIL
+
+  [iframe.align: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [iframe.align: IDL set to object "test-valueOf"]
+    expected: FAIL
+
+  [iframe.scrolling: typeof IDL attribute]
+    expected: FAIL
+
+  [iframe.scrolling: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [iframe.scrolling: setAttribute() to ""]
+    expected: FAIL
+
+  [iframe.scrolling: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [iframe.scrolling: setAttribute() to undefined]
+    expected: FAIL
+
+  [iframe.scrolling: setAttribute() to 7]
+    expected: FAIL
+
+  [iframe.scrolling: setAttribute() to 1.5]
+    expected: FAIL
+
+  [iframe.scrolling: setAttribute() to "5%"]
+    expected: FAIL
+
+  [iframe.scrolling: setAttribute() to "+100"]
+    expected: FAIL
+
+  [iframe.scrolling: setAttribute() to ".5"]
+    expected: FAIL
+
+  [iframe.scrolling: setAttribute() to true]
+    expected: FAIL
+
+  [iframe.scrolling: setAttribute() to false]
+    expected: FAIL
+
+  [iframe.scrolling: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [iframe.scrolling: setAttribute() to NaN]
+    expected: FAIL
+
+  [iframe.scrolling: setAttribute() to Infinity]
+    expected: FAIL
+
+  [iframe.scrolling: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [iframe.scrolling: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [iframe.scrolling: setAttribute() to null]
+    expected: FAIL
+
+  [iframe.scrolling: setAttribute() to object "test-toString"]
+    expected: FAIL
+
+  [iframe.scrolling: setAttribute() to object "test-valueOf"]
+    expected: FAIL
+
+  [iframe.scrolling: IDL set to ""]
+    expected: FAIL
+
+  [iframe.scrolling: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [iframe.scrolling: IDL set to undefined]
+    expected: FAIL
+
+  [iframe.scrolling: IDL set to 7]
+    expected: FAIL
+
+  [iframe.scrolling: IDL set to 1.5]
+    expected: FAIL
+
+  [iframe.scrolling: IDL set to "5%"]
+    expected: FAIL
+
+  [iframe.scrolling: IDL set to "+100"]
+    expected: FAIL
+
+  [iframe.scrolling: IDL set to ".5"]
+    expected: FAIL
+
+  [iframe.scrolling: IDL set to true]
+    expected: FAIL
+
+  [iframe.scrolling: IDL set to false]
+    expected: FAIL
+
+  [iframe.scrolling: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [iframe.scrolling: IDL set to NaN]
+    expected: FAIL
+
+  [iframe.scrolling: IDL set to Infinity]
+    expected: FAIL
+
+  [iframe.scrolling: IDL set to -Infinity]
+    expected: FAIL
+
+  [iframe.scrolling: IDL set to "\\0"]
+    expected: FAIL
+
+  [iframe.scrolling: IDL set to null]
+    expected: FAIL
+
+  [iframe.scrolling: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [iframe.scrolling: IDL set to object "test-valueOf"]
+    expected: FAIL
+
+  [iframe.longDesc: typeof IDL attribute]
+    expected: FAIL
+
+  [iframe.longDesc: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [iframe.longDesc: setAttribute() to ""]
+    expected: FAIL
+
+  [iframe.longDesc: setAttribute() to " foo "]
+    expected: FAIL
+
+  [iframe.longDesc: setAttribute() to "http://site.example/"]
+    expected: FAIL
+
+  [iframe.longDesc: setAttribute() to "//site.example/path???@#l"]
+    expected: FAIL
+
+  [iframe.longDesc: setAttribute() to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f "]
+    expected: FAIL
+
+  [iframe.longDesc: setAttribute() to undefined]
+    expected: FAIL
+
+  [iframe.longDesc: setAttribute() to 7]
+    expected: FAIL
+
+  [iframe.longDesc: setAttribute() to 1.5]
+    expected: FAIL
+
+  [iframe.longDesc: setAttribute() to "5%"]
+    expected: FAIL
+
+  [iframe.longDesc: setAttribute() to "+100"]
+    expected: FAIL
+
+  [iframe.longDesc: setAttribute() to ".5"]
+    expected: FAIL
+
+  [iframe.longDesc: setAttribute() to true]
+    expected: FAIL
+
+  [iframe.longDesc: setAttribute() to false]
+    expected: FAIL
+
+  [iframe.longDesc: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [iframe.longDesc: setAttribute() to NaN]
+    expected: FAIL
+
+  [iframe.longDesc: setAttribute() to Infinity]
+    expected: FAIL
+
+  [iframe.longDesc: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [iframe.longDesc: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [iframe.longDesc: setAttribute() to null]
+    expected: FAIL
+
+  [iframe.longDesc: setAttribute() to object "test-toString"]
+    expected: FAIL
+
+  [iframe.longDesc: setAttribute() to object "test-valueOf"]
+    expected: FAIL
+
+  [iframe.longDesc: IDL set to ""]
+    expected: FAIL
+
+  [iframe.longDesc: IDL set to " foo "]
+    expected: FAIL
+
+  [iframe.longDesc: IDL set to "http://site.example/"]
+    expected: FAIL
+
+  [iframe.longDesc: IDL set to "//site.example/path???@#l"]
+    expected: FAIL
+
+  [iframe.longDesc: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f "]
+    expected: FAIL
+
+  [iframe.longDesc: IDL set to undefined]
+    expected: FAIL
+
+  [iframe.longDesc: IDL set to 7]
+    expected: FAIL
+
+  [iframe.longDesc: IDL set to 1.5]
+    expected: FAIL
+
+  [iframe.longDesc: IDL set to "5%"]
+    expected: FAIL
+
+  [iframe.longDesc: IDL set to "+100"]
+    expected: FAIL
+
+  [iframe.longDesc: IDL set to ".5"]
+    expected: FAIL
+
+  [iframe.longDesc: IDL set to true]
+    expected: FAIL
+
+  [iframe.longDesc: IDL set to false]
+    expected: FAIL
+
+  [iframe.longDesc: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [iframe.longDesc: IDL set to NaN]
+    expected: FAIL
+
+  [iframe.longDesc: IDL set to Infinity]
+    expected: FAIL
+
+  [iframe.longDesc: IDL set to -Infinity]
+    expected: FAIL
+
+  [iframe.longDesc: IDL set to "\\0"]
+    expected: FAIL
+
+  [iframe.longDesc: IDL set to null]
+    expected: FAIL
+
+  [iframe.longDesc: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [iframe.longDesc: IDL set to object "test-valueOf"]
+    expected: FAIL
+
+  [iframe.marginHeight: typeof IDL attribute]
+    expected: FAIL
+
+  [iframe.marginHeight: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [iframe.marginHeight: setAttribute() to ""]
+    expected: FAIL
+
+  [iframe.marginHeight: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [iframe.marginHeight: setAttribute() to undefined]
+    expected: FAIL
+
+  [iframe.marginHeight: setAttribute() to 7]
+    expected: FAIL
+
+  [iframe.marginHeight: setAttribute() to 1.5]
+    expected: FAIL
+
+  [iframe.marginHeight: setAttribute() to "5%"]
+    expected: FAIL
+
+  [iframe.marginHeight: setAttribute() to "+100"]
+    expected: FAIL
+
+  [iframe.marginHeight: setAttribute() to ".5"]
+    expected: FAIL
+
+  [iframe.marginHeight: setAttribute() to true]
+    expected: FAIL
+
+  [iframe.marginHeight: setAttribute() to false]
+    expected: FAIL
+
+  [iframe.marginHeight: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [iframe.marginHeight: setAttribute() to NaN]
+    expected: FAIL
+
+  [iframe.marginHeight: setAttribute() to Infinity]
+    expected: FAIL
+
+  [iframe.marginHeight: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [iframe.marginHeight: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [iframe.marginHeight: setAttribute() to null]
+    expected: FAIL
+
+  [iframe.marginHeight: setAttribute() to object "test-toString"]
+    expected: FAIL
+
+  [iframe.marginHeight: setAttribute() to object "test-valueOf"]
+    expected: FAIL
+
+  [iframe.marginHeight: IDL set to ""]
+    expected: FAIL
+
+  [iframe.marginHeight: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [iframe.marginHeight: IDL set to undefined]
+    expected: FAIL
+
+  [iframe.marginHeight: IDL set to 7]
+    expected: FAIL
+
+  [iframe.marginHeight: IDL set to 1.5]
+    expected: FAIL
+
+  [iframe.marginHeight: IDL set to "5%"]
+    expected: FAIL
+
+  [iframe.marginHeight: IDL set to "+100"]
+    expected: FAIL
+
+  [iframe.marginHeight: IDL set to ".5"]
+    expected: FAIL
+
+  [iframe.marginHeight: IDL set to true]
+    expected: FAIL
+
+  [iframe.marginHeight: IDL set to false]
+    expected: FAIL
+
+  [iframe.marginHeight: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [iframe.marginHeight: IDL set to NaN]
+    expected: FAIL
+
+  [iframe.marginHeight: IDL set to Infinity]
+    expected: FAIL
+
+  [iframe.marginHeight: IDL set to -Infinity]
+    expected: FAIL
+
+  [iframe.marginHeight: IDL set to "\\0"]
+    expected: FAIL
+
+  [iframe.marginHeight: IDL set to null]
+    expected: FAIL
+
+  [iframe.marginHeight: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [iframe.marginHeight: IDL set to object "test-valueOf"]
+    expected: FAIL
+
+  [iframe.marginWidth: typeof IDL attribute]
+    expected: FAIL
+
+  [iframe.marginWidth: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [iframe.marginWidth: setAttribute() to ""]
+    expected: FAIL
+
+  [iframe.marginWidth: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [iframe.marginWidth: setAttribute() to undefined]
+    expected: FAIL
+
+  [iframe.marginWidth: setAttribute() to 7]
+    expected: FAIL
+
+  [iframe.marginWidth: setAttribute() to 1.5]
+    expected: FAIL
+
+  [iframe.marginWidth: setAttribute() to "5%"]
+    expected: FAIL
+
+  [iframe.marginWidth: setAttribute() to "+100"]
+    expected: FAIL
+
+  [iframe.marginWidth: setAttribute() to ".5"]
+    expected: FAIL
+
+  [iframe.marginWidth: setAttribute() to true]
+    expected: FAIL
+
+  [iframe.marginWidth: setAttribute() to false]
+    expected: FAIL
+
+  [iframe.marginWidth: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [iframe.marginWidth: setAttribute() to NaN]
+    expected: FAIL
+
+  [iframe.marginWidth: setAttribute() to Infinity]
+    expected: FAIL
+
+  [iframe.marginWidth: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [iframe.marginWidth: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [iframe.marginWidth: setAttribute() to null]
+    expected: FAIL
+
+  [iframe.marginWidth: setAttribute() to object "test-toString"]
+    expected: FAIL
+
+  [iframe.marginWidth: setAttribute() to object "test-valueOf"]
+    expected: FAIL
+
+  [iframe.marginWidth: IDL set to ""]
+    expected: FAIL
+
+  [iframe.marginWidth: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [iframe.marginWidth: IDL set to undefined]
+    expected: FAIL
+
+  [iframe.marginWidth: IDL set to 7]
+    expected: FAIL
+
+  [iframe.marginWidth: IDL set to 1.5]
+    expected: FAIL
+
+  [iframe.marginWidth: IDL set to "5%"]
+    expected: FAIL
+
+  [iframe.marginWidth: IDL set to "+100"]
+    expected: FAIL
+
+  [iframe.marginWidth: IDL set to ".5"]
+    expected: FAIL
+
+  [iframe.marginWidth: IDL set to true]
+    expected: FAIL
+
+  [iframe.marginWidth: IDL set to false]
+    expected: FAIL
+
+  [iframe.marginWidth: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [iframe.marginWidth: IDL set to NaN]
+    expected: FAIL
+
+  [iframe.marginWidth: IDL set to Infinity]
+    expected: FAIL
+
+  [iframe.marginWidth: IDL set to -Infinity]
+    expected: FAIL
+
+  [iframe.marginWidth: IDL set to "\\0"]
+    expected: FAIL
+
+  [iframe.marginWidth: IDL set to null]
+    expected: FAIL
+
+  [iframe.marginWidth: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [iframe.marginWidth: IDL set to object "test-valueOf"]
+    expected: FAIL
+
+  [embed.accessKey: typeof IDL attribute]
+    expected: FAIL
+
+  [embed.accessKey: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [embed.accessKey: setAttribute() to ""]
+    expected: FAIL
+
+  [embed.accessKey: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [embed.accessKey: setAttribute() to undefined]
+    expected: FAIL
+
+  [embed.accessKey: setAttribute() to 7]
+    expected: FAIL
+
+  [embed.accessKey: setAttribute() to 1.5]
+    expected: FAIL
+
+  [embed.accessKey: setAttribute() to "5%"]
+    expected: FAIL
+
+  [embed.accessKey: setAttribute() to "+100"]
+    expected: FAIL
+
+  [embed.accessKey: setAttribute() to ".5"]
+    expected: FAIL
+
+  [embed.accessKey: setAttribute() to true]
+    expected: FAIL
+
+  [embed.accessKey: setAttribute() to false]
+    expected: FAIL
+
+  [embed.accessKey: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [embed.accessKey: setAttribute() to NaN]
+    expected: FAIL
+
+  [embed.accessKey: setAttribute() to Infinity]
+    expected: FAIL
+
+  [embed.accessKey: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [embed.accessKey: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [embed.accessKey: setAttribute() to null]
+    expected: FAIL
+
+  [embed.accessKey: setAttribute() to object "test-toString"]
+    expected: FAIL
+
+  [embed.accessKey: setAttribute() to object "test-valueOf"]
+    expected: FAIL
+
+  [embed.accessKey: IDL set to ""]
+    expected: FAIL
+
+  [embed.accessKey: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [embed.accessKey: IDL set to undefined]
+    expected: FAIL
+
+  [embed.accessKey: IDL set to 7]
+    expected: FAIL
+
+  [embed.accessKey: IDL set to 1.5]
+    expected: FAIL
+
+  [embed.accessKey: IDL set to "5%"]
+    expected: FAIL
+
+  [embed.accessKey: IDL set to "+100"]
+    expected: FAIL
+
+  [embed.accessKey: IDL set to ".5"]
+    expected: FAIL
+
+  [embed.accessKey: IDL set to true]
+    expected: FAIL
+
+  [embed.accessKey: IDL set to false]
+    expected: FAIL
+
+  [embed.accessKey: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [embed.accessKey: IDL set to NaN]
+    expected: FAIL
+
+  [embed.accessKey: IDL set to Infinity]
+    expected: FAIL
+
+  [embed.accessKey: IDL set to -Infinity]
+    expected: FAIL
+
+  [embed.accessKey: IDL set to "\\0"]
+    expected: FAIL
+
+  [embed.accessKey: IDL set to null]
+    expected: FAIL
+
+  [embed.accessKey: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [embed.accessKey: IDL set to object "test-valueOf"]
+    expected: FAIL
+
+  [embed.tabIndex: typeof IDL attribute]
+    expected: FAIL
+
+  [embed.tabIndex: setAttribute() to -36]
+    expected: FAIL
+
+  [embed.tabIndex: setAttribute() to -1]
+    expected: FAIL
+
+  [embed.tabIndex: setAttribute() to 0]
+    expected: FAIL
+
+  [embed.tabIndex: setAttribute() to 1]
+    expected: FAIL
+
+  [embed.tabIndex: setAttribute() to 2147483647]
+    expected: FAIL
+
+  [embed.tabIndex: setAttribute() to -2147483648]
+    expected: FAIL
+
+  [embed.tabIndex: setAttribute() to "-1"]
+    expected: FAIL
+
+  [embed.tabIndex: setAttribute() to "-0"]
+    expected: FAIL
+
+  [embed.tabIndex: setAttribute() to "0"]
+    expected: FAIL
+
+  [embed.tabIndex: setAttribute() to "1"]
+    expected: FAIL
+
+  [embed.tabIndex: setAttribute() to "\\t7"]
+    expected: FAIL
+
+  [embed.tabIndex: setAttribute() to "\\f7"]
+    expected: FAIL
+
+  [embed.tabIndex: setAttribute() to " 7"]
+    expected: FAIL
+
+  [embed.tabIndex: setAttribute() to "\\n7"]
+    expected: FAIL
+
+  [embed.tabIndex: setAttribute() to "\\r7"]
+    expected: FAIL
+
+  [embed.tabIndex: setAttribute() to "7\\v"]
+    expected: FAIL
+
+  [embed.tabIndex: setAttribute() to 1.5]
+    expected: FAIL
+
+  [embed.tabIndex: setAttribute() to "5%"]
+    expected: FAIL
+
+  [embed.tabIndex: setAttribute() to "+100"]
+    expected: FAIL
+
+  [embed.tabIndex: setAttribute() to object "2"]
+    expected: FAIL
+
+  [embed.tabIndex: setAttribute() to object "3"]
+    expected: FAIL
+
+  [embed.tabIndex: IDL set to -36]
+    expected: FAIL
+
+  [embed.tabIndex: IDL set to -1]
+    expected: FAIL
+
+  [embed.tabIndex: IDL set to 0]
+    expected: FAIL
+
+  [embed.tabIndex: IDL set to 1]
+    expected: FAIL
+
+  [embed.tabIndex: IDL set to 2147483647]
+    expected: FAIL
+
+  [embed.tabIndex: IDL set to -2147483648]
+    expected: FAIL
+
+  [embed.src: typeof IDL attribute]
+    expected: FAIL
+
+  [embed.src: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [embed.src: setAttribute() to ""]
+    expected: FAIL
+
+  [embed.src: setAttribute() to " foo "]
+    expected: FAIL
+
+  [embed.src: setAttribute() to "http://site.example/"]
+    expected: FAIL
+
+  [embed.src: setAttribute() to "//site.example/path???@#l"]
+    expected: FAIL
+
+  [embed.src: setAttribute() to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f "]
+    expected: FAIL
+
+  [embed.src: setAttribute() to undefined]
+    expected: FAIL
+
+  [embed.src: setAttribute() to 7]
+    expected: FAIL
+
+  [embed.src: setAttribute() to 1.5]
+    expected: FAIL
+
+  [embed.src: setAttribute() to "5%"]
+    expected: FAIL
+
+  [embed.src: setAttribute() to "+100"]
+    expected: FAIL
+
+  [embed.src: setAttribute() to ".5"]
+    expected: FAIL
+
+  [embed.src: setAttribute() to true]
+    expected: FAIL
+
+  [embed.src: setAttribute() to false]
+    expected: FAIL
+
+  [embed.src: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [embed.src: setAttribute() to NaN]
+    expected: FAIL
+
+  [embed.src: setAttribute() to Infinity]
+    expected: FAIL
+
+  [embed.src: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [embed.src: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [embed.src: setAttribute() to null]
+    expected: FAIL
+
+  [embed.src: setAttribute() to object "test-toString"]
+    expected: FAIL
+
+  [embed.src: setAttribute() to object "test-valueOf"]
+    expected: FAIL
+
+  [embed.src: IDL set to ""]
+    expected: FAIL
+
+  [embed.src: IDL set to " foo "]
+    expected: FAIL
+
+  [embed.src: IDL set to "http://site.example/"]
+    expected: FAIL
+
+  [embed.src: IDL set to "//site.example/path???@#l"]
+    expected: FAIL
+
+  [embed.src: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f "]
+    expected: FAIL
+
+  [embed.src: IDL set to undefined]
+    expected: FAIL
+
+  [embed.src: IDL set to 7]
+    expected: FAIL
+
+  [embed.src: IDL set to 1.5]
+    expected: FAIL
+
+  [embed.src: IDL set to "5%"]
+    expected: FAIL
+
+  [embed.src: IDL set to "+100"]
+    expected: FAIL
+
+  [embed.src: IDL set to ".5"]
+    expected: FAIL
+
+  [embed.src: IDL set to true]
+    expected: FAIL
+
+  [embed.src: IDL set to false]
+    expected: FAIL
+
+  [embed.src: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [embed.src: IDL set to NaN]
+    expected: FAIL
+
+  [embed.src: IDL set to Infinity]
+    expected: FAIL
+
+  [embed.src: IDL set to -Infinity]
+    expected: FAIL
+
+  [embed.src: IDL set to "\\0"]
+    expected: FAIL
+
+  [embed.src: IDL set to null]
+    expected: FAIL
+
+  [embed.src: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [embed.src: IDL set to object "test-valueOf"]
+    expected: FAIL
+
+  [embed.type: typeof IDL attribute]
+    expected: FAIL
+
+  [embed.type: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [embed.type: setAttribute() to ""]
+    expected: FAIL
+
+  [embed.type: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [embed.type: setAttribute() to undefined]
+    expected: FAIL
+
+  [embed.type: setAttribute() to 7]
+    expected: FAIL
+
+  [embed.type: setAttribute() to 1.5]
+    expected: FAIL
+
+  [embed.type: setAttribute() to "5%"]
+    expected: FAIL
+
+  [embed.type: setAttribute() to "+100"]
+    expected: FAIL
+
+  [embed.type: setAttribute() to ".5"]
+    expected: FAIL
+
+  [embed.type: setAttribute() to true]
+    expected: FAIL
+
+  [embed.type: setAttribute() to false]
+    expected: FAIL
+
+  [embed.type: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [embed.type: setAttribute() to NaN]
+    expected: FAIL
+
+  [embed.type: setAttribute() to Infinity]
+    expected: FAIL
+
+  [embed.type: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [embed.type: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [embed.type: setAttribute() to null]
+    expected: FAIL
+
+  [embed.type: setAttribute() to object "test-toString"]
+    expected: FAIL
+
+  [embed.type: setAttribute() to object "test-valueOf"]
+    expected: FAIL
+
+  [embed.type: IDL set to ""]
+    expected: FAIL
+
+  [embed.type: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [embed.type: IDL set to undefined]
+    expected: FAIL
+
+  [embed.type: IDL set to 7]
+    expected: FAIL
+
+  [embed.type: IDL set to 1.5]
+    expected: FAIL
+
+  [embed.type: IDL set to "5%"]
+    expected: FAIL
+
+  [embed.type: IDL set to "+100"]
+    expected: FAIL
+
+  [embed.type: IDL set to ".5"]
+    expected: FAIL
+
+  [embed.type: IDL set to true]
+    expected: FAIL
+
+  [embed.type: IDL set to false]
+    expected: FAIL
+
+  [embed.type: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [embed.type: IDL set to NaN]
+    expected: FAIL
+
+  [embed.type: IDL set to Infinity]
+    expected: FAIL
+
+  [embed.type: IDL set to -Infinity]
+    expected: FAIL
+
+  [embed.type: IDL set to "\\0"]
+    expected: FAIL
+
+  [embed.type: IDL set to null]
+    expected: FAIL
+
+  [embed.type: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [embed.type: IDL set to object "test-valueOf"]
+    expected: FAIL
+
+  [embed.width: typeof IDL attribute]
+    expected: FAIL
+
+  [embed.width: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [embed.width: setAttribute() to ""]
+    expected: FAIL
+
+  [embed.width: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [embed.width: setAttribute() to undefined]
+    expected: FAIL
+
+  [embed.width: setAttribute() to 7]
+    expected: FAIL
+
+  [embed.width: setAttribute() to 1.5]
+    expected: FAIL
+
+  [embed.width: setAttribute() to "5%"]
+    expected: FAIL
+
+  [embed.width: setAttribute() to "+100"]
+    expected: FAIL
+
+  [embed.width: setAttribute() to ".5"]
+    expected: FAIL
+
+  [embed.width: setAttribute() to true]
+    expected: FAIL
+
+  [embed.width: setAttribute() to false]
+    expected: FAIL
+
+  [embed.width: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [embed.width: setAttribute() to NaN]
+    expected: FAIL
+
+  [embed.width: setAttribute() to Infinity]
+    expected: FAIL
+
+  [embed.width: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [embed.width: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [embed.width: setAttribute() to null]
+    expected: FAIL
+
+  [embed.width: setAttribute() to object "test-toString"]
+    expected: FAIL
+
+  [embed.width: setAttribute() to object "test-valueOf"]
+    expected: FAIL
+
+  [embed.width: IDL set to ""]
+    expected: FAIL
+
+  [embed.width: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [embed.width: IDL set to undefined]
+    expected: FAIL
+
+  [embed.width: IDL set to 7]
+    expected: FAIL
+
+  [embed.width: IDL set to 1.5]
+    expected: FAIL
+
+  [embed.width: IDL set to "5%"]
+    expected: FAIL
+
+  [embed.width: IDL set to "+100"]
+    expected: FAIL
+
+  [embed.width: IDL set to ".5"]
+    expected: FAIL
+
+  [embed.width: IDL set to true]
+    expected: FAIL
+
+  [embed.width: IDL set to false]
+    expected: FAIL
+
+  [embed.width: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [embed.width: IDL set to NaN]
+    expected: FAIL
+
+  [embed.width: IDL set to Infinity]
+    expected: FAIL
+
+  [embed.width: IDL set to -Infinity]
+    expected: FAIL
+
+  [embed.width: IDL set to "\\0"]
+    expected: FAIL
+
+  [embed.width: IDL set to null]
+    expected: FAIL
+
+  [embed.width: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [embed.width: IDL set to object "test-valueOf"]
+    expected: FAIL
+
+  [embed.height: typeof IDL attribute]
+    expected: FAIL
+
+  [embed.height: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [embed.height: setAttribute() to ""]
+    expected: FAIL
+
+  [embed.height: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [embed.height: setAttribute() to undefined]
+    expected: FAIL
+
+  [embed.height: setAttribute() to 7]
+    expected: FAIL
+
+  [embed.height: setAttribute() to 1.5]
+    expected: FAIL
+
+  [embed.height: setAttribute() to "5%"]
+    expected: FAIL
+
+  [embed.height: setAttribute() to "+100"]
+    expected: FAIL
+
+  [embed.height: setAttribute() to ".5"]
+    expected: FAIL
+
+  [embed.height: setAttribute() to true]
+    expected: FAIL
+
+  [embed.height: setAttribute() to false]
+    expected: FAIL
+
+  [embed.height: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [embed.height: setAttribute() to NaN]
+    expected: FAIL
+
+  [embed.height: setAttribute() to Infinity]
+    expected: FAIL
+
+  [embed.height: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [embed.height: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [embed.height: setAttribute() to null]
+    expected: FAIL
+
+  [embed.height: setAttribute() to object "test-toString"]
+    expected: FAIL
+
+  [embed.height: setAttribute() to object "test-valueOf"]
+    expected: FAIL
+
+  [embed.height: IDL set to ""]
+    expected: FAIL
+
+  [embed.height: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [embed.height: IDL set to undefined]
+    expected: FAIL
+
+  [embed.height: IDL set to 7]
+    expected: FAIL
+
+  [embed.height: IDL set to 1.5]
+    expected: FAIL
+
+  [embed.height: IDL set to "5%"]
+    expected: FAIL
+
+  [embed.height: IDL set to "+100"]
+    expected: FAIL
+
+  [embed.height: IDL set to ".5"]
+    expected: FAIL
+
+  [embed.height: IDL set to true]
+    expected: FAIL
+
+  [embed.height: IDL set to false]
+    expected: FAIL
+
+  [embed.height: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [embed.height: IDL set to NaN]
+    expected: FAIL
+
+  [embed.height: IDL set to Infinity]
+    expected: FAIL
+
+  [embed.height: IDL set to -Infinity]
+    expected: FAIL
+
+  [embed.height: IDL set to "\\0"]
+    expected: FAIL
+
+  [embed.height: IDL set to null]
+    expected: FAIL
+
+  [embed.height: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [embed.height: IDL set to object "test-valueOf"]
+    expected: FAIL
+
+  [embed.align: typeof IDL attribute]
+    expected: FAIL
+
+  [embed.align: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [embed.align: setAttribute() to ""]
+    expected: FAIL
+
+  [embed.align: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [embed.align: setAttribute() to undefined]
+    expected: FAIL
+
+  [embed.align: setAttribute() to 7]
+    expected: FAIL
+
+  [embed.align: setAttribute() to 1.5]
+    expected: FAIL
+
+  [embed.align: setAttribute() to "5%"]
+    expected: FAIL
+
+  [embed.align: setAttribute() to "+100"]
+    expected: FAIL
+
+  [embed.align: setAttribute() to ".5"]
+    expected: FAIL
+
+  [embed.align: setAttribute() to true]
+    expected: FAIL
+
+  [embed.align: setAttribute() to false]
+    expected: FAIL
+
+  [embed.align: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [embed.align: setAttribute() to NaN]
+    expected: FAIL
+
+  [embed.align: setAttribute() to Infinity]
+    expected: FAIL
+
+  [embed.align: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [embed.align: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [embed.align: setAttribute() to null]
+    expected: FAIL
+
+  [embed.align: setAttribute() to object "test-toString"]
+    expected: FAIL
+
+  [embed.align: setAttribute() to object "test-valueOf"]
+    expected: FAIL
+
+  [embed.align: IDL set to ""]
+    expected: FAIL
+
+  [embed.align: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [embed.align: IDL set to undefined]
+    expected: FAIL
+
+  [embed.align: IDL set to 7]
+    expected: FAIL
+
+  [embed.align: IDL set to 1.5]
+    expected: FAIL
+
+  [embed.align: IDL set to "5%"]
+    expected: FAIL
+
+  [embed.align: IDL set to "+100"]
+    expected: FAIL
+
+  [embed.align: IDL set to ".5"]
+    expected: FAIL
+
+  [embed.align: IDL set to true]
+    expected: FAIL
+
+  [embed.align: IDL set to false]
+    expected: FAIL
+
+  [embed.align: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [embed.align: IDL set to NaN]
+    expected: FAIL
+
+  [embed.align: IDL set to Infinity]
+    expected: FAIL
+
+  [embed.align: IDL set to -Infinity]
+    expected: FAIL
+
+  [embed.align: IDL set to "\\0"]
+    expected: FAIL
+
+  [embed.align: IDL set to null]
+    expected: FAIL
+
+  [embed.align: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [embed.align: IDL set to object "test-valueOf"]
+    expected: FAIL
+
+  [embed.name: typeof IDL attribute]
+    expected: FAIL
+
+  [embed.name: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [embed.name: setAttribute() to ""]
+    expected: FAIL
+
+  [embed.name: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [embed.name: setAttribute() to undefined]
+    expected: FAIL
+
+  [embed.name: setAttribute() to 7]
+    expected: FAIL
+
+  [embed.name: setAttribute() to 1.5]
+    expected: FAIL
+
+  [embed.name: setAttribute() to "5%"]
+    expected: FAIL
+
+  [embed.name: setAttribute() to "+100"]
+    expected: FAIL
+
+  [embed.name: setAttribute() to ".5"]
+    expected: FAIL
+
+  [embed.name: setAttribute() to true]
+    expected: FAIL
+
+  [embed.name: setAttribute() to false]
+    expected: FAIL
+
+  [embed.name: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [embed.name: setAttribute() to NaN]
+    expected: FAIL
+
+  [embed.name: setAttribute() to Infinity]
+    expected: FAIL
+
+  [embed.name: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [embed.name: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [embed.name: setAttribute() to null]
+    expected: FAIL
+
+  [embed.name: setAttribute() to object "test-toString"]
+    expected: FAIL
+
+  [embed.name: setAttribute() to object "test-valueOf"]
+    expected: FAIL
+
+  [embed.name: IDL set to ""]
+    expected: FAIL
+
+  [embed.name: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [embed.name: IDL set to undefined]
+    expected: FAIL
+
+  [embed.name: IDL set to 7]
+    expected: FAIL
+
+  [embed.name: IDL set to 1.5]
+    expected: FAIL
+
+  [embed.name: IDL set to "5%"]
+    expected: FAIL
+
+  [embed.name: IDL set to "+100"]
+    expected: FAIL
+
+  [embed.name: IDL set to ".5"]
+    expected: FAIL
+
+  [embed.name: IDL set to true]
+    expected: FAIL
+
+  [embed.name: IDL set to false]
+    expected: FAIL
+
+  [embed.name: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [embed.name: IDL set to NaN]
+    expected: FAIL
+
+  [embed.name: IDL set to Infinity]
+    expected: FAIL
+
+  [embed.name: IDL set to -Infinity]
+    expected: FAIL
+
+  [embed.name: IDL set to "\\0"]
+    expected: FAIL
+
+  [embed.name: IDL set to null]
+    expected: FAIL
+
+  [embed.name: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [embed.name: IDL set to object "test-valueOf"]
+    expected: FAIL
+
+  [object.accessKey: typeof IDL attribute]
+    expected: FAIL
+
+  [object.accessKey: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [object.accessKey: setAttribute() to ""]
+    expected: FAIL
+
+  [object.accessKey: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [object.accessKey: setAttribute() to undefined]
+    expected: FAIL
+
+  [object.accessKey: setAttribute() to 7]
+    expected: FAIL
+
+  [object.accessKey: setAttribute() to 1.5]
+    expected: FAIL
+
+  [object.accessKey: setAttribute() to "5%"]
+    expected: FAIL
+
+  [object.accessKey: setAttribute() to "+100"]
+    expected: FAIL
+
+  [object.accessKey: setAttribute() to ".5"]
+    expected: FAIL
+
+  [object.accessKey: setAttribute() to true]
+    expected: FAIL
+
+  [object.accessKey: setAttribute() to false]
+    expected: FAIL
+
+  [object.accessKey: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [object.accessKey: setAttribute() to NaN]
+    expected: FAIL
+
+  [object.accessKey: setAttribute() to Infinity]
+    expected: FAIL
+
+  [object.accessKey: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [object.accessKey: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [object.accessKey: setAttribute() to null]
+    expected: FAIL
+
+  [object.accessKey: setAttribute() to object "test-toString"]
+    expected: FAIL
+
+  [object.accessKey: setAttribute() to object "test-valueOf"]
+    expected: FAIL
+
+  [object.accessKey: IDL set to ""]
+    expected: FAIL
+
+  [object.accessKey: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [object.accessKey: IDL set to undefined]
+    expected: FAIL
+
+  [object.accessKey: IDL set to 7]
+    expected: FAIL
+
+  [object.accessKey: IDL set to 1.5]
+    expected: FAIL
+
+  [object.accessKey: IDL set to "5%"]
+    expected: FAIL
+
+  [object.accessKey: IDL set to "+100"]
+    expected: FAIL
+
+  [object.accessKey: IDL set to ".5"]
+    expected: FAIL
+
+  [object.accessKey: IDL set to true]
+    expected: FAIL
+
+  [object.accessKey: IDL set to false]
+    expected: FAIL
+
+  [object.accessKey: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [object.accessKey: IDL set to NaN]
+    expected: FAIL
+
+  [object.accessKey: IDL set to Infinity]
+    expected: FAIL
+
+  [object.accessKey: IDL set to -Infinity]
+    expected: FAIL
+
+  [object.accessKey: IDL set to "\\0"]
+    expected: FAIL
+
+  [object.accessKey: IDL set to null]
+    expected: FAIL
+
+  [object.accessKey: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [object.accessKey: IDL set to object "test-valueOf"]
+    expected: FAIL
+
+  [object.tabIndex: typeof IDL attribute]
+    expected: FAIL
+
+  [object.tabIndex: setAttribute() to -36]
+    expected: FAIL
+
+  [object.tabIndex: setAttribute() to -1]
+    expected: FAIL
+
+  [object.tabIndex: setAttribute() to 0]
+    expected: FAIL
+
+  [object.tabIndex: setAttribute() to 1]
+    expected: FAIL
+
+  [object.tabIndex: setAttribute() to 2147483647]
+    expected: FAIL
+
+  [object.tabIndex: setAttribute() to -2147483648]
+    expected: FAIL
+
+  [object.tabIndex: setAttribute() to "-1"]
+    expected: FAIL
+
+  [object.tabIndex: setAttribute() to "-0"]
+    expected: FAIL
+
+  [object.tabIndex: setAttribute() to "0"]
+    expected: FAIL
+
+  [object.tabIndex: setAttribute() to "1"]
+    expected: FAIL
+
+  [object.tabIndex: setAttribute() to "\\t7"]
+    expected: FAIL
+
+  [object.tabIndex: setAttribute() to "\\f7"]
+    expected: FAIL
+
+  [object.tabIndex: setAttribute() to " 7"]
+    expected: FAIL
+
+  [object.tabIndex: setAttribute() to "\\n7"]
+    expected: FAIL
+
+  [object.tabIndex: setAttribute() to "\\r7"]
+    expected: FAIL
+
+  [object.tabIndex: setAttribute() to "7\\v"]
+    expected: FAIL
+
+  [object.tabIndex: setAttribute() to 1.5]
+    expected: FAIL
+
+  [object.tabIndex: setAttribute() to "5%"]
+    expected: FAIL
+
+  [object.tabIndex: setAttribute() to "+100"]
+    expected: FAIL
+
+  [object.tabIndex: setAttribute() to object "2"]
+    expected: FAIL
+
+  [object.tabIndex: setAttribute() to object "3"]
+    expected: FAIL
+
+  [object.tabIndex: IDL set to -36]
+    expected: FAIL
+
+  [object.tabIndex: IDL set to -1]
+    expected: FAIL
+
+  [object.tabIndex: IDL set to 0]
+    expected: FAIL
+
+  [object.tabIndex: IDL set to 1]
+    expected: FAIL
+
+  [object.tabIndex: IDL set to 2147483647]
+    expected: FAIL
+
+  [object.tabIndex: IDL set to -2147483648]
+    expected: FAIL
+
+  [object.data: typeof IDL attribute]
+    expected: FAIL
+
+  [object.data: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [object.data: setAttribute() to ""]
+    expected: FAIL
+
+  [object.data: setAttribute() to " foo "]
+    expected: FAIL
+
+  [object.data: setAttribute() to "http://site.example/"]
+    expected: FAIL
+
+  [object.data: setAttribute() to "//site.example/path???@#l"]
+    expected: FAIL
+
+  [object.data: setAttribute() to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f "]
+    expected: FAIL
+
+  [object.data: setAttribute() to undefined]
+    expected: FAIL
+
+  [object.data: setAttribute() to 7]
+    expected: FAIL
+
+  [object.data: setAttribute() to 1.5]
+    expected: FAIL
+
+  [object.data: setAttribute() to "5%"]
+    expected: FAIL
+
+  [object.data: setAttribute() to "+100"]
+    expected: FAIL
+
+  [object.data: setAttribute() to ".5"]
+    expected: FAIL
+
+  [object.data: setAttribute() to true]
+    expected: FAIL
+
+  [object.data: setAttribute() to false]
+    expected: FAIL
+
+  [object.data: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [object.data: setAttribute() to NaN]
+    expected: FAIL
+
+  [object.data: setAttribute() to Infinity]
+    expected: FAIL
+
+  [object.data: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [object.data: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [object.data: setAttribute() to null]
+    expected: FAIL
+
+  [object.data: setAttribute() to object "test-toString"]
+    expected: FAIL
+
+  [object.data: setAttribute() to object "test-valueOf"]
+    expected: FAIL
+
+  [object.data: IDL set to ""]
+    expected: FAIL
+
+  [object.data: IDL set to " foo "]
+    expected: FAIL
+
+  [object.data: IDL set to "http://site.example/"]
+    expected: FAIL
+
+  [object.data: IDL set to "//site.example/path???@#l"]
+    expected: FAIL
+
+  [object.data: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f "]
+    expected: FAIL
+
+  [object.data: IDL set to undefined]
+    expected: FAIL
+
+  [object.data: IDL set to 7]
+    expected: FAIL
+
+  [object.data: IDL set to 1.5]
+    expected: FAIL
+
+  [object.data: IDL set to "5%"]
+    expected: FAIL
+
+  [object.data: IDL set to "+100"]
+    expected: FAIL
+
+  [object.data: IDL set to ".5"]
+    expected: FAIL
+
+  [object.data: IDL set to true]
+    expected: FAIL
+
+  [object.data: IDL set to false]
+    expected: FAIL
+
+  [object.data: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [object.data: IDL set to NaN]
+    expected: FAIL
+
+  [object.data: IDL set to Infinity]
+    expected: FAIL
+
+  [object.data: IDL set to -Infinity]
+    expected: FAIL
+
+  [object.data: IDL set to "\\0"]
+    expected: FAIL
+
+  [object.data: IDL set to null]
+    expected: FAIL
+
+  [object.data: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [object.data: IDL set to object "test-valueOf"]
+    expected: FAIL
+
+  [object.name: typeof IDL attribute]
+    expected: FAIL
+
+  [object.name: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [object.name: setAttribute() to ""]
+    expected: FAIL
+
+  [object.name: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [object.name: setAttribute() to undefined]
+    expected: FAIL
+
+  [object.name: setAttribute() to 7]
+    expected: FAIL
+
+  [object.name: setAttribute() to 1.5]
+    expected: FAIL
+
+  [object.name: setAttribute() to "5%"]
+    expected: FAIL
+
+  [object.name: setAttribute() to "+100"]
+    expected: FAIL
+
+  [object.name: setAttribute() to ".5"]
+    expected: FAIL
+
+  [object.name: setAttribute() to true]
+    expected: FAIL
+
+  [object.name: setAttribute() to false]
+    expected: FAIL
+
+  [object.name: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [object.name: setAttribute() to NaN]
+    expected: FAIL
+
+  [object.name: setAttribute() to Infinity]
+    expected: FAIL
+
+  [object.name: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [object.name: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [object.name: setAttribute() to null]
+    expected: FAIL
+
+  [object.name: setAttribute() to object "test-toString"]
+    expected: FAIL
+
+  [object.name: setAttribute() to object "test-valueOf"]
+    expected: FAIL
+
+  [object.name: IDL set to ""]
+    expected: FAIL
+
+  [object.name: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [object.name: IDL set to undefined]
+    expected: FAIL
+
+  [object.name: IDL set to 7]
+    expected: FAIL
+
+  [object.name: IDL set to 1.5]
+    expected: FAIL
+
+  [object.name: IDL set to "5%"]
+    expected: FAIL
+
+  [object.name: IDL set to "+100"]
+    expected: FAIL
+
+  [object.name: IDL set to ".5"]
+    expected: FAIL
+
+  [object.name: IDL set to true]
+    expected: FAIL
+
+  [object.name: IDL set to false]
+    expected: FAIL
+
+  [object.name: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [object.name: IDL set to NaN]
+    expected: FAIL
+
+  [object.name: IDL set to Infinity]
+    expected: FAIL
+
+  [object.name: IDL set to -Infinity]
+    expected: FAIL
+
+  [object.name: IDL set to "\\0"]
+    expected: FAIL
+
+  [object.name: IDL set to null]
+    expected: FAIL
+
+  [object.name: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [object.name: IDL set to object "test-valueOf"]
+    expected: FAIL
+
+  [object.useMap: typeof IDL attribute]
+    expected: FAIL
+
+  [object.useMap: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [object.useMap: setAttribute() to ""]
+    expected: FAIL
+
+  [object.useMap: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [object.useMap: setAttribute() to undefined]
+    expected: FAIL
+
+  [object.useMap: setAttribute() to 7]
+    expected: FAIL
+
+  [object.useMap: setAttribute() to 1.5]
+    expected: FAIL
+
+  [object.useMap: setAttribute() to "5%"]
+    expected: FAIL
+
+  [object.useMap: setAttribute() to "+100"]
+    expected: FAIL
+
+  [object.useMap: setAttribute() to ".5"]
+    expected: FAIL
+
+  [object.useMap: setAttribute() to true]
+    expected: FAIL
+
+  [object.useMap: setAttribute() to false]
+    expected: FAIL
+
+  [object.useMap: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [object.useMap: setAttribute() to NaN]
+    expected: FAIL
+
+  [object.useMap: setAttribute() to Infinity]
+    expected: FAIL
+
+  [object.useMap: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [object.useMap: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [object.useMap: setAttribute() to null]
+    expected: FAIL
+
+  [object.useMap: setAttribute() to object "test-toString"]
+    expected: FAIL
+
+  [object.useMap: setAttribute() to object "test-valueOf"]
+    expected: FAIL
+
+  [object.useMap: IDL set to ""]
+    expected: FAIL
+
+  [object.useMap: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [object.useMap: IDL set to undefined]
+    expected: FAIL
+
+  [object.useMap: IDL set to 7]
+    expected: FAIL
+
+  [object.useMap: IDL set to 1.5]
+    expected: FAIL
+
+  [object.useMap: IDL set to "5%"]
+    expected: FAIL
+
+  [object.useMap: IDL set to "+100"]
+    expected: FAIL
+
+  [object.useMap: IDL set to ".5"]
+    expected: FAIL
+
+  [object.useMap: IDL set to true]
+    expected: FAIL
+
+  [object.useMap: IDL set to false]
+    expected: FAIL
+
+  [object.useMap: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [object.useMap: IDL set to NaN]
+    expected: FAIL
+
+  [object.useMap: IDL set to Infinity]
+    expected: FAIL
+
+  [object.useMap: IDL set to -Infinity]
+    expected: FAIL
+
+  [object.useMap: IDL set to "\\0"]
+    expected: FAIL
+
+  [object.useMap: IDL set to null]
+    expected: FAIL
+
+  [object.useMap: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [object.useMap: IDL set to object "test-valueOf"]
+    expected: FAIL
+
+  [object.width: typeof IDL attribute]
+    expected: FAIL
+
+  [object.width: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [object.width: setAttribute() to ""]
+    expected: FAIL
+
+  [object.width: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [object.width: setAttribute() to undefined]
+    expected: FAIL
+
+  [object.width: setAttribute() to 7]
+    expected: FAIL
+
+  [object.width: setAttribute() to 1.5]
+    expected: FAIL
+
+  [object.width: setAttribute() to "5%"]
+    expected: FAIL
+
+  [object.width: setAttribute() to "+100"]
+    expected: FAIL
+
+  [object.width: setAttribute() to ".5"]
+    expected: FAIL
+
+  [object.width: setAttribute() to true]
+    expected: FAIL
+
+  [object.width: setAttribute() to false]
+    expected: FAIL
+
+  [object.width: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [object.width: setAttribute() to NaN]
+    expected: FAIL
+
+  [object.width: setAttribute() to Infinity]
+    expected: FAIL
+
+  [object.width: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [object.width: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [object.width: setAttribute() to null]
+    expected: FAIL
+
+  [object.width: setAttribute() to object "test-toString"]
+    expected: FAIL
+
+  [object.width: setAttribute() to object "test-valueOf"]
+    expected: FAIL
+
+  [object.width: IDL set to ""]
+    expected: FAIL
+
+  [object.width: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [object.width: IDL set to undefined]
+    expected: FAIL
+
+  [object.width: IDL set to 7]
+    expected: FAIL
+
+  [object.width: IDL set to 1.5]
+    expected: FAIL
+
+  [object.width: IDL set to "5%"]
+    expected: FAIL
+
+  [object.width: IDL set to "+100"]
+    expected: FAIL
+
+  [object.width: IDL set to ".5"]
+    expected: FAIL
+
+  [object.width: IDL set to true]
+    expected: FAIL
+
+  [object.width: IDL set to false]
+    expected: FAIL
+
+  [object.width: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [object.width: IDL set to NaN]
+    expected: FAIL
+
+  [object.width: IDL set to Infinity]
+    expected: FAIL
+
+  [object.width: IDL set to -Infinity]
+    expected: FAIL
+
+  [object.width: IDL set to "\\0"]
+    expected: FAIL
+
+  [object.width: IDL set to null]
+    expected: FAIL
+
+  [object.width: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [object.width: IDL set to object "test-valueOf"]
+    expected: FAIL
+
+  [object.height: typeof IDL attribute]
+    expected: FAIL
+
+  [object.height: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [object.height: setAttribute() to ""]
+    expected: FAIL
+
+  [object.height: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [object.height: setAttribute() to undefined]
+    expected: FAIL
+
+  [object.height: setAttribute() to 7]
+    expected: FAIL
+
+  [object.height: setAttribute() to 1.5]
+    expected: FAIL
+
+  [object.height: setAttribute() to "5%"]
+    expected: FAIL
+
+  [object.height: setAttribute() to "+100"]
+    expected: FAIL
+
+  [object.height: setAttribute() to ".5"]
+    expected: FAIL
+
+  [object.height: setAttribute() to true]
+    expected: FAIL
+
+  [object.height: setAttribute() to false]
+    expected: FAIL
+
+  [object.height: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [object.height: setAttribute() to NaN]
+    expected: FAIL
+
+  [object.height: setAttribute() to Infinity]
+    expected: FAIL
+
+  [object.height: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [object.height: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [object.height: setAttribute() to null]
+    expected: FAIL
+
+  [object.height: setAttribute() to object "test-toString"]
+    expected: FAIL
+
+  [object.height: setAttribute() to object "test-valueOf"]
+    expected: FAIL
+
+  [object.height: IDL set to ""]
+    expected: FAIL
+
+  [object.height: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [object.height: IDL set to undefined]
+    expected: FAIL
+
+  [object.height: IDL set to 7]
+    expected: FAIL
+
+  [object.height: IDL set to 1.5]
+    expected: FAIL
+
+  [object.height: IDL set to "5%"]
+    expected: FAIL
+
+  [object.height: IDL set to "+100"]
+    expected: FAIL
+
+  [object.height: IDL set to ".5"]
+    expected: FAIL
+
+  [object.height: IDL set to true]
+    expected: FAIL
+
+  [object.height: IDL set to false]
+    expected: FAIL
+
+  [object.height: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [object.height: IDL set to NaN]
+    expected: FAIL
+
+  [object.height: IDL set to Infinity]
+    expected: FAIL
+
+  [object.height: IDL set to -Infinity]
+    expected: FAIL
+
+  [object.height: IDL set to "\\0"]
+    expected: FAIL
+
+  [object.height: IDL set to null]
+    expected: FAIL
+
+  [object.height: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [object.height: IDL set to object "test-valueOf"]
+    expected: FAIL
+
+  [object.align: typeof IDL attribute]
+    expected: FAIL
+
+  [object.align: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [object.align: setAttribute() to ""]
+    expected: FAIL
+
+  [object.align: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [object.align: setAttribute() to undefined]
+    expected: FAIL
+
+  [object.align: setAttribute() to 7]
+    expected: FAIL
+
+  [object.align: setAttribute() to 1.5]
+    expected: FAIL
+
+  [object.align: setAttribute() to "5%"]
+    expected: FAIL
+
+  [object.align: setAttribute() to "+100"]
+    expected: FAIL
+
+  [object.align: setAttribute() to ".5"]
+    expected: FAIL
+
+  [object.align: setAttribute() to true]
+    expected: FAIL
+
+  [object.align: setAttribute() to false]
+    expected: FAIL
+
+  [object.align: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [object.align: setAttribute() to NaN]
+    expected: FAIL
+
+  [object.align: setAttribute() to Infinity]
+    expected: FAIL
+
+  [object.align: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [object.align: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [object.align: setAttribute() to null]
+    expected: FAIL
+
+  [object.align: setAttribute() to object "test-toString"]
+    expected: FAIL
+
+  [object.align: setAttribute() to object "test-valueOf"]
+    expected: FAIL
+
+  [object.align: IDL set to ""]
+    expected: FAIL
+
+  [object.align: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [object.align: IDL set to undefined]
+    expected: FAIL
+
+  [object.align: IDL set to 7]
+    expected: FAIL
+
+  [object.align: IDL set to 1.5]
+    expected: FAIL
+
+  [object.align: IDL set to "5%"]
+    expected: FAIL
+
+  [object.align: IDL set to "+100"]
+    expected: FAIL
+
+  [object.align: IDL set to ".5"]
+    expected: FAIL
+
+  [object.align: IDL set to true]
+    expected: FAIL
+
+  [object.align: IDL set to false]
+    expected: FAIL
+
+  [object.align: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [object.align: IDL set to NaN]
+    expected: FAIL
+
+  [object.align: IDL set to Infinity]
+    expected: FAIL
+
+  [object.align: IDL set to -Infinity]
+    expected: FAIL
+
+  [object.align: IDL set to "\\0"]
+    expected: FAIL
+
+  [object.align: IDL set to null]
+    expected: FAIL
+
+  [object.align: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [object.align: IDL set to object "test-valueOf"]
+    expected: FAIL
+
+  [object.archive: typeof IDL attribute]
+    expected: FAIL
+
+  [object.archive: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [object.archive: setAttribute() to ""]
+    expected: FAIL
+
+  [object.archive: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [object.archive: setAttribute() to undefined]
+    expected: FAIL
+
+  [object.archive: setAttribute() to 7]
+    expected: FAIL
+
+  [object.archive: setAttribute() to 1.5]
+    expected: FAIL
+
+  [object.archive: setAttribute() to "5%"]
+    expected: FAIL
+
+  [object.archive: setAttribute() to "+100"]
+    expected: FAIL
+
+  [object.archive: setAttribute() to ".5"]
+    expected: FAIL
+
+  [object.archive: setAttribute() to true]
+    expected: FAIL
+
+  [object.archive: setAttribute() to false]
+    expected: FAIL
+
+  [object.archive: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [object.archive: setAttribute() to NaN]
+    expected: FAIL
+
+  [object.archive: setAttribute() to Infinity]
+    expected: FAIL
+
+  [object.archive: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [object.archive: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [object.archive: setAttribute() to null]
+    expected: FAIL
+
+  [object.archive: setAttribute() to object "test-toString"]
+    expected: FAIL
+
+  [object.archive: setAttribute() to object "test-valueOf"]
+    expected: FAIL
+
+  [object.archive: IDL set to ""]
+    expected: FAIL
+
+  [object.archive: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [object.archive: IDL set to undefined]
+    expected: FAIL
+
+  [object.archive: IDL set to 7]
+    expected: FAIL
+
+  [object.archive: IDL set to 1.5]
+    expected: FAIL
+
+  [object.archive: IDL set to "5%"]
+    expected: FAIL
+
+  [object.archive: IDL set to "+100"]
+    expected: FAIL
+
+  [object.archive: IDL set to ".5"]
+    expected: FAIL
+
+  [object.archive: IDL set to true]
+    expected: FAIL
+
+  [object.archive: IDL set to false]
+    expected: FAIL
+
+  [object.archive: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [object.archive: IDL set to NaN]
+    expected: FAIL
+
+  [object.archive: IDL set to Infinity]
+    expected: FAIL
+
+  [object.archive: IDL set to -Infinity]
+    expected: FAIL
+
+  [object.archive: IDL set to "\\0"]
+    expected: FAIL
+
+  [object.archive: IDL set to null]
+    expected: FAIL
+
+  [object.archive: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [object.archive: IDL set to object "test-valueOf"]
+    expected: FAIL
+
+  [object.code: typeof IDL attribute]
+    expected: FAIL
+
+  [object.code: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [object.code: setAttribute() to ""]
+    expected: FAIL
+
+  [object.code: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [object.code: setAttribute() to undefined]
+    expected: FAIL
+
+  [object.code: setAttribute() to 7]
+    expected: FAIL
+
+  [object.code: setAttribute() to 1.5]
+    expected: FAIL
+
+  [object.code: setAttribute() to "5%"]
+    expected: FAIL
+
+  [object.code: setAttribute() to "+100"]
+    expected: FAIL
+
+  [object.code: setAttribute() to ".5"]
+    expected: FAIL
+
+  [object.code: setAttribute() to true]
+    expected: FAIL
+
+  [object.code: setAttribute() to false]
+    expected: FAIL
+
+  [object.code: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [object.code: setAttribute() to NaN]
+    expected: FAIL
+
+  [object.code: setAttribute() to Infinity]
+    expected: FAIL
+
+  [object.code: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [object.code: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [object.code: setAttribute() to null]
+    expected: FAIL
+
+  [object.code: setAttribute() to object "test-toString"]
+    expected: FAIL
+
+  [object.code: setAttribute() to object "test-valueOf"]
+    expected: FAIL
+
+  [object.code: IDL set to ""]
+    expected: FAIL
+
+  [object.code: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [object.code: IDL set to undefined]
+    expected: FAIL
+
+  [object.code: IDL set to 7]
+    expected: FAIL
+
+  [object.code: IDL set to 1.5]
+    expected: FAIL
+
+  [object.code: IDL set to "5%"]
+    expected: FAIL
+
+  [object.code: IDL set to "+100"]
+    expected: FAIL
+
+  [object.code: IDL set to ".5"]
+    expected: FAIL
+
+  [object.code: IDL set to true]
+    expected: FAIL
+
+  [object.code: IDL set to false]
+    expected: FAIL
+
+  [object.code: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [object.code: IDL set to NaN]
+    expected: FAIL
+
+  [object.code: IDL set to Infinity]
+    expected: FAIL
+
+  [object.code: IDL set to -Infinity]
+    expected: FAIL
+
+  [object.code: IDL set to "\\0"]
+    expected: FAIL
+
+  [object.code: IDL set to null]
+    expected: FAIL
+
+  [object.code: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [object.code: IDL set to object "test-valueOf"]
+    expected: FAIL
+
+  [object.declare: typeof IDL attribute]
+    expected: FAIL
+
+  [object.declare: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [object.declare: setAttribute() to ""]
+    expected: FAIL
+
+  [object.declare: setAttribute() to " foo "]
+    expected: FAIL
+
+  [object.declare: setAttribute() to undefined]
+    expected: FAIL
+
+  [object.declare: setAttribute() to null]
+    expected: FAIL
+
+  [object.declare: setAttribute() to 7]
+    expected: FAIL
+
+  [object.declare: setAttribute() to 1.5]
+    expected: FAIL
+
+  [object.declare: setAttribute() to "5%"]
+    expected: FAIL
+
+  [object.declare: setAttribute() to "+100"]
+    expected: FAIL
+
+  [object.declare: setAttribute() to ".5"]
+    expected: FAIL
+
+  [object.declare: setAttribute() to true]
+    expected: FAIL
+
+  [object.declare: setAttribute() to false]
+    expected: FAIL
+
+  [object.declare: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [object.declare: setAttribute() to NaN]
+    expected: FAIL
+
+  [object.declare: setAttribute() to Infinity]
+    expected: FAIL
+
+  [object.declare: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [object.declare: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [object.declare: setAttribute() to object "test-toString"]
+    expected: FAIL
+
+  [object.declare: setAttribute() to object "test-valueOf"]
+    expected: FAIL
+
+  [object.declare: setAttribute() to "declare"]
+    expected: FAIL
+
+  [object.declare: IDL set to ""]
+    expected: FAIL
+
+  [object.declare: IDL set to " foo "]
+    expected: FAIL
+
+  [object.declare: IDL set to undefined]
+    expected: FAIL
+
+  [object.declare: IDL set to null]
+    expected: FAIL
+
+  [object.declare: IDL set to 7]
+    expected: FAIL
+
+  [object.declare: IDL set to 1.5]
+    expected: FAIL
+
+  [object.declare: IDL set to "5%"]
+    expected: FAIL
+
+  [object.declare: IDL set to "+100"]
+    expected: FAIL
+
+  [object.declare: IDL set to ".5"]
+    expected: FAIL
+
+  [object.declare: IDL set to false]
+    expected: FAIL
+
+  [object.declare: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [object.declare: IDL set to NaN]
+    expected: FAIL
+
+  [object.declare: IDL set to Infinity]
+    expected: FAIL
+
+  [object.declare: IDL set to -Infinity]
+    expected: FAIL
+
+  [object.declare: IDL set to "\\0"]
+    expected: FAIL
+
+  [object.declare: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [object.declare: IDL set to object "test-valueOf"]
+    expected: FAIL
+
+  [object.hspace: typeof IDL attribute]
+    expected: FAIL
+
+  [object.hspace: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to -2147483649]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to -2147483648]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to -36]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to -1]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to 0]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to 1]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to 257]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to 2147483647]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to 2147483648]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to 4294967295]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to 4294967296]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to ""]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to "-"]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to "+"]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to "-1"]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to "-0"]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to "0"]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to "1"]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to "\\t7"]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to "\\v7"]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to "\\f7"]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to " 7"]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to " 7"]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to "﻿7"]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to "\\n7"]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to "\\r7"]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to " 7"]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to " 7"]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to " 7"]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to "᠎7"]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to " 7"]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to " 7"]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to " 7"]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to " 7"]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to " 7"]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to " 7"]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to " 7"]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to " 7"]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to " 7"]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to " 7"]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to " 7"]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to " 7"]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to "　7"]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to "\\t\\v7"]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to "\\n\\v7"]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to "\\f\\v7"]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to "\\r\\v7"]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to " \\v7"]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to "7\\v"]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to undefined]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to 1.5]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to "5%"]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to "+100"]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to ".5"]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to true]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to false]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to NaN]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to Infinity]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to object "2"]
+    expected: FAIL
+
+  [object.hspace: setAttribute() to object "3"]
+    expected: FAIL
+
+  [object.hspace: IDL set to 0]
+    expected: FAIL
+
+  [object.hspace: IDL set to 1]
+    expected: FAIL
+
+  [object.hspace: IDL set to 257]
+    expected: FAIL
+
+  [object.hspace: IDL set to 2147483647]
+    expected: FAIL
+
+  [object.hspace: IDL set to "-0"]
+    expected: FAIL
+
+  [object.hspace: IDL set to 2147483648]
+    expected: FAIL
+
+  [object.hspace: IDL set to 4294967295]
+    expected: FAIL
+
+  [object.standby: typeof IDL attribute]
+    expected: FAIL
+
+  [object.standby: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [object.standby: setAttribute() to ""]
+    expected: FAIL
+
+  [object.standby: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [object.standby: setAttribute() to undefined]
+    expected: FAIL
+
+  [object.standby: setAttribute() to 7]
+    expected: FAIL
+
+  [object.standby: setAttribute() to 1.5]
+    expected: FAIL
+
+  [object.standby: setAttribute() to "5%"]
+    expected: FAIL
+
+  [object.standby: setAttribute() to "+100"]
+    expected: FAIL
+
+  [object.standby: setAttribute() to ".5"]
+    expected: FAIL
+
+  [object.standby: setAttribute() to true]
+    expected: FAIL
+
+  [object.standby: setAttribute() to false]
+    expected: FAIL
+
+  [object.standby: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [object.standby: setAttribute() to NaN]
+    expected: FAIL
+
+  [object.standby: setAttribute() to Infinity]
+    expected: FAIL
+
+  [object.standby: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [object.standby: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [object.standby: setAttribute() to null]
+    expected: FAIL
+
+  [object.standby: setAttribute() to object "test-toString"]
+    expected: FAIL
+
+  [object.standby: setAttribute() to object "test-valueOf"]
+    expected: FAIL
+
+  [object.standby: IDL set to ""]
+    expected: FAIL
+
+  [object.standby: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [object.standby: IDL set to undefined]
+    expected: FAIL
+
+  [object.standby: IDL set to 7]
+    expected: FAIL
+
+  [object.standby: IDL set to 1.5]
+    expected: FAIL
+
+  [object.standby: IDL set to "5%"]
+    expected: FAIL
+
+  [object.standby: IDL set to "+100"]
+    expected: FAIL
+
+  [object.standby: IDL set to ".5"]
+    expected: FAIL
+
+  [object.standby: IDL set to true]
+    expected: FAIL
+
+  [object.standby: IDL set to false]
+    expected: FAIL
+
+  [object.standby: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [object.standby: IDL set to NaN]
+    expected: FAIL
+
+  [object.standby: IDL set to Infinity]
+    expected: FAIL
+
+  [object.standby: IDL set to -Infinity]
+    expected: FAIL
+
+  [object.standby: IDL set to "\\0"]
+    expected: FAIL
+
+  [object.standby: IDL set to null]
+    expected: FAIL
+
+  [object.standby: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [object.standby: IDL set to object "test-valueOf"]
+    expected: FAIL
+
+  [object.vspace: typeof IDL attribute]
+    expected: FAIL
+
+  [object.vspace: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to -2147483649]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to -2147483648]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to -36]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to -1]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to 0]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to 1]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to 257]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to 2147483647]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to 2147483648]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to 4294967295]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to 4294967296]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to ""]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to "-"]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to "+"]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to "-1"]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to "-0"]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to "0"]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to "1"]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to "\\t7"]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to "\\v7"]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to "\\f7"]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to " 7"]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to " 7"]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to "﻿7"]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to "\\n7"]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to "\\r7"]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to " 7"]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to " 7"]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to " 7"]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to "᠎7"]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to " 7"]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to " 7"]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to " 7"]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to " 7"]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to " 7"]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to " 7"]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to " 7"]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to " 7"]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to " 7"]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to " 7"]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to " 7"]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to " 7"]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to "　7"]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to "\\t\\v7"]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to "\\n\\v7"]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to "\\f\\v7"]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to "\\r\\v7"]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to " \\v7"]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to "7\\v"]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to undefined]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to 1.5]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to "5%"]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to "+100"]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to ".5"]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to true]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to false]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to NaN]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to Infinity]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to object "2"]
+    expected: FAIL
+
+  [object.vspace: setAttribute() to object "3"]
+    expected: FAIL
+
+  [object.vspace: IDL set to 0]
+    expected: FAIL
+
+  [object.vspace: IDL set to 1]
+    expected: FAIL
+
+  [object.vspace: IDL set to 257]
+    expected: FAIL
+
+  [object.vspace: IDL set to 2147483647]
+    expected: FAIL
+
+  [object.vspace: IDL set to "-0"]
+    expected: FAIL
+
+  [object.vspace: IDL set to 2147483648]
+    expected: FAIL
+
+  [object.vspace: IDL set to 4294967295]
+    expected: FAIL
+
+  [object.codeBase: typeof IDL attribute]
+    expected: FAIL
+
+  [object.codeBase: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [object.codeBase: setAttribute() to ""]
+    expected: FAIL
+
+  [object.codeBase: setAttribute() to " foo "]
+    expected: FAIL
+
+  [object.codeBase: setAttribute() to "http://site.example/"]
+    expected: FAIL
+
+  [object.codeBase: setAttribute() to "//site.example/path???@#l"]
+    expected: FAIL
+
+  [object.codeBase: setAttribute() to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f "]
+    expected: FAIL
+
+  [object.codeBase: setAttribute() to undefined]
+    expected: FAIL
+
+  [object.codeBase: setAttribute() to 7]
+    expected: FAIL
+
+  [object.codeBase: setAttribute() to 1.5]
+    expected: FAIL
+
+  [object.codeBase: setAttribute() to "5%"]
+    expected: FAIL
+
+  [object.codeBase: setAttribute() to "+100"]
+    expected: FAIL
+
+  [object.codeBase: setAttribute() to ".5"]
+    expected: FAIL
+
+  [object.codeBase: setAttribute() to true]
+    expected: FAIL
+
+  [object.codeBase: setAttribute() to false]
+    expected: FAIL
+
+  [object.codeBase: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [object.codeBase: setAttribute() to NaN]
+    expected: FAIL
+
+  [object.codeBase: setAttribute() to Infinity]
+    expected: FAIL
+
+  [object.codeBase: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [object.codeBase: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [object.codeBase: setAttribute() to null]
+    expected: FAIL
+
+  [object.codeBase: setAttribute() to object "test-toString"]
+    expected: FAIL
+
+  [object.codeBase: setAttribute() to object "test-valueOf"]
+    expected: FAIL
+
+  [object.codeBase: IDL set to ""]
+    expected: FAIL
+
+  [object.codeBase: IDL set to " foo "]
+    expected: FAIL
+
+  [object.codeBase: IDL set to "http://site.example/"]
+    expected: FAIL
+
+  [object.codeBase: IDL set to "//site.example/path???@#l"]
+    expected: FAIL
+
+  [object.codeBase: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f "]
+    expected: FAIL
+
+  [object.codeBase: IDL set to undefined]
+    expected: FAIL
+
+  [object.codeBase: IDL set to 7]
+    expected: FAIL
+
+  [object.codeBase: IDL set to 1.5]
+    expected: FAIL
+
+  [object.codeBase: IDL set to "5%"]
+    expected: FAIL
+
+  [object.codeBase: IDL set to "+100"]
+    expected: FAIL
+
+  [object.codeBase: IDL set to ".5"]
+    expected: FAIL
+
+  [object.codeBase: IDL set to true]
+    expected: FAIL
+
+  [object.codeBase: IDL set to false]
+    expected: FAIL
+
+  [object.codeBase: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [object.codeBase: IDL set to NaN]
+    expected: FAIL
+
+  [object.codeBase: IDL set to Infinity]
+    expected: FAIL
+
+  [object.codeBase: IDL set to -Infinity]
+    expected: FAIL
+
+  [object.codeBase: IDL set to "\\0"]
+    expected: FAIL
+
+  [object.codeBase: IDL set to null]
+    expected: FAIL
+
+  [object.codeBase: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [object.codeBase: IDL set to object "test-valueOf"]
+    expected: FAIL
+
+  [object.codeType: typeof IDL attribute]
+    expected: FAIL
+
+  [object.codeType: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [object.codeType: setAttribute() to ""]
+    expected: FAIL
+
+  [object.codeType: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [object.codeType: setAttribute() to undefined]
+    expected: FAIL
+
+  [object.codeType: setAttribute() to 7]
+    expected: FAIL
+
+  [object.codeType: setAttribute() to 1.5]
+    expected: FAIL
+
+  [object.codeType: setAttribute() to "5%"]
+    expected: FAIL
+
+  [object.codeType: setAttribute() to "+100"]
+    expected: FAIL
+
+  [object.codeType: setAttribute() to ".5"]
+    expected: FAIL
+
+  [object.codeType: setAttribute() to true]
+    expected: FAIL
+
+  [object.codeType: setAttribute() to false]
+    expected: FAIL
+
+  [object.codeType: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [object.codeType: setAttribute() to NaN]
+    expected: FAIL
+
+  [object.codeType: setAttribute() to Infinity]
+    expected: FAIL
+
+  [object.codeType: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [object.codeType: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [object.codeType: setAttribute() to null]
+    expected: FAIL
+
+  [object.codeType: setAttribute() to object "test-toString"]
+    expected: FAIL
+
+  [object.codeType: setAttribute() to object "test-valueOf"]
+    expected: FAIL
+
+  [object.codeType: IDL set to ""]
+    expected: FAIL
+
+  [object.codeType: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [object.codeType: IDL set to undefined]
+    expected: FAIL
+
+  [object.codeType: IDL set to 7]
+    expected: FAIL
+
+  [object.codeType: IDL set to 1.5]
+    expected: FAIL
+
+  [object.codeType: IDL set to "5%"]
+    expected: FAIL
+
+  [object.codeType: IDL set to "+100"]
+    expected: FAIL
+
+  [object.codeType: IDL set to ".5"]
+    expected: FAIL
+
+  [object.codeType: IDL set to true]
+    expected: FAIL
+
+  [object.codeType: IDL set to false]
+    expected: FAIL
+
+  [object.codeType: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [object.codeType: IDL set to NaN]
+    expected: FAIL
+
+  [object.codeType: IDL set to Infinity]
+    expected: FAIL
+
+  [object.codeType: IDL set to -Infinity]
+    expected: FAIL
+
+  [object.codeType: IDL set to "\\0"]
+    expected: FAIL
+
+  [object.codeType: IDL set to null]
+    expected: FAIL
+
+  [object.codeType: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [object.codeType: IDL set to object "test-valueOf"]
+    expected: FAIL
+
+  [object.border: typeof IDL attribute]
+    expected: FAIL
+
+  [object.border: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [object.border: setAttribute() to ""]
+    expected: FAIL
+
+  [object.border: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [object.border: setAttribute() to undefined]
+    expected: FAIL
+
+  [object.border: setAttribute() to 7]
+    expected: FAIL
+
+  [object.border: setAttribute() to 1.5]
+    expected: FAIL
+
+  [object.border: setAttribute() to "5%"]
+    expected: FAIL
+
+  [object.border: setAttribute() to "+100"]
+    expected: FAIL
+
+  [object.border: setAttribute() to ".5"]
+    expected: FAIL
+
+  [object.border: setAttribute() to true]
+    expected: FAIL
+
+  [object.border: setAttribute() to false]
+    expected: FAIL
+
+  [object.border: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [object.border: setAttribute() to NaN]
+    expected: FAIL
+
+  [object.border: setAttribute() to Infinity]
+    expected: FAIL
+
+  [object.border: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [object.border: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [object.border: setAttribute() to null]
+    expected: FAIL
+
+  [object.border: setAttribute() to object "test-toString"]
+    expected: FAIL
+
+  [object.border: setAttribute() to object "test-valueOf"]
+    expected: FAIL
+
+  [object.border: IDL set to ""]
+    expected: FAIL
+
+  [object.border: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [object.border: IDL set to undefined]
+    expected: FAIL
+
+  [object.border: IDL set to 7]
+    expected: FAIL
+
+  [object.border: IDL set to 1.5]
+    expected: FAIL
+
+  [object.border: IDL set to "5%"]
+    expected: FAIL
+
+  [object.border: IDL set to "+100"]
+    expected: FAIL
+
+  [object.border: IDL set to ".5"]
+    expected: FAIL
+
+  [object.border: IDL set to true]
+    expected: FAIL
+
+  [object.border: IDL set to false]
+    expected: FAIL
+
+  [object.border: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [object.border: IDL set to NaN]
+    expected: FAIL
+
+  [object.border: IDL set to Infinity]
+    expected: FAIL
+
+  [object.border: IDL set to -Infinity]
+    expected: FAIL
+
+  [object.border: IDL set to "\\0"]
+    expected: FAIL
+
+  [object.border: IDL set to null]
+    expected: FAIL
+
+  [object.border: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [object.border: IDL set to object "test-valueOf"]
+    expected: FAIL
+
+  [param.accessKey: typeof IDL attribute]
+    expected: FAIL
+
+  [param.accessKey: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [param.accessKey: setAttribute() to ""]
+    expected: FAIL
+
+  [param.accessKey: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [param.accessKey: setAttribute() to undefined]
+    expected: FAIL
+
+  [param.accessKey: setAttribute() to 7]
+    expected: FAIL
+
+  [param.accessKey: setAttribute() to 1.5]
+    expected: FAIL
+
+  [param.accessKey: setAttribute() to "5%"]
+    expected: FAIL
+
+  [param.accessKey: setAttribute() to "+100"]
+    expected: FAIL
+
+  [param.accessKey: setAttribute() to ".5"]
+    expected: FAIL
+
+  [param.accessKey: setAttribute() to true]
+    expected: FAIL
+
+  [param.accessKey: setAttribute() to false]
+    expected: FAIL
+
+  [param.accessKey: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [param.accessKey: setAttribute() to NaN]
+    expected: FAIL
+
+  [param.accessKey: setAttribute() to Infinity]
+    expected: FAIL
+
+  [param.accessKey: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [param.accessKey: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [param.accessKey: setAttribute() to null]
+    expected: FAIL
+
+  [param.accessKey: setAttribute() to object "test-toString"]
+    expected: FAIL
+
+  [param.accessKey: setAttribute() to object "test-valueOf"]
+    expected: FAIL
+
+  [param.accessKey: IDL set to ""]
+    expected: FAIL
+
+  [param.accessKey: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [param.accessKey: IDL set to undefined]
+    expected: FAIL
+
+  [param.accessKey: IDL set to 7]
+    expected: FAIL
+
+  [param.accessKey: IDL set to 1.5]
+    expected: FAIL
+
+  [param.accessKey: IDL set to "5%"]
+    expected: FAIL
+
+  [param.accessKey: IDL set to "+100"]
+    expected: FAIL
+
+  [param.accessKey: IDL set to ".5"]
+    expected: FAIL
+
+  [param.accessKey: IDL set to true]
+    expected: FAIL
+
+  [param.accessKey: IDL set to false]
+    expected: FAIL
+
+  [param.accessKey: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [param.accessKey: IDL set to NaN]
+    expected: FAIL
+
+  [param.accessKey: IDL set to Infinity]
+    expected: FAIL
+
+  [param.accessKey: IDL set to -Infinity]
+    expected: FAIL
+
+  [param.accessKey: IDL set to "\\0"]
+    expected: FAIL
+
+  [param.accessKey: IDL set to null]
+    expected: FAIL
+
+  [param.accessKey: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [param.accessKey: IDL set to object "test-valueOf"]
+    expected: FAIL
+
+  [param.tabIndex: typeof IDL attribute]
+    expected: FAIL
+
+  [param.tabIndex: setAttribute() to -36]
+    expected: FAIL
+
+  [param.tabIndex: setAttribute() to -1]
+    expected: FAIL
+
+  [param.tabIndex: setAttribute() to 0]
+    expected: FAIL
+
+  [param.tabIndex: setAttribute() to 1]
+    expected: FAIL
+
+  [param.tabIndex: setAttribute() to 2147483647]
+    expected: FAIL
+
+  [param.tabIndex: setAttribute() to -2147483648]
+    expected: FAIL
+
+  [param.tabIndex: setAttribute() to "-1"]
+    expected: FAIL
+
+  [param.tabIndex: setAttribute() to "-0"]
+    expected: FAIL
+
+  [param.tabIndex: setAttribute() to "0"]
+    expected: FAIL
+
+  [param.tabIndex: setAttribute() to "1"]
+    expected: FAIL
+
+  [param.tabIndex: setAttribute() to "\\t7"]
+    expected: FAIL
+
+  [param.tabIndex: setAttribute() to "\\f7"]
+    expected: FAIL
+
+  [param.tabIndex: setAttribute() to " 7"]
+    expected: FAIL
+
+  [param.tabIndex: setAttribute() to "\\n7"]
+    expected: FAIL
+
+  [param.tabIndex: setAttribute() to "\\r7"]
+    expected: FAIL
+
+  [param.tabIndex: setAttribute() to "7\\v"]
+    expected: FAIL
+
+  [param.tabIndex: setAttribute() to 1.5]
+    expected: FAIL
+
+  [param.tabIndex: setAttribute() to "5%"]
+    expected: FAIL
+
+  [param.tabIndex: setAttribute() to "+100"]
+    expected: FAIL
+
+  [param.tabIndex: setAttribute() to object "2"]
+    expected: FAIL
+
+  [param.tabIndex: setAttribute() to object "3"]
+    expected: FAIL
+
+  [param.tabIndex: IDL set to -36]
+    expected: FAIL
+
+  [param.tabIndex: IDL set to -1]
+    expected: FAIL
+
+  [param.tabIndex: IDL set to 0]
+    expected: FAIL
+
+  [param.tabIndex: IDL set to 1]
+    expected: FAIL
+
+  [param.tabIndex: IDL set to 2147483647]
+    expected: FAIL
+
+  [param.tabIndex: IDL set to -2147483648]
+    expected: FAIL
+
+  [param.name: typeof IDL attribute]
+    expected: FAIL
+
+  [param.name: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [param.name: setAttribute() to ""]
+    expected: FAIL
+
+  [param.name: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [param.name: setAttribute() to undefined]
+    expected: FAIL
+
+  [param.name: setAttribute() to 7]
+    expected: FAIL
+
+  [param.name: setAttribute() to 1.5]
+    expected: FAIL
+
+  [param.name: setAttribute() to "5%"]
+    expected: FAIL
+
+  [param.name: setAttribute() to "+100"]
+    expected: FAIL
+
+  [param.name: setAttribute() to ".5"]
+    expected: FAIL
+
+  [param.name: setAttribute() to true]
+    expected: FAIL
+
+  [param.name: setAttribute() to false]
+    expected: FAIL
+
+  [param.name: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [param.name: setAttribute() to NaN]
+    expected: FAIL
+
+  [param.name: setAttribute() to Infinity]
+    expected: FAIL
+
+  [param.name: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [param.name: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [param.name: setAttribute() to null]
+    expected: FAIL
+
+  [param.name: setAttribute() to object "test-toString"]
+    expected: FAIL
+
+  [param.name: setAttribute() to object "test-valueOf"]
+    expected: FAIL
+
+  [param.name: IDL set to ""]
+    expected: FAIL
+
+  [param.name: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [param.name: IDL set to undefined]
+    expected: FAIL
+
+  [param.name: IDL set to 7]
+    expected: FAIL
+
+  [param.name: IDL set to 1.5]
+    expected: FAIL
+
+  [param.name: IDL set to "5%"]
+    expected: FAIL
+
+  [param.name: IDL set to "+100"]
+    expected: FAIL
+
+  [param.name: IDL set to ".5"]
+    expected: FAIL
+
+  [param.name: IDL set to true]
+    expected: FAIL
+
+  [param.name: IDL set to false]
+    expected: FAIL
+
+  [param.name: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [param.name: IDL set to NaN]
+    expected: FAIL
+
+  [param.name: IDL set to Infinity]
+    expected: FAIL
+
+  [param.name: IDL set to -Infinity]
+    expected: FAIL
+
+  [param.name: IDL set to "\\0"]
+    expected: FAIL
+
+  [param.name: IDL set to null]
+    expected: FAIL
+
+  [param.name: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [param.name: IDL set to object "test-valueOf"]
+    expected: FAIL
+
+  [param.value: typeof IDL attribute]
+    expected: FAIL
+
+  [param.value: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [param.value: setAttribute() to ""]
+    expected: FAIL
+
+  [param.value: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [param.value: setAttribute() to undefined]
+    expected: FAIL
+
+  [param.value: setAttribute() to 7]
+    expected: FAIL
+
+  [param.value: setAttribute() to 1.5]
+    expected: FAIL
+
+  [param.value: setAttribute() to "5%"]
+    expected: FAIL
+
+  [param.value: setAttribute() to "+100"]
+    expected: FAIL
+
+  [param.value: setAttribute() to ".5"]
+    expected: FAIL
+
+  [param.value: setAttribute() to true]
+    expected: FAIL
+
+  [param.value: setAttribute() to false]
+    expected: FAIL
+
+  [param.value: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [param.value: setAttribute() to NaN]
+    expected: FAIL
+
+  [param.value: setAttribute() to Infinity]
+    expected: FAIL
+
+  [param.value: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [param.value: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [param.value: setAttribute() to null]
+    expected: FAIL
+
+  [param.value: setAttribute() to object "test-toString"]
+    expected: FAIL
+
+  [param.value: setAttribute() to object "test-valueOf"]
+    expected: FAIL
+
+  [param.value: IDL set to ""]
+    expected: FAIL
+
+  [param.value: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [param.value: IDL set to undefined]
+    expected: FAIL
+
+  [param.value: IDL set to 7]
+    expected: FAIL
+
+  [param.value: IDL set to 1.5]
+    expected: FAIL
+
+  [param.value: IDL set to "5%"]
+    expected: FAIL
+
+  [param.value: IDL set to "+100"]
+    expected: FAIL
+
+  [param.value: IDL set to ".5"]
+    expected: FAIL
+
+  [param.value: IDL set to true]
+    expected: FAIL
+
+  [param.value: IDL set to false]
+    expected: FAIL
+
+  [param.value: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [param.value: IDL set to NaN]
+    expected: FAIL
+
+  [param.value: IDL set to Infinity]
+    expected: FAIL
+
+  [param.value: IDL set to -Infinity]
+    expected: FAIL
+
+  [param.value: IDL set to "\\0"]
+    expected: FAIL
+
+  [param.value: IDL set to null]
+    expected: FAIL
+
+  [param.value: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [param.value: IDL set to object "test-valueOf"]
+    expected: FAIL
+
+  [param.type: typeof IDL attribute]
+    expected: FAIL
+
+  [param.type: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [param.type: setAttribute() to ""]
+    expected: FAIL
+
+  [param.type: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [param.type: setAttribute() to undefined]
+    expected: FAIL
+
+  [param.type: setAttribute() to 7]
+    expected: FAIL
+
+  [param.type: setAttribute() to 1.5]
+    expected: FAIL
+
+  [param.type: setAttribute() to "5%"]
+    expected: FAIL
+
+  [param.type: setAttribute() to "+100"]
+    expected: FAIL
+
+  [param.type: setAttribute() to ".5"]
+    expected: FAIL
+
+  [param.type: setAttribute() to true]
+    expected: FAIL
+
+  [param.type: setAttribute() to false]
+    expected: FAIL
+
+  [param.type: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [param.type: setAttribute() to NaN]
+    expected: FAIL
+
+  [param.type: setAttribute() to Infinity]
+    expected: FAIL
+
+  [param.type: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [param.type: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [param.type: setAttribute() to null]
+    expected: FAIL
+
+  [param.type: setAttribute() to object "test-toString"]
+    expected: FAIL
+
+  [param.type: setAttribute() to object "test-valueOf"]
+    expected: FAIL
+
+  [param.type: IDL set to ""]
+    expected: FAIL
+
+  [param.type: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [param.type: IDL set to undefined]
+    expected: FAIL
+
+  [param.type: IDL set to 7]
+    expected: FAIL
+
+  [param.type: IDL set to 1.5]
+    expected: FAIL
+
+  [param.type: IDL set to "5%"]
+    expected: FAIL
+
+  [param.type: IDL set to "+100"]
+    expected: FAIL
+
+  [param.type: IDL set to ".5"]
+    expected: FAIL
+
+  [param.type: IDL set to true]
+    expected: FAIL
+
+  [param.type: IDL set to false]
+    expected: FAIL
+
+  [param.type: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [param.type: IDL set to NaN]
+    expected: FAIL
+
+  [param.type: IDL set to Infinity]
+    expected: FAIL
+
+  [param.type: IDL set to -Infinity]
+    expected: FAIL
+
+  [param.type: IDL set to "\\0"]
+    expected: FAIL
+
+  [param.type: IDL set to null]
+    expected: FAIL
+
+  [param.type: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [param.type: IDL set to object "test-valueOf"]
+    expected: FAIL
+
+  [param.valueType: typeof IDL attribute]
+    expected: FAIL
+
+  [param.valueType: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [param.valueType: setAttribute() to ""]
+    expected: FAIL
+
+  [param.valueType: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [param.valueType: setAttribute() to undefined]
+    expected: FAIL
+
+  [param.valueType: setAttribute() to 7]
+    expected: FAIL
+
+  [param.valueType: setAttribute() to 1.5]
+    expected: FAIL
+
+  [param.valueType: setAttribute() to "5%"]
+    expected: FAIL
+
+  [param.valueType: setAttribute() to "+100"]
+    expected: FAIL
+
+  [param.valueType: setAttribute() to ".5"]
+    expected: FAIL
+
+  [param.valueType: setAttribute() to true]
+    expected: FAIL
+
+  [param.valueType: setAttribute() to false]
+    expected: FAIL
+
+  [param.valueType: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [param.valueType: setAttribute() to NaN]
+    expected: FAIL
+
+  [param.valueType: setAttribute() to Infinity]
+    expected: FAIL
+
+  [param.valueType: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [param.valueType: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [param.valueType: setAttribute() to null]
+    expected: FAIL
+
+  [param.valueType: setAttribute() to object "test-toString"]
+    expected: FAIL
+
+  [param.valueType: setAttribute() to object "test-valueOf"]
+    expected: FAIL
+
+  [param.valueType: IDL set to ""]
+    expected: FAIL
+
+  [param.valueType: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [param.valueType: IDL set to undefined]
+    expected: FAIL
+
+  [param.valueType: IDL set to 7]
+    expected: FAIL
+
+  [param.valueType: IDL set to 1.5]
+    expected: FAIL
+
+  [param.valueType: IDL set to "5%"]
+    expected: FAIL
+
+  [param.valueType: IDL set to "+100"]
+    expected: FAIL
+
+  [param.valueType: IDL set to ".5"]
+    expected: FAIL
+
+  [param.valueType: IDL set to true]
+    expected: FAIL
+
+  [param.valueType: IDL set to false]
+    expected: FAIL
+
+  [param.valueType: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [param.valueType: IDL set to NaN]
+    expected: FAIL
+
+  [param.valueType: IDL set to Infinity]
+    expected: FAIL
+
+  [param.valueType: IDL set to -Infinity]
+    expected: FAIL
+
+  [param.valueType: IDL set to "\\0"]
+    expected: FAIL
+
+  [param.valueType: IDL set to null]
+    expected: FAIL
+
+  [param.valueType: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [param.valueType: IDL set to object "test-valueOf"]
+    expected: FAIL
+
+  [video.accessKey: typeof IDL attribute]
+    expected: FAIL
+
+  [video.accessKey: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [video.accessKey: setAttribute() to ""]
+    expected: FAIL
+
+  [video.accessKey: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [video.accessKey: setAttribute() to undefined]
+    expected: FAIL
+
+  [video.accessKey: setAttribute() to 7]
+    expected: FAIL
+
+  [video.accessKey: setAttribute() to 1.5]
+    expected: FAIL
+
+  [video.accessKey: setAttribute() to "5%"]
+    expected: FAIL
+
+  [video.accessKey: setAttribute() to "+100"]
+    expected: FAIL
+
+  [video.accessKey: setAttribute() to ".5"]
+    expected: FAIL
+
+  [video.accessKey: setAttribute() to true]
+    expected: FAIL
+
+  [video.accessKey: setAttribute() to false]
+    expected: FAIL
+
+  [video.accessKey: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [video.accessKey: setAttribute() to NaN]
+    expected: FAIL
+
+  [video.accessKey: setAttribute() to Infinity]
+    expected: FAIL
+
+  [video.accessKey: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [video.accessKey: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [video.accessKey: setAttribute() to null]
+    expected: FAIL
+
+  [video.accessKey: setAttribute() to object "test-toString"]
+    expected: FAIL
+
+  [video.accessKey: setAttribute() to object "test-valueOf"]
+    expected: FAIL
+
+  [video.accessKey: IDL set to ""]
+    expected: FAIL
+
+  [video.accessKey: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [video.accessKey: IDL set to undefined]
+    expected: FAIL
+
+  [video.accessKey: IDL set to 7]
+    expected: FAIL
+
+  [video.accessKey: IDL set to 1.5]
+    expected: FAIL
+
+  [video.accessKey: IDL set to "5%"]
+    expected: FAIL
+
+  [video.accessKey: IDL set to "+100"]
+    expected: FAIL
+
+  [video.accessKey: IDL set to ".5"]
+    expected: FAIL
+
+  [video.accessKey: IDL set to true]
+    expected: FAIL
+
+  [video.accessKey: IDL set to false]
+    expected: FAIL
+
+  [video.accessKey: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [video.accessKey: IDL set to NaN]
+    expected: FAIL
+
+  [video.accessKey: IDL set to Infinity]
+    expected: FAIL
+
+  [video.accessKey: IDL set to -Infinity]
+    expected: FAIL
+
+  [video.accessKey: IDL set to "\\0"]
+    expected: FAIL
+
+  [video.accessKey: IDL set to null]
+    expected: FAIL
+
+  [video.accessKey: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [video.accessKey: IDL set to object "test-valueOf"]
+    expected: FAIL
+
+  [video.tabIndex: typeof IDL attribute]
+    expected: FAIL
+
+  [video.tabIndex: setAttribute() to -36]
+    expected: FAIL
+
+  [video.tabIndex: setAttribute() to -1]
+    expected: FAIL
+
+  [video.tabIndex: setAttribute() to 0]
+    expected: FAIL
+
+  [video.tabIndex: setAttribute() to 1]
+    expected: FAIL
+
+  [video.tabIndex: setAttribute() to 2147483647]
+    expected: FAIL
+
+  [video.tabIndex: setAttribute() to -2147483648]
+    expected: FAIL
+
+  [video.tabIndex: setAttribute() to "-1"]
+    expected: FAIL
+
+  [video.tabIndex: setAttribute() to "-0"]
+    expected: FAIL
+
+  [video.tabIndex: setAttribute() to "0"]
+    expected: FAIL
+
+  [video.tabIndex: setAttribute() to "1"]
+    expected: FAIL
+
+  [video.tabIndex: setAttribute() to "\\t7"]
+    expected: FAIL
+
+  [video.tabIndex: setAttribute() to "\\f7"]
+    expected: FAIL
+
+  [video.tabIndex: setAttribute() to " 7"]
+    expected: FAIL
+
+  [video.tabIndex: setAttribute() to "\\n7"]
+    expected: FAIL
+
+  [video.tabIndex: setAttribute() to "\\r7"]
+    expected: FAIL
+
+  [video.tabIndex: setAttribute() to "7\\v"]
+    expected: FAIL
+
+  [video.tabIndex: setAttribute() to 1.5]
+    expected: FAIL
+
+  [video.tabIndex: setAttribute() to "5%"]
+    expected: FAIL
+
+  [video.tabIndex: setAttribute() to "+100"]
+    expected: FAIL
+
+  [video.tabIndex: setAttribute() to object "2"]
+    expected: FAIL
+
+  [video.tabIndex: setAttribute() to object "3"]
+    expected: FAIL
+
+  [video.tabIndex: IDL set to -36]
+    expected: FAIL
+
+  [video.tabIndex: IDL set to -1]
+    expected: FAIL
+
+  [video.tabIndex: IDL set to 0]
+    expected: FAIL
+
+  [video.tabIndex: IDL set to 1]
+    expected: FAIL
+
+  [video.tabIndex: IDL set to 2147483647]
+    expected: FAIL
+
+  [video.tabIndex: IDL set to -2147483648]
+    expected: FAIL
+
+  [video.width: typeof IDL attribute]
+    expected: FAIL
+
+  [video.width: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [video.width: setAttribute() to -2147483649]
+    expected: FAIL
+
+  [video.width: setAttribute() to -2147483648]
+    expected: FAIL
+
+  [video.width: setAttribute() to -36]
+    expected: FAIL
+
+  [video.width: setAttribute() to -1]
+    expected: FAIL
+
+  [video.width: setAttribute() to 0]
+    expected: FAIL
+
+  [video.width: setAttribute() to 1]
+    expected: FAIL
+
+  [video.width: setAttribute() to 257]
+    expected: FAIL
+
+  [video.width: setAttribute() to 2147483647]
+    expected: FAIL
+
+  [video.width: setAttribute() to 2147483648]
+    expected: FAIL
+
+  [video.width: setAttribute() to 4294967295]
+    expected: FAIL
+
+  [video.width: setAttribute() to 4294967296]
+    expected: FAIL
+
+  [video.width: setAttribute() to ""]
+    expected: FAIL
+
+  [video.width: setAttribute() to "-"]
+    expected: FAIL
+
+  [video.width: setAttribute() to "+"]
+    expected: FAIL
+
+  [video.width: setAttribute() to "-1"]
+    expected: FAIL
+
+  [video.width: setAttribute() to "-0"]
+    expected: FAIL
+
+  [video.width: setAttribute() to "0"]
+    expected: FAIL
+
+  [video.width: setAttribute() to "1"]
+    expected: FAIL
+
+  [video.width: setAttribute() to "\\t7"]
+    expected: FAIL
+
+  [video.width: setAttribute() to "\\v7"]
+    expected: FAIL
+
+  [video.width: setAttribute() to "\\f7"]
+    expected: FAIL
+
+  [video.width: setAttribute() to " 7"]
+    expected: FAIL
+
+  [video.width: setAttribute() to " 7"]
+    expected: FAIL
+
+  [video.width: setAttribute() to "﻿7"]
+    expected: FAIL
+
+  [video.width: setAttribute() to "\\n7"]
+    expected: FAIL
+
+  [video.width: setAttribute() to "\\r7"]
+    expected: FAIL
+
+  [video.width: setAttribute() to " 7"]
+    expected: FAIL
+
+  [video.width: setAttribute() to " 7"]
+    expected: FAIL
+
+  [video.width: setAttribute() to " 7"]
+    expected: FAIL
+
+  [video.width: setAttribute() to "᠎7"]
+    expected: FAIL
+
+  [video.width: setAttribute() to " 7"]
+    expected: FAIL
+
+  [video.width: setAttribute() to " 7"]
+    expected: FAIL
+
+  [video.width: setAttribute() to " 7"]
+    expected: FAIL
+
+  [video.width: setAttribute() to " 7"]
+    expected: FAIL
+
+  [video.width: setAttribute() to " 7"]
+    expected: FAIL
+
+  [video.width: setAttribute() to " 7"]
+    expected: FAIL
+
+  [video.width: setAttribute() to " 7"]
+    expected: FAIL
+
+  [video.width: setAttribute() to " 7"]
+    expected: FAIL
+
+  [video.width: setAttribute() to " 7"]
+    expected: FAIL
+
+  [video.width: setAttribute() to " 7"]
+    expected: FAIL
+
+  [video.width: setAttribute() to " 7"]
+    expected: FAIL
+
+  [video.width: setAttribute() to " 7"]
+    expected: FAIL
+
+  [video.width: setAttribute() to "　7"]
+    expected: FAIL
+
+  [video.width: setAttribute() to "\\t\\v7"]
+    expected: FAIL
+
+  [video.width: setAttribute() to "\\n\\v7"]
+    expected: FAIL
+
+  [video.width: setAttribute() to "\\f\\v7"]
+    expected: FAIL
+
+  [video.width: setAttribute() to "\\r\\v7"]
+    expected: FAIL
+
+  [video.width: setAttribute() to " \\v7"]
+    expected: FAIL
+
+  [video.width: setAttribute() to "7\\v"]
+    expected: FAIL
+
+  [video.width: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [video.width: setAttribute() to undefined]
+    expected: FAIL
+
+  [video.width: setAttribute() to 1.5]
+    expected: FAIL
+
+  [video.width: setAttribute() to "5%"]
+    expected: FAIL
+
+  [video.width: setAttribute() to "+100"]
+    expected: FAIL
+
+  [video.width: setAttribute() to ".5"]
+    expected: FAIL
+
+  [video.width: setAttribute() to true]
+    expected: FAIL
+
+  [video.width: setAttribute() to false]
+    expected: FAIL
+
+  [video.width: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [video.width: setAttribute() to NaN]
+    expected: FAIL
+
+  [video.width: setAttribute() to Infinity]
+    expected: FAIL
+
+  [video.width: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [video.width: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [video.width: setAttribute() to object "2"]
+    expected: FAIL
+
+  [video.width: setAttribute() to object "3"]
+    expected: FAIL
+
+  [video.width: IDL set to 0]
+    expected: FAIL
+
+  [video.width: IDL set to 1]
+    expected: FAIL
+
+  [video.width: IDL set to 257]
+    expected: FAIL
+
+  [video.width: IDL set to 2147483647]
+    expected: FAIL
+
+  [video.width: IDL set to "-0"]
+    expected: FAIL
+
+  [video.width: IDL set to 2147483648]
+    expected: FAIL
+
+  [video.width: IDL set to 4294967295]
+    expected: FAIL
+
+  [video.height: typeof IDL attribute]
+    expected: FAIL
+
+  [video.height: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [video.height: setAttribute() to -2147483649]
+    expected: FAIL
+
+  [video.height: setAttribute() to -2147483648]
+    expected: FAIL
+
+  [video.height: setAttribute() to -36]
+    expected: FAIL
+
+  [video.height: setAttribute() to -1]
+    expected: FAIL
+
+  [video.height: setAttribute() to 0]
+    expected: FAIL
+
+  [video.height: setAttribute() to 1]
+    expected: FAIL
+
+  [video.height: setAttribute() to 257]
+    expected: FAIL
+
+  [video.height: setAttribute() to 2147483647]
+    expected: FAIL
+
+  [video.height: setAttribute() to 2147483648]
+    expected: FAIL
+
+  [video.height: setAttribute() to 4294967295]
+    expected: FAIL
+
+  [video.height: setAttribute() to 4294967296]
+    expected: FAIL
+
+  [video.height: setAttribute() to ""]
+    expected: FAIL
+
+  [video.height: setAttribute() to "-"]
+    expected: FAIL
+
+  [video.height: setAttribute() to "+"]
+    expected: FAIL
+
+  [video.height: setAttribute() to "-1"]
+    expected: FAIL
+
+  [video.height: setAttribute() to "-0"]
+    expected: FAIL
+
+  [video.height: setAttribute() to "0"]
+    expected: FAIL
+
+  [video.height: setAttribute() to "1"]
+    expected: FAIL
+
+  [video.height: setAttribute() to "\\t7"]
+    expected: FAIL
+
+  [video.height: setAttribute() to "\\v7"]
+    expected: FAIL
+
+  [video.height: setAttribute() to "\\f7"]
+    expected: FAIL
+
+  [video.height: setAttribute() to " 7"]
+    expected: FAIL
+
+  [video.height: setAttribute() to " 7"]
+    expected: FAIL
+
+  [video.height: setAttribute() to "﻿7"]
+    expected: FAIL
+
+  [video.height: setAttribute() to "\\n7"]
+    expected: FAIL
+
+  [video.height: setAttribute() to "\\r7"]
+    expected: FAIL
+
+  [video.height: setAttribute() to " 7"]
+    expected: FAIL
+
+  [video.height: setAttribute() to " 7"]
+    expected: FAIL
+
+  [video.height: setAttribute() to " 7"]
+    expected: FAIL
+
+  [video.height: setAttribute() to "᠎7"]
+    expected: FAIL
+
+  [video.height: setAttribute() to " 7"]
+    expected: FAIL
+
+  [video.height: setAttribute() to " 7"]
+    expected: FAIL
+
+  [video.height: setAttribute() to " 7"]
+    expected: FAIL
+
+  [video.height: setAttribute() to " 7"]
+    expected: FAIL
+
+  [video.height: setAttribute() to " 7"]
+    expected: FAIL
+
+  [video.height: setAttribute() to " 7"]
+    expected: FAIL
+
+  [video.height: setAttribute() to " 7"]
+    expected: FAIL
+
+  [video.height: setAttribute() to " 7"]
+    expected: FAIL
+
+  [video.height: setAttribute() to " 7"]
+    expected: FAIL
+
+  [video.height: setAttribute() to " 7"]
+    expected: FAIL
+
+  [video.height: setAttribute() to " 7"]
+    expected: FAIL
+
+  [video.height: setAttribute() to " 7"]
+    expected: FAIL
+
+  [video.height: setAttribute() to "　7"]
+    expected: FAIL
+
+  [video.height: setAttribute() to "\\t\\v7"]
+    expected: FAIL
+
+  [video.height: setAttribute() to "\\n\\v7"]
+    expected: FAIL
+
+  [video.height: setAttribute() to "\\f\\v7"]
+    expected: FAIL
+
+  [video.height: setAttribute() to "\\r\\v7"]
+    expected: FAIL
+
+  [video.height: setAttribute() to " \\v7"]
+    expected: FAIL
+
+  [video.height: setAttribute() to "7\\v"]
+    expected: FAIL
+
+  [video.height: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [video.height: setAttribute() to undefined]
+    expected: FAIL
+
+  [video.height: setAttribute() to 1.5]
+    expected: FAIL
+
+  [video.height: setAttribute() to "5%"]
+    expected: FAIL
+
+  [video.height: setAttribute() to "+100"]
+    expected: FAIL
+
+  [video.height: setAttribute() to ".5"]
+    expected: FAIL
+
+  [video.height: setAttribute() to true]
+    expected: FAIL
+
+  [video.height: setAttribute() to false]
+    expected: FAIL
+
+  [video.height: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [video.height: setAttribute() to NaN]
+    expected: FAIL
+
+  [video.height: setAttribute() to Infinity]
+    expected: FAIL
+
+  [video.height: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [video.height: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [video.height: setAttribute() to object "2"]
+    expected: FAIL
+
+  [video.height: setAttribute() to object "3"]
+    expected: FAIL
+
+  [video.height: IDL set to 0]
+    expected: FAIL
+
+  [video.height: IDL set to 1]
+    expected: FAIL
+
+  [video.height: IDL set to 257]
+    expected: FAIL
+
+  [video.height: IDL set to 2147483647]
+    expected: FAIL
+
+  [video.height: IDL set to "-0"]
+    expected: FAIL
+
+  [video.height: IDL set to 2147483648]
+    expected: FAIL
+
+  [video.height: IDL set to 4294967295]
+    expected: FAIL
+
+  [video.poster: setAttribute() to ""]
+    expected: FAIL
+
+  [video.poster: setAttribute() to " foo "]
+    expected: FAIL
+
+  [video.poster: setAttribute() to "//site.example/path???@#l"]
+    expected: FAIL
+
+  [video.poster: setAttribute() to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f "]
+    expected: FAIL
+
+  [video.poster: setAttribute() to undefined]
+    expected: FAIL
+
+  [video.poster: setAttribute() to 7]
+    expected: FAIL
+
+  [video.poster: setAttribute() to 1.5]
+    expected: FAIL
+
+  [video.poster: setAttribute() to "5%"]
+    expected: FAIL
+
+  [video.poster: setAttribute() to "+100"]
+    expected: FAIL
+
+  [video.poster: setAttribute() to ".5"]
+    expected: FAIL
+
+  [video.poster: setAttribute() to true]
+    expected: FAIL
+
+  [video.poster: setAttribute() to false]
+    expected: FAIL
+
+  [video.poster: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [video.poster: setAttribute() to NaN]
+    expected: FAIL
+
+  [video.poster: setAttribute() to Infinity]
+    expected: FAIL
+
+  [video.poster: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [video.poster: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [video.poster: setAttribute() to null]
+    expected: FAIL
+
+  [video.poster: setAttribute() to object "test-toString"]
+    expected: FAIL
+
+  [video.poster: setAttribute() to object "test-valueOf"]
+    expected: FAIL
+
+  [video.poster: IDL set to ""]
+    expected: FAIL
+
+  [video.poster: IDL set to " foo "]
+    expected: FAIL
+
+  [video.poster: IDL set to "//site.example/path???@#l"]
+    expected: FAIL
+
+  [video.poster: IDL set to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f "]
+    expected: FAIL
+
+  [video.poster: IDL set to undefined]
+    expected: FAIL
+
+  [video.poster: IDL set to 7]
+    expected: FAIL
+
+  [video.poster: IDL set to 1.5]
+    expected: FAIL
+
+  [video.poster: IDL set to "5%"]
+    expected: FAIL
+
+  [video.poster: IDL set to "+100"]
+    expected: FAIL
+
+  [video.poster: IDL set to ".5"]
+    expected: FAIL
+
+  [video.poster: IDL set to true]
+    expected: FAIL
+
+  [video.poster: IDL set to false]
+    expected: FAIL
+
+  [video.poster: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [video.poster: IDL set to NaN]
+    expected: FAIL
+
+  [video.poster: IDL set to Infinity]
+    expected: FAIL
+
+  [video.poster: IDL set to -Infinity]
+    expected: FAIL
+
+  [video.poster: IDL set to "\\0"]
+    expected: FAIL
+
+  [video.poster: IDL set to null]
+    expected: FAIL
+
+  [video.poster: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [video.poster: IDL set to object "test-valueOf"]
+    expected: FAIL
+
+  [video.playsInline: typeof IDL attribute]
+    expected: FAIL
+
+  [video.playsInline: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [video.playsInline: setAttribute() to ""]
+    expected: FAIL
+
+  [video.playsInline: setAttribute() to " foo "]
+    expected: FAIL
+
+  [video.playsInline: setAttribute() to undefined]
+    expected: FAIL
+
+  [video.playsInline: setAttribute() to null]
+    expected: FAIL
+
+  [video.playsInline: setAttribute() to 7]
+    expected: FAIL
+
+  [video.playsInline: setAttribute() to 1.5]
+    expected: FAIL
+
+  [video.playsInline: setAttribute() to "5%"]
+    expected: FAIL
+
+  [video.playsInline: setAttribute() to "+100"]
+    expected: FAIL
+
+  [video.playsInline: setAttribute() to ".5"]
+    expected: FAIL
+
+  [video.playsInline: setAttribute() to true]
+    expected: FAIL
+
+  [video.playsInline: setAttribute() to false]
+    expected: FAIL
+
+  [video.playsInline: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [video.playsInline: setAttribute() to NaN]
+    expected: FAIL
+
+  [video.playsInline: setAttribute() to Infinity]
+    expected: FAIL
+
+  [video.playsInline: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [video.playsInline: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [video.playsInline: setAttribute() to object "test-toString"]
+    expected: FAIL
+
+  [video.playsInline: setAttribute() to object "test-valueOf"]
+    expected: FAIL
+
+  [video.playsInline: setAttribute() to "playsInline"]
+    expected: FAIL
+
+  [video.playsInline: IDL set to ""]
+    expected: FAIL
+
+  [video.playsInline: IDL set to " foo "]
+    expected: FAIL
+
+  [video.playsInline: IDL set to undefined]
+    expected: FAIL
+
+  [video.playsInline: IDL set to null]
+    expected: FAIL
+
+  [video.playsInline: IDL set to 7]
+    expected: FAIL
+
+  [video.playsInline: IDL set to 1.5]
+    expected: FAIL
+
+  [video.playsInline: IDL set to "5%"]
+    expected: FAIL
+
+  [video.playsInline: IDL set to "+100"]
+    expected: FAIL
+
+  [video.playsInline: IDL set to ".5"]
+    expected: FAIL
+
+  [video.playsInline: IDL set to false]
+    expected: FAIL
+
+  [video.playsInline: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [video.playsInline: IDL set to NaN]
+    expected: FAIL
+
+  [video.playsInline: IDL set to Infinity]
+    expected: FAIL
+
+  [video.playsInline: IDL set to -Infinity]
+    expected: FAIL
+
+  [video.playsInline: IDL set to "\\0"]
+    expected: FAIL
+
+  [video.playsInline: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [video.playsInline: IDL set to object "test-valueOf"]
+    expected: FAIL
+
+  [audio.accessKey: typeof IDL attribute]
+    expected: FAIL
+
+  [audio.accessKey: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [audio.accessKey: setAttribute() to ""]
+    expected: FAIL
+
+  [audio.accessKey: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [audio.accessKey: setAttribute() to undefined]
+    expected: FAIL
+
+  [audio.accessKey: setAttribute() to 7]
+    expected: FAIL
+
+  [audio.accessKey: setAttribute() to 1.5]
+    expected: FAIL
+
+  [audio.accessKey: setAttribute() to "5%"]
+    expected: FAIL
+
+  [audio.accessKey: setAttribute() to "+100"]
+    expected: FAIL
+
+  [audio.accessKey: setAttribute() to ".5"]
+    expected: FAIL
+
+  [audio.accessKey: setAttribute() to true]
+    expected: FAIL
+
+  [audio.accessKey: setAttribute() to false]
+    expected: FAIL
+
+  [audio.accessKey: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [audio.accessKey: setAttribute() to NaN]
+    expected: FAIL
+
+  [audio.accessKey: setAttribute() to Infinity]
+    expected: FAIL
+
+  [audio.accessKey: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [audio.accessKey: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [audio.accessKey: setAttribute() to null]
+    expected: FAIL
+
+  [audio.accessKey: setAttribute() to object "test-toString"]
+    expected: FAIL
+
+  [audio.accessKey: setAttribute() to object "test-valueOf"]
+    expected: FAIL
+
+  [audio.accessKey: IDL set to ""]
+    expected: FAIL
+
+  [audio.accessKey: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [audio.accessKey: IDL set to undefined]
+    expected: FAIL
+
+  [audio.accessKey: IDL set to 7]
+    expected: FAIL
+
+  [audio.accessKey: IDL set to 1.5]
+    expected: FAIL
+
+  [audio.accessKey: IDL set to "5%"]
+    expected: FAIL
+
+  [audio.accessKey: IDL set to "+100"]
+    expected: FAIL
+
+  [audio.accessKey: IDL set to ".5"]
+    expected: FAIL
+
+  [audio.accessKey: IDL set to true]
+    expected: FAIL
+
+  [audio.accessKey: IDL set to false]
+    expected: FAIL
+
+  [audio.accessKey: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [audio.accessKey: IDL set to NaN]
+    expected: FAIL
+
+  [audio.accessKey: IDL set to Infinity]
+    expected: FAIL
+
+  [audio.accessKey: IDL set to -Infinity]
+    expected: FAIL
+
+  [audio.accessKey: IDL set to "\\0"]
+    expected: FAIL
+
+  [audio.accessKey: IDL set to null]
+    expected: FAIL
+
+  [audio.accessKey: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [audio.accessKey: IDL set to object "test-valueOf"]
+    expected: FAIL
+
+  [audio.tabIndex: typeof IDL attribute]
+    expected: FAIL
+
+  [audio.tabIndex: setAttribute() to -36]
+    expected: FAIL
+
+  [audio.tabIndex: setAttribute() to -1]
+    expected: FAIL
+
+  [audio.tabIndex: setAttribute() to 0]
+    expected: FAIL
+
+  [audio.tabIndex: setAttribute() to 1]
+    expected: FAIL
+
+  [audio.tabIndex: setAttribute() to 2147483647]
+    expected: FAIL
+
+  [audio.tabIndex: setAttribute() to -2147483648]
+    expected: FAIL
+
+  [audio.tabIndex: setAttribute() to "-1"]
+    expected: FAIL
+
+  [audio.tabIndex: setAttribute() to "-0"]
+    expected: FAIL
+
+  [audio.tabIndex: setAttribute() to "0"]
+    expected: FAIL
+
+  [audio.tabIndex: setAttribute() to "1"]
+    expected: FAIL
+
+  [audio.tabIndex: setAttribute() to "\\t7"]
+    expected: FAIL
+
+  [audio.tabIndex: setAttribute() to "\\f7"]
+    expected: FAIL
+
+  [audio.tabIndex: setAttribute() to " 7"]
+    expected: FAIL
+
+  [audio.tabIndex: setAttribute() to "\\n7"]
+    expected: FAIL
+
+  [audio.tabIndex: setAttribute() to "\\r7"]
+    expected: FAIL
+
+  [audio.tabIndex: setAttribute() to "7\\v"]
+    expected: FAIL
+
+  [audio.tabIndex: setAttribute() to 1.5]
+    expected: FAIL
+
+  [audio.tabIndex: setAttribute() to "5%"]
+    expected: FAIL
+
+  [audio.tabIndex: setAttribute() to "+100"]
+    expected: FAIL
+
+  [audio.tabIndex: setAttribute() to object "2"]
+    expected: FAIL
+
+  [audio.tabIndex: setAttribute() to object "3"]
+    expected: FAIL
+
+  [audio.tabIndex: IDL set to -36]
+    expected: FAIL
+
+  [audio.tabIndex: IDL set to -1]
+    expected: FAIL
+
+  [audio.tabIndex: IDL set to 0]
+    expected: FAIL
+
+  [audio.tabIndex: IDL set to 1]
+    expected: FAIL
+
+  [audio.tabIndex: IDL set to 2147483647]
+    expected: FAIL
+
+  [audio.tabIndex: IDL set to -2147483648]
+    expected: FAIL
+
+  [source.accessKey: typeof IDL attribute]
+    expected: FAIL
+
+  [source.accessKey: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [source.accessKey: setAttribute() to ""]
+    expected: FAIL
+
+  [source.accessKey: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [source.accessKey: setAttribute() to undefined]
+    expected: FAIL
+
+  [source.accessKey: setAttribute() to 7]
+    expected: FAIL
+
+  [source.accessKey: setAttribute() to 1.5]
+    expected: FAIL
+
+  [source.accessKey: setAttribute() to "5%"]
+    expected: FAIL
+
+  [source.accessKey: setAttribute() to "+100"]
+    expected: FAIL
+
+  [source.accessKey: setAttribute() to ".5"]
+    expected: FAIL
+
+  [source.accessKey: setAttribute() to true]
+    expected: FAIL
+
+  [source.accessKey: setAttribute() to false]
+    expected: FAIL
+
+  [source.accessKey: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [source.accessKey: setAttribute() to NaN]
+    expected: FAIL
+
+  [source.accessKey: setAttribute() to Infinity]
+    expected: FAIL
+
+  [source.accessKey: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [source.accessKey: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [source.accessKey: setAttribute() to null]
+    expected: FAIL
+
+  [source.accessKey: setAttribute() to object "test-toString"]
+    expected: FAIL
+
+  [source.accessKey: setAttribute() to object "test-valueOf"]
+    expected: FAIL
+
+  [source.accessKey: IDL set to ""]
+    expected: FAIL
+
+  [source.accessKey: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [source.accessKey: IDL set to undefined]
+    expected: FAIL
+
+  [source.accessKey: IDL set to 7]
+    expected: FAIL
+
+  [source.accessKey: IDL set to 1.5]
+    expected: FAIL
+
+  [source.accessKey: IDL set to "5%"]
+    expected: FAIL
+
+  [source.accessKey: IDL set to "+100"]
+    expected: FAIL
+
+  [source.accessKey: IDL set to ".5"]
+    expected: FAIL
+
+  [source.accessKey: IDL set to true]
+    expected: FAIL
+
+  [source.accessKey: IDL set to false]
+    expected: FAIL
+
+  [source.accessKey: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [source.accessKey: IDL set to NaN]
+    expected: FAIL
+
+  [source.accessKey: IDL set to Infinity]
+    expected: FAIL
+
+  [source.accessKey: IDL set to -Infinity]
+    expected: FAIL
+
+  [source.accessKey: IDL set to "\\0"]
+    expected: FAIL
+
+  [source.accessKey: IDL set to null]
+    expected: FAIL
+
+  [source.accessKey: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [source.accessKey: IDL set to object "test-valueOf"]
+    expected: FAIL
+
+  [source.tabIndex: typeof IDL attribute]
+    expected: FAIL
+
+  [source.tabIndex: setAttribute() to -36]
+    expected: FAIL
+
+  [source.tabIndex: setAttribute() to -1]
+    expected: FAIL
+
+  [source.tabIndex: setAttribute() to 0]
+    expected: FAIL
+
+  [source.tabIndex: setAttribute() to 1]
+    expected: FAIL
+
+  [source.tabIndex: setAttribute() to 2147483647]
+    expected: FAIL
+
+  [source.tabIndex: setAttribute() to -2147483648]
+    expected: FAIL
+
+  [source.tabIndex: setAttribute() to "-1"]
+    expected: FAIL
+
+  [source.tabIndex: setAttribute() to "-0"]
+    expected: FAIL
+
+  [source.tabIndex: setAttribute() to "0"]
+    expected: FAIL
+
+  [source.tabIndex: setAttribute() to "1"]
+    expected: FAIL
+
+  [source.tabIndex: setAttribute() to "\\t7"]
+    expected: FAIL
+
+  [source.tabIndex: setAttribute() to "\\f7"]
+    expected: FAIL
+
+  [source.tabIndex: setAttribute() to " 7"]
+    expected: FAIL
+
+  [source.tabIndex: setAttribute() to "\\n7"]
+    expected: FAIL
+
+  [source.tabIndex: setAttribute() to "\\r7"]
+    expected: FAIL
+
+  [source.tabIndex: setAttribute() to "7\\v"]
+    expected: FAIL
+
+  [source.tabIndex: setAttribute() to 1.5]
+    expected: FAIL
+
+  [source.tabIndex: setAttribute() to "5%"]
+    expected: FAIL
+
+  [source.tabIndex: setAttribute() to "+100"]
+    expected: FAIL
+
+  [source.tabIndex: setAttribute() to object "2"]
+    expected: FAIL
+
+  [source.tabIndex: setAttribute() to object "3"]
+    expected: FAIL
+
+  [source.tabIndex: IDL set to -36]
+    expected: FAIL
+
+  [source.tabIndex: IDL set to -1]
+    expected: FAIL
+
+  [source.tabIndex: IDL set to 0]
+    expected: FAIL
+
+  [source.tabIndex: IDL set to 1]
+    expected: FAIL
+
+  [source.tabIndex: IDL set to 2147483647]
+    expected: FAIL
+
+  [source.tabIndex: IDL set to -2147483648]
+    expected: FAIL
+
+  [source.srcset: setAttribute() to ""]
+    expected: FAIL
+
+  [source.srcset: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [source.srcset: setAttribute() to undefined]
+    expected: FAIL
+
+  [source.srcset: setAttribute() to 7]
+    expected: FAIL
+
+  [source.srcset: setAttribute() to 1.5]
+    expected: FAIL
+
+  [source.srcset: setAttribute() to "5%"]
+    expected: FAIL
+
+  [source.srcset: setAttribute() to "+100"]
+    expected: FAIL
+
+  [source.srcset: setAttribute() to ".5"]
+    expected: FAIL
+
+  [source.srcset: setAttribute() to true]
+    expected: FAIL
+
+  [source.srcset: setAttribute() to false]
+    expected: FAIL
+
+  [source.srcset: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [source.srcset: setAttribute() to NaN]
+    expected: FAIL
+
+  [source.srcset: setAttribute() to Infinity]
+    expected: FAIL
+
+  [source.srcset: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [source.srcset: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [source.srcset: setAttribute() to null]
+    expected: FAIL
+
+  [source.srcset: setAttribute() to object "test-toString"]
+    expected: FAIL
+
+  [source.srcset: setAttribute() to object "test-valueOf"]
+    expected: FAIL
+
+  [source.srcset: IDL set to ""]
+    expected: FAIL
+
+  [source.srcset: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [source.srcset: IDL set to undefined]
+    expected: FAIL
+
+  [source.srcset: IDL set to 7]
+    expected: FAIL
+
+  [source.srcset: IDL set to 1.5]
+    expected: FAIL
+
+  [source.srcset: IDL set to "5%"]
+    expected: FAIL
+
+  [source.srcset: IDL set to "+100"]
+    expected: FAIL
+
+  [source.srcset: IDL set to ".5"]
+    expected: FAIL
+
+  [source.srcset: IDL set to true]
+    expected: FAIL
+
+  [source.srcset: IDL set to false]
+    expected: FAIL
+
+  [source.srcset: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [source.srcset: IDL set to NaN]
+    expected: FAIL
+
+  [source.srcset: IDL set to Infinity]
+    expected: FAIL
+
+  [source.srcset: IDL set to -Infinity]
+    expected: FAIL
+
+  [source.srcset: IDL set to "\\0"]
+    expected: FAIL
+
+  [source.srcset: IDL set to null]
+    expected: FAIL
+
+  [source.srcset: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [source.srcset: IDL set to object "test-valueOf"]
+    expected: FAIL
+
+  [track.accessKey: typeof IDL attribute]
+    expected: FAIL
+
+  [track.accessKey: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [track.accessKey: setAttribute() to ""]
+    expected: FAIL
+
+  [track.accessKey: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [track.accessKey: setAttribute() to undefined]
+    expected: FAIL
+
+  [track.accessKey: setAttribute() to 7]
+    expected: FAIL
+
+  [track.accessKey: setAttribute() to 1.5]
+    expected: FAIL
+
+  [track.accessKey: setAttribute() to "5%"]
+    expected: FAIL
+
+  [track.accessKey: setAttribute() to "+100"]
+    expected: FAIL
+
+  [track.accessKey: setAttribute() to ".5"]
+    expected: FAIL
+
+  [track.accessKey: setAttribute() to true]
+    expected: FAIL
+
+  [track.accessKey: setAttribute() to false]
+    expected: FAIL
+
+  [track.accessKey: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [track.accessKey: setAttribute() to NaN]
+    expected: FAIL
+
+  [track.accessKey: setAttribute() to Infinity]
+    expected: FAIL
+
+  [track.accessKey: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [track.accessKey: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [track.accessKey: setAttribute() to null]
+    expected: FAIL
+
+  [track.accessKey: setAttribute() to object "test-toString"]
+    expected: FAIL
+
+  [track.accessKey: setAttribute() to object "test-valueOf"]
+    expected: FAIL
+
+  [track.accessKey: IDL set to ""]
+    expected: FAIL
+
+  [track.accessKey: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [track.accessKey: IDL set to undefined]
+    expected: FAIL
+
+  [track.accessKey: IDL set to 7]
+    expected: FAIL
+
+  [track.accessKey: IDL set to 1.5]
+    expected: FAIL
+
+  [track.accessKey: IDL set to "5%"]
+    expected: FAIL
+
+  [track.accessKey: IDL set to "+100"]
+    expected: FAIL
+
+  [track.accessKey: IDL set to ".5"]
+    expected: FAIL
+
+  [track.accessKey: IDL set to true]
+    expected: FAIL
+
+  [track.accessKey: IDL set to false]
+    expected: FAIL
+
+  [track.accessKey: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [track.accessKey: IDL set to NaN]
+    expected: FAIL
+
+  [track.accessKey: IDL set to Infinity]
+    expected: FAIL
+
+  [track.accessKey: IDL set to -Infinity]
+    expected: FAIL
+
+  [track.accessKey: IDL set to "\\0"]
+    expected: FAIL
+
+  [track.accessKey: IDL set to null]
+    expected: FAIL
+
+  [track.accessKey: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [track.accessKey: IDL set to object "test-valueOf"]
+    expected: FAIL
+
+  [track.tabIndex: typeof IDL attribute]
+    expected: FAIL
+
+  [track.tabIndex: setAttribute() to -36]
+    expected: FAIL
+
+  [track.tabIndex: setAttribute() to -1]
+    expected: FAIL
+
+  [track.tabIndex: setAttribute() to 0]
+    expected: FAIL
+
+  [track.tabIndex: setAttribute() to 1]
+    expected: FAIL
+
+  [track.tabIndex: setAttribute() to 2147483647]
+    expected: FAIL
+
+  [track.tabIndex: setAttribute() to -2147483648]
+    expected: FAIL
+
+  [track.tabIndex: setAttribute() to "-1"]
+    expected: FAIL
+
+  [track.tabIndex: setAttribute() to "-0"]
+    expected: FAIL
+
+  [track.tabIndex: setAttribute() to "0"]
+    expected: FAIL
+
+  [track.tabIndex: setAttribute() to "1"]
+    expected: FAIL
+
+  [track.tabIndex: setAttribute() to "\\t7"]
+    expected: FAIL
+
+  [track.tabIndex: setAttribute() to "\\f7"]
+    expected: FAIL
+
+  [track.tabIndex: setAttribute() to " 7"]
+    expected: FAIL
+
+  [track.tabIndex: setAttribute() to "\\n7"]
+    expected: FAIL
+
+  [track.tabIndex: setAttribute() to "\\r7"]
+    expected: FAIL
+
+  [track.tabIndex: setAttribute() to "7\\v"]
+    expected: FAIL
+
+  [track.tabIndex: setAttribute() to 1.5]
+    expected: FAIL
+
+  [track.tabIndex: setAttribute() to "5%"]
+    expected: FAIL
+
+  [track.tabIndex: setAttribute() to "+100"]
+    expected: FAIL
+
+  [track.tabIndex: setAttribute() to object "2"]
+    expected: FAIL
+
+  [track.tabIndex: setAttribute() to object "3"]
+    expected: FAIL
+
+  [track.tabIndex: IDL set to -36]
+    expected: FAIL
+
+  [track.tabIndex: IDL set to -1]
+    expected: FAIL
+
+  [track.tabIndex: IDL set to 0]
+    expected: FAIL
+
+  [track.tabIndex: IDL set to 1]
+    expected: FAIL
+
+  [track.tabIndex: IDL set to 2147483647]
+    expected: FAIL
+
+  [track.tabIndex: IDL set to -2147483648]
+    expected: FAIL
+
+  [track.kind: setAttribute() to ""]
+    expected: FAIL
+
+  [track.kind: IDL set to ""]
+    expected: FAIL
+
+  [canvas.accessKey: typeof IDL attribute]
+    expected: FAIL
+
+  [canvas.accessKey: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [canvas.accessKey: setAttribute() to ""]
+    expected: FAIL
+
+  [canvas.accessKey: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [canvas.accessKey: setAttribute() to undefined]
+    expected: FAIL
+
+  [canvas.accessKey: setAttribute() to 7]
+    expected: FAIL
+
+  [canvas.accessKey: setAttribute() to 1.5]
+    expected: FAIL
+
+  [canvas.accessKey: setAttribute() to "5%"]
+    expected: FAIL
+
+  [canvas.accessKey: setAttribute() to "+100"]
+    expected: FAIL
+
+  [canvas.accessKey: setAttribute() to ".5"]
+    expected: FAIL
+
+  [canvas.accessKey: setAttribute() to true]
+    expected: FAIL
+
+  [canvas.accessKey: setAttribute() to false]
+    expected: FAIL
+
+  [canvas.accessKey: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [canvas.accessKey: setAttribute() to NaN]
+    expected: FAIL
+
+  [canvas.accessKey: setAttribute() to Infinity]
+    expected: FAIL
+
+  [canvas.accessKey: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [canvas.accessKey: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [canvas.accessKey: setAttribute() to null]
+    expected: FAIL
+
+  [canvas.accessKey: setAttribute() to object "test-toString"]
+    expected: FAIL
+
+  [canvas.accessKey: setAttribute() to object "test-valueOf"]
+    expected: FAIL
+
+  [canvas.accessKey: IDL set to ""]
+    expected: FAIL
+
+  [canvas.accessKey: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [canvas.accessKey: IDL set to undefined]
+    expected: FAIL
+
+  [canvas.accessKey: IDL set to 7]
+    expected: FAIL
+
+  [canvas.accessKey: IDL set to 1.5]
+    expected: FAIL
+
+  [canvas.accessKey: IDL set to "5%"]
+    expected: FAIL
+
+  [canvas.accessKey: IDL set to "+100"]
+    expected: FAIL
+
+  [canvas.accessKey: IDL set to ".5"]
+    expected: FAIL
+
+  [canvas.accessKey: IDL set to true]
+    expected: FAIL
+
+  [canvas.accessKey: IDL set to false]
+    expected: FAIL
+
+  [canvas.accessKey: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [canvas.accessKey: IDL set to NaN]
+    expected: FAIL
+
+  [canvas.accessKey: IDL set to Infinity]
+    expected: FAIL
+
+  [canvas.accessKey: IDL set to -Infinity]
+    expected: FAIL
+
+  [canvas.accessKey: IDL set to "\\0"]
+    expected: FAIL
+
+  [canvas.accessKey: IDL set to null]
+    expected: FAIL
+
+  [canvas.accessKey: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [canvas.accessKey: IDL set to object "test-valueOf"]
+    expected: FAIL
+
+  [canvas.tabIndex: typeof IDL attribute]
+    expected: FAIL
+
+  [canvas.tabIndex: setAttribute() to -36]
+    expected: FAIL
+
+  [canvas.tabIndex: setAttribute() to -1]
+    expected: FAIL
+
+  [canvas.tabIndex: setAttribute() to 0]
+    expected: FAIL
+
+  [canvas.tabIndex: setAttribute() to 1]
+    expected: FAIL
+
+  [canvas.tabIndex: setAttribute() to 2147483647]
+    expected: FAIL
+
+  [canvas.tabIndex: setAttribute() to -2147483648]
+    expected: FAIL
+
+  [canvas.tabIndex: setAttribute() to "-1"]
+    expected: FAIL
+
+  [canvas.tabIndex: setAttribute() to "-0"]
+    expected: FAIL
+
+  [canvas.tabIndex: setAttribute() to "0"]
+    expected: FAIL
+
+  [canvas.tabIndex: setAttribute() to "1"]
+    expected: FAIL
+
+  [canvas.tabIndex: setAttribute() to "\\t7"]
+    expected: FAIL
+
+  [canvas.tabIndex: setAttribute() to "\\f7"]
+    expected: FAIL
+
+  [canvas.tabIndex: setAttribute() to " 7"]
+    expected: FAIL
+
+  [canvas.tabIndex: setAttribute() to "\\n7"]
+    expected: FAIL
+
+  [canvas.tabIndex: setAttribute() to "\\r7"]
+    expected: FAIL
+
+  [canvas.tabIndex: setAttribute() to "7\\v"]
+    expected: FAIL
+
+  [canvas.tabIndex: setAttribute() to 1.5]
+    expected: FAIL
+
+  [canvas.tabIndex: setAttribute() to "5%"]
+    expected: FAIL
+
+  [canvas.tabIndex: setAttribute() to "+100"]
+    expected: FAIL
+
+  [canvas.tabIndex: setAttribute() to object "2"]
+    expected: FAIL
+
+  [canvas.tabIndex: setAttribute() to object "3"]
+    expected: FAIL
+
+  [canvas.tabIndex: IDL set to -36]
+    expected: FAIL
+
+  [canvas.tabIndex: IDL set to -1]
+    expected: FAIL
+
+  [canvas.tabIndex: IDL set to 0]
+    expected: FAIL
+
+  [canvas.tabIndex: IDL set to 1]
+    expected: FAIL
+
+  [canvas.tabIndex: IDL set to 2147483647]
+    expected: FAIL
+
+  [canvas.tabIndex: IDL set to -2147483648]
+    expected: FAIL
+
+  [map.accessKey: typeof IDL attribute]
+    expected: FAIL
+
+  [map.accessKey: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [map.accessKey: setAttribute() to ""]
+    expected: FAIL
+
+  [map.accessKey: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [map.accessKey: setAttribute() to undefined]
+    expected: FAIL
+
+  [map.accessKey: setAttribute() to 7]
+    expected: FAIL
+
+  [map.accessKey: setAttribute() to 1.5]
+    expected: FAIL
+
+  [map.accessKey: setAttribute() to "5%"]
+    expected: FAIL
+
+  [map.accessKey: setAttribute() to "+100"]
+    expected: FAIL
+
+  [map.accessKey: setAttribute() to ".5"]
+    expected: FAIL
+
+  [map.accessKey: setAttribute() to true]
+    expected: FAIL
+
+  [map.accessKey: setAttribute() to false]
+    expected: FAIL
+
+  [map.accessKey: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [map.accessKey: setAttribute() to NaN]
+    expected: FAIL
+
+  [map.accessKey: setAttribute() to Infinity]
+    expected: FAIL
+
+  [map.accessKey: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [map.accessKey: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [map.accessKey: setAttribute() to null]
+    expected: FAIL
+
+  [map.accessKey: setAttribute() to object "test-toString"]
+    expected: FAIL
+
+  [map.accessKey: setAttribute() to object "test-valueOf"]
+    expected: FAIL
+
+  [map.accessKey: IDL set to ""]
+    expected: FAIL
+
+  [map.accessKey: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [map.accessKey: IDL set to undefined]
+    expected: FAIL
+
+  [map.accessKey: IDL set to 7]
+    expected: FAIL
+
+  [map.accessKey: IDL set to 1.5]
+    expected: FAIL
+
+  [map.accessKey: IDL set to "5%"]
+    expected: FAIL
+
+  [map.accessKey: IDL set to "+100"]
+    expected: FAIL
+
+  [map.accessKey: IDL set to ".5"]
+    expected: FAIL
+
+  [map.accessKey: IDL set to true]
+    expected: FAIL
+
+  [map.accessKey: IDL set to false]
+    expected: FAIL
+
+  [map.accessKey: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [map.accessKey: IDL set to NaN]
+    expected: FAIL
+
+  [map.accessKey: IDL set to Infinity]
+    expected: FAIL
+
+  [map.accessKey: IDL set to -Infinity]
+    expected: FAIL
+
+  [map.accessKey: IDL set to "\\0"]
+    expected: FAIL
+
+  [map.accessKey: IDL set to null]
+    expected: FAIL
+
+  [map.accessKey: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [map.accessKey: IDL set to object "test-valueOf"]
+    expected: FAIL
+
+  [map.tabIndex: typeof IDL attribute]
+    expected: FAIL
+
+  [map.tabIndex: setAttribute() to -36]
+    expected: FAIL
+
+  [map.tabIndex: setAttribute() to -1]
+    expected: FAIL
+
+  [map.tabIndex: setAttribute() to 0]
+    expected: FAIL
+
+  [map.tabIndex: setAttribute() to 1]
+    expected: FAIL
+
+  [map.tabIndex: setAttribute() to 2147483647]
+    expected: FAIL
+
+  [map.tabIndex: setAttribute() to -2147483648]
+    expected: FAIL
+
+  [map.tabIndex: setAttribute() to "-1"]
+    expected: FAIL
+
+  [map.tabIndex: setAttribute() to "-0"]
+    expected: FAIL
+
+  [map.tabIndex: setAttribute() to "0"]
+    expected: FAIL
+
+  [map.tabIndex: setAttribute() to "1"]
+    expected: FAIL
+
+  [map.tabIndex: setAttribute() to "\\t7"]
+    expected: FAIL
+
+  [map.tabIndex: setAttribute() to "\\f7"]
+    expected: FAIL
+
+  [map.tabIndex: setAttribute() to " 7"]
+    expected: FAIL
+
+  [map.tabIndex: setAttribute() to "\\n7"]
+    expected: FAIL
+
+  [map.tabIndex: setAttribute() to "\\r7"]
+    expected: FAIL
+
+  [map.tabIndex: setAttribute() to "7\\v"]
+    expected: FAIL
+
+  [map.tabIndex: setAttribute() to 1.5]
+    expected: FAIL
+
+  [map.tabIndex: setAttribute() to "5%"]
+    expected: FAIL
+
+  [map.tabIndex: setAttribute() to "+100"]
+    expected: FAIL
+
+  [map.tabIndex: setAttribute() to object "2"]
+    expected: FAIL
+
+  [map.tabIndex: setAttribute() to object "3"]
+    expected: FAIL
+
+  [map.tabIndex: IDL set to -36]
+    expected: FAIL
+
+  [map.tabIndex: IDL set to -1]
+    expected: FAIL
+
+  [map.tabIndex: IDL set to 0]
+    expected: FAIL
+
+  [map.tabIndex: IDL set to 1]
+    expected: FAIL
+
+  [map.tabIndex: IDL set to 2147483647]
+    expected: FAIL
+
+  [map.tabIndex: IDL set to -2147483648]
+    expected: FAIL
+
+  [map.name: typeof IDL attribute]
+    expected: FAIL
+
+  [map.name: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [map.name: setAttribute() to ""]
+    expected: FAIL
+
+  [map.name: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [map.name: setAttribute() to undefined]
+    expected: FAIL
+
+  [map.name: setAttribute() to 7]
+    expected: FAIL
+
+  [map.name: setAttribute() to 1.5]
+    expected: FAIL
+
+  [map.name: setAttribute() to "5%"]
+    expected: FAIL
+
+  [map.name: setAttribute() to "+100"]
+    expected: FAIL
+
+  [map.name: setAttribute() to ".5"]
+    expected: FAIL
+
+  [map.name: setAttribute() to true]
+    expected: FAIL
+
+  [map.name: setAttribute() to false]
+    expected: FAIL
+
+  [map.name: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [map.name: setAttribute() to NaN]
+    expected: FAIL
+
+  [map.name: setAttribute() to Infinity]
+    expected: FAIL
+
+  [map.name: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [map.name: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [map.name: setAttribute() to null]
+    expected: FAIL
+
+  [map.name: setAttribute() to object "test-toString"]
+    expected: FAIL
+
+  [map.name: setAttribute() to object "test-valueOf"]
+    expected: FAIL
+
+  [map.name: IDL set to ""]
+    expected: FAIL
+
+  [map.name: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [map.name: IDL set to undefined]
+    expected: FAIL
+
+  [map.name: IDL set to 7]
+    expected: FAIL
+
+  [map.name: IDL set to 1.5]
+    expected: FAIL
+
+  [map.name: IDL set to "5%"]
+    expected: FAIL
+
+  [map.name: IDL set to "+100"]
+    expected: FAIL
+
+  [map.name: IDL set to ".5"]
+    expected: FAIL
+
+  [map.name: IDL set to true]
+    expected: FAIL
+
+  [map.name: IDL set to false]
+    expected: FAIL
+
+  [map.name: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [map.name: IDL set to NaN]
+    expected: FAIL
+
+  [map.name: IDL set to Infinity]
+    expected: FAIL
+
+  [map.name: IDL set to -Infinity]
+    expected: FAIL
+
+  [map.name: IDL set to "\\0"]
+    expected: FAIL
+
+  [map.name: IDL set to null]
+    expected: FAIL
+
+  [map.name: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [map.name: IDL set to object "test-valueOf"]
+    expected: FAIL
+
+  [area.accessKey: typeof IDL attribute]
+    expected: FAIL
+
+  [area.accessKey: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [area.accessKey: setAttribute() to ""]
+    expected: FAIL
+
+  [area.accessKey: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [area.accessKey: setAttribute() to undefined]
+    expected: FAIL
+
+  [area.accessKey: setAttribute() to 7]
+    expected: FAIL
+
+  [area.accessKey: setAttribute() to 1.5]
+    expected: FAIL
+
+  [area.accessKey: setAttribute() to "5%"]
+    expected: FAIL
+
+  [area.accessKey: setAttribute() to "+100"]
+    expected: FAIL
+
+  [area.accessKey: setAttribute() to ".5"]
+    expected: FAIL
+
+  [area.accessKey: setAttribute() to true]
+    expected: FAIL
+
+  [area.accessKey: setAttribute() to false]
+    expected: FAIL
+
+  [area.accessKey: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [area.accessKey: setAttribute() to NaN]
+    expected: FAIL
+
+  [area.accessKey: setAttribute() to Infinity]
+    expected: FAIL
+
+  [area.accessKey: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [area.accessKey: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [area.accessKey: setAttribute() to null]
+    expected: FAIL
+
+  [area.accessKey: setAttribute() to object "test-toString"]
+    expected: FAIL
+
+  [area.accessKey: setAttribute() to object "test-valueOf"]
+    expected: FAIL
+
+  [area.accessKey: IDL set to ""]
+    expected: FAIL
+
+  [area.accessKey: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [area.accessKey: IDL set to undefined]
+    expected: FAIL
+
+  [area.accessKey: IDL set to 7]
+    expected: FAIL
+
+  [area.accessKey: IDL set to 1.5]
+    expected: FAIL
+
+  [area.accessKey: IDL set to "5%"]
+    expected: FAIL
+
+  [area.accessKey: IDL set to "+100"]
+    expected: FAIL
+
+  [area.accessKey: IDL set to ".5"]
+    expected: FAIL
+
+  [area.accessKey: IDL set to true]
+    expected: FAIL
+
+  [area.accessKey: IDL set to false]
+    expected: FAIL
+
+  [area.accessKey: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [area.accessKey: IDL set to NaN]
+    expected: FAIL
+
+  [area.accessKey: IDL set to Infinity]
+    expected: FAIL
+
+  [area.accessKey: IDL set to -Infinity]
+    expected: FAIL
+
+  [area.accessKey: IDL set to "\\0"]
+    expected: FAIL
+
+  [area.accessKey: IDL set to null]
+    expected: FAIL
+
+  [area.accessKey: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [area.accessKey: IDL set to object "test-valueOf"]
+    expected: FAIL
+
+  [area.tabIndex: typeof IDL attribute]
+    expected: FAIL
+
+  [area.tabIndex: setAttribute() to -36]
+    expected: FAIL
+
+  [area.tabIndex: setAttribute() to -1]
+    expected: FAIL
+
+  [area.tabIndex: setAttribute() to 0]
+    expected: FAIL
+
+  [area.tabIndex: setAttribute() to 1]
+    expected: FAIL
+
+  [area.tabIndex: setAttribute() to 2147483647]
+    expected: FAIL
+
+  [area.tabIndex: setAttribute() to -2147483648]
+    expected: FAIL
+
+  [area.tabIndex: setAttribute() to "-1"]
+    expected: FAIL
+
+  [area.tabIndex: setAttribute() to "-0"]
+    expected: FAIL
+
+  [area.tabIndex: setAttribute() to "0"]
+    expected: FAIL
+
+  [area.tabIndex: setAttribute() to "1"]
+    expected: FAIL
+
+  [area.tabIndex: setAttribute() to "\\t7"]
+    expected: FAIL
+
+  [area.tabIndex: setAttribute() to "\\f7"]
+    expected: FAIL
+
+  [area.tabIndex: setAttribute() to " 7"]
+    expected: FAIL
+
+  [area.tabIndex: setAttribute() to "\\n7"]
+    expected: FAIL
+
+  [area.tabIndex: setAttribute() to "\\r7"]
+    expected: FAIL
+
+  [area.tabIndex: setAttribute() to "7\\v"]
+    expected: FAIL
+
+  [area.tabIndex: setAttribute() to 1.5]
+    expected: FAIL
+
+  [area.tabIndex: setAttribute() to "5%"]
+    expected: FAIL
+
+  [area.tabIndex: setAttribute() to "+100"]
+    expected: FAIL
+
+  [area.tabIndex: setAttribute() to object "2"]
+    expected: FAIL
+
+  [area.tabIndex: setAttribute() to object "3"]
+    expected: FAIL
+
+  [area.tabIndex: IDL set to -36]
+    expected: FAIL
+
+  [area.tabIndex: IDL set to -1]
+    expected: FAIL
+
+  [area.tabIndex: IDL set to 0]
+    expected: FAIL
+
+  [area.tabIndex: IDL set to 1]
+    expected: FAIL
+
+  [area.tabIndex: IDL set to 2147483647]
+    expected: FAIL
+
+  [area.tabIndex: IDL set to -2147483648]
+    expected: FAIL
+
+  [area.alt: typeof IDL attribute]
+    expected: FAIL
+
+  [area.alt: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [area.alt: setAttribute() to ""]
+    expected: FAIL
+
+  [area.alt: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [area.alt: setAttribute() to undefined]
+    expected: FAIL
+
+  [area.alt: setAttribute() to 7]
+    expected: FAIL
+
+  [area.alt: setAttribute() to 1.5]
+    expected: FAIL
+
+  [area.alt: setAttribute() to "5%"]
+    expected: FAIL
+
+  [area.alt: setAttribute() to "+100"]
+    expected: FAIL
+
+  [area.alt: setAttribute() to ".5"]
+    expected: FAIL
+
+  [area.alt: setAttribute() to true]
+    expected: FAIL
+
+  [area.alt: setAttribute() to false]
+    expected: FAIL
+
+  [area.alt: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [area.alt: setAttribute() to NaN]
+    expected: FAIL
+
+  [area.alt: setAttribute() to Infinity]
+    expected: FAIL
+
+  [area.alt: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [area.alt: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [area.alt: setAttribute() to null]
+    expected: FAIL
+
+  [area.alt: setAttribute() to object "test-toString"]
+    expected: FAIL
+
+  [area.alt: setAttribute() to object "test-valueOf"]
+    expected: FAIL
+
+  [area.alt: IDL set to ""]
+    expected: FAIL
+
+  [area.alt: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [area.alt: IDL set to undefined]
+    expected: FAIL
+
+  [area.alt: IDL set to 7]
+    expected: FAIL
+
+  [area.alt: IDL set to 1.5]
+    expected: FAIL
+
+  [area.alt: IDL set to "5%"]
+    expected: FAIL
+
+  [area.alt: IDL set to "+100"]
+    expected: FAIL
+
+  [area.alt: IDL set to ".5"]
+    expected: FAIL
+
+  [area.alt: IDL set to true]
+    expected: FAIL
+
+  [area.alt: IDL set to false]
+    expected: FAIL
+
+  [area.alt: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [area.alt: IDL set to NaN]
+    expected: FAIL
+
+  [area.alt: IDL set to Infinity]
+    expected: FAIL
+
+  [area.alt: IDL set to -Infinity]
+    expected: FAIL
+
+  [area.alt: IDL set to "\\0"]
+    expected: FAIL
+
+  [area.alt: IDL set to null]
+    expected: FAIL
+
+  [area.alt: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [area.alt: IDL set to object "test-valueOf"]
+    expected: FAIL
+
+  [area.coords: typeof IDL attribute]
+    expected: FAIL
+
+  [area.coords: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [area.coords: setAttribute() to ""]
+    expected: FAIL
+
+  [area.coords: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [area.coords: setAttribute() to undefined]
+    expected: FAIL
+
+  [area.coords: setAttribute() to 7]
+    expected: FAIL
+
+  [area.coords: setAttribute() to 1.5]
+    expected: FAIL
+
+  [area.coords: setAttribute() to "5%"]
+    expected: FAIL
+
+  [area.coords: setAttribute() to "+100"]
+    expected: FAIL
+
+  [area.coords: setAttribute() to ".5"]
+    expected: FAIL
+
+  [area.coords: setAttribute() to true]
+    expected: FAIL
+
+  [area.coords: setAttribute() to false]
+    expected: FAIL
+
+  [area.coords: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [area.coords: setAttribute() to NaN]
+    expected: FAIL
+
+  [area.coords: setAttribute() to Infinity]
+    expected: FAIL
+
+  [area.coords: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [area.coords: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [area.coords: setAttribute() to null]
+    expected: FAIL
+
+  [area.coords: setAttribute() to object "test-toString"]
+    expected: FAIL
+
+  [area.coords: setAttribute() to object "test-valueOf"]
+    expected: FAIL
+
+  [area.coords: IDL set to ""]
+    expected: FAIL
+
+  [area.coords: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [area.coords: IDL set to undefined]
+    expected: FAIL
+
+  [area.coords: IDL set to 7]
+    expected: FAIL
+
+  [area.coords: IDL set to 1.5]
+    expected: FAIL
+
+  [area.coords: IDL set to "5%"]
+    expected: FAIL
+
+  [area.coords: IDL set to "+100"]
+    expected: FAIL
+
+  [area.coords: IDL set to ".5"]
+    expected: FAIL
+
+  [area.coords: IDL set to true]
+    expected: FAIL
+
+  [area.coords: IDL set to false]
+    expected: FAIL
+
+  [area.coords: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [area.coords: IDL set to NaN]
+    expected: FAIL
+
+  [area.coords: IDL set to Infinity]
+    expected: FAIL
+
+  [area.coords: IDL set to -Infinity]
+    expected: FAIL
+
+  [area.coords: IDL set to "\\0"]
+    expected: FAIL
+
+  [area.coords: IDL set to null]
+    expected: FAIL
+
+  [area.coords: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [area.coords: IDL set to object "test-valueOf"]
+    expected: FAIL
+
+  [area.shape: typeof IDL attribute]
+    expected: FAIL
+
+  [area.shape: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [area.shape: setAttribute() to ""]
+    expected: FAIL
+
+  [area.shape: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [area.shape: setAttribute() to undefined]
+    expected: FAIL
+
+  [area.shape: setAttribute() to 7]
+    expected: FAIL
+
+  [area.shape: setAttribute() to 1.5]
+    expected: FAIL
+
+  [area.shape: setAttribute() to "5%"]
+    expected: FAIL
+
+  [area.shape: setAttribute() to "+100"]
+    expected: FAIL
+
+  [area.shape: setAttribute() to ".5"]
+    expected: FAIL
+
+  [area.shape: setAttribute() to true]
+    expected: FAIL
+
+  [area.shape: setAttribute() to false]
+    expected: FAIL
+
+  [area.shape: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [area.shape: setAttribute() to NaN]
+    expected: FAIL
+
+  [area.shape: setAttribute() to Infinity]
+    expected: FAIL
+
+  [area.shape: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [area.shape: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [area.shape: setAttribute() to null]
+    expected: FAIL
+
+  [area.shape: setAttribute() to object "test-toString"]
+    expected: FAIL
+
+  [area.shape: setAttribute() to object "test-valueOf"]
+    expected: FAIL
+
+  [area.shape: IDL set to ""]
+    expected: FAIL
+
+  [area.shape: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [area.shape: IDL set to undefined]
+    expected: FAIL
+
+  [area.shape: IDL set to 7]
+    expected: FAIL
+
+  [area.shape: IDL set to 1.5]
+    expected: FAIL
+
+  [area.shape: IDL set to "5%"]
+    expected: FAIL
+
+  [area.shape: IDL set to "+100"]
+    expected: FAIL
+
+  [area.shape: IDL set to ".5"]
+    expected: FAIL
+
+  [area.shape: IDL set to true]
+    expected: FAIL
+
+  [area.shape: IDL set to false]
+    expected: FAIL
+
+  [area.shape: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [area.shape: IDL set to NaN]
+    expected: FAIL
+
+  [area.shape: IDL set to Infinity]
+    expected: FAIL
+
+  [area.shape: IDL set to -Infinity]
+    expected: FAIL
+
+  [area.shape: IDL set to "\\0"]
+    expected: FAIL
+
+  [area.shape: IDL set to null]
+    expected: FAIL
+
+  [area.shape: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [area.shape: IDL set to object "test-valueOf"]
+    expected: FAIL
+
+  [area.download: typeof IDL attribute]
+    expected: FAIL
+
+  [area.download: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [area.download: setAttribute() to ""]
+    expected: FAIL
+
+  [area.download: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [area.download: setAttribute() to undefined]
+    expected: FAIL
+
+  [area.download: setAttribute() to 7]
+    expected: FAIL
+
+  [area.download: setAttribute() to 1.5]
+    expected: FAIL
+
+  [area.download: setAttribute() to "5%"]
+    expected: FAIL
+
+  [area.download: setAttribute() to "+100"]
+    expected: FAIL
+
+  [area.download: setAttribute() to ".5"]
+    expected: FAIL
+
+  [area.download: setAttribute() to true]
+    expected: FAIL
+
+  [area.download: setAttribute() to false]
+    expected: FAIL
+
+  [area.download: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [area.download: setAttribute() to NaN]
+    expected: FAIL
+
+  [area.download: setAttribute() to Infinity]
+    expected: FAIL
+
+  [area.download: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [area.download: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [area.download: setAttribute() to null]
+    expected: FAIL
+
+  [area.download: setAttribute() to object "test-toString"]
+    expected: FAIL
+
+  [area.download: setAttribute() to object "test-valueOf"]
+    expected: FAIL
+
+  [area.download: IDL set to ""]
+    expected: FAIL
+
+  [area.download: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [area.download: IDL set to undefined]
+    expected: FAIL
+
+  [area.download: IDL set to 7]
+    expected: FAIL
+
+  [area.download: IDL set to 1.5]
+    expected: FAIL
+
+  [area.download: IDL set to "5%"]
+    expected: FAIL
+
+  [area.download: IDL set to "+100"]
+    expected: FAIL
+
+  [area.download: IDL set to ".5"]
+    expected: FAIL
+
+  [area.download: IDL set to true]
+    expected: FAIL
+
+  [area.download: IDL set to false]
+    expected: FAIL
+
+  [area.download: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [area.download: IDL set to NaN]
+    expected: FAIL
+
+  [area.download: IDL set to Infinity]
+    expected: FAIL
+
+  [area.download: IDL set to -Infinity]
+    expected: FAIL
+
+  [area.download: IDL set to "\\0"]
+    expected: FAIL
+
+  [area.download: IDL set to null]
+    expected: FAIL
+
+  [area.download: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [area.download: IDL set to object "test-valueOf"]
+    expected: FAIL
+
+  [area.ping: typeof IDL attribute]
+    expected: FAIL
+
+  [area.ping: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [area.ping: setAttribute() to ""]
+    expected: FAIL
+
+  [area.ping: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [area.ping: setAttribute() to undefined]
+    expected: FAIL
+
+  [area.ping: setAttribute() to 7]
+    expected: FAIL
+
+  [area.ping: setAttribute() to 1.5]
+    expected: FAIL
+
+  [area.ping: setAttribute() to "5%"]
+    expected: FAIL
+
+  [area.ping: setAttribute() to "+100"]
+    expected: FAIL
+
+  [area.ping: setAttribute() to ".5"]
+    expected: FAIL
+
+  [area.ping: setAttribute() to true]
+    expected: FAIL
+
+  [area.ping: setAttribute() to false]
+    expected: FAIL
+
+  [area.ping: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [area.ping: setAttribute() to NaN]
+    expected: FAIL
+
+  [area.ping: setAttribute() to Infinity]
+    expected: FAIL
+
+  [area.ping: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [area.ping: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [area.ping: setAttribute() to null]
+    expected: FAIL
+
+  [area.ping: setAttribute() to object "test-toString"]
+    expected: FAIL
+
+  [area.ping: setAttribute() to object "test-valueOf"]
+    expected: FAIL
+
+  [area.ping: IDL set to ""]
+    expected: FAIL
+
+  [area.ping: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
+    expected: FAIL
+
+  [area.ping: IDL set to undefined]
+    expected: FAIL
+
+  [area.ping: IDL set to 7]
+    expected: FAIL
+
+  [area.ping: IDL set to 1.5]
+    expected: FAIL
+
+  [area.ping: IDL set to "5%"]
+    expected: FAIL
+
+  [area.ping: IDL set to "+100"]
+    expected: FAIL
+
+  [area.ping: IDL set to ".5"]
+    expected: FAIL
+
+  [area.ping: IDL set to true]
+    expected: FAIL
+
+  [area.ping: IDL set to false]
+    expected: FAIL
+
+  [area.ping: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [area.ping: IDL set to NaN]
+    expected: FAIL
+
+  [area.ping: IDL set to Infinity]
+    expected: FAIL
+
+  [area.ping: IDL set to -Infinity]
+    expected: FAIL
+
+  [area.ping: IDL set to "\\0"]
+    expected: FAIL
+
+  [area.ping: IDL set to null]
+    expected: FAIL
+
+  [area.ping: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [area.ping: IDL set to object "test-valueOf"]
+    expected: FAIL
+
+  [area.noHref: typeof IDL attribute]
+    expected: FAIL
+
+  [area.noHref: IDL get with DOM attribute unset]
+    expected: FAIL
+
+  [area.noHref: setAttribute() to ""]
+    expected: FAIL
+
+  [area.noHref: setAttribute() to " foo "]
+    expected: FAIL
+
+  [area.noHref: setAttribute() to undefined]
+    expected: FAIL
+
+  [area.noHref: setAttribute() to null]
+    expected: FAIL
+
+  [area.noHref: setAttribute() to 7]
+    expected: FAIL
+
+  [area.noHref: setAttribute() to 1.5]
+    expected: FAIL
+
+  [area.noHref: setAttribute() to "5%"]
+    expected: FAIL
+
+  [area.noHref: setAttribute() to "+100"]
+    expected: FAIL
+
+  [area.noHref: setAttribute() to ".5"]
+    expected: FAIL
+
+  [area.noHref: setAttribute() to true]
+    expected: FAIL
+
+  [area.noHref: setAttribute() to false]
+    expected: FAIL
+
+  [area.noHref: setAttribute() to object "[object Object\]"]
+    expected: FAIL
+
+  [area.noHref: setAttribute() to NaN]
+    expected: FAIL
+
+  [area.noHref: setAttribute() to Infinity]
+    expected: FAIL
+
+  [area.noHref: setAttribute() to -Infinity]
+    expected: FAIL
+
+  [area.noHref: setAttribute() to "\\0"]
+    expected: FAIL
+
+  [area.noHref: setAttribute() to object "test-toString"]
+    expected: FAIL
+
+  [area.noHref: setAttribute() to object "test-valueOf"]
+    expected: FAIL
+
+  [area.noHref: setAttribute() to "noHref"]
+    expected: FAIL
+
+  [area.noHref: IDL set to ""]
+    expected: FAIL
+
+  [area.noHref: IDL set to " foo "]
+    expected: FAIL
+
+  [area.noHref: IDL set to undefined]
+    expected: FAIL
+
+  [area.noHref: IDL set to null]
+    expected: FAIL
+
+  [area.noHref: IDL set to 7]
+    expected: FAIL
+
+  [area.noHref: IDL set to 1.5]
+    expected: FAIL
+
+  [area.noHref: IDL set to "5%"]
+    expected: FAIL
+
+  [area.noHref: IDL set to "+100"]
+    expected: FAIL
+
+  [area.noHref: IDL set to ".5"]
+    expected: FAIL
+
+  [area.noHref: IDL set to false]
+    expected: FAIL
+
+  [area.noHref: IDL set to object "[object Object\]"]
+    expected: FAIL
+
+  [area.noHref: IDL set to NaN]
+    expected: FAIL
+
+  [area.noHref: IDL set to Infinity]
+    expected: FAIL
+
+  [area.noHref: IDL set to -Infinity]
+    expected: FAIL
+
+  [area.noHref: IDL set to "\\0"]
+    expected: FAIL
+
+  [area.noHref: IDL set to object "test-toString"]
+    expected: FAIL
+
+  [area.noHref: IDL set to object "test-valueOf"]
+    expected: FAIL

--- a/tests/wpt/mozilla/meta/mozilla/sslfail.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/sslfail.html.ini
@@ -1,3 +1,0 @@
-[sslfail.html]
-  type: reftest
-  disabled: https://github.com/servo/servo/issues/10760

--- a/tests/wpt/webgl/meta/conformance/more/conformance/quickCheckAPI-S_V.html.ini
+++ b/tests/wpt/webgl/meta/conformance/more/conformance/quickCheckAPI-S_V.html.ini
@@ -1,2 +1,3 @@
 [quickCheckAPI-S_V.html]
-  disabled: https://github.com/servo/servo/issues/10656
+  [WebGL test #0]
+    expected: FAIL


### PR DESCRIPTION
These were disabled long ago, but nowadays the intermittent filter can
ignore them when they flake. In addition, running them will allow us to
know if they are still intermittent or not since all intermittent
failures are tracked in GitHub via mentions on issues.

Testing: This is a change to test configuration.
