### PR TITLE
layout: Use the viewport size as the `background-attachment: fixed` positioning area

### DIFF
--- a/components/layout/display_list/background.rs
+++ b/components/layout/display_list/background.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use app_units::Au;
-use euclid::{Point2D, Size2D, Vector2D};
+use euclid::{Size2D, Vector2D};
 use style::computed_values::background_attachment::SingleComputedValue as BackgroundAttachment;
 use style::computed_values::background_clip::single_value::T as Clip;
 use style::computed_values::background_origin::single_value::T as Origin;
@@ -15,7 +15,6 @@ use style::values::specified::background::{
 };
 use webrender_api::{self as wr, units};
 use wr::ClipChainId;
-use wr::units::LayoutSize;
 
 use crate::replaced::NaturalSizes;
 
@@ -66,8 +65,7 @@ impl<'a> BackgroundPainter<'a> {
         if &BackgroundAttachment::Fixed ==
             get_cyclic(&background.background_attachment.0, layer_index)
         {
-            let viewport_size = builder.compositor_info.viewport_size;
-            return units::LayoutRect::from_origin_and_size(Point2D::origin(), viewport_size);
+            return builder.compositor_info.viewport_size.into();
         }
 
         match get_cyclic(&background.background_clip.0, layer_index) {
@@ -132,6 +130,7 @@ impl<'a> BackgroundPainter<'a> {
     pub(super) fn positioning_area(
         &self,
         fragment_builder: &'a super::BuilderForBoxFragment,
+        builder: &mut super::DisplayListBuilder,
         layer_index: usize,
     ) -> units::LayoutRect {
         if let Some(positioning_area_override) = self.positioning_area_override {
@@ -150,14 +149,7 @@ impl<'a> BackgroundPainter<'a> {
                 Origin::PaddingBox => *fragment_builder.padding_rect(),
                 Origin::BorderBox => fragment_builder.border_rect,
             },
-            BackgroundAttachment::Fixed => {
-                // This isn't the viewport size because that rects larger than the viewport might be
-                // transformed down into areas smaller than the viewport.
-                units::LayoutRect::from_origin_and_size(
-                    Point2D::origin(),
-                    LayoutSize::new(f32::MAX, f32::MAX),
-                )
-            },
+            BackgroundAttachment::Fixed => builder.compositor_info.viewport_size.into(),
         }
     }
 }
@@ -170,7 +162,7 @@ pub(super) fn layout_layer(
     natural_sizes: NaturalSizes,
 ) -> Option<BackgroundLayer> {
     let painting_area = painter.painting_area(fragment_builder, builder, layer_index);
-    let positioning_area = painter.positioning_area(fragment_builder, layer_index);
+    let positioning_area = painter.positioning_area(fragment_builder, builder, layer_index);
     let common = painter.common_properties(fragment_builder, builder, layer_index, painting_area);
 
     // https://drafts.csswg.org/css-backgrounds/#background-size

--- a/tests/wpt/meta/css/CSS2/backgrounds/background-bg-pos-206.xht.ini
+++ b/tests/wpt/meta/css/CSS2/backgrounds/background-bg-pos-206.xht.ini
@@ -1,2 +1,0 @@
-[background-bg-pos-206.xht]
-  expected: FAIL


### PR DESCRIPTION
This fixes the combination of `background-attachment: fixed` and
`no-repeat`. The positioning of the background should be relative to the
viewport, so using an infinite rectangle breaks things like `center`.

I'm not sure what the original motivation of using an infinite rectangle here
and it doesn't seem to break any tests to stop using it.

Testing: This fixes `/css/CSS2/backgrounds/background-bg-pos-206.xht`.
Fixes #37082.
