### PR TITLE
imagebitmap: Make ImageBitmap serializable and transferable

### DIFF
--- a/components/script_bindings/webidls/ImageBitmap.webidl
+++ b/components/script_bindings/webidls/ImageBitmap.webidl
@@ -9,8 +9,7 @@
  * You are granted a license to use, reproduce and create derivative works of this document.
  */
 
-//[Exposed=(Window,Worker), Serializable, Transferable]
-[Exposed=(Window,Worker), Pref="dom_imagebitmap_enabled"]
+[Exposed=(Window,Worker), Serializable, Transferable, Pref="dom_imagebitmap_enabled"]
 interface ImageBitmap {
   readonly attribute unsigned long width;
   readonly attribute unsigned long height;

--- a/components/shared/base/id.rs
+++ b/components/shared/base/id.rs
@@ -371,6 +371,8 @@ namespace_id! {DomExceptionId, DomExceptionIndex, "DomException"}
 
 namespace_id! {HistoryStateId, HistoryStateIndex, "HistoryState"}
 
+namespace_id! {ImageBitmapId, ImageBitmapIndex, "ImageBitmap"}
+
 // We provide ids just for unit testing.
 pub const TEST_NAMESPACE: PipelineNamespaceId = PipelineNamespaceId(1234);
 #[allow(unsafe_code)]

--- a/components/shared/constellation/structured_data/mod.rs
+++ b/components/shared/constellation/structured_data/mod.rs
@@ -10,7 +10,7 @@ mod transferable;
 
 use std::collections::HashMap;
 
-use base::id::{BlobId, DomExceptionId, DomPointId, MessagePortId};
+use base::id::{BlobId, DomExceptionId, DomPointId, ImageBitmapId, MessagePortId};
 use log::warn;
 use malloc_size_of_derive::MallocSizeOf;
 use serde::{Deserialize, Serialize};
@@ -34,6 +34,10 @@ pub struct StructuredSerializedData {
     pub ports: Option<HashMap<MessagePortId, MessagePortImpl>>,
     /// Transform streams transferred objects.
     pub transform_streams: Option<HashMap<MessagePortId, TransformStreamData>>,
+    /// Serialized image bitmap objects.
+    pub image_bitmaps: Option<HashMap<ImageBitmapId, SerializableImageBitmap>>,
+    /// Transferred image bitmap objects.
+    pub transferred_image_bitmaps: Option<HashMap<ImageBitmapId, SerializableImageBitmap>>,
 }
 
 impl StructuredSerializedData {
@@ -42,6 +46,7 @@ impl StructuredSerializedData {
             field.as_ref().is_some_and(|h| h.is_empty())
         }
         match val {
+            Transferrable::ImageBitmap => is_field_empty(&self.transferred_image_bitmaps),
             Transferrable::MessagePort => is_field_empty(&self.ports),
             Transferrable::ReadableStream => is_field_empty(&self.ports),
             Transferrable::WritableStream => is_field_empty(&self.ports),

--- a/components/shared/constellation/structured_data/transferable.rs
+++ b/components/shared/constellation/structured_data/transferable.rs
@@ -24,6 +24,8 @@ pub struct TransformStreamData {
 /// All the DOM interfaces that can be transferred.
 #[derive(Clone, Copy, Debug, EnumIter)]
 pub enum Transferrable {
+    /// The `ImageBitmap` interface.
+    ImageBitmap,
     /// The `MessagePort` interface.
     MessagePort,
     /// The `ReadableStream` interface.

--- a/tests/wpt/meta/html/canvas/element/manual/imagebitmap/createImageBitmap-serializable.html.ini
+++ b/tests/wpt/meta/html/canvas/element/manual/imagebitmap/createImageBitmap-serializable.html.ini
@@ -5,13 +5,7 @@
   [Serialize ImageBitmap created from an HTMLVideoElement]
     expected: FAIL
 
-  [Serialize ImageBitmap created from an HTMLCanvasElement]
-    expected: FAIL
-
   [Serialize ImageBitmap created from an HTMLVideoElement from a data URL]
-    expected: FAIL
-
-  [Serialize ImageBitmap created from an OffscreenCanvas]
     expected: FAIL
 
   [Serialize ImageBitmap created from a vector HTMLImageElement]

--- a/tests/wpt/meta/html/canvas/element/manual/imagebitmap/createImageBitmap-transfer.html.ini
+++ b/tests/wpt/meta/html/canvas/element/manual/imagebitmap/createImageBitmap-transfer.html.ini
@@ -11,12 +11,6 @@
   [Transfer ImageBitmap created from a Blob]
     expected: FAIL
 
-  [Transfer ImageBitmap created from an HTMLCanvasElement]
-    expected: FAIL
-
-  [Transfer ImageBitmap created from an OffscreenCanvas]
-    expected: FAIL
-
   [Transfer ImageBitmap created from a bitmap HTMLImageElement]
     expected: FAIL
 

--- a/tests/wpt/meta/html/canvas/offscreen/manual/filter/offscreencanvas.filter.w.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/manual/filter/offscreencanvas.filter.w.html.ini
@@ -1,3 +1,4 @@
 [offscreencanvas.filter.w.html]
+  expected: ERROR
   [offscreencanvas]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.js.ini
+++ b/tests/wpt/meta/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.js.ini
@@ -49,24 +49,6 @@
   [Object ImageData object, ImageData 1x1 non-transparent non-black]
     expected: FAIL
 
-  [ImageBitmap 1x1 transparent black]
-    expected: FAIL
-
-  [ImageBitmap 1x1 non-transparent non-black]
-    expected: FAIL
-
-  [Array ImageBitmap object, ImageBitmap 1x1 transparent black]
-    expected: FAIL
-
-  [Array ImageBitmap object, ImageBitmap 1x1 transparent non-black]
-    expected: FAIL
-
-  [Object ImageBitmap object, ImageBitmap 1x1 transparent black]
-    expected: FAIL
-
-  [Object ImageBitmap object, ImageBitmap 1x1 transparent non-black]
-    expected: FAIL
-
   [A subclass instance will deserialize as its closest serializable superclass]
     expected: FAIL
 

--- a/tests/wpt/meta/html/infrastructure/safe-passing-of-structured-data/transfer-errors.window.js.ini
+++ b/tests/wpt/meta/html/infrastructure/safe-passing-of-structured-data/transfer-errors.window.js.ini
@@ -5,13 +5,7 @@
   [Serialize should throw before a detached MessagePort is found]
     expected: FAIL
 
-  [Serialize should make the ImageBitmap detached, so it cannot be transferred again]
-    expected: FAIL
-
   [Serialize should throw before a detached ImageBitmap is found]
-    expected: FAIL
-
-  [Cannot transfer ImageBitmap detached while the message was serialized]
     expected: FAIL
 
   [Serialize should make the OffscreenCanvas detached, so it cannot be transferred again]

--- a/tests/wpt/meta/html/infrastructure/safe-passing-of-structured-data/window-postmessage.window.js.ini
+++ b/tests/wpt/meta/html/infrastructure/safe-passing-of-structured-data/window-postmessage.window.js.ini
@@ -29,24 +29,6 @@
   [Object ImageData object, ImageData 1x1 non-transparent non-black]
     expected: FAIL
 
-  [ImageBitmap 1x1 transparent black]
-    expected: FAIL
-
-  [ImageBitmap 1x1 non-transparent non-black]
-    expected: FAIL
-
-  [Array ImageBitmap object, ImageBitmap 1x1 transparent black]
-    expected: FAIL
-
-  [Array ImageBitmap object, ImageBitmap 1x1 transparent non-black]
-    expected: FAIL
-
-  [Object ImageBitmap object, ImageBitmap 1x1 transparent black]
-    expected: FAIL
-
-  [Object ImageBitmap object, ImageBitmap 1x1 transparent non-black]
-    expected: FAIL
-
   [A subclass instance will deserialize as its closest serializable superclass]
     expected: FAIL
 

--- a/tests/wpt/meta/html/webappapis/structured-clone/structured-clone.any.js.ini
+++ b/tests/wpt/meta/html/webappapis/structured-clone/structured-clone.any.js.ini
@@ -43,24 +43,6 @@
   [Object ImageData object, ImageData 1x1 non-transparent non-black]
     expected: FAIL
 
-  [ImageBitmap 1x1 transparent black]
-    expected: FAIL
-
-  [ImageBitmap 1x1 non-transparent non-black]
-    expected: FAIL
-
-  [Array ImageBitmap object, ImageBitmap 1x1 transparent black]
-    expected: FAIL
-
-  [Array ImageBitmap object, ImageBitmap 1x1 transparent non-black]
-    expected: FAIL
-
-  [Object ImageBitmap object, ImageBitmap 1x1 transparent black]
-    expected: FAIL
-
-  [Object ImageBitmap object, ImageBitmap 1x1 transparent non-black]
-    expected: FAIL
-
   [A subclass instance will deserialize as its closest serializable superclass]
     expected: FAIL
 

--- a/tests/wpt/meta/webmessaging/postMessage_cross_domain_image_transfer_2d.sub.htm.ini
+++ b/tests/wpt/meta/webmessaging/postMessage_cross_domain_image_transfer_2d.sub.htm.ini
@@ -1,9 +1,10 @@
 [postMessage_cross_domain_image_transfer_2d.sub.htm]
+  expected: TIMEOUT
   [sending 2D canvas ImageBitmap to http://web-platform.test:8000]
-    expected: FAIL
+    expected: TIMEOUT
 
   [sending 2D canvas ImageBitmap to http://www1.web-platform.test:8000]
-    expected: FAIL
+    expected: NOTRUN
 
   [sending 2D canvas ImageBitmap to http://not-web-platform.test:8000]
-    expected: FAIL
+    expected: NOTRUN

--- a/tests/wpt/meta/workers/semantics/structured-clone/dedicated.html.ini
+++ b/tests/wpt/meta/workers/semantics/structured-clone/dedicated.html.ini
@@ -32,24 +32,6 @@
   [Object with a getter that throws]
     expected: FAIL
 
-  [ImageBitmap 1x1 transparent black]
-    expected: FAIL
-
-  [ImageBitmap 1x1 non-transparent non-black]
-    expected: FAIL
-
-  [Array ImageBitmap object, ImageBitmap 1x1 transparent black]
-    expected: FAIL
-
-  [Array ImageBitmap object, ImageBitmap 1x1 transparent non-black]
-    expected: FAIL
-
-  [Object ImageBitmap object, ImageBitmap 1x1 transparent black]
-    expected: FAIL
-
-  [Object ImageBitmap object, ImageBitmap 1x1 transparent non-black]
-    expected: FAIL
-
   [A subclass instance will deserialize as its closest serializable superclass]
     expected: FAIL
 

--- a/third_party/WebIDL/WebIDL.py
+++ b/third_party/WebIDL/WebIDL.py
@@ -2106,6 +2106,7 @@ class IDLInterface(IDLInterfaceOrNamespace):
                 or identifier == "Serializable"
                 or identifier == "Abstract"
                 or identifier == "Inline"
+                or identifier == "Transferable"
             ):
                 # Known extended attributes that do not take values
                 if not attr.noArguments():

--- a/third_party/WebIDL/transferable.patch
+++ b/third_party/WebIDL/transferable.patch
@@ -1,0 +1,12 @@
+diff --git a/third_party/WebIDL/WebIDL.py b/third_party/WebIDL/WebIDL.py
+index 40e118e3781..bad5cbe54ca 100644
+--- a/third_party/WebIDL/WebIDL.py
++++ b/third_party/WebIDL/WebIDL.py
+@@ -2106,6 +2106,7 @@ class IDLInterface(IDLInterfaceOrNamespace):
+                 or identifier == "Serializable"
+                 or identifier == "Abstract"
+                 or identifier == "Inline"
++                or identifier == "Transferable"
+             ):
+                 # Known extended attributes that do not take values
+                 if not attr.noArguments():

--- a/third_party/WebIDL/update.sh
+++ b/third_party/WebIDL/update.sh
@@ -7,6 +7,7 @@ patch < inline.patch
 patch < like-as-iterable.patch
 patch < builtin-array.patch
 patch < array-type.patch
+patch < transferable.patch
 
 wget https://hg.mozilla.org/mozilla-central/archive/tip.zip/dom/bindings/parser/tests/ -O tests.zip
 rm -r tests


### PR DESCRIPTION
According to specification ImageBitmap objects are serializable objects and transferable objects.
https://html.spec.whatwg.org/multipage/#the-imagebitmap-interface:imagebitmap-11

Testing:
 - html/canvas/element/manual/imagebitmap/*
 - html/infrastructure/safe-passing-of-structured-data/*
 - html/webappapis/structured-clone/*
 - workers/semantics/structured-clone/*

