### PR TITLE
SVG Path stubs

### DIFF
--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -545,9 +545,12 @@ pub(crate) mod stylesheet;
 pub(crate) mod stylesheetlist;
 pub(crate) mod submitevent;
 pub(crate) mod subtlecrypto;
+pub(crate) mod svganimatednumber;
 pub(crate) mod svgelement;
+pub(crate) mod svggeometryelement;
 pub(crate) mod svggraphicselement;
 pub(crate) mod svgimageelement;
+pub(crate) mod svgpathelement;
 pub(crate) mod svgsvgelement;
 #[cfg(feature = "testbinding")]
 pub(crate) mod testbinding;

--- a/components/script/dom/svganimatednumber.rs
+++ b/components/script/dom/svganimatednumber.rs
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::cell::Cell;
+
+use dom_struct::dom_struct;
+use crate::dom::virtualmethods::VirtualMethods;
+
+#[dom_struct]
+pub(crate) struct SVGAnimatedNumber {
+    anim_val: f32,
+    base_val: Cell<f32>,
+}
+
+impl SVGAnimatedNumber {
+    // attribute float baseVal;
+    pub fn base_val(&self) -> f32 {
+        self.base_val.get()
+    }
+
+    pub fn set_base_val(&self, value: f32) {
+        self.base_val.set(value);
+    }
+
+    // readonly attribute float animVal;
+    pub fn anim_val(&self) -> f32 {
+        self.anim_val
+    }
+}
+
+impl VirtualMethods for SVGAnimatedNumber {
+    fn super_type(&self) -> Option<&dyn VirtualMethods> {
+        None
+    }
+}

--- a/components/script/dom/svggeometryelement.rs
+++ b/components/script/dom/svggeometryelement.rs
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use dom_struct::dom_struct;
+use html5ever::{LocalName, Prefix};
+use stylo_dom::ElementState;
+
+use crate::dom::bindings::inheritance::Castable;
+use crate::dom::document::Document;
+use crate::dom::svggraphicselement::SVGGraphicsElement;
+use crate::dom::svganimatednumber::SVGAnimatedNumber;
+use crate::dom::virtualmethods::VirtualMethods;
+
+#[dom_struct]
+pub(crate) struct SVGGeometryElement {
+    svggraphicelement: SVGGraphicsElement,
+}
+
+impl SVGGeometryElement {
+    pub(crate) fn new_inherited(
+        tag_name: LocalName,
+        prefix: Option<Prefix>,
+        document: &Document,
+    ) -> SVGGeometryElement {
+        SVGGeometryElement::new_inherited_with_state(
+            ElementState::empty(),
+            tag_name,
+            prefix,
+            document,
+        )
+    }
+
+    pub(crate) fn new_inherited_with_state(
+        state: ElementState,
+        tag_name: LocalName,
+        prefix: Option<Prefix>,
+        document: &Document,
+    ) -> SVGGeometryElement {
+        SVGGeometryElement {
+            svggraphicelement: SVGGraphicsElement::new_inherited_with_state(
+                state,
+                tag_name,
+                prefix,
+                document,
+            ),
+        }
+    }
+}
+
+impl VirtualMethods for SVGGeometryElement {
+    fn super_type(&self) -> Option<&dyn VirtualMethods> {
+        Some(self.upcast::<SVGGraphicsElement>() as &dyn VirtualMethods)
+    }
+}

--- a/components/script/dom/svgpathelement.rs
+++ b/components/script/dom/svgpathelement.rs
@@ -1,0 +1,54 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use dom_struct::dom_struct;
+use html5ever::{LocalName, Prefix};
+use stylo_dom::ElementState;
+
+use crate::dom::bindings::inheritance::Castable;
+use crate::dom::document::Document;
+use crate::dom::svggeometryelement::SVGGeometryElement;
+use crate::dom::virtualmethods::VirtualMethods;
+
+#[dom_struct]
+pub(crate) struct SVGPathElement {
+    svggeometryelement: SVGGeometryElement,
+}
+
+impl SVGPathElement {
+    pub(crate) fn new_inherited(
+        tag_name: LocalName,
+        prefix: Option<Prefix>,
+        document: &Document,
+    ) -> SVGPathElement {
+        SVGPathElement::new_inherited_with_state(
+            ElementState::empty(),
+            tag_name,
+            prefix,
+            document,
+        )
+    }
+
+    pub(crate) fn new_inherited_with_state(
+        state: ElementState,
+        tag_name: LocalName,
+        prefix: Option<Prefix>,
+        document: &Document,
+    ) -> SVGPathElement {
+        SVGPathElement {
+            svggeometryelement: SVGGeometryElement::new_inherited_with_state(
+                state,
+                tag_name,
+                prefix,
+                document,
+            ),
+        }
+    }
+}
+
+impl VirtualMethods for SVGPathElement {
+    fn super_type(&self) -> Option<&dyn VirtualMethods> {
+        Some(self.upcast::<SVGGeometryElement>() as &dyn VirtualMethods)
+    }
+}

--- a/components/script_bindings/webidls/SVGAnimatedNumber.webidl
+++ b/components/script_bindings/webidls/SVGAnimatedNumber.webidl
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// https://www.w3.org/TR/SVG/types.html#InterfaceSVGAnimatedNumber
+[Exposed=Window, Pref="dom_svg_enabled"]
+interface SVGAnimatedNumber {
+           attribute float baseVal;
+  readonly attribute float animVal;
+};

--- a/components/script_bindings/webidls/SVGGeometryElement.webidl
+++ b/components/script_bindings/webidls/SVGGeometryElement.webidl
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// https://www.w3.org/TR/SVG/types.html#InterfaceSVGGeometryElement
+[Exposed=Window, Pref="dom_svg_enabled"]
+interface SVGGeometryElement : SVGGraphicsElement {
+  // [SameObject] readonly attribute SVGAnimatedNumber pathLength;
+
+  // boolean isPointInFill(optional DOMPointInit point);
+  // boolean isPointInStroke(optional DOMPointInit point);
+  // float getTotalLength();
+  // DOMPoint getPointAtLength(float distance);
+};

--- a/components/script_bindings/webidls/SVGPathElement.webidl
+++ b/components/script_bindings/webidls/SVGPathElement.webidl
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// https://www.w3.org/TR/SVG/paths.html#InterfaceSVGPathElement
+[Exposed=Window, Pref="dom_svg_enabled"]
+interface SVGPathElement : SVGGeometryElement {
+};


### PR DESCRIPTION
Just stubs for SVG related dom interfaces. Related to #12973.

Adds interfaces for
- SvgAnimatedNumber
- SvgGeometryElement
- SvgPathElement
