### PR TITLE
Unconditionally enable the URLPattern API

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -116,10 +116,6 @@ pub struct Preferences {
     // https://testutils.spec.whatwg.org#availability
     pub dom_testutils_enabled: bool,
     pub dom_trusted_types_enabled: bool,
-    /// Enable the [URLPattern] API.
-    ///
-    /// [URLPattern]: https://developer.mozilla.org/en-US/docs/Web/API/URLPattern
-    pub dom_urlpattern_enabled: bool,
     pub dom_xpath_enabled: bool,
     /// Enable WebGL2 APIs.
     pub dom_webgl2_enabled: bool,
@@ -292,7 +288,6 @@ impl Preferences {
             dom_testperf_enabled: false,
             dom_testutils_enabled: false,
             dom_trusted_types_enabled: false,
-            dom_urlpattern_enabled: false,
             dom_webgl2_enabled: false,
             dom_webgpu_enabled: false,
             dom_webgpu_wgpu_backend: String::new(),

--- a/components/script_bindings/webidls/URLPattern.webidl
+++ b/components/script_bindings/webidls/URLPattern.webidl
@@ -6,7 +6,7 @@
 
 typedef (USVString or URLPatternInit)    URLPatternInput;
 
-[Exposed=(Window,Worker), Pref="dom_urlpattern_enabled"]
+[Exposed=(Window,Worker)]
 interface URLPattern {
   [Throws] constructor(URLPatternInput input, USVString baseURL, optional URLPatternOptions options = {});
   [Throws] constructor(optional URLPatternInput input = {}, optional URLPatternOptions options = {});

--- a/tests/wpt/meta/__dir__.ini
+++ b/tests/wpt/meta/__dir__.ini
@@ -1,5 +1,4 @@
 prefs: [
   "dom_serviceworker_enabled:true",
   "dom_testutils_enabled:true",
-  "dom_urlpattern_enabled:true",
 ]

--- a/tests/wpt/mozilla/meta/__dir__.ini
+++ b/tests/wpt/mozilla/meta/__dir__.ini
@@ -10,6 +10,5 @@ prefs: [
   "dom_testbinding_preference_value_string_empty:",
   "dom_testbinding_preference_value_string_test:test",
   "dom_testbinding_preference_value_truthy:true",
-  "dom_urlpattern_enabled:true",
   "media_testing_enabled:true",
 ]


### PR DESCRIPTION
We fail only a couple of the URLPattern tests and I think that's mostly due to bugs in the `urlpattern` crate.