### PR TITLE
script: Return global objects for DOM objects in the relevant realm

### DIFF
--- a/components/script_bindings/reflector.rs
+++ b/components/script_bindings/reflector.rs
@@ -8,7 +8,7 @@ use malloc_size_of_derive::MallocSizeOf;
 
 use crate::interfaces::GlobalScopeHelpers;
 use crate::iterable::{Iterable, IterableIterator};
-use crate::realms::{AlreadyInRealm, InRealm};
+use crate::realms::InRealm;
 use crate::root::{Dom, DomRoot, Root};
 use crate::script_runtime::{CanGc, JSContext};
 use crate::{DomTypes, JSTraceable};
@@ -107,17 +107,6 @@ pub trait DomGlobalGeneric<D: DomTypes>: DomObject {
         Self: Sized,
     {
         D::GlobalScope::from_reflector(self, realm)
-    }
-
-    /// Returns the [`GlobalScope`] of the realm that the [`DomObject`] was created in.  If this
-    /// object is a `Node`, this will be different from it's owning `Document` if adopted by. For
-    /// `Node`s it's almost always better to use `NodeTraits::owning_global`.
-    fn global(&self) -> DomRoot<D::GlobalScope>
-    where
-        Self: Sized,
-    {
-        let realm = AlreadyInRealm::assert_for_cx(D::GlobalScope::get_cx());
-        D::GlobalScope::from_reflector(self, InRealm::already(&realm))
     }
 }
 


### PR DESCRIPTION
DomObject::global is a tricky API because it's used pervasively but has subtle requirements that are not documented and not yet enforced by the type system (#36116). The method returns the relevant global object for a given DOM object, but that operation is only meaningful if there is an active realm. We usually, but not always, have an active realm.

This change avoids a footgun by following the principle of least surprise. Rather than making every single caller of `something.global()` both prove that there is an active realm and think about which realm they want active, we implement the obvious behaviour: always activate the realm of the callee before obtaining the relevant global.
 
Testing: Existing WPT coverage is sufficient; this method is called all over the codebase.
Fixes: #37070 #27037
