### PR TITLE
Rename `Stylesheet::Type_` to `Stylesheet::Type`

### DIFF
--- a/components/script/dom/stylesheet.rs
+++ b/components/script/dom/stylesheet.rs
@@ -39,8 +39,8 @@ impl StyleSheet {
 }
 
 impl StyleSheetMethods<crate::DomTypeHolder> for StyleSheet {
-    // https://drafts.csswg.org/cssom/#dom-stylesheet-type
-    fn Type_(&self) -> DOMString {
+    /// <https://drafts.csswg.org/cssom/#dom-stylesheet-type>
+    fn Type(&self) -> DOMString {
         self.type_.clone()
     }
 

--- a/components/script_bindings/webidls/StyleSheet.webidl
+++ b/components/script_bindings/webidls/StyleSheet.webidl
@@ -5,7 +5,7 @@
 // https://drafts.csswg.org/cssom/#the-stylesheet-interface
 [Exposed=Window]
 interface StyleSheet {
-  readonly attribute DOMString type_;
+  readonly attribute DOMString type;
   readonly attribute DOMString? href;
 
   readonly attribute Element? ownerNode;

--- a/tests/wpt/meta/css/cssom/idlharness.html.ini
+++ b/tests/wpt/meta/css/cssom/idlharness.html.ini
@@ -53,9 +53,6 @@
   [CSSStyleDeclaration interface: sheet.cssRules[2\].style must inherit property "setProperty(CSSOMString, CSSOMString, optional CSSOMString)" with the proper type]
     expected: FAIL
 
-  [StyleSheet interface: attribute type]
-    expected: FAIL
-
   [Stringification of sheet.cssRules[2\].cssRules[0\]]
     expected: FAIL
 
@@ -252,9 +249,6 @@
     expected: FAIL
 
   [CSSStyleDeclaration interface: sheet.cssRules[2\].cssRules[0\].style must inherit property "parentRule" with the proper type]
-    expected: FAIL
-
-  [StyleSheet interface: sheet must inherit property "type" with the proper type]
     expected: FAIL
 
   [CSSStyleDeclaration interface: sheet.cssRules[2\].cssRules[0\].style must inherit property "cssText" with the proper type]


### PR DESCRIPTION
I'm not sure if `CodegenRust.py` was supposed to remove the underscore, but we end up exposing `type_` to javascript which is obviously wrong. There's no need to rename the method in the first place, because `Type` (with a capital T) is not a rust keyword. 

Testing: Covered by existing web platform tests
