### PR TITLE
servoshell: Ensure that the theme is applied properly on startup

### DIFF
--- a/ports/servoshell/desktop/app_state.rs
+++ b/ports/servoshell/desktop/app_state.rs
@@ -113,6 +113,7 @@ impl RunningAppState {
             .delegate(self.clone())
             .build();
 
+        webview.notify_theme_change(self.inner().window.theme());
         webview.focus();
         webview.raise_to_top(true);
 
@@ -475,6 +476,7 @@ impl WebViewDelegate for RunningAppState {
             .delegate(parent_webview.delegate())
             .build();
 
+        webview.notify_theme_change(self.inner().window.theme());
         webview.focus();
         webview.raise_to_top(true);
 

--- a/ports/servoshell/desktop/egui_glue.rs
+++ b/ports/servoshell/desktop/egui_glue.rs
@@ -70,7 +70,7 @@ impl EguiGlow {
                 ViewportId::ROOT,
                 event_loop,
                 None,
-                None,
+                event_loop.system_theme(),
                 None,
             ),
             egui_ctx,

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -732,6 +732,13 @@ impl WindowPortsMethods for Window {
     fn hide_ime(&self) {
         self.winit_window.set_ime_allowed(false);
     }
+
+    fn theme(&self) -> servo::Theme {
+        match self.winit_window.theme() {
+            Some(winit::window::Theme::Dark) => servo::Theme::Dark,
+            Some(winit::window::Theme::Light) | None => servo::Theme::Light,
+        }
+    }
 }
 
 fn winit_phase_to_touch_event_type(phase: TouchPhase) -> TouchEventType {

--- a/ports/servoshell/desktop/window_trait.rs
+++ b/ports/servoshell/desktop/window_trait.rs
@@ -48,6 +48,8 @@ pub trait WindowPortsMethods {
         _position: servo::webrender_api::units::DeviceIntRect,
     ) {
     }
-
     fn hide_ime(&self) {}
+    fn theme(&self) -> servo::Theme {
+        servo::Theme::Light
+    }
 }


### PR DESCRIPTION
Instead of only applying the theme when it changes, apply it to both egui and all
newly created `WebView`s. 

Reference Zulip thread: https://servo.zulipchat.com/#narrow/channel/437943-embedding/topic/Theme.20.28light.2Fdark.20mode.29.20support.20on.20initial.20page.20load/with/520082314

Testing: There are tests for servoshell currently, so all testing is manual.
Fixes: #34913