### PR TITLE
Layout: begin support incremental box tree update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6653,7 +6653,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.28.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#47c2a67d4cf4441d46274b8298915ad745099168"
+source = "git+https://github.com/coding-joedow/stylo?branch=main#9a87b429580c4b8504b6259b8f9c674d1cb10fe6"
 dependencies = [
  "bitflags 2.9.1",
  "cssparser",
@@ -6948,7 +6948,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.1"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#47c2a67d4cf4441d46274b8298915ad745099168"
+source = "git+https://github.com/coding-joedow/stylo?branch=main#9a87b429580c4b8504b6259b8f9c674d1cb10fe6"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -7409,7 +7409,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#47c2a67d4cf4441d46274b8298915ad745099168"
+source = "git+https://github.com/coding-joedow/stylo?branch=main#9a87b429580c4b8504b6259b8f9c674d1cb10fe6"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -7467,7 +7467,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#47c2a67d4cf4441d46274b8298915ad745099168"
+source = "git+https://github.com/coding-joedow/stylo?branch=main#9a87b429580c4b8504b6259b8f9c674d1cb10fe6"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -7476,12 +7476,12 @@ dependencies = [
 [[package]]
 name = "stylo_config"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#47c2a67d4cf4441d46274b8298915ad745099168"
+source = "git+https://github.com/coding-joedow/stylo?branch=main#9a87b429580c4b8504b6259b8f9c674d1cb10fe6"
 
 [[package]]
 name = "stylo_derive"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#47c2a67d4cf4441d46274b8298915ad745099168"
+source = "git+https://github.com/coding-joedow/stylo?branch=main#9a87b429580c4b8504b6259b8f9c674d1cb10fe6"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -7493,7 +7493,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#47c2a67d4cf4441d46274b8298915ad745099168"
+source = "git+https://github.com/coding-joedow/stylo?branch=main#9a87b429580c4b8504b6259b8f9c674d1cb10fe6"
 dependencies = [
  "bitflags 2.9.1",
  "stylo_malloc_size_of",
@@ -7502,7 +7502,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#47c2a67d4cf4441d46274b8298915ad745099168"
+source = "git+https://github.com/coding-joedow/stylo?branch=main#9a87b429580c4b8504b6259b8f9c674d1cb10fe6"
 dependencies = [
  "app_units",
  "cssparser",
@@ -7519,12 +7519,12 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#47c2a67d4cf4441d46274b8298915ad745099168"
+source = "git+https://github.com/coding-joedow/stylo?branch=main#9a87b429580c4b8504b6259b8f9c674d1cb10fe6"
 
 [[package]]
 name = "stylo_traits"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#47c2a67d4cf4441d46274b8298915ad745099168"
+source = "git+https://github.com/coding-joedow/stylo?branch=main#9a87b429580c4b8504b6259b8f9c674d1cb10fe6"
 dependencies = [
  "app_units",
  "bitflags 2.9.1",
@@ -7933,7 +7933,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#47c2a67d4cf4441d46274b8298915ad745099168"
+source = "git+https://github.com/coding-joedow/stylo?branch=main#9a87b429580c4b8504b6259b8f9c674d1cb10fe6"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -7946,7 +7946,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#47c2a67d4cf4441d46274b8298915ad745099168"
+source = "git+https://github.com/coding-joedow/stylo?branch=main#9a87b429580c4b8504b6259b8f9c674d1cb10fe6"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,7 @@ rustls-pemfile = "2.0"
 rustls-pki-types = "1.12"
 script_layout_interface = { path = "components/shared/script_layout" }
 script_traits = { path = "components/shared/script" }
-selectors = { git = "https://github.com/servo/stylo", branch = "2025-05-01" }
+selectors = { git = "https://github.com/coding-joedow/stylo", branch = "main" }
 serde = "1.0.219"
 serde_bytes = "0.11"
 serde_json = "1.0"
@@ -127,7 +127,7 @@ servo-media = { git = "https://github.com/servo/media" }
 servo-media-dummy = { git = "https://github.com/servo/media" }
 servo-media-gstreamer = { git = "https://github.com/servo/media" }
 servo-tracing = { path = "components/servo_tracing" }
-servo_arc = { git = "https://github.com/servo/stylo", branch = "2025-05-01" }
+servo_arc = { git = "https://github.com/coding-joedow/stylo", branch = "main" }
 smallbitvec = "2.6.0"
 smallvec = "1.15"
 snapshot = { path = "./components/shared/snapshot" }
@@ -136,12 +136,12 @@ string_cache = "0.8"
 string_cache_codegen = "0.5"
 strum = "0.26"
 strum_macros = "0.26"
-stylo = { git = "https://github.com/servo/stylo", branch = "2025-05-01" }
-stylo_atoms = { git = "https://github.com/servo/stylo", branch = "2025-05-01" }
-stylo_config = { git = "https://github.com/servo/stylo", branch = "2025-05-01" }
-stylo_dom = { git = "https://github.com/servo/stylo", branch = "2025-05-01" }
-stylo_malloc_size_of = { git = "https://github.com/servo/stylo", branch = "2025-05-01" }
-stylo_traits = { git = "https://github.com/servo/stylo", branch = "2025-05-01" }
+stylo = { git = "https://github.com/coding-joedow/stylo", branch = "main" }
+stylo_atoms = { git = "https://github.com/coding-joedow/stylo", branch = "main" }
+stylo_config = { git = "https://github.com/coding-joedow/stylo", branch = "main" }
+stylo_dom = { git = "https://github.com/coding-joedow/stylo", branch = "main" }
+stylo_malloc_size_of = { git = "https://github.com/coding-joedow/stylo", branch = "main" }
+stylo_traits = { git = "https://github.com/coding-joedow/stylo", branch = "main" }
 surfman = { git = "https://github.com/servo/surfman", rev = "f7688b4585f9e0b5d4bf8ee8e4a91e82349610b1", features = ["chains"] }
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"

--- a/components/layout/cell.rs
+++ b/components/layout/cell.rs
@@ -21,6 +21,10 @@ impl<T> ArcRefCell<T> {
             value: Arc::new(AtomicRefCell::new(value)),
         }
     }
+
+    pub fn ptr_eq(this: &Self, other: &Self) -> bool {
+        Arc::ptr_eq(&this.value, &other.value)
+    }
 }
 
 impl<T> Clone for ArcRefCell<T> {

--- a/components/layout/flexbox/mod.rs
+++ b/components/layout/flexbox/mod.rs
@@ -142,6 +142,12 @@ impl FlexContainer {
         self.config = FlexContainerConfig::new(new_style);
         self.style = new_style.clone();
     }
+
+    pub(crate) fn invalidate_subtree_caches(&self) {
+        for flex_level_box in &self.children {
+            flex_level_box.borrow().invalidate_subtree_caches();
+        }
+    }
 }
 
 #[derive(Debug, MallocSizeOf)]
@@ -179,6 +185,17 @@ impl FlexLevelBox {
                 .context
                 .base
                 .invalidate_cached_fragment(),
+        }
+    }
+
+    pub(crate) fn invalidate_subtree_caches(&self) {
+        match self {
+            FlexLevelBox::FlexItem(flex_item_box) => flex_item_box
+                .independent_formatting_context
+                .invalidate_subtree_caches(),
+            FlexLevelBox::OutOfFlowAbsolutelyPositionedBox(positioned_box) => {
+                positioned_box.borrow().context.invalidate_subtree_caches()
+            },
         }
     }
 

--- a/components/layout/layout_box_base.rs
+++ b/components/layout/layout_box_base.rs
@@ -74,6 +74,12 @@ impl LayoutBoxBase {
         let _ = self.cached_layout_result.borrow_mut().take();
     }
 
+    pub(crate) fn invalidate_all_caches(&self) {
+        let _ = self.cached_inline_content_size.borrow_mut().take();
+        self.invalidate_cached_fragment();
+        self.clear_fragments();
+    }
+
     pub(crate) fn fragments(&self) -> Vec<Fragment> {
         self.fragments.borrow().clone()
     }

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -778,7 +778,7 @@ impl LayoutThread {
             compute_damage_and_repair_style(layout_context.shared_context(), root_node);
         if viewport_changed {
             damage = RestyleDamage::REBUILD_BOX;
-        } else if !damage.contains(RestyleDamage::REBUILD_BOX) {
+        } else if !damage.will_change_box_subtree() {
             layout_context.style_context.stylist.rule_tree().maybe_gc();
             return damage;
         }

--- a/components/layout/table/mod.rs
+++ b/components/layout/table/mod.rs
@@ -207,6 +207,35 @@ impl Table {
             new_style,
         );
     }
+
+    pub(crate) fn invalidate_subtree_caches(&self) {
+        for caption in &self.captions {
+            caption.borrow().context.invalidate_subtree_caches();
+        }
+        for column_group in &self.column_groups {
+            column_group.borrow().base.invalidate_all_caches();
+        }
+        for row_group in &self.row_groups {
+            row_group.borrow().base.invalidate_all_caches();
+        }
+        for column in &self.columns {
+            column.borrow().base.invalidate_all_caches();
+        }
+        for row in &self.rows {
+            row.borrow().base.invalidate_all_caches();
+        }
+        for slot_cell_row in &self.slots {
+            for slot in slot_cell_row {
+                match slot {
+                    TableSlot::Cell(cell) => {
+                        cell.borrow().base.invalidate_all_caches();
+                        cell.borrow().contents.contents.invalidate_subtree_caches();
+                    },
+                    TableSlot::Spanned(..) | TableSlot::Empty => {},
+                }
+            }
+        }
+    }
 }
 
 type TableSlotCoordinates = Point2D<usize, UnknownUnit>;

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -940,7 +940,7 @@ impl Document {
 
         // FIXME(emilio): This is very inefficient, ideally the flag above would
         // be enough and incremental layout could figure out from there.
-        node.dirty(NodeDamage::OtherNodeDamage);
+        node.dirty(NodeDamage::NodeContentOrHeritageDamaged);
     }
 
     /// Remove any existing association between the provided id and any elements in this document.

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -360,8 +360,9 @@ impl Element {
         // NodeStyleDamaged, but I'm preserving existing behavior.
         restyle.hint.insert(RestyleHint::RESTYLE_SELF);
 
-        if damage == NodeDamage::OtherNodeDamage {
-            doc.note_node_with_dirty_descendants(self.upcast());
+        if damage == NodeDamage::NodeContentOrHeritageDamaged {
+            restyle.damage = RestyleDamage::repair();
+        } else if damage == NodeDamage::OtherNodeDamage {
             restyle.damage = RestyleDamage::reconstruct();
         }
     }

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -3910,9 +3910,17 @@ impl VirtualMethods for Node {
 
 /// A summary of the changes that happened to a node.
 #[derive(Clone, Copy, MallocSizeOf, PartialEq)]
+// FIXME(joedow): The enum-variant-name-threshold's default is 3, so add the
+// `NodeContentOrHeritageDamaged` variant leads to the lint being triggered, reference:
+// https://rust-lang.github.io/rust-clippy/master/index.html#enum_variant_names
+//
+// Allow this lint temperarily, and its fix will be done in a follow-up PR.
+#[allow(clippy::enum_variant_names)]
 pub(crate) enum NodeDamage {
     /// The node's `style` attribute changed.
     NodeStyleDamaged,
+    /// The node's content or heritage changed: children removed or added, text content changed.
+    NodeContentOrHeritageDamaged,
     /// Other parts of a node changed; attributes, text content, etc.
     OtherNodeDamage,
 }


### PR DESCRIPTION
Currently, we just rebuild boxes for all nodes from the update point downward, and the unique valid candidates as update point is just the absolutely positioned ancestor of the style recalc dirty dom root node. It is quite crude way for incremental box tree update and incremental layout, because it will lead to a lot of boxes to be rebuilt even though their originating nodes have no style change, i.e. only some child nodes are newly added or removed. Meanwhile, all cached fragments need to be invalidated from the update point downward, even though there is no any change of the layout constraits and containing block for some of those rebuilt boxes.

To preserve more boxes and cached fragments as much as possible, this PR try to rebuild those boxes whose originating node has `REBUILD_BOX` restyle damage and try to repair those boxes whose originating node has `REPAIR_BOX` damage. It is a relative big task. To implement it step by step, this PR only repair and reuse the block level boxes. In the future, the others kind of boxes will be repaired or reused.

The mainly modification of this PR:
1. Optimize the dirty marking during dom tree mutation: add or remove child node do
not require the parent node's flow to be rebuilt. Conversely, only mark it with REPAIR.
2. Add new RestyleDamage kind in stylo repo https://github.com/servo/stylo/pull/188 to support detect box tree damage. Then,
propagating up this damage to parent.
3. Do the incremental box tree update:
    - repair the boxes which has descendants that need to be rebuilt or removed.
    - copy the boxes whose originating node has neither REPAIR nor REBUILD damage.
    - generate new boxes for those node which has REBUILD damage.

Testing: This is covered existing WPT tests. And all exising unit-test passed.
