### PR TITLE
imagebitmap: Use snapshot::Snapshot as bitmap data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1209,6 +1209,7 @@ dependencies = [
  "serde",
  "servo_malloc_size_of",
  "servo_url",
+ "snapshot",
  "strum",
  "strum_macros",
  "uuid",
@@ -7116,8 +7117,10 @@ version = "0.0.1"
 dependencies = [
  "euclid",
  "ipc-channel",
+ "malloc_size_of_derive",
  "pixels",
  "serde",
+ "servo_malloc_size_of",
 ]
 
 [[package]]

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -2991,9 +2991,7 @@ impl GlobalScope {
                 }
 
                 if let Some(snapshot) = canvas.get_image_data() {
-                    let size = snapshot.size().cast();
-                    let image_bitmap = ImageBitmap::new(self, size.width, size.height, can_gc);
-                    image_bitmap.set_bitmap_data(snapshot.to_vec());
+                    let image_bitmap = ImageBitmap::new(self, snapshot, can_gc);
                     image_bitmap.set_origin_clean(canvas.origin_is_clean());
                     p.resolve_native(&(image_bitmap), can_gc);
                 }
@@ -3007,9 +3005,7 @@ impl GlobalScope {
                 }
 
                 if let Some(snapshot) = canvas.get_image_data() {
-                    let size = snapshot.size().cast();
-                    let image_bitmap = ImageBitmap::new(self, size.width, size.height, can_gc);
-                    image_bitmap.set_bitmap_data(snapshot.to_vec());
+                    let image_bitmap = ImageBitmap::new(self, snapshot, can_gc);
                     image_bitmap.set_origin_clean(canvas.origin_is_clean());
                     p.resolve_native(&(image_bitmap), can_gc);
                 }

--- a/components/shared/constellation/Cargo.toml
+++ b/components/shared/constellation/Cargo.toml
@@ -31,6 +31,7 @@ net_traits = { workspace = true }
 profile_traits = { workspace = true }
 serde = { workspace = true }
 servo_url = { path = "../../url" }
+snapshot = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
 uuid = { workspace = true }

--- a/components/shared/constellation/structured_data/serializable.rs
+++ b/components/shared/constellation/structured_data/serializable.rs
@@ -16,6 +16,7 @@ use malloc_size_of_derive::MallocSizeOf;
 use net_traits::filemanager_thread::RelativePos;
 use serde::{Deserialize, Serialize};
 use servo_url::ImmutableOrigin;
+use snapshot::Snapshot;
 use strum::EnumIter;
 use uuid::Uuid;
 
@@ -321,9 +322,7 @@ impl BroadcastClone for DomException {
 #[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
 /// A serializable version of the ImageBitmap interface.
 pub struct SerializableImageBitmap {
-    pub width: u32,
-    pub height: u32,
-    pub bitmap_data: Vec<u8>,
+    pub bitmap_data: Snapshot,
 }
 
 impl BroadcastClone for SerializableImageBitmap {

--- a/components/shared/snapshot/Cargo.toml
+++ b/components/shared/snapshot/Cargo.toml
@@ -15,5 +15,7 @@ path = "lib.rs"
 [dependencies]
 euclid = { workspace = true }
 ipc-channel = { workspace = true }
+malloc_size_of = { workspace = true }
+malloc_size_of_derive = { workspace = true }
 serde = { workspace = true }
 pixels = { path = "../../pixels" }

--- a/components/shared/snapshot/lib.rs
+++ b/components/shared/snapshot/lib.rs
@@ -6,17 +6,18 @@ use std::ops::{Deref, DerefMut};
 
 use euclid::default::Size2D;
 use ipc_channel::ipc::IpcSharedMemory;
+use malloc_size_of_derive::MallocSizeOf;
 use pixels::Multiply;
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, MallocSizeOf, PartialEq, Serialize)]
 pub enum PixelFormat {
     #[default]
     RGBA,
     BGRA,
 }
 
-#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, MallocSizeOf, PartialEq, Serialize)]
 pub enum AlphaMode {
     /// Internal data is opaque (alpha is cleared to 1)
     Opaque,
@@ -48,7 +49,7 @@ impl AlphaMode {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
 pub enum Data {
     // TODO: https://github.com/servo/servo/issues/36594
     //IPC(IpcSharedMemory),
@@ -84,7 +85,7 @@ pub type IpcSnapshot = Snapshot<IpcSharedMemory>;
 ///
 /// Inspired by snapshot for concept in WebGPU spec:
 /// <https://gpuweb.github.io/gpuweb/#abstract-opdef-get-a-copy-of-the-image-contents-of-a-context>
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
 pub struct Snapshot<T = Data> {
     size: Size2D<u64>,
     /// internal data (can be any format it will be converted on use if needed)


### PR DESCRIPTION
Replace the holder of actual pixel data of the ImageBitmap interface
([[BitmapData]] slot) from Vec<u8> to snapshot::Snapshot (image bitmap with metadata).
https://html.spec.whatwg.org/multipage/#the-imagebitmap-interface

It will allow to have all required information (e.g. size, pixel format, alpha mode)
for further drawing processing to/from canvas2D output bitmap.

Testing: No required tests
Fixes: https://github.com/servo/servo/issues/34112