### PR TITLE
Get href and title when building a stylesheet from a html link element

### DIFF
--- a/components/script/dom/htmllinkelement.rs
+++ b/components/script/dom/htmllinkelement.rs
@@ -183,8 +183,8 @@ impl HTMLLinkElement {
                     &self.owner_window(),
                     Some(self.upcast::<Element>()),
                     "text/css".into(),
-                    None, // todo handle location
-                    None, // todo handle title
+                    get_attr(self.upcast(), &local_name!("href")).map(DOMString::from_string),
+                    get_attr(self.upcast(), &local_name!("title")).map(DOMString::from_string),
                     sheet,
                     false, // is_constructed
                     can_gc,

--- a/components/script/dom/htmlstyleelement.rs
+++ b/components/script/dom/htmlstyleelement.rs
@@ -167,8 +167,8 @@ impl HTMLStyleElement {
                     &self.owner_window(),
                     Some(self.upcast::<Element>()),
                     "text/css".into(),
-                    None, // todo handle location
-                    None, // todo handle title
+                    None,
+                    None,
                     sheet,
                     false, // is_constructed
                     CanGc::note(),

--- a/tests/wpt/meta/html/semantics/document-metadata/the-link-element/stylesheet-not-removed-until-next-stylesheet-loads.html.ini
+++ b/tests/wpt/meta/html/semantics/document-metadata/the-link-element/stylesheet-not-removed-until-next-stylesheet-loads.html.ini
@@ -1,3 +1,3 @@
 [stylesheet-not-removed-until-next-stylesheet-loads.html]
   [Check that a style sheet loaded by a <link> is available until its successor is loaded]
-    expected: FAIL
+    expected: PASS


### PR DESCRIPTION
Get href and title when building a stylesheet from a html link element

Testing: 

tests/wpt/meta/html/semantics/document-metadata/the-link-element/stylesheet-not-removed-until-next-stylesheet-loads.html now passes

Fixes:  #25102  
