### PR TITLE
CI: Check MSRV in CI

### DIFF
--- a/.github/actions/parse_msrv/action.yml
+++ b/.github/actions/parse_msrv/action.yml
@@ -1,0 +1,21 @@
+name: Parse rust-version from libservo
+description: "Parse rust-version from libservo. Requires cargo-metadata."
+outputs:
+  rust_version:
+    description: "Minimum rust-version defined by libservo"
+    value: ${{ steps.parse_version.outputs.LIBSERVO_RUST_VERSION }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Parse libservo version
+      id: parse_version
+      shell: bash
+      run:  |
+        msrv=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "libservo") | .rust_version')
+        if [[ "${msrv}" == "null" ]]; then
+          echo "Failed to determine MSRV of libservo"
+          exit 1
+        fi
+        echo "libservo has a minimum supported Rust version of ${msrv}."
+        echo "LIBSERVO_RUST_VERSION=${msrv}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -193,10 +193,6 @@ jobs:
       - name: Devtools tests
         if: ${{ inputs.unit-tests }}
         run: ./mach test-devtools --${{ inputs.profile }}
-      - name: Build libservo with examples
-        if: ${{ inputs.build-libservo }}
-        continue-on-error: true
-        run: cargo build -p libservo --all-targets
       - name: Archive build timing
         uses: actions/upload-artifact@v4
         with:
@@ -254,3 +250,34 @@ jobs:
       speedometer: ${{ inputs.profile == 'release' }}
       dromaeo: ${{ inputs.profile == 'release' }}
     secrets: inherit
+
+  build-libservo:
+    if: ${{ inputs.build-libservo }}
+    name: Build libservo and MSRV check
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        if: github.event_name != 'pull_request_target'
+        with:
+          fetch-depth: 1
+      # This is necessary to checkout the pull request if this run was triggered via a
+      # `pull_request_target` event.
+      - uses: actions/checkout@v4
+        if: github.event_name == 'pull_request_target'
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 1
+      - name: Set LIBCLANG_PATH env # needed for bindgen in mozangle
+        run: echo "LIBCLANG_PATH=/usr/lib/llvm-14/lib" >> $GITHUB_ENV
+      - name: Setup Python
+        uses: ./.github/actions/setup-python
+      - name: Determine MSRV
+        id: msrv
+        uses: ./.github/actions/parse_msrv
+      - name: Install MSRV
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.msrv.outputs.rust_version }}
+      - name: Compile libservo with MSRV
+        run: |
+          cargo +${{ steps.msrv.outputs.rust_version }} build -p libservo --locked --all-targets

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -177,10 +177,6 @@ jobs:
       - name: Devtools tests
         if: ${{ inputs.unit-tests }}
         run: ./mach test-devtools --${{ inputs.profile }}
-      - name: Build libservo with examples
-        if: ${{ inputs.build-libservo }}
-        continue-on-error: true
-        run: cargo build -p libservo --all-targets
       - name: Build mach package
         run: ./mach package --${{ inputs.profile }}
       - name: Run DMG smoketest
@@ -241,3 +237,32 @@ jobs:
       speedometer: false
       dromaeo: false
     secrets: inherit
+
+  build-libservo:
+    if: ${{ inputs.build-libservo }}
+    name: Build libservo and MSRV check
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        if: github.event_name != 'pull_request_target'
+        with:
+          fetch-depth: 1
+      # This is necessary to checkout the pull request if this run was triggered via a
+      # `pull_request_target` event.
+      - uses: actions/checkout@v4
+        if: github.event_name == 'pull_request_target'
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 1
+      - name: Setup Python
+        uses: ./.github/actions/setup-python
+      - name: Determine MSRV
+        id: msrv
+        uses: ./.github/actions/parse_msrv
+      - name: Install MSRV
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.msrv.outputs.rust_version }}
+      - name: Compile libservo with MSRV
+        run: |
+          cargo +${{ steps.msrv.outputs.rust_version }} build -p libservo --locked --all-targets

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -190,10 +190,6 @@ jobs:
       - name: Devtools tests
         if: ${{ inputs.unit-tests }}
         run: .\mach test-devtools --${{ inputs.profile }}
-      - name: Build libservo with examples
-        if: ${{ inputs.build-libservo }}
-        continue-on-error: true
-        run: cargo build -p libservo --all-targets
       - name: Archive build timing
         uses: actions/upload-artifact@v4
         with:
@@ -233,3 +229,35 @@ jobs:
       speedometer: false
       dromaeo: false
     secrets: inherit
+
+  build-libservo:
+    if: ${{ inputs.build-libservo }}
+    name: Build libservo and MSRV check
+    runs-on: windows-2022
+    steps:
+      - uses: actions/checkout@v4
+        if: github.event_name != 'pull_request_target'
+        with:
+          fetch-depth: 1
+      # This is necessary to checkout the pull request if this run was triggered via a
+      # `pull_request_target` event.
+      - uses: actions/checkout@v4
+        if: github.event_name == 'pull_request_target'
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 1
+      - name: Setup Python
+        uses: ./.github/actions/setup-python
+      - name: Upgrade llvm
+        if: ${{ runner.environment != 'self-hosted' }}
+        run: choco upgrade llvm
+      - name: Determine MSRV
+        id: msrv
+        uses: ./.github/actions/parse_msrv
+      - name: Install MSRV
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.msrv.outputs.rust_version }}
+      - name: Compile libservo with MSRV
+        run: |
+          cargo +${{ steps.msrv.outputs.rust_version }} build -p libservo --locked --all-targets

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,11 @@ authors = ["The Servo Project Developers"]
 license = "MPL-2.0"
 edition = "2024"
 publish = false
+# We have yet to decide on a policy for updating the minimum supported rust version.
+# Before increasing this, please open a discussion on zulip explaining the reason
+# why we should consider increasing our minimum supported rust version.
+# Please also note, that the **default** rust version in rust-toolchain.toml may be
+# bumped freely.
 rust-version = "1.85.0"
 
 [workspace.dependencies]

--- a/python/servo/try_parser.py
+++ b/python/servo/try_parser.py
@@ -210,6 +210,7 @@ class Config(object):
             if word == "full":
                 words.extend(["linux-unit-tests", "linux-wpt", "linux-bencher"])
                 words.extend(["macos-unit-tests", "windows-unit-tests", "android", "ohos", "lint"])
+                words.extend(["linux-build-libservo", "macos-build-libservo", "windows-build-libservo"])
                 continue  # skip over keyword
             if word == "bencher":
                 words.extend(["linux-bencher", "macos-bencher", "windows-bencher", "android-bencher", "ohos-bencher"])
@@ -278,37 +279,37 @@ class TestParser(unittest.TestCase):
                 "fail_fast": False,
                 "matrix": [
                     {
-                        "name": "Linux (Unit Tests, WPT, Bencher)",
+                        "name": "Linux (Unit Tests, Build libservo, WPT, Bencher)",
                         "number_of_wpt_chunks": 20,
                         "workflow": "linux",
                         "wpt": True,
                         "profile": "release",
                         "unit_tests": True,
-                        "build_libservo": False,
+                        "build_libservo": True,
                         "bencher": True,
                         "wpt_args": "",
                         "build_args": "",
                     },
                     {
-                        "name": "MacOS (Unit Tests)",
+                        "name": "MacOS (Unit Tests, Build libservo)",
                         "number_of_wpt_chunks": 20,
                         "workflow": "macos",
                         "wpt": False,
                         "profile": "release",
                         "unit_tests": True,
-                        "build_libservo": False,
+                        "build_libservo": True,
                         "bencher": False,
                         "wpt_args": "",
                         "build_args": "",
                     },
                     {
-                        "name": "Windows (Unit Tests)",
+                        "name": "Windows (Unit Tests, Build libservo)",
                         "number_of_wpt_chunks": 20,
                         "workflow": "windows",
                         "wpt": False,
                         "profile": "release",
                         "unit_tests": True,
-                        "build_libservo": False,
+                        "build_libservo": True,
                         "bencher": False,
                         "wpt_args": "",
                         "build_args": "",


### PR DESCRIPTION
As previously proposed on zulip and discussed in the coordination meeting, add a check to CI to see if
servo still compiles with our minimum supported Rust version.
To avoid requiring changes, we define our MSRV as the current version we are using now (1.85.0).

This does not prevent us from updating the default compiler version, which we should still do, to
get benefits like faster compile times, newer lints and making sure crown stays up-to-date.

We simply test that libservo compiles in CI, since libservo (and dependencies) is what embedders would care about. We also don't need mach (or bootstrap!) for this, so we just use cargo build.

Testing: This PR adds a CI test. [`./mach try windows-build-libservo linux-build-libservo mac-build-libservo`](https://github.com/jschwe/servo/actions/runs/16901171766)
