### PR TITLE
net: Perform CSP checks on fetch responses.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1228,7 +1228,7 @@ dependencies = [
 [[package]]
 name = "content-security-policy"
 version = "0.5.4"
-source = "git+https://github.com/servo/rust-content-security-policy/?branch=servo-csp#58a09ee320fd6fbb828748ae04255e4c8d3f9c9e"
+source = "git+https://github.com/servo/rust-content-security-policy/?branch=servo-csp#dc1fd32b2b32b704a43f4ae170bb2cbb80a7cf59"
 dependencies = [
  "base64 0.22.1",
  "bitflags 2.9.1",

--- a/tests/wpt/meta/content-security-policy/connect-src/connect-src-syncxmlhttprequest-redirect-to-blocked.sub.html.ini
+++ b/tests/wpt/meta/content-security-policy/connect-src/connect-src-syncxmlhttprequest-redirect-to-blocked.sub.html.ini
@@ -1,3 +1,0 @@
-[connect-src-syncxmlhttprequest-redirect-to-blocked.sub.html]
-  [Expecting logs: ["PASS Sync XMLHttpRequest.send() did not follow the disallowed redirect.","TEST COMPLETE","violated-directive=connect-src"\]]
-    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/connect-src/connect-src-xmlhttprequest-redirect-to-blocked.sub.html.ini
+++ b/tests/wpt/meta/content-security-policy/connect-src/connect-src-xmlhttprequest-redirect-to-blocked.sub.html.ini
@@ -1,3 +1,0 @@
-[connect-src-xmlhttprequest-redirect-to-blocked.sub.html]
-  [Expecting logs: ["PASS XMLHttpRequest.send() did not follow the disallowed redirect.","TEST COMPLETE","violated-directive=connect-src"\]]
-    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/gen/top.http-rp/script-src-self/script-tag.http.html.ini
+++ b/tests/wpt/meta/content-security-policy/gen/top.http-rp/script-src-self/script-tag.http.html.ini
@@ -1,6 +1,3 @@
 [script-tag.http.html]
   [Content Security Policy: Expects blocked for script-tag to same-http origin and swap-origin redirection from http context.]
     expected: FAIL
-
-  [Content Security Policy: Expects blocked for script-tag to same-http origin and swap-origin redirection from http context.: securitypolicyviolation]
-    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/gen/top.http-rp/script-src-self/script-tag.https.html.ini
+++ b/tests/wpt/meta/content-security-policy/gen/top.http-rp/script-src-self/script-tag.https.html.ini
@@ -1,6 +1,3 @@
 [script-tag.https.html]
   [Content Security Policy: Expects blocked for script-tag to same-https origin and swap-origin redirection from https context.]
     expected: FAIL
-
-  [Content Security Policy: Expects blocked for script-tag to same-https origin and swap-origin redirection from https context.: securitypolicyviolation]
-    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/gen/top.meta/script-src-self/script-tag.http.html.ini
+++ b/tests/wpt/meta/content-security-policy/gen/top.meta/script-src-self/script-tag.http.html.ini
@@ -1,6 +1,3 @@
 [script-tag.http.html]
   [Content Security Policy: Expects blocked for script-tag to same-http origin and swap-origin redirection from http context.]
     expected: FAIL
-
-  [Content Security Policy: Expects blocked for script-tag to same-http origin and swap-origin redirection from http context.: securitypolicyviolation]
-    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/gen/top.meta/script-src-self/script-tag.https.html.ini
+++ b/tests/wpt/meta/content-security-policy/gen/top.meta/script-src-self/script-tag.https.html.ini
@@ -1,6 +1,3 @@
 [script-tag.https.html]
   [Content Security Policy: Expects blocked for script-tag to same-https origin and swap-origin redirection from https context.]
     expected: FAIL
-
-  [Content Security Policy: Expects blocked for script-tag to same-https origin and swap-origin redirection from https context.: securitypolicyviolation]
-    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/generic/wildcard-host-part.sub.window.js.ini
+++ b/tests/wpt/meta/content-security-policy/generic/wildcard-host-part.sub.window.js.ini
@@ -1,2 +1,0 @@
-[wildcard-host-part.sub.window.html]
-  expected: CRASH

--- a/tests/wpt/meta/content-security-policy/inside-worker/dedicatedworker-connect-src.html.ini
+++ b/tests/wpt/meta/content-security-policy/inside-worker/dedicatedworker-connect-src.html.ini
@@ -1,7 +1,4 @@
 [dedicatedworker-connect-src.html]
-  [Same-origin => cross-origin 'fetch()' in http: with connect-src 'self']
-    expected: FAIL
-
   [Reports match in http: with connect-src 'self']
     expected: FAIL
 

--- a/tests/wpt/meta/content-security-policy/reporting/report-original-url.sub.html.ini
+++ b/tests/wpt/meta/content-security-policy/reporting/report-original-url.sub.html.ini
@@ -1,10 +1,3 @@
 [report-original-url.sub.html]
-  expected: TIMEOUT
-  [Block after redirect, same-origin = original URL in report]
-    expected: TIMEOUT
-
-  [Block after redirect, cross-origin = original URL in report]
-    expected: TIMEOUT
-
   [Violation report status OK.]
     expected: FAIL

--- a/tests/wpt/meta/content-security-policy/securitypolicyviolation/img-src-redirect.sub.html.ini
+++ b/tests/wpt/meta/content-security-policy/securitypolicyviolation/img-src-redirect.sub.html.ini
@@ -1,3 +1,0 @@
-[img-src-redirect.sub.html]
-  [The blocked URI in the security policy violation event should be the original URI before redirects.]
-    expected: FAIL

--- a/tests/wpt/tests/content-security-policy/default-src/default-src-sri_hash.sub.html
+++ b/tests/wpt/tests/content-security-policy/default-src/default-src-sri_hash.sub.html
@@ -7,6 +7,9 @@
     <script src='/resources/testharnessreport.js' nonce='dummy'></script>
 
     <!-- CSP served: default-src {{domains[www]}}:* 'nonce-dummy' 'sha256-wIc3KtqOuTFEu6t17sIBuOswgkV406VJvhSk79Gw6U0=' 'ShA256-L7/UQ9VWpyG7C9RDEC4ctS5hI3Zcw+ta+haPGlByG9c=' 'sha512-rYCVMxWV5nq8IsMo+UZNObWtEiWGok/vDN8BMoEQi41s0znSes6E1Q2aag3Lw3u2J1w2rqH7uF2ws6FpQhfSOA=='; style-src 'unsafe-inline' -->
+    <!-- The domain here is intentionally served with `www`. In the event that the integrity check fails,
+         the request should be disallowed by the source list. If we were to use {{domains[]}},
+         then we would not be able to observe the difference with regards to the integrity check -->
     <!-- ShA256 is intentionally mixed case -->
 </head>
 
@@ -18,6 +21,8 @@
         var port = "{{ports[http][0]}}";
         if (location.protocol === "https:")
           port = "{{ports[https][0]}}";
+        // Since {{domains[www]}} is allowed by the CSP policy, regardless of the integrity check
+        // the request would be allowed.
         var crossorigin_base = location.protocol + "//{{domains[www]}}:" + port;
 
         // Test name, src, integrity, expected to run.

--- a/tests/wpt/tests/content-security-policy/script-src/script-src-sri_hash.sub.html
+++ b/tests/wpt/tests/content-security-policy/script-src/script-src-sri_hash.sub.html
@@ -7,6 +7,9 @@
     <script src='/resources/testharnessreport.js' nonce='dummy'></script>
 
     <!-- CSP served: script-src {{domains[www]}}:* 'nonce-dummy' 'sha256-wIc3KtqOuTFEu6t17sIBuOswgkV406VJvhSk79Gw6U0=' 'ShA256-L7/UQ9VWpyG7C9RDEC4ctS5hI3Zcw+ta+haPGlByG9c=' 'sha512-rYCVMxWV5nq8IsMo+UZNObWtEiWGok/vDN8BMoEQi41s0znSes6E1Q2aag3Lw3u2J1w2rqH7uF2ws6FpQhfSOA==' -->
+    <!-- The domain here is intentionally served with `www`. In the event that the integrity check fails,
+      the request should be disallowed by the source list. If we were to use {{domains[]}},
+      then we would not be able to observe the difference with regards to the integrity check -->
     <!-- ShA256 is intentionally mixed case -->
 </head>
 
@@ -18,6 +21,8 @@
         var port = "{{ports[http][0]}}";
         if (location.protocol === "https:")
           port = "{{ports[https][0]}}";
+        // Since {{domains[www]}} is allowed by the CSP policy, regardless of the integrity check
+        // the request would be allowed.
         var crossorigin_base = location.protocol + "//{{domains[www]}}:" + port;
 
         // Test name, src, integrity, expected to run.

--- a/tests/wpt/tests/content-security-policy/script-src/script-src-strict_dynamic_parser_inserted.html
+++ b/tests/wpt/tests/content-security-policy/script-src/script-src-strict_dynamic_parser_inserted.html
@@ -2,11 +2,12 @@
 <html>
 
 <head>
-    <title>Parser-inserted scripts without a correct nonce are not allowed with `strict-dynamic` in the script-src directive.</title>
+    <title>Parser-inserted scripts without a correct nonce are not allowed with `Strict-Dynamic` in the script-src directive.</title>
     <script src='/resources/testharness.js' nonce='dummy'></script>
     <script src='/resources/testharnessreport.js' nonce='dummy'></script>
 
-    <!-- CSP served: script-src 'strict-dynamic' 'nonce-dummy' -->
+    <!-- CSP served: script-src 'Strict-Dynamic' 'nonce-dummy' -->
+    <!-- Strict-Dynamic is intentionally mixed case -->
 </head>
 
 <body>

--- a/tests/wpt/tests/content-security-policy/script-src/script-src-strict_dynamic_parser_inserted.html.headers
+++ b/tests/wpt/tests/content-security-policy/script-src/script-src-strict_dynamic_parser_inserted.html.headers
@@ -2,4 +2,4 @@ Expires: Mon, 26 Jul 1997 05:00:00 GMT
 Cache-Control: no-store, no-cache, must-revalidate
 Cache-Control: post-check=0, pre-check=0, false
 Pragma: no-cache
-Content-Security-Policy: script-src 'strict-dynamic' 'nonce-dummy'
+Content-Security-Policy: script-src 'Strict-Dynamic' 'nonce-dummy'


### PR DESCRIPTION
Also add clarifying comments to the SRI WPT tests with
regards to the `www.` domain and how that interacts with
the integrity checks.

Lastly, adjust the casing for `Strict-Dynamic`, as in
the post-request check that should also be case-insensitive.

Closes servo/servo#37200
Closes servo/servo#36760
Fixes servo/servo#36499
Part of w3c/webappsec-csp#727
Fixes w3c/webappsec-csp#728
Part of servo/servo#4577