### PR TITLE
Refactor the memory profiler code to return the struct.

### DIFF
--- a/components/profile/mem.rs
+++ b/components/profile/mem.rs
@@ -12,9 +12,9 @@ use ipc_channel::ipc::{self, IpcReceiver};
 use ipc_channel::router::ROUTER;
 use log::debug;
 use profile_traits::mem::{
-    MemoryReportResult, ProfilerChan, ProfilerMsg, Report, Reporter, ReporterRequest, ReportsChan,
+    MemoryReport, MemoryReportResult, ProfilerChan, ProfilerMsg, Report, Reporter, ReporterRequest,
+    ReportsChan,
 };
-use serde::Serialize;
 
 use crate::system_reporter;
 
@@ -100,28 +100,18 @@ impl Profiler {
             ProfilerMsg::Report(sender) => {
                 let main_pid = std::process::id();
 
-                #[derive(Serialize)]
-                struct JsonReport {
-                    pid: u32,
-                    #[serde(rename = "isMainProcess")]
-                    is_main_process: bool,
-                    reports: Vec<Report>,
-                }
-
                 let reports = self.collect_reports();
                 // Turn the pid -> reports map into a vector and add the
                 // hint to find the main process.
-                let json_reports: Vec<JsonReport> = reports
+                let results: Vec<MemoryReport> = reports
                     .into_iter()
-                    .map(|(pid, reports)| JsonReport {
+                    .map(|(pid, reports)| MemoryReport {
                         pid,
                         reports,
                         is_main_process: pid == main_pid,
                     })
                     .collect();
-                let content = serde_json::to_string(&json_reports)
-                    .unwrap_or_else(|_| "{ error: \"failed to create memory report\"}".to_owned());
-                let _ = sender.send(MemoryReportResult { content });
+                let _ = sender.send(MemoryReportResult { results });
                 true
             },
 

--- a/components/script/dom/servointernals.rs
+++ b/components/script/dom/servointernals.rs
@@ -59,7 +59,8 @@ impl ServoInternalsMethods<crate::DomTypeHolder> for ServoInternals {
 
 impl RoutedPromiseListener<MemoryReportResult> for ServoInternals {
     fn handle_response(&self, response: MemoryReportResult, promise: &Rc<Promise>, can_gc: CanGc) {
-        let stringified = serde_json::to_string(&response.results).unwrap();
+        let stringified = serde_json::to_string(&response.results)
+            .unwrap_or_else(|_| "{ error: \"failed to create memory report\"}".to_owned());
         promise.resolve_native(&stringified, can_gc);
     }
 }

--- a/components/script/dom/servointernals.rs
+++ b/components/script/dom/servointernals.rs
@@ -59,7 +59,8 @@ impl ServoInternalsMethods<crate::DomTypeHolder> for ServoInternals {
 
 impl RoutedPromiseListener<MemoryReportResult> for ServoInternals {
     fn handle_response(&self, response: MemoryReportResult, promise: &Rc<Promise>, can_gc: CanGc) {
-        promise.resolve_native(&response.content, can_gc);
+        let stringified = serde_json::to_string(&response.results).unwrap();
+        promise.resolve_native(&stringified, can_gc);
     }
 }
 

--- a/components/shared/profile/mem.rs
+++ b/components/shared/profile/mem.rs
@@ -247,8 +247,19 @@ macro_rules! path {
 /// The results produced by the memory reporter.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct MemoryReportResult {
-    /// The stringified output.
-    pub content: String,
+    /// All the results from the MemoryReports
+    pub results: Vec<MemoryReport>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+/// A simple memory report
+pub struct MemoryReport {
+    /// The pid of the report
+    pub pid: u32,
+    /// Is this the main process
+    pub is_main_process: bool,
+    /// All the reports for this pid
+    pub reports: Vec<Report>,
 }
 
 /// Messages that can be sent to the memory profiler thread.


### PR DESCRIPTION
Refactor the memory profiler code to return the struct and handle the serializing in servointernal page.
This allows other users of the memory profiler to see the whole report without parsing json.

Testing: I do not know if the memory page is covered by tests.
