### PR TITLE
layout: Allow changes `transform` and `filter` to skip layout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6634,7 +6634,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.28.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#1707256dd825f14e98161a49fdd6749f8ca0d506"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F190%2Fhead#f63374493723974a6ec303f30a647ca22c3ae07b"
 dependencies = [
  "bitflags 2.9.1",
  "cssparser",
@@ -6929,7 +6929,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.1"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#1707256dd825f14e98161a49fdd6749f8ca0d506"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F190%2Fhead#f63374493723974a6ec303f30a647ca22c3ae07b"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -7390,7 +7390,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#1707256dd825f14e98161a49fdd6749f8ca0d506"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F190%2Fhead#f63374493723974a6ec303f30a647ca22c3ae07b"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -7448,7 +7448,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#1707256dd825f14e98161a49fdd6749f8ca0d506"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F190%2Fhead#f63374493723974a6ec303f30a647ca22c3ae07b"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -7457,12 +7457,12 @@ dependencies = [
 [[package]]
 name = "stylo_config"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#1707256dd825f14e98161a49fdd6749f8ca0d506"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F190%2Fhead#f63374493723974a6ec303f30a647ca22c3ae07b"
 
 [[package]]
 name = "stylo_derive"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#1707256dd825f14e98161a49fdd6749f8ca0d506"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F190%2Fhead#f63374493723974a6ec303f30a647ca22c3ae07b"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -7474,7 +7474,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#1707256dd825f14e98161a49fdd6749f8ca0d506"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F190%2Fhead#f63374493723974a6ec303f30a647ca22c3ae07b"
 dependencies = [
  "bitflags 2.9.1",
  "stylo_malloc_size_of",
@@ -7483,7 +7483,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#1707256dd825f14e98161a49fdd6749f8ca0d506"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F190%2Fhead#f63374493723974a6ec303f30a647ca22c3ae07b"
 dependencies = [
  "app_units",
  "cssparser",
@@ -7500,12 +7500,12 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#1707256dd825f14e98161a49fdd6749f8ca0d506"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F190%2Fhead#f63374493723974a6ec303f30a647ca22c3ae07b"
 
 [[package]]
 name = "stylo_traits"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#1707256dd825f14e98161a49fdd6749f8ca0d506"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F190%2Fhead#f63374493723974a6ec303f30a647ca22c3ae07b"
 dependencies = [
  "app_units",
  "bitflags 2.9.1",
@@ -7914,7 +7914,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#1707256dd825f14e98161a49fdd6749f8ca0d506"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F190%2Fhead#f63374493723974a6ec303f30a647ca22c3ae07b"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -7927,7 +7927,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#1707256dd825f14e98161a49fdd6749f8ca0d506"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F190%2Fhead#f63374493723974a6ec303f30a647ca22c3ae07b"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,7 @@ rustls-pemfile = "2.0"
 rustls-pki-types = "1.12"
 script_layout_interface = { path = "components/shared/script_layout" }
 script_traits = { path = "components/shared/script" }
-selectors = { git = "https://github.com/servo/stylo", branch = "2025-05-01" }
+selectors = { git = "https://github.com/servo/stylo", rev = "refs/pull/190/head" }
 serde = "1.0.219"
 serde_bytes = "0.11"
 serde_json = "1.0"
@@ -127,7 +127,7 @@ servo-media = { git = "https://github.com/servo/media" }
 servo-media-dummy = { git = "https://github.com/servo/media" }
 servo-media-gstreamer = { git = "https://github.com/servo/media" }
 servo-tracing = { path = "components/servo_tracing" }
-servo_arc = { git = "https://github.com/servo/stylo", branch = "2025-05-01" }
+servo_arc = { git = "https://github.com/servo/stylo", rev = "refs/pull/190/head" }
 smallbitvec = "2.6.0"
 smallvec = "1.15"
 snapshot = { path = "./components/shared/snapshot" }
@@ -136,12 +136,12 @@ string_cache = "0.8"
 string_cache_codegen = "0.5"
 strum = "0.26"
 strum_macros = "0.26"
-stylo = { git = "https://github.com/servo/stylo", branch = "2025-05-01" }
-stylo_atoms = { git = "https://github.com/servo/stylo", branch = "2025-05-01" }
-stylo_config = { git = "https://github.com/servo/stylo", branch = "2025-05-01" }
-stylo_dom = { git = "https://github.com/servo/stylo", branch = "2025-05-01" }
-stylo_malloc_size_of = { git = "https://github.com/servo/stylo", branch = "2025-05-01" }
-stylo_traits = { git = "https://github.com/servo/stylo", branch = "2025-05-01" }
+stylo = { git = "https://github.com/servo/stylo", rev = "refs/pull/190/head" }
+stylo_atoms = { git = "https://github.com/servo/stylo", rev = "refs/pull/190/head" }
+stylo_config = { git = "https://github.com/servo/stylo", rev = "refs/pull/190/head" }
+stylo_dom = { git = "https://github.com/servo/stylo", rev = "refs/pull/190/head" }
+stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "refs/pull/190/head" }
+stylo_traits = { git = "https://github.com/servo/stylo", rev = "refs/pull/190/head" }
 surfman = { git = "https://github.com/servo/surfman", rev = "f7688b4585f9e0b5d4bf8ee8e4a91e82349610b1", features = ["chains"] }
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -846,10 +846,12 @@ impl LayoutThread {
         let Some(fragment_tree) = &*self.fragment_tree.borrow() else {
             return;
         };
-        if !damage.contains(RestyleDamage::REBUILD_STACKING_CONTEXT) &&
-            self.stacking_context_tree.borrow().is_some()
-        {
-            return;
+
+        if !damage.contains(RestyleDamage::REBUILD_STACKING_CONTEXT) {
+            if let Some(stacking_context_tree) = &mut *self.stacking_context_tree.borrow_mut() {
+                stacking_context_tree.repair_scroll_tree_for_repaint_only_layout();
+                return;
+            }
         }
 
         let viewport_size = self.stylist.device().au_viewport_size();


### PR DESCRIPTION
Changes to `transform` and `filter`-related properties do not need a
new layout. Instead, they can simply cause a regeneration of the display
list. The one caveat is that any pre-existing compositor scroll tree
needs to be patched up with new reference frame values before being sent
to the compositor.

This should improve performance of `transform`-only changes, commonly
used during animations.

Testing: This should not change WPT test results, but increase performance.
Since we do not have performance tests yet, this relies on existing WPT
tests to ensure no regression in behavior.
