### PR TITLE
Refactoring `HTMLOptionElement::Text` into iterative style

### DIFF
--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -2035,6 +2035,10 @@ impl TreeIterator {
         self.current = None;
         Some(current)
     }
+
+    pub(crate) fn peek(&self) -> Option<&DomRoot<Node>> {
+        self.current.as_ref()
+    }
 }
 
 impl Iterator for TreeIterator {


### PR DESCRIPTION
The original implementation of `HTMLOptionElement::Text` is recursive, and the program may run out of stack space for a sufficiently large number of iterations. The patch switches to an iterative implementation, with `TreeIterator`.

Note that, instead of the usual `while let Some(node) = iterator.next()` approach, we use `while let Some(node) = iterator.peek()` with the newly added `TreeIterator::peek` function. This is because the choice of the next node depends on some checks performed inside the `while` block, whereas the `next` function determines the next node before entering the block.

Moreover, the `TreeIterator::peek` function is added, instead of wrapping the iterator into `Peekable`. This is because we will lose access to the `TreeIterator::next_skipping_children` function if we wrap it into `Peekable`.

Testing: This refactoring has to pass the existing tests.
Fixes: #36959 
