### PR TITLE
Add a user agent style for the `<slot>` element

### DIFF
--- a/components/layout/stylesheets/servo.css
+++ b/components/layout/stylesheets/servo.css
@@ -266,3 +266,7 @@ select {
   /* Don't show a text cursor when hovering selected option */
   cursor: default;
 }
+
+slot {
+  display: contents;
+}

--- a/tests/wpt/meta/shadow-dom/directionality-001.tentative.html.ini
+++ b/tests/wpt/meta/shadow-dom/directionality-001.tentative.html.ini
@@ -1,2 +1,0 @@
-[directionality-001.tentative.html]
-  expected: FAIL


### PR DESCRIPTION
In Chromium, the slot user agent stylesheet is located in [html.css](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/html/resources/html.css;l=1654).

Testing: This change fixes `tests/wpt/meta/shadow-dom/directionality-001.tentative.html.ini`.

