### PR TITLE
Send synthetic keydown/keyup at ime_insert_text

### DIFF
--- a/components/script/textinput.rs
+++ b/components/script/textinput.rs
@@ -984,6 +984,9 @@ impl<T: ClipboardProvider> TextInput<T> {
                     self.insert_string(c.as_str());
                     return KeyReaction::DispatchInput;
                 }
+                if matches!(key, Key::Process) {
+                    return KeyReaction::DispatchInput;
+                }
                 KeyReaction::Nothing
             })
             .unwrap()

--- a/ports/servoshell/egl/app_state.rs
+++ b/ports/servoshell/egl/app_state.rs
@@ -620,11 +620,27 @@ impl RunningAppState {
     }
 
     pub fn ime_insert_text(&self, text: String) {
-        self.active_webview()
-            .notify_input_event(InputEvent::Ime(ImeEvent::Composition(CompositionEvent {
+        // In OHOS, we get empty text after the intended text.
+        if text.is_empty() {
+            return;
+        }
+        let active_webview = self.active_webview();
+        active_webview.notify_input_event(InputEvent::Keyboard(KeyboardEvent {
+            state: KeyState::Down,
+            key: Key::Process,
+            ..KeyboardEvent::default()
+        }));
+        active_webview.notify_input_event(InputEvent::Ime(ImeEvent::Composition(
+            CompositionEvent {
                 state: CompositionState::End,
                 data: text,
-            })));
+            },
+        )));
+        active_webview.notify_input_event(InputEvent::Keyboard(KeyboardEvent {
+            state: KeyState::Up,
+            key: Key::Process,
+            ..KeyboardEvent::default()
+        }));
         self.perform_updates();
     }
 


### PR DESCRIPTION
At `egl/app_state.rs`, send keydown and keyup with PROCESS KEY when inserting text. This fixes OHOS input event, but maybe also for Android in the future (if it implements `ime_insert_text`). We will get input event since keydown is dispatched (https://github.com/servo/servo/pull/37078).

This implementation is similar to [Chromium's](https://source.chromium.org/chromium/chromium/src/+/main:content/public/android/java/src/org/chromium/content/browser/input/ImeAdapterImpl.java;drc=404e8d654e8b26336d2cb103b9c21faecbf7f73a;bpv=1;bpt=1;l=851?gsn=sendCompositionToNative&gs=KYTHE%3A%2F%2Fkythe%3A%2F%2Fchromium.googlesource.com%2Fcodesearch%2Fchromium%2Fsrc%2F%2Fmain%3Flang%3Djava%3Fpath%3Dorg.chromium.content.browser.input.ImeAdapterImpl%23d840961d441fd4bb569f9689c86da91fb714c0c153366e3198a85e9c7a098dce) Android key event.

Testing: manually checked on OHOS device
For: https://github.com/servo/servo/issues/36259, but only in OHOS