### PR TITLE
build(deps): bump ohos-ime from 0.2.0 to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5341,9 +5341,9 @@ dependencies = [
 
 [[package]]
 name = "ohos-ime"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48107e68ed8451c17c2ff95938e1ba86003fb290a04f7a0213ce2d16ce4b3ee6"
+checksum = "ee3ea454e31a3372cd9c4ed903db4fae861e92f57cf51852a3cd80f9d3945dcd"
 dependencies = [
  "log",
  "ohos-ime-sys",

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -90,7 +90,7 @@ hilog = "0.2.0"
 ipc-channel = { workspace = true, features = ["force-inprocess"] }
 napi-derive-ohos = "1.0.4"
 napi-ohos = "1.0.4"
-ohos-ime = "0.2"
+ohos-ime = "0.3.0"
 ohos-ime-sys = "0.1.4"
 ohos-vsync = "0.1.3"
 xcomponent-sys = { version = "0.3.1", features = ["api-12", "keyboard-types"] }

--- a/ports/servoshell/egl/ohos.rs
+++ b/ports/servoshell/egl/ohos.rs
@@ -867,14 +867,14 @@ impl HostTrait for HostCallbacks {
         let mut ime_proxy = self.ime_proxy.borrow_mut();
         let ime = ime_proxy.get_or_insert_with(|| {
             let attach_options = AttachOptions::new(true);
-            let editor = RawTextEditorProxy::new();
             let configbuilder = ohos_ime::TextConfigBuilder::new();
             let options = convert_ime_options(input_type, multiline);
             let text_config = configbuilder
                 .input_type(options.input_type)
                 .enterkey_type(options.enterkey_type)
                 .build();
-            ImeProxy::new(editor, attach_options, Box::new(ServoIme { text_config }))
+            let editor = RawTextEditorProxy::new(Box::new(ServoIme { text_config }));
+            ImeProxy::new(editor, attach_options)
         });
         match ime.show_keyboard() {
             Ok(()) => debug!("IME show keyboard - success"),


### PR DESCRIPTION
This patch updates the ohos-ime version from v0.2.0 to v0.3.0

Testing: N/A
Fixes: #37181 
