### PR TITLE
constellation: Wait for canvas thread to shut down before shutting down system font service

### DIFF
--- a/components/canvas/canvas_paint_thread.rs
+++ b/components/canvas/canvas_paint_thread.rs
@@ -97,7 +97,10 @@ impl<'a> CanvasPaintThread<'a> {
                                     let canvas_data = canvas_paint_thread.create_canvas(size);
                                     creator.send(canvas_data).unwrap();
                                 },
-                                Ok(ConstellationCanvasMsg::Exit) => break,
+                                Ok(ConstellationCanvasMsg::Exit(exit_sender)) => {
+                                    let _ = exit_sender.send(());
+                                    break;
+                                },
                                 Err(e) => {
                                     warn!("Error on CanvasPaintThread receive ({})", e);
                                     break;

--- a/components/shared/canvas/lib.rs
+++ b/components/shared/canvas/lib.rs
@@ -21,5 +21,5 @@ pub enum ConstellationCanvasMsg {
         sender: Sender<(CanvasId, ImageKey)>,
         size: Size2D<u64>,
     },
-    Exit,
+    Exit(Sender<()>),
 }


### PR DESCRIPTION
The canvas thread might need access to the system font service before it
shuts down. Ensure that it finishes shutting down before triggering the
shutdown of the system font service. This should avoid issues where
canvas tries to access fonts right before shutting down.

Fixes: #36849.
Testing: Since this fixes a flaky crash on shutdown, there isn't a good
way to write a test for it.
