### PR TITLE
mach: Allow using ASAN on ohos

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -803,15 +803,16 @@ class CommandBase(object):
                 "--manifest-path",
                 path.join(self.context.topdir, "ports", "servoshell", "Cargo.toml"),
             ]
-        if target_override:
-            args += ["--target", target_override]
-        elif self.target.is_cross_build():
+
+        if self.target.is_cross_build():
             args += ["--target", self.target.triple()]
             if type(self.target) in [AndroidTarget, OpenHarmonyTarget]:
                 # Note: in practice `cargo rustc` should just be used unconditionally.
                 assert command != "build", "For Android / OpenHarmony `cargo rustc` must be used instead of cargo build"
                 if command == "rustc":
                     args += ["--lib", "--crate-type=cdylib"]
+        elif target_override:
+            args += ["--target", target_override]
 
         features = []
 

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -305,6 +305,7 @@ class CommandBase(object):
         self.config["build"].setdefault("incremental", None)
         self.config["build"].setdefault("webgl-backtrace", False)
         self.config["build"].setdefault("dom-backtrace", False)
+        self.config["build"].setdefault("with_asan", False)
 
         self.config.setdefault("android", {})
         self.config["android"].setdefault("sdk", "")

--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -184,6 +184,9 @@ class PackageCommands(CommandBase):
                 "-p",
                 f"buildMode={build_mode}",
             ]
+            if with_asan:
+                hvigor_command.extend(["-p", "ohos-debug-asan=true"])
+
             # Detect if PATH already has hvigor, or else fallback to npm installation
             # provided via HVIGOR_PATH
             if "HVIGOR_PATH" not in env:


### PR DESCRIPTION
Allow using ASAN on OpenHarmony by adding target specific configuration.
This also relaxes the version requirement for the clang compiler
when using asan, since asan also has runtime checks, which should fail
if instrumented code relies on an incompatible libasan version (not tested).

Additional comments: 

- Remove `TARGET_LDFLAGS = -static-libasan` since anyway rustc
  invokes the linker, so this flag has no effect.
- Enable frame pointers with ASAN, since we are anyway debugging.
  It should probably be the default anyway.
- We pass the with_asan option also to mach package, since hvigor
  needs to know that we are building for ASAN, otherwise it leads
  to a crash at startup.

Testing: Tested manually on arm64 OpenHarmony.

Known issues: ASAN increases the stack usage, and this can cause segfaults due to hitting the stack protector on more complex pages. A follow-up PR could address this by increasing the stack size when compiled with asan in threads that hit this issue.
