### PR TITLE
script: Allow reflows that do not produce display lists

### DIFF
--- a/components/compositing/refresh_driver.rs
+++ b/components/compositing/refresh_driver.rs
@@ -14,7 +14,7 @@ use constellation_traits::EmbedderToConstellationMessage;
 use crossbeam_channel::{Sender, select};
 use embedder_traits::EventLoopWaker;
 use log::warn;
-use timers::{BoxedTimerCallback, TimerEventId, TimerEventRequest, TimerScheduler, TimerSource};
+use timers::{BoxedTimerCallback, TimerEventRequest, TimerScheduler};
 
 use crate::compositor::RepaintReason;
 use crate::webview_renderer::WebViewRenderer;
@@ -62,7 +62,7 @@ impl RefreshDriver {
     fn timer_callback(&self) -> BoxedTimerCallback {
         let waiting_for_frame_timeout = self.waiting_for_frame_timeout.clone();
         let event_loop_waker = self.event_loop_waker.clone_box();
-        Box::new(move |_| {
+        Box::new(move || {
             waiting_for_frame_timeout.store(false, Ordering::Relaxed);
             event_loop_waker.wake();
         })
@@ -226,8 +226,6 @@ impl TimerThread {
             .sender
             .send(TimerThreadMessage::Request(TimerEventRequest {
                 callback,
-                source: TimerSource::FromWorker,
-                id: TimerEventId(0),
                 duration,
             }));
     }

--- a/components/script/dom/documentorshadowroot.rs
+++ b/components/script/dom/documentorshadowroot.rs
@@ -103,13 +103,8 @@ impl DocumentOrShadowRoot {
         query_type: NodesFromPointQueryType,
         can_gc: CanGc,
     ) -> Vec<UntrustedNodeAddress> {
-        if !self
-            .window
-            .layout_reflow(QueryMsg::NodesFromPointQuery, can_gc)
-        {
-            return vec![];
-        };
-
+        self.window
+            .layout_reflow(QueryMsg::NodesFromPointQuery, can_gc);
         self.window
             .layout()
             .query_nodes_from_point(*client_point, query_type)

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -1443,12 +1443,8 @@ impl Node {
     }
 
     pub(crate) fn style(&self, can_gc: CanGc) -> Option<Arc<ComputedValues>> {
-        if !self
-            .owner_window()
-            .layout_reflow(QueryMsg::StyleQuery, can_gc)
-        {
-            return None;
-        }
+        self.owner_window()
+            .layout_reflow(QueryMsg::StyleQuery, can_gc);
         self.style_data
             .borrow()
             .as_ref()

--- a/components/shared/script_layout/lib.rs
+++ b/components/shared/script_layout/lib.rs
@@ -394,6 +394,8 @@ pub type IFrameSizes = FnvHashMap<BrowsingContextId, IFrameSize>;
 /// Information derived from a layout pass that needs to be returned to the script thread.
 #[derive(Debug, Default)]
 pub struct ReflowResult {
+    /// Whether or not this reflow produced a display list.
+    pub built_display_list: bool,
     /// The list of images that were encountered that are in progress.
     pub pending_images: Vec<PendingImage>,
     /// The list of vector images that were encountered that still need to be rasterized.


### PR DESCRIPTION
This change has two parts which depend on each other:

1. An early exit in the layout process, which allows for skipping
   display list construction entirely when nothing would change.
2. A simplification and unification of the way that "fake" animation
   frames are triggered. Now this happens on an entire ScriptThread at
   once and is based on whether or not any Pipeline triggered a display
   list update.

   Animations are never canceled in the compositor when the Pipeline
   isn't updating, instead the fake animation frame is triggered far
   enough in the future that an unexpected compositor tick will cancel
   it. This could happen, for instance, if some other Pipeline in some
   other ScriptThread produced a new display list for a tick. This makes
   everything simpler about these ticks.

The goal is that in a future change the ScriptThread-based animation
ticks will be made more generic so that they can throttle the number of
"update the rendering" calls triggered by script.

This should make Servo do a lot less work when moving the cursor over a
page. Before it would constantly produce new display lists.

Fixes: #17029.
Testing: This should not cause any web observable changes. The fact that
all WPT tests keep passing is the test for this change.
