### PR TITLE
script: Set HTTP status code when aborting an `XMLHttpRequest`

### DIFF
--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -797,6 +797,7 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
         if self.ready_state.get() == XMLHttpRequestState::Done {
             self.change_ready_state(XMLHttpRequestState::Unsent, can_gc);
             self.response_status.set(Err(()));
+            *self.status.borrow_mut() = HttpStatus::new_error();
             self.response.borrow_mut().clear();
             self.response_headers.borrow_mut().clear();
         }

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -1189,6 +1189,8 @@ impl XMLHttpRequest {
 
                 self.discard_subsequent_responses();
                 self.send_flag.set(false);
+                *self.status.borrow_mut() = HttpStatus::new_error();
+                self.response_headers.borrow_mut().clear();
                 // XXXManishearth set response to NetworkError
                 self.change_ready_state(XMLHttpRequestState::Done, can_gc);
                 return_if_fetch_was_terminated!();

--- a/tests/wpt/meta/xhr/abort-during-done.window.js.ini
+++ b/tests/wpt/meta/xhr/abort-during-done.window.js.ini
@@ -1,9 +1,0 @@
-[abort-during-done.window.html]
-  [XMLHttpRequest: abort() during DONE (sync)]
-    expected: FAIL
-
-  [XMLHttpRequest: abort() during DONE (sync aborted in readystatechange)]
-    expected: FAIL
-
-  [XMLHttpRequest: abort() during DONE (async)]
-    expected: FAIL

--- a/tests/wpt/meta/xhr/abort-during-headers-received.window.js.ini
+++ b/tests/wpt/meta/xhr/abort-during-headers-received.window.js.ini
@@ -1,3 +1,0 @@
-[abort-during-headers-received.window.html]
-  [XMLHttpRequest: abort() during HEADERS_RECEIVED]
-    expected: FAIL

--- a/tests/wpt/meta/xhr/abort-during-loading.window.js.ini
+++ b/tests/wpt/meta/xhr/abort-during-loading.window.js.ini
@@ -1,3 +1,0 @@
-[abort-during-loading.window.html]
-  [XMLHttpRequest: abort() during LOADING]
-    expected: FAIL


### PR DESCRIPTION
Correctly set status when aborting a XMLHttpRequest.

Testing: WPT test xhr/abort-during-done.window.html
