### PR TITLE
servoshell: Replace `getopts` with `bpaf` for argument parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -997,6 +997,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bpaf"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "473976d7a8620bb1e06dcdd184407c2363fe4fec8e983ee03ed9197222634a31"
+dependencies = [
+ "bpaf_derive",
+]
+
+[[package]]
+name = "bpaf_derive"
+version = "0.5.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fefb4feeec9a091705938922f26081aad77c64cd2e76cd1c4a9ece8e42e1618a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3049,15 +3069,6 @@ checksum = "fc257fdb4038301ce4b9cd1b3b51704509692bb3ff716a410cbd07925d9dae55"
 dependencies = [
  "rustix 1.0.8",
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "getopts"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -7963,6 +7974,7 @@ dependencies = [
  "accesskit_winit",
  "android_logger",
  "backtrace",
+ "bpaf",
  "cc",
  "cfg-if",
  "constellation_traits",
@@ -7976,7 +7988,6 @@ dependencies = [
  "embedder_traits",
  "env_filter",
  "euclid",
- "getopts",
  "gilrs",
  "glow",
  "headers 0.4.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,6 @@ fnv = "1.0"
 fonts_traits = { path = "components/shared/fonts" }
 freetype-sys = "0.20"
 fxhash = "0.2"
-getopts = "0.2.24"
 gleam = "0.15"
 glow = "0.16"
 gstreamer = { version = "0.23", features = ["v1_18"] }

--- a/components/config/opts.rs
+++ b/components/config/opts.rs
@@ -176,7 +176,7 @@ impl DebugOptions {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub enum OutputOptions {
     /// Database connection config (hostname, name, user, pass)
     FileName(String),

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -55,13 +55,13 @@ vello = ["libservo/vello"]
 vello_cpu = ["libservo/vello_cpu"]
 
 [dependencies]
+bpaf = { version = "0.9.20", features = ["derive"] }
 cfg-if = { workspace = true }
 constellation_traits = { workspace = true }
 crossbeam-channel = { workspace = true }
 dpi = { workspace = true }
 embedder_traits = { path = "../../components/shared/embedder" }
 euclid = { workspace = true }
-getopts = { workspace = true }
 hitrace = { workspace = true, optional = true }
 image = { workspace = true }
 ipc-channel = { workspace = true }

--- a/ports/servoshell/desktop/cli.rs
+++ b/ports/servoshell/desktop/cli.rs
@@ -24,6 +24,12 @@ pub fn main() {
         ArgumentParsingResult::ChromeProcess(opts, preferences, servoshell_preferences) => {
             (opts, preferences, servoshell_preferences)
         },
+        ArgumentParsingResult::Exit => {
+            std::process::exit(0);
+        },
+        ArgumentParsingResult::ErrorParsing => {
+            std::process::exit(1);
+        },
     };
 
     crate::init_tracing(servoshell_preferences.tracing_filter.as_deref());

--- a/ports/servoshell/egl/android.rs
+++ b/ports/servoshell/egl/android.rs
@@ -61,7 +61,7 @@ pub extern "C" fn Java_org_servo_servoview_JNIServo_version<'local>(
     env: JNIEnv<'local>,
     _class: JClass<'local>,
 ) -> JString<'local> {
-    let v = crate::servo_version();
+    let v = crate::VERSION;
     env.new_string(&v)
         .unwrap_or_else(|_str| JObject::null().into())
 }

--- a/ports/servoshell/egl/android/simpleservo.rs
+++ b/ports/servoshell/egl/android/simpleservo.rs
@@ -58,6 +58,10 @@ pub fn init(
         ArgumentParsingResult::ChromeProcess(opts, preferences, servoshell_preferences) => {
             (opts, preferences, servoshell_preferences)
         },
+        ArgumentParsingResult::Exit => {
+            std::process::exit(0);
+        },
+        ArgumentParsingResult::ErrorParsing => std::process::exit(1),
     };
 
     crate::init_tracing(servoshell_preferences.tracing_filter.as_deref());

--- a/ports/servoshell/egl/ohos/simpleservo.rs
+++ b/ports/servoshell/egl/ohos/simpleservo.rs
@@ -153,6 +153,8 @@ pub fn init(
         ArgumentParsingResult::ChromeProcess(opts, preferences, servoshell_preferences) => {
             (opts, preferences, servoshell_preferences)
         },
+        ArgumentParsingResult::Exit => std::process::exit(0),
+        ArgumentParsingResult::ErrorParsing => std::process::exit(1),
     };
 
     if servoshell_preferences.log_to_file {

--- a/ports/servoshell/lib.rs
+++ b/ports/servoshell/lib.rs
@@ -97,9 +97,7 @@ pub fn init_tracing(filter_directives: Option<&str>) {
     }
 }
 
-pub fn servo_version() -> String {
-    format!("Servo {}-{}", env!("CARGO_PKG_VERSION"), env!("GIT_SHA"))
-}
+pub const VERSION: &str = concat!("Servo ", env!("CARGO_PKG_VERSION"), "-", env!("GIT_SHA"));
 
 /// Plumbs tracing spans into HiTrace, with the following caveats:
 ///

--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -2,23 +2,27 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use core::panic;
 use std::collections::HashMap;
-use std::fs::{File, read_to_string};
+use std::fs::{self, File, read_to_string};
 use std::io::Read;
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 #[cfg(any(target_os = "android", target_env = "ohos"))]
 use std::sync::OnceLock;
-use std::{env, fs, process};
+use std::{env, process};
 
+use bpaf::*;
 use euclid::Size2D;
-use getopts::{Matches, Options};
-use log::{error, warn};
+use log::warn;
 use serde_json::Value;
 use servo::config::opts::{DebugOptions, Opts, OutputOptions};
 use servo::config::prefs::{PrefValue, Preferences};
 use servo::servo_geometry::DeviceIndependentPixel;
 use servo::servo_url::ServoUrl;
 use url::Url;
+
+use crate::VERSION;
 
 pub(crate) static EXPERIMENTAL_PREFS: &[&str] = &[
     "dom_async_clipboard_enabled",
@@ -80,6 +84,9 @@ pub(crate) struct ServoShellPreferences {
     /// remote WebDriver commands.
     pub webdriver_port: Option<u16>,
 
+    /// Whether the CLI option to enable experimental prefs was present at startup.
+    pub experimental_prefs_enabled: bool,
+
     /// Log filter given in the `log_filter` spec as a String, if any.
     /// If a filter is passed, the logger should adjust accordingly.
     #[cfg(target_env = "ohos")]
@@ -88,9 +95,6 @@ pub(crate) struct ServoShellPreferences {
     /// Log also to a file
     #[cfg(target_env = "ohos")]
     pub log_to_file: bool,
-
-    /// Whether the CLI option to enable experimental prefs was present at startup.
-    pub experimental_prefs_enabled: bool,
 }
 
 impl Default for ServoShellPreferences {
@@ -160,7 +164,7 @@ pub fn default_config_dir() -> Option<PathBuf> {
 /// Get a Servo [`Preferences`] to use when initializing Servo by first reading the user
 /// preferences file and then overriding these preferences with the ones from the `--prefs-file`
 /// command-line argument, if given.
-fn get_preferences(opts_matches: &Matches, config_dir: &Option<PathBuf>) -> Preferences {
+fn get_preferences(prefs_files: &[PathBuf], config_dir: &Option<PathBuf>) -> Preferences {
     // Do not read any preferences files from the disk when testing as we do not want it
     // to throw off test results.
     if cfg!(test) {
@@ -182,7 +186,7 @@ fn get_preferences(opts_matches: &Matches, config_dir: &Option<PathBuf>) -> Pref
 
     let mut preferences = Preferences::default();
     apply_preferences(&mut preferences, user_prefs_hash);
-    for pref_file_path in opts_matches.opt_strs("prefs-file").iter() {
+    for pref_file_path in prefs_files.iter() {
         apply_preferences(&mut preferences, read_prefs_file(pref_file_path))
     }
 
@@ -214,440 +218,391 @@ pub fn read_prefs_map(txt: &str) -> HashMap<String, PrefValue> {
 pub(crate) enum ArgumentParsingResult {
     ChromeProcess(Opts, Preferences, ServoShellPreferences),
     ContentProcess(String),
+    Exit,
+    ErrorParsing,
 }
 
-pub(crate) fn parse_command_line_arguments(args: Vec<String>) -> ArgumentParsingResult {
-    let (app_name, args) = args.split_first().unwrap();
-
-    let mut opts = Options::new();
-    opts.optopt(
-        "o",
-        "output",
-        "Path to an output image. The format of the image is determined by the extension. \
-         Supports all formats that `rust-image` does.",
-        "output.png",
-    );
-    opts.optopt("s", "size", "Size of tiles", "512");
-    opts.optflagopt(
-        "p",
-        "profile",
-        "Time profiler flag and either a TSV output filename \
-         OR an interval for output to Stdout (blank for Stdout with interval of 5s)",
-        "10 \
-         OR time.tsv",
-    );
-    opts.optflagopt(
-        "",
-        "profiler-trace-path",
-        "Path to dump a self-contained HTML timeline of profiler traces",
-        "",
-    );
-    opts.optflag(
-        "x",
-        "exit",
-        "Exit after Servo has loaded the page and detected a stable output image",
-    );
-    opts.optopt(
-        "y",
-        "layout-threads",
-        "Number of threads to use for layout",
-        "1",
-    );
-    opts.optflag(
-        "i",
-        "nonincremental-layout",
-        "Enable to turn off incremental layout.",
-    );
-    opts.optflagopt(
-        "",
-        "userscripts",
-        "Uses userscripts in resources/user-agent-js, or a specified full path",
-        "",
-    );
-    opts.optmulti(
-        "",
-        "user-stylesheet",
-        "A user stylesheet to be added to every document",
-        "file.css",
-    );
-    opts.optopt(
-        "",
-        "shaders",
-        "Shaders will be loaded from the specified directory instead of using the builtin ones.",
-        "",
-    );
-    opts.optflag("z", "headless", "Headless mode");
-    opts.optflag(
-        "f",
-        "hard-fail",
-        "Exit on thread failure instead of displaying about:failure",
-    );
-    opts.optflag(
-        "F",
-        "soft-fail",
-        "Display about:failure on thread failure instead of exiting",
-    );
-    opts.optflagopt("", "devtools", "Start remote devtools server on port", "0");
-    opts.optflagopt(
-        "",
-        "webdriver",
-        "Start remote WebDriver server on port",
-        "7000",
-    );
-    opts.optopt(
-        "",
-        "window-size",
-        "Set the initial window size in logical (device independent) pixels",
-        "1024x740",
-    );
-    opts.optopt(
-        "",
-        "screen-size",
-        "Override the screen resolution in logical (device independent) pixels",
-        "1024x768",
-    );
-    opts.optflag("M", "multiprocess", "Run in multiprocess mode");
-    opts.optflag("I", "force-ipc", "Use ipc_channel in singleprocess mode");
-    opts.optflag("B", "bhm", "Background Hang Monitor enabled");
-    opts.optflag("S", "sandbox", "Run in a sandbox if multiprocess");
-    opts.optopt(
-        "",
-        "random-pipeline-closure-probability",
-        "Probability of randomly closing a pipeline (for testing constellation hardening).",
-        "0.0",
-    );
-    opts.optopt(
-        "",
-        "random-pipeline-closure-seed",
-        "A fixed seed for repeatbility of random pipeline closure.",
-        "",
-    );
-    opts.optmulti(
-        "Z",
-        "debug",
-        "A comma-separated string of debug options. Pass help to show available options.",
-        "",
-    );
-    opts.optflag("h", "help", "Print this message");
-    opts.optopt(
-        "",
-        "resources-path",
-        "Path to find static resources",
-        "/home/servo/resources",
-    );
-    opts.optopt(
-        "",
-        "certificate-path",
-        "Path to find SSL certificates",
-        "/home/servo/resources/certs",
-    );
-    opts.optflag(
-        "",
-        "ignore-certificate-errors",
-        "Whether or not to completely ignore certificate errors",
-    );
-    opts.optopt(
-        "",
-        "content-process",
-        "Run as a content process and connect to the given pipe",
-        "servo-ipc-channel.abcdefg",
-    );
-    opts.optopt(
-        "",
-        "config-dir",
-        "config directory following xdg spec on linux platform",
-        "",
-    );
-    opts.optflag("v", "version", "Display servo version information");
-    opts.optflag("", "unminify-js", "Unminify Javascript");
-    opts.optflag("", "print-pwm", "Print Progressive Web Metrics");
-    opts.optopt(
-        "",
-        "local-script-source",
-        "Directory root with unminified scripts",
-        "",
-    );
-    opts.optflag("", "unminify-css", "Unminify Css");
-
-    opts.optflag(
-        "",
-        "clean-shutdown",
-        "Do not shutdown until all threads have finished (macos only)",
-    );
-    opts.optflag("b", "no-native-titlebar", "Do not use native titlebar");
-    opts.optopt("", "device-pixel-ratio", "Device pixels per px", "");
-    opts.optopt(
-        "u",
-        "user-agent",
-        "Set custom user agent string (or ios / android / desktop for platform default)",
-        "NCSA Mosaic/1.0 (X11;SunOS 4.1.4 sun4m)",
-    );
-    opts.optmulti(
-        "",
-        "tracing-filter",
-        "Define a custom filter for traces. Overrides `SERVO_TRACING` if set.",
-        "FILTER",
-    );
-
-    #[cfg(target_env = "ohos")]
-    opts.optmulti(
-        "",
-        "log-filter",
-        "Define a custom filter for logging.",
-        "FILTER",
-    );
-
-    #[cfg(target_env = "ohos")]
-    opts.optflag(
-        "",
-        "log-to-file",
-        "Also log to a file (/data/app/el2/100/base/org.servo.servo/cache/servo.log)",
-    );
-
-    opts.optflag(
-        "",
-        "enable-experimental-web-platform-features",
-        "Whether or not to enable experimental web platform features.",
-    );
-    opts.optmulti(
-        "",
-        "pref",
-        "A preference to set to enable",
-        "dom_bluetooth_enabled",
-    );
-    opts.optmulti(
-        "",
-        "pref",
-        "A preference to set to disable",
-        "dom_webgpu_enabled=false",
-    );
-    opts.optmulti(
-        "",
-        "prefs-file",
-        "Load in additional prefs from a file.",
-        "/path/to/prefs.json",
-    );
-
-    let opt_match = match opts.parse(args) {
-        Ok(m) => m,
-        Err(f) => args_fail(&f.to_string()),
-    };
-
-    if opt_match.opt_present("v") || opt_match.opt_present("version") {
-        println!("{}", crate::servo_version());
-        process::exit(0);
-    }
-
-    if opt_match.opt_present("h") || opt_match.opt_present("help") {
-        print_usage(app_name, &opts);
-        process::exit(0);
-    };
-
-    let config_dir = opt_match
-        .opt_str("config-dir")
-        .map(Into::into)
-        .or_else(default_config_dir)
-        .inspect(|path| {
-            if !path.exists() {
-                fs::create_dir_all(path).unwrap_or_else(|e| {
-                    error!("Failed to create config directory at {:?}: {:?}", path, e)
-                })
-            }
-        });
-
-    let mut preferences = get_preferences(&opt_match, &config_dir);
-
-    // If this is the content process, we'll receive the real options over IPC. So just fill in
-    // some dummy options for now.
-    if let Some(content_process) = opt_match.opt_str("content-process") {
-        return ArgumentParsingResult::ContentProcess(content_process);
-    }
-    // Env-Filter directives are comma seperated.
-    let filters = opt_match.opt_strs("tracing-filter").join(",");
-    let tracing_filter = (!filters.is_empty()).then_some(filters);
-
-    #[cfg(target_env = "ohos")]
-    let log_filter = {
-        let filters = opt_match.opt_strs("log-filter").join(",");
-        let log_filter = (!filters.is_empty()).then_some(filters).or_else(|| {
-            (!preferences.log_filter.is_empty()).then_some(preferences.log_filter.clone())
-        });
-        log::debug!("Set log_filter to: {:?}", log_filter);
-        log_filter
-    };
-
-    #[cfg(target_env = "ohos")]
-    let log_to_file = opt_match.opt_present("log-to-file");
-
-    let mut debug_options = DebugOptions::default();
-    for debug_string in opt_match.opt_strs("Z") {
-        if let Err(e) = debug_options.extend(debug_string) {
-            args_fail(&format!("error: unrecognized debug option: {}", e));
-        }
-    }
-
-    if debug_options.help {
-        print_debug_options_usage(app_name);
-    }
-
-    // If only the flag is present, default to a 5 second period for both profilers
-    let time_profiling = if opt_match.opt_present("p") {
-        match opt_match.opt_str("p") {
-            Some(argument) => match argument.parse::<f64>() {
-                Ok(interval) => Some(OutputOptions::Stdout(interval)),
-                Err(_) => match ServoUrl::parse(&argument) {
-                    Ok(_) => panic!("influxDB isn't supported anymore"),
-                    Err(_) => Some(OutputOptions::FileName(argument)),
-                },
-            },
-            None => Some(OutputOptions::Stdout(5.0)),
-        }
+/// Parse a resolution string into a Size2D.
+fn parse_resolution_string(
+    string: String,
+) -> Result<Option<Size2D<u32, DeviceIndependentPixel>>, std::num::ParseIntError> {
+    if string.is_empty() {
+        Ok(None)
     } else {
-        // if the p option doesn't exist:
-        None
-    };
-
-    if let Some(ref time_profiler_trace_path) = opt_match.opt_str("profiler-trace-path") {
-        let mut path = PathBuf::from(time_profiler_trace_path);
-        path.pop();
-        if let Err(why) = fs::create_dir_all(&path) {
-            error!(
-                "Couldn't create/open {:?}: {:?}",
-                Path::new(time_profiler_trace_path).to_string_lossy(),
-                why
-            );
-        }
-    }
-
-    let layout_threads: Option<usize> = opt_match.opt_str("y").map(|layout_threads_str| {
-        layout_threads_str
-            .parse()
-            .unwrap_or_else(|err| args_fail(&format!("Error parsing option: -y ({})", err)))
-    });
-
-    let nonincremental_layout = opt_match.opt_present("i");
-
-    let random_pipeline_closure_probability = opt_match
-        .opt_str("random-pipeline-closure-probability")
-        .map(|prob| {
-            prob.parse().unwrap_or_else(|err| {
-                args_fail(&format!(
-                    "Error parsing option: --random-pipeline-closure-probability ({})",
-                    err
-                ))
-            })
-        });
-
-    let random_pipeline_closure_seed =
-        opt_match
-            .opt_str("random-pipeline-closure-seed")
-            .map(|seed| {
-                seed.parse().unwrap_or_else(|err| {
-                    args_fail(&format!(
-                        "Error parsing option: --random-pipeline-closure-seed ({})",
-                        err
-                    ))
-                })
-            });
-
-    if opt_match.opt_present("devtools") {
-        let port = opt_match
-            .opt_str("devtools")
-            .map(|port| {
-                port.parse().unwrap_or_else(|err| {
-                    args_fail(&format!("Error parsing option: --devtools ({})", err))
-                })
-            })
-            .unwrap_or(preferences.devtools_server_port);
-        preferences.devtools_server_enabled = true;
-        preferences.devtools_server_port = port;
-    }
-
-    if opt_match.opt_present("webdriver") {
-        preferences.dom_testing_html_input_element_select_files_enabled = true;
-    }
-
-    let parse_resolution_string = |string: String| {
-        let components: Vec<u32> = string
+        let components = string
             .split('x')
-            .map(|component| {
-                component.parse().unwrap_or_else(|error| {
-                    args_fail(&format!("Error parsing resolution '{string}': {error}"));
-                })
-            })
-            .collect();
-        Size2D::new(components[0], components[1])
-    };
+            .map(|component| component.parse::<u32>())
+            .collect::<Result<Vec<_>, std::num::ParseIntError>>()?;
+        Ok(Some(Size2D::new(components[0], components[1])))
+    }
+}
 
-    let screen_size_override = opt_match
-        .opt_str("screen-size")
-        .map(parse_resolution_string);
-
-    // Make sure the default window size is not larger than any provided screen size.
-    let default_window_size = Size2D::new(1024, 740);
-    let default_window_size = screen_size_override
-        .map_or(default_window_size, |screen_size_override| {
-            default_window_size.min(screen_size_override)
-        });
-    let initial_window_size = opt_match
-        .opt_str("window-size")
-        .map_or(default_window_size, parse_resolution_string);
-
-    let user_stylesheets = opt_match
-        .opt_strs("user-stylesheet")
-        .iter()
+/// Parse stylesheets into the byte stream.
+fn parse_user_stylesheets(string: String) -> Result<Vec<(Vec<u8>, ServoUrl)>, std::io::Error> {
+    Ok(string
+        .split_whitespace()
         .map(|filename| {
             let cwd = env::current_dir().unwrap();
             let path = cwd.join(filename);
             let url = ServoUrl::from_url(Url::from_file_path(&path).unwrap());
             let mut contents = Vec::new();
             File::open(path)
-                .unwrap_or_else(|err| args_fail(&format!("Couldn't open {}: {}", filename, err)))
+                .unwrap()
                 .read_to_end(&mut contents)
-                .unwrap_or_else(|err| args_fail(&format!("Couldn't read {}: {}", filename, err)));
+                .unwrap();
             (contents, url)
         })
-        .collect();
+        .collect())
+}
 
-    let experimental_prefs_enabled =
-        opt_match.opt_present("enable-experimental-web-platform-features");
-    if experimental_prefs_enabled {
+/// This is a helper function that fulfills the following parsing task
+/// check for long/short cmd. If there is the flag with this
+/// If the flag is not there, parse `None``
+/// If the flag is there but no argument, parse `Some(default)`
+/// If the flag is there and an argument parse the arugment
+fn flag_with_default_parser<S, T>(
+    short_cmd: Option<char>,
+    long_cmd: &'static str,
+    argument_help: &'static str,
+    help: &'static str,
+    default: T,
+    transform: fn(S) -> T,
+) -> impl Parser<Option<T>>
+where
+    S: FromStr + 'static,
+    <S as FromStr>::Err: std::fmt::Display,
+    T: Clone + 'static,
+{
+    let just_flag = if let Some(c) = short_cmd {
+        short(c).long(long_cmd)
+    } else {
+        long(long_cmd)
+    }
+    .req_flag(default)
+    .hide();
+
+    let arg = if let Some(c) = short_cmd {
+        short(c).long(long_cmd)
+    } else {
+        long(long_cmd)
+    }
+    .argument::<S>(argument_help)
+    .help(help)
+    .map(transform);
+
+    construct!([arg, just_flag]).optional()
+}
+
+fn profile() -> impl Parser<Option<OutputOptions>> {
+    flag_with_default_parser(
+        Some('p'),
+        "profile",
+        "",
+        "uses 5.0 output as standard if no argument supplied",
+        OutputOptions::Stdout(5.0),
+        |val: String| {
+            if let Ok(float) = val.parse::<f64>() {
+                OutputOptions::Stdout(float)
+            } else {
+                OutputOptions::FileName(val)
+            }
+        },
+    )
+}
+
+fn userscripts() -> impl Parser<Option<PathBuf>> {
+    flag_with_default_parser(
+        None,
+        "userscripts_directory",
+        "your/directory",
+        "Uses userscripts in resources/user-agent-js, or a specified full path",
+        PathBuf::from("resources/user-agent-js"),
+        |val: String| PathBuf::from(val),
+    )
+}
+
+fn webdriver_port() -> impl Parser<Option<u16>> {
+    flag_with_default_parser(
+        None,
+        "webdriver",
+        "7000",
+        "Start remote WebDriver server on port",
+        7000,
+        |val| val,
+    )
+}
+
+fn map_debug_options(arg: String) -> Vec<String> {
+    arg.split(',').map(|s| s.to_owned()).collect()
+}
+
+#[derive(Bpaf, Clone, Debug)]
+#[bpaf(options, version(VERSION))]
+struct CmdArgs {
+    /// Background Hang Monitor enabled.
+    #[bpaf(short('B'), long("bhm"))]
+    background_hang_monitor: bool,
+
+    /// Path to find SSL certificates.
+    #[bpaf(argument("/home/servo/resources/certs"))]
+    certificate_path: Option<PathBuf>,
+
+    /// Do not shutdown until all threads have finished (macos only).
+    #[bpaf(long)]
+    clean_shutdown: bool,
+
+    /// Config directory following xdg spec on linux platform.
+    #[bpaf(argument("~/.config/servo"))]
+    config_dir: Option<PathBuf>,
+
+    /// Run as a content process and connect to the given pipe.
+    #[bpaf(argument("servo-ipc-channel.abcdefg"))]
+    content_process: Option<String>,
+
+    /// A comma-separated string of debug options. Pass help to show available options.
+    #[bpaf(
+        short('Z'),
+        argument("layout_grid_enabled=true,dom_async_clipboard_enabled"),
+        long,
+        map(map_debug_options),
+        fallback(vec![])
+    )]
+    debug: Vec<String>,
+
+    /// Device pixels per px.
+    #[bpaf(argument("1.0"))]
+    device_pixel_ratio: Option<f32>,
+
+    /// Start remote devtools server on port.
+    #[bpaf(argument("0"))]
+    devtools: Option<u16>,
+
+    /// Whether or not to enable experimental web platform features.
+    #[bpaf(long)]
+    enable_experimental_web_platform_features: bool,
+
+    // Exit after Servo has loaded the page and detected a stable output image.
+    #[bpaf(short('x'), long)]
+    exit: bool,
+
+    // Use ipc_channel in singleprocess mode.
+    #[bpaf(short('I'), long("force-ipc"))]
+    force_ipc: bool,
+
+    /// Exit on thread failure instead of displaying about:failure.
+    #[bpaf(short('f'), long)]
+    hard_fail: bool,
+
+    /// Headless mode.
+    #[bpaf(short('z'), long)]
+    headless: bool,
+
+    /// Whether or not to completely ignore certificate errors.
+    #[bpaf(long)]
+    ignore_certificate_errors: bool,
+
+    /// Number of threads to use for layout.
+    #[bpaf(short('y'), long, argument("1"))]
+    layout_threads: Option<i64>,
+
+    /// Directory root with unminified scripts.
+    #[bpaf(argument("~/.local/share/servo"))]
+    local_script_source: Option<PathBuf>,
+
+    #[cfg(target_env = "ohos")]
+    /// Define a custom filter for logging.
+    #[bpaf(argument("FILTER"))]
+    log_filter: Option<String>,
+
+    #[cfg(target_env = "ohos")]
+    /// Also log to a file (/data/app/el2/100/base/org.servo.servo/cache/servo.log).
+    #[bpaf(long)]
+    log_to_file: bool,
+
+    /// Run in multiprocess mode.
+    #[bpaf(short('M'), long)]
+    multiprocess: bool,
+
+    /// Do not use native titlebar.
+    #[bpaf(short('b'), long)]
+    no_native_titlebar: bool,
+
+    /// Enable to turn off incremental layout.
+    #[bpaf(short('i'), long, flag(false, true))]
+    nonincremental_layout: bool,
+
+    /// Path to an output image. The format of the image is determined by the extension.
+    /// Supports all formats that `rust-image` does.
+    #[bpaf(short('o'), argument("test.png"), long)]
+    output: Option<PathBuf>,
+
+    /// Time profiler flag and either a TSV output filename
+    /// OR an interval for output to Stdout (blank for Stdout with interval of 5s).
+    #[bpaf(external)]
+    profile: Option<OutputOptions>,
+
+    /// Path to dump a self-contained HTML timeline of profiler traces.
+    #[bpaf(argument("trace.html"), long)]
+    profiler_trace_path: Option<PathBuf>,
+
+    /// A preference to set.
+    #[bpaf(argument("dom_bluetooth_enabled"), many)]
+    pref: Vec<String>,
+
+    /// Load in additional prefs from a file.
+    #[bpaf(long, argument("/path/to/prefs.json"), many)]
+    prefs_file: Vec<PathBuf>,
+
+    /// Print Progressive Web Metrics.
+    #[bpaf(long)]
+    print_pwm: bool,
+
+    /// Probability of randomly closing a pipeline (for testing constellation hardening).
+    #[bpaf(argument("0.25"))]
+    random_pipeline_closure_probability: Option<f32>,
+
+    /// A fixed seed for repeatbility of random pipeline closure.
+    random_pipeline_closure_seed: Option<usize>,
+
+    /// Run in a sandbox if multiprocess.
+    #[bpaf(short('S'), long)]
+    sandbox: bool,
+
+    /// Shaders will be loaded from the specified directory instead of using the builtin ones.
+    shaders: Option<PathBuf>,
+
+    /// Override the screen resolution in logical (device independent) pixels.
+    #[bpaf(long("screen-size"), argument::<String>("1024x768"),
+        parse(parse_resolution_string), fallback(None))]
+    screen_size_override: Option<Size2D<u32, DeviceIndependentPixel>>,
+
+    /// Define a custom filter for traces. Overrides `SERVO_TRACING` if set.
+    #[bpaf(long("tracing-filter"), argument("FILTER"))]
+    tracing_filter: Option<String>,
+
+    /// Unminify Javascript.
+    #[bpaf(long)]
+    unminify_js: bool,
+
+    /// Unminify Css.
+    #[bpaf(long)]
+    unminify_css: bool,
+
+    /// Set custom user agent string (or ios / android / desktop for platform default).
+    #[bpaf(short('u'),long,argument::<String>("NCSA mosaic/1.0 (X11;SunOS 4.1.4 sun4m"))]
+    user_agent: Option<String>,
+
+    /// Uses userscripts in resources/user-agent-js, or a specified full path.
+    #[bpaf(external)]
+    userscripts: Option<PathBuf>,
+
+    /// A user stylesheet to be added to every document.
+    #[bpaf(argument::<String>("file.css"), parse(parse_user_stylesheets), fallback(vec![]))]
+    user_stylesheet: Vec<(Vec<u8>, ServoUrl)>,
+
+    /// Start remote WebDriver server on port.
+    #[bpaf(external)]
+    webdriver_port: Option<u16>,
+
+    /// Set the initial window size in logical (device independent) pixels.
+    #[bpaf(argument::<String>("1024x740"), parse(parse_resolution_string), fallback(None))]
+    window_size: Option<Size2D<u32, DeviceIndependentPixel>>,
+
+    /// The url we should load.
+    #[bpaf(positional("URL"), fallback(String::from("https://www.servo.org")))]
+    url: String,
+}
+
+fn update_preferences_from_command_line_arguemnts(
+    preferences: &mut Preferences,
+    cmd_args: &CmdArgs,
+) {
+    if let Some(port) = cmd_args.devtools {
+        preferences.devtools_server_enabled = true;
+        preferences.devtools_server_port = port as i64;
+    }
+
+    if cmd_args.enable_experimental_web_platform_features {
         for pref in EXPERIMENTAL_PREFS {
             preferences.set_value(pref, PrefValue::Bool(true));
         }
     }
 
-    // Handle all command-line preferences overrides.
-    for pref in opt_match.opt_strs("pref") {
+    for pref in &cmd_args.pref {
         let split: Vec<&str> = pref.splitn(2, '=').collect();
         let pref_name = split[0];
         let pref_value = PrefValue::from_booleanish_str(split.get(1).copied().unwrap_or("true"));
         preferences.set_value(pref_name, pref_value);
     }
 
-    if let Some(layout_threads) = layout_threads {
-        preferences.layout_threads = layout_threads as i64;
+    if let Some(layout_threads) = cmd_args.layout_threads {
+        preferences.layout_threads = layout_threads;
     }
 
-    let no_native_titlebar = opt_match.opt_present("no-native-titlebar");
-    let mut device_pixel_ratio_override = opt_match.opt_str("device-pixel-ratio").map(|dppx_str| {
-        dppx_str.parse().unwrap_or_else(|err| {
-            error!("Error parsing option: --device-pixel-ratio ({})", err);
-            process::exit(1);
-        })
-    });
-
-    // If an output file is specified the device pixel ratio is always 1.
-    let output_image_path = opt_match.opt_str("o");
-    if output_image_path.is_some() {
-        device_pixel_ratio_override = Some(1.0);
+    if cmd_args.headless && preferences.media_glvideo_enabled {
+        warn!("GL video rendering is not supported on headless windows.");
+        preferences.media_glvideo_enabled = false;
     }
 
-    let url = if !opt_match.free.is_empty() {
-        Some(opt_match.free[0][..].into())
-    } else {
-        None
-    };
+    if let Some(user_agent) = cmd_args.user_agent.clone() {
+        preferences.user_agent = user_agent;
+    }
+
+    if cmd_args.webdriver_port.is_some() {
+        preferences.dom_testing_html_input_element_select_files_enabled = true;
+    }
+}
+
+pub(crate) fn parse_command_line_arguments(args: Vec<String>) -> ArgumentParsingResult {
+    // Remove the binary name from the list of arguments.
+    let args_without_binary = args
+        .split_first()
+        .expect("Expectd executable name and and arguments")
+        .1;
+    let cmd_args = cmd_args().run_inner(Args::from(args_without_binary));
+    if let Err(error) = cmd_args {
+        error.print_message(80);
+        return if error.exit_code() == 0 {
+            ArgumentParsingResult::Exit
+        } else {
+            ArgumentParsingResult::ErrorParsing
+        };
+    }
+
+    let cmd_args = cmd_args.unwrap();
+
+    if cmd_args
+        .debug
+        .iter()
+        .any(|debug_option| debug_option.contains("help"))
+    {
+        print_debug_options_usage("servo");
+        return ArgumentParsingResult::Exit;
+    }
+
+    // If this is the content process, we'll receive the real options over IPC. So fill in some dummy options for now.
+    if let Some(content_process) = cmd_args.content_process {
+        return ArgumentParsingResult::ContentProcess(content_process);
+    }
+
+    let config_dir = cmd_args
+        .config_dir
+        .clone()
+        .or_else(default_config_dir)
+        .inspect(|config_dir| {
+            if !config_dir.exists() {
+                fs::create_dir_all(config_dir).expect("Could not create config_dir");
+            }
+        });
+    if let Some(ref time_profiler_trace_path) = cmd_args.profiler_trace_path {
+        let mut path = PathBuf::from(time_profiler_trace_path);
+        path.pop();
+        fs::create_dir_all(&path).expect("Error in creating profiler trace path");
+    }
+
+    let mut preferences = get_preferences(&cmd_args.prefs_file, &config_dir);
+
+    update_preferences_from_command_line_arguemnts(&mut preferences, &cmd_args);
 
     // FIXME: enable JIT compilation on 32-bit Android after the startup crash issue (#31134) is fixed.
     if cfg!(target_os = "android") && cfg!(target_pointer_width = "32") {
@@ -656,84 +611,85 @@ pub(crate) fn parse_command_line_arguments(args: Vec<String>) -> ArgumentParsing
         preferences.js_ion_enabled = false;
     }
 
-    let webdriver_port = opt_match.opt_default("webdriver", "7000").map(|port| {
-        port.parse().unwrap_or_else(|err| {
-            args_fail(&format!("Error parsing option: --webdriver ({})", err))
-        })
-    });
+    let device_pixel_ratio_override = if cmd_args.output.is_some() {
+        Some(1.0)
+    } else {
+        cmd_args.device_pixel_ratio
+    };
 
-    let exit_after_load = opt_match.opt_present("x") || output_image_path.is_some();
-    let wait_for_stable_image = exit_after_load;
+    // Make sure the default window size is not larger than any provided screen size.
+    let default_window_size = Size2D::new(1024, 740);
+    let default_window_size = cmd_args
+        .screen_size_override
+        .map_or(default_window_size, |screen_size_override| {
+            default_window_size.min(screen_size_override)
+        });
+
     let servoshell_preferences = ServoShellPreferences {
-        url,
-        no_native_titlebar,
+        url: Some(cmd_args.url),
+        no_native_titlebar: cmd_args.no_native_titlebar,
         device_pixel_ratio_override,
-        clean_shutdown: opt_match.opt_present("clean-shutdown"),
-        headless: opt_match.opt_present("z"),
-        tracing_filter,
-        initial_window_size,
-        screen_size_override,
-        output_image_path,
-        exit_after_stable_image: exit_after_load,
-        userscripts_directory: opt_match
-            .opt_default("userscripts", "resources/user-agent-js")
-            .map(PathBuf::from),
-        webdriver_port,
+        clean_shutdown: cmd_args.clean_shutdown,
+        headless: cmd_args.headless,
+        tracing_filter: cmd_args.tracing_filter,
+        initial_window_size: cmd_args.window_size.unwrap_or(default_window_size),
+        screen_size_override: cmd_args.screen_size_override,
+        webdriver_port: cmd_args.webdriver_port,
+        output_image_path: cmd_args.output.map(|p| p.to_string_lossy().into_owned()),
+        exit_after_stable_image: cmd_args.exit,
+        userscripts_directory: cmd_args.userscripts,
+        experimental_prefs_enabled: cmd_args.enable_experimental_web_platform_features,
         #[cfg(target_env = "ohos")]
-        log_filter,
+        log_filter: Some(
+            cmd_args
+                .log_filter
+                .unwrap_or(preferences.log_filter.clone()),
+        ),
         #[cfg(target_env = "ohos")]
-        log_to_file,
-        experimental_prefs_enabled,
+        log_to_file: cmd_args.log_to_file,
         ..Default::default()
     };
 
-    if servoshell_preferences.headless && preferences.media_glvideo_enabled {
-        warn!("GL video rendering is not supported on headless windows.");
-        preferences.media_glvideo_enabled = false;
-    }
-
-    if let Some(user_agent) = opt_match.opt_str("user-agent") {
-        preferences.user_agent = user_agent;
+    let mut debug_options = DebugOptions::default();
+    for debug_string in cmd_args.debug {
+        let result = debug_options.extend(debug_string);
+        if let Err(error) = result {
+            println!("error: urnecognized debug option: {}", error);
+            return ArgumentParsingResult::ErrorParsing;
+        }
     }
 
     let opts = Opts {
-        debug: debug_options.clone(),
-        wait_for_stable_image,
-        time_profiling,
-        time_profiler_trace_path: opt_match.opt_str("profiler-trace-path"),
-        nonincremental_layout,
-        user_stylesheets,
-        hard_fail: opt_match.opt_present("f") && !opt_match.opt_present("F"),
-        multiprocess: opt_match.opt_present("M"),
-        force_ipc: opt_match.opt_present("I"),
-        background_hang_monitor: opt_match.opt_present("B"),
-        sandbox: opt_match.opt_present("S"),
-        random_pipeline_closure_probability,
-        random_pipeline_closure_seed,
-        config_dir,
-        shaders_dir: opt_match.opt_str("shaders").map(Into::into),
-        certificate_path: opt_match.opt_str("certificate-path"),
-        ignore_certificate_errors: opt_match.opt_present("ignore-certificate-errors"),
-        unminify_js: opt_match.opt_present("unminify-js"),
-        local_script_source: opt_match.opt_str("local-script-source"),
-        unminify_css: opt_match.opt_present("unminify-css"),
-        print_pwm: opt_match.opt_present("print-pwm"),
+        debug: debug_options,
+        wait_for_stable_image: cmd_args.exit,
+        time_profiling: cmd_args.profile,
+        time_profiler_trace_path: cmd_args
+            .profiler_trace_path
+            .map(|p| p.to_string_lossy().into_owned()),
+        nonincremental_layout: cmd_args.nonincremental_layout,
+        user_stylesheets: cmd_args.user_stylesheet,
+        hard_fail: cmd_args.hard_fail,
+        multiprocess: cmd_args.multiprocess,
+        background_hang_monitor: cmd_args.background_hang_monitor,
+        sandbox: cmd_args.sandbox,
+        random_pipeline_closure_probability: cmd_args.random_pipeline_closure_probability,
+        random_pipeline_closure_seed: cmd_args.random_pipeline_closure_seed,
+        config_dir: config_dir.clone(),
+        shaders_dir: cmd_args.shaders,
+        certificate_path: cmd_args
+            .certificate_path
+            .map(|p| p.to_string_lossy().into_owned()),
+        ignore_certificate_errors: cmd_args.ignore_certificate_errors,
+        unminify_js: cmd_args.unminify_js,
+        local_script_source: cmd_args
+            .local_script_source
+            .map(|p| p.to_string_lossy().into_owned()),
+        unminify_css: cmd_args.unminify_css,
+        print_pwm: cmd_args.print_pwm,
+        force_ipc: cmd_args.force_ipc,
     };
 
     ArgumentParsingResult::ChromeProcess(opts, preferences, servoshell_preferences)
-}
-
-fn args_fail(msg: &str) -> ! {
-    eprintln!("{}", msg);
-    process::exit(1)
-}
-
-fn print_usage(app: &str, opts: &Options) {
-    let message = format!(
-        "Usage: {} [ options ... ] [URL]\n\twhere options include",
-        app
-    );
-    println!("{}", opts.usage(&message));
 }
 
 fn print_debug_options_usage(app: &str) {
@@ -827,6 +783,12 @@ fn test_parse_pref(arg: &str) -> Preferences {
             unreachable!("No preferences for content process")
         },
         ArgumentParsingResult::ChromeProcess(_, preferences, _) => preferences,
+        ArgumentParsingResult::Exit => {
+            panic!("we supplied a --pref argument above which should be parsed")
+        },
+        ArgumentParsingResult::ErrorParsing => {
+            unreachable!("we supplied a --pref argument above which should be parsed")
+        },
     }
 }
 
@@ -874,4 +836,70 @@ fn test_create_prefs_map() {
         \"shell.homepage\": \"https://servo.org\"
     }";
     assert_eq!(read_prefs_map(json_str).len(), 3);
+}
+
+#[cfg(test)]
+fn test_parse(arg: &str) -> (Opts, Preferences, ServoShellPreferences) {
+    let mut args = vec!["servo".to_string()];
+    // bpaf requires the arguments that are separated by whitespace to be different elements of the vector.
+    let mut args_split = arg.split_whitespace().map(|s| s.to_owned()).collect();
+    args.append(&mut args_split);
+    match parse_command_line_arguments(args) {
+        ArgumentParsingResult::ContentProcess(..) => {
+            unreachable!("No preferences for content process")
+        },
+        ArgumentParsingResult::ChromeProcess(opts, preferences, servoshell_preferences) => {
+            (opts, preferences, servoshell_preferences)
+        },
+        ArgumentParsingResult::Exit | ArgumentParsingResult::ErrorParsing => {
+            unreachable!("We always have valid preference in our test cases")
+        },
+    }
+}
+
+#[test]
+fn test_profiling_args() {
+    assert_eq!(
+        test_parse("-p").0.time_profiling.unwrap(),
+        OutputOptions::Stdout(5_f64)
+    );
+
+    assert_eq!(
+        test_parse("-p 10").0.time_profiling.unwrap(),
+        OutputOptions::Stdout(10_f64)
+    );
+
+    assert_eq!(
+        test_parse("-p 10.0").0.time_profiling.unwrap(),
+        OutputOptions::Stdout(10_f64)
+    );
+
+    assert_eq!(
+        test_parse("-p foo.txt").0.time_profiling.unwrap(),
+        OutputOptions::FileName(String::from("foo.txt"))
+    );
+}
+
+#[test]
+fn test_servoshell_cmd() {
+    assert_eq!(
+        test_parse("-o foo.png").2.device_pixel_ratio_override,
+        Some(1.0)
+    );
+
+    assert_eq!(
+        test_parse("--screen-size=1000x1000")
+            .2
+            .screen_size_override
+            .unwrap(),
+        Size2D::new(1000, 1000)
+    );
+
+    assert_eq!(
+        test_parse("--certificate-path=/tmp/test")
+            .0
+            .certificate_path
+            .unwrap(),
+        String::from("/tmp/test")
+    );
 }


### PR DESCRIPTION
This includes some small refactoring and some small breaking changes as
listed below. Other than these I tried to keep the functionality exactly
the same but because in the old code the parsing and settings of
preferences was intermingled it was difficult to figure out.

Small Breaking:
- Size and resources-path were unused but appeared in the help.
- soft-fail and hard-fail: Soft-fail flag got removed because it is too
  difficult to keep both. The default is now soft-fail and hard-fail can
be enabled.
- The help strings are obviously formatted differently now.
- -V does not work anymore but -v and --version.

Ideally, we want to have the ServoShellPreferences and Preferences be directly the Argument structure but that needs a bit more discussion because it would break backwards compatibility with the commandline.

This increases the binary size by ~280kb.

Testing: The testcases are still working but they do not cover much.
I added a unit test for the -p flag because it is the most difficult to parse in general.
Fixes: This will fix a small number of various parsing misshaps. It will also show if we are removing an option via unused lint.
