### PR TITLE
mach: Add TSAN support

### DIFF
--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -128,7 +128,7 @@ class MachCommands(CommandBase):
         host = servo.platform.host_triple()
         target_triple = self.target.triple()
 
-        if sanitizer.is_none():
+        if sanitizer.is_some():
             self.build_sanitizer_env(env, opts, kwargs, target_triple, sanitizer)
 
         build_start = time()

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -220,7 +220,7 @@ class MachCommands(CommandBase):
         self, env: Dict, opts: List[str], kwargs, target_triple, sanitizer: SanitizerKind = SanitizerKind.NONE
     ):
         if sanitizer.is_none():
-            return None
+            return
         # do not use crown (clashes with different rust version)
         env["RUSTC"] = "rustc"
         # Enable usage of unstable rust flags
@@ -285,8 +285,6 @@ class MachCommands(CommandBase):
             env["RUSTFLAGS"] += " -Zsanitizer=thread"
             env["TARGET_CFLAGS"] += " -fsanitize=thread"
             env["TARGET_CXXFLAGS"] += " -fsanitize=thread"
-
-        return None
 
     def notify(self, title: str, message: str):
         """Generate desktop notification when build is complete and the

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -330,7 +330,7 @@ class CommandBase(object):
     def get_top_dir(self):
         return self.context.topdir
 
-    def get_binary_path(self, build_type: BuildType, sanitizer: SanitizerKind = None):
+    def get_binary_path(self, build_type: BuildType, sanitizer: SanitizerKind = SanitizerKind.NONE):
         base_path = util.get_target_dir()
         if sanitizer.is_some() or self.target.is_cross_build():
             base_path = path.join(base_path, self.target.triple())

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -307,7 +307,7 @@ class CommandBase(object):
         self.config["build"].setdefault("incremental", None)
         self.config["build"].setdefault("webgl-backtrace", False)
         self.config["build"].setdefault("dom-backtrace", False)
-        self.config["build"].setdefault("sanitizer", None)
+        self.config["build"].setdefault("sanitizer", SanitizerKind.NONE)
 
         self.config.setdefault("android", {})
         self.config["android"].setdefault("sdk", "")
@@ -330,9 +330,9 @@ class CommandBase(object):
     def get_top_dir(self):
         return self.context.topdir
 
-    def get_binary_path(self, build_type: BuildType, sanitizer=None):
+    def get_binary_path(self, build_type: BuildType, sanitizer: SanitizerKind = None):
         base_path = util.get_target_dir()
-        if sanitizer is not None or self.target.is_cross_build():
+        if sanitizer.is_some() or self.target.is_cross_build():
             base_path = path.join(base_path, self.target.triple())
         binary_name = self.target.binary_name()
         binary_path = path.join(base_path, build_type.directory_name(), binary_name)
@@ -546,7 +546,16 @@ class CommandBase(object):
                     dest="sanitizer",
                     action="store_const",
                     const=SanitizerKind.ASAN,
+                    default=SanitizerKind.NONE,
                     help="Build with AddressSanitizer",
+                ),
+                CommandArgument(
+                    "--with-tsan",
+                    group="Sanitizer",
+                    dest="sanitizer",
+                    action="store_const",
+                    const=SanitizerKind.TSAN,
+                    help="Build with ThreadSanitizer",
                 ),
             ]
 

--- a/python/servo/gstreamer.py
+++ b/python/servo/gstreamer.py
@@ -237,7 +237,7 @@ def find_non_system_dependencies_with_otool(binary_path: str) -> Set[str]:
 
         # No need to do any processing for system libraries. They should be
         # present on all macOS systems.
-        if not is_macos_system_library(dependency):
+        if not (is_macos_system_library(dependency) or 'librustc-stable_rt' in dependency):
             output.add(dependency)
     return output
 

--- a/python/servo/gstreamer.py
+++ b/python/servo/gstreamer.py
@@ -237,7 +237,7 @@ def find_non_system_dependencies_with_otool(binary_path: str) -> Set[str]:
 
         # No need to do any processing for system libraries. They should be
         # present on all macOS systems.
-        if not (is_macos_system_library(dependency) or 'librustc-stable_rt' in dependency):
+        if not (is_macos_system_library(dependency) or "librustc-stable_rt" in dependency):
             output.add(dependency)
     return output
 

--- a/python/servo/platform/build_target.py
+++ b/python/servo/platform/build_target.py
@@ -15,6 +15,7 @@ import platform
 import shutil
 import subprocess
 import sys
+from enum import Enum
 
 from os import path
 from packaging.version import parse as parse_version
@@ -22,6 +23,11 @@ from typing import Any, Dict, Optional
 
 import servo.platform
 import servo.util as util
+
+
+class SanitizerKind(Enum):
+    UNKNOWN = 0
+    ASAN = 1
 
 
 class BuildTarget(object):
@@ -398,7 +404,7 @@ class OpenHarmonyTarget(CrossBuildTarget):
         env[bindgen_extra_clangs_args_var] = bindgen_extra_clangs_args
 
         # On OpenHarmony we add some additional flags when asan is enabled
-        if config["build"]["with_asan"]:
+        if config["build"]["sanitizer"] == SanitizerKind.ASAN:
             # Lookup `<sdk>/native/llvm/lib/clang/15.0.4/lib/aarch64-linux-ohos/libclang_rt.asan.so`
             lib_clang = llvm_toolchain.joinpath("lib", "clang")
             children = [f.path for f in os.scandir(lib_clang) if f.is_dir()]

--- a/python/servo/platform/build_target.py
+++ b/python/servo/platform/build_target.py
@@ -26,8 +26,25 @@ import servo.util as util
 
 
 class SanitizerKind(Enum):
-    UNKNOWN = 0
+    NONE = 0
     ASAN = 1
+    TSAN = 2
+
+    # Apparently enums don't always compare across modules, so we define
+    # helper methods.
+    def is_asan(self) -> bool:
+        return self is self.ASAN
+
+    def is_tsan(self) -> bool:
+        return self is self.TSAN
+
+    # Returns true if no sanitizer is enabled.
+    def is_none(self) -> bool:
+        return self is self.NONE
+
+    # Returns true if a sanitizer is enabled.
+    def is_some(self) -> bool:
+        return not self.is_none()
 
 
 class BuildTarget(object):
@@ -403,8 +420,9 @@ class OpenHarmonyTarget(CrossBuildTarget):
         bindgen_extra_clangs_args = bindgen_extra_clangs_args + " " + ohos_cflags_str
         env[bindgen_extra_clangs_args_var] = bindgen_extra_clangs_args
 
-        # On OpenHarmony we add some additional flags when asan is enabled
-        if config["build"]["sanitizer"] == SanitizerKind.ASAN:
+        sanitizer: SanitizerKind = config["build"]["sanitizer"]
+        san_compile_flags = []
+        if sanitizer.is_some():
             # Lookup `<sdk>/native/llvm/lib/clang/15.0.4/lib/aarch64-linux-ohos/libclang_rt.asan.so`
             lib_clang = llvm_toolchain.joinpath("lib", "clang")
             children = [f.path for f in os.scandir(lib_clang) if f.is_dir()]
@@ -412,6 +430,12 @@ class OpenHarmonyTarget(CrossBuildTarget):
                 raise RuntimeError(f"Expected exactly 1 libclang version: `{children}`")
             lib_clang_version_dir = pathlib.Path(children[0])
             libclang_arch = lib_clang_version_dir.joinpath("lib", clang_target_triple).resolve()
+            # Use the clangrt from the NDK to use the same library for both C++ and Rust.
+            env["RUSTFLAGS"] += " -Zexternal-clangrt"
+            san_compile_flags.append("-fno-omit-frame-pointer")
+
+        # On OpenHarmony we add some additional flags when asan is enabled
+        if sanitizer.is_asan():
             libasan_so_path = libclang_arch.joinpath("libclang_rt.asan.so")
             libasan_preinit_path = libclang_arch.joinpath("libclang_rt.asan-preinit.a")
             if not libasan_so_path.exists():
@@ -428,23 +452,26 @@ class OpenHarmonyTarget(CrossBuildTarget):
                 ]
             )
 
-            # Use the clangrt from the NDK to use the same library for both C++ and Rust.
-            env["RUSTFLAGS"] += " -Zexternal-clangrt"
-
-            asan_compile_flags = (
-                " -fsanitize=address -shared-libasan -fno-omit-frame-pointer -fsanitize-recover=address"
-            )
+            san_compile_flags.extend(["-fsanitize=address", "-shared-libasan", "-fsanitize-recover=address"])
 
             arch_asan_ignore_list = lib_clang_version_dir.joinpath("share", "asan_ignorelist.txt")
             if arch_asan_ignore_list.exists():
-                asan_compile_flags += " -fsanitize-system-ignorelist=" + str(arch_asan_ignore_list)
+                san_compile_flags.append("-fsanitize-system-ignorelist=" + str(arch_asan_ignore_list))
             else:
                 print(f"Warning: Couldn't find system ASAN ignorelist at `{arch_asan_ignore_list}`")
-            env["TARGET_CFLAGS"] += asan_compile_flags
-            env["TARGET_CXXFLAGS"] += asan_compile_flags
+        elif sanitizer.is_tsan():
+            libtsan_so_path = libclang_arch.joinpath("libclang_rt.tsan.so")
+            builtins_path = libclang_arch.joinpath("libclang_rt.builtins.a")
+
+            link_args.extend(
+                ["-fsanitize=thread", "--rtlib=compiler-rt", "-shared-libsan", str(libtsan_so_path), str(builtins_path)]
+            )
+            san_compile_flags.append("-shared-libsan")
 
         link_args = [f"-Clink-arg={arg}" for arg in link_args]
         env["RUSTFLAGS"] += " " + " ".join(link_args)
+        env["TARGET_CFLAGS"] += " " + " ".join(san_compile_flags)
+        env["TARGET_CXXFLAGS"] += " " + " ".join(san_compile_flags)
 
     def binary_name(self) -> str:
         return "libservoshell.so"


### PR DESCRIPTION
Add ThreadSanitizer support to mach (`--with-tsan`).

This refactors the current infrastructure to support `--with-asan` to a more generic `Santiizer`. 
If the need for adding multiple sanitizers at once (e.g. address + leak sanitizer) arises, we can easily change the `SanitizerKind` enum to a `enum.Flag` instead.

Testing: Manually run `./mach build --with-tsan` and `./mach run --with-tsan` (on macos) and observe TSAN reporting data races.

Closes: #14869

