### PR TITLE
DevTools: Fix empty `debugger > source` panel

### DIFF
--- a/components/devtools/actors/breakpoint.rs
+++ b/components/devtools/actors/breakpoint.rs
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use serde::Serialize;
+
+use crate::EmptyReplyMsg;
+use crate::actor::{Actor, ActorMessageStatus};
+use crate::protocol::JsonPacketStream;
+
+#[derive(Serialize)]
+pub struct BreakpointListActorMsg {
+    actor: String,
+}
+
+pub struct BreakpointListActor {
+    name: String,
+}
+
+impl Actor for BreakpointListActor {
+    fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    fn handle_message(
+        &self,
+        _registry: &crate::actor::ActorRegistry,
+        msg_type: &str,
+        _msg: &serde_json::Map<String, serde_json::Value>,
+        stream: &mut std::net::TcpStream,
+        _stream_id: crate::StreamId,
+    ) -> Result<crate::actor::ActorMessageStatus, ()> {
+        Ok(match msg_type {
+            "setBreakpoint" => {
+                let msg = EmptyReplyMsg { from: self.name() };
+                let _ = stream.write_json_packet(&msg);
+
+                ActorMessageStatus::Processed
+            },
+            "setActiveEventBreakpoints" => {
+                let msg = EmptyReplyMsg { from: self.name() };
+                let _ = stream.write_json_packet(&msg);
+
+                ActorMessageStatus::Processed
+            },
+            _ => ActorMessageStatus::Ignored,
+        })
+    }
+}
+
+impl BreakpointListActor {
+    pub fn new(name: String) -> Self {
+        Self { name }
+    }
+}

--- a/components/devtools/actors/watcher.rs
+++ b/components/devtools/actors/watcher.rs
@@ -19,6 +19,7 @@ use serde::Serialize;
 use serde_json::{Map, Value};
 
 use self::network_parent::{NetworkParentActor, NetworkParentActorMsg};
+use super::breakpoint::BreakpointListActor;
 use super::thread::ThreadActor;
 use super::worker::WorkerMsg;
 use crate::actor::{Actor, ActorMessageStatus, ActorRegistry};
@@ -362,10 +363,14 @@ impl Actor for WatcherActor {
                 ActorMessageStatus::Processed
             },
             "getBreakpointListActor" => {
+                let breakpoint_list_name = registry.new_name("breakpoint-list");
+                let breakpoint_list = BreakpointListActor::new(breakpoint_list_name.clone());
+                registry.register_later(Box::new(breakpoint_list));
+
                 let _ = stream.write_json_packet(&GetBreakpointListActorReply {
                     from: self.name(),
                     breakpoint_list: GetBreakpointListActorReplyInner {
-                        actor: registry.new_name("breakpoint-list"),
+                        actor: breakpoint_list_name,
                     },
                 });
                 ActorMessageStatus::Processed

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -53,6 +53,7 @@ use crate::protocol::JsonPacketStream;
 mod actor;
 /// <https://searchfox.org/mozilla-central/source/devtools/server/actors>
 mod actors {
+    pub mod breakpoint;
     pub mod browsing_context;
     pub mod console;
     pub mod device;


### PR DESCRIPTION
This patch fixes the source panel in the DevTools that was broken due to missing breakpoint actor implementation. The client was sending messages to the breakpoint actor that didn't exist in Servo, resulting in "unknown actor" 
warnings in the logs(See logs in issue description)

To fix this this patch implements the `BreakpointListActor` that handles `setBreakpoint`  and  `setActiveEventBreakpoints` messages with empty replies. This PR does not implement `breakpoint` functionality

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/ac4985a6-9fd3-4854-a491-b39241e19d13" />



Fixes: https://github.com/servo/servo/issues/37196
